### PR TITLE
feat(ios): list installed apps on physical devices via devicectl

### DIFF
--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -23,6 +23,8 @@ import {
   getIosInstalledAppBundleId,
   type IosInstalledAppRecord,
 } from "../../utils/ios-cmdline-tools/iosInstalledApp";
+import { DeviceAppManager } from "../../utils/ios-cmdline-tools/DeviceAppManager";
+import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 const INSTALLED_APPS_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -38,10 +40,20 @@ export interface IosInstalledAppsDetailedResult {
   successful: boolean;
 }
 
+/**
+ * Physical-device app listing seam (`devicectl device info apps`), narrowed to
+ * the single call this feature makes so tests can inject a fake without a
+ * `DeviceAppManager`.
+ */
+export interface IosPhysicalAppLister {
+  listInstalledApps(deviceUdid: string): Promise<IosInstalledAppRecord[]>;
+}
+
 interface ListInstalledAppsOptions {
   cacheEnabled?: boolean;
   installedAppsRepository?: InstalledAppsStore;
   timer?: Timer;
+  iosPhysicalAppLister?: IosPhysicalAppLister;
 }
 
 export class ListInstalledApps {
@@ -51,6 +63,7 @@ export class ListInstalledApps {
   private installedAppsRepository: InstalledAppsStore;
   private cacheEnabled: boolean;
   private timer: Timer;
+  private iosPhysicalAppLister: IosPhysicalAppLister | null;
   /**
    * Create an ListInstalledApps instance
    * @param device - Device to run ADB commands against
@@ -72,6 +85,17 @@ export class ListInstalledApps {
     const defaultCacheEnabled = adbFactory === defaultAdbClientFactory;
     this.cacheEnabled = options.cacheEnabled ?? defaultCacheEnabled;
     this.timer = options.timer ?? defaultTimer;
+    this.iosPhysicalAppLister = options.iosPhysicalAppLister ?? null;
+  }
+
+  /**
+   * Physical iOS devices have no simctl; `devicectl device info apps` is the
+   * only listing available there. Constructed lazily so simulator-only callers
+   * never build a DeviceAppManager.
+   */
+  private getIosPhysicalAppLister(): IosPhysicalAppLister {
+    this.iosPhysicalAppLister ??= new DeviceAppManager();
+    return this.iosPhysicalAppLister;
   }
 
   /**
@@ -153,7 +177,13 @@ export class ListInstalledApps {
     }
 
     try {
-      const apps = await this.simctl.listApps(this.device.deviceId);
+      // Only a positively physical-looking UDID routes to devicectl. Anything
+      // else (simulator UUID, or a non-UDID id) keeps the simctl path, so an
+      // unrecognized id degrades to today's behavior rather than shelling out
+      // to a tool that cannot serve it.
+      const apps = isIosPhysicalUdid(this.device.deviceId)
+        ? await this.getIosPhysicalAppLister().listInstalledApps(this.device.deviceId)
+        : await this.simctl.listApps(this.device.deviceId);
       const appsByBundleId = new Map<string, IosInstalledAppRecord>();
       for (const app of apps) {
         if (!app || typeof app !== "object" || Array.isArray(app)) {

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -15,7 +15,10 @@ import { logger } from "../utils/logger";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
-import { getIosInstalledAppBundleId } from "../utils/ios-cmdline-tools/iosInstalledApp";
+import {
+  getIosInstalledAppBundleId,
+  getIosInstalledAppPath,
+} from "../utils/ios-cmdline-tools/iosInstalledApp";
 
 // Resource URI templates
 export const APP_RESOURCE_TEMPLATES = {
@@ -222,7 +225,9 @@ function extractIosVersion(app: Record<string, unknown>): string | undefined {
 }
 
 function extractIosPath(app: Record<string, unknown>): string | undefined {
-  return readIosAppField(app, ["bundlePath", "bundleContainer", "path", "Path", "dataContainer"]);
+  // Shared with the devicectl listing so a physical device's `file://` bundle
+  // URL reaches this resource as a filesystem path, same as a simulator's.
+  return getIosInstalledAppPath(app);
 }
 
 function toQueryIosApp(app: IosInstalledAppInfo): AppsQueryAppInfo {

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -114,19 +114,24 @@ export const findBundleEntry = (
  * pin it) writes a bare `{ apps: [...] }`. Search for the first `apps` array
  * either way rather than hardcoding one envelope, and drop non-object
  * members so callers can treat every entry as a record.
+ *
+ * Returns null when the payload carries no `apps` array at all — that is a
+ * payload this code does not understand, which must not be reported as the
+ * device having no apps installed. An `apps` array that is present but empty
+ * returns `[]`, because that genuinely means "nothing installed".
  */
-export const extractInstalledAppEntries = (data: unknown): Record<string, unknown>[] => {
+export const extractInstalledAppEntries = (data: unknown): Record<string, unknown>[] | null => {
   if (!data || typeof data !== "object") {
-    return [];
+    return null;
   }
   if (Array.isArray(data)) {
     for (const item of data) {
       const found = extractInstalledAppEntries(item);
-      if (found.length > 0) {
+      if (found) {
         return found;
       }
     }
-    return [];
+    return null;
   }
 
   const record = data as Record<string, unknown>;
@@ -139,11 +144,11 @@ export const extractInstalledAppEntries = (data: unknown): Record<string, unknow
 
   for (const value of Object.values(record)) {
     const found = extractInstalledAppEntries(value);
-    if (found.length > 0) {
+    if (found) {
       return found;
     }
   }
-  return [];
+  return null;
 };
 
 const extractBundlePath = (entry: Record<string, unknown>): string | null => {
@@ -904,14 +909,28 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       ]);
 
       const raw = await this.deps.readFile(jsonPath);
-      return extractInstalledAppEntries(JSON.parse(raw) as unknown);
+      const apps = extractInstalledAppEntries(JSON.parse(raw) as unknown);
+      if (!apps) {
+        throw new ActionableError(
+          `devicectl reported no app listing for ${deviceUdid}; its JSON output carried no "apps" array`,
+        );
+      }
+      return apps;
     } catch (error) {
       throw toActionableError(
         error,
         `Failed to list installed apps on physical iOS device ${deviceUdid}`,
       );
     } finally {
-      await this.deps.rm(tempDir);
+      // A failed temp-dir cleanup must not replace the devicectl or JSON
+      // diagnostic the caller needs.
+      try {
+        await this.deps.rm(tempDir);
+      } catch (cleanupError) {
+        this.deps.logger.warn(
+          `[DeviceAppManager] Failed to remove temporary app listing directory ${tempDir}: ${getErrorMessage(cleanupError)}`,
+        );
+      }
     }
   }
 

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -7,6 +7,7 @@ import { ActionableError, toActionableError } from "../../models/ActionableError
 import { hashAppBundle } from "./AppBundleHasher";
 import { isProcessAlreadyGoneError } from "./iosProcessErrors";
 import { iosMajorVersionFromDevicectlDetails } from "./iosVersion";
+import { normalizeIosDevicePath as normalizeDevicePath } from "./iosInstalledApp";
 import { logger } from "../logger";
 import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
 import type { Logger } from "../logger";
@@ -59,17 +60,6 @@ const parseJsonOutputPath = (command: string): string | null => {
   return null;
 };
 
-const normalizeDevicePath = (rawPath: string): string => {
-  if (rawPath.startsWith("file://")) {
-    try {
-      return decodeURIComponent(new URL(rawPath).pathname);
-    } catch {
-      return rawPath.replace("file://", "");
-    }
-  }
-  return rawPath;
-};
-
 export const findBundleEntry = (
   data: unknown,
   bundleId: string,
@@ -115,10 +105,11 @@ export const findBundleEntry = (
  * either way rather than hardcoding one envelope, and drop non-object
  * members so callers can treat every entry as a record.
  *
- * Returns null when the payload carries no `apps` array at all — that is a
- * payload this code does not understand, which must not be reported as the
- * device having no apps installed. An `apps` array that is present but empty
- * returns `[]`, because that genuinely means "nothing installed".
+ * Returns null when the payload carries no `apps` array at all, or carries one
+ * whose members are all unreadable — those are payloads this code does not
+ * understand, which must not be reported as the device having no apps
+ * installed. An `apps` array that is present but empty returns `[]`, because
+ * that genuinely means "nothing installed".
  */
 export const extractInstalledAppEntries = (data: unknown): Record<string, unknown>[] | null => {
   if (!data || typeof data !== "object") {
@@ -136,10 +127,16 @@ export const extractInstalledAppEntries = (data: unknown): Record<string, unknow
 
   const record = data as Record<string, unknown>;
   if (Array.isArray(record.apps)) {
-    return record.apps.filter(
+    const entries = record.apps.filter(
       (entry): entry is Record<string, unknown> =>
         Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
     );
+    // An array that carried members but none we can read is a payload shape we
+    // do not understand; only an originally empty array means "nothing installed".
+    if (entries.length === 0 && record.apps.length > 0) {
+      return null;
+    }
+    return entries;
   }
 
   for (const value of Object.values(record)) {
@@ -912,7 +909,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       const apps = extractInstalledAppEntries(JSON.parse(raw) as unknown);
       if (!apps) {
         throw new ActionableError(
-          `devicectl reported no app listing for ${deviceUdid}; its JSON output carried no "apps" array`,
+          `devicectl reported no readable app listing for ${deviceUdid}; its JSON output carried no usable "apps" array`,
         );
       }
       return apps;

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -107,6 +107,45 @@ export const findBundleEntry = (
   return null;
 };
 
+/**
+ * Pull the installed-app records out of a `devicectl device info apps`
+ * payload. devicectl nests the listing under `result.apps`, while the
+ * `--bundle-id` shape used elsewhere in this module (and the fixtures that
+ * pin it) writes a bare `{ apps: [...] }`. Search for the first `apps` array
+ * either way rather than hardcoding one envelope, and drop non-object
+ * members so callers can treat every entry as a record.
+ */
+export const extractInstalledAppEntries = (data: unknown): Record<string, unknown>[] => {
+  if (!data || typeof data !== "object") {
+    return [];
+  }
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const found = extractInstalledAppEntries(item);
+      if (found.length > 0) {
+        return found;
+      }
+    }
+    return [];
+  }
+
+  const record = data as Record<string, unknown>;
+  if (Array.isArray(record.apps)) {
+    return record.apps.filter(
+      (entry): entry is Record<string, unknown> =>
+        Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+    );
+  }
+
+  for (const value of Object.values(record)) {
+    const found = extractInstalledAppEntries(value);
+    if (found.length > 0) {
+      return found;
+    }
+  }
+  return [];
+};
+
 const extractBundlePath = (entry: Record<string, unknown>): string | null => {
   const candidates = [
     entry.bundleURL,
@@ -825,6 +864,52 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       const raw = await this.deps.readFile(jsonPath);
       const data = JSON.parse(raw) as unknown;
       return findBundleEntry(data, bundleId);
+    } finally {
+      await this.deps.rm(tempDir);
+    }
+  }
+
+  /**
+   * List every app `devicectl device info apps` reports for a physical device,
+   * as raw devicectl records. This is the physical-device counterpart of
+   * `simctl listapps`, so `ListInstalledApps` can answer on real hardware
+   * instead of returning an empty list (issue #2883).
+   *
+   * Unlike {@link queryInstalledAppEntry} this omits `--bundle-id`, which is
+   * what turns the lookup into a full listing. devicectl exec / JSON-read
+   * failures are wrapped and PROPAGATE: an empty list must mean "no apps", not
+   * "devicectl is broken", because callers report that distinction as their
+   * `successful` flag. macOS-only.
+   */
+  public async listInstalledApps(deviceUdid: string): Promise<Record<string, unknown>[]> {
+    if (this.deps.platform() !== "darwin") {
+      throw new ActionableError(
+        "Listing apps on a physical iOS device requires macOS (devicectl is Xcode-only)",
+      );
+    }
+
+    const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
+    const jsonPath = join(tempDir, "apps.json");
+    try {
+      await this.execute("xcrun", [
+        "devicectl",
+        "device",
+        "info",
+        "apps",
+        "--device",
+        deviceUdid,
+        "--json-output",
+        jsonPath,
+        "--quiet",
+      ]);
+
+      const raw = await this.deps.readFile(jsonPath);
+      return extractInstalledAppEntries(JSON.parse(raw) as unknown);
+    } catch (error) {
+      throw toActionableError(
+        error,
+        `Failed to list installed apps on physical iOS device ${deviceUdid}`,
+      );
     } finally {
       await this.deps.rm(tempDir);
     }

--- a/src/utils/ios-cmdline-tools/iosInstalledApp.ts
+++ b/src/utils/ios-cmdline-tools/iosInstalledApp.ts
@@ -1,3 +1,5 @@
+import { logger } from "../logger";
+
 export type IosInstalledAppRecord = Record<string, unknown>;
 
 const BUNDLE_ID_KEYS = ["bundleId", "bundleIdentifier", "bundleID", "CFBundleIdentifier"] as const;
@@ -15,6 +17,63 @@ export function getIosInstalledAppBundleId(app: IosInstalledAppRecord): string |
     const bundleId = value.trim();
     if (bundleId) {
       return bundleId;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Path-carrying keys across the simulator (`simctl listapps`) and devicectl
+ * (`devicectl device info apps`) record formats, most specific first: an
+ * explicit bundle location beats a container. devicectl spells the bundle
+ * location as a `file://` URL under `url`/`bundleURL`.
+ */
+const APP_PATH_KEYS = [
+  "bundlePath",
+  "bundleURL",
+  "bundleURLString",
+  "bundle_path",
+  "bundle_url",
+  "url",
+  "path",
+  "Path",
+  "bundleContainer",
+  "dataContainer",
+] as const;
+
+/**
+ * Returns `rawPath` as a filesystem path, decoding the `file://` URL form
+ * devicectl uses. A path that is not a URL is returned unchanged.
+ */
+export function normalizeIosDevicePath(rawPath: string): string {
+  if (rawPath.startsWith("file://")) {
+    try {
+      return decodeURIComponent(new URL(rawPath).pathname);
+    } catch (error) {
+      // A malformed file:// value (bad percent-escape, unparseable URL) is still
+      // more useful with the scheme stripped than not at all; this is a
+      // display/metadata path, not an opened handle.
+      logger.debug(`[iosInstalledApp] Could not parse device path URL ${rawPath}: ${error}`);
+      return rawPath.replace("file://", "");
+    }
+  }
+  return rawPath;
+}
+
+/**
+ * Returns the normalized on-device path from the simulator and devicectl record
+ * formats used by installed-app callers, or undefined when the record carries
+ * no path.
+ */
+export function getIosInstalledAppPath(app: IosInstalledAppRecord): string | undefined {
+  for (const key of APP_PATH_KEYS) {
+    const value = app[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return normalizeIosDevicePath(trimmed);
     }
   }
   return undefined;

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -603,3 +603,125 @@ describe("ListInstalledApps", function () {
     });
   });
 });
+
+describe("ListInstalledApps physical iOS devices", function () {
+  const PHYSICAL_UDID = "00008130-001C2D3E1234567A";
+  const SIMULATOR_UDID = "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D";
+
+  class FakePhysicalAppLister {
+    calls: string[] = [];
+    apps: Record<string, unknown>[] = [];
+    failure: Error | null = null;
+
+    async listInstalledApps(deviceUdid: string): Promise<Record<string, unknown>[]> {
+      this.calls.push(deviceUdid);
+      if (this.failure) {
+        throw this.failure;
+      }
+      return this.apps;
+    }
+  }
+
+  const iosDevice = (deviceId: string): BootedDevice =>
+    ({ deviceId, platform: "ios" }) as BootedDevice;
+
+  const createFakeAdbFactory = () => new FakeAdbClientFactory(new FakeAdbExecutor());
+
+  test("lists apps via devicectl instead of simctl on a physical UDID", async function () {
+    const lister = new FakePhysicalAppLister();
+    lister.apps = [
+      { bundleIdentifier: "com.example.device", name: "Device App" },
+      { bundleIdentifier: "com.example.other" },
+    ];
+    const simctl = new FakeSimctl();
+    simctl.setInstalledApps([{ bundleId: "com.example.simulator" }]);
+
+    const list = new ListInstalledApps(iosDevice(PHYSICAL_UDID), createFakeAdbFactory(), simctl, {
+      iosPhysicalAppLister: lister,
+    });
+
+    await expect(list.execute()).resolves.toEqual(["com.example.device", "com.example.other"]);
+    expect(lister.calls).toEqual([PHYSICAL_UDID]);
+    expect(simctl.getMethodCallCount("listApps")).toBe(0);
+  });
+
+  test("preserves devicectl app metadata in the detailed result", async function () {
+    const lister = new FakePhysicalAppLister();
+    lister.apps = [
+      {
+        bundleIdentifier: "com.example.device",
+        name: "Device App",
+        version: "4.2.0",
+        url: "file:///private/var/containers/Bundle/Application/ABC/Device.app",
+      },
+    ];
+
+    const list = new ListInstalledApps(
+      iosDevice(PHYSICAL_UDID),
+      createFakeAdbFactory(),
+      new FakeSimctl(),
+      { iosPhysicalAppLister: lister },
+    );
+
+    await expect(list.executeIosDetailedResult()).resolves.toEqual({
+      apps: [
+        {
+          bundleIdentifier: "com.example.device",
+          name: "Device App",
+          version: "4.2.0",
+          url: "file:///private/var/containers/Bundle/Application/ABC/Device.app",
+        },
+      ],
+      successful: true,
+    });
+  });
+
+  test("reports successful:false when devicectl fails rather than an empty listing", async function () {
+    const lister = new FakePhysicalAppLister();
+    lister.failure = new Error("devicectl is not installed");
+
+    const list = new ListInstalledApps(
+      iosDevice(PHYSICAL_UDID),
+      createFakeAdbFactory(),
+      new FakeSimctl(),
+      { iosPhysicalAppLister: lister },
+    );
+
+    await expect(list.executeIosDetailedResult()).resolves.toEqual({
+      apps: [],
+      successful: false,
+    });
+  });
+
+  test("keeps the simctl path for simulator UDIDs", async function () {
+    const lister = new FakePhysicalAppLister();
+    const simctl = new FakeSimctl();
+    simctl.setInstalledApps([{ bundleId: "com.example.simulator" }]);
+
+    const list = new ListInstalledApps(iosDevice(SIMULATOR_UDID), createFakeAdbFactory(), simctl, {
+      iosPhysicalAppLister: lister,
+    });
+
+    await expect(list.execute()).resolves.toEqual(["com.example.simulator"]);
+    expect(lister.calls).toEqual([]);
+  });
+
+  test("dedupes bundle identifiers reported twice by devicectl", async function () {
+    const lister = new FakePhysicalAppLister();
+    lister.apps = [
+      { bundleIdentifier: "com.example.device", version: "1.0.0" },
+      { bundleIdentifier: "com.example.device", version: "2.0.0" },
+    ];
+
+    const list = new ListInstalledApps(
+      iosDevice(PHYSICAL_UDID),
+      createFakeAdbFactory(),
+      new FakeSimctl(),
+      { iosPhysicalAppLister: lister },
+    );
+
+    await expect(list.executeIosDetailed()).resolves.toEqual([
+      { bundleIdentifier: "com.example.device", version: "2.0.0" },
+    ]);
+  });
+});

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -6,6 +6,7 @@ import {
   DeviceAppManager,
   findProcessIdentifier,
   findRunningProcessPid,
+  extractInstalledAppEntries,
   isDevicectlProcessGoneError,
   parseDevicectlJsonOutputPath,
 } from "../../../src/utils/ios-cmdline-tools/DeviceAppManager";
@@ -1495,5 +1496,120 @@ describe("isDevicectlProcessGoneError", () => {
     ]) {
       expect(isDevicectlProcessGoneError(phrasing)).toBe(true);
     }
+  });
+});
+
+describe("extractInstalledAppEntries", () => {
+  test("reads devicectl's nested result.apps envelope", () => {
+    const payload = {
+      info: { outcome: "success" },
+      result: {
+        apps: [{ bundleIdentifier: "com.example.a" }, { bundleIdentifier: "com.example.b" }],
+      },
+    };
+    expect(extractInstalledAppEntries(payload)).toEqual([
+      { bundleIdentifier: "com.example.a" },
+      { bundleIdentifier: "com.example.b" },
+    ]);
+  });
+
+  test("reads the flat apps envelope", () => {
+    expect(extractInstalledAppEntries({ apps: [{ bundleIdentifier: "com.example.a" }] })).toEqual([
+      { bundleIdentifier: "com.example.a" },
+    ]);
+  });
+
+  test("drops non-object entries and returns [] for payloads with no listing", () => {
+    expect(extractInstalledAppEntries({ apps: ["nope", null, { bundleId: "com.a" }] })).toEqual([
+      { bundleId: "com.a" },
+    ]);
+    expect(extractInstalledAppEntries({ result: {} })).toEqual([]);
+    expect(extractInstalledAppEntries(null)).toEqual([]);
+    expect(extractInstalledAppEntries("apps")).toEqual([]);
+  });
+});
+
+describe("DeviceAppManager.listInstalledApps", () => {
+  const createManager = (
+    overrides: {
+      platform?: () => NodeJS.Platform;
+      execute?: (file: string, args: string[]) => Promise<never> | Promise<ExecLike>;
+    } = {},
+    commands: string[] = [],
+    payload: unknown = { result: { apps: [{ bundleIdentifier: "com.example.a" }] } },
+  ) => {
+    const execute =
+      overrides.execute ??
+      (async (file: string, args: string[]) => {
+        const command = [file, ...args].join(" ");
+        commands.push(command);
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify(payload), "utf-8");
+        }
+        return emptyExecResult();
+      });
+    return new DeviceAppManager({
+      platform: overrides.platform ?? (() => "darwin"),
+      execute,
+      readFile: async (path: string) => fs.readFile(path, "utf-8"),
+      mkdtemp: async (prefix: string) => fs.mkdtemp(prefix),
+      rm: async (path: string) => fs.rm(path, { recursive: true, force: true }),
+      readdir: async (path: string) => fs.readdir(path),
+      stat: async (path: string) => fs.stat(path),
+      tmpdir,
+      logger: createFakeLogger(),
+    });
+  };
+
+  type ExecLike = ReturnType<typeof emptyExecResult>;
+
+  function emptyExecResult() {
+    return {
+      stdout: "",
+      stderr: "",
+      toString() {
+        return this.stdout;
+      },
+      trim() {
+        return this.stdout.trim();
+      },
+      includes(searchString: string) {
+        return this.stdout.includes(searchString);
+      },
+    };
+  }
+
+  test("queries devicectl for the whole listing, without --bundle-id", async () => {
+    const commands: string[] = [];
+    const manager = createManager({}, commands);
+
+    const apps = await manager.listInstalledApps("00008130-001C2D3E1234567A");
+
+    expect(apps).toEqual([{ bundleIdentifier: "com.example.a" }]);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain("devicectl device info apps");
+    expect(commands[0]).toContain("--device 00008130-001C2D3E1234567A");
+    expect(commands[0]).not.toContain("--bundle-id");
+  });
+
+  test("propagates devicectl failures instead of reporting an empty listing", async () => {
+    const manager = createManager({
+      execute: async () => {
+        throw new Error("xcrun: devicectl not found");
+      },
+    });
+
+    await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).rejects.toBeInstanceOf(
+      ActionableError,
+    );
+  });
+
+  test("requires macOS", async () => {
+    const manager = createManager({ platform: () => "linux" });
+
+    await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).rejects.toBeInstanceOf(
+      ActionableError,
+    );
   });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -1525,6 +1525,13 @@ describe("extractInstalledAppEntries", () => {
     ]);
   });
 
