### PR TITLE
feat(storage): add read-only resources for bounded user-visible file namespaces (#5601)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -77,6 +77,7 @@ import { registerDatabaseResources } from "./databaseResources";
 import { registerFailuresResources } from "./failuresResources";
 import { registerStorageResources } from "./storageResources";
 import { registerAppFileResources } from "./appFileResources";
+import { registerSharedStorageResources } from "./sharedStorageResources";
 import { registerFeatureFlagResources } from "./featureFlagResources";
 import { registerNetworkResources } from "./networkResources";
 import { registerEmulatorLossIncidentResources } from "./emulatorLossIncidentResources";
@@ -350,6 +351,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerFailuresResources();
   registerStorageResources();
   registerAppFileResources();
+  registerSharedStorageResources();
   registerFeatureFlagResources();
   registerNetworkResources();
   registerEmulatorLossIncidentResources();

--- a/src/server/sharedStorageReadService.ts
+++ b/src/server/sharedStorageReadService.ts
@@ -68,14 +68,6 @@ export function getSharedStorageReadService(): SharedStorageReadService {
   return sharedStorageReadService;
 }
 
-export function setSharedStorageReadServiceForTesting(service: SharedStorageReadService): void {
-  sharedStorageReadService = service;
-}
-
-export function resetSharedStorageReadServiceForTesting(): void {
-  sharedStorageReadService = null;
-}
-
 export function createSharedStorageReadServiceForTesting(
   dependencies: SharedStorageReadServiceDependencies = {},
 ): SharedStorageReadService {
@@ -133,6 +125,10 @@ class DefaultSharedStorageReadService implements SharedStorageReadService {
         signal: request.signal,
       });
     } catch (error) {
+      logger.warn(
+        `[SharedStorageRead] resolve user failed for list: ${errorMessage(error)}`,
+        error,
+      );
       return { ...base, observation: "unavailable", reason: errorMessage(error) };
     }
 
@@ -156,6 +152,10 @@ class DefaultSharedStorageReadService implements SharedStorageReadService {
         files: parseListing(statOutput, shaOutput, directory, request.deviceId, namespace),
       };
     } catch (error) {
+      // A permission-denied read of a non-primary profile's storage also lands
+      // here as "unavailable"; note that a missing/inaccessible directory can
+      // instead surface as "missing" via the shell existence probe above.
+      logger.warn(`[SharedStorageRead] list ${directory} failed: ${errorMessage(error)}`, error);
       return { ...resolved, observation: "unavailable", reason: errorMessage(error) };
     }
   }
@@ -193,6 +193,10 @@ class DefaultSharedStorageReadService implements SharedStorageReadService {
         signal: request.signal,
       });
     } catch (error) {
+      logger.warn(
+        `[SharedStorageRead] resolve user failed for read: ${errorMessage(error)}`,
+        error,
+      );
       return { ...base, observation: "unavailable", reason: errorMessage(error) };
     }
     base.userId = target.userId;
@@ -224,6 +228,7 @@ class DefaultSharedStorageReadService implements SharedStorageReadService {
           : { mimeType: mimeTypeForPath(path) ?? "text/plain; charset=utf-8", text }),
       };
     } catch (error) {
+      logger.warn(`[SharedStorageRead] read ${file} failed: ${errorMessage(error)}`, error);
       return { ...base, observation: "unavailable", reason: errorMessage(error) };
     }
   }

