### PR TITLE
fix(ios): report a failure when the installed-app listing fails

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -11,6 +11,8 @@ import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType"
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { ListInstalledApps } from "../observe/ListInstalledApps";
+import { getIosInstalledAppBundleId } from "../../utils/ios-cmdline-tools/iosInstalledApp";
 import { IOSCtrlProxyClient } from "../observe/ios";
 
 /**
@@ -242,18 +244,39 @@ export class TerminateApp extends BaseVisualChange {
   }
 
   /**
-   * Simulator terminate via simctl (unchanged from the original iOS path):
-   * check install via `simctl listapps`, then `simctl terminate`, treating a
-   * "nothing to terminate" error as wasRunning=false.
+   * Simulator terminate via simctl: check install via the shared
+   * `ListInstalledApps` listing, then `simctl terminate`, treating a "nothing
+   * to terminate" error as wasRunning=false.
+   *
+   * The listing goes through `executeIosDetailedResult()` so a listing that
+   * *failed* is distinguishable from a device that genuinely has no such app
+   * (issue #5621) — the same contract `UninstallApp` uses. Caching stays off so
+   * the pre-terminate check always reflects live device state.
    */
   private async terminateSimulator(
     bundleId: string,
     perf: ReturnType<typeof createGlobalPerformanceTracker>,
   ): Promise<TerminateAppResult> {
-    const installedApps = await perf.track("checkInstalled", () =>
-      this.simctl.listApps(this.device.deviceId),
-    );
-    const wasInstalled = installedApps.some((app) => this.getBundleId(app) === bundleId);
+    const listApps = new ListInstalledApps(this.device, { create: () => this.adb }, this.simctl, {
+      cacheEnabled: false,
+    });
+    const listing = await perf.track("checkInstalled", () => listApps.executeIosDetailedResult());
+
+    if (!listing.successful) {
+      // Omit wasInstalled/wasRunning: install state was never established, so
+      // reporting them as `false` would assert a fact we do not have.
+      return {
+        success: false,
+        packageName: bundleId,
+        wasForeground: false,
+        error:
+          `Could not determine whether ${bundleId} is installed on iOS device ` +
+          `${this.device.deviceId}: the installed-app listing failed. Confirm the device ` +
+          `is booted and that Xcode command line tools are available, then retry.`,
+      };
+    }
+
+    const wasInstalled = listing.apps.some((app) => getIosInstalledAppBundleId(app) === bundleId);
 
     if (!wasInstalled) {
       return {
@@ -339,21 +362,5 @@ export class TerminateApp extends BaseVisualChange {
         error: message,
       };
     }
-  }
-
-  private getBundleId(app: any): string | undefined {
-    if (!app || typeof app !== "object") {
-      return undefined;
-    }
-    if (typeof app.bundleId === "string" && app.bundleId.trim().length > 0) {
-      return app.bundleId;
-    }
-    if (typeof app.bundleIdentifier === "string" && app.bundleIdentifier.trim().length > 0) {
-      return app.bundleIdentifier;
-    }
-    if (typeof app.CFBundleIdentifier === "string" && app.CFBundleIdentifier.trim().length > 0) {
-      return app.CFBundleIdentifier;
-    }
-    return undefined;
   }
 }

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -8,6 +8,7 @@ import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/And
 import { UninstallAppResult } from "../../models/UninstallAppResult";
 import { BootedDevice } from "../../models";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
