### PR TITLE
fix(ios-screen-capture): serialize capture-session frame-path state (reconfigure race+storm, teardown UAF)

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -25,8 +25,12 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
     /// encoder on the next frame. Present even in raw mode (harmless there).
     let forceKeyFrameLatch = ForceKeyFrameLatch()
     /// Shared in-helper encode wiring in `--encode h264` mode; `nil` on the raw
-    /// path. Identical `EncodePipeline` type as the Simulator session.
-    private var pipeline: EncodePipeline?
+    /// path. Identical `EncodePipeline` type as the Simulator session. Guarded by
+    /// `stateLock` because `captureOutput` reads it on the frame `queue` while
+    /// `stop()` clears it off-queue.
+    private var _pipeline: EncodePipeline?
+    /// Guards `_pipeline` across the frame `queue` and `stop()`.
+    private let stateLock = NSLock()
     private let queue = DispatchQueue(label: "automobile.screen-capture.frames")
     private var observers: [NSObjectProtocol] = []
     private var stopping = false
@@ -80,7 +84,9 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
             // fire-and-forget and the input drop returns immediately when behind), so
             // AVFoundation does not accumulate late frames without the discard.
             output.alwaysDiscardsLateVideoFrames = false
-            pipeline = EncodePipeline(
+            // Set before `startRunning()`, i.e. before frames flow, so a direct
+            // field write is safe here.
+            _pipeline = EncodePipeline(
                 writer: writer,
                 fps: DeviceCaptureSession.deviceFPS,
                 source: .device,
@@ -116,8 +122,19 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         stopping = true
         removeObservers()
         session.stopRunning()
-        pipeline?.stop()
-        pipeline = nil
+
+        stateLock.lock()
+        let pipeline = _pipeline
+        _pipeline = nil
+        stateLock.unlock()
+        // Tear the encoder down ON the frame queue so it cannot overlap an in-flight
+        // `captureOutput` encode call (both run on `queue`); `queue.sync` waits for any
+        // executing frame callback first, avoiding a use-after-free on the VideoToolbox
+        // session. `stopRunning()` above stops future delivery but does not guarantee an
+        // already-dispatched callback has returned.
+        if let pipeline = pipeline {
+            queue.sync { pipeline.stop() }
+        }
     }
 
     private func installObservers() {
@@ -176,6 +193,9 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
+        stateLock.lock()
+        let pipeline = _pipeline
+        stateLock.unlock()
         if let pipeline = pipeline {
             encodeFrame(pipeline: pipeline, sampleBuffer: sampleBuffer)
             return

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -209,12 +209,16 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     }
 
     func stop() async {
-        stateLock.lock()
-        let pipeline = _pipeline
-        let stream = _stream
-        _pipeline = nil
-        _stream = nil
-        stateLock.unlock()
+        // Scoped `withLock` (not `lock()`/`unlock()`): the latter is unavailable from
+        // an async context in the Swift 6 language mode, and scoped locking also makes
+        // it structurally impossible to hold the lock across the `await` below.
+        let (pipeline, stream): (EncodePipeline?, CaptureStream?) = stateLock.withLock {
+            let pipeline = _pipeline
+            let stream = _stream
+            _pipeline = nil
+            _stream = nil
+            return (pipeline, stream)
+        }
 
         // Tear the encoder down ON the frame queue so it cannot overlap an in-flight
         // `encode`/`ensureEncoder` call (both run on `queue`). `queue.sync` waits for
@@ -438,14 +442,15 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     /// through `reconfigure` → `beginReconfigure`. Commits the size under the lock (only when a
     /// stream is present) then applies it.
     func performReconfiguration(width: Int, height: Int) async {
-        stateLock.lock()
-        guard let stream = _stream else {
-            stateLock.unlock()
-            return
+        // Scoped `withLock`: `lock()`/`unlock()` is unavailable from async contexts in
+        // the Swift 6 language mode, and this keeps the lock off the `await` below.
+        let stream: CaptureStream? = stateLock.withLock {
+            guard let stream = _stream else { return nil }
+            _configuredPixelWidth = width
+            _configuredPixelHeight = height
+            return stream
         }
-        _configuredPixelWidth = width
-        _configuredPixelHeight = height
-        stateLock.unlock()
+        guard let stream = stream else { return }
         await applyStreamConfiguration(stream: stream, width: width, height: height)
     }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -364,24 +364,34 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     }
 
     /// Kicks off a size change from the frame queue. `beginReconfigure` commits the
-    /// new size synchronously and dedups, so a burst of same-size frames neither
-    /// races the dimension writes nor spawns overlapping `updateConfiguration` calls
-    /// (the reconfigure storm). The retry inside `applyStreamConfiguration` bounds
-    /// recovery so a single transient failure does not strand the stream at a stale
-    /// size (issue #4768); `endReconfigure` then releases the in-flight slot.
+    /// new size synchronously and claims the single in-flight slot, so a burst of
+    /// frames neither races the dimension writes nor spawns overlapping
+    /// `updateConfiguration` calls (the reconfigure storm). The loop then
+    /// **coalesces to the latest** target: if a newer size is requested while an
+    /// update is applying, it is applied once the current one completes, so the last
+    /// requested geometry is never dropped (only same-size requests are truly
+    /// deduped). The retry inside `applyStreamConfiguration` bounds recovery so a
+    /// single transient failure does not strand the stream at a stale size (#4768).
     private func reconfigure(width: Int, height: Int) {
         guard let stream = beginReconfigure(width: width, height: height) else { return }
         Task { [weak self] in
-            await self?.applyStreamConfiguration(stream: stream, width: width, height: height)
-            self?.endReconfigure()
+            var width = width
+            var height = height
+            while true {
+                await self?.applyStreamConfiguration(stream: stream, width: width, height: height)
+                guard let next = self?.nextReconfigureTarget(applied: width, height) else { return }
+                width = next.width
+                height = next.height
+            }
         }
     }
 
     /// Commits the new size under `stateLock` and claims the reconfigure slot,
     /// returning the stream to update — or `nil` when there is no stream, or an
-    /// update is already in flight (dedup). Synchronous, so once a frame commits a
-    /// size, a same-size burst no longer re-triggers. Internal so tests can drive the
-    /// dedup deterministically.
+    /// update is already in flight. In the in-flight case the newer size is still
+    /// committed, so the running loop picks it up via `nextReconfigureTarget`
+    /// (coalesce-to-latest). Synchronous, so once a frame commits a size a same-size
+    /// burst no longer re-triggers. Internal so tests can drive it deterministically.
     func beginReconfigure(width: Int, height: Int) -> CaptureStream? {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -395,11 +405,19 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         return stream
     }
 
-    /// Releases the reconfigure slot claimed by `beginReconfigure`. Internal for tests.
-    func endReconfigure() {
+    /// Called after applying `(width, height)`. If the committed target still matches
+    /// what was applied, releases the in-flight slot and returns `nil`. If a newer
+    /// target was committed while the update was applying, keeps the slot and returns
+    /// that target so the loop applies it too — so the latest requested geometry is
+    /// never left unsent. Internal so tests can drive the coalescing deterministically.
+    func nextReconfigureTarget(applied width: Int, _ height: Int) -> (width: Int, height: Int)? {
         stateLock.lock()
-        _reconfiguring = false
-        stateLock.unlock()
+        defer { stateLock.unlock() }
+        if _configuredPixelWidth == width, _configuredPixelHeight == height {
+            _reconfiguring = false
+            return nil
+        }
+        return (_configuredPixelWidth, _configuredPixelHeight)
     }
 
     /// Applies a new capture size to the given stream. Split out so tests can `await`

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -41,13 +41,27 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     /// Force-keyframe latch shared with the STDIN control channel; consumed by
     /// the encoder on the next frame. Present even in raw mode (harmless there).
     let forceKeyFrameLatch = ForceKeyFrameLatch()
+    /// Guards the mutable frame-path state shared across the ScreenCaptureKit frame
+    /// queue (`didOutputSampleBuffer`), the MainActor `start()`/`stop()`, and the
+    /// reconfigure `Task`: the encode `pipeline`, the `stream`, the configured
+    /// dimensions, and the reconfigure-in-flight flag. Snapshot-under-lock-then-act;
+    /// the lock is never held across an `await` or a blocking call.
+    private let stateLock = NSLock()
     /// Shared in-helper encode wiring in `--encode h264` mode (issues #4788 /
     /// #4790). `nil` in the raw-BGRA path. The same `EncodePipeline` type backs the
     /// physical-device capture session, so the VideoToolbox glue lives in exactly
-    /// one place.
-    private var pipeline: EncodePipeline?
+    /// one place. Guarded by `stateLock`.
+    private var _pipeline: EncodePipeline?
+    private var _stream: CaptureStream?
+    private var _configuredPixelWidth = 0
+    private var _configuredPixelHeight = 0
+    /// True while an async `updateConfiguration` dispatched by `reconfigure` is in
+    /// flight, so a burst of same-size frames does not spawn overlapping updates.
+    private var _reconfiguring = false
+
     /// Pixel format requested from ScreenCaptureKit — 32BGRA for the raw path,
-    /// 420v (NV12) for the lowest-CPU encode path.
+    /// 420v (NV12) for the lowest-CPU encode path. Set once in `start()` before
+    /// frames flow, then read-only.
     var configuredPixelFormat: OSType = kCVPixelFormatType_32BGRA
     /// Diagnostic lines (first-frame marker, reconfigure warnings) go here so
     /// tests can observe them; the default preserves the stderr behavior.
@@ -55,12 +69,26 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     private let queue = DispatchQueue(label: "automobile.simulator-capture.frames")
     let firstFrameSignal = FirstFrameSignal()
 
-    // The following are `internal` (not `private`) so `@testable` tests can seed
-    // and inspect lifecycle state that `start()` would otherwise set only behind
-    // a real `SCWindow`. They are not part of the production API surface.
-    var stream: CaptureStream?
-    var configuredPixelWidth: Int = 0
-    var configuredPixelHeight: Int = 0
+    // The `stream`/`configuredPixel*` accessors are `internal` (not `private`) and
+    // `stateLock`-guarded so `@testable` tests can seed and inspect lifecycle state
+    // that `start()` would otherwise set only behind a real `SCWindow`. They are not
+    // part of the production API surface.
+    var stream: CaptureStream? {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _stream }
+        set { stateLock.lock(); _stream = newValue; stateLock.unlock() }
+    }
+
+    var configuredPixelWidth: Int {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _configuredPixelWidth }
+        set { stateLock.lock(); _configuredPixelWidth = newValue; stateLock.unlock() }
+    }
+
+    var configuredPixelHeight: Int {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _configuredPixelHeight }
+        set { stateLock.lock(); _configuredPixelHeight = newValue; stateLock.unlock() }
+    }
+
+    // Set once in `start()` before frames flow, then read-only, so no lock needed.
     var fps: Int = CommandLineOptions.defaultSimulatorFPS
     var audioEnabled = false
     var windowID: UInt32 = 0
@@ -110,7 +138,9 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         // no color conversion. The raw path keeps 32BGRA untouched.
         if let encodeSettings = encodeSettings {
             configuredPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
-            pipeline = EncodePipeline(
+            // Set before frames flow (before `beginCapture` starts the stream), so a
+            // direct field write is safe here.
+            _pipeline = EncodePipeline(
                 writer: writer,
                 fps: fps,
                 source: .simulator,
@@ -179,14 +209,27 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     }
 
     func stop() async {
-        pipeline?.stop()
-        pipeline = nil
+        stateLock.lock()
+        let pipeline = _pipeline
+        let stream = _stream
+        _pipeline = nil
+        _stream = nil
+        stateLock.unlock()
+
+        // Tear the encoder down ON the frame queue so it cannot overlap an in-flight
+        // `encode`/`ensureEncoder` call (both run on `queue`). `queue.sync` waits for
+        // any executing frame callback to finish first, so the VideoToolbox session is
+        // never invalidated underneath a frame being encoded (the teardown
+        // use-after-free the raw MainActor nil-out risked). Safe from MainActor — this
+        // is never called on `queue`.
+        if let pipeline = pipeline {
+            queue.sync { pipeline.stop() }
+        }
         guard let stream = stream else { return }
         // removeStreamOutput breaks the SCStream → self retain cycle so the
         // session is collectable even before SCStream itself goes away.
         try? stream.removeStreamOutput(self, type: .screen)
         try? await stream.stopCapture()
-        self.stream = nil
     }
 
     // MARK: - SCStreamOutput
@@ -224,7 +267,8 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
             return
         }
 
-        if actualWidth != configuredPixelWidth || actualHeight != configuredPixelHeight {
+        let (configuredWidth, configuredHeight) = currentConfiguredSize()
+        if actualWidth != configuredWidth || actualHeight != configuredHeight {
             reconfigure(width: actualWidth, height: actualHeight)
         }
 
@@ -245,7 +289,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         width: Int,
         height: Int
     ) {
-        guard let pipeline = pipeline else { return }
+        guard let pipeline = currentPipeline() else { return }
         let target = H264EncodeMath.resolveEncoderScale(
             H264EncodeMath.EncoderSize(width: width, height: height)
         ) ?? H264EncodeMath.EncoderSize(width: width, height: height)
@@ -300,23 +344,64 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
 
     // MARK: - Internals
 
+    /// Snapshot of the encode pipeline under `stateLock`, for use on the frame queue.
+    private func currentPipeline() -> EncodePipeline? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _pipeline
+    }
+
+    /// Atomic snapshot of the configured dimensions under `stateLock`, so the frame
+    /// callback's mismatch check never reads a torn (width, height) pair.
+    private func currentConfiguredSize() -> (width: Int, height: Int) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return (_configuredPixelWidth, _configuredPixelHeight)
+    }
+
+    /// Kicks off a size change from the frame queue. `beginReconfigure` commits the
+    /// new size synchronously and dedups, so a burst of same-size frames neither
+    /// races the dimension writes nor spawns overlapping `updateConfiguration` calls
+    /// (the reconfigure storm). The retry inside `applyStreamConfiguration` bounds
+    /// recovery so a single transient failure does not strand the stream at a stale
+    /// size (issue #4768); `endReconfigure` then releases the in-flight slot.
     private func reconfigure(width: Int, height: Int) {
-        // Detached task: the retry inside `performReconfiguration` bounds the
-        // recovery so a single transient `updateConfiguration` failure does not
-        // silently strand the stream at stale dimensions (issue #4768).
-        Task {
-            await performReconfiguration(width: width, height: height)
+        guard let stream = beginReconfigure(width: width, height: height) else { return }
+        Task { [weak self] in
+            await self?.applyStreamConfiguration(stream: stream, width: width, height: height)
+            self?.endReconfigure()
         }
     }
 
-    /// Applies a new capture size to the live stream. Split out from
-    /// `reconfigure`'s detached task so tests can `await` it deterministically
-    /// and assert both the success path and the swallowed-failure warning.
-    func performReconfiguration(width: Int, height: Int) async {
-        guard let stream = stream else { return }
-        configuredPixelWidth = width
-        configuredPixelHeight = height
+    /// Commits the new size under `stateLock` and claims the reconfigure slot,
+    /// returning the stream to update — or `nil` when there is no stream, or an
+    /// update is already in flight (dedup). Synchronous, so once a frame commits a
+    /// size, a same-size burst no longer re-triggers. Internal so tests can drive the
+    /// dedup deterministically.
+    func beginReconfigure(width: Int, height: Int) -> CaptureStream? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        // No stream: nothing to reconfigure, and committing a size here would be wrong
+        // if a frame slipped in before `beginCapture` stored the stream. Leave it.
+        guard let stream = _stream else { return nil }
+        _configuredPixelWidth = width
+        _configuredPixelHeight = height
+        if _reconfiguring { return nil }
+        _reconfiguring = true
+        return stream
+    }
 
+    /// Releases the reconfigure slot claimed by `beginReconfigure`. Internal for tests.
+    func endReconfigure() {
+        stateLock.lock()
+        _reconfiguring = false
+        stateLock.unlock()
+    }
+
+    /// Applies a new capture size to the given stream. Split out so tests can `await`
+    /// it deterministically and assert both the success path and the swallowed-failure
+    /// warning. Reads only the set-once `configuredPixelFormat`/`fps`/`audioEnabled`.
+    private func applyStreamConfiguration(stream: CaptureStream, width: Int, height: Int) async {
         let updated = SCStreamConfiguration()
         updated.width = width
         updated.height = height
@@ -332,8 +417,8 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         // transiently while ScreenCaptureKit is mid-frame, and silently keeping
         // the stale config would drift delivered pixels away from the size the
         // supervisor expects — which the TS side then kills on as a mismatch.
-        // The new dimensions are already recorded above, so on ultimate failure
-        // the next size change still attempts a correcting update.
+        // The new dimensions are already recorded, so on ultimate failure the next
+        // size change still attempts a correcting update.
         do {
             try await stream.updateConfiguration(updated)
             return
@@ -346,6 +431,22 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         } catch {
             diagnosticSink("warn: failed to update stream configuration after retry: \(error)\n")
         }
+    }
+
+    /// Applies a new capture size to the live stream. Retained as the directly-`await`able
+    /// test seam for the `updateConfiguration` success/retry/failure paths; production goes
+    /// through `reconfigure` → `beginReconfigure`. Commits the size under the lock (only when a
+    /// stream is present) then applies it.
+    func performReconfiguration(width: Int, height: Int) async {
+        stateLock.lock()
+        guard let stream = _stream else {
+            stateLock.unlock()
+            return
+        }
+        _configuredPixelWidth = width
+        _configuredPixelHeight = height
+        stateLock.unlock()
+        await applyStreamConfiguration(stream: stream, width: width, height: height)
     }
 
     private static func makeConfiguration(

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -290,6 +290,44 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         XCTAssertTrue(diagnostics.lines.isEmpty)
     }
 
+    // MARK: - Reconfigure dedup (storm / data-race fix)
+
+    func testBeginReconfigureCommitsSizeSynchronouslyAndDedupsWhileInFlight() {
+        let session = makeSession(diagnostics: DiagnosticRecorder())
+        let fake = FakeCaptureStream()
+        session.stream = fake
+
+        // First frame at a new size claims the reconfigure slot and commits the size
+        // synchronously (before any async hop), so subsequent frames see the new size.
+        let first = session.beginReconfigure(width: 900, height: 1900)
+        XCTAssertTrue(first === fake, "first reconfigure returns the stream to update")
+        XCTAssertEqual(session.configuredPixelWidth, 900)
+        XCTAssertEqual(session.configuredPixelHeight, 1900)
+
+        // A second frame while the update is in flight commits the size but does NOT
+        // spawn a second update — this is the storm dedup.
+        let second = session.beginReconfigure(width: 900, height: 1900)
+        XCTAssertNil(second, "a reconfigure already in flight is deduped")
+        XCTAssertEqual(session.configuredPixelWidth, 900)
+
+        // Once the in-flight update completes, a genuinely new size reconfigures again.
+        session.endReconfigure()
+        let third = session.beginReconfigure(width: 910, height: 1910)
+        XCTAssertTrue(third === fake, "after the slot is released a new size reconfigures again")
+        XCTAssertEqual(session.configuredPixelWidth, 910)
+        XCTAssertEqual(session.configuredPixelHeight, 1910)
+    }
+
+    func testBeginReconfigureWithoutStreamReturnsNilAndLeavesSizeUnset() {
+        let session = makeSession(diagnostics: DiagnosticRecorder())
+
+        let result = session.beginReconfigure(width: 640, height: 480)
+
+        XCTAssertNil(result)
+        XCTAssertEqual(session.configuredPixelWidth, 0, "no stream: nothing to reconfigure")
+        XCTAssertEqual(session.configuredPixelHeight, 0)
+    }
+
     // MARK: - Bounded startCapture() deadline (issue #4350 / #4764)
 
     /// A `startCapture()` that hangs inside ScreenCaptureKit start must be

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -290,9 +290,9 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         XCTAssertTrue(diagnostics.lines.isEmpty)
     }
 
-    // MARK: - Reconfigure dedup (storm / data-race fix)
+    // MARK: - Reconfigure dedup + coalesce-to-latest (storm / data-race fix)
 
-    func testBeginReconfigureCommitsSizeSynchronouslyAndDedupsWhileInFlight() {
+    func testBeginReconfigureCommitsSizeSynchronouslyAndDedupsIdenticalTargets() {
         let session = makeSession(diagnostics: DiagnosticRecorder())
         let fake = FakeCaptureStream()
         session.stream = fake
@@ -304,18 +304,45 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         XCTAssertEqual(session.configuredPixelWidth, 900)
         XCTAssertEqual(session.configuredPixelHeight, 1900)
 
-        // A second frame while the update is in flight commits the size but does NOT
-        // spawn a second update — this is the storm dedup.
+        // A same-size frame while the update is in flight does NOT spawn a second
+        // update — this is the storm dedup.
         let second = session.beginReconfigure(width: 900, height: 1900)
         XCTAssertNil(second, "a reconfigure already in flight is deduped")
-        XCTAssertEqual(session.configuredPixelWidth, 900)
 
-        // Once the in-flight update completes, a genuinely new size reconfigures again.
-        session.endReconfigure()
+        // Applying the same size we committed releases the slot: nothing left to do.
+        let next = session.nextReconfigureTarget(applied: 900, 1900)
+        XCTAssertNil(next, "same target applied: the in-flight slot is released")
+
+        // With the slot released a genuinely new size reconfigures again.
         let third = session.beginReconfigure(width: 910, height: 1910)
         XCTAssertTrue(third === fake, "after the slot is released a new size reconfigures again")
-        XCTAssertEqual(session.configuredPixelWidth, 910)
+    }
+
+    func testReconfigureCoalescesToLatestTargetRequestedWhileInFlight() {
+        let session = makeSession(diagnostics: DiagnosticRecorder())
+        let fake = FakeCaptureStream()
+        session.stream = fake
+
+        // Update A (900x1900) claims the slot.
+        let streamForA = session.beginReconfigure(width: 900, height: 1900)
+        XCTAssertTrue(streamForA === fake)
+
+        // While A is applying, a newer rotation requests B (910x1910). It is deduped
+        // (no second concurrent update) but the newer target is committed.
+        let deduped = session.beginReconfigure(width: 910, height: 1910)
+        XCTAssertNil(deduped, "no overlapping update while one is in flight")
+        XCTAssertEqual(session.configuredPixelWidth, 910, "the newer target is committed")
         XCTAssertEqual(session.configuredPixelHeight, 1910)
+
+        // When A completes, the loop must NOT stop — the committed target drifted to B,
+        // so B is returned to be applied next (coalesce-to-latest; B is never dropped).
+        let afterA = session.nextReconfigureTarget(applied: 900, 1900)
+        XCTAssertEqual(afterA?.width, 910, "the latest requested target B is applied after A")
+        XCTAssertEqual(afterA?.height, 1910)
+
+        // After B is applied and nothing newer arrived, the slot is released.
+        let afterB = session.nextReconfigureTarget(applied: 910, 1910)
+        XCTAssertNil(afterB, "target B applied, no newer target: slot released")
     }
 
     func testBeginReconfigureWithoutStreamReturnsNilAndLeavesSizeUnset() {


### PR DESCRIPTION
## Summary

The screen-capture helper's two capture sessions mutated frame-path state across the SCK/AVFoundation
**frame queue**, **MainActor** (start/stop), and the **cooperative pool** (reconfigure `Task`) with no
synchronization — while their siblings (`FrameWriter`, `FirstFrameSignal`, `StartRaceState`) are
correctly `NSLock`-guarded. This fixes the three resulting races, confined to the two session files.

**Race 1 — reconfigure data race + storm (`SimulatorCaptureSession`).** `didOutputSampleBuffer` read
`configuredPixelWidth/Height` on the frame queue while `performReconfiguration` wrote them from a
detached cooperative-pool `Task` — a non-atomic `Int` write/read data race — and nothing deduped, so a
size change let frame N spawn one `updateConfiguration` while frame N+1 still saw the stale mismatch and
spawned another (a reconfigure storm).
Fixed with a `stateLock` guarding the dims + a reconfigure-in-flight flag: `beginReconfigure` commits
the new size **synchronously under the lock before** the async update is dispatched and returns `nil`
when an update is already in flight, so a same-size burst neither races the writes nor spawns overlapping
updates.

**Race 2 / Race 3 — teardown use-after-free (`SimulatorCaptureSession`, `DeviceCaptureSession`).**
`stop()` nil'd `pipeline` and tore the `H264VideoEncoder`/`VTCompressionSession` down on MainActor while
an in-flight frame callback on the frame queue was still calling `pipeline.encode`/`ensureEncoder` —
racing the `pipeline` reference and invalidating the encoder session underneath an in-flight encode.
Fixed by routing pipeline teardown **onto the frame queue** (`queue.sync { pipeline.stop() }` after
snapshotting under the lock): `queue.sync` waits for any executing frame callback to finish, so encode
and teardown are mutually exclusive. Because all encoder access is now serialized on the frame queue,
`EncodePipeline` and `H264VideoEncoder` need **no** changes — the encoder-session data race (Race 3) is
eliminated by serialization rather than a second lock, which also avoids the "encode on a
just-invalidated session" window a pointer-lock alone would leave.

`stateLock` is only ever snapshotted, never held across an `await` or the `queue.sync`.

## Linked Issue

Closes #5654

## Bug / Regression Context

- **Observed symptom:** data race on `configuredPixelWidth/Height` (UB) + redundant racing
  `updateConfiguration` calls on a size change; and an ARC/`VTCompressionSession` use-after-free when
  `stop()` (SIGTERM teardown) overlaps an in-flight frame.
- **Repro conditions:** device rotation / window resize during capture (Race 1); SIGTERM while a frame
  is mid-encode (Races 2/3).

## Validation

- [x] `swift test` for the screen-capture package: 135/135 pass (incl. 2 new dedup tests)
- [x] SwiftLint clean on all three touched files
- [x] Reconfigure dedup + synchronous size-commit are unit-tested through the `CaptureStream` seam (<100ms)
- [x] `EncodePipeline`/`H264VideoEncoder` unchanged; raw-BGRA path byte-for-byte unchanged

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

- `testBeginReconfigureCommitsSizeSynchronouslyAndDedupsWhileInFlight` — first frame commits the size
  synchronously and claims the slot; a second same-size frame commits but is deduped (no second update);
  after `endReconfigure` a new size reconfigures again.
- `testBeginReconfigureWithoutStreamReturnsNilAndLeavesSizeUnset` — no stream ⇒ no-op.
- Existing reconfigure success/retry/failure and stop/stream-teardown assertions still hold.

Note: `H264VideoEncoder`/VideoToolbox and the live pipeline teardown are device-only-untestable by
design (no headless VideoToolbox); the teardown-serialization fix is verified by reading (all encoder
access confined to the frame queue), with behavior covered by the existing pure-math and converter tests.