--- a/src/server/sharedStorageReadService.ts
+++ b/src/server/sharedStorageReadService.ts
@@ -1,0 +1,394 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+import { TextDecoder } from "node:util";
+import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { BootedDevice } from "../models";
+import { ActionableError } from "../models";
+import {
+  defaultAdbClientFactory,
+  type AdbClientFactory,
+} from "../utils/android-cmdline-tools/AdbClientFactory";
+import {
+  AndroidUserTargetResolver,
+  type ResolvedUserTarget,
+  type UserTargetRequest,
+} from "../utils/android-cmdline-tools/AndroidUserTargetResolver";
+import { shellQuote } from "../utils/shellQuote";
+import { errorMessage } from "../utils/describeUnknownError";
+import { logger } from "../utils/logger";
+import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
+import {
+  buildSharedStorageResourceUri,
+  type SharedStorageFileEntry,
+  type SharedStorageFileReadResult,
+  type SharedStorageNamespaceListing,
+} from "./sharedStorageResourceContract";
+import {
+  normalizeSharedStorageNamespace,
+  normalizeSharedStorageRelativePath,
+} from "./sharedStorageContract";
+
+const SHARED_STORAGE_MAX_BUFFER = 64 * 1024 * 1024;
+const NAMESPACE_MISSING_MARKER = "__AUTOMOBILE_NS_MISSING__";
+const FILE_MISSING_MARKER = "__AUTOMOBILE_FILE_MISSING__";
+
+export interface ListSharedStorageRequest {
+  deviceId: string;
+  namespace: string;
+  explicitUserId?: number;
+  signal?: AbortSignal;
+}
+
+export interface ReadSharedStorageRequest extends ListSharedStorageRequest {
+  path: string;
+}
+
+export interface SharedStorageReadService {
+  list(request: ListSharedStorageRequest): Promise<SharedStorageNamespaceListing>;
+  read(request: ReadSharedStorageRequest): Promise<SharedStorageFileReadResult>;
+}
+
+/** Narrow seam over {@link AndroidUserTargetResolver} so tests can pin the profile. */
+export interface SharedStorageUserResolver {
+  resolve(request: UserTargetRequest): Promise<ResolvedUserTarget>;
+}
+
+export interface SharedStorageReadServiceDependencies {
+  adbFactory?: AdbClientFactory;
+  createUserResolver?: (adb: AdbExecutor) => SharedStorageUserResolver;
+  deviceResolver?: (deviceId: string) => Promise<BootedDevice | null>;
+}
+
+let sharedStorageReadService: SharedStorageReadService | null = null;
+
+export function getSharedStorageReadService(): SharedStorageReadService {
+  if (!sharedStorageReadService) {
+    sharedStorageReadService = createSharedStorageReadServiceForTesting();
+  }
+  return sharedStorageReadService;
+}
+
+export function setSharedStorageReadServiceForTesting(service: SharedStorageReadService): void {
+  sharedStorageReadService = service;
+}
+
+export function resetSharedStorageReadServiceForTesting(): void {
+  sharedStorageReadService = null;
+}
+
+export function createSharedStorageReadServiceForTesting(
+  dependencies: SharedStorageReadServiceDependencies = {},
+): SharedStorageReadService {
+  return new DefaultSharedStorageReadService(
+    dependencies.adbFactory ?? defaultAdbClientFactory,
+    dependencies.createUserResolver ?? ((adb) => new AndroidUserTargetResolver(adb)),
+    dependencies.deviceResolver ?? findBootedDevice,
+  );
+}
+
+async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
+  const manager = PlatformDeviceManagerFactory.getInstance();
+  const devices = [
+    ...(await manager.getBootedDevices("android")),
+    ...(await manager.getBootedDevices("ios")),
+  ];
+  return devices.find((candidate) => candidate.deviceId === deviceId) ?? null;
+}
+
+class DefaultSharedStorageReadService implements SharedStorageReadService {
+  constructor(
+    private readonly adbFactory: AdbClientFactory,
+    private readonly createUserResolver: (adb: AdbExecutor) => SharedStorageUserResolver,
+    private readonly deviceResolver: (deviceId: string) => Promise<BootedDevice | null>,
+  ) {}
+
+  async list(request: ListSharedStorageRequest): Promise<SharedStorageNamespaceListing> {
+    const namespace = normalizeSharedStorageNamespace(request.namespace);
+    const base: SharedStorageNamespaceListing = {
+      deviceId: request.deviceId,
+      platform: "android",
+      namespace,
+      observation: "complete",
+      files: [],
+    };
+
+    const device = await this.deviceResolver(request.deviceId);
+    if (!device) {
+      return {
+        ...base,
+        observation: "unavailable",
+        reason: deviceNotBootedReason(request.deviceId),
+      };
+    }
+    base.platform = device.platform;
+    if (device.platform !== "android") {
+      return { ...base, observation: "unsupported", reason: unsupportedReason(device.platform) };
+    }
+
+    const adb = this.adbFactory.create(device);
+    let target: ResolvedUserTarget;
+    try {
+      target = await this.createUserResolver(adb).resolve({
+        explicitUserId: request.explicitUserId,
+        signal: request.signal,
+      });
+    } catch (error) {
+      return { ...base, observation: "unavailable", reason: errorMessage(error) };
+    }
+
+    const directory = downloadsDirectory(target.userId, namespace);
+    const resolved: SharedStorageNamespaceListing = {
+      ...base,
+      userId: target.userId,
+      userSource: target.source,
+      downloadsDirectory: directory,
+    };
+
+    try {
+      const statOutput = await executeShell(adb, listStatScript(directory), request.signal);
+      if (statOutput.trim() === NAMESPACE_MISSING_MARKER) {
+        return { ...resolved, observation: "missing", reason: namespaceMissingReason(directory) };
+      }
+      const shaOutput = await executeShell(adb, listShaScript(directory), request.signal);
+      return {
+        ...resolved,
+        observation: "complete",
+        files: parseListing(statOutput, shaOutput, directory, request.deviceId, namespace),
+      };
+    } catch (error) {
+      return { ...resolved, observation: "unavailable", reason: errorMessage(error) };
+    }
+  }
+
+  async read(request: ReadSharedStorageRequest): Promise<SharedStorageFileReadResult> {
+    const namespace = normalizeSharedStorageNamespace(request.namespace);
+    const path = normalizeSharedStorageRelativePath(request.path);
+    const base: SharedStorageFileReadResult = {
+      deviceId: request.deviceId,
+      platform: "android",
+      namespace,
+      path,
+      observation: "complete",
+      resourceUri: buildSharedStorageResourceUri({ deviceId: request.deviceId, namespace, path }),
+    };
+
+    const device = await this.deviceResolver(request.deviceId);
+    if (!device) {
+      return {
+        ...base,
+        observation: "unavailable",
+        reason: deviceNotBootedReason(request.deviceId),
+      };
+    }
+    base.platform = device.platform;
+    if (device.platform !== "android") {
+      return { ...base, observation: "unsupported", reason: unsupportedReason(device.platform) };
+    }
+
+    const adb = this.adbFactory.create(device);
+    let target: ResolvedUserTarget;
+    try {
+      target = await this.createUserResolver(adb).resolve({
+        explicitUserId: request.explicitUserId,
+        signal: request.signal,
+      });
+    } catch (error) {
+      return { ...base, observation: "unavailable", reason: errorMessage(error) };
+    }
+    base.userId = target.userId;
+
+    const directory = downloadsDirectory(target.userId, namespace);
+    const file = posix.join(directory, path);
+    // Defense in depth: the joined path can never leave the declared namespace.
+    if (file !== directory && !file.startsWith(`${directory}/`)) {
+      throw new ActionableError(`path escapes shared-storage namespace ${namespace}`);
+    }
+
+    try {
+      const output = await executeShell(adb, readScript(file), request.signal);
+      if (output.trim() === FILE_MISSING_MARKER) {
+        return { ...base, observation: "missing", reason: fileMissingReason(file) };
+      }
+      const buffer = Buffer.from(output.replace(/\s+/g, ""), "base64");
+      const text = decodeUtf8Text(buffer);
+      return {
+        ...base,
+        observation: "complete",
+        byteCount: buffer.byteLength,
+        sha256: createHash("sha256").update(buffer).digest("hex"),
+        ...(text === undefined
+          ? {
+              mimeType: mimeTypeForPath(path) ?? "application/octet-stream",
+              blob: buffer.toString("base64"),
+            }
+          : { mimeType: mimeTypeForPath(path) ?? "text/plain; charset=utf-8", text }),
+      };
+    } catch (error) {
+      return { ...base, observation: "unavailable", reason: errorMessage(error) };
+    }
+  }
+}
+
+function downloadsDirectory(userId: number, namespace: string): string {
+  return posix.join(`/storage/emulated/${userId}/Download`, namespace);
+}
+
+function listStatScript(directory: string): string {
+  return (
+    `if [ -d ${shellQuote(directory)} ]; then ` +
+    `find ${shellQuote(directory)} -type f -exec stat -c '%s|%Y|%n' {} \\; ; ` +
+    `else printf '%s' ${shellQuote(NAMESPACE_MISSING_MARKER)}; fi`
+  );
+}
+
+function listShaScript(directory: string): string {
+  return (
+    `if [ -d ${shellQuote(directory)} ]; then ` +
+    `find ${shellQuote(directory)} -type f -exec sha256sum {} \\; ; fi`
+  );
+}
+
+function readScript(file: string): string {
+  return (
+    `if [ -f ${shellQuote(file)} ]; then base64 ${shellQuote(file)}; ` +
+    `else printf '%s' ${shellQuote(FILE_MISSING_MARKER)}; fi`
+  );
+}
+
+async function executeShell(
+  adb: AdbExecutor,
+  script: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const result = await adb.executeCommand(
+    `shell ${script}`,
+    undefined,
+    SHARED_STORAGE_MAX_BUFFER,
+    true,
+    signal,
+  );
+  return result.stdout;
+}
+
+function parseListing(
+  statOutput: string,
+  shaOutput: string,
+  directory: string,
+  deviceId: string,
+  namespace: string,
+): SharedStorageFileEntry[] {
+  const hashes = parseShaOutput(shaOutput);
+  const prefix = `${directory}/`;
+  return statOutput
+    .split(/\n/)
+    .map((line) => line.replace(/\r$/, ""))
+    .filter((line) => line.length > 0)
+    .map((line): SharedStorageFileEntry | null => {
+      const firstBar = line.indexOf("|");
+      const secondBar = line.indexOf("|", firstBar + 1);
+      if (firstBar < 0 || secondBar < 0) {
+        return null;
+      }
+      const absolutePath = line.slice(secondBar + 1);
+      if (!absolutePath.startsWith(prefix)) {
+        return null;
+      }
+      const relativePath = absolutePath.slice(prefix.length);
+      const byteCount = Number(line.slice(0, firstBar));
+      const modifiedSeconds = Number(line.slice(firstBar + 1, secondBar));
+      const mimeType = mimeTypeForPath(relativePath);
+      const sha256 = hashes.get(absolutePath);
+      return {
+        path: relativePath,
+        name: posix.basename(relativePath),
+        ...(Number.isFinite(byteCount) ? { byteCount } : {}),
+        ...(mimeType ? { mimeType } : {}),
+        ...(sha256 ? { sha256 } : {}),
+        ...(Number.isFinite(modifiedSeconds)
+          ? { lastModified: new Date(modifiedSeconds * 1000).toISOString() }
+          : {}),
+        resourceUri: buildSharedStorageResourceUri({ deviceId, namespace, path: relativePath }),
+      };
+    })
+    .filter((entry): entry is SharedStorageFileEntry => entry !== null);
+}
+
+function parseShaOutput(shaOutput: string): Map<string, string> {
+  const hashes = new Map<string, string>();
+  for (const rawLine of shaOutput.split(/\n/)) {
+    const line = rawLine.replace(/\r$/, "");
+    const match = line.match(/^([0-9a-fA-F]{64})\s+\*?(.*)$/);
+    if (match) {
+      hashes.set(match[2], match[1].toLowerCase());
+    }
+  }
+  return hashes;
+}
+
+function decodeUtf8Text(buffer: Buffer): string | undefined {
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+    return text.includes("\u0000") ? undefined : text;
+  } catch (error) {
+    // Strict UTF-8 decoding throws on binary/invalid-encoding data; undefined
+    // tells the caller to treat the file as a binary blob instead of text.
+    logger.debug(`src/server/sharedStorageReadService.ts utf8 decode failed: ${error}`, error);
+    return undefined;
+  }
+}
+
+// Extension -> MIME for the user-visible file types staged into Downloads. Kept
+// deliberately small (no untyped `mime` dependency); unknown extensions fall back
+// to the UTF-8/binary split at the call site, so this only adds "when known" types.
+const MIME_TYPES_BY_EXTENSION: Record<string, string> = {
+  txt: "text/plain",
+  md: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+  xml: "application/xml",
+  html: "text/html",
+  pdf: "application/pdf",
+  zip: "application/zip",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  heic: "image/heic",
+  mp4: "video/mp4",
+  mov: "video/quicktime",
+  mkv: "video/x-matroska",
+  webm: "video/webm",
+  mp3: "audio/mpeg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  ogg: "audio/ogg",
+  wav: "audio/wav",
+};
+
+function mimeTypeForPath(path: string): string | undefined {
+  const base = posix.basename(path);
+  const dotIndex = base.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return undefined;
+  }
+  return MIME_TYPES_BY_EXTENSION[base.slice(dotIndex + 1).toLowerCase()];
+}
+
+function deviceNotBootedReason(deviceId: string): string {
+  return `Device not found or not booted: ${deviceId}`;
+}
+
+function unsupportedReason(platform: string): string {
+  return `User-visible Downloads resources are only supported on Android devices, not ${platform}.`;
+}
+
+function namespaceMissingReason(directory: string): string {
+  return `Downloads namespace directory does not exist: ${directory}`;
+}
+
+function fileMissingReason(file: string): string {
+  return `File does not exist in the Downloads namespace: ${file}`;
+}

