### PR TITLE
fix(ios): CtrlProxy WebSocket ping frame desyncs the wire (mask/payload not consumed)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -689,7 +689,7 @@ class WebSocketConnection: WebSocketResponding {
     }
 
     func send(_ data: Data) {
-        let frame = createWebSocketFrame(data: data, opcode: 0x01) // Text frame
+        let frame = Self.createWebSocketFrame(data: data, opcode: 0x01) // Text frame
         connection.send(content: frame, completion: .contentProcessed { error in
             if let error = error {
                 print("[WebSocketConnection] Send error: \(error)")
@@ -951,12 +951,21 @@ class WebSocketConnection: WebSocketResponding {
             return
         }
 
-        // Handle ping
+        // Handle ping (RFC 6455 §5.5.2). A client→server frame is always masked
+        // (§5.3), so the masking key and any ping payload still sit unread in the
+        // stream after the 2-byte header. Route the ping through the same masked
+        // `readPayload` path as data frames so those bytes are consumed before the
+        // next frame header is read — otherwise the mask bytes are mis-read as a
+        // new header and the wire desyncs (issue #5669). A control-frame payload is
+        // at most 125 bytes and MUST NOT use the 126/127 extended-length forms
+        // (§5.5); a ping violating that is malformed → close rather than mis-parse.
         if opcode == 0x09 {
-            // Send pong
-            let pongFrame = createWebSocketFrame(data: Data(), opcode: 0x0A)
-            connection.send(content: pongFrame, completion: .contentProcessed { _ in })
-            receiveWebSocketFrame()
+            guard Self.isValidControlFramePayloadLength(payloadLength) else {
+                print("[WebSocketConnection] Ping payload too large (\(payloadLength) bytes), closing connection")
+                onClose()
+                return
+            }
+            readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode)
             return
         }
 
@@ -1028,6 +1037,38 @@ class WebSocketConnection: WebSocketResponding {
         return unmasked
     }
 
+    /// RFC 6455 §5.5: a control-frame payload is at most 125 bytes and MUST NOT
+    /// use the 126/127 extended-length forms. Ping length is validated with this
+    /// bound (a stricter cousin of `maxFramePayloadLength` for control frames)
+    /// before the payload is read, so a malformed/oversized ping closes the
+    /// connection instead of being mis-parsed (issue #5669).
+    static let maxControlFramePayloadLength: UInt64 = 125
+
+    static func isValidControlFramePayloadLength(_ payloadLength: UInt64) -> Bool {
+        payloadLength <= maxControlFramePayloadLength
+    }
+
+    /// What to do with a frame whose payload has been fully read and unmasked.
+    /// Keeping the decision pure (opcode + unmasked bytes in, action out) lets the
+    /// ping → pong-echo and data-delivery wiring be unit-tested without a socket
+    /// (issue #5669).
+    enum FrameAction: Equatable {
+        /// Text/binary frame → deliver as an application message.
+        case deliver(Data)
+        /// Ping frame → reply with a pong echoing the application data (§5.5.3).
+        case pong(Data)
+        /// Pong and other non-actionable opcodes → consumed, nothing to emit.
+        case ignore
+    }
+
+    static func frameAction(opcode: UInt8, unmaskedPayload: Data) -> FrameAction {
+        switch opcode {
+        case 0x01, 0x02: return .deliver(unmaskedPayload)
+        case 0x09: return .pong(unmaskedPayload)
+        default: return .ignore
+        }
+    }
+
     private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8) {
         guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
             print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
@@ -1049,16 +1090,25 @@ class WebSocketConnection: WebSocketResponding {
 
                 let payload: Data = isMasked ? Self.unmaskFrame(data) : data
 
-                // Handle text or binary frame
-                if opcode == 0x01 || opcode == 0x02 {
-                    self.onMessage(payload)
+                switch Self.frameAction(opcode: opcode, unmaskedPayload: payload) {
+                case let .deliver(message):
+                    self.onMessage(message)
+                case let .pong(applicationData):
+                    // Echo the ping application data back in the pong (§5.5.3).
+                    let pongFrame = Self.createWebSocketFrame(data: applicationData, opcode: 0x0A)
+                    self.connection.send(content: pongFrame, completion: .contentProcessed { _ in })
+                case .ignore:
+                    break
                 }
 
                 self.receiveWebSocketFrame()
             }
     }
 
-    private func createWebSocketFrame(data: Data, opcode: UInt8) -> Data {
+    /// Build an unmasked server→client frame (server frames are never masked,
+    /// RFC 6455 §5.1). `static` and internal so the pong-echo wire format can be
+    /// pinned by `WebSocketServerTests` (issue #5669).
+    static func createWebSocketFrame(data: Data, opcode: UInt8) -> Data {
         var frame = Data()
 
         // FIN + opcode
@@ -1083,7 +1133,7 @@ class WebSocketConnection: WebSocketResponding {
     }
 
     private func sendCloseFrame() {
-        let frame = createWebSocketFrame(data: Data(), opcode: 0x08)
+        let frame = Self.createWebSocketFrame(data: Data(), opcode: 0x08)
         connection.send(content: frame, completion: .contentProcessed { _ in })
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -541,6 +541,138 @@ final class WebSocketServerTests: XCTestCase {
         )
     }
 
+    // MARK: - Inbound ping frame handling (#5669)
+
+    /// End-to-end regression over a real socket for the ping-desync bug (#5669):
+    /// a client→server ping frame is always masked (RFC 6455 §5.3), so after the
+    /// 2-byte header there are 4 masking-key bytes still in the stream. The pre-fix
+    /// ping branch sent a pong and immediately read the *next* 2 bytes as a new
+    /// frame header — consuming the mask bytes as a bogus header and desyncing the
+    /// wire, so every subsequent frame was misparsed. This drives the real
+    /// `WebSocketServer` (real `NWListener`, real sockets on 127.0.0.1): it pings,
+    /// waits for the pong, then sends a data command. The command's typed response
+    /// must still come back — pre-fix it never does because the wire is desynced.
+    func testDataFrameAfterPingStillDecodes() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let wsURL = try XCTUnwrap(URL(string: "ws://127.0.0.1:\(port)/"))
+        let session = URLSession(configuration: .ephemeral)
+        let wsTask = session.webSocketTask(with: wsURL)
+        wsTask.resume()
+        defer {
+            wsTask.cancel(with: .goingAway, reason: nil)
+            session.invalidateAndCancel()
+        }
+
+        // Drain frames until the command response arrives, ignoring the initial
+        // `connected` event the server sends on upgrade. The receive loop is
+        // started *before* the ping so the task keeps pumping the connection —
+        // URLSession only processes an inbound pong (and thus fires `sendPing`'s
+        // completion) while a `receive` is outstanding. Pre-fix the wire is
+        // desynced after the ping, so this response never decodes and the wait
+        // times out.
+        let responseReceived = expectation(description: "command response decodes after ping")
+        func receiveNext() {
+            wsTask.receive { result in
+                switch result {
+                case let .success(message):
+                    let data: Data?
+                    switch message {
+                    case let .string(text): data = Data(text.utf8)
+                    case let .data(bytes): data = bytes
+                    @unknown default: data = nil
+                    }
+                    let object = data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String: Any]
+                    if object?["type"] as? String == "press_back_result" {
+                        XCTAssertEqual(object?["requestId"] as? String, "after-ping")
+                        XCTAssertEqual(object?["success"] as? Bool, true)
+                        responseReceived.fulfill()
+                    } else {
+                        receiveNext()
+                    }
+                case let .failure(error):
+                    // Do not fulfill: a desynced/closed connection surfaces as the
+                    // wait timing out, which is the failure this test guards.
+                    print("[testDataFrameAfterPingStillDecodes] receive failed: \(error)")
+                }
+            }
+        }
+        receiveNext()
+
+        // The client library masks the ping per RFC §5.3. Sending the data command
+        // from the pong completion strictly orders it *after* the server has
+        // processed the ping — so a surviving desync manifests purely as the
+        // command response never coming back.
+        wsTask.sendPing { error in
+            XCTAssertNil(error, "ping should be answered with a pong")
+            wsTask.send(.data(Data(#"{"type":"request_press_back","requestId":"after-ping"}"#.utf8))) { sendError in
+                XCTAssertNil(sendError, "sending the data command should not error")
+            }
+        }
+        wait(for: [responseReceived], timeout: 15)
+    }
+
+    /// A ping's unmasked application data is routed to a pong (AC2/§5.5.3), while
+    /// text/binary frames are delivered and pong/other opcodes are ignored — the
+    /// pure decision the socket-facing `readPayload` completion executes.
+    func testFrameActionRoutesPingToPongEchoingPayload() {
+        let payload = Data("keepalive-42".utf8)
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x09, unmaskedPayload: payload), .pong(payload))
+    }
+
+    /// An empty ping yields an empty pong (AC2: empty payload → empty pong).
+    func testFrameActionEmptyPingYieldsEmptyPong() {
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x09, unmaskedPayload: Data()), .pong(Data()))
+    }
+
+    /// Text (0x01) and binary (0x02) frames are delivered as application messages,
+    /// unchanged by the ping fix (AC4).
+    func testFrameActionDeliversTextAndBinary() {
+        let text = Data("hello".utf8)
+        let binary = Data([0x00, 0x01, 0x02])
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x01, unmaskedPayload: text), .deliver(text))
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x02, unmaskedPayload: binary), .deliver(binary))
+    }
+
+    /// An inbound pong (0x0A) and any other non-actionable opcode are consumed and
+    /// ignored — no pong is echoed back at a pong, so two peers cannot ping-pong
+    /// forever (AC4: existing pong handling unchanged).
+    func testFrameActionIgnoresPongAndOther() {
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x0A, unmaskedPayload: Data("x".utf8)), .ignore)
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x00, unmaskedPayload: Data()), .ignore)
+    }
+
+    /// The pong echo is built as a proper unmasked server frame: FIN|pong opcode,
+    /// a 7-bit length, then the payload verbatim (AC2 wire format).
+    func testCreateWebSocketFramePongEchoesPayloadOnTheWire() {
+        let payload = Data([0x61, 0x62, 0x63]) // "abc"
+        let frame = WebSocketConnection.createWebSocketFrame(data: payload, opcode: 0x0A)
+        XCTAssertEqual(Array(frame), [0x8A, 0x03, 0x61, 0x62, 0x63])
+
+        let empty = WebSocketConnection.createWebSocketFrame(data: Data(), opcode: 0x0A)
+        XCTAssertEqual(Array(empty), [0x8A, 0x00])
+    }
+
+    /// Control-frame payload length is bounded at 125 (RFC 6455 §5.5): 125 is the
+    /// last accepted value; 126/127 (the extended-length indicators) and anything
+    /// larger are rejected, so an over-cap/malformed ping closes the connection
+    /// rather than being mis-parsed (AC3).
+    func testControlFramePayloadLengthBound() {
+        XCTAssertEqual(WebSocketConnection.maxControlFramePayloadLength, 125)
+        XCTAssertTrue(WebSocketConnection.isValidControlFramePayloadLength(0))
+        XCTAssertTrue(WebSocketConnection.isValidControlFramePayloadLength(125))
+        XCTAssertFalse(WebSocketConnection.isValidControlFramePayloadLength(126))
+        XCTAssertFalse(WebSocketConnection.isValidControlFramePayloadLength(127))
+    }
+
     // MARK: - Client presence gating (#5477)
 
     /// Presence tracks only upgraded WebSocket clients and fires the hook exactly