+  test("rejects a nonempty listing whose members are all malformed", () => {
+    // An array that carried entries but none we can read is a payload we do not
+    // understand — reporting [] would publish a false empty inventory.
+    expect(extractInstalledAppEntries({ result: { apps: ["unexpected", null] } })).toBeNull();
+    expect(extractInstalledAppEntries({ apps: [[], 7] })).toBeNull();
+  });
+
   test("distinguishes an empty listing from an unrecognized payload", () => {
     // Present but empty: the device genuinely has nothing installed.
     expect(extractInstalledAppEntries({ result: { apps: [] } })).toEqual([]);

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -1519,13 +1519,20 @@ describe("extractInstalledAppEntries", () => {
     ]);
   });
 
-  test("drops non-object entries and returns [] for payloads with no listing", () => {
+  test("drops non-object entries", () => {
     expect(extractInstalledAppEntries({ apps: ["nope", null, { bundleId: "com.a" }] })).toEqual([
       { bundleId: "com.a" },
     ]);
-    expect(extractInstalledAppEntries({ result: {} })).toEqual([]);
-    expect(extractInstalledAppEntries(null)).toEqual([]);
-    expect(extractInstalledAppEntries("apps")).toEqual([]);
+  });
+
+  test("distinguishes an empty listing from an unrecognized payload", () => {
+    // Present but empty: the device genuinely has nothing installed.
+    expect(extractInstalledAppEntries({ result: { apps: [] } })).toEqual([]);
+    // No apps array anywhere: a payload we do not understand, not "no apps".
+    expect(extractInstalledAppEntries({ result: {} })).toBeNull();
+    expect(extractInstalledAppEntries({ info: { outcome: "failed" } })).toBeNull();
+    expect(extractInstalledAppEntries(null)).toBeNull();
+    expect(extractInstalledAppEntries("apps")).toBeNull();
   });
 });
 