--- a/src/server/sharedStorageResourceContract.ts
+++ b/src/server/sharedStorageResourceContract.ts
@@ -1,0 +1,90 @@
+import {
+  normalizeSharedStorageNamespace,
+  normalizeSharedStorageRelativePath,
+} from "./sharedStorageContract";
+
+/**
+ * Read-only MCP resources for files staged into a bounded, user-visible
+ * Downloads namespace (the read counterpart of {@link stageSharedStorageSchema}).
+ * The namespace-list resource enumerates normalized relative paths with bounded
+ * verification metadata; the file resource returns UTF-8 text or a binary blob.
+ */
+export const SHARED_STORAGE_RESOURCE_TEMPLATES = {
+  NAMESPACE: "automobile:devices/{deviceId}/downloads/{namespace}",
+  FILE: "automobile:devices/{deviceId}/downloads/{namespace}/{path}",
+} as const;
+
+/** How completely a namespace or file could be observed on the device. */
+export type SharedStorageObservation = "complete" | "missing" | "unavailable" | "unsupported";
+
+export interface SharedStorageResourceParts {
+  deviceId: string;
+  namespace: string;
+  path?: string;
+}
+
+export interface SharedStorageFileEntry {
+  path: string;
+  name: string;
+  byteCount?: number;
+  mimeType?: string;
+  sha256?: string;
+  lastModified?: string;
+  resourceUri: string;
+}
+
+export interface SharedStorageNamespaceListing {
+  deviceId: string;
+  platform: string;
+  namespace: string;
+  userId?: number;
+  userSource?: string;
+  downloadsDirectory?: string;
+  observation: SharedStorageObservation;
+  reason?: string;
+  files: SharedStorageFileEntry[];
+}
+
+export interface SharedStorageFileReadResult {
+  deviceId: string;
+  platform: string;
+  namespace: string;
+  path: string;
+  userId?: number;
+  observation: SharedStorageObservation;
+  reason?: string;
+  byteCount?: number;
+  mimeType?: string;
+  sha256?: string;
+  text?: string;
+  blob?: string;
+  resourceUri: string;
+}
+
+function encodePathSegments(path: string): string {
+  return normalizeSharedStorageRelativePath(path)
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+export function buildSharedStorageResourceUri(parts: SharedStorageResourceParts): string {
+  const namespace = normalizeSharedStorageNamespace(parts.namespace);
+  const base =
+    `automobile:devices/${encodeURIComponent(parts.deviceId)}` +
+    `/downloads/${encodeURIComponent(namespace)}`;
+  return parts.path === undefined ? base : `${base}/${encodePathSegments(parts.path)}`;
+}
+
+export function parseSharedStorageResourceParams(
+  params: Record<string, string>,
+): SharedStorageResourceParts {
+  const namespace = normalizeSharedStorageNamespace(decodeURIComponent(params.namespace));
+  return {
+    deviceId: decodeURIComponent(params.deviceId),
+    namespace,
+    ...(params.path !== undefined
+      ? { path: normalizeSharedStorageRelativePath(decodeURIComponent(params.path)) }
+      : {}),
+  };
+}

--- a/src/server/sharedStorageResources.ts
+++ b/src/server/sharedStorageResources.ts
@@ -1,0 +1,89 @@
+import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
+import {
+  SHARED_STORAGE_RESOURCE_TEMPLATES,
+  buildSharedStorageResourceUri,
+  parseSharedStorageResourceParams,
+} from "./sharedStorageResourceContract";
+import type { SharedStorageReadService } from "./sharedStorageReadService";
+
+type SharedStorageReadServiceResolver = () => Promise<SharedStorageReadService>;
+
+async function getDefaultSharedStorageReadService(): Promise<SharedStorageReadService> {
+  const { getSharedStorageReadService } = await import("./sharedStorageReadService");
+  return getSharedStorageReadService();
+}
+
+function createListNamespaceResource(service: SharedStorageReadServiceResolver) {
+  return async (params: Record<string, string>): Promise<ResourceContent> => {
+    const parts = parseSharedStorageResourceParams(params);
+    const listing = await (
+      await service()
+    ).list({
+      deviceId: parts.deviceId,
+      namespace: parts.namespace,
+    });
+    return {
+      uri: buildSharedStorageResourceUri({ deviceId: parts.deviceId, namespace: parts.namespace }),
+      mimeType: "application/json",
+      text: JSON.stringify(listing, null, 2),
+    };
+  };
+}
+
+function createReadFileResource(service: SharedStorageReadServiceResolver) {
+  return async (params: Record<string, string>): Promise<ResourceContent> => {
+    const parts = parseSharedStorageResourceParams(params);
+    if (parts.path === undefined) {
+      throw new Error("Shared-storage file resource path is required.");
+    }
+
+    const result = await (
+      await service()
+    ).read({
+      deviceId: parts.deviceId,
+      namespace: parts.namespace,
+      path: parts.path,
+    });
+    const uri = buildSharedStorageResourceUri({
+      deviceId: parts.deviceId,
+      namespace: parts.namespace,
+      path: parts.path,
+    });
+
+    // A completed read returns the file's bytes with its content type; any other
+    // observation (missing/unavailable/unsupported) is a typed JSON envelope so
+    // the client can distinguish "no such file" from an empty file.
+    if (result.observation !== "complete") {
+      return { uri, mimeType: "application/json", text: JSON.stringify(result, null, 2) };
+    }
+    return {
+      uri,
+      mimeType: result.mimeType ?? "application/octet-stream",
+      ...(result.text !== undefined ? { text: result.text } : { blob: result.blob ?? "" }),
+    };
+  };
+}
+
+export function registerSharedStorageResources(service?: SharedStorageReadService): void {
+  const resolver: SharedStorageReadServiceResolver = service
+    ? async () => service
+    : getDefaultSharedStorageReadService;
+
+  ResourceRegistry.registerTemplate(
+    SHARED_STORAGE_RESOURCE_TEMPLATES.NAMESPACE,
+    "Downloads Namespace Files",
+    "List files staged into one bounded, user-visible Android Downloads namespace, " +
+      "with normalized relative paths, byte counts, MIME types, and SHA-256 verification hashes.",
+    "application/json",
+    createListNamespaceResource(resolver),
+  );
+
+  ResourceRegistry.registerTemplate(
+    SHARED_STORAGE_RESOURCE_TEMPLATES.FILE,
+    "Downloads Namespace File",
+    "Read one file from a bounded Android Downloads namespace. UTF-8 content is returned " +
+      "as text; binary content is returned as a base64 MCP blob.",
+    "application/octet-stream",
+    createReadFileResource(resolver),
+  );
+}

--- a/test/server/sharedStorageReadService.test.ts
+++ b/test/server/sharedStorageReadService.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { createSharedStorageReadServiceForTesting } from "../../src/server/sharedStorageReadService";
+import type { SharedStorageUserResolver } from "../../src/server/sharedStorageReadService";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import type { BootedDevice } from "../../src/models";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type {
+  ResolvedUserTarget,
+  UserTargetRequest,
+} from "../../src/utils/android-cmdline-tools/AndroidUserTargetResolver";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+};
+
+function execResult(stdout: string) {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (text: string) => stdout.includes(text),
+  };
+}
+
+function adbFactoryFor(executor: FakeAdbExecutor): AdbClientFactory {
+  return { create: () => executor };
+}
+
+function resolverReturning(target: ResolvedUserTarget, captured?: UserTargetRequest[]) {
+  const resolver: SharedStorageUserResolver = {
+    resolve: async (request: UserTargetRequest = {}) => {
+      captured?.push(request);
+      return target;
+    },
+  };
+  return () => resolver;
+}
+
+function serviceWith(
+  executor: FakeAdbExecutor,
+  target: ResolvedUserTarget = { userId: 0, source: "primary" },
+  options: { device?: BootedDevice | null; captured?: UserTargetRequest[] } = {},
+) {
+  return createSharedStorageReadServiceForTesting({
+    adbFactory: adbFactoryFor(executor),
+    createUserResolver: resolverReturning(target, options.captured),
+    deviceResolver: async () => (options.device === undefined ? androidDevice : options.device),
+  });
+}
+
+describe("SharedStorageReadService.list", () => {
+  test("lists staged files with byte count, MIME, hash, and per-file resource URIs", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse(
+      "-exec stat",
+      execResult(
+        "7|1690000000|/storage/emulated/0/Download/run-42/docs/read me.txt\n" +
+          "3|1690000100|/storage/emulated/0/Download/run-42/media/photo.png\n",
+      ),
+    );
+    executor.setCommandResponse(
+      "sha256sum",
+      execResult(
+        "1111111111111111111111111111111111111111111111111111111111111111  /storage/emulated/0/Download/run-42/docs/read me.txt\n" +
+          "2222222222222222222222222222222222222222222222222222222222222222  /storage/emulated/0/Download/run-42/media/photo.png\n",
+      ),
+    );
+
+    const listing = await serviceWith(executor).list({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+    });
+
+    expect(listing).toEqual({
+      deviceId: "emulator-5554",
+      platform: "android",
+      namespace: "run-42",
+      userId: 0,
+      userSource: "primary",
+      downloadsDirectory: "/storage/emulated/0/Download/run-42",
+      observation: "complete",
+      files: [
+        {
+          path: "docs/read me.txt",
+          name: "read me.txt",
+          byteCount: 7,
+          mimeType: "text/plain",
+          sha256: "1111111111111111111111111111111111111111111111111111111111111111",
+          lastModified: new Date(1690000000 * 1000).toISOString(),
+          resourceUri: "automobile:devices/emulator-5554/downloads/run-42/docs/read%20me.txt",
+        },
+        {
+          path: "media/photo.png",
+          name: "photo.png",
+          byteCount: 3,
+          mimeType: "image/png",
+          sha256: "2222222222222222222222222222222222222222222222222222222222222222",
+          lastModified: new Date(1690000100 * 1000).toISOString(),
+          resourceUri: "automobile:devices/emulator-5554/downloads/run-42/media/photo.png",
+        },
+      ],
+    });
+  });
+
+  test("distinguishes an existing-but-empty namespace from a missing one", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("-exec stat", execResult(""));
+    executor.setCommandResponse("sha256sum", execResult(""));
+
+    const empty = await serviceWith(executor).list({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+    });
+    expect(empty.observation).toBe("complete");
+    expect(empty.files).toEqual([]);
+  });
+
+  test("reports a missing namespace as a typed observation, not an authoritative empty list", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("-exec stat", execResult("__AUTOMOBILE_NS_MISSING__"));
+
+    const listing = await serviceWith(executor).list({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+    });
+    expect(listing.observation).toBe("missing");
+    expect(listing.files).toEqual([]);
+    expect(listing.reason).toBeDefined();
+  });
+
+  test("reports an unavailable observation when the device cannot be observed", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setDefaultError(new Error("device offline"));
+
+    const listing = await serviceWith(executor).list({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+    });
+    expect(listing.observation).toBe("unavailable");
+    expect(listing.reason).toContain("device offline");
+    expect(listing.files).toEqual([]);
+  });
+
+  test("reports unsupported for non-Android devices without issuing commands", async () => {
+    const executor = new FakeAdbExecutor();
+    const listing = await serviceWith(
+      executor,
+      { userId: 0, source: "primary" },
+      {
+        device: { deviceId: "ios", name: "iPhone", platform: "ios" },
+      },
+    ).list({ deviceId: "ios", namespace: "run-42" });
+    expect(listing.observation).toBe("unsupported");
+    expect(listing.files).toEqual([]);
+    expect(executor.getExecutedCommands()).toEqual([]);
+  });
+
+  test("reports unavailable when the device is not booted", async () => {
+    const executor = new FakeAdbExecutor();
+    const listing = await serviceWith(
+      executor,
+      { userId: 0, source: "primary" },
+      {
+        device: null,
+      },
+    ).list({ deviceId: "ghost", namespace: "run-42" });
+    expect(listing.observation).toBe("unavailable");
+    expect(listing.reason).toContain("not booted");
+  });
+
+  test("targets the resolved profile's Downloads for work-profile devices", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("-exec stat", execResult(""));
+    executor.setCommandResponse("sha256sum", execResult(""));
+    const captured: UserTargetRequest[] = [];
+
+    const listing = await serviceWith(
+      executor,
+      { userId: 10, source: "managedProfile" },
+      { captured },
+    ).list({ deviceId: "emulator-5554", namespace: "run-42", explicitUserId: 10 });
+
+    expect(listing.userId).toBe(10);
+    expect(listing.userSource).toBe("managedProfile");
+    expect(listing.downloadsDirectory).toBe("/storage/emulated/10/Download/run-42");
+    expect(captured[0]?.explicitUserId).toBe(10);
+    expect(
+      executor
+        .getExecutedCommands()
+        .some((c) => c.includes("/storage/emulated/10/Download/run-42")),
+    ).toBe(true);
+  });
+
+  test("reports unavailable when the active profile cannot be resolved", async () => {
+    const executor = new FakeAdbExecutor();
+    const resolver: SharedStorageUserResolver = {
+      resolve: async () => {
+        throw new Error("Android target user is ambiguous");
+      },
+    };
+    const service = createSharedStorageReadServiceForTesting({
+      adbFactory: adbFactoryFor(executor),
+      createUserResolver: () => resolver,
+      deviceResolver: async () => androidDevice,
+    });
+    const listing = await service.list({ deviceId: "emulator-5554", namespace: "run-42" });
+    expect(listing.observation).toBe("unavailable");
+    expect(listing.reason).toContain("ambiguous");
+    expect(executor.getExecutedCommands()).toEqual([]);
+  });
+});
+
+describe("SharedStorageReadService.read", () => {
+  test("reads a UTF-8 file as text with byte count, MIME, and hash", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse(
+      "base64",
+      execResult(Buffer.from("hello", "utf8").toString("base64")),
+    );
+
+    const result = await serviceWith(executor).read({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+      path: "notes/hi.txt",
+    });
+
+    expect(result.observation).toBe("complete");
+    expect(result.text).toBe("hello");
+    expect(result.blob).toBeUndefined();
+    expect(result.byteCount).toBe(5);
+    expect(result.mimeType).toBe("text/plain");
+    expect(result.sha256).toBe(
+      createHash("sha256").update(Buffer.from("hello", "utf8")).digest("hex"),
+    );
+    expect(result.resourceUri).toBe(
+      "automobile:devices/emulator-5554/downloads/run-42/notes/hi.txt",
+    );
+  });
+
+  test("reads a binary file as a lossless base64 blob", async () => {
+    const executor = new FakeAdbExecutor();
+    const bytes = Buffer.from([0x00, 0x01, 0xff]);
+    executor.setCommandResponse("base64", execResult(bytes.toString("base64")));
+
+    const result = await serviceWith(executor).read({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+      path: "media/blob.bin",
+    });
+
+    expect(result.observation).toBe("complete");
+    expect(result.text).toBeUndefined();
+    expect(result.blob).toBe(bytes.toString("base64"));
+    expect(result.byteCount).toBe(3);
+    expect(result.mimeType).toBe("application/octet-stream");
+    expect(result.sha256).toBe(createHash("sha256").update(bytes).digest("hex"));
+  });
+
+  test("reports a missing file as a typed observation", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("base64", execResult("__AUTOMOBILE_FILE_MISSING__"));
+
+    const result = await serviceWith(executor).read({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+      path: "notes/gone.txt",
+    });
+    expect(result.observation).toBe("missing");
+    expect(result.text).toBeUndefined();
+    expect(result.blob).toBeUndefined();
+  });
+
+  test("rejects a path that escapes the declared namespace", async () => {
+    const executor = new FakeAdbExecutor();
+    await expect(
+      serviceWith(executor).read({
+        deviceId: "emulator-5554",
+        namespace: "run-42",
+        path: "../../etc/hosts",
+      }),
+    ).rejects.toThrow();
+    expect(executor.getExecutedCommands()).toEqual([]);
+  });
+});

