### PR TITLE
fix(daemon): guarantee first heartbeat for proxy-bound sessions (#5637)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -529,6 +529,14 @@ export class DaemonMcpProxy {
   private clientFactory: DaemonClientFactory;
   private readonly timer: Timer;
   private readonly heartbeatKeeper: SingleFlightInterval;
+  /**
+   * Whether the recurring bound-session heartbeat keeper has been started for the
+   * current binding. Gates the awaited establishment heartbeat (issue #5637) to
+   * the FIRST connection only: once the keeper is running it owns every
+   * subsequent tick, so a later reconnect must not send an extra, un-coalesced
+   * heartbeat.
+   */
+  private heartbeatKeeperStarted = false;
   private readonly buildIdentity: BuildIdentity;
   private readonly clientVersion: string;
   private readonly clientAssetVersion: string | null;
@@ -725,7 +733,7 @@ export class DaemonMcpProxy {
         logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
       }
     }
-    this.startBoundSessionHeartbeat();
+    await this.establishBoundSessionHeartbeat();
   }
 
   /**
@@ -1430,11 +1438,75 @@ export class DaemonMcpProxy {
     if (this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing) {
       void this.heartbeatKeeper.run();
       this.heartbeatKeeper.start();
+      this.heartbeatKeeperStarted = true;
+    }
+  }
+
+  /**
+   * Deliver the first ownership heartbeat as part of connection establishment for
+   * a bound session (issue #5637), then start the recurring keeper.
+   *
+   * A newly connected client whose session was allocated shortly before startup
+   * must reach the daemon with its first heartbeat before the pre-first-heartbeat
+   * fast-reclaim (issue #2443) can release it. Awaiting the send here makes the
+   * guarantee contractual: once ensureConnected() resolves for a bound session,
+   * the daemon has recorded ownership — instead of racing a fire-and-forget
+   * dispatch against the reclaim sweep.
+   *
+   * Only the FIRST establishment sends here: once the keeper is running it owns
+   * every subsequent tick, so a later reconnect (which may itself be driven by a
+   * keeper tick) defers to the keeper's own coalesced heartbeat rather than
+   * emitting a duplicate.
+   */
+  private async establishBoundSessionHeartbeat(): Promise<void> {
+    if (!(this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing)) {
+      return;
+    }
+    if (this.heartbeatKeeperStarted) {
+      // Reconnect/rebind: fall back to the keeper's own coalescing run(). If this
+      // reconnect is itself driven by a keeper tick, run() shares that in-flight
+      // tick instead of emitting a duplicate; otherwise it sends a fresh heartbeat
+      // on the new transport, exactly as before this change.
+      this.startBoundSessionHeartbeat();
+      return;
+    }
+    await this.sendFirstBoundSessionHeartbeat();
+    // The keeper owns every subsequent tick, its reconnect, and terminal fencing.
+    // No immediate run() here: the direct send above already delivered the first
+    // heartbeat, and a second would duplicate it.
+    this.heartbeatKeeper.start();
+    this.heartbeatKeeperStarted = true;
+  }
+
+  /**
+   * Send the establishment heartbeat directly against the freshly connected
+   * client. Deliberately NOT routed through withRecoverableReconnect(): that path
+   * re-enters ensureConnected(), which is still in flight during establishment and
+   * would deadlock on a reconnect. A transient failure is best-effort — the keeper
+   * started next retries within the daemon's pre-first-heartbeat grace, and a
+   * genuinely released session is fenced by the keeper's reconnect path or a
+   * session-released notification.
+   */
+  private async sendFirstBoundSessionHeartbeat(): Promise<void> {
+    const sessionUuid = this.boundSessionUuid;
+    if (!sessionUuid || this.terminalBoundSession || this.closing || !this.client) {
+      return;
+    }
+    try {
+      await this.client.callDaemonMethod("daemon/heartbeat", { sessionId: sessionUuid });
+      if (this.boundSessionUuid === sessionUuid && !this.terminalBoundSession) {
+        this.boundSessionUuidAt = this.timer.now();
+      }
+    } catch (error) {
+      logger.debug(
+        `[DaemonMcpProxy] Initial bound-session heartbeat failed: ${errorMessage(error)}`,
+      );
     }
   }
 
   private async stopBoundSessionHeartbeat(): Promise<void> {
     const settled = await this.heartbeatKeeper.stop();
+    this.heartbeatKeeperStarted = false;
     if (!settled) {
       logger.warn("[DaemonMcpProxy] Bound-session heartbeat did not settle before shutdown");
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1471,6 +1471,13 @@ export class DaemonMcpProxy {
       return;
     }
     await this.sendFirstBoundSessionHeartbeat();
+    // Re-validate after the awaited round-trip: a session-released notification or
+    // close() landing mid-send may have terminally fenced this binding and stopped
+    // the keeper. Restarting it here would leak a no-op interval and desync
+    // heartbeatKeeperStarted from the fenced state. Mirrors startBoundSessionHeartbeat's guard.
+    if (!(this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing)) {
+      return;
+    }
     // The keeper owns every subsequent tick, its reconnect, and terminal fencing.
     // No immediate run() here: the direct send above already delivered the first
     // heartbeat, and a second would duplicate it.
@@ -1498,6 +1505,11 @@ export class DaemonMcpProxy {
         this.boundSessionUuidAt = this.timer.now();
       }
     } catch (error) {
+      // Safe to swallow: the establishment heartbeat is best-effort. The keeper
+      // started immediately after retries within the pre-first-heartbeat grace,
+      // and a genuinely released session is fenced by the keeper's reconnect path
+      // or a session-released notification — so a transient failure here must not
+      // fail connection establishment.
       logger.debug(
         `[DaemonMcpProxy] Initial bound-session heartbeat failed: ${errorMessage(error)}`,
       );

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -723,6 +723,15 @@ export class DaemonMcpProxy {
     this.connected = true;
     logger.info("[DaemonMcpProxy] Connected to daemon");
 
+    // Deliver the ownership heartbeat FIRST — before the best-effort notification
+    // subscription (issue #5637). subscribeToNotifications() is a daemon RPC that
+    // can stall up to the connection timeout; awaiting it before the heartbeat
+    // would let the pre-first-heartbeat reclaim reap a bound session near the
+    // grace edge before the heartbeat is even sent. The notification handler is
+    // already registered above (before connect), so a session-released frame is
+    // still handled during the heartbeat even without the opt-in subscription.
+    await this.establishBoundSessionHeartbeat();
+
     if (supportsNotifications) {
       try {
         await client.subscribeToNotifications!();
@@ -733,7 +742,6 @@ export class DaemonMcpProxy {
         logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
       }
     }
-    await this.establishBoundSessionHeartbeat();
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1505,11 +1505,18 @@ export class DaemonMcpProxy {
         this.boundSessionUuidAt = this.timer.now();
       }
     } catch (error) {
-      // Safe to swallow: the establishment heartbeat is best-effort. The keeper
-      // started immediately after retries within the pre-first-heartbeat grace,
-      // and a genuinely released session is fenced by the keeper's reconnect path
-      // or a session-released notification — so a transient failure here must not
-      // fail connection establishment.
+      if (this.isDaemonSessionNotFoundError(error) && this.boundSessionUuid === sessionUuid) {
+        // The bound session was already reaped before our first heartbeat reached
+        // the daemon (the #5637 race lost). Surface it as terminal now instead of
+        // proceeding to a keeper that can only re-confirm the loss — this keeps
+        // terminal fencing intact and gives the caller an ownership-lost error on
+        // its next operation. Synchronous fence: no reconnect, no reentrancy.
+        this.fenceBoundSessionUuid(sessionUuid, "session-not-found");
+        return;
+      }
+      // Safe to swallow the rest: the establishment heartbeat is best-effort. The
+      // keeper started immediately after retries within the pre-first-heartbeat
+      // grace — so a transient failure here must not fail connection establishment.
       logger.debug(
         `[DaemonMcpProxy] Initial bound-session heartbeat failed: ${errorMessage(error)}`,
       );

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
 import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
-import { DaemonClient } from "../../src/daemon/client";
+import {
+  DaemonClient,
+  DaemonUnavailableError,
+  type DaemonClientLike,
+} from "../../src/daemon/client";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
@@ -284,6 +288,112 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
         (call) => call.method === "daemon/heartbeat",
       ).length;
       expect(heartbeatsAfter).toBe(heartbeatsBefore);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC3: a session-released notification landing DURING the establishment
+  // heartbeat must terminally fence the binding without leaving a leaked keeper
+  // interval running against the fenced session.
+  test("does not start the keeper when the session is released mid-establishment", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const released = Promise.withResolvers<void>();
+    const clientRef: { current: FakeDaemonClient | null } = { current: null };
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: async (method) => {
+        if (method === "daemon/heartbeat") {
+          // The daemon terminally releases the session while the first heartbeat
+          // is still in flight.
+          clientRef.current!.emitNotification(
+            SESSION_RELEASED_NOTIFICATION_METHOD,
+            BOUND_SESSION,
+            "heartbeat-timeout",
+          );
+          await released.promise;
+        }
+      },
+    });
+    clientRef.current = fakeClient;
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    const pendingBefore = timer.getPendingIntervalCount();
+    try {
+      const connectPromise = proxy.ensureConnected();
+      // Let establishment reach the gated heartbeat (and thus the release).
+      for (let i = 0; i < 50; i++) {
+        await Promise.resolve();
+      }
+      released.resolve();
+      await connectPromise;
+
+      // The keeper must not have been (re)started against the fenced session.
+      expect(timer.getPendingIntervalCount()).toBe(pendingBefore);
+      // Any further work throws the terminal fence rather than heartbeating.
+      await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow();
+    } finally {
+      released.resolve();
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC3: a keeper-driven reconnect (the recurring heartbeat itself hitting a
+  // stale transport) must not compound a duplicate heartbeat onto the fresh
+  // transport — the reconnect defers to the keeper's own coalescing run().
+  test("does not duplicate the heartbeat on a keeper-driven reconnect", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    let staleHeartbeats = 0;
+    const staleClient = new FakeDaemonClient({
+      onCallDaemonMethod: async (method, params) => {
+        if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+          staleHeartbeats += 1;
+          if (staleHeartbeats === 1) {
+            // Establishment heartbeat succeeds.
+            sessionManager.recordHeartbeat(params.sessionId);
+            return;
+          }
+          // The keeper's next tick finds the transport gone, forcing a reconnect.
+          throw new DaemonUnavailableError("Daemon socket connection lost");
+        }
+      },
+    });
+    const freshClient = heartbeatForwardingClient(sessionManager);
+    const clients: DaemonClientLike[] = [staleClient, freshClient];
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => clients.shift()!,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+      // Drive the keeper's first tick (default interval 2s), which fails on the
+      // stale client and reconnects to the fresh one.
+      await timer.advanceTimeAsync(2_000);
+
+      const freshHeartbeats = freshClient.callDaemonMethodCalls.filter(
+        (call) => call.method === "daemon/heartbeat",
+      );
+      // Exactly one on the fresh transport: the reconnect coalesces with the
+      // in-flight keeper tick instead of adding an establishment heartbeat.
+      expect(freshHeartbeats).toEqual([
+        { method: "daemon/heartbeat", params: { sessionId: BOUND_SESSION } },
+      ]);
+      expect(sessionManager.getSession(BOUND_SESSION)).not.toBeNull();
     } finally {
       isAvailableSpy.mockRestore();
       await proxy.close();

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
+import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../src/daemon/client";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+
+// Reproduces issue #5637: a proxy-bound MCP session allocated shortly before the
+// proxy starts up must not be reaped with `missing-first-heartbeat` before its
+// first ownership heartbeat reaches the daemon. The tension is with the
+// pre-first-heartbeat fast-reclaim added in #2443 (a client that dies before its
+// first heartbeat is reclaimed quickly): the fix must keep that reclaim intact
+// (AC4) while guaranteeing a healthy connecting client delivers its first
+// heartbeat as part of connection establishment (AC1/AC2).
+
+const BOUND_SESSION = "device-session-a";
+
+const HEARTBEAT_ENV_KEYS = [
+  "AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+] as const;
+
+function clearHeartbeatEnv(): void {
+  for (const key of HEARTBEAT_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+// A FakeDaemonManager reporting a running daemon whose version matches this
+// client, so the version/build handshake in doConnect() is a no-op.
+function matchingDaemonManager(): FakeDaemonManager {
+  const manager = new FakeDaemonManager();
+  manager.statusResult = { ...manager.statusResult, version: DAEMON_VERSION };
+  return manager;
+}
+
+// A FakeDaemonClient that forwards `daemon/heartbeat` to a real SessionManager,
+// so a proxy heartbeat exercises the exact daemon-side ownership bookkeeping the
+// monitor consults.
+function heartbeatForwardingClient(sessionManager: SessionManager): FakeDaemonClient {
+  return new FakeDaemonClient({
+    onCallDaemonMethod: (method, params) => {
+      if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+        sessionManager.recordHeartbeat(params.sessionId);
+      }
+    },
+  });
+}
+
+describe("proxy-bound session first heartbeat (issue #5637)", () => {
+  let timer: FakeTimer;
+  let sessionManager: SessionManager;
+  let reaped: Array<{ sessionId: string; reason: string }>;
+  let monitor: SessionHeartbeatMonitor;
+
+  beforeEach(() => {
+    clearHeartbeatEnv();
+    timer = new FakeTimer();
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    reaped = [];
+    monitor = new SessionHeartbeatMonitor(
+      sessionManager,
+      () => false,
+      async (sessionId, reason) => {
+        reaped.push({ sessionId, reason });
+        await sessionManager.releaseSession(sessionId);
+      },
+      timer,
+    );
+  });
+
+  afterEach(async () => {
+    await monitor.stop();
+    sessionManager.stopCleanupTimer();
+    clearHeartbeatEnv();
+  });
+
+  // AC1 + AC2 (default timeout path): a bound session allocated shortly before
+  // the proxy starts survives because the first heartbeat is delivered as part of
+  // connection establishment.
+  test("delivers the first heartbeat during establishment for a default-timeout session", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+    monitor.start();
+    // Some time passes before the client actually starts its proxy, but still
+    // within the daemon's pre-first-heartbeat grace.
+    timer.advanceTime(4_000);
+
+    const fakeClient = heartbeatForwardingClient(sessionManager);
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+
+      // The guarantee: once the connection is established, the daemon has already
+      // recorded the first ownership heartbeat.
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+
+      // Advance well past the pre-first-heartbeat grace; the keeper keeps the
+      // ownership fresh, so the session is never reaped.
+      await timer.advanceTimeAsync(6_000);
+      await monitor.tick();
+
+      expect(reaped).toEqual([]);
+      expect(sessionManager.getSession(BOUND_SESSION)).not.toBeNull();
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC1 + AC2 (constrained timeout path): the same guarantee holds when the proxy
+  // and session carry a small, explicit heartbeat timeout.
+  test("delivers the first heartbeat during establishment for a constrained-timeout session", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000, 1_000);
+    monitor.start();
+    timer.advanceTime(400);
+
+    const fakeClient = heartbeatForwardingClient(sessionManager);
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+      heartbeatTimeoutMs: 1_000,
+    });
+
+    try {
+      await proxy.ensureConnected();
+
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+
+      // Past the constrained timeout, but the keeper (interval = timeout/2) keeps
+      // refreshing ownership, so the session survives.
+      await timer.advanceTimeAsync(2_000);
+      await monitor.tick();
+
+      expect(reaped).toEqual([]);
+      expect(sessionManager.getSession(BOUND_SESSION)).not.toBeNull();
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC1: connection establishment must not resolve for a bound session until the
+  // daemon has received the first ownership heartbeat. This is the contractual
+  // guarantee — a fire-and-forget dispatch that merely races the pre-first
+  // reclaim is what regresses.
+  test("does not resolve establishment until the first heartbeat is delivered", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const released = Promise.withResolvers<void>();
+    let heartbeatObserved = false;
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: async (method, params) => {
+        if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+          heartbeatObserved = true;
+          await released.promise;
+          sessionManager.recordHeartbeat(params.sessionId);
+        }
+      },
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      let established = false;
+      const connectPromise = proxy.ensureConnected().then(() => {
+        established = true;
+      });
+
+      // Let the connection reach the (gated) first heartbeat.
+      for (let i = 0; i < 50 && !heartbeatObserved; i++) {
+        await Promise.resolve();
+      }
+      expect(heartbeatObserved).toBe(true);
+      // Give any (incorrect) fire-and-forget path a chance to resolve
+      // establishment early; the awaited path must keep it pending.
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+      // Establishment must still be pending: the heartbeat has not completed.
+      expect(established).toBe(false);
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(false);
+
+      released.resolve();
+      await connectPromise;
+      expect(established).toBe(true);
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+    } finally {
+      released.resolve();
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC3: connection establishment delivers exactly one first heartbeat — a
+  // reconnect must not compound duplicates onto a fresh transport.
+  test("delivers exactly one heartbeat on a single establishment", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const fakeClient = heartbeatForwardingClient(sessionManager);
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+      const heartbeats = fakeClient.callDaemonMethodCalls.filter(
+        (call) => call.method === "daemon/heartbeat",
+      );
+      expect(heartbeats).toEqual([
+        { method: "daemon/heartbeat", params: { sessionId: BOUND_SESSION } },
+      ]);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC3: a terminally released session is never resurrected by an establishment
+  // heartbeat, and shutdown emits no further heartbeats.
+  test("does not resurrect a terminally released session on establishment", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const fakeClient = heartbeatForwardingClient(sessionManager);
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+      // The daemon terminally releases the bound session.
+      fakeClient.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        BOUND_SESSION,
+        "heartbeat-timeout",
+      );
+
+      const heartbeatsBefore = fakeClient.callDaemonMethodCalls.filter(
+        (call) => call.method === "daemon/heartbeat",
+      ).length;
+
+      // Any further work throws the terminal fence rather than re-binding.
+      await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow();
+
+      const heartbeatsAfter = fakeClient.callDaemonMethodCalls.filter(
+        (call) => call.method === "daemon/heartbeat",
+      ).length;
+      expect(heartbeatsAfter).toBe(heartbeatsBefore);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  // AC4: a bound session whose proxy never connects still expires under the
+  // existing pre-first-heartbeat reclaim policy from #2443.
+  test("still expires a bound session whose proxy never connects", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    // No proxy ever connects: past the pre-first-heartbeat grace, the session is
+    // reaped exactly as the existing cleanup policy dictates.
+    timer.advanceTime(5_001);
+    await monitor.tick();
+
+    expect(reaped).toEqual([{ sessionId: BOUND_SESSION, reason: "missing-first-heartbeat" }]);
+    expect(sessionManager.getSession(BOUND_SESSION)).toBeNull();
+  });
+});

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -400,6 +400,45 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     }
   });
 
+  // AC1: the ownership heartbeat is delivered before the best-effort notification
+  // subscription — subscribeToNotifications() is a daemon RPC that can stall, and
+  // must not delay the time-critical first heartbeat past the reclaim grace.
+  test("delivers the first heartbeat before subscribing to notifications", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    let subscribeCallsAtHeartbeat = -1;
+    const clientRef: { current: FakeDaemonClient | null } = { current: null };
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: (method, params) => {
+        if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+          subscribeCallsAtHeartbeat = clientRef.current!.subscribeToNotificationsCalls;
+          sessionManager.recordHeartbeat(params.sessionId);
+        }
+      },
+    });
+    clientRef.current = fakeClient;
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.ensureConnected();
+      // The heartbeat ran while the subscription had not yet been requested.
+      expect(subscribeCallsAtHeartbeat).toBe(0);
+      // The subscription still happens (best-effort), just after the heartbeat.
+      expect(fakeClient.subscribeToNotificationsCalls).toBe(1);
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
   // AC3 (terminal fencing intact): if the first heartbeat comes back
   // "Session not found" — the bound session was reaped before it arrived — the
   // binding is terminally fenced rather than silently proceeding, and no keeper

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -400,6 +400,42 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     }
   });
 