### PR DESCRIPTION
## Summary

The iOS CtrlProxy WebSocket server mishandled inbound **ping** frames: the
`opcode == 0x09` branch in `WebSocketConnection.parseWebSocketFrame` sent a pong
and then immediately read the next 2 bytes as a new frame header — without
consuming the ping frame's 4-byte masking key (and any ping payload). Because a
client→server frame is always masked (RFC 6455 §5.3), those unconsumed bytes
desynced the wire and every subsequent frame was misparsed. It also violated
§5.5.3 by never echoing the ping payload in the pong.

The fix routes ping through the same masked `readPayload` path as data frames, so
the mask + payload are consumed via the existing `frameReadLength` / `unmaskFrame`
helpers (no parallel masked-read path); echoes the unmasked ping application data
in the pong; and rejects a malformed/oversized control frame — payload > 125
bytes, or the 126/127 extended-length forms illegal for control frames (§5.5) — by
closing the connection rather than mis-parsing.

This edits the runner **source** only. The runner ships as a pinned, checksummed
release artifact, so the fix reaches production when the runner is re-cut, which
is tracked as a separate follow-on and is out of scope here.

## Linked Issue

Closes #5669

## Bug / Regression Context

- **Observed symptom:** any pinging WebSocket peer (browser inspector, a future
  keepalive) desyncs the connection; subsequent frames garble/drop. Latent today
  because the current TS `ws` client does not send pings.
