### PR TITLE
fix(ios-xctestrunner): bound runBlocking so a hung model call can't wedge the plan runner

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
@@ -42,8 +42,9 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
     private let timer: AutoMobileTimer
     private let logger: AutoMobileLogger
     private let responderFactory: (RecoveryModelConfig) -> ModelResponding
+    private let asyncBridge: AsyncCallBridging
 
-    public init(
+    public convenience init(
         mcpClient: AutoMobileMCPClient,
         configProvider: RecoveryConfigProviding,
         modelConfig: RecoveryModelConfig? = RecoveryModelConfig.resolve(),
@@ -54,6 +55,30 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
             TachikomaModelResponder(modelName: config.modelName)
         }
     ) {
+        self.init(
+            mcpClient: mcpClient,
+            configProvider: configProvider,
+            modelConfig: modelConfig,
+            timeoutSeconds: timeoutSeconds,
+            timer: timer,
+            logger: logger,
+            responderFactory: responderFactory,
+            asyncBridge: SemaphoreAsyncCallBridge()
+        )
+    }
+
+    /// Designated initializer. Internal so tests can inject a fake `AsyncCallBridging` (the seam is
+    /// not part of the public API surface).
+    init(
+        mcpClient: AutoMobileMCPClient,
+        configProvider: RecoveryConfigProviding,
+        modelConfig: RecoveryModelConfig?,
+        timeoutSeconds: TimeInterval,
+        timer: AutoMobileTimer,
+        logger: AutoMobileLogger,
+        responderFactory: @escaping (RecoveryModelConfig) -> ModelResponding,
+        asyncBridge: AsyncCallBridging
+    ) {
         self.mcpClient = mcpClient
         self.configProvider = configProvider
         self.modelConfig = modelConfig
@@ -61,6 +86,7 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         self.timer = timer
         self.logger = logger
         self.responderFactory = responderFactory
+        self.asyncBridge = asyncBridge
     }
 
     public func attemptRecovery(_ context: FailedStepContext) -> RecoveryOutcome {
@@ -121,7 +147,7 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
                 systemInstructions: Self.systemInstructions
             )
 
-            let response = try runBlocking { try await responder.respond(request) }
+            let response = try asyncBridge.run(timeout: timeoutSeconds) { try await responder.respond(request) }
             messages.append(.assistant(content: response.content))
 
             let toolCalls = response.content.compactMap { content -> ToolCallItem? in
@@ -391,11 +417,33 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         Int((timer.now() - start) * 1000)
     }
 
-    /// Bridge a single async model call to the synchronous executor thread. The rest of the recovery
-    /// loop (MCP tool calls) stays synchronous on the caller's thread, matching how the executor
-    /// already drives `AutoMobileMCPClient`. The executor runs on the XCTest thread, not the Swift
-    /// concurrency cooperative pool, so blocking here is safe.
-    private func runBlocking<T>(_ operation: @escaping () async throws -> T) throws -> T {
+}
+
+// MARK: - Async bridge seam (for testability + bounded blocking)
+
+/// Bridges a single async call to the synchronous XCTest executor thread with a **bound**. The
+/// recovery loop drives the model call synchronously (matching how the executor already drives
+/// `AutoMobileMCPClient`), but a hung model call must fail the recovery attempt rather than wedge
+/// the runner forever (issue #5644). A seam so the handler's timeout handling is unit-testable with
+/// a fake, and the production bound is testable directly with a tiny timeout.
+protocol AsyncCallBridging {
+    /// Runs `operation` and blocks the caller until it completes or `timeout` seconds elapse.
+    /// Throws `RecoveryTimeoutError` on timeout; rethrows any error `operation` throws.
+    func run<T>(timeout: TimeInterval, _ operation: @escaping () async throws -> T) throws -> T
+}
+
+/// Thrown when a bridged async call does not complete within its timeout.
+struct RecoveryTimeoutError: Error, CustomStringConvertible, Equatable {
+    let timeoutSeconds: TimeInterval
+    var description: String { "Recovery model call timed out after \(timeoutSeconds)s" }
+}
+
+/// Production bridge: runs the async work on the cooperative pool and blocks the executor thread on a
+/// **bounded** semaphore wait. Blocking the executor thread is safe (it is the XCTest thread, not a
+/// cooperative-pool thread); the timeout guarantees the wait cannot block indefinitely. On timeout the
+/// spawned `Task` is left to finish on its own — it can no longer affect the abandoned recovery attempt.
+struct SemaphoreAsyncCallBridge: AsyncCallBridging {
+    func run<T>(timeout: TimeInterval, _ operation: @escaping () async throws -> T) throws -> T {
         let box = ResultBox<T>()
         let semaphore = DispatchSemaphore(value: 0)
         Task {
@@ -406,7 +454,9 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
             }
             semaphore.signal()
         }
-        semaphore.wait()
+        if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            throw RecoveryTimeoutError(timeoutSeconds: timeout)
+        }
         switch box.result {
         case let .success(value):
             return value
@@ -418,8 +468,9 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
     }
 }
 
