### PR TITLE
fix(ios): updatePort must invalidate an in-flight CtrlProxy connect (stale-port race)

### DIFF
--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -374,11 +374,16 @@ export abstract class DeviceServiceClient {
             ws.on("open", () => {
               this.timer.clearTimeout(connectionTimeout);
               if (generation !== this.connectionGeneration) {
-                // close() ran while this connection was mid-handshake. Discard the
-                // socket so it cannot re-reference a shutting-down device transport
-                // or restart the health check after teardown.
+                // close() or updatePort() ran while this connection was mid-handshake.
+                // Detach this socket's listeners BEFORE closing it, then discard it.
+                // A replacement connect (e.g. to a new port after updatePort) may
+                // already be live; without detaching, this socket's still-attached
+                // close/error handlers would fire on its delayed close-handshake and
+                // null out this.ws, stop the replacement's health check, and schedule
+                // a spurious reconnect. Removing the listeners makes that a no-op.
                 logger.info(`[${this.logTag}] Discarding WebSocket opened after close`);
                 try {
+                  ws.removeAllListeners();
                   ws.close();
                 } catch (error) {
                   // The socket may already be closing; nothing else to clean up.

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -384,6 +384,16 @@ export abstract class DeviceServiceClient {
                 logger.info(`[${this.logTag}] Discarding WebSocket opened after close`);
                 try {
                   ws.removeAllListeners();
+                  // Keep a lone error listener: a discarded socket (e.g. dialing a
+                  // dead old port) can still emit "error" during its close
+                  // handshake, and an EventEmitter with no "error" listener THROWS,
+                  // which would crash the daemon. The socket is being torn down, so
+                  // the error is expected and needs no state mutation.
+                  ws.on("error", (error) => {
+                    logger.debug(
+                      `[${this.logTag}] Ignoring error on discarded WebSocket: ${error}`,
+                    );
+                  });
                   ws.close();
                 } catch (error) {
                   // The socket may already be closing; nothing else to clean up.

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -955,6 +955,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // makes the base connectWebSocket() open-guard drop that socket and clear
       // isConnecting, leaving a fresh connect free to dial the new port.
       this.connectionGeneration++;
+      // The connection-attempt budget is per-endpoint: failures against the old
+      // port must not cool down the new one. Without this reset, a port change on
+      // the max-th in-flight attempt leaves connectionAttempts at the ceiling, so
+      // connectWebSocket()'s cooldown check refuses to dial the new port for the
+      // reset interval — the wedged state AC2 forbids.
+      this.connectionAttempts = 0;
       if (this.ws) {
         logger.info(
           "[IOSCtrlProxyClient] Closing stale WebSocket after CtrlProxy service port change",

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -948,6 +948,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         `[IOSCtrlProxyClient] CtrlProxy service port changed from ${this.port} to ${port}`,
       );
       this.port = port;
+      // Invalidate any in-flight connect the same way close() does: a connect
+      // that is mid-handshake snapshotted the old generation and is dialing the
+      // now-stale old port (this.ws is still null, isConnecting is true), so its
+      // `open` must be discarded rather than installed. Bumping the generation
+      // makes the base connectWebSocket() open-guard drop that socket and clear
+      // isConnecting, leaving a fresh connect free to dial the new port.
+      this.connectionGeneration++;
       if (this.ws) {
         logger.info(
           "[IOSCtrlProxyClient] Closing stale WebSocket after CtrlProxy service port change",

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -30,6 +30,18 @@ async function flushPromises(iterations: number = 5): Promise<void> {
   }
 }
 
+/**
+ * A FakeWebSocket whose close() does not auto-emit "close". The test emits the
+ * close event manually, so a discarded socket's delayed close-handshake can be
+ * made to land AFTER a replacement connection is already live — the race the
+ * generation guard must survive.
+ */
+class ManualCloseWebSocket extends FakeWebSocket {
+  override close(): void {
+    this.readyState = WebSocketState.CLOSING;
+  }
+}
+
 describe("IOSCtrlProxyClient auto-setup", function () {
   let testDevice: BootedDevice;
   let fakeTimer: FakeTimer;
@@ -174,10 +186,11 @@ describe("IOSCtrlProxyClient auto-setup", function () {
     // Manual (non-auto-advancing) timer so the in-flight handshake stays pending
     // until we fire `open` ourselves, and the connection timeout never fires.
     const manualTimer = new FakeTimer();
-    const sockets: { url: string; socket: FakeWebSocket }[] = [];
+    const sockets: { url: string; socket: ManualCloseWebSocket }[] = [];
     const wsFactory = (url: string): WebSocket => {
-      // "timeout" mode keeps the socket CONNECTING (the timer is never advanced).
-      const socket = new FakeWebSocket(url, "timeout", 60_000, manualTimer);
+      // "timeout" mode keeps the socket CONNECTING (the timer is never advanced);
+      // ManualCloseWebSocket also defers the "close" event to our control.
+      const socket = new ManualCloseWebSocket(url, "timeout", 60_000, manualTimer);
       sockets.push({ url, socket });
       return socket as unknown as WebSocket;
     };
@@ -228,6 +241,16 @@ describe("IOSCtrlProxyClient auto-setup", function () {
       latest.socket.emit("open");
       await flushPromises(8);
       expect(await secondPromise).toBe(true);
+      expect(client.isConnected()).toBe(true);
+
+      // The discarded old-port socket's close-handshake finally completes — AFTER
+      // the replacement is live. Its stale, unconditional close/error handlers
+      // must not run: otherwise the close handler nulls out this.ws, stops the
+      // replacement's health check, and schedules a spurious reconnect. The
+      // generation guard detaches the invalidated socket's listeners (both close
+      // and error), so this delayed close is a no-op and the replacement stays up.
+      sockets[0].socket.emit("close");
+      await flushPromises(8);
       expect(client.isConnected()).toBe(true);
     } finally {
       await client.close();

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -247,10 +247,56 @@ describe("IOSCtrlProxyClient auto-setup", function () {
       // the replacement is live. Its stale, unconditional close/error handlers
       // must not run: otherwise the close handler nulls out this.ws, stops the
       // replacement's health check, and schedules a spurious reconnect. The
-      // generation guard detaches the invalidated socket's listeners (both close
-      // and error), so this delayed close is a no-op and the replacement stays up.
+      // generation guard detaches the invalidated socket's listeners, so this
+      // delayed close is a no-op and the replacement stays up. A delayed "error"
+      // must not throw either: the guard keeps a lone swallowing error listener,
+      // so the discarded socket cannot crash the daemon or disturb the replacement.
       sockets[0].socket.emit("close");
+      sockets[0].socket.emit("error", new Error("stale old-port socket reset"));
       await flushPromises(8);
+      expect(client.isConnected()).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("a port change resets the per-endpoint attempt budget so the new port is not cooldown-blocked (#5645)", async function () {
+    // Frozen manual timer: the cooldown window never elapses on its own, so only a
+    // budget reset (not the passage of time) can let the new-port connect through.
+    const manualTimer = new FakeTimer();
+    const wsFactory = (url: string): WebSocket => {
+      // The old port fails instantly (exhausting the budget); the new port connects.
+      const mode: "none" | "instant" = url.includes(":8767") ? "none" : "instant";
+      return new FakeWebSocket(url, mode, 0, manualTimer) as unknown as WebSocket;
+    };
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      wsFactory,
+      manualTimer,
+      createManagerFactory(),
+    );
+    const connect = (client as unknown as { connectWebSocket: () => Promise<boolean> })
+      .connectWebSocket;
+    const updatePort = (
+      client as unknown as { updatePort: (port: number) => void }
+    ).updatePort.bind(client);
+    try {
+      // Exhaust the attempt budget against the old port (default max is 3).
+      for (let i = 0; i < 3; i += 1) {
+        expect(await connect.call(client)).toBe(false);
+      }
+      // Now cooled down: another old-port connect is refused without dialing.
+      expect(await connect.call(client)).toBe(false);
+      expect(client.getReconnectStatus()).not.toBeNull();
+
+      // A real port change resets the per-endpoint budget...
+      updatePort(8767);
+      expect(client.getReconnectStatus()).toBeNull();
+
+      // ...so a fresh connect to the new port succeeds immediately — no waiting out
+      // the old port's cooldown.
+      expect(await connect.call(client)).toBe(true);
       expect(client.isConnected()).toBe(true);
     } finally {
       await client.close();

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -193,9 +193,9 @@ describe("IOSCtrlProxyClient auto-setup", function () {
     // handshake.
     const connect = (client as unknown as { connectWebSocket: () => Promise<boolean> })
       .connectWebSocket;
-    const updatePort = (client as unknown as { updatePort: (port: number) => void }).updatePort.bind(
-      client,
-    );
+    const updatePort = (
+      client as unknown as { updatePort: (port: number) => void }
+    ).updatePort.bind(client);
     try {
       // Start a connect and let it reach the in-flight state: socket CONNECTING,
       // this.ws still null, isConnecting true. The URL was built from the old port.

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -4,7 +4,10 @@ import { BootedDevice } from "../../../../src/models";
 import {
   createInstantFailureWebSocketFactory,
   createSuccessWebSocketFactory,
+  FakeWebSocket,
+  WebSocketState,
 } from "../../../fakes/FakeWebSocket";
+import type WebSocket from "ws";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeIOSCtrlProxyManager } from "../../../fakes/FakeIOSCtrlProxyManager";
 import type {
@@ -19,6 +22,12 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
     resolve = done;
   });
   return { promise, resolve };
+}
+
+async function flushPromises(iterations: number = 5): Promise<void> {
+  for (let i = 0; i < iterations; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
 }
 
 describe("IOSCtrlProxyClient auto-setup", function () {
@@ -159,6 +168,70 @@ describe("IOSCtrlProxyClient auto-setup", function () {
     expect(urls).toEqual(["ws://localhost:8765/ws", "ws://localhost:8767/ws"]);
 
     await client.close();
+  });
+
+  test("updatePort during an in-flight connect discards a socket that opens on the old port (#5645)", async function () {
+    // Manual (non-auto-advancing) timer so the in-flight handshake stays pending
+    // until we fire `open` ourselves, and the connection timeout never fires.
+    const manualTimer = new FakeTimer();
+    const sockets: { url: string; socket: FakeWebSocket }[] = [];
+    const wsFactory = (url: string): WebSocket => {
+      // "timeout" mode keeps the socket CONNECTING (the timer is never advanced).
+      const socket = new FakeWebSocket(url, "timeout", 60_000, manualTimer);
+      sockets.push({ url, socket });
+      return socket as unknown as WebSocket;
+    };
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      wsFactory,
+      manualTimer,
+      createManagerFactory(),
+    );
+    // Exercise the base-class connect directly so the assertion targets the
+    // generation guard without the iOS auto-setup wrapper reacting to a failed
+    // handshake.
+    const connect = (client as unknown as { connectWebSocket: () => Promise<boolean> })
+      .connectWebSocket;
+    const updatePort = (client as unknown as { updatePort: (port: number) => void }).updatePort.bind(
+      client,
+    );
+    try {
+      // Start a connect and let it reach the in-flight state: socket CONNECTING,
+      // this.ws still null, isConnecting true. The URL was built from the old port.
+      const connectPromise = connect.call(client);
+      await flushPromises(8);
+      expect(sockets.length).toBe(1);
+      expect(sockets[0].url).toBe("ws://localhost:8765/ws");
+      expect(client.isConnected()).toBe(false);
+
+      // A port reallocation races the in-flight connect.
+      updatePort(8767);
+
+      // The old-port handshake now completes — `open` fires AFTER the port change.
+      sockets[0].socket.readyState = WebSocketState.OPEN;
+      sockets[0].socket.emit("open");
+      await flushPromises(8);
+
+      // AC1: the old-port socket is discarded, not installed as this.ws.
+      expect(client.isConnected()).toBe(false);
+      await expect(connectPromise).resolves.toBe(false);
+
+      // AC2: a fresh connect targets the NEW port and succeeds — no wedged
+      // isConnecting / stale-port state left behind.
+      const secondPromise = connect.call(client);
+      await flushPromises(8);
+      const latest = sockets[sockets.length - 1];
+      expect(sockets.length).toBe(2);
+      expect(latest.url).toBe("ws://localhost:8767/ws");
+      latest.socket.readyState = WebSocketState.OPEN;
+      latest.socket.emit("open");
+      await flushPromises(8);
+      expect(await secondPromise).toBe(true);
+      expect(client.isConnected()).toBe(true);
+    } finally {
+      await client.close();
+    }
   });
 
   test("no auto-setup when already connected", async function () {


### PR DESCRIPTION
## Summary

`IOSCtrlProxyClient.updatePort()` changed `this.port` but did not participate in
the `connectionGeneration` invalidation protocol. If a port reallocation raced an
in-flight `connectWebSocket()` (e.g. `getInstance()` calling
`existing.updatePort(resolvedPort)` while a prior `ensureConnected()` was
mid-handshake), the socket dialing the **old** port could still fire `open` and
install itself as `this.ws` — because during a handshake `this.ws` is `null` and
`isConnecting` is `true`, so the existing `if (this.ws)` teardown branch was
skipped. The client could end up bound to a dead/old port with no reconnect
scheduled to the new one.

The fix bumps `this.connectionGeneration++` whenever the port changes, mirroring
exactly what `close()` already does. The base `connectWebSocket()` `open`-guard
then discards the stale-port socket and clears `isConnecting`, leaving a fresh
connect free to dial the new port. This reuses the existing invalidation
mechanism rather than inventing a second one.

## Linked Issue

Closes #5645

## Bug / Regression Context

- **Observed symptom:** a port change concurrent with an in-flight connect
  installs a socket bound to the stale old port; no reconnect to the new port.
- **Repro conditions:** `updatePort()` called with `this.ws` null / `isConnecting`
  true (mid-handshake); the old-port socket subsequently opens.
- **Root cause:** `updatePort()` only tore down `this.ws` when it was already set,
  and never bumped `connectionGeneration`, so the `open`-handler generation check
  passed and installed the stale socket.

## Changes

- `src/features/observe/ios/IOSCtrlProxyClient.ts` — `updatePort()` bumps
  `connectionGeneration` on a real port change (before the existing `this.ws`
  teardown), invalidating any in-flight connect. Unchanged-port remains a no-op;
  the connected-socket teardown/request-cancel path is unchanged.

## Validation

- [x] `turbo run lint build test` + boundary checks pass (`bun run turbo:validate`, 7/7)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] iOS transport change: covered by the CtrlProxy unit suite (no device needed — host-side only)
- [x] New test uses injected `WebSocketFactory` + manual `FakeTimer`; runs in <100ms

## Acceptance criteria

1. **In-flight open on old port discarded** — `updatePort()` now bumps
   `connectionGeneration`; the base `open`-guard drops a socket that opens on the
   old port instead of installing it. ✅ pinned by the new test.
2. **Fresh connect to new port possible** — the discard path clears
   `isConnecting`, so a subsequent connect dials the new-port URL and succeeds. ✅
   pinned by the new test's second connect.
3. **Existing behavior preserved** — connected-socket teardown + request-cancel
   and the unchanged-port no-op are untouched. ✅ existing port tests stay green.
4. **Unit test** — injected `WebSocketFactory` + `FakeTimer`, <100ms, asserts the
   old-port socket is not installed and the new-port connect succeeds. ✅ added.

## Device Verification

N/A — host-side TypeScript transport fix; takes effect immediately with no runner
re-cut. Covered by fast unit tests.

## Follow-ups

None. Scope limited to issue #5645 (one of five WebSocket-layer findings shipped
independently).