@@ -1602,6 +1609,42 @@ describe("DeviceAppManager.listInstalledApps", () => {
 
     await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).rejects.toBeInstanceOf(
       ActionableError,
+    );
+  });
+
+  test("rejects a payload with no apps array instead of reporting an empty listing", async () => {
+    const manager = createManager({}, [], { info: { outcome: "failed" } });
+
+    await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).rejects.toBeInstanceOf(
+      ActionableError,
+    );
+  });
+
+  test("returns an empty listing when devicectl reports no installed apps", async () => {
+    const manager = createManager({}, [], { result: { apps: [] } });
+
+    await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).resolves.toEqual([]);
+  });
+
+  test("keeps the devicectl diagnostic when temp-dir cleanup also fails", async () => {
+    const manager = new DeviceAppManager({
+      platform: () => "darwin",
+      execute: async () => {
+        throw new Error("xcrun: devicectl not found");
+      },
+      readFile: async (path: string) => fs.readFile(path, "utf-8"),
+      mkdtemp: async (prefix: string) => fs.mkdtemp(prefix),
+      rm: async () => {
+        throw new Error("cleanup exploded");
+      },
+      readdir: async (path: string) => fs.readdir(path),
+      stat: async (path: string) => fs.stat(path),
+      tmpdir,
+      logger: createFakeLogger(),
+    });
+
+    await expect(manager.listInstalledApps("00008130-001C2D3E1234567A")).rejects.toThrow(
+      /devicectl not found/,
     );
   });
 