--- a/test/server/sharedStorageResourceContract.test.ts
+++ b/test/server/sharedStorageResourceContract.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SHARED_STORAGE_RESOURCE_TEMPLATES,
+  buildSharedStorageResourceUri,
+  parseSharedStorageResourceParams,
+} from "../../src/server/sharedStorageResourceContract";
+
+describe("shared-storage resource contract", () => {
+  test("exposes namespace-list and file-read templates", () => {
+    expect(SHARED_STORAGE_RESOURCE_TEMPLATES.NAMESPACE).toBe(
+      "automobile:devices/{deviceId}/downloads/{namespace}",
+    );
+    expect(SHARED_STORAGE_RESOURCE_TEMPLATES.FILE).toBe(
+      "automobile:devices/{deviceId}/downloads/{namespace}/{path}",
+    );
+  });
+
+  test("round-trips a namespace URI with encoded segments", () => {
+    const uri = buildSharedStorageResourceUri({ deviceId: "emulator-5554", namespace: "run 42" });
+    expect(uri).toBe("automobile:devices/emulator-5554/downloads/run%2042");
+    expect(
+      parseSharedStorageResourceParams({ deviceId: "emulator-5554", namespace: "run%2042" }),
+    ).toEqual({
+      deviceId: "emulator-5554",
+      namespace: "run 42",
+    });
+  });
+
+  test("round-trips a nested file URI, encoding each path segment", () => {
+    const uri = buildSharedStorageResourceUri({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+      path: "docs/read me.txt",
+    });
+    expect(uri).toBe("automobile:devices/emulator-5554/downloads/run-42/docs/read%20me.txt");
+    expect(
+      parseSharedStorageResourceParams({
+        deviceId: "emulator-5554",
+        namespace: "run-42",
+        path: "docs/read%20me.txt",
+      }),
+    ).toEqual({
+      deviceId: "emulator-5554",
+      namespace: "run-42",
+      path: "docs/read me.txt",
+    });
+  });
+
+  test("rejects a namespace that is not a single Downloads child", () => {
+    for (const namespace of ["", ".", "..", "a%2Fb", "a%5Cb"]) {
+      expect(() =>
+        parseSharedStorageResourceParams({ deviceId: "emulator-5554", namespace }),
+      ).toThrow();
+    }
+  });
+
+  test("rejects file paths that traverse or escape the namespace", () => {
+    for (const path of ["../outside.txt", "%2e%2e/outside.txt", "/etc/hosts", "docs/../../x"]) {
+      expect(() =>
+        parseSharedStorageResourceParams({ deviceId: "emulator-5554", namespace: "run-42", path }),
+      ).toThrow();
+    }
+  });
+});

