### PR TITLE
fix(lint): block aliased host shell execution

### DIFF
--- a/scripts/check-host-shell-boundary.ts
+++ b/scripts/check-host-shell-boundary.ts
@@ -117,6 +117,17 @@ export function findViolationsInSource(file: string, source: string): Violation[
     );
   };
 
+  // A child_process value source: either an inline require()/dynamic import, or
+  // an identifier already registered as a child_process namespace. This lets
+  // `const { exec: run } = cp;` (destructured from a namespace) be recognized.
+  const isChildProcessSource = (expression: ts.Expression): boolean => {
+    if (isChildProcessLoaderExpression(expression)) {
+      return true;
+    }
+    const unwrapped = unwrapExpression(expression);
+    return ts.isIdentifier(unwrapped) && childProcessNamespaces.has(unwrapped.text);
+  };
+
   const recordImportedApi = (imported: string, local: string): void => {
     if (SHELL_APIS.has(imported)) {
       importedShellApis.add(local);
@@ -181,21 +192,110 @@ export function findViolationsInSource(file: string, source: string): Violation[
 
   const isDeclarationName = (node: ts.Identifier): boolean => {
     const { parent } = node;
-    return (
-      ts.isImportSpecifier(parent) ||
-      ((ts.isBindingElement(parent) ||
+    if (ts.isImportSpecifier(parent)) {
+      return true;
+    }
+    if (
+      (ts.isBindingElement(parent) ||
         ts.isVariableDeclaration(parent) ||
         ts.isParameter(parent) ||
         ts.isPropertyDeclaration(parent)) &&
-        parent.name === node)
+      parent.name === node
+    ) {
+      return true;
+    }
+    // Non-computed property/method names (e.g. `{ exec: false }`, `exec() {}`)
+    // are declaration positions, not references to the imported API. Shorthand
+    // `{ exec }` is a ShorthandPropertyAssignment and is intentionally excluded
+    // here so it stays detectable as a value reference.
+    return (
+      (ts.isPropertyAssignment(parent) ||
+        ts.isMethodDeclaration(parent) ||
+        ts.isGetAccessorDeclaration(parent) ||
+        ts.isSetAccessorDeclaration(parent)) &&
+      parent.name === node
     );
   };
 
+  // An identifier used purely in a type position (`typeof exec`,
+  // `type X = exec`) does not execute the shell API at runtime.
+  const isTypePositionReference = (node: ts.Identifier): boolean => {
+    let current: ts.Node = node;
+    let parent = current.parent;
+    while (parent && ts.isQualifiedName(parent)) {
+      current = parent;
+      parent = current.parent;
+    }
+    return !!parent && (ts.isTypeQueryNode(parent) || ts.isTypeReferenceNode(parent));
+  };
+
+  const bindingIntroducesName = (binding: ts.BindingName, name: string): boolean => {
+    if (ts.isIdentifier(binding)) {
+      return binding.text === name;
+    }
+    return binding.elements.some(
+      (element) => ts.isBindingElement(element) && bindingIntroducesName(element.name, name),
+    );
+  };
+
+  // A local binding whose initializer is itself a child_process value source
+  // (`const { exec } = require(...)`, `const { exec: run } = cp`, `const run =
+  // cp.exec`) is the API's origin, not a shadow of it.
+  const isApiSourceInitializer = (initializer: ts.Expression | undefined): boolean =>
+    initializer !== undefined &&
+    (isChildProcessSource(initializer) || childProcessApiFromMember(initializer) !== undefined);
+
+  const scopeDeclaresName = (scope: ts.Node, name: string): boolean => {
+    if (ts.isFunctionLike(scope) && scope.parameters.some((p) => bindingIntroducesName(p.name, name))) {
+      return true;
+    }
+    const statements =
+      ts.isSourceFile(scope) || ts.isBlock(scope) || ts.isModuleBlock(scope)
+        ? scope.statements
+        : undefined;
+    if (!statements) {
+      return false;
+    }
+    // Import declarations and API-source locals are the origin binding for the
+    // shell API, not a shadow of it.
+    return statements.some(
+      (statement) =>
+        (ts.isVariableStatement(statement) &&
+          statement.declarationList.declarations.some(
+            (d) => bindingIntroducesName(d.name, name) && !isApiSourceInitializer(d.initializer),
+          )) ||
+        (ts.isFunctionDeclaration(statement) && statement.name?.text === name) ||
+        (ts.isClassDeclaration(statement) && statement.name?.text === name),
+    );
+  };
+
+  // Resolve the identifier by lexical binding: a closer parameter/local of the
+  // same name shadows the imported shell API, so the reference is not the API.
+  const isLexicallyShadowed = (node: ts.Identifier): boolean => {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+      if (scopeDeclaresName(current, node.text)) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  };
+
   const visit = (node: ts.Node): void => {
-    if (ts.isImportDeclaration(node) && isChildProcessModule(node.moduleSpecifier)) {
+    if (
+      ts.isImportDeclaration(node) &&
+      isChildProcessModule(node.moduleSpecifier) &&
+      // `import type { exec }` introduces no runtime binding.
+      node.importClause?.isTypeOnly !== true
+    ) {
       const bindings = node.importClause?.namedBindings;
       if (bindings && ts.isNamedImports(bindings)) {
         for (const specifier of bindings.elements) {
+          // `import { type exec }` is likewise type-only, not a runtime import.
+          if (specifier.isTypeOnly) {
+            continue;
+          }
           const imported = specifier.propertyName?.text ?? specifier.name.text;
           recordImportedApi(imported, specifier.name.text);
         }
@@ -208,7 +308,7 @@ export function findViolationsInSource(file: string, source: string): Violation[
       ts.isVariableDeclaration(node) &&
       ts.isObjectBindingPattern(node.name) &&
       node.initializer &&
-      isChildProcessLoaderExpression(node.initializer)
+      isChildProcessSource(node.initializer)
     ) {
       for (const element of node.name.elements) {
         const imported =
@@ -222,7 +322,7 @@ export function findViolationsInSource(file: string, source: string): Violation[
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
       node.initializer &&
-      isChildProcessLoaderExpression(node.initializer)
+      isChildProcessSource(node.initializer)
     ) {
       childProcessNamespaces.add(node.name.text);
     }
@@ -252,6 +352,8 @@ export function findViolationsInSource(file: string, source: string): Violation[
       ts.isIdentifier(node) &&
       importedShellApis.has(node.text) &&
       !isDeclarationName(node) &&
+      !isTypePositionReference(node) &&
+      !isLexicallyShadowed(node) &&
       !(ts.isCallExpression(node.parent) && node.parent.expression === node)
     ) {
       record(node);
@@ -265,7 +367,10 @@ export function findViolationsInSource(file: string, source: string): Violation[
       record(node);
     }
     if (ts.isCallExpression(node)) {
-      const localApi = ts.isIdentifier(node.expression) ? node.expression.text : undefined;
+      const localCallee = ts.isIdentifier(node.expression) ? node.expression : undefined;
+      // A locally shadowed callee (e.g. a parameter named `exec`) is not the API.
+      const localApi =
+        localCallee && !isLexicallyShadowed(localCallee) ? localCallee.text : undefined;
       const namespaceApi = childProcessApiFromMember(node.expression);
       const api = localApi ?? namespaceApi;
       if (

--- a/scripts/check-host-shell-boundary.ts
+++ b/scripts/check-host-shell-boundary.ts
@@ -246,7 +246,10 @@ export function findViolationsInSource(file: string, source: string): Violation[
     (isChildProcessSource(initializer) || childProcessApiFromMember(initializer) !== undefined);
 
   const scopeDeclaresName = (scope: ts.Node, name: string): boolean => {
-    if (ts.isFunctionLike(scope) && scope.parameters.some((p) => bindingIntroducesName(p.name, name))) {
+    if (
+      ts.isFunctionLike(scope) &&
+      scope.parameters.some((p) => bindingIntroducesName(p.name, name))
+    ) {
       return true;
     }
     const statements =

--- a/scripts/check-host-shell-boundary.ts
+++ b/scripts/check-host-shell-boundary.ts
@@ -179,6 +179,18 @@ export function findViolationsInSource(file: string, source: string): Violation[
     });
   };
 
+  const isDeclarationName = (node: ts.Identifier): boolean => {
+    const { parent } = node;
+    return (
+      ts.isImportSpecifier(parent) ||
+      ((ts.isBindingElement(parent) ||
+        ts.isVariableDeclaration(parent) ||
+        ts.isParameter(parent) ||
+        ts.isPropertyDeclaration(parent)) &&
+        parent.name === node)
+    );
+  };
+
   const visit = (node: ts.Node): void => {
     if (ts.isImportDeclaration(node) && isChildProcessModule(node.moduleSpecifier)) {
       const bindings = node.importClause?.namedBindings;
@@ -229,7 +241,28 @@ export function findViolationsInSource(file: string, source: string): Violation[
       node.initializer &&
       childProcessApiFromMember(node.initializer)
     ) {
-      recordImportedApi(childProcessApiFromMember(node.initializer)!, node.name.text);
+      const memberApi = childProcessApiFromMember(node.initializer)!;
+      if (SHELL_APIS.has(memberApi)) {
+        record(node);
+      } else {
+        recordImportedApi(memberApi, node.name.text);
+      }
+    }
+    if (
+      ts.isIdentifier(node) &&
+      importedShellApis.has(node.text) &&
+      !isDeclarationName(node) &&
+      !(ts.isCallExpression(node.parent) && node.parent.expression === node)
+    ) {
+      record(node);
+    }
+    if (
+      (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+      SHELL_APIS.has(childProcessApiFromMember(node) ?? "") &&
+      !(ts.isCallExpression(node.parent) && node.parent.expression === node) &&
+      !(ts.isVariableDeclaration(node.parent) && node.parent.initializer === node)
+    ) {
+      record(node);
     }
     if (ts.isCallExpression(node)) {
       const localApi = ts.isIdentifier(node.expression) ? node.expression.text : undefined;

--- a/test/lint/hostShellBoundary.test.ts
+++ b/test/lint/hostShellBoundary.test.ts
@@ -102,6 +102,45 @@ describe("host shell execution boundary (issue #4068)", () => {
     ).toEqual([]);
   });
 
+  test("rejects aliases of directly imported shell APIs", () => {
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; const run = exec; run("curl $HOST");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { execSync } from "node:child_process"; class Runner { constructor(private readonly run = execSync) {} execute() { this.run("curl $HOST"); } }',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; function acceptRunner(_run: unknown) {} acceptRunner(exec);',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; const runner = { run: exec }; runner.run("curl $HOST");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as childProcess from "node:child_process"; function acceptRunner(_run: unknown) {} acceptRunner(childProcess.exec);',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { execFile } from "node:child_process"; function acceptRunner(_run: unknown) {} acceptRunner(execFile);',
+      ),
+    ).toEqual([]);
+  });
+
   test("fails closed outside a Git worktree", () => {
     expect(() => changedSourceFiles("origin/main", false, false)).toThrow(
       "not a Git or Jujutsu worktree",

--- a/test/lint/hostShellBoundary.test.ts
+++ b/test/lint/hostShellBoundary.test.ts
@@ -177,7 +177,7 @@ describe("host shell execution boundary (issue #4068)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
-        "import { exec } from \"node:child_process\"; function forward(exec: unknown) { consume(exec); }",
+        'import { exec } from "node:child_process"; function forward(exec: unknown) { consume(exec); }',
       ),
     ).toEqual([]);
     expect(

--- a/test/lint/hostShellBoundary.test.ts
+++ b/test/lint/hostShellBoundary.test.ts
@@ -141,6 +141,86 @@ describe("host shell execution boundary (issue #4068)", () => {
     ).toEqual([]);
   });
 
+  test("rejects shell aliases destructured from a namespace import", () => {
+    // Object binding pattern destructured from a registered child_process
+    // namespace escaped the boundary before (no property/element access node).
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as cp from "node:child_process"; const { exec: run } = cp; run("curl $HOST");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as cp from "node:child_process"; const { exec } = cp; exec("curl $HOST");',
+      ),
+    ).toHaveLength(1);
+    // A namespace re-aliased to another identifier stays covered too.
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as cp from "node:child_process"; const cp2 = cp; cp2.exec("curl $HOST");',
+      ),
+    ).toHaveLength(1);
+    // Non-shell APIs destructured from a namespace remain argv-first (allowed).
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as cp from "node:child_process"; const { execFile } = cp; execFile("curl", [url]);',
+      ),
+    ).toEqual([]);
+  });
+
+  test("excludes references that never execute the shell API", () => {
+    // Shadowing parameter resolves to the local binding, not the import.
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        "import { exec } from \"node:child_process\"; function forward(exec: unknown) { consume(exec); }",
+      ),
+    ).toEqual([]);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; function forward(exec: (c: string) => void) { exec("curl $HOST"); }',
+      ),
+    ).toEqual([]);
+    // Non-computed property/method names are declaration positions.
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; const opts = { exec: false };',
+      ),
+    ).toEqual([]);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; const api = { exec() { return 1; } };',
+      ),
+    ).toEqual([]);
+    // Shorthand property is a value reference and stays detectable.
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { exec } from "node:child_process"; const runner = { exec }; runner.exec("curl $HOST");',
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+    // Type-only imports and type-position references introduce no runtime call.
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import type { exec } from "node:child_process"; type Executor = typeof exec;',
+      ),
+    ).toEqual([]);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import { type exec } from "node:child_process"; type Executor = typeof exec;',
+      ),
+    ).toEqual([]);
+  });
+
   test("fails closed outside a Git worktree", () => {
     expect(() => changedSourceFiles("origin/main", false, false)).toThrow(
       "not a Git or Jujutsu worktree",


### PR DESCRIPTION
## What
- Reject `exec`/`execSync` aliases and escaped references in the host-shell AST lint while preserving argv-first APIs.
## Why
- Aliasing a shell API bypassed the boundary check and could hide user-controlled command execution.
## Risk
- Low: lint/test-only change; validated by focused tests, full Turbo, and typecheck.