+import { getIosInstalledAppBundleId } from "../../utils/ios-cmdline-tools/iosInstalledApp";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppManager } from "../../utils/ios-cmdline-tools/DeviceAppManager";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
@@ -109,7 +110,24 @@ export class UninstallApp {
       const listApps = new ListInstalledApps(this.device, this.adbFactory, this.simctl, {
         cacheEnabled: false,
       });
-      const installed = (await listApps.execute()).find((app) => app === bundleId) !== undefined;
+      // `execute()` collapses a failed listing into an empty array, which reads
+      // as "the app is absent" and turns a broken listing into a silent
+      // success no-op (issue #5621). Consume the detailed result so a failed
+      // listing is reported as a failure instead.
+      const preCheck = await listApps.executeIosDetailedResult();
+      if (!preCheck.successful) {
+        return {
+          success: false,
+          packageName: bundleId,
+          keepData: false,
+          error:
+            `Could not determine whether ${bundleId} is installed on iOS device ` +
+            `${this.device.deviceId}: the installed-app listing failed. Confirm the device ` +
+            `is connected and unlocked and that Xcode command line tools are available, ` +
+            `then retry.`,
+        };
+      }
+      const installed = preCheck.apps.some((app) => getIosInstalledAppBundleId(app) === bundleId);
 
       if (!installed) {
         IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(
@@ -136,9 +154,18 @@ export class UninstallApp {
       await this.deviceAppUninstaller.uninstallApp(this.device.deviceId, bundleId, simulator);
       await this.markInstalledAppsCacheStale();
 
-      // Verify the app was uninstalled
+      // Verify the app was uninstalled. A listing that fails here is
+      // inconclusive rather than a contradiction: the uninstall command itself
+      // already succeeded, so trust it and only log the lost verification.
+      const verification = await listApps.executeIosDetailedResult();
+      if (!verification.successful) {
+        logger.warn(
+          `[UninstallApp] Could not verify removal of ${bundleId}: the post-uninstall listing failed; trusting the uninstall command`,
+        );
+      }
       const isStillInstalled =
-        (await listApps.execute()).find((app) => app === bundleId) !== undefined;
+        verification.successful &&
+        verification.apps.some((app) => getIosInstalledAppBundleId(app) === bundleId);
 
       if (isStillInstalled) {
         return {

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -177,13 +177,17 @@ export class ListInstalledApps {
     }
 
     try {
+      // `listAppsOrThrow` (not `listApps`) so a simctl listing that failed
+      // surfaces as successful:false instead of being collapsed into an empty
+      // array, which callers would read as "the app is absent" (issue #5621).
+      //
       // Only a positively physical-looking UDID routes to devicectl. Anything
       // else (simulator UUID, or a non-UDID id) keeps the simctl path, so an
       // unrecognized id degrades to today's behavior rather than shelling out
       // to a tool that cannot serve it.
       const apps = isIosPhysicalUdid(this.device.deviceId)
         ? await this.getIosPhysicalAppLister().listInstalledApps(this.device.deviceId)
-        : await this.simctl.listApps(this.device.deviceId);
+        : await this.simctl.listAppsOrThrow(this.device.deviceId);
       const appsByBundleId = new Map<string, IosInstalledAppRecord>();
       for (const app of apps) {
         if (!app || typeof app !== "object" || Array.isArray(app)) {

--- a/src/models/UninstallAppResult.ts
+++ b/src/models/UninstallAppResult.ts
@@ -6,7 +6,13 @@ import { BaseActionResult } from "./BaseActionResult";
 export interface UninstallAppResult extends BaseActionResult {
   packageName: string;
   keepData: boolean;
-  wasInstalled: boolean;
+  /**
+   * Whether the app was installed before the uninstall. Optional/omitted when
+   * the install state could not be established — e.g. an iOS installed-app
+   * listing that failed rather than reported an empty device (issue #5621).
+   * Always read `success` before trusting this field.
+   */
+  wasInstalled?: boolean;
   /** Android user ID where the app was uninstalled from (0 for primary user, 10+ for work profiles) */
   userId?: number;
 }

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -327,12 +327,23 @@ export function registerAppTools() {
         skipUiStability: true, // skip the 12+ second stability polling
       });
 
+      // A typed failure (e.g. an iOS installed-app listing that failed, or a
+      // devicectl termination error) must surface as an error rather than a
+      // response claiming the app was terminated — issue #5621. Mirrors the
+      // uninstall handler below.
+      if (!result.success) {
+        throw new ActionableError(result.error || `Failed to terminate app ${args.appId}`);
+      }
+
       return createJSONToolResponse({
         message: `Terminated app ${args.appId}`,
         observation: result.observation,
         ...result,
       });
     } catch (error) {
+      if (error instanceof ActionableError) {
+        throw error;
+      }
       throw new ActionableError(`Failed to terminate app: ${error}`);
     } finally {
       try {

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1758,53 +1758,69 @@ export class SimCtlClient implements SimCtl {
    * @returns Promise with array of app objects containing bundle identifiers and other metadata
    */
   async listApps(deviceId?: string): Promise<any[]> {
-    const targetDevice = deviceId || this.device?.deviceId || "booted";
-    logger.debug(`Listing installed apps on iOS simulator ${targetDevice}`);
-
     try {
-      const parseApps = (payload: string): any[] => {
-        const appsData = JSON.parse(payload);
-
-        if (Array.isArray(appsData)) {
-          return appsData;
-        }
-
-        if (!appsData || typeof appsData !== "object") {
-          return [];
-        }
-
-        // Convert the apps object to an array, preserving bundle IDs from keys.
-        return Object.entries(appsData).map(([bundleId, appInfo]) => {
-          const record = appInfo && typeof appInfo === "object" ? appInfo : {};
-          return { ...record, bundleId };
-        });
-      };
-
-      // simctl listapps may return an old-style plist instead of JSON (Xcode
-      // 26+). The plist owner receives the exact bytes over stdin, avoiding a
-      // shell pipe and a temporary host file.
-      const listAppsJson = async (args: string[]): Promise<string> => {
-        const result = await this.executeCommandArgs(["listapps", ...args]);
-        try {
-          JSON.parse(result.stdout);
-          return result.stdout;
-        } catch (error) {
-          logger.debug(`[iOS] listapps returned plist; converting with plutil: ${error}`);
-          return JSON.stringify(await this.plist.readJsonBytes(Buffer.from(result.stdout, "utf8")));
-        }
-      };
-
-      try {
-        return parseApps(await listAppsJson([targetDevice, "--all"]));
-      } catch (error) {
-        logger.warn(`Failed to list iOS apps with --all: ${error}`);
-      }
-
-      return parseApps(await listAppsJson([targetDevice]));
+      return await this.listAppsOrThrow(deviceId);
     } catch (error) {
+      // Legacy lenient contract: callers of `listApps` treat an unavailable
+      // listing as "no apps". Callers that must distinguish a failed listing
+      // from an empty device use `listAppsOrThrow` instead (issue #5621).
       logger.warn(`Failed to list iOS apps: ${error}`);
       return [];
     }
+  }
+
+  /**
+   * List installed apps, propagating a listing failure instead of collapsing it
+   * into an empty array. `listApps` swallows the error for its existing
+   * callers; consumers that must tell "the listing failed" apart from "the
+   * device has no such app" — the install pre-checks in `UninstallApp` and
+   * `TerminateApp` — call this variant (issue #5621).
+   * @param deviceId - Optional device ID (defaults to "booted" for current booted simulator)
+   * @returns Promise with array of app objects containing bundle identifiers and other metadata
+   */
+  async listAppsOrThrow(deviceId?: string): Promise<any[]> {
+    const targetDevice = deviceId || this.device?.deviceId || "booted";
+    logger.debug(`Listing installed apps on iOS simulator ${targetDevice}`);
+
+    const parseApps = (payload: string): any[] => {
+      const appsData = JSON.parse(payload);
+
+      if (Array.isArray(appsData)) {
+        return appsData;
+      }
+
+      if (!appsData || typeof appsData !== "object") {
+        return [];
+      }
+
+      // Convert the apps object to an array, preserving bundle IDs from keys.
+      return Object.entries(appsData).map(([bundleId, appInfo]) => {
+        const record = appInfo && typeof appInfo === "object" ? appInfo : {};
+        return { ...record, bundleId };
+      });
+    };
+
+    // simctl listapps may return an old-style plist instead of JSON (Xcode
+    // 26+). The plist owner receives the exact bytes over stdin, avoiding a
+    // shell pipe and a temporary host file.
+    const listAppsJson = async (args: string[]): Promise<string> => {
+      const result = await this.executeCommandArgs(["listapps", ...args]);
+      try {
+        JSON.parse(result.stdout);
+        return result.stdout;
+      } catch (error) {
+        logger.debug(`[iOS] listapps returned plist; converting with plutil: ${error}`);
+        return JSON.stringify(await this.plist.readJsonBytes(Buffer.from(result.stdout, "utf8")));
+      }
+    };
+
+    try {
+      return parseApps(await listAppsJson([targetDevice, "--all"]));
+    } catch (error) {
+      logger.warn(`Failed to list iOS apps with --all: ${error}`);
+    }
+
+    return parseApps(await listAppsJson([targetDevice]));
   }
 
   /**

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -22,6 +22,7 @@ type FakeSimCtlClientContract = Pick<
   | "getDeviceTypes"
   | "getRuntimes"
   | "listApps"
+  | "listAppsOrThrow"
   | "terminateApp"
   | "openSimulatorApp"
   | "pushNotification"
@@ -219,6 +220,11 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
 
   async listApps(deviceId?: string): Promise<any[]> {
     this.recordCall("listApps", { deviceId });
+    return this.installedApps;
+  }
+
+  async listAppsOrThrow(deviceId?: string): Promise<any[]> {
+    this.recordCall("listAppsOrThrow", { deviceId });
     return this.installedApps;
   }
 

--- a/test/fakes/FakeSimctl.ts
+++ b/test/fakes/FakeSimctl.ts
@@ -279,6 +279,15 @@ export class FakeSimctl implements ISimCtl {
 
   async listApps(deviceId?: string): Promise<any[]> {
     this.recordCall("listApps", { deviceId });
+    // Mirrors production: the lenient variant swallows a listing failure.
+    if (this.listAppsError) {
+      return [];
+    }
+    return this.installedApps;
+  }
+
+  async listAppsOrThrow(deviceId?: string): Promise<any[]> {
+    this.recordCall("listAppsOrThrow", { deviceId });
     if (this.listAppsError) {
       throw this.listAppsError;
     }

--- a/test/fakes/FakeSimctl.ts
+++ b/test/fakes/FakeSimctl.ts
@@ -19,6 +19,7 @@ export class FakeSimctl implements ISimCtl {
   private deviceTypes: AppleDeviceType[] = [];
   private runtimes: AppleDeviceRuntime[] = [];
   private installedApps: any[] = [];
+  private listAppsError: Error | null = null;
   private launchAppResult: {
     success: boolean;
     pid?: number;
@@ -85,6 +86,15 @@ export class FakeSimctl implements ISimCtl {
    */
   setInstalledApps(apps: any[]): void {
     this.installedApps = apps;
+  }
+
+  /**
+   * Configure `listApps` to fail, modelling a simctl listing that could not be
+   * produced (locked/disconnected device, unavailable Xcode) as distinct from a
+   * device that genuinely has no matching app installed.
+   */
+  setListAppsError(error: Error | null): void {
+    this.listAppsError = error;
   }
 
   /**
@@ -269,6 +279,9 @@ export class FakeSimctl implements ISimCtl {
 
   async listApps(deviceId?: string): Promise<any[]> {
     this.recordCall("listApps", { deviceId });
+    if (this.listAppsError) {
+      throw this.listAppsError;
+    }
     return this.installedApps;
   }
 

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -112,6 +112,23 @@ describe("TerminateApp (iOS)", () => {
     expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
   });
 
+  test("reports a failure instead of a no-op when the installed-app listing fails", async () => {
+    // A locked/disconnected device or an unavailable Xcode makes the listing
+    // fail. That is not "the app is absent" — terminating must not silently
+    // report success (issue #5621).
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+    fakeSimctl.setListAppsError(new Error("Unable to boot device in current state"));
+
+    const terminateApp = new TerminateApp(iosDevice, null, fakeSimctl, fakeTimer);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("com.example.app");
+    expect(result.wasInstalled).toBeUndefined();
+    expect(result.wasRunning).toBeUndefined();
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
+  });
+
   test("detects install when bundleIdentifier is provided", async () => {
     fakeSimctl.setInstalledApps([{ bundleIdentifier: "com.example.app" }]);
 

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -569,3 +569,62 @@ describe("UninstallApp (Android)", () => {
     expect(result.error).toBe("Invalid package name provided");
   });
 });
+
+describe("UninstallApp (iOS listing failure)", () => {
+  // Issue #5621: `ListInstalledApps.execute()` collapses "listing failed" into
+  // an empty array, so a failed listing used to read as "app is absent" and the
+  // uninstall silently no-op'd with success:true.
+  const iosSimDevice: BootedDevice = {
+    deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  let fakeSimctl: FakeSimctl;
+  let fakeUninstaller: FakeDeviceAppUninstaller;
+
+  beforeEach(() => {
+    fakeSimctl = new FakeSimctl();
+    fakeUninstaller = new FakeDeviceAppUninstaller();
+  });
+
+  test("reports a failure instead of a success no-op when the listing fails", async () => {
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+    fakeSimctl.setListAppsError(new Error("Unable to boot device in current state"));
+
+    const uninstall = new UninstallApp(iosSimDevice, nullAdbFactory, fakeSimctl, fakeUninstaller);
+    const result = await uninstall.execute("com.example.app");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("com.example.app");
+    expect(result.wasInstalled).toBeUndefined();
+    // The destructive step must not run on an unknown install state.
+    expect(fakeUninstaller.calls).toHaveLength(0);
+  });
+
+  test("preserves the not-installed result when the listing succeeds and the app is absent", async () => {
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.other" }]);
+
+    const uninstall = new UninstallApp(iosSimDevice, nullAdbFactory, fakeSimctl, fakeUninstaller);
+    const result = await uninstall.execute("com.example.app");
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(false);
+    expect(fakeUninstaller.calls).toHaveLength(0);
+  });
+
+  test("uninstalls when the listing succeeds and the app is present", async () => {
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+    fakeUninstaller.uninstallApp = async (deviceUdid, bundleId, isSimulator) => {
+      fakeUninstaller.calls.push({ deviceUdid, bundleId, isSimulator });
+      fakeSimctl.setInstalledApps([]);
+    };
+
+    const uninstall = new UninstallApp(iosSimDevice, nullAdbFactory, fakeSimctl, fakeUninstaller);
+    const result = await uninstall.execute("com.example.app");
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(fakeUninstaller.calls).toHaveLength(1);
+  });
+});

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -349,7 +349,7 @@ describe("ListInstalledApps", function () {
           bundlePath: "/Applications/Cached.app",
         },
       ]);
-      expect(simctl.getMethodCallCount("listApps")).toBe(1);
+      expect(simctl.getMethodCallCount("listAppsOrThrow")).toBe(1);
     });
 
     test("normalizes all supported iOS bundle ID fields", async function () {
@@ -642,7 +642,7 @@ describe("ListInstalledApps physical iOS devices", function () {
 
     await expect(list.execute()).resolves.toEqual(["com.example.device", "com.example.other"]);
     expect(lister.calls).toEqual([PHYSICAL_UDID]);
-    expect(simctl.getMethodCallCount("listApps")).toBe(0);
+    expect(simctl.getMethodCallCount("listAppsOrThrow")).toBe(0);
   });
 
   test("preserves devicectl app metadata in the detailed result", async function () {

--- a/test/utils/ios-cmdline-tools/simctl-client.listApps.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.listApps.test.ts
@@ -115,4 +115,37 @@ describe("SimCtlClient listApps", () => {
     expect(calls.some((call) => call.startsWith("plutil "))).toBe(false);
     expect(apps).toEqual([{ bundleId: "com.apple.Maps", bundleName: "Maps" }]);
   });
+
+  // Issue #5621: `listApps` keeps its lenient "failure reads as no apps"
+  // contract for existing callers, but the install pre-checks in UninstallApp /
+  // TerminateApp need the failure preserved, so `listAppsOrThrow` propagates it.
+  const failingSimctl = (deviceId: string): SimCtlClient => {
+    const device: BootedDevice = {
+      deviceId,
+      name: "iOS Device",
+      platform: "ios",
+      source: "local",
+    };
+    const execAsync = async (file: string, args: string[]) => {
+      if (args.join(" ") === "simctl --version") {
+        return createExecResult("simctl version 1.0.0", "");
+      }
+      throw new Error("Unable to boot device in current state");
+    };
+    return new SimCtlClient(device, execAsync);
+  };
+
+  test("listAppsOrThrow propagates a listing failure", async () => {
+    const simctl = failingSimctl("ios-device-fails");
+
+    await expect(simctl.listAppsOrThrow()).rejects.toThrow(
+      "Unable to boot device in current state",
+    );
+  });
+
+  test("listApps still collapses a listing failure into an empty array", async () => {
+    const simctl = failingSimctl("ios-device-fails-lenient");
+
+    expect(await simctl.listApps()).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes [#5621](https://github.com/kaeawc/auto-mobile/issues/5621).

## Problem

`ListInstalledApps.execute()` collapses "the listing failed" into an empty array, dropping the `successful` flag that `executeIosDetailedResult()` already carries. Callers that pre-check installation through `execute()` therefore read a failed listing as "the app is absent":

- `UninstallApp.executeiOS` concluded not-installed and returned `{ success: true, wasInstalled: false }` without attempting the uninstall.
- `TerminateApp.terminateSimulator` called `simctl.listApps` directly, so a failed listing escaped as an unstructured throw rather than the typed failure the physical path already returns.

With the devicectl listing from [#5619](https://github.com/kaeawc/auto-mobile/pull/5619) in place this is newly reachable on hardware: a locked/disconnected device or an unavailable Xcode makes the listing fail rather than trivially return `[]`.

The same collapse turned out to exist one layer lower, and at the MCP boundary above — both found in review and fixed here (see the last two bullets).

## Change

- **Uninstall** — a failed pre-check listing returns an actionable `success: false`, and the destructive uninstall does not run on an unknown install state. The *post*-uninstall verification listing is treated as inconclusive rather than contradictory: the uninstall command already succeeded, so a failed verification only logs a warning instead of flipping the result.
- **Terminate** — the simulator path routes through the same shared `ListInstalledApps` listing, so a failed listing becomes a typed `success: false` with an actionable message. Its local `getBundleId` duplicate is dropped in favor of the shared `getIosInstalledAppBundleId` helper, which is a superset (it also handles the `bundleID` spelling).
- `UninstallAppResult.wasInstalled` becomes optional, matching `TerminateAppResult`. On a failed listing the install state was never established, so reporting `false` would assert a fact we do not have. The one consumer (`src/server/appTools.ts`) reads it only after checking `success`.
- **`SimCtlClient.listApps()` swallowed its own error and returned `[]`**, so on a real simulator the failure never reached `executeIosDetailedResult()` at all. The listing body moved to `listAppsOrThrow()`, which propagates; `listApps()` keeps the lenient contract for its four existing callers (`InstallApp`, `RestoreSnapshot`, `GetAppMetadata`, `appResources`), whose "no apps" fallback is unaffected.
- **`terminateAppHandler` never checked `result.success`**, so any typed failure — the new listing branch and the pre-existing devicectl branch alike — returned an MCP response reading "Terminated app …". It now throws an `ActionableError` carrying `result.error`, mirroring `uninstallAppHandler`.

Successful-listing behavior is unchanged: app absent still yields `{ success: true, wasInstalled: false }`, app present still uninstalls/terminates.

## Tests

`FakeSimctl` gains a `setListAppsError` seam and mirrors the production split (lenient `listApps` swallows, `listAppsOrThrow` throws), so "the listing failed" is expressible without a device. Tests were written failing first:

- `test/features/action/UninstallApp.test.ts` — new `UninstallApp (iOS listing failure)` describe covering all three states: listed, absent, listing-failed.
- `test/features/action/TerminateApp.test.ts` — listing-failure asserts no `terminateApp` call and omitted `wasInstalled`/`wasRunning`.
- `test/utils/ios-cmdline-tools/simctl-client.listApps.test.ts` — drives the exec seam to fail: `listAppsOrThrow` rejects, `listApps` still returns `[]`.

One gap noted honestly: `terminateAppHandler` constructs `new TerminateApp(device)` with no injection seam, so the handler guard has no handler-level test. Adding one means introducing a DI seam in `appTools.ts`, which is beyond this issue; the behavior it guards is unit tested at the `TerminateApp` layer.

Validation: `bun test` 14285 pass / 0 fail, `bun run typecheck` (no new errors), `bun run lint` (no new violations, 13/13 boundary checks), `bun run format:check`, `bun run build`.

## Manual verification needed

The behavior change is proven by unit tests with fakes, but the *real* trigger — a physical iOS device whose `devicectl` listing fails while locked or disconnected, or a simulator whose `simctl listapps` fails — has not been exercised on hardware. Worth confirming on a device that the failure message surfaces through the `uninstallApp`/`terminateApp` MCP tools rather than a silent no-op.