--- a/test/server/sharedStorageResources.test.ts
+++ b/test/server/sharedStorageResources.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerSharedStorageResources } from "../../src/server/sharedStorageResources";
+import type { SharedStorageReadService } from "../../src/server/sharedStorageReadService";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+
+const fakeService: SharedStorageReadService = {
+  list: async (request) => ({
+    deviceId: request.deviceId,
+    platform: "android",
+    namespace: request.namespace,
+    userId: 0,
+    userSource: "primary",
+    downloadsDirectory: `/storage/emulated/0/Download/${request.namespace}`,
+    observation: "complete",
+    files: [
+      {
+        path: "docs/read me.txt",
+        name: "read me.txt",
+        byteCount: 7,
+        mimeType: "text/plain",
+        sha256: "1111",
+        lastModified: "2023-07-22T06:13:20.000Z",
+        resourceUri: `automobile:devices/${request.deviceId}/downloads/${request.namespace}/docs/read%20me.txt`,
+      },
+    ],
+  }),
+  read: async (request) => ({
+    deviceId: request.deviceId,
+    platform: "android",
+    namespace: request.namespace,
+    path: request.path,
+    userId: 0,
+    observation: "complete",
+    byteCount: 3,
+    mimeType: "application/octet-stream",
+    sha256: "2222",
+    blob: "AAH/",
+    resourceUri: `automobile:devices/${request.deviceId}/downloads/${request.namespace}/${request.path}`,
+  }),
+};
+
+describe("Shared-storage read resources", () => {
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  afterEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  test("registers namespace-list and file-read templates", () => {
+    registerSharedStorageResources(fakeService);
+    const templates = ResourceRegistry.getTemplateDefinitions().map((t) => t.uriTemplate);
+    expect(templates).toContain("automobile:devices/{deviceId}/downloads/{namespace}");
+    expect(templates).toContain("automobile:devices/{deviceId}/downloads/{namespace}/{path}");
+  });
+
+  test("lists a namespace as JSON with verification metadata", async () => {
+    registerSharedStorageResources(fakeService);
+    const match = ResourceRegistry.matchTemplate(
+      "automobile:devices/emulator-5554/downloads/run-42",
+    );
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    expect(content.mimeType).toBe("application/json");
+    const payload = JSON.parse(content.text!);
+    expect(payload).toMatchObject({
+      deviceId: "emulator-5554",
+      platform: "android",
+      namespace: "run-42",
+      observation: "complete",
+    });
+    expect(payload.files[0]).toMatchObject({
+      path: "docs/read me.txt",
+      byteCount: 7,
+      mimeType: "text/plain",
+      sha256: "1111",
+      resourceUri: "automobile:devices/emulator-5554/downloads/run-42/docs/read%20me.txt",
+    });
+  });
+
+  test("reads a binary file as a lossless MCP blob", async () => {
+    registerSharedStorageResources(fakeService);
+    const uri = "automobile:devices/emulator-5554/downloads/run-42/media/photo.png";
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    expect(content.uri).toBe(uri);
+    expect(content.mimeType).toBe("application/octet-stream");
+    expect(content.blob).toBe("AAH/");
+    expect(content.text).toBeUndefined();
+  });
+
+  test("reads a UTF-8 file as MCP text content", async () => {
+    registerSharedStorageResources({
+      ...fakeService,
+      read: async (request) => ({
+        deviceId: request.deviceId,
+        platform: "android",
+        namespace: request.namespace,
+        path: request.path,
+        userId: 0,
+        observation: "complete",
+        byteCount: 5,
+        mimeType: "text/plain",
+        sha256: "3333",
+        text: "hello",
+        resourceUri: `automobile:devices/${request.deviceId}/downloads/${request.namespace}/${request.path}`,
+      }),
+    });
+    const uri = "automobile:devices/emulator-5554/downloads/run-42/notes/hi.txt";
+    const match = ResourceRegistry.matchTemplate(uri);
+    const content = await match!.template.handler(match!.params);
+    expect(content.mimeType).toBe("text/plain");
+    expect(content.text).toBe("hello");
+    expect(content.blob).toBeUndefined();
+  });
+
+  test("returns a typed JSON envelope when a file read is not complete", async () => {
+    registerSharedStorageResources({
+      ...fakeService,
+      read: async (request) => ({
+        deviceId: request.deviceId,
+        platform: "android",
+        namespace: request.namespace,
+        path: request.path,
+        observation: "missing",
+        reason: "file not found",
+        resourceUri: `automobile:devices/${request.deviceId}/downloads/${request.namespace}/${request.path}`,
+      }),
+    });
+    const uri = "automobile:devices/emulator-5554/downloads/run-42/notes/gone.txt";
+    const match = ResourceRegistry.matchTemplate(uri);
+    const content = await match!.template.handler(match!.params);
+    expect(content.mimeType).toBe("application/json");
+    const payload = JSON.parse(content.text!);
+    expect(payload.observation).toBe("missing");
+    expect(content.blob).toBeUndefined();
+  });
+
+  test("rejects a file URI that traverses out of the namespace", async () => {
+    registerSharedStorageResources(fakeService);
+    const match = ResourceRegistry.matchTemplate(
+      "automobile:devices/emulator-5554/downloads/run-42/../../etc/hosts",
+    );
+    // The traversal URI must not resolve to a readable file.
+    if (match) {
+      await expect(match.template.handler(match.params)).rejects.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the read counterpart of the `stageSharedStorage` write surface. Today staging
returns only a write receipt; a client cannot list, read, or verify the resulting
namespace. This exposes two read-only MCP resource templates, beginning with Android
Downloads:

- `automobile:devices/{deviceId}/downloads/{namespace}` — lists normalized relative
  paths with bounded metadata: `byteCount`, `mimeType` (when known), `sha256`,
  `lastModified`, and a per-file `resourceUri`.
- `automobile:devices/{deviceId}/downloads/{namespace}/{path}` — returns UTF-8 text
  or a base64 binary blob, consistent with the app-container file resources.

Reads are profile-aware: the Downloads root resolves through `AndroidUserTargetResolver`
to `/storage/emulated/<userId>/Download/<namespace>`, so work-profile / multi-user
devices target the correct profile (default primary user 0 matches the write side's
`/sdcard/Download`). Only a device target + a single-segment namespace are accepted —
never an arbitrary device path — and every joined path is re-checked so it cannot
escape the declared namespace.

Missing, empty, unavailable, and unsupported observations are typed
(`observation: "complete" | "missing" | "unavailable" | "unsupported"`) rather than an
authoritative empty list, so a client can tell "no such namespace" from "empty namespace".

## Linked Issue

Closes #5601

(Dependency #5599 — profile targeting — is closed; unblocked.)

## Changes

- `src/server/sharedStorageResourceContract.ts` — URI templates, encode/decode + build
  helpers, result types; reuses the existing `normalizeSharedStorageNamespace` /
  `normalizeSharedStorageRelativePath` traversal guards.
- `src/server/sharedStorageReadService.ts` — `SharedStorageReadService` (list/read) over
  ADB (`find … stat` + on-device `sha256sum`; `base64` for content), with injected
  `adbFactory`, `deviceResolver`, and an `AndroidUserTargetResolver` seam. Small local
  extension→MIME map (no new/untyped `mime` dependency).
- `src/server/sharedStorageResources.ts` — resource registration mirroring
  `appFileResources`.
- `src/server/index.ts` — register the resources alongside the other read resources.

## Validation

- [x] `bun run lint` + `bun test` (new suites + full run; the single full-suite failure
      is `test/lint/oxlintConfigScoping.test.ts`, a pre-existing worktree artifact — no
      `node_modules/.bin/oxlint` in a git worktree — unrelated to this change)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds; `oxfmt --check` clean on touched files
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [x] New generic code reuses the standard library / existing helpers; no new dependency

## Acceptance criteria

- [x] A staged bounded namespace can be listed and a named file read through MCP resources
- [x] Resource paths reject traversal and cannot escape the declared namespace
- [x] Missing, partial, and unsupported observations have typed results
- [x] Tests cover text, binary, invalid paths, and profile-aware device targeting
- [x] Byte count, MIME (when known), and a SHA-256 verification field are included

## Device Verification

- [ ] Not run on hardware — logic is fully covered by fakes; behavior against a real
      emulator's Downloads is a natural manual-test follow-up.