--- a/test/utils/ios-cmdline-tools/iosInstalledApp.test.ts
+++ b/test/utils/ios-cmdline-tools/iosInstalledApp.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getIosInstalledAppBundleId,
+  getIosInstalledAppPath,
+  normalizeIosDevicePath,
+} from "../../../src/utils/ios-cmdline-tools/iosInstalledApp";
+
+describe("getIosInstalledAppBundleId", () => {
+  test("reads the simulator and devicectl bundle-id spellings", () => {
+    expect(getIosInstalledAppBundleId({ bundleId: "com.example.a" })).toBe("com.example.a");
+    expect(getIosInstalledAppBundleId({ bundleIdentifier: "com.example.b" })).toBe("com.example.b");
+    expect(getIosInstalledAppBundleId({ CFBundleIdentifier: " com.example.c " })).toBe(
+      "com.example.c",
+    );
+    expect(getIosInstalledAppBundleId({ other: "com.example.d" })).toBeUndefined();
+  });
+});
+
+describe("normalizeIosDevicePath", () => {
+  test("decodes a file:// URL into a filesystem path", () => {
+    expect(normalizeIosDevicePath("file:///private/var/containers/Bundle/My%20App.app/")).toBe(
+      "/private/var/containers/Bundle/My App.app/",
+    );
+  });
+
+  test("passes a plain path through unchanged", () => {
+    expect(normalizeIosDevicePath("/private/var/containers/Bundle/App.app")).toBe(
+      "/private/var/containers/Bundle/App.app",
+    );
+  });
+});
+
+describe("getIosInstalledAppPath", () => {
+  test("reads the simulator record spellings", () => {
+    expect(getIosInstalledAppPath({ bundlePath: "/sim/App.app" })).toBe("/sim/App.app");
+    expect(getIosInstalledAppPath({ dataContainer: "/sim/data" })).toBe("/sim/data");
+  });
+
+  // devicectl reports a physical device's bundle location as a file:// URL under
+  // `url`/`bundleURL`; without these keys the apps resource silently omits the
+  // path it was handed.
+  test("reads and normalizes devicectl's url and bundleURL spellings", () => {
+    expect(getIosInstalledAppPath({ url: "file:///private/var/containers/Bundle/A.app/" })).toBe(
+      "/private/var/containers/Bundle/A.app/",
+    );
+    expect(getIosInstalledAppPath({ bundleURL: "file:///private/var/B.app/" })).toBe(
+      "/private/var/B.app/",
+    );
+  });
+
+  test("prefers an explicit bundle path over a data container", () => {
+    expect(getIosInstalledAppPath({ dataContainer: "/sim/data", bundlePath: "/sim/App.app" })).toBe(
+      "/sim/App.app",
+    );
+  });
+
+  test("returns undefined when no path field is present", () => {
+    expect(getIosInstalledAppPath({ bundleId: "com.example.a" })).toBeUndefined();
+    expect(getIosInstalledAppPath({ bundlePath: "   " })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`ListInstalledApps.executeIosDetailed` was simctl-only, so it returned `[]` on a physical device and every installed-app check built on it (`uninstallApp` pre/post checks, `terminateApp`'s `wasInstalled`) was blind on real hardware.

## What changed

- **`DeviceAppManager.listInstalledApps(deviceUdid)`** — runs `xcrun devicectl device info apps --device <udid> --json-output <file> --quiet`. Omitting `--bundle-id` is what turns the module's existing lookup into a full listing. macOS-only; devicectl exec/JSON failures are wrapped in `ActionableError` and **propagate**, so an empty list can only mean "no apps".
- **`extractInstalledAppEntries`** — pulls records out of devicectl's nested `result.apps` envelope or the flat `{ apps: [...] }` shape the existing fixtures pin, and drops non-object members.
- **`ListInstalledApps`** routes the iOS branch to an injectable `IosPhysicalAppLister` when the device id positively looks like a physical UDID (`isIosPhysicalUdid`). Anything else — simulator UUID or a non-UDID id — keeps the simctl path, so an unrecognized id degrades to today's behavior instead of shelling out to a tool that cannot serve it. The lister is constructed lazily, so simulator-only callers never build a `DeviceAppManager`.

Failure stays honest end to end: a devicectl error surfaces as `{ apps: [], successful: false }`, which is what keeps the resource cache from retaining a degraded listing.

## Tests

10 new unit tests, all with fakes — no device, no real devicectl:
- envelope extraction (nested, flat, junk entries, empty)
- the devicectl invocation shape (`device info apps`, `--device`, **no** `--bundle-id`), failure propagation, macOS guard
- physical UDID routes to devicectl and not simctl; metadata preserved; devicectl failure → `successful:false`; simulator UDID still uses simctl; duplicate bundle ids deduped

Verified failing before the source change (4 of the 5 `ListInstalledApps` cases fail on the parent commit; the simulator-path case passes by construction).

`bunx turbo run lint build test` green (14235 pass / 0 fail), `bun run typecheck` reports no new type errors.

## Manual verification needed

The listing itself cannot be proven without hardware. On a real iOS 17+ device, confirm `listApps` returns the installed set and that the records carry the bundle-id key `getIosInstalledAppBundleId` expects (`bundleIdentifier`). Also worth confirming on hardware: this uses devicectl's **default** app scope (no `--include-all-apps`/`--include-default-apps`), which is user-installed apps — narrower than simctl's listing. If parity needs the system apps too, that is a one-flag follow-up.

Closes #2883