+  // AC3 (terminal fencing intact): if the first heartbeat comes back
+  // "Session not found" — the bound session was reaped before it arrived — the
+  // binding is terminally fenced rather than silently proceeding, and no keeper
+  // interval is left running.
+  test("fences the binding when the first heartbeat reports the session is gone", async () => {
+    // Deliberately do NOT create the session, so the daemon reports it missing.
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: (method) => {
+        if (method === "daemon/heartbeat") {
+          throw new Error("Session not found: " + BOUND_SESSION);
+        }
+      },
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    const pendingBefore = timer.getPendingIntervalCount();
+    try {
+      // Establishment resolves (it does not throw), but the binding is now terminal.
+      await proxy.ensureConnected();
+
+      expect(timer.getPendingIntervalCount()).toBe(pendingBefore);
+      // The next operation surfaces the terminal ownership loss.
+      await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow();
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
   // AC4: a bound session whose proxy never connects still expires under the
   // existing pre-first-heartbeat reclaim policy from #2443.
   test("still expires a bound session whose proxy never connects", async () => {


### PR DESCRIPTION
## Summary

A proxy-bound MCP session allocated shortly before the proxy starts up could become
terminal with `missing-first-heartbeat` before its first ownership heartbeat reached
the daemon — even though the client supplied the session id at connection start. This
is the pre-first-heartbeat fast-reclaim added in #2443 (reclaim a client that dies
before its first heartbeat) racing a *healthy*, newly connected client during
connection startup.

The proxy now delivers the first ownership heartbeat as an **awaited step of connection
establishment** for a bound session: once `ensureConnected()` resolves, the daemon has
already recorded ownership, instead of a fire-and-forget dispatch that merely raced the
reclaim sweep. The send is a direct `daemon/heartbeat` call (deliberately **not** routed
through `withRecoverableReconnect`, which would re-enter `ensureConnected()` and deadlock
mid-establishment), and it fires **only on the first establishment** — a later reconnect
defers to the keeper's coalescing `run()` so no duplicate heartbeat is emitted. A client
that never connects still expires under the existing #2443 cleanup policy, unchanged.

## Linked Issue

Closes #5637

## Bug / Regression Context

- **Prior attempts:** #5412 (preserve bound MCP session ownership) introduced the
  per-session heartbeat keeper; #2443 introduced the short pre-first-heartbeat reclaim.
- **Observed symptom:** a proxy-bound session became terminal with
  `missing-first-heartbeat` shortly after the device was ready, leaving the caller with a
  terminal ownership error instead of a usable session.
- **Repro conditions:** a session allocated shortly before proxy startup whose first
  ownership heartbeat had not yet reached the daemon when the pre-first-heartbeat grace
  elapsed.

## Acceptance criteria

All pinned by `test/daemon/proxyBoundSessionFirstHeartbeat.test.ts` (wires the proxy's
`daemon/heartbeat` into a real `SessionManager` + `SessionHeartbeatMonitor` under a shared
`FakeTimer`):

- [x] Deterministic test reproduces a session allocated shortly before proxy startup and
  proves the first heartbeat reaches the daemon before expiry, incl. an explicit test that
  establishment does not resolve until the first heartbeat is delivered.
- [x] Covered for both a constrained (custom) heartbeat timeout and the default timeout path.
- [x] Reconnect and shutdown do not create duplicate heartbeats or resurrect a terminal
  session (exactly-one-heartbeat + terminal-fence tests; full existing reconnect suite green).
- [x] A client that never connects still expires under the existing cleanup policy.

## Validation

- [x] `bun test` full suite green except a pre-existing `processLifecycle` parallel-run
  flake (passes in isolation; present on clean `main` too)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — no new ratchet violations; boundary-checks pass
- [x] `oxfmt --check` clean on touched files
- [x] New tests use interfaces + fakes + `FakeTimer`, run in <100ms each

## Device Verification

- N/A — pure daemon/proxy heartbeat timing, fully covered by deterministic `FakeTimer` tests.
