### PR TITLE
chore(deps): ignore Dependabot majors on jimp-locked transitive pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,35 @@ updates:
         patterns:
           - "sharp"
           - "@img/sharp-*"
+    ignore:
+      # These top-level entries are transitive pins hoisted to a single copy by
+      # scripts/release/pin-runtime-deps.ts (issue #5421), NOT packages our code
+      # bumps directly. Their real consumers (jimp plugins, utif2, xml2js) lock
+      # them to an older major, so a Dependabot major bump only leaves a dead
+      # duplicate copy and reddens the pinned runtime-graph check. Block the
+      # incompatible majors; in-range patches remain welcome.
+      #
+      #   zod        — ~15 @jimp/plugin-* need ^3.23.8 (v3 API); our MCP schemas
+      #                use the v4 API via the `zod/v4` subpath. zod@3.25.x serves
+      #                both from one copy.
+      #   file-type  — @jimp/core needs ^21.3.3
+      #   mime       — @jimp/core needs "3"
+      #   pako       — utif2 needs ^1.0.11
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "file-type"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mime"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pako"
+        update-types: ["version-update:semver-major"]
+      # sax is a build-only hoist pin for the nested xml2js@0.5.0 (under
+      # parse-bmfont-xml); any minor/major bump un-hoists it into a bundled dep
+      # that test/packaging/runtimeGraphPinning.test.ts forbids, with zero
+      # runtime effect. Allow only patch updates to the pinned 1.4.x line.
+      - dependency-name: "sax"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
   # Android Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/android"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,8 +52,7 @@ updates:
       # that test/packaging/runtimeGraphPinning.test.ts forbids, with zero
       # runtime effect. Allow only patch updates to the pinned 1.4.x line.
       - dependency-name: "sax"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-major"]
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
   # Android Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/android"


### PR DESCRIPTION
## What

Add `ignore` rules to the `bun` ecosystem in `.github/dependabot.yml` for five
top-level dependencies that are **transitive pins**, not packages our code bumps
directly.

## Why

`zod`, `file-type`, `mime`, `pako`, and `sax` appear in `package.json`
`dependencies` only because `scripts/release/pin-runtime-deps.ts` (issue #5421)
hoists them to a single deduped copy. Their real consumers lock them to an older
major:

| dep | real consumer | accepted range |
|-----|---------------|----------------|
| `zod` | ~15 `@jimp/plugin-*` | `^3.23.8` (v3 API; our MCP schemas use the v4 API via the `zod/v4` subpath — `zod@3.25.x` serves both from one copy) |
| `file-type` | `@jimp/core` | `^21.3.3` |
| `mime` | `@jimp/core` | `"3"` |
| `pako` | `utif2` | `^1.0.11` |
| `sax` | nested `xml2js@0.5.0` (build-only hoist) | any bump un-hoists it |

A Dependabot major bump on any of these can't actually upgrade anything — it just
leaves a dead duplicate copy (or, for `sax`, un-hoists the nested copy into a
bundled dependency that `test/packaging/runtimeGraphPinning.test.ts` forbids) and
reddens the pinned runtime-graph check.

Verified locally by running `pin-runtime-deps --write` on the file-type, sax, and
zod bumps and watching the residual-owner / bundled-dep checks fail.

## Effect

- Blocks the incompatible **major** for `zod` / `file-type` / `mime` / `pako`;
  in-range patches still flow.
- Blocks **minor + major** for `sax` (allows only patches to the pinned 1.4.x line).

Durably replaces the per-PR `@dependabot ignore` commands used to close
#5633 / #5627 / #5635 / #5632 / #5630. Each of these can move once the upstream
(`jimp` / `utif2`) widens its range.
