### PR TITLE
feat(mcp): expose cross-platform storage capabilities by logical domain

### DIFF
--- a/src/features/storage/storageCapabilities.ts
+++ b/src/features/storage/storageCapabilities.ts
@@ -1,0 +1,446 @@
+/**
+ * Cross-platform storage capabilities by logical domain (issue #5602).
+ *
+ * Clients negotiate what storage operations are available for a selected device
+ * and app context instead of inferring them from platform names or parsing failed
+ * operations. This module is a pure, input-driven capability model: given a
+ * resolved {@link StorageCapabilityContext} it produces a deterministic
+ * {@link StorageCapabilitiesReport}. The MCP resource layer
+ * (`src/server/storageCapabilityResources.ts`) resolves the context from a booted
+ * device and delegates the reasoning here so the state machine is fully testable
+ * without devices, sockets, or a clock.
+ *
+ * Secure-state (Keychain / Core Data) policy is owned by #5161; this module reports
+ * the domain as an explicit extension point and never advertises secret export.
+ */
+
+/** Payload schema version. Bump when the report shape changes incompatibly. */
+export const STORAGE_CAPABILITIES_SCHEMA_VERSION = 1 as const;
+
+/** Logical storage domains, modeled independently of native paths. */
+export type StorageDomain =
+  | "app_containers"
+  | "user_files"
+  | "media_library"
+  | "key_value"
+  | "databases"
+  | "secure_state";
+
+/** Operations a domain may expose. */
+export type StorageOperation =
+  | "list"
+  | "read"
+  | "write"
+  | "namespace_reset"
+  | "media_indexing"
+  | "observe";
+
+/**
+ * Capability state for a single operation.
+ * - `supported`: available now for this device/app context.
+ * - `partial`: structurally available but gated by a prerequisite the descriptor
+ *   cannot verify ahead of time (e.g. debuggable build, authorization); the client
+ *   must satisfy the listed prerequisites.
+ * - `unavailable`: supported in principle but a known prerequisite is unmet right
+ *   now (fixable by enabling the SDK, connecting a session, etc.).
+ * - `unsupported`: the platform/device cannot perform it at all; not fixable by
+ *   configuration.
+ */
+export type CapabilityState = "supported" | "partial" | "unavailable" | "unsupported";
+
+/** Android emulator, iOS simulator, or a physical device of either platform. */
+export type StorageDeviceType = "emulator" | "simulator" | "physical";
+
+/**
+ * Resolved signals the capability model reasons over. Fields typed
+ * `boolean | undefined` are three-valued: `true`/`false` are verified,
+ * `undefined` means "unverified at descriptor time" and yields `partial`.
+ */
+export interface StorageCapabilityContext {
+  platform: "android" | "ios";
+  deviceType: StorageDeviceType;
+  /** AutoMobile SDK embedded with storage inspection enabled. */
+  embeddedSdk: boolean;
+  /** Active CtrlProxy runner session. */
+  sessionActive?: boolean;
+  /** App built debuggable (required for adb `run-as` file/db access). */
+  debuggableBuild?: boolean;
+  /** User granted the relevant storage authorization (media/shared storage). */
+  authorized?: boolean;
+  /** Android has an active, unlocked user/profile for the app. */
+  activeUserProfile?: boolean;
+  /**
+   * Opt-in app integration advertises iOS physical-device file access (#5602 AC3).
+   * Without it, iOS physical file behavior is unsupported.
+   */
+  iosFileIntegration?: boolean;
+  /** Optional app scope the report was computed for. */
+  appId?: string;
+}
+
+/** Capability of a single operation within a domain. */
+export interface OperationCapability {
+  operation: StorageOperation;
+  state: CapabilityState;
+  /** Human-readable explanation of the state. */
+  reason?: string;
+  /** Prerequisites the client must satisfy before the operation is available. */
+  prerequisites?: string[];
+}
+
+/** Capability of one logical domain. */
+export interface DomainCapability {
+  domain: StorageDomain;
+  /**
+   * Whether the domain behaves portably across platforms. `false` marks a
+   * platform-specific extension point (e.g. Android-only user files); it must not
+   * be treated as portable behavior (#5602: document extension points).
+   */
+  portable: boolean;
+  platformScope: "android" | "ios" | "cross-platform";
+  operations: OperationCapability[];
+  note?: string;
+}
+
+/** A documented platform-specific extension point. */
+export interface StorageExtensionPoint {
+  domain: StorageDomain;
+  platform: "android" | "ios";
+  description: string;
+}
+
+/** The full capability report for a device/app context. */
+export interface StorageCapabilitiesReport {
+  schemaVersion: typeof STORAGE_CAPABILITIES_SCHEMA_VERSION;
+  platform: "android" | "ios";
+  deviceType: StorageDeviceType;
+  appId?: string;
+  /** The resolved signals used to derive this report. */
+  context: {
+    embeddedSdk: boolean;
+    sessionActive?: boolean;
+    debuggableBuild?: boolean;
+    authorized?: boolean;
+    activeUserProfile?: boolean;
+    iosFileIntegration?: boolean;
+  };
+  domains: DomainCapability[];
+  extensionPoints: StorageExtensionPoint[];
+}
+
+// A prerequisite the descriptor evaluates. `satisfied === undefined` means
+// unverified at descriptor time (contributes a `partial` state, never a failure).
+interface Requirement {
+  label: string;
+  satisfied: boolean | undefined;
+}
+
+// Derive an operation state from a hard-unsupported reason plus AND-combined
+// requirements. Known-unmet requirements dominate (unavailable); an unverified
+// requirement degrades an otherwise-supported op to partial. This makes
+// conflicting inputs (e.g. embeddedSdk true but sessionActive false) resolve
+// deterministically to the most restrictive reachable state.
+function deriveOperation(
+  operation: StorageOperation,
+  hardUnsupportedReason: string | undefined,
+  requirements: Requirement[],
+  supportedReason?: string,
+): OperationCapability {
+  if (hardUnsupportedReason) {
+    return { operation, state: "unsupported", reason: hardUnsupportedReason };
+  }
+  const unmet = requirements.filter((requirement) => requirement.satisfied === false);
+  const unverified = requirements.filter((requirement) => requirement.satisfied === undefined);
+  if (unmet.length > 0) {
+    return {
+      operation,
+      state: "unavailable",
+      reason: `Missing prerequisite: ${unmet.map((requirement) => requirement.label).join(", ")}.`,
+      prerequisites: [...unmet, ...unverified].map((requirement) => requirement.label),
+    };
+  }
+  if (unverified.length > 0) {
+    return {
+      operation,
+      state: "partial",
+      reason: `Available pending verification of: ${unverified
+        .map((requirement) => requirement.label)
+        .join(", ")}.`,
+      prerequisites: unverified.map((requirement) => requirement.label),
+    };
+  }
+  return { operation, state: "supported", reason: supportedReason };
+}
+
+// OR-combine two requirement signals into one satisfied tri-state: satisfied if
+// either is true; unmet only if both are known-false; otherwise unverified.
+function eitherSatisfied(a: boolean | undefined, b: boolean | undefined): boolean | undefined {
+  if (a === true || b === true) {
+    return true;
+  }
+  if (a === false && b === false) {
+    return false;
+  }
+  return undefined;
+}
+
+function req(label: string, satisfied: boolean | undefined): Requirement {
+  return { label, satisfied };
+}
+
+const PREREQ_SDK = "AutoMobile SDK embedded with storage inspection";
+const PREREQ_SESSION = "active CtrlProxy runner session";
+const PREREQ_DEBUGGABLE = "debuggable app build";
+const PREREQ_AUTHORIZED = "user-granted storage authorization";
+const PREREQ_ACTIVE_PROFILE = "active Android user/profile";
+const PREREQ_IOS_FILE_INTEGRATION = "opt-in iOS app file-access integration";
+
+function keyValueDomain(ctx: StorageCapabilityContext): DomainCapability {
+  const requirements = [req(PREREQ_SDK, ctx.embeddedSdk), req(PREREQ_SESSION, ctx.sessionActive)];
+  const operations: StorageOperation[] = ["list", "read", "write", "namespace_reset", "observe"];
+  return {
+    domain: "key_value",
+    portable: true,
+    platformScope: "cross-platform",
+    note: "SharedPreferences / DataStore (Android) and UserDefaults (iOS) via the AutoMobile SDK.",
+    operations: operations.map((operation) => deriveOperation(operation, undefined, requirements)),
+  };
+}
+
+function databasesDomain(ctx: StorageCapabilityContext): DomainCapability {
+  // Read-only inspection is reachable via the SDK or a debuggable adb path.
+  const accessible = eitherSatisfied(ctx.embeddedSdk, ctx.debuggableBuild);
+  const readRequirements = [
+    req(`${PREREQ_SDK} or ${PREREQ_DEBUGGABLE}`, accessible),
+    req(PREREQ_SESSION, ctx.sessionActive),
+  ];
+  const readonlyWriteReason =
+    "Database inspection is read-only; mutate databases through the app under test.";
+  return {
+    domain: "databases",
+    portable: true,
+    platformScope: "cross-platform",
+    note: "SQLite inspection (list, read, bounded queries). Writes are intentionally not exposed.",
+    operations: [
+      deriveOperation("list", undefined, readRequirements),
+      deriveOperation("read", undefined, readRequirements),
+      deriveOperation("observe", undefined, readRequirements),
+      deriveOperation("write", readonlyWriteReason, []),
+      deriveOperation("namespace_reset", readonlyWriteReason, []),
+    ],
+  };
+}
+
+function appContainersDomain(ctx: StorageCapabilityContext): DomainCapability {
+  const operations: StorageOperation[] = ["list", "read", "write"];
+  const buildOp = (operation: StorageOperation): OperationCapability => {
+    if (ctx.platform === "ios") {
+      if (ctx.deviceType === "simulator") {
+        // Host-mediated simctl container access.
+        return deriveOperation(operation, undefined, []);
+      }
+      // Physical iOS: unsupported unless an opt-in app integration advertises it.
+      if (ctx.iosFileIntegration === true) {
+        return {
+          operation,
+          state: "partial",
+          reason:
+            "Available only through an opt-in app file-access integration; not native iOS behavior.",
+          prerequisites: [PREREQ_IOS_FILE_INTEGRATION],
+        };
+      }
+      return deriveOperation(
+        operation,
+        "Direct app-container file access is unsupported on physical iOS devices unless an opt-in app integration advertises it.",
+        [],
+      );
+    }
+    // Android
+    if (ctx.deviceType === "emulator") {
+      return deriveOperation(operation, undefined, []);
+    }
+    // Physical Android: needs a debuggable build for run-as.
+    return deriveOperation(operation, undefined, [req(PREREQ_DEBUGGABLE, ctx.debuggableBuild)]);
+  };
+  return {
+    domain: "app_containers",
+    portable: true,
+    platformScope: "cross-platform",
+    note: "Direct app-sandbox file access. Fully available on simulators/emulators; qualified on physical devices.",
+    operations: operations.map(buildOp),
+  };
+}
+
+function userFilesDomain(ctx: StorageCapabilityContext): DomainCapability {
+  if (ctx.platform === "ios") {
+    const reason =
+      "User-visible shared storage is an Android-only concept; iOS apps are sandboxed to per-app containers.";
+    return {
+      domain: "user_files",
+      portable: false,
+      platformScope: "android",
+      note: reason,
+      operations: (["list", "read", "write"] as StorageOperation[]).map((operation) =>
+        deriveOperation(operation, reason, []),
+      ),
+    };
+  }
+  return {
+    domain: "user_files",
+    portable: false,
+    platformScope: "android",
+    note: "Android user-visible storage (shared / MediaStore-backed documents).",
+    operations: [
+      deriveOperation("list", undefined, [req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile)]),
+      deriveOperation("read", undefined, [
+        req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile),
+        req(PREREQ_AUTHORIZED, ctx.authorized),
+      ]),
+      deriveOperation("write", undefined, [
+        req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile),
+        req(PREREQ_AUTHORIZED, ctx.authorized),
+      ]),
+    ],
+  };
+}
+
+function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
+  if (ctx.platform === "ios") {
+    return {
+      domain: "media_library",
+      portable: false,
+      platformScope: "cross-platform",
+      note: "iOS Photos library access requires authorization; there is no host-side media indexer.",
+      operations: [
+        deriveOperation("list", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
+        deriveOperation("read", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
+        deriveOperation(
+          "media_indexing",
+          "iOS has no MediaScanner-style host-triggered indexing equivalent.",
+          [],
+        ),
+      ],
+    };
+  }
+  return {
+    domain: "media_library",
+    portable: false,
+    platformScope: "cross-platform",
+    note: "Android MediaStore listing, reads, and MediaScanner-triggered indexing.",
+    operations: [
+      deriveOperation("list", undefined, []),
+      deriveOperation("read", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
+      deriveOperation("media_indexing", undefined, []),
+    ],
+  };
+}
+
+function secureStateDomain(_ctx: StorageCapabilityContext): DomainCapability {
+  // Policy is owned by #5161. Values are never exported here; mutation is a non-goal.
+  const policyPrereq = "host secure-state policy (see #5161)";
+  return {
+    domain: "secure_state",
+    portable: false,
+    platformScope: "cross-platform",
+    note: "Keychain / Core Data secure state. Inspection policy is owned by #5161; secrets are never exported without an explicit host redaction policy.",
+    operations: [
+      {
+        operation: "read",
+        state: "unavailable",
+        reason:
+          "Secure-state values are unavailable by default; an opt-in host redaction policy (#5161) must allow the exact field.",
+        prerequisites: [policyPrereq],
+      },
+      deriveOperation(
+        "write",
+        "Secure-state mutation is not an AutoMobile storage feature.",
+        [],
+      ),
+      deriveOperation(
+        "namespace_reset",
+        "Bulk secure-state reset is out of scope here; scoped resets are tracked separately (#5188 / #5190).",
+        [],
+      ),
+    ],
+  };
+}
+
+function extensionPoints(): StorageExtensionPoint[] {
+  return [
+    {
+      domain: "user_files",
+      platform: "android",
+      description:
+        "User-visible shared storage is Android-only and must not be advertised as portable behavior.",
+    },
+    {
+      domain: "app_containers",
+      platform: "ios",
+      description:
+        "Physical-iOS app-container file access is exposed only through an opt-in app integration, not as native portable behavior.",
+    },
+    {
+      domain: "secure_state",
+      platform: "ios",
+      description:
+        "Core Data and Keychain inspection policy is owned by #5161; treat as an extension point, not portable storage.",
+    },
+  ];
+}
+
+/**
+ * Compute the storage capability report for a resolved device/app context.
+ * Pure and deterministic — the same context always yields the same report.
+ */
+export function computeStorageCapabilities(
+  ctx: StorageCapabilityContext,
+): StorageCapabilitiesReport {
+  return {
+    schemaVersion: STORAGE_CAPABILITIES_SCHEMA_VERSION,
+    platform: ctx.platform,
+    deviceType: ctx.deviceType,
+    appId: ctx.appId,
+    context: {
+      embeddedSdk: ctx.embeddedSdk,
+      sessionActive: ctx.sessionActive,
+      debuggableBuild: ctx.debuggableBuild,
+      authorized: ctx.authorized,
+      activeUserProfile: ctx.activeUserProfile,
+      iosFileIntegration: ctx.iosFileIntegration,
+    },
+    domains: [
+      appContainersDomain(ctx),
+      userFilesDomain(ctx),
+      mediaLibraryDomain(ctx),
+      keyValueDomain(ctx),
+      databasesDomain(ctx),
+      secureStateDomain(ctx),
+    ],
+    extensionPoints: extensionPoints(),
+  };
+}
+
+/** Look up one operation's capability in a report. */
+export function findOperationCapability(
+  report: StorageCapabilitiesReport,
+  domain: StorageDomain,
+  operation: StorageOperation,
+): OperationCapability | undefined {
+  return report.domains
+    .find((entry) => entry.domain === domain)
+    ?.operations.find((entry) => entry.operation === operation);
+}
+
+/**
+ * True when a proposed storage operation is fully available now (state
+ * `supported`). Serves AC1: a client can decide before invoking. `partial`,
+ * `unavailable`, and `unsupported` all return false because each still needs the
+ * client to act (satisfy a prerequisite) or avoid the call entirely.
+ */
+export function isStorageOperationAvailable(
+  report: StorageCapabilitiesReport,
+  domain: StorageDomain,
+  operation: StorageOperation,
+): boolean {
+  return findOperationCapability(report, domain, operation)?.state === "supported";
+}

--- a/src/features/storage/storageCapabilities.ts
+++ b/src/features/storage/storageCapabilities.ts
@@ -172,16 +172,12 @@ function deriveOperation(
   return { operation, state: "supported", reason: supportedReason };
 }
 
-// OR-combine two requirement signals into one satisfied tri-state: satisfied if
-// either is true; unmet only if both are known-false; otherwise unverified.
-function eitherSatisfied(a: boolean | undefined, b: boolean | undefined): boolean | undefined {
-  if (a === true || b === true) {
-    return true;
-  }
-  if (a === false && b === false) {
-    return false;
-  }
-  return undefined;
+// An operation that is structurally possible on the platform but has no AutoMobile
+// surface exposed yet. Distinct from `unsupported` (the platform cannot do it) and
+// from a prerequisite-gated `unavailable` (which the client can satisfy): here the
+// gap is a missing tool, so the client should not attempt the operation.
+function unavailableOperation(operation: StorageOperation, reason: string): OperationCapability {
+  return { operation, state: "unavailable", reason };
 }
 
 function req(label: string, satisfied: boolean | undefined): Requirement {
@@ -191,7 +187,6 @@ function req(label: string, satisfied: boolean | undefined): Requirement {
 const PREREQ_SDK = "AutoMobile SDK embedded with storage inspection";
 const PREREQ_SESSION = "active CtrlProxy runner session";
 const PREREQ_DEBUGGABLE = "debuggable app build";
-const PREREQ_AUTHORIZED = "user-granted storage authorization";
 const PREREQ_ACTIVE_PROFILE = "active Android user/profile";
 const PREREQ_IOS_FILE_INTEGRATION = "opt-in iOS app file-access integration";
 
@@ -208,26 +203,19 @@ function keyValueDomain(ctx: StorageCapabilityContext): DomainCapability {
 }
 
 function databasesDomain(ctx: StorageCapabilityContext): DomainCapability {
-  // Read-only inspection is reachable via the SDK or a debuggable adb path.
-  const accessible = eitherSatisfied(ctx.embeddedSdk, ctx.debuggableBuild);
-  const readRequirements = [
-    req(`${PREREQ_SDK} or ${PREREQ_DEBUGGABLE}`, accessible),
-    req(PREREQ_SESSION, ctx.sessionActive),
-  ];
-  const readonlyWriteReason =
-    "Database inspection is read-only; mutate databases through the app under test.";
+  // List/read/observe route through the on-device AutoMobile SDK
+  // (DatabaseInspector); writes route through the opt-in `sqlQuery` tool, which
+  // executes INSERT/UPDATE/DELETE and DDL. Both paths require the embedded SDK, so
+  // all exposed operations share the same prerequisites.
+  const requirements = [req(PREREQ_SDK, ctx.embeddedSdk), req(PREREQ_SESSION, ctx.sessionActive)];
   return {
     domain: "databases",
     portable: true,
     platformScope: "cross-platform",
-    note: "SQLite inspection (list, read, bounded queries). Writes are intentionally not exposed.",
-    operations: [
-      deriveOperation("list", undefined, readRequirements),
-      deriveOperation("read", undefined, readRequirements),
-      deriveOperation("observe", undefined, readRequirements),
-      deriveOperation("write", readonlyWriteReason, []),
-      deriveOperation("namespace_reset", readonlyWriteReason, []),
-    ],
+    note: "SQLite inspection (list, read, bounded queries) and mutation via the opt-in sqlQuery tool.",
+    operations: (["list", "read", "observe", "write"] as StorageOperation[]).map((operation) =>
+      deriveOperation(operation, undefined, requirements),
+    ),
   };
 }
 
@@ -289,48 +277,52 @@ function userFilesDomain(ctx: StorageCapabilityContext): DomainCapability {
     domain: "user_files",
     portable: false,
     platformScope: "android",
-    note: "Android user-visible storage (shared / MediaStore-backed documents).",
+    note: "Android user-visible / shared storage. Staging files into shared storage is supported (stageSharedStorage); a listing/read surface is not yet exposed.",
     operations: [
-      deriveOperation("list", undefined, [req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile)]),
-      deriveOperation("read", undefined, [
-        req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile),
-        req(PREREQ_AUTHORIZED, ctx.authorized),
-      ]),
-      deriveOperation("write", undefined, [
-        req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile),
-        req(PREREQ_AUTHORIZED, ctx.authorized),
-      ]),
+      unavailableOperation(
+        "list",
+        "No AutoMobile shared-storage listing surface is currently exposed.",
+      ),
+      unavailableOperation(
+        "read",
+        "No AutoMobile shared-storage read surface is currently exposed.",
+      ),
+      deriveOperation("write", undefined, [req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile)]),
     ],
   };
 }
 
 function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
