### PR TITLE
fix(ios-sdk): guard torn-reference fields under existing locks (currentScreenProvider, persistence/retryPolicy)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
@@ -34,8 +34,13 @@ public final class AutoMobileCrashes: @unchecked Sendable {
         }
         set {
             lock.lock()
+            let old = _currentScreenProvider
             _currentScreenProvider = newValue
             lock.unlock()
+            // Release the replaced closure AFTER unlocking: if it owned the last
+            // reference to an object whose deinit re-enters this lock, releasing it
+            // under the lock would deadlock (the non-recursive lock is not re-entrant).
+            withExtendedLifetime(old) {}
         }
     }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
@@ -21,7 +21,23 @@ public final class AutoMobileCrashes: @unchecked Sendable {
     private static let monitoredSignals: [Int32] = [SIGABRT, SIGSEGV, SIGBUS, SIGFPE, SIGILL]
 
     /// Provide a closure that returns the current screen name for crash context.
-    public var currentScreenProvider: (@Sendable () -> String?)?
+    /// Read in the exception handler and written from arbitrary threads (host app,
+    /// `reset()`), so it is serialized by `lock` — reference/Optional assignment is
+    /// not atomic in Swift's memory model (issue #3632), and every other field in
+    /// this class is already lock-guarded.
+    private var _currentScreenProvider: (@Sendable () -> String?)?
+    public var currentScreenProvider: (@Sendable () -> String?)? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _currentScreenProvider
+        }
+        set {
+            lock.lock()
+            _currentScreenProvider = newValue
+            lock.unlock()
+        }
+    }
 
     /// The process-global uncaught-exception handler that routes to this class.
     private static let uncaughtExceptionHandler: @convention(c) (NSException) -> Void = { exception in
@@ -119,11 +135,14 @@ public final class AutoMobileCrashes: @unchecked Sendable {
         lock.lock()
         let currentBuffer = buffer
         let previousHandler = previousExceptionHandler
+        // Snapshot the provider under the lock; invoke it below, outside the lock,
+        // so the (host-supplied) closure can never re-enter the non-recursive lock.
+        let screenProvider = _currentScreenProvider
         lock.unlock()
 
         if enabled {
             let currentBundleId = bundleId ?? Bundle.main.bundleIdentifier ?? ""
-            let currentScreen = currentScreenProvider?()
+            let currentScreen = screenProvider?()
             let stackTrace = exception.callStackSymbols.joined(separator: "\n")
 
             let event = SdkCrashEvent(
@@ -163,7 +182,9 @@ public final class AutoMobileCrashes: @unchecked Sendable {
         // if initialize() is called again (e.g. between tests)
         let prevHandler = previousExceptionHandler
         previousExceptionHandler = nil
-        currentScreenProvider = nil
+        // Direct backing-field write: we already hold `lock` here, and the computed
+        // `currentScreenProvider` setter would re-acquire the non-recursive lock.
+        _currentScreenProvider = nil
         // Note: signal handlers cannot be safely uninstalled, leave installedSignalHandlers as-is
         lock.unlock()
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -57,8 +57,12 @@ final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
         }
         set {
             configLock.lock()
-            defer { configLock.unlock() }
+            let old = _persistence
             _persistence = newValue
+            configLock.unlock()
+            // Release the replaced persistence AFTER unlocking, in case its deinit
+            // re-enters this lock (the non-recursive lock is not re-entrant).
+            withExtendedLifetime(old) {}
         }
     }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -25,28 +25,46 @@ final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
     /// and written from arbitrary threads (`setCtrlProxyUrl`), so all access is
     /// serialized by a lock — Optional/reference assignment is not atomic in
     /// Swift's memory model (issue #3632).
-    private let ctrlProxyUrlLock = NSLock()
+    /// Guards the cross-thread config references (`_ctrlProxyUrl`, `_persistence`),
+    /// read on the event buffer's flush thread and the URLSession completion handler
+    /// while written from arbitrary threads — Optional/reference assignment is not
+    /// atomic in Swift's memory model (issue #3632).
+    private let configLock = NSLock()
     private var _ctrlProxyUrl: URL?
     var ctrlProxyUrl: URL? {
         get {
-            ctrlProxyUrlLock.lock()
-            defer { ctrlProxyUrlLock.unlock() }
+            configLock.lock()
+            defer { configLock.unlock() }
             return _ctrlProxyUrl
         }
         set {
-            ctrlProxyUrlLock.lock()
-            defer { ctrlProxyUrlLock.unlock() }
+            configLock.lock()
+            defer { configLock.unlock() }
             _ctrlProxyUrl = newValue
         }
     }
 
     private let urlSession: URLSession
 
-    /// Disk-first event persistence for reliable delivery.
-    var persistence: (any EventPersisting)?
+    /// Disk-first event persistence for reliable delivery. Same cross-thread access
+    /// pattern as `ctrlProxyUrl`, so it is guarded by the same `configLock`.
+    private var _persistence: (any EventPersisting)?
+    var persistence: (any EventPersisting)? {
+        get {
+            configLock.lock()
+            defer { configLock.unlock() }
+            return _persistence
+        }
+        set {
+            configLock.lock()
+            defer { configLock.unlock() }
+            _persistence = newValue
+        }
+    }
 
-    /// Retry policy for failed HTTP delivery.
-    var retryPolicy: RetryPolicy = RetryPolicy()
+    /// Retry policy for failed HTTP delivery. A `Sendable` value type that is never
+    /// reassigned, so `let` makes cross-thread reads race-free with no lock.
+    let retryPolicy = RetryPolicy()
 
     private init() {
         let config = URLSessionConfiguration.default

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
@@ -64,4 +64,41 @@ final class CrashesTests: XCTestCase {
         }
         XCTAssertNotNil(crashes.currentScreenProvider)
     }
+
+    /// Replacing the provider must release the previous closure OUTSIDE the lock. If a
+    /// captured object's `deinit` re-enters the (non-recursive) lock, releasing the old
+    /// closure while still holding it would deadlock. This test would hang on a setter
+    /// that releases under the lock; it passes only with release-after-unlock.
+    func testReplacingProviderReleasesOldClosureWithoutDeadlock() {
+        let crashes = AutoMobileCrashes.makeTestInstance()
+
+        final class ReentrantSentinel {
+            let crashes: AutoMobileCrashes
+            let onDeinit: () -> Void
+            init(_ crashes: AutoMobileCrashes, onDeinit: @escaping () -> Void) {
+                self.crashes = crashes
+                self.onDeinit = onDeinit
+            }
+            deinit {
+                // Re-enter the lock via the getter as the closure is released.
+                _ = crashes.currentScreenProvider
+                onDeinit()
+            }
+        }
+
+        var deinitRan = false
+        var sentinel: ReentrantSentinel? = ReentrantSentinel(crashes) { deinitRan = true }
+        crashes.currentScreenProvider = { [sentinel] in
+            _ = sentinel
+            return "a"
+        }
+        sentinel = nil // the provider closure now holds the only reference
+
+        // Replacing the provider releases the old closure → sentinel.deinit re-enters
+        // the getter. With release-under-lock this deadlocks; with the fix it returns.
+        crashes.currentScreenProvider = { "b" }
+
+        XCTAssertTrue(deinitRan, "the replaced closure's captured object was released")
+        XCTAssertEqual(crashes.currentScreenProvider?(), "b")
+    }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
@@ -51,4 +51,17 @@ final class CrashesTests: XCTestCase {
         XCTAssertTrue(crashes.isInitialized)
         crashes.reset()
     }
+
+    /// Concurrent get/set/invoke of `currentScreenProvider` must not race. It was a
+    /// plain `public var` read in the exception handler while written from arbitrary
+    /// threads (#3632) — now serialized by the class lock, snapshotted before use.
+    func testCurrentScreenProviderConcurrentAccessDoesNotCrash() {
+        let crashes = AutoMobileCrashes.makeTestInstance()
+        DispatchQueue.concurrentPerform(iterations: 2_000) { i in
+            crashes.currentScreenProvider = { "screen-\(i % 100)" }
+            _ = crashes.currentScreenProvider
+            _ = crashes.currentScreenProvider?()
+        }
+        XCTAssertNotNil(crashes.currentScreenProvider)
+    }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
@@ -14,6 +14,19 @@ final class SdkEventBroadcasterTests: XCTestCase {
         XCTAssertNotNil(broadcaster.ctrlProxyUrl)
     }
 
+    /// Concurrent get/set of `persistence` must not race. It was a plain `var` read
+    /// on the flush thread and the URLSession completion handler while written from
+    /// the config/shutdown threads (#3632) — now guarded by the same config lock.
+    func testPersistenceConcurrentAccessDoesNotCrash() {
+        let broadcaster = SdkEventBroadcaster.makeTestInstance()
+        let fakes = (0..<8).map { _ in FakeEventPersistence() }
+        DispatchQueue.concurrentPerform(iterations: 2_000) { i in
+            broadcaster.persistence = fakes[i % fakes.count]
+            _ = broadcaster.persistence
+        }
+        XCTAssertNotNil(broadcaster.persistence)
+    }
+
     func testSetCtrlProxyUrlUpdatesValue() {
         let broadcaster = SdkEventBroadcaster.makeTestInstance()
         let url = URL(string: "http://localhost:9999/sdk-events")


### PR DESCRIPTION
## Summary

Two SDK managers lock-guarded most of their mutable state but left one cross-thread reference field
bare — the torn-reference data race the repo already named in issue #3632 (Optional/reference
assignment is not atomic in Swift's memory model). This guards those fields under the existing locks.

- **`AutoMobileCrashes.currentScreenProvider`** — was a bare `public var` read in the exception handler
  (`currentScreenProvider?()`) while written from arbitrary threads, though every other field in the
  class is `lock`-guarded. Now a lock-guarded computed property over a private backing field; the
  exception handler snapshots the provider under the *existing* locked region and invokes the closure
  outside the lock (so a host-supplied closure can't re-enter the non-recursive lock), and `reset()`
  clears the backing field directly (already under the lock). Public `var` API is unchanged.
- **`SdkEventBroadcaster.persistence`** — was a bare `var` read on the flush thread and in the
  URLSession completion handler, assigned from the config/shutdown threads. Now guarded by the same
  lock as its sibling `ctrlProxyUrl` (renamed `ctrlProxyUrlLock` → `configLock` to cover both).
- **`SdkEventBroadcaster.retryPolicy`** — a `Sendable` value type (`struct RetryPolicy: Sendable`) that
  is never reassigned; changed `var` → `let`, so cross-thread reads are race-free with no lock (the
  strongest fix).

## Linked Issue

Closes #5661

## Bug / Regression Context

- **Observed symptom:** torn read of a reference/closure field concurrent with its assignment (UB /
  potential crash), at crash-report time (`currentScreenProvider`) and on the event flush/retry path
  (`persistence`).

## Validation

- [x] `swift test` for the SDK package: 298/298 pass (incl. 2 new concurrency-smoke tests)
- [x] `swift build -c release` clean (no Swift-6 `noasync` issues — locks are all in sync contexts)
- [x] SwiftLint clean (one pre-existing cyclomatic warning on an untouched function; non-strict gate)

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

- `testCurrentScreenProviderConcurrentAccessDoesNotCrash` and
  `testPersistenceConcurrentAccessDoesNotCrash` — mirror the existing
  `testCtrlProxyUrlConcurrentAccessDoesNotCrash` (`DispatchQueue.concurrentPerform`), the repo's
  established smoke test for this #3632 bug class; they exercise the lock and would trip TSan / crash
  on the pre-fix bare `var`.

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices through the normal SDK
build, not a same-PR artifact re-cut.
