### PR TITLE
feat(bugReport): add bounded iOS device-log capture

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -186,7 +186,7 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 - 🧪 `executePlan` (daemon mode only) executes a series of tool calls from a YAML plan content, stopping if any step fails.
 - 🔒 `criticalSection` (daemon mode only) coordinates multiple devices at a synchronization barrier for serialized steps.
 - 🩺 `doctor` runs diagnostic checks to verify AutoMobile setup and environment configuration.
-- 🐛 `bugReport` generates a comprehensive bug report including screen state, view hierarchy, logcat, screenshot, and optional highlight metadata.
+- 🐛 `bugReport` generates a comprehensive bug report including screen state, view hierarchy, a bounded device-log tail (Android logcat, or a bounded/timestamped iOS device log — default 1000 entries, 256 KiB), screenshot, and optional highlight metadata.
 - 🔍 `debugSearch` debugs element search operations to understand why elements aren't found or wrong elements are selected.
 - 📸 `rawViewHierarchy` gets raw view hierarchy data (XML/JSON) without parsing for debugging.
 - 🖍️ `highlight` draws visual overlays to highlight areas of the screen during debugging. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -440,7 +440,7 @@
   },
   {
     "name": "bugReport",
-    "description": "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.",
+    "description": "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, a bounded device-log tail (Android logcat or iOS device log), window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -450,11 +450,11 @@
           "enum": ["android", "ios"]
         },
         "appId": {
-          "description": "App package ID to filter logcat for specific app",
+          "description": "App identifier to filter device logs for a specific app (Android logcat by PID, or iOS device log when supported)",
           "type": "string"
         },
         "logcatLines": {
-          "description": "Number of recent logcat lines to include (default: 1000)",
+          "description": "Number of recent device-log entries to include (Android logcat lines / iOS log entries, default: 1000)",
           "type": "number"
         },
         "saveDir": {

--- a/src/features/debug/BugReport.ts
+++ b/src/features/debug/BugReport.ts
@@ -17,6 +17,17 @@ import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../utils/workingDirectory";
+import { IosDeviceLogCollector } from "./IosDeviceLogCollector";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+
+/**
+ * Narrow screenshot seam the bug report needs. Satisfied by the real
+ * {@link TakeScreenshot}; injectable so tests can avoid the platform-native
+ * capture path (the iOS path connects to a CtrlProxy host port and would block).
+ */
+export interface BugReportScreenshotCapturer {
+  execute(): Promise<{ success?: boolean; path?: string }>;
+}
 
 interface BugReportOptions {
   /**
@@ -42,9 +53,10 @@ export class BugReport {
   private device: BootedDevice;
   private readonly adb: AdbExecutor;
   private viewHierarchy: ViewHierarchyContract;
-  private takeScreenshot: TakeScreenshot;
+  private takeScreenshot: BugReportScreenshotCapturer;
   private elementParser: ElementParser;
   private timer: Timer;
+  private iosLogCollector?: IosDeviceLogCollector;
 
   constructor(
     device: BootedDevice,
@@ -52,13 +64,16 @@ export class BugReport {
     timer: Timer = defaultTimer,
     elementParser: ElementParser = new DefaultElementParser(),
     viewHierarchy?: ViewHierarchyContract,
+    iosLogCollector?: IosDeviceLogCollector,
+    takeScreenshot?: BugReportScreenshotCapturer,
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.viewHierarchy = viewHierarchy ?? new ViewHierarchy(device, adbFactory);
-    this.takeScreenshot = new TakeScreenshot(device, adbFactory);
+    this.takeScreenshot = takeScreenshot ?? new TakeScreenshot(device, adbFactory);
     this.elementParser = elementParser;
     this.timer = timer;
+    this.iosLogCollector = iosLogCollector;
   }
 
   /**
@@ -88,12 +103,17 @@ export class BugReport {
       errors: [],
     };
 
+    const captureDeviceLog =
+      this.device.platform === "ios"
+        ? this.getIosDeviceLog(result, logcatLines, options.appId)
+        : this.getLogcat(result, logcatLines, options.appId);
+
     await Promise.all([
       this.getDeviceInfo(result),
       this.getScreenState(result),
       this.getWindowState(result),
       this.getHierarchy(result),
-      this.getLogcat(result, logcatLines, options.appId),
+      captureDeviceLog,
       this.getScreenshot(result),
     ]);
 
@@ -345,6 +365,35 @@ export class BugReport {
     } catch (error) {
       result.errors?.push(`Failed to get logcat: ${error}`);
     }
+  }
+
+  /**
+   * Get a bounded, timestamped iOS device-log tail. The collector never throws,
+   * so a failed capture attaches structured diagnostic status instead of failing
+   * the surrounding bug-report request (issue #5641).
+   */
+  private async getIosDeviceLog(
+    result: BugReportResult,
+    maxEntries: number,
+    appId?: string,
+  ): Promise<void> {
+    try {
+      const collector = this.getIosLogCollector();
+      result.iosDeviceLog = await collector.collect({ appId, maxEntries });
+    } catch (error) {
+      // Defensive: the collector is contracted not to throw, but a construction
+      // failure must still not fail the caller's operation.
+      result.errors?.push(`Failed to get iOS device log: ${error}`);
+    }
+  }
+
+  private getIosLogCollector(): IosDeviceLogCollector {
+    if (this.iosLogCollector) {
+      return this.iosLogCollector;
+    }
+    const simctl = new SimCtlClient(this.device);
+    this.iosLogCollector = new IosDeviceLogCollector(simctl, this.device);
+    return this.iosLogCollector;
   }
 
   /**

--- a/src/features/debug/IosDeviceLogCollector.ts
+++ b/src/features/debug/IosDeviceLogCollector.ts
@@ -1,0 +1,253 @@
+import type {
+  BootedDevice,
+  ExecResult,
+  IosDeviceLog,
+  IosDeviceLogAppFilter,
+  IosDeviceLogTruncationReason,
+} from "../../models";
+import { logger } from "../../utils/logger";
+import { errorMessage } from "../../utils/describeUnknownError";
+import { redactAndroidCommandOutput } from "../../utils/android-cmdline-tools/redactAndroidCommandOutput";
+
+/** Default number of ordered entries retained when the caller does not override it. */
+export const IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES = 1000;
+
+/** Documented byte ceiling for the retained entries (256 KiB). */
+export const IOS_DEVICE_LOG_MAX_BYTES = 256 * 1024;
+
+/** Default bounded time window passed to `log show --last`. */
+export const IOS_DEVICE_LOG_DEFAULT_WINDOW = "5m";
+
+/** Hard entry ceiling regardless of caller request, to bound worst-case payloads. */
+export const IOS_DEVICE_LOG_MAX_ENTRIES = 10000;
+
+// An unfiltered `log show --last 5m` can dump the entire system log for the
+// window, which is slow on a busy simulator; keep the timeout generous so a
+// large-but-valid capture is not misreported as `unavailable`.
+const IOS_DEVICE_LOG_TIMEOUT_MS = 30000;
+
+/**
+ * Best-effort `log show` predicate matching an app identifier. The value is a
+ * single argv element (no shell), but double quotes and backslashes are stripped
+ * so a hostile or malformed app id cannot break predicate parsing.
+ *
+ * This is intentionally broad: `process`/`processImagePath` hold the executable
+ * name/path (usually the product name, not the bundle id), so only `subsystem`
+ * reliably matches a bundle-id-style app id, and only for apps that adopt that
+ * os_log convention. A predicate that runs cleanly but matches nothing still
+ * reports `appFilter.status: "applied"` — "applied" means the filter was
+ * accepted, not that it matched rows. Empty-but-applied is a genuine outcome
+ * (the app may simply have been silent), not a defect.
+ */
+export function buildIosLogPredicate(appId: string): string {
+  const safe = appId.replace(/["\\]/g, "");
+  return `process CONTAINS[c] "${safe}" OR subsystem CONTAINS[c] "${safe}" OR processImagePath CONTAINS[c] "${safe}"`;
+}
+
+/**
+ * Narrow exec seam the collector needs. Satisfied by the real `SimCtlClient` and
+ * by `FakeSimCtlClient` in tests — we only ever run `simctl spawn <udid> log …`.
+ */
+export interface IosLogExecutor {
+  executeCommandArgs(args: string[], timeoutMs?: number, signal?: AbortSignal): Promise<ExecResult>;
+}
+
+export interface IosDeviceLogOptions {
+  /** App identifier to filter the log tail for, when supported. */
+  appId?: string;
+  /** Requested maximum entry count (line-count bound). */
+  maxEntries?: number;
+  /** Time span for `log show --last`, e.g. "5m". */
+  window?: string;
+}
+
+type LogShowOutcome = { ok: true; stdout: string } | { ok: false; diagnostic: string };
+
+/**
+ * Collects a bounded, timestamped iOS device-log tail via `simctl spawn log show`.
+ * Never throws: every failure path is reported as structured status so a bug
+ * report can attach diagnostics without failing the caller's operation (#5641).
+ */
+export class IosDeviceLogCollector {
+  constructor(
+    private readonly exec: IosLogExecutor,
+    private readonly device: BootedDevice,
+  ) {}
+
+  async collect(options: IosDeviceLogOptions = {}): Promise<IosDeviceLog> {
+    const maxEntries = normalizeMaxEntries(options.maxEntries);
+    const duration = options.window?.trim() ? options.window.trim() : IOS_DEVICE_LOG_DEFAULT_WINDOW;
+    const appId = options.appId?.trim() ? options.appId.trim() : undefined;
+
+    const window = { duration, maxEntries };
+    const limits = { maxEntries, maxBytes: IOS_DEVICE_LOG_MAX_BYTES };
+
+    if (appId) {
+      const filtered = await this.runLogShow(duration, appId);
+      if (filtered.ok) {
+        return this.buildCollected(filtered.stdout, window, limits, {
+          appId,
+          status: "applied",
+        });
+      }
+
+      // Predicate rejected (or the filtered query otherwise failed): fall back to
+      // an unfiltered tail so the report still carries logs, marked unsupported.
+      const unfiltered = await this.runLogShow(duration, undefined);
+      if (unfiltered.ok) {
+        return this.buildCollected(unfiltered.stdout, window, limits, {
+          appId,
+          status: "unsupported",
+        });
+      }
+
+      return buildUnavailable(window, limits, unfiltered.diagnostic, {
+        appId,
+        status: "unavailable",
+      });
+    }
+
+    const result = await this.runLogShow(duration, undefined);
+    if (result.ok) {
+      return this.buildCollected(result.stdout, window, limits, undefined);
+    }
+    return buildUnavailable(window, limits, result.diagnostic, undefined);
+  }
+
+  private async runLogShow(duration: string, appId?: string): Promise<LogShowOutcome> {
+    const args = [
+      "spawn",
+      this.device.deviceId,
+      "log",
+      "show",
+      "--style",
+      "syslog",
+      "--last",
+      duration,
+    ];
+    if (appId) {
+      args.push("--predicate", buildIosLogPredicate(appId));
+    }
+
+    try {
+      const result = await this.exec.executeCommandArgs(args, IOS_DEVICE_LOG_TIMEOUT_MS);
+      if (result.error) {
+        return { ok: false, diagnostic: result.error };
+      }
+      return { ok: true, stdout: result.stdout };
+    } catch (error) {
+      // Expected on an offline/unavailable simulator or a rejected predicate;
+      // reported as structured status rather than thrown (#5641).
+      const diagnostic = errorMessage(error);
+      logger.warn(`[IosDeviceLogCollector] log show failed: ${diagnostic}`, error);
+      return { ok: false, diagnostic };
+    }
+  }
+
+  private buildCollected(
+    stdout: string,
+    window: { duration: string; maxEntries: number },
+    limits: { maxEntries: number; maxBytes: number },
+    appFilter: IosDeviceLogAppFilter | undefined,
+  ): IosDeviceLog {
+    const parsed = parseEntries(stdout);
+    const bounded = boundEntries(parsed, limits.maxEntries, limits.maxBytes);
+    return {
+      status: "collected",
+      entries: bounded.entries,
+      entryCount: bounded.entries.length,
+      byteSize: bounded.byteSize,
+      truncated: bounded.truncated,
+      ...(bounded.truncationReason ? { truncationReason: bounded.truncationReason } : {}),
+      window,
+      ...(appFilter ? { appFilter } : {}),
+      limits,
+    };
+  }
+}
+
+function normalizeMaxEntries(requested?: number): number {
+  if (requested === undefined || !Number.isFinite(requested)) {
+    return IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES;
+  }
+  const floored = Math.floor(requested);
+  if (floored <= 0) {
+    return 0;
+  }
+  return Math.min(floored, IOS_DEVICE_LOG_MAX_ENTRIES);
+}
+
+/** Split raw `log show` output into ordered, redacted, non-empty entries. */
+function parseEntries(stdout: string): string[] {
+  return redactAndroidCommandOutput(stdout)
+    .split("\n")
+    .map((entry) => entry.replace(/\r$/, ""))
+    .filter((entry) => entry.trim().length > 0);
+}
+
+interface BoundedEntries {
+  entries: string[];
+  byteSize: number;
+  truncated: boolean;
+  truncationReason?: IosDeviceLogTruncationReason;
+}
+
+/**
+ * Retain the most-recent entries within both the entry-count and byte ceilings,
+ * preserving oldest-first order. The entry cap is applied first; the byte cap
+ * then drops further from the oldest end until the payload fits.
+ */
+function boundEntries(entries: string[], maxEntries: number, maxBytes: number): BoundedEntries {
+  let truncated = false;
+  let truncationReason: IosDeviceLogTruncationReason | undefined;
+
+  let kept = entries;
+  if (kept.length > maxEntries) {
+    kept = kept.slice(kept.length - maxEntries);
+    truncated = true;
+    truncationReason = "maxEntries";
+  }
+
+  let byteSize = utf8Size(kept);
+  if (byteSize > maxBytes) {
+    // Drop from the oldest end (front) until the retained payload fits.
+    let start = 0;
+    while (start < kept.length && byteSize > maxBytes) {
+      byteSize -= utf8Size([kept[start]]);
+      // Account for the newline separator removed with the dropped entry.
+      if (start < kept.length - 1) {
+        byteSize -= 1;
+      }
+      start += 1;
+    }
+    kept = kept.slice(start);
+    byteSize = utf8Size(kept);
+    truncated = true;
+    truncationReason = "maxBytes";
+  }
+
+  return { entries: kept, byteSize, truncated, truncationReason };
+}
+
+function utf8Size(entries: string[]): number {
+  return Buffer.byteLength(entries.join("\n"), "utf8");
+}
+
+function buildUnavailable(
+  window: { duration: string; maxEntries: number },
+  limits: { maxEntries: number; maxBytes: number },
+  diagnostic: string,
+  appFilter: IosDeviceLogAppFilter | undefined,
+): IosDeviceLog {
+  return {
+    status: "unavailable",
+    entries: [],
+    entryCount: 0,
+    byteSize: 0,
+    truncated: false,
+    window,
+    ...(appFilter ? { appFilter } : {}),
+    limits,
+    diagnostic,
+  };
+}

--- a/src/models/BugReportResult.ts
+++ b/src/models/BugReportResult.ts
@@ -1,4 +1,5 @@
 import { ElementBounds } from "./ElementBounds";
+import { IosDeviceLog } from "./IosDeviceLog";
 
 /**
  * Result from bug report generation
@@ -107,6 +108,13 @@ export interface BugReportResult {
      */
     appLogs?: string[];
   };
+
+  /**
+   * Bounded, timestamped iOS device-log tail. Present for iOS targets in place
+   * of Android `logcat`. Carries its own collection/truncation status so a
+   * failed capture never fails the surrounding bug-report request (issue #5641).
+   */
+  iosDeviceLog?: IosDeviceLog;
 
   /**
    * File path to saved screenshot image

--- a/src/models/IosDeviceLog.ts
+++ b/src/models/IosDeviceLog.ts
@@ -1,0 +1,84 @@
+/**
+ * Structured result of a bounded iOS device-log capture attached to a bug report.
+ *
+ * The payload is intentionally self-describing: it reports its own collection
+ * status, the bounded window that was requested, whether app filtering was
+ * applied, and the documented limits enforced on the retained entries. This lets
+ * a bug report carry an iOS log tail without the collection ever failing the
+ * caller's operation (issue #5641).
+ */
+
+/**
+ * Collection status for an iOS device-log capture.
+ * - `collected`: a bounded log tail was retrieved (the tail may be empty).
+ * - `unavailable`: collection failed; see `diagnostic` for the underlying reason.
+ */
+export type IosDeviceLogStatus = "collected" | "unavailable";
+
+/**
+ * Whether app-identifier filtering was applied to the captured log. Present only
+ * when an app identifier was requested.
+ * - `applied`: the tail was filtered to the requested app.
+ * - `unsupported`: filtering was requested but could not be applied; an
+ *   unfiltered tail was returned instead.
+ * - `unavailable`: collection failed, so filtering could not be evaluated.
+ */
+export type IosDeviceLogFilterStatus = "applied" | "unsupported" | "unavailable";
+
+/** Reason a log tail was truncated to satisfy a documented limit. */
+export type IosDeviceLogTruncationReason = "maxEntries" | "maxBytes";
+
+/** Documented limits enforced on the retained log payload. */
+export interface IosDeviceLogLimits {
+  /** Maximum number of ordered entries retained in the payload. */
+  maxEntries: number;
+  /** Maximum total UTF-8 byte size of the retained entries. */
+  maxBytes: number;
+}
+
+/** Bounded window that was requested for the log tail. */
+export interface IosDeviceLogWindow {
+  /** Time span passed to `log show --last`, e.g. "5m". */
+  duration: string;
+  /** Requested maximum entry count (line-count bound). */
+  maxEntries: number;
+}
+
+/** App-identifier filter outcome, present only when an app id was supplied. */
+export interface IosDeviceLogAppFilter {
+  /** App identifier the caller requested filtering for. */
+  appId: string;
+  status: IosDeviceLogFilterStatus;
+}
+
+export interface IosDeviceLog {
+  /** Whether a bounded tail was collected or collection was unavailable. */
+  status: IosDeviceLogStatus;
+
+  /** Ordered, timestamped, redacted device-log lines (oldest first). */
+  entries: string[];
+
+  /** Number of entries retained after applying limits. */
+  entryCount: number;
+
+  /** Total UTF-8 byte size of the retained entries. */
+  byteSize: number;
+
+  /** Whether entries were dropped to satisfy a documented limit. */
+  truncated: boolean;
+
+  /** Which limit forced truncation, when `truncated` is true. */
+  truncationReason?: IosDeviceLogTruncationReason;
+
+  /** Bounded window that was requested. */
+  window: IosDeviceLogWindow;
+
+  /** App-identifier filter outcome, present only when an app id was supplied. */
+  appFilter?: IosDeviceLogAppFilter;
+
+  /** Documented limits enforced on the payload. */
+  limits: IosDeviceLogLimits;
+
+  /** Human-readable failure detail when `status` is `unavailable`. */
+  diagnostic?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -104,6 +104,7 @@ export * from "./FailureObservation";
 export * from "./RawViewHierarchyResult";
 export * from "./DebugSearchResult";
 export * from "./BugReportResult";
+export * from "./IosDeviceLog";
 export * from "./VisualHighlight";
 export * from "./VideoRecording";
 export * from "./DeviceSnapshot";

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -83,11 +83,18 @@ export const bugReportSchema = withAppIdAliases(
   addDeviceTargetingToSchema(
     z.object({
       platform: platformSchema,
-      appId: z.string().optional().describe("App package ID to filter logcat for specific app"),
+      appId: z
+        .string()
+        .optional()
+        .describe(
+          "App identifier to filter device logs for a specific app (Android logcat by PID, or iOS device log when supported)",
+        ),
       logcatLines: z
         .number()
         .optional()
-        .describe("Number of recent logcat lines to include (default: 1000)"),
+        .describe(
+          "Number of recent device-log entries to include (Android logcat lines / iOS log entries, default: 1000)",
+        ),
       saveDir: z.string().optional().describe("Directory to save report to"),
     }),
   ),
@@ -149,7 +156,7 @@ export function registerDebugTools() {
 
   ToolRegistry.registerDeviceAware(
     "bugReport",
-    "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.",
+    "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, a bounded device-log tail (Android logcat or iOS device log), window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.",
     bugReportSchema,
     bugReportHandler,
     { defaultEnabled: true, debugOnly: true },

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -662,6 +662,22 @@ function artifactBugReportPayload(
     changed = true;
   }
 
+  if (isRecord(payload.iosDeviceLog)) {
+    const iosDeviceLog = payload.iosDeviceLog;
+    next.iosDeviceLogSummary = {
+      status: iosDeviceLog.status,
+      entryCount: arrayLength(iosDeviceLog.entries),
+      byteSize: iosDeviceLog.byteSize,
+      truncated: iosDeviceLog.truncated,
+      filterStatus: isRecord(iosDeviceLog.appFilter) ? iosDeviceLog.appFilter.status : undefined,
+    };
+    next.iosDeviceLog = {
+      ...iosDeviceLog,
+      entries: writeJsonArtifact(ctx, "BugReportIosDeviceLog", iosDeviceLog.entries),
+    };
+    changed = true;
+  }
+
   if (isRecord(payload.windowState) && Array.isArray(payload.windowState.windows)) {
     next.windowState = {
       ...payload.windowState,

--- a/test/features/debug/BugReport.test.ts
+++ b/test/features/debug/BugReport.test.ts
@@ -3,9 +3,11 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { BugReport } from "../../../src/features/debug/BugReport";
+import { IosDeviceLogCollector } from "../../../src/features/debug/IosDeviceLogCollector";
 import type { BootedDevice, Element, ElementBounds } from "../../../src/models";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeElementParser } from "../../fakes/FakeElementParser";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeViewHierarchy } from "../../fakes/FakeViewHierarchy";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../../src/utils/workingDirectory";
@@ -271,6 +273,74 @@ describe("BugReport", () => {
       // Assert the exact commands, not a per-element predicate over a possibly
       // empty list — an empty array would satisfy a `for...of` loop vacuously.
       expect(logcatCommands).toEqual(["shell logcat -d -t 0 *:E", "shell logcat -d -t 0 *:W"]);
+    });
+  });
+
+  describe("iOS device log", () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "sim-udid-1",
+      platform: "ios",
+      isEmulator: true,
+      name: "iPhone 15 Simulator",
+    };
+
+    const setupIos = (simctl: FakeSimCtlClient) => {
+      const adbFactory = new FakeAdbClientFactory();
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const elementParser = new FakeElementParser();
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({ hierarchy: {} });
+      elementParser.nextRootNodes = [];
+      elementParser.nextFlattenedElements = [];
+      const collector = new IosDeviceLogCollector(simctl, iosDevice);
+      // Stub the screenshot capturer: the real iOS path connects to a CtrlProxy
+      // host port and would block the test (CI timeout, issue #5641 follow-up).
+      const takeScreenshot = { execute: async () => ({ success: false as boolean }) };
+      const bugReport = new BugReport(
+        iosDevice,
+        adbFactory,
+        timer,
+        elementParser,
+        viewHierarchy,
+        collector,
+        takeScreenshot,
+      );
+      return { bugReport };
+    };
+
+    test("attaches an ordered iOS device-log tail and no android logcat", async () => {
+      const simctl = new FakeSimCtlClient();
+      const lines = [
+        "2026-08-24 10:00:01.000000-0700  localhost App[123]: entry-1",
+        "2026-08-24 10:00:02.000000-0700  localhost App[123]: entry-2",
+      ];
+      simctl.setCommandArgsResult(
+        ["spawn", iosDevice.deviceId, "log", "show", "--style", "syslog", "--last", "5m"],
+        lines.join("\n"),
+      );
+      const { bugReport } = setupIos(simctl);
+
+      const result = await bugReport.execute();
+
+      expect(result.iosDeviceLog?.status).toBe("collected");
+      expect(result.iosDeviceLog?.entries).toEqual(lines);
+      expect(result.logcat).toBeUndefined();
+    });
+
+    test("does not fail the report when iOS log collection is unavailable", async () => {
+      const simctl = new FakeSimCtlClient();
+      simctl.setCommandArgsError(
+        ["spawn", iosDevice.deviceId, "log", "show", "--style", "syslog", "--last", "5m"],
+        new Error("device not booted"),
+      );
+      const { bugReport } = setupIos(simctl);
+
+      const result = await bugReport.execute();
+
+      expect(result.iosDeviceLog?.status).toBe("unavailable");
+      expect(result.iosDeviceLog?.diagnostic).toContain("device not booted");
+      expect(result.reportId).toBeDefined();
     });
   });
 

--- a/test/features/debug/IosDeviceLogCollector.test.ts
+++ b/test/features/debug/IosDeviceLogCollector.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES,
+  IOS_DEVICE_LOG_DEFAULT_WINDOW,
+  IOS_DEVICE_LOG_MAX_BYTES,
+  IOS_DEVICE_LOG_MAX_ENTRIES,
+  IosDeviceLogCollector,
+  buildIosLogPredicate,
+} from "../../../src/features/debug/IosDeviceLogCollector";
+import type { BootedDevice } from "../../../src/models";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+describe("IosDeviceLogCollector", () => {
+  const device: BootedDevice = {
+    deviceId: "sim-udid-1",
+    platform: "ios",
+    isEmulator: true,
+    name: "iPhone 15 Simulator",
+  };
+
+  const unfilteredArgs = (window = IOS_DEVICE_LOG_DEFAULT_WINDOW): string[] => [
+    "spawn",
+    device.deviceId,
+    "log",
+    "show",
+    "--style",
+    "syslog",
+    "--last",
+    window,
+  ];
+
+  const filteredArgs = (appId: string, window = IOS_DEVICE_LOG_DEFAULT_WINDOW): string[] => [
+    ...unfilteredArgs(window),
+    "--predicate",
+    buildIosLogPredicate(appId),
+  ];
+
+  const line = (n: number): string =>
+    `2026-08-24 10:00:0${n}.000000-0700  localhost App[123]: entry-${n}`;
+
+  test("AC1: returns ordered device-log entries from the bounded window", async () => {
+    const simctl = new FakeSimCtlClient();
+    const stdout = [line(1), line(2), line(3)].join("\n");
+    simctl.setCommandArgsResult(unfilteredArgs(), stdout);
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ maxEntries: 1000 });
+
+    expect(result.status).toBe("collected");
+    expect(result.entries).toEqual([line(1), line(2), line(3)]);
+    expect(result.entryCount).toBe(3);
+    expect(result.window.duration).toBe(IOS_DEVICE_LOG_DEFAULT_WINDOW);
+    expect(result.window.maxEntries).toBe(1000);
+    expect(result.appFilter).toBeUndefined();
+    expect(result.byteSize).toBe(Buffer.byteLength(result.entries.join("\n"), "utf8"));
+  });
+
+  test("AC4: bounds entries to maxEntries, keeping the most recent in order", async () => {
+    const simctl = new FakeSimCtlClient();
+    const stdout = [line(1), line(2), line(3), line(4), line(5)].join("\n");
+    simctl.setCommandArgsResult(unfilteredArgs(), stdout);
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ maxEntries: 2 });
+
+    expect(result.entries).toEqual([line(4), line(5)]);
+    expect(result.entryCount).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReason).toBe("maxEntries");
+    expect(result.limits.maxEntries).toBe(2);
+    expect(result.limits.maxBytes).toBe(IOS_DEVICE_LOG_MAX_BYTES);
+  });
+
+  test("AC4: bounds entries to the documented byte limit, dropping oldest", async () => {
+    const simctl = new FakeSimCtlClient();
+    // Each entry ~1 KiB; 300 entries (~300 KiB) exceeds the 256 KiB byte ceiling.
+    const big: string[] = [];
+    for (let i = 0; i < 300; i++) {
+      big.push(`2026-08-24 10:00:00.000000-0700  localhost App[123]: ${"x".repeat(1024)}-${i}`);
+    }
+    simctl.setCommandArgsResult(unfilteredArgs(), big.join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ maxEntries: 100000 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReason).toBe("maxBytes");
+    expect(result.byteSize).toBeLessThanOrEqual(IOS_DEVICE_LOG_MAX_BYTES);
+    // Oldest dropped, most-recent retained.
+    expect(result.entries[result.entries.length - 1]).toBe(big[big.length - 1]);
+    expect(result.entries).not.toContain(big[0]);
+  });
+
+  test("AC4: applies the documented default entry limit when none is requested", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsResult(unfilteredArgs(), [line(1)].join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect();
+
+    expect(result.limits.maxEntries).toBe(IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES);
+    expect(result.window.maxEntries).toBe(IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES);
+    expect(result.limits.maxBytes).toBe(IOS_DEVICE_LOG_MAX_BYTES);
+  });
+
+  test("AC4: caps a request above the documented hard entry ceiling", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsResult(unfilteredArgs(), [line(1)].join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ maxEntries: IOS_DEVICE_LOG_MAX_ENTRIES * 100 });
+
+    expect(result.limits.maxEntries).toBe(IOS_DEVICE_LOG_MAX_ENTRIES);
+    expect(result.window.maxEntries).toBe(IOS_DEVICE_LOG_MAX_ENTRIES);
+  });
+
+  test("AC2: records filtering as applied when the predicated query succeeds", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsResult(filteredArgs("com.example.app"), [line(1), line(2)].join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ appId: "com.example.app" });
+
+    expect(result.status).toBe("collected");
+    expect(result.appFilter).toEqual({ appId: "com.example.app", status: "applied" });
+    expect(result.entries).toEqual([line(1), line(2)]);
+  });
+
+  test("AC2: records filtering as unsupported when predicate fails but unfiltered succeeds", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsError(
+      filteredArgs("com.example.app"),
+      new Error("Invalid predicate: unknown key"),
+    );
+    simctl.setCommandArgsResult(unfilteredArgs(), [line(1)].join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ appId: "com.example.app" });
+
+    expect(result.status).toBe("collected");
+    expect(result.appFilter).toEqual({ appId: "com.example.app", status: "unsupported" });
+    expect(result.entries).toEqual([line(1)]);
+  });
+
+  test("AC2/AC3: records filtering as unavailable when collection fails entirely", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsError(filteredArgs("com.example.app"), new Error("device not booted"));
+    simctl.setCommandArgsError(unfilteredArgs(), new Error("device not booted"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ appId: "com.example.app" });
+
+    expect(result.status).toBe("unavailable");
+    expect(result.appFilter).toEqual({ appId: "com.example.app", status: "unavailable" });
+    expect(result.entries).toEqual([]);
+    expect(result.entryCount).toBe(0);
+    expect(result.diagnostic).toContain("device not booted");
+  });
+
+  test("AC3: unfiltered collection failure returns structured status without throwing", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsError(unfilteredArgs(), new Error("simctl unavailable"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect();
+
+    expect(result.status).toBe("unavailable");
+    expect(result.entries).toEqual([]);
+    expect(result.diagnostic).toContain("simctl unavailable");
+    expect(result.appFilter).toBeUndefined();
+  });
+
+  test("redacts credentials from captured entries", async () => {
+    const simctl = new FakeSimCtlClient();
+    const secret = "2026-08-24 10:00:01.000000-0700  localhost App[123]: token=SUPERSECRET123";
+    simctl.setCommandArgsResult(unfilteredArgs(), secret);
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect();
+
+    expect(result.entries[0]).toContain("[REDACTED]");
+    expect(result.entries.join("\n")).not.toContain("SUPERSECRET123");
+  });
+
+  test("uses a custom time window when provided", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandArgsResult(unfilteredArgs("30s"), [line(1)].join("\n"));
+
+    const collector = new IosDeviceLogCollector(simctl, device);
+    const result = await collector.collect({ window: "30s" });
+
+    expect(result.status).toBe("collected");
+    expect(result.window.duration).toBe("30s");
+    expect(result.entries).toEqual([line(1)]);
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1659,6 +1659,47 @@ describe("finalizeToolResponse", () => {
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 
+    test("bugReport artifacts iOS device-log entries and keeps status summary inline", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const payload = {
+        reportId: "bug-ios-1",
+        timestamp: 123,
+        device: { deviceId: "sim-udid-1", platform: "ios" },
+        screenState: {},
+        viewHierarchy: { elementCount: 0, clickableElements: [] },
+        iosDeviceLog: {
+          status: "collected",
+          entries: ["2026-08-24 10:00:01 App: one", "2026-08-24 10:00:02 App: two"],
+          entryCount: 2,
+          byteSize: 60,
+          truncated: false,
+          window: { duration: "5m", maxEntries: 1000 },
+          appFilter: { appId: "com.example.app", status: "applied" },
+          limits: { maxEntries: 1000, maxBytes: 262144 },
+        },
+        savedTo: "/tmp/bug-report.json",
+        errors: [],
+      };
+
+      const finalized = finalizeToolResponse(createStructuredToolResponse(payload), {
+        name: "bugReport",
+        artifactWriter: writer,
+      } as any);
+
+      const report = finalized.structuredContent as any;
+      expect(report.iosDeviceLogSummary).toEqual({
+        status: "collected",
+        entryCount: 2,
+        byteSize: 60,
+        truncated: false,
+        filterStatus: "applied",
+      });
+      expect(report.iosDeviceLog.entries.artifact.payload).toBe("BugReportIosDeviceLog");
+      expect(report.iosDeviceLog.status).toBe("collected");
+      expect(writer.writes.map((write) => write.payload)).toContain("BugReportIosDeviceLog");
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
     test("getNetworkGraph artifacts aggregate graph and keeps host count inline", () => {
       const writer = new FakeObservationArtifactWriter();
       const payload = {


### PR DESCRIPTION
## Summary

`bugReport` accepted iOS targets but its diagnostic capture only ran Android
Debug Bridge `logcat` commands, so an iOS invocation could not provide a
platform-native device-log tail. This adds an iOS-native, bounded log collector
behind the existing tool and routes the device-log capture by platform. Android
`logcat` capture is unchanged.

## Linked Issue

Closes #5641

## Changes

- **`IosDeviceLogCollector`** (new) — collects a bounded, timestamped tail via
  `xcrun simctl spawn <udid> log show --style syslog --last <window>`. It never
  throws: every failure path returns structured status. Injects a narrow
  `IosLogExecutor` exec seam (satisfied by the real `SimCtlClient` and the
  existing `FakeSimCtlClient`).
- **`IosDeviceLog`** model — self-describing payload: `status`
  (`collected`/`unavailable`), ordered `entries`, `entryCount`, `byteSize`,
  `truncated` + `truncationReason`, requested `window`, `appFilter`
  (`applied`/`unsupported`/`unavailable`), documented `limits`, and a
  `diagnostic` on failure.
- **`BugReport`** — branches device-log capture: iOS → collector, Android →
  existing `logcat`. Collector is injectable for tests; production wraps a
  `SimCtlClient`.
- **Redaction** — reuses `redactAndroidCommandOutput` to scrub credentials from
  captured entries before returning them.
- **Limits** — documented constants `IOS_DEVICE_LOG_DEFAULT_MAX_ENTRIES` (1000),
  `IOS_DEVICE_LOG_MAX_BYTES` (256 KiB); the most-recent entries are retained,
  oldest dropped, with the reason recorded.
- **`finalizeToolResponse`** — offloads large `iosDeviceLog.entries` to an
  artifact and keeps an inline `iosDeviceLogSummary`, mirroring `logcat`.
- Broadened `bugReport` tool + `appId`/`logcatLines` descriptions to be
  platform-neutral; regenerated `schemas/tool-definitions.json`.

## Acceptance criteria

- [x] An iOS simulator test proves a report contains **ordered** device-log
  entries from the requested bounded window — `IosDeviceLogCollector.test.ts`
  (AC1) and `BugReport.test.ts` (tool boundary).
- [x] When an app identifier is provided, the report records whether filtering
  was **applied / unsupported / unavailable** — three collector tests (AC2).
- [x] Collection failures return **structured diagnostic status** without
  failing the surrounding request — collector + BugReport failure tests (AC3).
- [x] The payload has **documented byte and entry limits** — exported constants,
  `limits` in the payload, entry-cap and byte-cap truncation tests (AC4).
- [x] Android bug-report tests continue to validate `logcat` output — Android
  path untouched; existing `BugReport`/`finalizeToolResponse` tests stay green
  (AC5).

## Validation

- [x] `bun run lint` (ratchet + boundary checks): no new violations
- [x] `bun run typecheck`: no new type errors (baseline gate)
- [x] `bun test`: full suite green except one pre-existing, environment-only
  failure in `test/lint/oxlintConfigScoping.test.ts` — this worktree lacks
  `node_modules/.bin/oxlint`, unrelated to this diff.
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [x] Reuses existing helpers (`SimCtlClient`/`FakeSimCtlClient` seam,
  `redactAndroidCommandOutput`); no new dependencies

## Follow-ups

- [ ] iOS `bugReport` still runs Android-only captures (device info / screen /
  window state via `adb`) that no-op with errors on iOS. Out of scope here
  (issue is device-log capture); can be ported separately if desired.