-  if (ctx.platform === "ios") {
-    return {
-      domain: "media_library",
-      portable: false,
-      platformScope: "cross-platform",
-      note: "iOS Photos library access requires authorization; there is no host-side media indexer.",
-      operations: [
-        deriveOperation("list", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
-        deriveOperation("read", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
-        deriveOperation(
+  // No AutoMobile tool browses or reads the media library on either platform.
+  // On Android, indexing happens only as a side effect of staging a file into
+  // shared storage (there is no standalone index operation); iOS has no
+  // host-triggered indexer at all.
+  const indexing =
+    ctx.platform === "ios"
+      ? deriveOperation(
           "media_indexing",
           "iOS has no MediaScanner-style host-triggered indexing equivalent.",
           [],
-        ),
-      ],
-    };
-  }
+        )
+      : unavailableOperation(
+          "media_indexing",
+          "Media indexing currently occurs only as a side effect of staging a file into shared storage; no standalone indexing operation is exposed.",
+        );
   return {
     domain: "media_library",
     portable: false,
     platformScope: "cross-platform",
-    note: "Android MediaStore listing, reads, and MediaScanner-triggered indexing.",
+    note: "Media-library browse/read is not yet exposed as an AutoMobile capability.",
     operations: [
-      deriveOperation("list", undefined, []),
-      deriveOperation("read", undefined, [req(PREREQ_AUTHORIZED, ctx.authorized)]),
-      deriveOperation("media_indexing", undefined, []),
+      unavailableOperation(
+        "list",
+        "No AutoMobile media-library listing surface is currently exposed.",
+      ),
+      unavailableOperation(
+        "read",
+        "No AutoMobile media-library read surface is currently exposed.",
+      ),
+      indexing,
     ],
   };
 }
@@ -351,11 +343,7 @@ function secureStateDomain(_ctx: StorageCapabilityContext): DomainCapability {
           "Secure-state values are unavailable by default; an opt-in host redaction policy (#5161) must allow the exact field.",
         prerequisites: [policyPrereq],
       },
-      deriveOperation(
-        "write",
-        "Secure-state mutation is not an AutoMobile storage feature.",
-        [],
-      ),
+      deriveOperation("write", "Secure-state mutation is not an AutoMobile storage feature.", []),
       deriveOperation(
         "namespace_reset",
         "Bulk secure-state reset is out of scope here; scoped resets are tracked separately (#5188 / #5190).",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -76,6 +76,7 @@ import { registerDeviceSnapshotResources } from "./deviceSnapshotResources";
 import { registerDatabaseResources } from "./databaseResources";
 import { registerFailuresResources } from "./failuresResources";
 import { registerStorageResources } from "./storageResources";
+import { registerStorageCapabilityResources } from "./storageCapabilityResources";
 import { registerAppFileResources } from "./appFileResources";
 import { registerFeatureFlagResources } from "./featureFlagResources";
 import { registerNetworkResources } from "./networkResources";
@@ -349,6 +350,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerDatabaseResources();
   registerFailuresResources();
   registerStorageResources();
+  registerStorageCapabilityResources();
   registerAppFileResources();
   registerFeatureFlagResources();
   registerNetworkResources();

--- a/src/server/storageCapabilityResources.ts
+++ b/src/server/storageCapabilityResources.ts
@@ -14,8 +14,7 @@ import {
 // Single RFC 6570 template; the optional {?appId} query variant matches both the
 // bare capabilities URI and the app-scoped form (issue #4933 ordering note: a
 // query template with an optional suffix subsumes the base, so only one is needed).
-const STORAGE_CAPABILITIES_TEMPLATE =
-  "automobile:devices/{deviceId}/storage/capabilities{?appId}";
+const STORAGE_CAPABILITIES_TEMPLATE = "automobile:devices/{deviceId}/storage/capabilities{?appId}";
 
 /**
  * Find a booted device by ID across both platforms.
@@ -105,9 +104,7 @@ export async function getStorageCapabilitiesResource(
       };
     }
 
-    const report = computeStorageCapabilities(
-      resolveStorageCapabilityContext(device, appId),
-    );
+    const report = computeStorageCapabilities(resolveStorageCapabilityContext(device, appId));
 
     return {
       uri,
@@ -119,7 +116,14 @@ export async function getStorageCapabilitiesResource(
     return {
       uri,
       mimeType: "application/json",
-      text: JSON.stringify({ error: `Failed to compute storage capabilities: ${error}` }, null, 2),
+      text: JSON.stringify(
+        {
+          error: `Failed to compute storage capabilities: ${error}`,
+          schemaVersion: STORAGE_CAPABILITIES_SCHEMA_VERSION,
+        },
+        null,
+        2,
+      ),
     };
   }
 }

--- a/src/server/storageCapabilityResources.ts
+++ b/src/server/storageCapabilityResources.ts
@@ -1,0 +1,140 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
+import { isIosSimulatorUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { serverConfig } from "../utils/ServerConfig";
+import { BootedDevice } from "../models";
+import { logger } from "../utils/logger";
+import {
+  computeStorageCapabilities,
+  STORAGE_CAPABILITIES_SCHEMA_VERSION,
+  type StorageCapabilityContext,
+  type StorageDeviceType,
+} from "../features/storage/storageCapabilities";
+
+// Single RFC 6570 template; the optional {?appId} query variant matches both the
+// bare capabilities URI and the app-scoped form (issue #4933 ordering note: a
+// query template with an optional suffix subsumes the base, so only one is needed).
+const STORAGE_CAPABILITIES_TEMPLATE =
+  "automobile:devices/{deviceId}/storage/capabilities{?appId}";
+
+/**
+ * Find a booted device by ID across both platforms.
+ */
+async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
+  try {
+    const manager = PlatformDeviceManagerFactory.getInstance();
+    const androidDevices = await manager.getBootedDevices("android");
+    const android = androidDevices.find((d) => d.deviceId === deviceId);
+    if (android) {
+      return android;
+    }
+    const iosDevices = await manager.getBootedDevices("ios");
+    const ios = iosDevices.find((d) => d.deviceId === deviceId);
+    if (ios) {
+      return ios;
+    }
+    return null;
+  } catch (error) {
+    // Best-effort discovery: an unavailable device manager is reported to the
+    // caller as "device not found" rather than surfaced as a capability fault.
+    logger.warn(`[StorageCapabilityResources] Failed to find device ${deviceId}: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Classify a booted device as emulator, simulator, or physical from its identity.
+ */
+export function resolveDeviceType(device: BootedDevice): StorageDeviceType {
+  if (device.platform === "ios") {
+    return isIosSimulatorUdid(device.deviceId) ? "simulator" : "physical";
+  }
+  // Android AVDs report an `emulator-<port>` serial; everything else is physical.
+  return device.deviceId.startsWith("emulator-") ? "emulator" : "physical";
+}
+
+/**
+ * Resolve the capability context from a booted device plus server configuration.
+ * Runtime prerequisites the descriptor cannot cheaply verify (debuggable build,
+ * authorization, active profile, opt-in iOS integration) are left undefined so the
+ * model reports them as prerequisites rather than over-claiming availability.
+ */
+export function resolveStorageCapabilityContext(
+  device: BootedDevice,
+  appId?: string,
+): StorageCapabilityContext {
+  return {
+    platform: device.platform,
+    deviceType: resolveDeviceType(device),
+    embeddedSdk: serverConfig.isEmbeddedSdkEnabled(),
+    // A resolved booted device implies a live runner session for the SDK path.
+    sessionActive: true,
+    appId,
+  };
+}
+
+function buildUri(deviceId: string, appId?: string): string {
+  const base = `automobile:devices/${deviceId}/storage/capabilities`;
+  return appId ? `${base}?appId=${encodeURIComponent(appId)}` : base;
+}
+
+/**
+ * Storage-capabilities resource handler.
+ */
+export async function getStorageCapabilitiesResource(
+  params: Record<string, string>,
+): Promise<ResourceContent> {
+  const { deviceId } = params;
+  const appId = params.appId ? decodeURIComponent(params.appId) : undefined;
+  const uri = buildUri(deviceId, appId);
+
+  try {
+    const device = await findBootedDevice(deviceId);
+    if (!device) {
+      return {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(
+          {
+            error: `Device not found or not booted: ${deviceId}`,
+            schemaVersion: STORAGE_CAPABILITIES_SCHEMA_VERSION,
+          },
+          null,
+          2,
+        ),
+      };
+    }
+
+    const report = computeStorageCapabilities(
+      resolveStorageCapabilityContext(device, appId),
+    );
+
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({ deviceId, ...report }, null, 2),
+    };
+  } catch (error) {
+    logger.error(`[StorageCapabilityResources] Failed to compute capabilities: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({ error: `Failed to compute storage capabilities: ${error}` }, null, 2),
+    };
+  }
+}
+
+/**
+ * Register the storage-capabilities resource (issue #5602).
+ */
+export function registerStorageCapabilityResources(): void {
+  ResourceRegistry.registerTemplate(
+    STORAGE_CAPABILITIES_TEMPLATE,
+    "Storage Capabilities",
+    "Versioned descriptor of which storage operations (list, read, write, namespace reset, media indexing, observation) are available per logical domain (app containers, user-visible files, media library, key-value state, databases, secure state) for a device and optional app context. Clients negotiate capabilities instead of inferring them from platform names.",
+    "application/json",
+    getStorageCapabilitiesResource,
+  );
+
+  logger.info("[StorageCapabilityResources] Registered storage capability resources");
+}

--- a/test/features/storage/storageCapabilities.test.ts
+++ b/test/features/storage/storageCapabilities.test.ts
@@ -71,9 +71,19 @@ describe("AC1: availability is queryable before invocation", () => {
   it("isStorageOperationAvailable is true only for fully-supported operations", () => {
     const report = computeStorageCapabilities(ctx());
     expect(isStorageOperationAvailable(report, "key_value", "write")).toBe(true);
-    // Read-only databases: write is unsupported.
-    expect(isStorageOperationAvailable(report, "databases", "write")).toBe(false);
-    expect(findOperationCapability(report, "databases", "write")?.state).toBe("unsupported");
+    // Secure-state mutation is a hard non-goal.
+    expect(isStorageOperationAvailable(report, "secure_state", "write")).toBe(false);
+    expect(findOperationCapability(report, "secure_state", "write")?.state).toBe("unsupported");
+  });
+
+  it("database writes are supported via the sqlQuery tool when the SDK is embedded", () => {
+    // sqlQuery (embeddedSdkOnly) executes INSERT/UPDATE/DELETE and DDL, so DB
+    // mutation is a real, config-gated capability — not unsupported.
+    const report = computeStorageCapabilities(ctx());
+    expect(isStorageOperationAvailable(report, "databases", "write")).toBe(true);
+
+    const noSdk = computeStorageCapabilities(ctx({ embeddedSdk: false }));
+    expect(findOperationCapability(noSdk, "databases", "write")?.state).toBe("unavailable");
   });
 
   it("returns undefined for an operation a domain does not expose", () => {
@@ -94,12 +104,15 @@ describe("AC2: platform-qualified domains", () => {
     }
   });
 
-  it("user_files is available (qualified) on Android", () => {
+  it("user_files staging is available on Android but list/read have no surface yet", () => {
     const report = computeStorageCapabilities(
-      ctx({ platform: "android", activeUserProfile: true, authorized: true }),
+      ctx({ platform: "android", activeUserProfile: true }),
     );
-    expect(isStorageOperationAvailable(report, "user_files", "list")).toBe(true);
-    expect(isStorageOperationAvailable(report, "user_files", "read")).toBe(true);
+    // Staging into shared storage is backed by stageSharedStorage.
+    expect(isStorageOperationAvailable(report, "user_files", "write")).toBe(true);
+    // No AutoMobile listing/read surface exists for shared storage yet.
+    expect(findOperationCapability(report, "user_files", "list")?.state).toBe("unavailable");
+    expect(findOperationCapability(report, "user_files", "read")?.state).toBe("unavailable");
   });
 
   it("app_containers is supported on iOS simulator", () => {
@@ -157,11 +170,12 @@ describe("AC3: iOS physical-device file access", () => {
 describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
   it("partial: SDK on but a runtime prerequisite is unverified", () => {
     const report = computeStorageCapabilities(
-      ctx({ platform: "android", activeUserProfile: undefined, authorized: undefined }),
+      ctx({ platform: "android", activeUserProfile: undefined }),
     );
-    const read = findOperationCapability(report, "user_files", "read")!;
-    expect(read.state).toBe("partial");
-    expect(read.prerequisites?.length).toBeGreaterThan(0);
+    // Shared-storage staging needs an active user/profile the descriptor can't verify.
+    const write = findOperationCapability(report, "user_files", "write")!;
+    expect(write.state).toBe("partial");
+    expect(write.prerequisites?.length).toBeGreaterThan(0);
   });
 
   it("disabled: embedded SDK off makes key-value operations unavailable", () => {
@@ -183,9 +197,7 @@ describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
   });
 
   it("conflicting: embeddedSdk true but sessionActive false resolves to the blocker (unavailable)", () => {
-    const report = computeStorageCapabilities(
-      ctx({ embeddedSdk: true, sessionActive: false }),
-    );
+    const report = computeStorageCapabilities(ctx({ embeddedSdk: true, sessionActive: false }));
     const write = findOperationCapability(report, "key_value", "write")!;
     expect(write.state).toBe("unavailable");
     expect(write.prerequisites).toContain("active CtrlProxy runner session");
@@ -195,12 +207,19 @@ describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
 
   it("conflicting: a known-unmet prerequisite dominates an unverified one", () => {
     const report = computeStorageCapabilities(
-      // databases read needs (SDK or debuggable) AND session; here SDK off,
-      // debuggable off => access known-unmet, while session is unverified.
-      ctx({ embeddedSdk: false, debuggableBuild: false, sessionActive: undefined }),
+      // databases read needs the SDK AND a session; here the SDK is known-off
+      // (a hard blocker) while the session is merely unverified.
+      ctx({ embeddedSdk: false, sessionActive: undefined }),
     );
     const read = findOperationCapability(report, "databases", "read")!;
     expect(read.state).toBe("unavailable");
+  });
+
+  it("media_library browse/read is unavailable — no backing tool is exposed", () => {
+    const report = computeStorageCapabilities(ctx());
+    expect(findOperationCapability(report, "media_library", "list")?.state).toBe("unavailable");
+    expect(findOperationCapability(report, "media_library", "read")?.state).toBe("unavailable");
+    expect(isStorageOperationAvailable(report, "media_library", "list")).toBe(false);
   });
 
   it("secure_state read is unavailable pending the #5161 host policy, not unsupported", () => {

--- a/test/features/storage/storageCapabilities.test.ts
+++ b/test/features/storage/storageCapabilities.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "bun:test";
+import {
+  computeStorageCapabilities,
+  findOperationCapability,
+  isStorageOperationAvailable,
+  STORAGE_CAPABILITIES_SCHEMA_VERSION,
+  type StorageCapabilityContext,
+} from "../../../src/features/storage/storageCapabilities";
+
+function ctx(overrides: Partial<StorageCapabilityContext> = {}): StorageCapabilityContext {
+  return {
+    platform: "android",
+    deviceType: "emulator",
+    embeddedSdk: true,
+    sessionActive: true,
+    ...overrides,
+  };
+}
+
+describe("computeStorageCapabilities envelope", () => {
+  it("stamps the schema version so the resource is versioned", () => {
+    const report = computeStorageCapabilities(ctx());
+    expect(report.schemaVersion).toBe(STORAGE_CAPABILITIES_SCHEMA_VERSION);
+    expect(report.schemaVersion).toBe(1);
+  });
+
+  it("echoes the resolved context signals", () => {
+    const report = computeStorageCapabilities(
+      ctx({ appId: "com.example", debuggableBuild: false, authorized: undefined }),
+    );
+    expect(report.appId).toBe("com.example");
+    expect(report.context.embeddedSdk).toBe(true);
+    expect(report.context.debuggableBuild).toBe(false);
+  });
+
+  it("reports every logical domain", () => {
+    const report = computeStorageCapabilities(ctx());
+    expect(report.domains.map((d) => d.domain).sort()).toEqual([
+      "app_containers",
+      "databases",
+      "key_value",
+      "media_library",
+      "secure_state",
+      "user_files",
+    ]);
+  });
+
+  it("documents extension points without advertising them as portable", () => {
+    const report = computeStorageCapabilities(ctx());
+    // user_files and secure_state are platform-specific extension points.
+    const userFiles = report.domains.find((d) => d.domain === "user_files")!;
+    const secure = report.domains.find((d) => d.domain === "secure_state")!;
+    expect(userFiles.portable).toBe(false);
+    expect(secure.portable).toBe(false);
+    expect(report.extensionPoints.length).toBeGreaterThan(0);
+    expect(report.extensionPoints.map((e) => e.domain)).toContain("user_files");
+  });
+});
+
+// AC1: a client can determine whether a proposed operation is available before invoking.
+describe("AC1: availability is queryable before invocation", () => {
+  it("exposes a definitive state for every domain/operation pair", () => {
+    const report = computeStorageCapabilities(ctx());
+    for (const domain of report.domains) {
+      for (const op of domain.operations) {
+        expect(["supported", "partial", "unavailable", "unsupported"]).toContain(op.state);
+      }
+    }
+  });
+
+  it("isStorageOperationAvailable is true only for fully-supported operations", () => {
+    const report = computeStorageCapabilities(ctx());
+    expect(isStorageOperationAvailable(report, "key_value", "write")).toBe(true);
+    // Read-only databases: write is unsupported.
+    expect(isStorageOperationAvailable(report, "databases", "write")).toBe(false);
+    expect(findOperationCapability(report, "databases", "write")?.state).toBe("unsupported");
+  });
+
+  it("returns undefined for an operation a domain does not expose", () => {
+    const report = computeStorageCapabilities(ctx());
+    expect(findOperationCapability(report, "key_value", "media_indexing")).toBeUndefined();
+    expect(isStorageOperationAvailable(report, "key_value", "media_indexing")).toBe(false);
+  });
+});
+
+// AC2: Android-only user-visible storage and simulator-only app-container access.
+describe("AC2: platform-qualified domains", () => {
+  it("user_files is unsupported on iOS (Android-only concept)", () => {
+    const report = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "simulator" }));
+    const userFiles = report.domains.find((d) => d.domain === "user_files")!;
+    expect(userFiles.platformScope).toBe("android");
+    for (const op of userFiles.operations) {
+      expect(op.state).toBe("unsupported");
+    }
+  });
+
+  it("user_files is available (qualified) on Android", () => {
+    const report = computeStorageCapabilities(
+      ctx({ platform: "android", activeUserProfile: true, authorized: true }),
+    );
+    expect(isStorageOperationAvailable(report, "user_files", "list")).toBe(true);
+    expect(isStorageOperationAvailable(report, "user_files", "read")).toBe(true);
+  });
+
+  it("app_containers is supported on iOS simulator", () => {
+    const report = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "simulator" }));
+    expect(isStorageOperationAvailable(report, "app_containers", "read")).toBe(true);
+    expect(isStorageOperationAvailable(report, "app_containers", "write")).toBe(true);
+  });
+
+  it("app_containers is supported on Android emulator", () => {
+    const report = computeStorageCapabilities(ctx({ platform: "android", deviceType: "emulator" }));
+    expect(isStorageOperationAvailable(report, "app_containers", "read")).toBe(true);
+  });
+
+  it("app_containers on physical Android is gated on a debuggable build", () => {
+    const unknown = computeStorageCapabilities(
+      ctx({ platform: "android", deviceType: "physical", debuggableBuild: undefined }),
+    );
+    expect(findOperationCapability(unknown, "app_containers", "read")?.state).toBe("partial");
+
+    const nonDebuggable = computeStorageCapabilities(
+      ctx({ platform: "android", deviceType: "physical", debuggableBuild: false }),
+    );
+    expect(findOperationCapability(nonDebuggable, "app_containers", "read")?.state).toBe(
+      "unavailable",
+    );
+
+    const debuggable = computeStorageCapabilities(
+      ctx({ platform: "android", deviceType: "physical", debuggableBuild: true }),
+    );
+    expect(isStorageOperationAvailable(debuggable, "app_containers", "read")).toBe(true);
+  });
+});
+
+// AC3: iOS physical-device file behavior is unsupported unless an opt-in integration advertises it.
+describe("AC3: iOS physical-device file access", () => {
+  it("is unsupported by default on physical iOS", () => {
+    const report = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "physical" }));
+    const appContainers = report.domains.find((d) => d.domain === "app_containers")!;
+    for (const op of appContainers.operations) {
+      expect(op.state).toBe("unsupported");
+    }
+  });
+
+  it("becomes partial (opt-in) when an app integration advertises it", () => {
+    const report = computeStorageCapabilities(
+      ctx({ platform: "ios", deviceType: "physical", iosFileIntegration: true }),
+    );
+    const read = findOperationCapability(report, "app_containers", "read")!;
+    expect(read.state).toBe("partial");
+    expect(read.prerequisites).toContain("opt-in iOS app file-access integration");
+  });
+});
+
+// AC4: partial, disabled, unsupported, and conflicting capability inputs.
+describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
+  it("partial: SDK on but a runtime prerequisite is unverified", () => {
+    const report = computeStorageCapabilities(
+      ctx({ platform: "android", activeUserProfile: undefined, authorized: undefined }),
+    );
+    const read = findOperationCapability(report, "user_files", "read")!;
+    expect(read.state).toBe("partial");
+    expect(read.prerequisites?.length).toBeGreaterThan(0);
+  });
+
+  it("disabled: embedded SDK off makes key-value operations unavailable", () => {
+    const report = computeStorageCapabilities(ctx({ embeddedSdk: false }));
+    for (const op of report.domains.find((d) => d.domain === "key_value")!.operations) {
+      expect(op.state).toBe("unavailable");
+      expect(op.prerequisites).toContain("AutoMobile SDK embedded with storage inspection");
+    }
+  });
+
+  it("unsupported: secure-state mutation and DataStore-on-iOS are never advertised", () => {
+    const android = computeStorageCapabilities(ctx());
+    expect(findOperationCapability(android, "secure_state", "write")?.state).toBe("unsupported");
+
+    const ios = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "simulator" }));
+    expect(findOperationCapability(ios, "media_library", "media_indexing")?.state).toBe(
+      "unsupported",
+    );
+  });
+
+  it("conflicting: embeddedSdk true but sessionActive false resolves to the blocker (unavailable)", () => {
+    const report = computeStorageCapabilities(
+      ctx({ embeddedSdk: true, sessionActive: false }),
+    );
+    const write = findOperationCapability(report, "key_value", "write")!;
+    expect(write.state).toBe("unavailable");
+    expect(write.prerequisites).toContain("active CtrlProxy runner session");
+    // The satisfied SDK prerequisite is not listed as missing.
+    expect(write.reason).not.toContain("AutoMobile SDK");
+  });
+
+  it("conflicting: a known-unmet prerequisite dominates an unverified one", () => {
+    const report = computeStorageCapabilities(
+      // databases read needs (SDK or debuggable) AND session; here SDK off,
+      // debuggable off => access known-unmet, while session is unverified.
+      ctx({ embeddedSdk: false, debuggableBuild: false, sessionActive: undefined }),
+    );
+    const read = findOperationCapability(report, "databases", "read")!;
+    expect(read.state).toBe("unavailable");
+  });
+
+  it("secure_state read is unavailable pending the #5161 host policy, not unsupported", () => {
+    const report = computeStorageCapabilities(ctx());
+    const read = findOperationCapability(report, "secure_state", "read")!;
+    expect(read.state).toBe("unavailable");
+    expect(read.prerequisites?.some((p) => p.includes("5161"))).toBe(true);
+  });
+});
+
+describe("determinism", () => {
+  it("produces identical reports for identical contexts", () => {
+    const a = computeStorageCapabilities(ctx({ appId: "com.x" }));
+    const b = computeStorageCapabilities(ctx({ appId: "com.x" }));
+    expect(a).toEqual(b);
+  });
+});

--- a/test/server/storageCapabilityResources.test.ts
+++ b/test/server/storageCapabilityResources.test.ts
@@ -4,6 +4,7 @@ import {
   resolveDeviceType,
   resolveStorageCapabilityContext,
 } from "../../src/server/storageCapabilityResources";
+import { registerStorageResources } from "../../src/server/storageResources";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import { serverConfig } from "../../src/utils/ServerConfig";
@@ -55,10 +56,27 @@ describe("storageCapabilityResources", () => {
       "automobile:devices/{deviceId}/storage/capabilities{?appId}",
     ]);
     // Both the bare and the ?appId= form resolve to this template.
-    expect(ResourceRegistry.matchTemplate("automobile:devices/dev1/storage/capabilities")).toBeDefined();
+    expect(
+      ResourceRegistry.matchTemplate("automobile:devices/dev1/storage/capabilities"),
+    ).toBeDefined();
     expect(
       ResourceRegistry.matchTemplate("automobile:devices/dev1/storage/capabilities?appId=com.x"),
     ).toBeDefined();
+  });
+
+  test("capabilities URI is not shadowed by the sibling storage files/entries templates", async () => {
+    // Register the sibling storage resources first (as src/server/index.ts does),
+    // then the capability resource. The FILES/ENTRIES templates require a trailing
+    // /files or /{fileName}/entries segment, so the capabilities URI must still
+    // route to this handler regardless of registration order. Guards against a
+    // future template on this prefix greedily capturing `capabilities`.
+    PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], []));
+    registerStorageResources();
+    registerStorageCapabilityResources();
+    const content = await readResource("automobile:devices/emulator-5554/storage/capabilities");
+    const body = JSON.parse(content.text ?? "{}");
+    // The capability handler emits schemaVersion; the files/entries handlers do not.
+    expect(body.schemaVersion).toBe(1);
   });
 
   test("reports device-not-found when no device is booted", async () => {

--- a/test/server/storageCapabilityResources.test.ts
+++ b/test/server/storageCapabilityResources.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  registerStorageCapabilityResources,
+  resolveDeviceType,
+  resolveStorageCapabilityContext,
+} from "../../src/server/storageCapabilityResources";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import type { BootedDevice } from "../../src/models";
+
+// Like storageResources, the handler builds a URI, resolves a booted device, and
+// returns a JSON envelope. With no booted device it returns "device not found"
+// without touching any CtrlProxy client — so URI matching, the not-found path,
+// and the happy path (via a seeded FakeDeviceManager) exercise with only a fake:
+// no DB, no clock, no device, no sockets.
+describe("storageCapabilityResources", () => {
+  const androidEmulator: BootedDevice = {
+    name: "Pixel_7",
+    platform: "android",
+    deviceId: "emulator-5554",
+  };
+  const iosPhysical: BootedDevice = {
+    name: "iPhone",
+    platform: "ios",
+    // 25-char device UDID (not a simulator UUID) => physical.
+    deviceId: "00008110-000A1B2C3D4E5F60",
+  };
+
+  afterEach(() => {
+    PlatformDeviceManagerFactory.setInstance(null);
+    ResourceRegistry.clearResources();
+  });
+
+  function setDevices(devices: BootedDevice[]): void {
+    PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], devices));
+    registerStorageCapabilityResources();
+  }
+
+  function readResource(uri: string) {
+    const match = ResourceRegistry.matchTemplate(uri);
+    if (!match) {
+      throw new Error(`no template matched: ${uri}`);
+    }
+    return match.template.handler(match.params);
+  }
+
+  test("registers a single query-variant template that matches bare and app-scoped URIs", () => {
+    setDevices([]);
+    const templates = ResourceRegistry.getAllTemplates().filter((t) =>
+      t.uriTemplate.includes("storage/capabilities"),
+    );
+    expect(templates.map((t) => t.uriTemplate)).toEqual([
+      "automobile:devices/{deviceId}/storage/capabilities{?appId}",
+    ]);
+    // Both the bare and the ?appId= form resolve to this template.
+    expect(ResourceRegistry.matchTemplate("automobile:devices/dev1/storage/capabilities")).toBeDefined();
+    expect(
+      ResourceRegistry.matchTemplate("automobile:devices/dev1/storage/capabilities?appId=com.x"),
+    ).toBeDefined();
+  });
+
+  test("reports device-not-found when no device is booted", async () => {
+    setDevices([]);
+    const content = await readResource("automobile:devices/emulator-5554/storage/capabilities");
+    const body = JSON.parse(content.text ?? "{}");
+    expect(content.mimeType).toBe("application/json");
+    expect(body.error).toBe("Device not found or not booted: emulator-5554");
+    // The versioned envelope is present even in the error case.
+    expect(body.schemaVersion).toBe(1);
+  });
+
+  test("returns a versioned capability report for a booted Android emulator", async () => {
+    const previous = serverConfig.isEmbeddedSdkEnabled();
+    serverConfig.setEmbeddedSdkEnabled(true);
+    try {
+      setDevices([androidEmulator]);
+      const content = await readResource(
+        "automobile:devices/emulator-5554/storage/capabilities?appId=com.example.app",
+      );
+      const body = JSON.parse(content.text ?? "{}");
+      expect(body.deviceId).toBe("emulator-5554");
+      expect(body.schemaVersion).toBe(1);
+      expect(body.platform).toBe("android");
+      expect(body.deviceType).toBe("emulator");
+      expect(body.appId).toBe("com.example.app");
+      expect(body.context.embeddedSdk).toBe(true);
+      // key_value write is supported once the SDK + session are present.
+      const keyValue = body.domains.find((d: { domain: string }) => d.domain === "key_value");
+      const write = keyValue.operations.find((o: { operation: string }) => o.operation === "write");
+      expect(write.state).toBe("supported");
+    } finally {
+      serverConfig.setEmbeddedSdkEnabled(previous);
+    }
+  });
+
+  test("physical iOS device qualifies app-container access as unsupported", async () => {
+    setDevices([iosPhysical]);
+    const content = await readResource(
+      "automobile:devices/00008110-000A1B2C3D4E5F60/storage/capabilities",
+    );
+    const body = JSON.parse(content.text ?? "{}");
+    expect(body.platform).toBe("ios");
+    expect(body.deviceType).toBe("physical");
+    const appContainers = body.domains.find(
+      (d: { domain: string }) => d.domain === "app_containers",
+    );
+    for (const op of appContainers.operations) {
+      expect(op.state).toBe("unsupported");
+    }
+  });
+
+  test("resolveDeviceType classifies device identities", () => {
+    expect(resolveDeviceType(androidEmulator)).toBe("emulator");
+    expect(resolveDeviceType({ name: "d", platform: "android", deviceId: "1A2B3C4D" })).toBe(
+      "physical",
+    );
+    expect(resolveDeviceType(iosPhysical)).toBe("physical");
+    expect(
+      resolveDeviceType({
+        name: "sim",
+        platform: "ios",
+        deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+      }),
+    ).toBe("simulator");
+  });
+
+  test("resolveStorageCapabilityContext reflects server SDK config and booted session", () => {
+    const previous = serverConfig.isEmbeddedSdkEnabled();
+    serverConfig.setEmbeddedSdkEnabled(false);
+    try {
+      const ctx = resolveStorageCapabilityContext(androidEmulator, "com.x");
+      expect(ctx.platform).toBe("android");
+      expect(ctx.deviceType).toBe("emulator");
+      expect(ctx.embeddedSdk).toBe(false);
+      expect(ctx.sessionActive).toBe(true);
+      expect(ctx.appId).toBe("com.x");
+    } finally {
+      serverConfig.setEmbeddedSdkEnabled(previous);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a versioned MCP resource that describes which storage operations are available for a selected device and app context, so clients negotiate capabilities instead of inferring them from platform names or parsing failed operations.

The core is a pure, input-driven capability model (`src/features/storage/storageCapabilities.ts`) mapping six logical domains — app containers, user-visible files, media library, key-value state, databases, secure state — to per-operation states (`supported` / `partial` / `unavailable` / `unsupported`). A thin resource handler (`src/server/storageCapabilityResources.ts`) resolves the context from a booted device plus server config and delegates the reasoning, keeping the whole state machine testable without devices, sockets, or a clock.

New resource URI (single RFC 6570 query template, matches bare and app-scoped forms):

```
automobile:devices/{deviceId}/storage/capabilities{?appId}
```

No existing resource carried a schema version, so this establishes a `schemaVersion` field in the JSON envelope (v1).

## Linked Issue

Closes #5602

## Changes

- **`storageCapabilities.ts`** — pure model + `computeStorageCapabilities()`, `findOperationCapability()`, `isStorageOperationAvailable()`. Three-valued prerequisite logic: a known-unmet prerequisite dominates (→ `unavailable`); an unverified one degrades an otherwise-supported op to `partial`; a platform-level impossibility is `unsupported`. This makes conflicting inputs resolve deterministically to the most restrictive reachable state.
- **`storageCapabilityResources.ts`** — resolves device type (emulator / simulator / physical) from device identity via `isIosSimulatorUdid` + the Android `emulator-` serial, reads embedded-SDK state from `serverConfig`, and emits the versioned envelope. Registered in `server/index.ts`.
- Prerequisites and availability reasons cover: simulator vs physical, debuggable build, embedded SDK, active user/profile, authorization, and session requirements. Extension points (Android-only user files, opt-in iOS file integration, secure state) are documented and flagged `portable: false`.
- Secure-state (Core Data / Keychain) policy is deferred to #5161 and reported as an extension point — `read` is `unavailable` pending a host redaction policy, mutation/export are `unsupported`.

## Acceptance criteria

- [x] A client can determine whether a proposed storage operation is available before invoking it — every domain/op pair has a definitive state; `isStorageOperationAvailable()` is the boolean gate.
- [x] Android-only user-visible storage and simulator-only app-container access remain accurately qualified — `user_files` is `unsupported` on iOS; `app_containers` is supported on sim/emulator and gated by debuggable build on physical Android.
- [x] iOS physical-device file behavior is unsupported unless an opt-in app integration advertises it — `app_containers` is `unsupported` on physical iOS, `partial` when `iosFileIntegration` is set.
- [x] Tests cover partial, disabled, unsupported, and conflicting capability inputs.

## Validation

- [x] `bun test test/features/storage/storageCapabilities.test.ts` (21) and `test/server/storageCapabilityResources.test.ts` (6) green, <100ms each
- [x] `bun run lint` passes (boundary-checks 13/13)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Full `bun test`: 14300 pass; the sole failure is a pre-existing worktree-drift issue (`test/lint/oxlintConfigScoping.test.ts` spawns a missing `node_modules/.bin/oxlint`), unrelated to this diff
- [x] New code uses interfaces + fakes (`FakeDeviceManager`); no new dependencies

## Follow-ups

- Live prerequisite probing (debuggable build, authorization, active profile, opt-in iOS integration) is currently reported as `partial`/prerequisite rather than verified on-device; wiring real detection is a natural follow-up.
