### PR TITLE
fix(observe): DeviceServiceClient.close() double-fires onConnectionClosed()

### DIFF
--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -266,11 +266,24 @@ export abstract class DeviceServiceClient {
 
       if (this.ws) {
         logger.info(`[${this.logTag}] Closing WebSocket connection`);
-        this.ws.close();
+        const socket = this.ws;
         this.ws = null;
+        // Detach the lifecycle listeners installed in connectWebSocket() BEFORE
+        // closing, so the socket's async `close` event cannot drive a SECOND
+        // onConnectionClosed() after the synchronous call below (issue #5657).
+        // Mirrors updatePort() and the discarded-socket path in connectWebSocket().
+        socket.removeAllListeners();
+        // Keep a lone error listener: a socket torn down mid-handshake can still
+        // emit "error", and an EventEmitter with no "error" listener THROWS,
+        // which would crash the daemon. The socket is going away, so the error
+        // is expected and needs no state mutation.
+        socket.on("error", (error) => {
+          logger.debug(`[${this.logTag}] Ignoring error on closed WebSocket: ${error}`);
+        });
+        socket.close();
       }
 
-      // Platform-specific cleanup
+      // Platform-specific cleanup — fires exactly once per close().
       this.onConnectionClosed();
     } catch (error) {
       logger.warn(`[${this.logTag}] Error during close: ${error}`);

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1894,9 +1894,11 @@ describe("AndroidCtrlProxyClient", function () {
         await resultPromise;
         await settleNavigationHierarchyInterleaving(testTimer);
 
-        // The navigation write and the CtrlProxy-close cache invalidation both
-        // register with the shared shutdown barrier.
-        expect(trackExistingSpy).toHaveBeenCalledTimes(2);
+        // The single navigation write registers with the shared shutdown barrier.
+        // (This previously asserted 2, silently absorbing a leaked second
+        // onConnectionClosed() from a prior test's close() — the #5657
+        // double-fire. With that fixed, only this test's own nav write counts.)
+        expect(trackExistingSpy).toHaveBeenCalledTimes(1);
         // Ordering still preserved: the write committed the SDK screen name.
         expect(navManager.getCurrentScreen()).toBe("SdkHome");
       } finally {

--- a/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { IOSCtrlProxyClient } from "../../../../src/features/observe/ios";
+import { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import type { DeviceConnectionLostNotifier } from "../../../../src/features/observe/DeviceConnectionLostNotifier";
+
+/**
+ * Pins single-cycle onConnectionClosed() semantics for issue #5657:
+ *
+ * - An explicit close() must drive exactly ONE onConnectionClosed() cycle, not
+ *   two (the synchronous call inside close() PLUS the socket's async `close`
+ *   event whose listeners were never detached).
+ * - An unsolicited socket drop (only the `close` event, no close() call) must
+ *   still drive exactly one cycle — no regression to the real-drop path.
+ *
+ * onDeviceConnectionLost fan-out is the public-observable side-effect of the
+ * cycle (it and consecutiveConnectionFailures++ live in the same
+ * onConnectionClosed() body), so its call count pins the cycle count.
+ */
+
+const testDevice: BootedDevice = {
+  deviceId: "test-sim-id",
+  platform: "ios",
+  name: "Test iPhone",
+};
+
+function createCountingNotifier(): DeviceConnectionLostNotifier & { count: number } {
+  const notifier = {
+    count: 0,
+    onDeviceConnectionLost(_deviceId: string): void {
+      notifier.count++;
+    },
+  };
+  return notifier;
+}
+
+/** Flush the FakeWebSocket's real-setImmediate close-handshake emit. */
+function flushSetImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("DeviceServiceClient close() single onConnectionClosed cycle (#5657)", () => {
+  let client: IOSCtrlProxyClient | null = null;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    // A connected iOS client polls the runner's /sdk-events endpoint on
+    // onConnectionEstablished(). Stub fetch so the unit test makes no real
+    // network call and leaks no polling handles into sibling suites.
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      ok: true,
+      json: async () => [],
+    })) as unknown as typeof fetch;
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = null;
+    }
+    globalThis.fetch = originalFetch;
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  test("explicit close() fires onDeviceConnectionLost exactly once", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const notifier = createCountingNotifier();
+
+    client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      (url) => new FakeWebSocket(url, "none", 0, fakeTimer),
+      fakeTimer,
+      undefined,
+      undefined,
+      notifier,
+    );
+
+    // Establish a real (fake) socket so close() has a live socket to tear down.
+    const connected = await client.ensureConnected();
+    expect(connected).toBe(true);
+
+    await client.close();
+    // Let the socket's async close-handshake emit fire; without the fix its
+    // still-attached `close` listener would drive a SECOND onConnectionClosed().
+    await flushSetImmediate();
+    await flushSetImmediate();
+
+    expect(notifier.count).toBe(1);
+    // afterEach's close() on an already-closed client must not re-fire the hook.
+    client = null;
+  });
+
+  test("unsolicited socket drop fires onDeviceConnectionLost exactly once", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const notifier = createCountingNotifier();
+
+    let socket: FakeWebSocket | null = null;
+    client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      (url) => {
+        socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+        return socket;
+      },
+      fakeTimer,
+      undefined,
+      undefined,
+      notifier,
+    );
+
+    const connected = await client.ensureConnected();
+    expect(connected).toBe(true);
+    expect(socket).not.toBeNull();
+
+    // Simulate a genuine network drop: the socket emits `close` on its own,
+    // no close() call. This must route through the ws.on("close") handler once.
+    socket!.emit("close");
+    await flushSetImmediate();
+
+    expect(notifier.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`DeviceServiceClient.close()` invoked the platform `onConnectionClosed()` hook **twice** for a single deliberate close: once synchronously inside `close()`, and again from the underlying socket's async `close` event, whose listeners were never removed. On the iOS subclass this double-counted `consecutiveConnectionFailures` and double-fired the device-connection-lost notification per close.

The fix detaches the socket's lifecycle listeners in `close()` before closing it — keeping a lone `error` listener so a mid-handshake error on the torn-down socket can't crash the daemon (an `EventEmitter` with no `error` listener throws) — then keeps the single synchronous `onConnectionClosed()` call. This mirrors `updatePort()` and the discarded-socket path introduced for the stale-port race ([#5649](https://github.com/kaeawc/auto-mobile/pull/5649)), so a closed/discarded socket can never drive a second `onConnectionClosed`. Genuine unsolicited drops still route through the `close` event only and correctly count once — no regression.

## Linked Issue

Closes #5657

## Bug / Regression Context

- **Observed symptom:** a single deliberate `close()` incremented `consecutiveConnectionFailures` by two and fired `deviceConnectionLost` twice, and could push the counter to a `MAX_FAILURES_BEFORE_RESTART` multiple — entering `triggerServiceRestart()` on an intentional teardown (previously no-oping only incidentally because `manager.isRunning()` was typically true).
- **Repro steps / conditions:** open the iOS CtrlProxy WebSocket, then call `close()`. The socket's async `close` event re-entered `onConnectionClosed()`.
- **Root cause:** `close()` did not `removeAllListeners()` on the socket (unlike `updatePort()`), so the `ws.on("close")` handler from `connectWebSocket()` still fired after the synchronous hook.

## Validation

- [x] `bun run turbo:validate` passes (lint + build + test + boundary checks; 14281 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate; 174 known)
- [x] New unit test uses injected `WebSocketFactory` + `FakeTimer`, runs in <100ms
- [x] New generic code reuses existing repo teardown pattern (no new dependency)

## Acceptance criteria

1. **A single `close()` yields exactly one `onConnectionClosed()` cycle** — pinned by `explicit close() fires onDeviceConnectionLost exactly once`.
2. **An unsolicited socket drop still yields exactly one cycle** — pinned by `unsolicited socket drop fires onDeviceConnectionLost exactly once`.
3. **Double-invocation eliminated at the transport layer** (listener detach in `close()`), not by per-subclass idempotency.
4. **Unit test with injected `WebSocketFactory` + `FakeTimer`, <100ms** — `test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts`.

A neighboring `#2885` DB-write-barrier test was silently absorbing the leaked second `onConnectionClosed()` from a prior test's `close()` as part of its own count; it now asserts `1` and passes both in-suite and in isolation (order-independent).