-/// Mutable, thread-crossing result holder for `runBlocking`. `@unchecked Sendable` because access is
-/// serialized by the semaphore (write happens-before the signal; read happens-after the wait).
+/// Mutable, thread-crossing result holder for `SemaphoreAsyncCallBridge`. `@unchecked Sendable`
+/// because access is serialized by the semaphore (the write happens-before `signal()`; the read
+/// happens-after a successful `wait()`), and on timeout the box is never read again.
 private final class ResultBox<T>: @unchecked Sendable {
     var result: Result<T, Error>?
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
@@ -446,7 +446,7 @@ struct SemaphoreAsyncCallBridge: AsyncCallBridging {
     func run<T>(timeout: TimeInterval, _ operation: @escaping () async throws -> T) throws -> T {
         let box = ResultBox<T>()
         let semaphore = DispatchSemaphore(value: 0)
-        Task {
+        let task = Task {
             do {
                 box.result = .success(try await operation())
             } catch {
@@ -455,6 +455,10 @@ struct SemaphoreAsyncCallBridge: AsyncCallBridging {
             semaphore.signal()
         }
         if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            // Cancel the abandoned work so a cancellation-aware provider can release its network
+            // request and drop its retained state promptly, rather than one orphaned task per
+            // timed-out recovery accumulating for the lifetime of the XCTest process.
+            task.cancel()
             throw RecoveryTimeoutError(timeoutSeconds: timeout)
         }
         switch box.result {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -364,6 +364,30 @@ final class RunBlockingBoundTests: XCTestCase {
         XCTAssertLessThan(Date().timeIntervalSince(start), 2.0, "timeout must return promptly, not block on the op")
     }
 
+    // On timeout the bridge must cancel the spawned task so a cancellation-aware operation unwinds
+    // promptly instead of running to completion and retaining its resources.
+    func testSemaphoreBridgeCancelsHungTaskOnTimeout() {
+        let cancelled = DispatchSemaphore(value: 0)
+        let bridge = SemaphoreAsyncCallBridge()
+        XCTAssertThrowsError(
+            try bridge.run(timeout: 0.05) { () async throws -> Int in
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                } catch {
+                    // `Task.sleep` throws `CancellationError` when the task is cancelled.
+                    cancelled.signal()
+                    throw error
+                }
+                return 1
+            }
+        )
+        XCTAssertEqual(
+            cancelled.wait(timeout: .now() + 2.0),
+            .success,
+            "timed-out task must be cancelled so a cancellation-aware operation unwinds promptly"
+        )
+    }
+
     func testSemaphoreBridgePassesThroughSuccess() throws {
         let bridge = SemaphoreAsyncCallBridge()
         let value = try bridge.run(timeout: 5) { () async throws -> Int in 42 }

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -310,6 +310,75 @@ final class TachikomaPlanRecoveryHandlerTests: XCTestCase {
     }
 }
 
+final class RunBlockingBoundTests: XCTestCase {
+    private func makeContext() -> FailedStepContext {
+        FailedStepContext(
+            failedStepIndex: 0,
+            failedTool: "tapOn",
+            error: "element not found",
+            succeededSteps: [],
+            planContent: "name: P\nsteps:\n  - tool: observe",
+            platform: "ios",
+            sessionUuid: "sess-1",
+            deviceId: "dev-1",
+            failureObservation: nil
+        )
+    }
+
+    // A hung model call must fail the recovery attempt (success == false) instead of blocking the
+    // XCTest runner forever. Uses a fake bridge so the handler's timeout handling is deterministic —
+    // no wall-clock wait, no leaked Task.
+    func testHungModelCallFailsRecoveryInsteadOfHanging() {
+        let client = RecoveryMCPClient()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timeoutSeconds: 120,
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in NeverReturningModelResponder() },
+            asyncBridge: TimeoutAsyncCallBridge(timeoutSeconds: 0.05)
+        )
+
+        let outcome = handler.attemptRecovery(makeContext())
+
+        XCTAssertFalse(outcome.success, "a timed-out model call must yield a failed recovery outcome")
+        XCTAssertTrue(client.calls.isEmpty, "no device tool calls when the model call times out before returning")
+    }
+
+    // The production bridge must actually bound the wait: a hung operation resolves via timeout, not
+    // by blocking forever. The op sleeps far longer (5s) than the timeout (0.05s), so the timeout
+    // path is deterministic with a huge margin — not flaky.
+    func testSemaphoreBridgeTimesOutOnHungOperation() {
+        let bridge = SemaphoreAsyncCallBridge()
+        let start = Date()
+        XCTAssertThrowsError(
+            try bridge.run(timeout: 0.05) { () async throws -> Int in
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+                return 1
+            }
+        ) { error in
+            XCTAssertTrue(error is RecoveryTimeoutError, "expected RecoveryTimeoutError, got \(error)")
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2.0, "timeout must return promptly, not block on the op")
+    }
+
+    func testSemaphoreBridgePassesThroughSuccess() throws {
+        let bridge = SemaphoreAsyncCallBridge()
+        let value = try bridge.run(timeout: 5) { () async throws -> Int in 42 }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testSemaphoreBridgeRethrowsOperationError() {
+        struct Boom: Error {}
+        let bridge = SemaphoreAsyncCallBridge()
+        XCTAssertThrowsError(try bridge.run(timeout: 5) { () async throws -> Int in throw Boom() }) { error in
+            XCTAssertTrue(error is Boom, "operation errors must propagate, not be swallowed")
+        }
+    }
+}
+
 // MARK: - Shared fakes
 
 private struct StubPlanLoader: AutoMobilePlanLoading {
@@ -415,6 +484,24 @@ private final class StubModelResponder: ModelResponding {
 
     static func final() -> ModelResponse {
         ModelResponse(id: "resp", content: [.outputText("recovery complete")])
+    }
+}
+
+/// Fake `ModelResponding` that never returns — models a hung provider call. Paired with a fake
+/// bridge in tests so the handler's timeout path is exercised without any real wait.
+private final class NeverReturningModelResponder: ModelResponding {
+    func respond(_: ModelRequest) async throws -> ModelResponse {
+        // Suspend forever without spinning; the fake bridge times out before this can complete.
+        await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in }
+        return StubModelResponder.final()
+    }
+}
+
+/// Fake `AsyncCallBridging` that always reports a timeout, deterministically and instantly.
+private struct TimeoutAsyncCallBridge: AsyncCallBridging {
+    let timeoutSeconds: TimeInterval
+    func run<T>(timeout _: TimeInterval, _: @escaping () async throws -> T) throws -> T {
+        throw RecoveryTimeoutError(timeoutSeconds: timeoutSeconds)
     }
 }
 


### PR DESCRIPTION
## Summary

`TachikomaPlanRecoveryHandler.runBlocking` bridged an async model call to the synchronous XCTest
executor thread with an **unbounded** `DispatchSemaphore.wait()`. If the Tachikoma model request hung
(stuck socket, provider stall, an internal `await` that never completes), the `Task` never signalled
and the XCTest thread blocked forever — wedging the whole plan run with no recovery. The handler's
`timeoutSeconds` (120s) was never applied to this call.

This extracts the sync-over-async bridge behind a small `AsyncCallBridging` seam whose production
implementation (`SemaphoreAsyncCallBridge`) does a **bounded** `wait(timeout:)` and throws
`RecoveryTimeoutError` on timeout. The handler passes its existing `timeoutSeconds` as the bound, so a
hung model call now fails the recovery attempt (which falls back to the normal plan-failure path)
instead of hanging. The sibling `StreamableHTTPMCPClient.performRequest` already bounds its wait this
way — this aligns `runBlocking` to the same discipline.

The public initializer keeps its exact signature (now a `convenience` init); a new internal designated
init injects the bridge so the timeout behavior is unit-testable with a fake — the seam is not added
to the public API surface.

## Linked Issue

Closes #5644

## Bug / Regression Context

- **Observed symptom:** a hung model call during AI recovery blocks the XCTest runner indefinitely.
- **Repro steps / conditions:** recovery is triggered, the model provider request never completes;
  `semaphore.wait()` (no timeout) never returns.

## Validation

- [x] `swift test` for the XCTestRunner package: 97/97 pass (incl. 4 new tests)
- [x] Android/iOS changes: SwiftLint clean on both touched files (SwiftFormat is not a CI gate here)
- [x] New code uses interfaces + fakes; the timeout test runs in ~55ms (deterministic 100× margin)
- [x] New generic code reuses the standard library (`DispatchSemaphore`); no new dependency

Not applicable: this is a pure Swift/`ios/` change touching zero TypeScript, so the TS
`bun run lint`/`bun test`/`typecheck` gates do not apply.

## Tests

- `testHungModelCallFailsRecoveryInsteadOfHanging` — a hung responder + fake timeout bridge yields
  `success: false` and zero device tool calls (deterministic, no wall-clock wait).
- `testSemaphoreBridgeTimesOutOnHungOperation` — the **production** bridge with a 0.05s timeout and a
  5s-sleeping operation throws `RecoveryTimeoutError` promptly, proving the real bound.
- `testSemaphoreBridgePassesThroughSuccess` / `testSemaphoreBridgeRethrowsOperationError` — success
  and error passthrough unchanged.