- **Root cause:** only the 2-byte header was read when the ping branch ran; it
  short-circuited before consuming `mask + payload`, unlike pong/data which fall
  through to `readPayload`.
- **Repro:** send a masked ping, then a data frame — pre-fix the data frame never
  decodes (pinned by `testDataFrameAfterPingStillDecodes`).

## Acceptance criteria

1. Masked ping fully consumed (4-byte mask + payload) before the next header — no
   desync. → `testDataFrameAfterPingStillDecodes` (real socket).
2. Pong echoes the unmasked ping application data (empty → empty). →
   `testFrameActionRoutesPingToPongEchoingPayload`, `testFrameActionEmptyPingYieldsEmptyPong`,
   `testCreateWebSocketFramePongEchoesPayloadOnTheWire`.
3. Ping length validated with the control-frame ≤125 bound; over-cap/malformed
   closes the connection. → `testControlFramePayloadLengthBound`.
4. Data/close/pong handling unchanged; a data frame after a ping still parses. →
   `testFrameActionDeliversTextAndBinary`, `testFrameActionIgnoresPongAndOther`,
   `testDataFrameAfterPingStillDecodes`.
5. Swift unit tests pin consume / echo / data-after-ping (there was previously no
   ping/pong coverage). → all of the above in `WebSocketServerTests.swift`.

## Validation

- [x] `./scripts/ios/swift-build.sh` and `./scripts/ios/swift-test.sh` green
  (control-proxy 510 tests, incl. the new ping coverage; run 3× for socket-test
  stability)
- [x] `bun run turbo:validate` green (lint + build + test + all boundary checks;
  14281 TS tests pass / 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] SwiftLint clean for CI (no force-unwraps; the two remaining warnings are
  pre-existing on `main` and non-blocking under non-strict)
- [x] No Swift files added/removed → no `project.pbxproj` drift

## Follow-ups

- Runner re-cut for the Swift framing fixes (tracked separately, out of scope).
