### PR TITLE
fix(doctor): pass iOS observe round trip on per-device host ports (#5636)

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -935,17 +935,21 @@ interface IosObserveRoundTripClassification {
 function classifyObserveRoundTrip(
   inspection: IosObserveRoundTripInspection,
 ): IosObserveRoundTripClassification {
-  const hasPortMismatch = inspection.runnerPort !== inspection.clientPort;
   const hasDegenerateScreen = inspection.screenSize.width <= 0 || inspection.screenSize.height <= 0;
   const hasHierarchyError =
     inspection.hierarchyError !== null && inspection.hierarchyError.trim().length > 0;
   const hasNoElements = inspection.elementCount < 1;
+  // A per-device host port legitimately differs from the runner's self-reported
+  // internal port when multiple simulators each run their own CtrlProxy (issue
+  // #5636): the runner always advertises its fixed on-device port (8765) via
+  // /health, while the client reaches it through a unique forwarded host port
+  // (8767, …). So runnerPort vs clientPort is only diagnostic context in the
+  // reported line — never an independent failure. A round trip that actually
+  // completed (connected, non-degenerate, error-free, non-empty) passes despite
+  // the divergence, and a genuine wrong-port bind (issue #2731) still fails here
+  // because it cannot connect (connected=false) and surfaces a hierarchyError.
   const failed =
-    !inspection.connected ||
-    hasPortMismatch ||
-    hasDegenerateScreen ||
-    hasHierarchyError ||
-    hasNoElements;
+    !inspection.connected || hasDegenerateScreen || hasHierarchyError || hasNoElements;
 
   const parts = [
     "platform=ios",

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -1100,8 +1100,9 @@ export async function checkIosObserveRoundTrip(
         status: "fail",
         message,
         recommendation:
-          "Restart the AutoMobile daemon and iOS CtrlProxy runner, then verify the runner WebSocket port " +
-          "matches the client port and re-run: auto-mobile --doctor --ios.",
+          "Restart the AutoMobile daemon and iOS CtrlProxy runner, then confirm each simulator's runner is " +
+          "reachable through its assigned client endpoint and returns a non-empty hierarchy, and re-run: " +
+          "auto-mobile --doctor --ios.",
       };
     }
 

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -948,8 +948,7 @@ function classifyObserveRoundTrip(
   // completed (connected, non-degenerate, error-free, non-empty) passes despite
   // the divergence, and a genuine wrong-port bind (issue #2731) still fails here
   // because it cannot connect (connected=false) and surfaces a hierarchyError.
-  const failed =
-    !inspection.connected || hasDegenerateScreen || hasHierarchyError || hasNoElements;
+  const failed = !inspection.connected || hasDegenerateScreen || hasHierarchyError || hasNoElements;
 
   const parts = [
     "platform=ios",

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -865,14 +865,56 @@ describe("checkIosObserveRoundTrip", () => {
     expect(result.message).toContain("elementCount=7");
   });
 
-  test("fails when the client port diverges from the runner serving port", async () => {
+  test("passes when a per-device host port diverges from the runner's internal port on a healthy round trip (#5636)", async () => {
+    // The runner self-reports its internal default port (8765) via /health while
+    // the client reaches it through a unique forwarded host port (8767). That
+    // divergence is expected for a per-device CtrlProxy and must not fail doctor
+    // once the observe round trip has otherwise succeeded.
     const result = await checkIosObserveRoundTrip(
-      withRoundTrips([inspection({ runnerPort: 8765, clientPort: 8766 })]),
+      withRoundTrips([inspection({ runnerPort: 8765, clientPort: 8767 })]),
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("runnerPort=8765");
+    expect(result.message).toContain("clientPort=8767");
+  });
+
+  test("passes two simulators with distinct per-device host ports (#5636)", async () => {
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([
+        inspection({ deviceId: "SIM-A", runnerPort: 8765, clientPort: 8765 }),
+        inspection({ deviceId: "SIM-B", runnerPort: 8765, clientPort: 8767 }),
+      ]),
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("device=SIM-A");
+    expect(result.message).toContain("device=SIM-B");
+    expect(result.message).toContain("clientPort=8765");
+    expect(result.message).toContain("clientPort=8767");
+  });
+
+  test("still fails when ports diverge and the round trip did not connect (#2731 preserved)", async () => {
+    // A genuine wrong-port bind (#2731): the runner is on 8765 but the client
+    // expects 8767 and cannot connect. The connection failure — not the port
+    // comparison — must keep this red.
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([
+        inspection({
+          runnerPort: 8765,
+          clientPort: 8767,
+          connected: false,
+          screenSize: { width: 0, height: 0 },
+          hierarchyError:
+            "iOS CtrlProxy runner is bound to port 8765 but the client expects port 8767",
+          elementCount: 0,
+        }),
+      ]),
     );
 
     expect(result.status).toBe("fail");
     expect(result.message).toContain("runnerPort=8765");
-    expect(result.message).toContain("clientPort=8766");
+    expect(result.message).toContain("clientPort=8767");
     expect(result.recommendation).toContain("CtrlProxy");
   });
 


### PR DESCRIPTION
## Summary

`auto-mobile --doctor --ios` failed the **iOS Observe Round Trip** check whenever two healthy simulators ran concurrently. Each simulator's CtrlProxy runner advertises its fixed on-device port (`8765`) via `/health`, while the client reaches it through a unique forwarded host port (`8767`, …). `classifyObserveRoundTrip` treated `runnerPort !== clientPort` as an independent hard failure, so the second simulator was flagged as failed even though it was connected, non-empty, and returned a valid hierarchy.

Closes #5636.

## Changes

- `src/doctor/checks/ios.ts` — drop the `hasPortMismatch` term from `classifyObserveRoundTrip`'s failure condition. `runnerPort`/`clientPort` still appear in the diagnostic line as context, but the port comparison no longer fails a successful round trip. The real health signals (`connected`, non-degenerate screen, no hierarchy error, ≥1 element) remain the sole failure criteria.

## Why this is safe (no #2731 regression)

The port compare was redundant. A genuine wrong-port bind (#2731, single simulator) is caught upstream: the client cannot connect, so `connected=false` and a `hierarchyError` explaining the mismatch already trip the failure. A *successful* round trip with divergent ports is the expected, correct multi-simulator shape — never a real defect.

## Testing

- `bun test test/doctor/ios.test.ts` — 74 pass (added/updated 3 cases; see below).
- `bun run typecheck` — no new type errors.
- `bun run lint` — no new ratchet violations.
- `bun run build` — success.

(Full-suite run has one unrelated red: `test/lint/oxlintConfigScoping.test.ts` `ENOENT` spawning `node_modules/.bin/oxlint`, a worktree node_modules layout artifact — CI installs node_modules, so it passes there. It never touches doctor/iOS code.)

## Acceptance criteria (from the issue, authored by @kaeawc)

- [x] **Multiple simulators pass doctor when each client can reach its assigned CtrlProxy** — a per-device host port differing from the runner's reported internal port no longer counts as a mismatch once the round trip succeeded.
  - Test: `passes when a per-device host port diverges from the runner's internal port on a healthy round trip (#5636)`
- [x] **Two-simulator regression test with distinct host ports** — SIM-A `8765/8765`, SIM-B `8765/8767`, both healthy ⇒ overall `pass`.
  - Test: `passes two simulators with distinct per-device host ports (#5636)`
- [x] **Genuine failures still fail (regression guard)** — divergent ports + `connected=false`/`hierarchyError` ⇒ `fail`.
  - Test: `still fails when ports diverge and the round trip did not connect (#2731 preserved)`
