### PR TITLE
fix(ios-sdk): generation-guard SessionTracker's timeout timer (stale timer ends current session)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Session/SessionTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Session/SessionTracker.swift
@@ -20,6 +20,13 @@ final class SessionTracker: SessionTracking, @unchecked Sendable {
     private var _sessionId: String?
     private var state: State = .ended
     private var timeoutTimer: (any TimerScheduling)?
+    /// Monotonic token identifying the current background cycle. Bumped on every
+    /// state transition so a timeout callback scheduled in an earlier cycle can be
+    /// recognized as stale and ignored — otherwise a timer from a previous
+    /// background could fire after a foreground/background round-trip, see the state
+    /// as `.backgrounded` again, and wrongly end the current session (the
+    /// `AutoMobileHangs` generation-guard pattern).
+    private var timerGeneration = 0
 
     convenience init(
         timeoutMs: Int = 30_000,
@@ -48,6 +55,8 @@ final class SessionTracker: SessionTracking, @unchecked Sendable {
         lock.lock()
         timeoutTimer?.cancel()
         timeoutTimer = nil
+        // Invalidate any in-flight timeout callback from the cycle we're leaving.
+        timerGeneration += 1
         switch state {
         case .ended:
             _sessionId = uuidProvider()
@@ -64,6 +73,8 @@ final class SessionTracker: SessionTracking, @unchecked Sendable {
         lock.lock()
         guard state == .active else { lock.unlock(); return }
         state = .backgrounded
+        timerGeneration += 1
+        let generation = timerGeneration
         let timer = timerFactory()
         timeoutTimer = timer
         lock.unlock()
@@ -71,10 +82,16 @@ final class SessionTracker: SessionTracking, @unchecked Sendable {
         timer.schedule(intervalMs: timeoutMs) { [weak self] in
             guard let self else { return }
             self.lock.lock()
-            if self.state == .backgrounded {
-                self.state = .ended
-                self._sessionId = nil
+            // Only the timer for the current background cycle may end the session. A
+            // stale timer (a foreground/background happened after it was scheduled) has
+            // an older generation and is ignored, so it can't end a session that is now
+            // active or belongs to a newer cycle.
+            guard generation == self.timerGeneration, self.state == .backgrounded else {
+                self.lock.unlock()
+                return
             }
+            self.state = .ended
+            self._sessionId = nil
             self.timeoutTimer?.cancel()
             self.timeoutTimer = nil
             self.lock.unlock()
@@ -85,6 +102,7 @@ final class SessionTracker: SessionTracking, @unchecked Sendable {
         lock.lock()
         timeoutTimer?.cancel()
         timeoutTimer = nil
+        timerGeneration += 1
         state = .ended
         _sessionId = nil
         lock.unlock()

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SessionTrackerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SessionTrackerTests.swift
@@ -99,12 +99,30 @@ final class SessionTrackerTests: XCTestCase {
 
     // MARK: - Stale timer must not end the current session (generation guard)
 
+    /// Models a timer whose callback was already dispatched when `cancel()` arrived:
+    /// `cancel()` cannot un-dispatch it, so — unlike `FakeTimer`, which clears its
+    /// block on cancel — the recorded block stays invokable via `fireStale()`. This is
+    /// exactly the race the generation guard defends against.
+    private final class DispatchedTimer: TimerScheduling, @unchecked Sendable {
+        private let lock = NSLock()
+        private var block: (@Sendable () -> Void)?
+        func schedule(intervalMs _: Int, block: @escaping @Sendable () -> Void) {
+            lock.lock(); self.block = block; lock.unlock()
+        }
+        // A callback already dispatched keeps running past cancel; do NOT clear it.
+        func cancel() {}
+        func fireStale() {
+            lock.lock(); let block = self.block; lock.unlock()
+            block?()
+        }
+    }
+
     /// A timeout timer scheduled in one background cycle must NOT end the session if a
     /// foreground→background round-trip happened after it was scheduled. Without the
     /// generation guard the stale timer sees `state == .backgrounded` again and wrongly
     /// ends the live session, orphaning the current cycle's timer.
     func testStaleTimerDoesNotEndCurrentSession() {
-        var timers: [FakeTimer] = []
+        var timers: [DispatchedTimer] = []
         var counter = 0
         let tracker = SessionTracker(
             timeoutMs: 30_000,
@@ -113,7 +131,7 @@ final class SessionTrackerTests: XCTestCase {
                 return "session-\(counter)"
             },
             timerFactory: {
-                let timer = FakeTimer()
+                let timer = DispatchedTimer()
                 timers.append(timer)
                 return timer
             }
@@ -121,13 +139,15 @@ final class SessionTrackerTests: XCTestCase {
 
         tracker.onForeground() // session-1, active
         tracker.onBackground() // timers[0] scheduled for session-1's cycle
-        tracker.onForeground() // back to active (session-1 continues)
+        tracker.onForeground() // back to active (session-1 continues); cancel can't stop timers[0]
         tracker.onBackground() // timers[1] scheduled — the current cycle
 
         XCTAssertEqual(timers.count, 2)
 
-        // Fire the STALE timer from the first cycle.
-        timers[0].fire()
+        // Fire the STALE timer from the first cycle — its callback was "already
+        // dispatched" before the round-trip. Without the generation guard it sees
+        // state == .backgrounded and ends session-1; the guard rejects it by generation.
+        timers[0].fireStale()
         XCTAssertEqual(
             tracker.currentSessionId(),
             "session-1",
@@ -135,7 +155,7 @@ final class SessionTrackerTests: XCTestCase {
         )
 
         // The current cycle's timer still ends the session correctly.
-        timers[1].fire()
+        timers[1].fireStale()
         XCTAssertNil(tracker.currentSessionId(), "the current cycle's timer ends the session")
     }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SessionTrackerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SessionTrackerTests.swift
@@ -97,4 +97,46 @@ final class SessionTrackerTests: XCTestCase {
         XCTAssertEqual(tracker.currentSessionId(), "session-1")
     }
 
+    // MARK: - Stale timer must not end the current session (generation guard)
+
+    /// A timeout timer scheduled in one background cycle must NOT end the session if a
+    /// foreground→background round-trip happened after it was scheduled. Without the
+    /// generation guard the stale timer sees `state == .backgrounded` again and wrongly
+    /// ends the live session, orphaning the current cycle's timer.
+    func testStaleTimerDoesNotEndCurrentSession() {
+        var timers: [FakeTimer] = []
+        var counter = 0
+        let tracker = SessionTracker(
+            timeoutMs: 30_000,
+            uuidProvider: {
+                counter += 1
+                return "session-\(counter)"
+            },
+            timerFactory: {
+                let timer = FakeTimer()
+                timers.append(timer)
+                return timer
+            }
+        )
+
+        tracker.onForeground() // session-1, active
+        tracker.onBackground() // timers[0] scheduled for session-1's cycle
+        tracker.onForeground() // back to active (session-1 continues)
+        tracker.onBackground() // timers[1] scheduled — the current cycle
+
+        XCTAssertEqual(timers.count, 2)
+
+        // Fire the STALE timer from the first cycle.
+        timers[0].fire()
+        XCTAssertEqual(
+            tracker.currentSessionId(),
+            "session-1",
+            "a stale timer from a previous background cycle must not end the current session"
+        )
+
+        // The current cycle's timer still ends the session correctly.
+        timers[1].fire()
+        XCTAssertNil(tracker.currentSessionId(), "the current cycle's timer ends the session")
+    }
+
 }


### PR DESCRIPTION
## Summary

`SessionTracker`'s background timeout timer had no generation/identity guard, so a stale timer from a
previous background cycle could end the current session. `onForeground()` only *cancels* the timer, but a
timer already firing has passed its cancel, and the callback (which ends the session when `state ==
.backgrounded`) could not tell a stale timer from the current one.

Interleaving: `onBackground` (timerA) → timerA fires, blocks on `lock` → `onForeground` (cancel is a
no-op) → `onBackground` (timerB) → timerA wakes, sees `.backgrounded` again, ends the session and
orphans timerB.

Fix: a monotonic `timerGeneration` token, bumped on every state transition (`onForeground`/`onBackground`
/`shutdown`), captured by the scheduled timer and checked in the callback under the lock — so only the
current cycle's timer may end the session. This is the same pattern `AutoMobileHangs` already uses
(`monitorGeneration`).

## Linked Issue

Closes #5666

## Bug / Regression Context

- **Observed symptom:** a stale background-timeout timer ends a session that should still be active,
  orphaning the current cycle's timer.
- **Repro conditions:** a foreground→background round-trip after a timer was scheduled but before it
  runs (the timer's callback is delayed behind the lock).

## Validation

- [x] `swift test` for the SDK package: 300/300 pass (incl. 1 new stale-timer test)
- [x] `swift build -c release` clean; SwiftLint clean
- [x] Existing session behavior preserved (first-foreground, quick-resume, timeout, shutdown tests green)

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

- `testStaleTimerDoesNotEndCurrentSession` — uses a `timerFactory` that yields distinct `FakeTimer`s;
  after onBackground→onForeground→onBackground, firing the *first* cycle's timer must not end the
  session, and the current cycle's timer still ends it. Fails without the generation guard.

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices through the normal SDK
build, not a same-PR artifact re-cut.
