### PR TITLE
fix(ios-sdk): close observer/listener registration races with shutdown

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
@@ -15,11 +15,6 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
     private var _isInitialized = false
     private var _isEnabled = true
     private var observers: [NSObjectProtocol] = []
-    /// Monotonic initialization generation, bumped on every `initialize()`/`shutdown()`.
-    /// The registering code captures it and only publishes its observers if it still
-    /// matches — so a shutdown+reinitialize (ABA) that happens while registration is in
-    /// flight can't let a stale init's observers land in a newer init's session.
-    private var _initGeneration = 0
 
     private init() {}
 
@@ -44,24 +39,23 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
 
     func initialize(bundleId: String?, buffer: SdkEventBuffer) {
         lock.lock()
-        guard !_isInitialized else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !_isInitialized else { return }
         _isInitialized = true
-        _initGeneration += 1
-        let generation = _initGeneration
         self.bundleId = bundleId
         self.buffer = buffer
-        lock.unlock()
-
-        registerObservers(generation: generation)
+        // Register the observers WHILE holding the lock so registration and publication
+        // are one critical section: a shutdown() (which also takes `lock`) cannot
+        // interleave between building an observer and storing it, so nothing can fire in
+        // — or leak through — a register-vs-shutdown gap. addObserver is fast and its
+        // callbacks fire only on later notification delivery (never synchronously here),
+        // so there is no re-entrancy while the lock is held.
+        registerObserversLocked()
     }
 
     func shutdown() {
         lock.lock()
         _isInitialized = false
-        _initGeneration += 1
         _isEnabled = true
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
@@ -74,7 +68,9 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
 
     // MARK: - Observer Registration
 
-    private func registerObservers(generation: Int) {
+    /// Builds and stores the observers. MUST be called with `lock` held (see
+    /// `initialize`), so registration is atomic with respect to `shutdown()`.
+    private func registerObserversLocked() {
         let notificationsToMonitor: [(Notification.Name, String)] = [
             (NSLocale.currentLocaleDidChangeNotification, "locale_changed"),
             (.NSSystemTimeZoneDidChange, "timezone_changed"),
@@ -104,41 +100,15 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
             newObservers.append(observer)
         }
 
-        storeObservers(newObservers, generation: generation)
+        observers = newObservers
     }
 
     /// Number of currently-stored observers. Internal so tests can assert the
-    /// register-vs-shutdown guard without reaching into `NotificationCenter`.
+    /// initialize/shutdown observer lifecycle.
     var observerCount: Int {
         lock.lock()
         defer { lock.unlock() }
         return observers.count
-    }
-
-    /// Current initialization generation — internal so tests can capture it and drive an
-    /// A→shutdown→B→A publication race deterministically.
-    var initGeneration: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _initGeneration
-    }
-
-    /// Publishes the just-registered observers only if `generation` is still the current
-    /// initialization generation — i.e. no `shutdown()` (nor a shutdown+reinitialize ABA)
-    /// interleaved since these observers were built. Otherwise removes them so they can't
-    /// fire after teardown or leak into a newer init's session. Internal so tests can
-    /// drive the drop path deterministically.
-    func storeObservers(_ newObservers: [NSObjectProtocol], generation: Int) {
-        lock.lock()
-        guard generation == _initGeneration else {
-            lock.unlock()
-            for observer in newObservers {
-                NotificationCenter.default.removeObserver(observer)
-            }
-            return
-        }
-        observers = newObservers
-        lock.unlock()
     }
 
     private func handleNotification(action: String, notification: Notification) {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
@@ -15,6 +15,11 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
     private var _isInitialized = false
     private var _isEnabled = true
     private var observers: [NSObjectProtocol] = []
+    /// Monotonic initialization generation, bumped on every `initialize()`/`shutdown()`.
+    /// The registering code captures it and only publishes its observers if it still
+    /// matches — so a shutdown+reinitialize (ABA) that happens while registration is in
+    /// flight can't let a stale init's observers land in a newer init's session.
+    private var _initGeneration = 0
 
     private init() {}
 
@@ -44,16 +49,19 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
             return
         }
         _isInitialized = true
+        _initGeneration += 1
+        let generation = _initGeneration
         self.bundleId = bundleId
         self.buffer = buffer
         lock.unlock()
 
-        registerObservers()
+        registerObservers(generation: generation)
     }
 
     func shutdown() {
         lock.lock()
         _isInitialized = false
+        _initGeneration += 1
         _isEnabled = true
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
@@ -66,7 +74,7 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
 
     // MARK: - Observer Registration
 
-    private func registerObservers() {
+    private func registerObservers(generation: Int) {
         let notificationsToMonitor: [(Notification.Name, String)] = [
             (NSLocale.currentLocaleDidChangeNotification, "locale_changed"),
             (.NSSystemTimeZoneDidChange, "timezone_changed"),
@@ -96,7 +104,7 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
             newObservers.append(observer)
         }
 
-        storeObservers(newObservers)
+        storeObservers(newObservers, generation: generation)
     }
 
     /// Number of currently-stored observers. Internal so tests can assert the
@@ -107,14 +115,22 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
         return observers.count
     }
 
-    /// Stores just-registered observers only if a `shutdown()` has not interleaved
-    /// between `initialize()` releasing the lock and here — otherwise it cleared
-    /// `observers` and set `_isInitialized = false`, and storing now would leak them
-    /// (they'd fire after shutdown and never be removed). Remove them instead. Internal
-    /// so tests can drive the drop-when-not-initialized path deterministically.
-    func storeObservers(_ newObservers: [NSObjectProtocol]) {
+    /// Current initialization generation — internal so tests can capture it and drive an
+    /// A→shutdown→B→A publication race deterministically.
+    var initGeneration: Int {
         lock.lock()
-        guard _isInitialized else {
+        defer { lock.unlock() }
+        return _initGeneration
+    }
+
+    /// Publishes the just-registered observers only if `generation` is still the current
+    /// initialization generation — i.e. no `shutdown()` (nor a shutdown+reinitialize ABA)
+    /// interleaved since these observers were built. Otherwise removes them so they can't
+    /// fire after teardown or leak into a newer init's session. Internal so tests can
+    /// drive the drop path deterministically.
+    func storeObservers(_ newObservers: [NSObjectProtocol], generation: Int) {
+        lock.lock()
+        guard generation == _initGeneration else {
             lock.unlock()
             for observer in newObservers {
                 NotificationCenter.default.removeObserver(observer)

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileNotificationObserver.swift
@@ -96,7 +96,31 @@ public final class AutoMobileNotificationObserver: @unchecked Sendable {
             newObservers.append(observer)
         }
 
+        storeObservers(newObservers)
+    }
+
+    /// Number of currently-stored observers. Internal so tests can assert the
+    /// register-vs-shutdown guard without reaching into `NotificationCenter`.
+    var observerCount: Int {
         lock.lock()
+        defer { lock.unlock() }
+        return observers.count
+    }
+
+    /// Stores just-registered observers only if a `shutdown()` has not interleaved
+    /// between `initialize()` releasing the lock and here — otherwise it cleared
+    /// `observers` and set `_isInitialized = false`, and storing now would leak them
+    /// (they'd fire after shutdown and never be removed). Remove them instead. Internal
+    /// so tests can drive the drop-when-not-initialized path deterministically.
+    func storeObservers(_ newObservers: [NSObjectProtocol]) {
+        lock.lock()
+        guard _isInitialized else {
+            lock.unlock()
+            for observer in newObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            return
+        }
         observers = newObservers
         lock.unlock()
     }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
@@ -25,11 +25,6 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
     private var lastBatteryCharging: Bool?
     private var observers: [NSObjectProtocol] = []
     private var _isEnabled = true
-    /// Monotonic initialization generation, bumped on every `initialize()`/`shutdown()`.
-    /// The setup code captures it and only publishes its observers / path-monitor if it
-    /// still matches — so a shutdown+reinitialize (ABA) during setup can't let a stale
-    /// init's resources land in a newer init's session.
-    private var _initGeneration = 0
 
     private init() {}
 
@@ -54,32 +49,32 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
 
     func initialize(bundleId: String?, buffer: SdkEventBuffer) {
         lock.lock()
-        guard !_isInitialized else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !_isInitialized else { return }
         _isInitialized = true
-        _initGeneration += 1
-        let generation = _initGeneration
         self.bundleId = bundleId
         self.buffer = buffer
-        lock.unlock()
 
+        // Register all observers and the path monitor WHILE holding the lock, so setup is
+        // one critical section with respect to shutdown(): a shutdown() cannot interleave
+        // between building a resource and storing it, so no observer, path monitor, or the
+        // `isBatteryMonitoringEnabled` side-effect can outlive a teardown that races setup.
+        // addObserver / NWPathMonitor.start deliver only asynchronously, so holding the
+        // lock across them cannot re-enter it.
         #if canImport(UIKit) && !os(watchOS)
-        setupLifecycleTracking(generation: generation)
-        setupBatteryTracking(generation: generation)
-        setupScreenTracking(generation: generation)
+        setupLifecycleTrackingLocked()
+        setupBatteryTrackingLocked()
+        setupScreenTrackingLocked()
         #endif
 
         #if canImport(Network)
-        setupConnectivityTracking(generation: generation)
+        setupConnectivityTrackingLocked()
         #endif
     }
 
     func shutdown() {
         lock.lock()
         _isInitialized = false
-        _initGeneration += 1
         _isEnabled = true
 
         for observer in observers {
@@ -112,36 +107,10 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
         return observers.count
     }
 
-    /// Current initialization generation — internal so tests can capture it and drive an
-    /// A→shutdown→B→A publication race deterministically.
-    var initGeneration: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _initGeneration
-    }
-
-    /// Publishes the just-registered observers only if `generation` is still the current
-    /// initialization generation — i.e. no `shutdown()` (nor a shutdown+reinitialize ABA)
-    /// interleaved since these observers were built. Otherwise removes them so they can't
-    /// fire after teardown or leak into a newer init's session. Internal so tests can
-    /// drive the drop path deterministically.
-    func storeObservers(_ newObservers: [NSObjectProtocol], generation: Int) {
-        lock.lock()
-        guard generation == _initGeneration else {
-            lock.unlock()
-            for observer in newObservers {
-                NotificationCenter.default.removeObserver(observer)
-            }
-            return
-        }
-        observers.append(contentsOf: newObservers)
-        lock.unlock()
-    }
-
     // MARK: - Lifecycle Tracking
 
     #if canImport(UIKit) && !os(watchOS)
-    private func setupLifecycleTracking(generation: Int) {
+    private func setupLifecycleTrackingLocked() {
         let fgObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
@@ -174,12 +143,12 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.postEvent(state: "terminated")
         }
 
-        storeObservers([fgObserver, bgObserver, willResignObserver, willTerminateObserver], generation: generation)
+        observers.append(contentsOf: [fgObserver, bgObserver, willResignObserver, willTerminateObserver])
     }
 
     // MARK: - Battery Tracking
 
-    private func setupBatteryTracking(generation: Int) {
+    private func setupBatteryTrackingLocked() {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
         let levelObserver = NotificationCenter.default.addObserver(
@@ -198,7 +167,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.reportBatteryChange()
         }
 
-        storeObservers([levelObserver, stateObserver], generation: generation)
+        observers.append(contentsOf: [levelObserver, stateObserver])
     }
 
     private func reportBatteryChange() {
@@ -228,7 +197,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
 
     // MARK: - Screen Tracking
 
-    private func setupScreenTracking(generation: Int) {
+    private func setupScreenTrackingLocked() {
         let brightnessObserver = NotificationCenter.default.addObserver(
             forName: UIScreen.brightnessDidChangeNotification,
             object: nil,
@@ -240,14 +209,14 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             ])
         }
 
-        storeObservers([brightnessObserver], generation: generation)
+        observers.append(brightnessObserver)
     }
     #endif
 
     // MARK: - Connectivity Tracking
 
     #if canImport(Network)
-    private func setupConnectivityTracking(generation: Int) {
+    private func setupConnectivityTrackingLocked() {
         let monitor = NWPathMonitor()
         let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.network-monitor")
 
@@ -270,19 +239,10 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             ])
         }
 
-        lock.lock()
-        // If a shutdown() (or shutdown+reinitialize ABA) interleaved since initialize()
-        // released the lock, this generation no longer matches — don't store or start the
-        // monitor, it would run after teardown / in a newer init's session. Cancel it.
-        guard generation == _initGeneration else {
-            lock.unlock()
-            monitor.cancel()
-            return
-        }
+        // Caller holds `lock`, so storing and starting the monitor is atomic with
+        // shutdown() (which cancels it under the same lock).
         pathMonitor = monitor
         monitorQueue = queue
-        lock.unlock()
-
         monitor.start(queue: queue)
     }
     #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
@@ -96,6 +96,32 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Number of currently-stored observers. Internal so tests can assert the
+    /// register-vs-shutdown guard without reaching into `NotificationCenter`.
+    var observerCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return observers.count
+    }
+
+    /// Stores just-registered observers only if a `shutdown()` has not interleaved
+    /// since `initialize()` released the lock; otherwise removes them so they cannot
+    /// fire after teardown. The `addObserver` calls happen outside the lock, so this
+    /// re-check under the lock closes the register-vs-shutdown window. Internal so
+    /// tests can drive the drop-when-not-initialized path deterministically.
+    func storeObservers(_ newObservers: [NSObjectProtocol]) {
+        lock.lock()
+        guard _isInitialized else {
+            lock.unlock()
+            for observer in newObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            return
+        }
+        observers.append(contentsOf: newObservers)
+        lock.unlock()
+    }
+
     // MARK: - Lifecycle Tracking
 
     #if canImport(UIKit) && !os(watchOS)
@@ -132,9 +158,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.postEvent(state: "terminated")
         }
 
-        lock.lock()
-        observers.append(contentsOf: [fgObserver, bgObserver, willResignObserver, willTerminateObserver])
-        lock.unlock()
+        storeObservers([fgObserver, bgObserver, willResignObserver, willTerminateObserver])
     }
 
     // MARK: - Battery Tracking
@@ -158,9 +182,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.reportBatteryChange()
         }
 
-        lock.lock()
-        observers.append(contentsOf: [levelObserver, stateObserver])
-        lock.unlock()
+        storeObservers([levelObserver, stateObserver])
     }
 
     private func reportBatteryChange() {
@@ -202,9 +224,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             ])
         }
 
-        lock.lock()
-        observers.append(brightnessObserver)
-        lock.unlock()
+        storeObservers([brightnessObserver])
     }
     #endif
 
@@ -235,6 +255,13 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
         }
 
         lock.lock()
+        // If a shutdown() interleaved since initialize() released the lock, don't store
+        // or start the monitor — it would run after teardown. Cancel it instead.
+        guard _isInitialized else {
+            lock.unlock()
+            monitor.cancel()
+            return
+        }
         pathMonitor = monitor
         monitorQueue = queue
         lock.unlock()

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/OsEvents/AutoMobileOsEvents.swift
@@ -25,6 +25,11 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
     private var lastBatteryCharging: Bool?
     private var observers: [NSObjectProtocol] = []
     private var _isEnabled = true
+    /// Monotonic initialization generation, bumped on every `initialize()`/`shutdown()`.
+    /// The setup code captures it and only publishes its observers / path-monitor if it
+    /// still matches — so a shutdown+reinitialize (ABA) during setup can't let a stale
+    /// init's resources land in a newer init's session.
+    private var _initGeneration = 0
 
     private init() {}
 
@@ -54,24 +59,27 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             return
         }
         _isInitialized = true
+        _initGeneration += 1
+        let generation = _initGeneration
         self.bundleId = bundleId
         self.buffer = buffer
         lock.unlock()
 
         #if canImport(UIKit) && !os(watchOS)
-        setupLifecycleTracking()
-        setupBatteryTracking()
-        setupScreenTracking()
+        setupLifecycleTracking(generation: generation)
+        setupBatteryTracking(generation: generation)
+        setupScreenTracking(generation: generation)
         #endif
 
         #if canImport(Network)
-        setupConnectivityTracking()
+        setupConnectivityTracking(generation: generation)
         #endif
     }
 
     func shutdown() {
         lock.lock()
         _isInitialized = false
+        _initGeneration += 1
         _isEnabled = true
 
         for observer in observers {
@@ -104,14 +112,22 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
         return observers.count
     }
 
-    /// Stores just-registered observers only if a `shutdown()` has not interleaved
-    /// since `initialize()` released the lock; otherwise removes them so they cannot
-    /// fire after teardown. The `addObserver` calls happen outside the lock, so this
-    /// re-check under the lock closes the register-vs-shutdown window. Internal so
-    /// tests can drive the drop-when-not-initialized path deterministically.
-    func storeObservers(_ newObservers: [NSObjectProtocol]) {
+    /// Current initialization generation — internal so tests can capture it and drive an
+    /// A→shutdown→B→A publication race deterministically.
+    var initGeneration: Int {
         lock.lock()
-        guard _isInitialized else {
+        defer { lock.unlock() }
+        return _initGeneration
+    }
+
+    /// Publishes the just-registered observers only if `generation` is still the current
+    /// initialization generation — i.e. no `shutdown()` (nor a shutdown+reinitialize ABA)
+    /// interleaved since these observers were built. Otherwise removes them so they can't
+    /// fire after teardown or leak into a newer init's session. Internal so tests can
+    /// drive the drop path deterministically.
+    func storeObservers(_ newObservers: [NSObjectProtocol], generation: Int) {
+        lock.lock()
+        guard generation == _initGeneration else {
             lock.unlock()
             for observer in newObservers {
                 NotificationCenter.default.removeObserver(observer)
@@ -125,7 +141,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
     // MARK: - Lifecycle Tracking
 
     #if canImport(UIKit) && !os(watchOS)
-    private func setupLifecycleTracking() {
+    private func setupLifecycleTracking(generation: Int) {
         let fgObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
@@ -158,12 +174,12 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.postEvent(state: "terminated")
         }
 
-        storeObservers([fgObserver, bgObserver, willResignObserver, willTerminateObserver])
+        storeObservers([fgObserver, bgObserver, willResignObserver, willTerminateObserver], generation: generation)
     }
 
     // MARK: - Battery Tracking
 
-    private func setupBatteryTracking() {
+    private func setupBatteryTracking(generation: Int) {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
         let levelObserver = NotificationCenter.default.addObserver(
@@ -182,7 +198,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             self?.reportBatteryChange()
         }
 
-        storeObservers([levelObserver, stateObserver])
+        storeObservers([levelObserver, stateObserver], generation: generation)
     }
 
     private func reportBatteryChange() {
@@ -212,7 +228,7 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
 
     // MARK: - Screen Tracking
 
-    private func setupScreenTracking() {
+    private func setupScreenTracking(generation: Int) {
         let brightnessObserver = NotificationCenter.default.addObserver(
             forName: UIScreen.brightnessDidChangeNotification,
             object: nil,
@@ -224,14 +240,14 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
             ])
         }
 
-        storeObservers([brightnessObserver])
+        storeObservers([brightnessObserver], generation: generation)
     }
     #endif
 
     // MARK: - Connectivity Tracking
 
     #if canImport(Network)
-    private func setupConnectivityTracking() {
+    private func setupConnectivityTracking(generation: Int) {
         let monitor = NWPathMonitor()
         let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.network-monitor")
 
@@ -255,9 +271,10 @@ public final class AutoMobileOsEvents: @unchecked Sendable {
         }
 
         lock.lock()
-        // If a shutdown() interleaved since initialize() released the lock, don't store
-        // or start the monitor — it would run after teardown. Cancel it instead.
-        guard _isInitialized else {
+        // If a shutdown() (or shutdown+reinitialize ABA) interleaved since initialize()
+        // released the lock, this generation no longer matches — don't store or start the
+        // monitor, it would run after teardown / in a newer init's session. Cancel it.
+        guard generation == _initGeneration else {
             lock.unlock()
             monitor.cancel()
             return

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -15,11 +15,6 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     private var buffer: SdkEventBuffer?
     private var sequenceCounter: Int64 = 0
     private var kvoObserver: NSObjectProtocol?
-    /// Monotonic listen generation, bumped by `stopListening()`. `startListening()`
-    /// captures it after its own stop and publishes only if it still matches, so a
-    /// stop (or newer start) that interleaves with an in-flight registration invalidates
-    /// it rather than leaving an observer live after teardown or leaking a duplicate.
-    private var listenGeneration = 0
 
     /// Last-observed key→value snapshot per suite, keyed by ``suiteKey(_:)``.
     /// `UserDefaults.didChangeNotification` does not identify which key changed,
@@ -122,17 +117,24 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         // would wrongly succeed and publish an observer after that stop. Bumping and
         // capturing together means only a stop/start that runs AFTER this point can
         // invalidate us — exactly what the store-time guard checks.
-        lock.lock()
-        listenGeneration += 1
-        let generation = listenGeneration
-        if let observer = kvoObserver {
-            NotificationCenter.default.removeObserver(observer)
-            kvoObserver = nil
-        }
-        lock.unlock()
-
         let defaults = suiteName.map { UserDefaults(suiteName: $0) } ?? UserDefaults.standard
         guard let defaults = suiteName != nil ? defaults : UserDefaults.standard else { return }
+
+        // Do the whole transition (remove old observer, seed baseline, register+publish the
+        // new observer) in ONE critical section. A concurrent stopListening()/
+        // startListening() takes `lock` and so runs entirely before or after this: it can
+        // never leave our observer live past a stop, leak a duplicate, or (with `queue: nil`
+        // synchronous delivery) fire a callback before we publish — such a callback blocks
+        // on `lock` until we finish. addObserver and the baseline read call back only later,
+        // so holding the lock across them cannot re-enter it.
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Remove any existing observer before registering a new one.
+        if let existing = kvoObserver {
+            NotificationCenter.default.removeObserver(existing)
+            kvoObserver = nil
+        }
 
         // Seed the baseline BEFORE registering the observer. If a write on
         // another thread raced observer installation, the notification could
@@ -141,39 +143,20 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         // closes that window; a write in the (now inverted) gap between seeding
         // and registration is simply picked up as a normal change on the next
         // notification rather than a burst of phantom adds.
-        captureBaseline(suiteName: suiteName)
+        captureBaselineLocked(suiteName: suiteName)
 
-        let observer = NotificationCenter.default.addObserver(
+        kvoObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: defaults,
             queue: nil
         ) { [weak self] _ in
             self?.handleDidChange(suiteName: suiteName)
         }
-
-        lock.lock()
-        // Reject our publication if the generation moved since we captured it — a
-        // stopListening() (stop-during-start: don't leave an observer live after a stop)
-        // or a newer startListening() (don't leak a duplicate) ran in between. Remove the
-        // observer we just registered instead of storing it.
-        guard generation == listenGeneration else {
-            lock.unlock()
-            NotificationCenter.default.removeObserver(observer)
-            return
-        }
-        // Belt-and-suspenders: remove any observer a same-generation racer stored.
-        if let existing = kvoObserver {
-            NotificationCenter.default.removeObserver(existing)
-        }
-        kvoObserver = observer
-        lock.unlock()
     }
 
-    /// Stop listening for changes. Bumps `listenGeneration` so any startListening()
-    /// registration still in flight is rejected rather than left live after the stop.
+    /// Stop listening for changes.
     public func stopListening() {
         lock.lock()
-        listenGeneration += 1
         if let observer = kvoObserver {
             NotificationCenter.default.removeObserver(observer)
             kvoObserver = nil
@@ -195,6 +178,12 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     func captureBaseline(suiteName: String?) {
         lock.lock()
         defer { lock.unlock() }
+        captureBaselineLocked(suiteName: suiteName)
+    }
+
+    /// Baseline capture without taking `lock` — for callers that already hold it
+    /// (`startListening` registers under the lock). MUST be called with `lock` held.
+    private func captureBaselineLocked(suiteName: String?) {
         guard let driver = _driver else { return }
         lastSnapshots[Self.suiteKey(suiteName)] = Self.snapshotDict(driver.getValues(suiteName: suiteName))
     }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -15,6 +15,11 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     private var buffer: SdkEventBuffer?
     private var sequenceCounter: Int64 = 0
     private var kvoObserver: NSObjectProtocol?
+    /// Monotonic listen generation, bumped by `stopListening()`. `startListening()`
+    /// captures it after its own stop and publishes only if it still matches, so a
+    /// stop (or newer start) that interleaves with an in-flight registration invalidates
+    /// it rather than leaving an observer live after teardown or leaking a duplicate.
+    private var listenGeneration = 0
 
     /// Last-observed key→value snapshot per suite, keyed by ``suiteKey(_:)``.
     /// `UserDefaults.didChangeNotification` does not identify which key changed,
@@ -110,8 +115,15 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     public func startListening(suiteName: String? = nil) {
         guard isEnabled else { return }
 
-        // Remove any existing observer before registering a new one
+        // Remove any existing observer before registering a new one. stopListening()
+        // bumps listenGeneration; capture it AFTER, so a concurrent stopListening() (or a
+        // newer startListening()) that runs while we register below bumps it again and our
+        // publication is rejected — otherwise a stop that "wins" the race would leave our
+        // just-registered observer live after teardown.
         stopListening()
+        lock.lock()
+        let generation = listenGeneration
+        lock.unlock()
 
         let defaults = suiteName.map { UserDefaults(suiteName: $0) } ?? UserDefaults.standard
         guard let defaults = suiteName != nil ? defaults : UserDefaults.standard else { return }
@@ -134,11 +146,16 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         }
 
         lock.lock()
-        // A concurrent startListening (two setEnabled(true)/initialize racers can both
-        // pass the `kvoObserver == nil` gate) may have installed an observer between our
-        // stopListening() above and here. Remove it before storing ours so we never leak
-        // a duplicate NotificationCenter observer — which would emit duplicate
-        // storage_changed events forever. Last writer wins; exactly one observer stays.
+        // Reject our publication if the generation moved since we captured it — a
+        // stopListening() (stop-during-start: don't leave an observer live after a stop)
+        // or a newer startListening() (don't leak a duplicate) ran in between. Remove the
+        // observer we just registered instead of storing it.
+        guard generation == listenGeneration else {
+            lock.unlock()
+            NotificationCenter.default.removeObserver(observer)
+            return
+        }
+        // Belt-and-suspenders: remove any observer a same-generation racer stored.
         if let existing = kvoObserver {
             NotificationCenter.default.removeObserver(existing)
         }
@@ -146,9 +163,11 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Stop listening for changes.
+    /// Stop listening for changes. Bumps `listenGeneration` so any startListening()
+    /// registration still in flight is rejected rather than left live after the stop.
     public func stopListening() {
         lock.lock()
+        listenGeneration += 1
         if let observer = kvoObserver {
             NotificationCenter.default.removeObserver(observer)
             kvoObserver = nil

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -115,14 +115,20 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     public func startListening(suiteName: String? = nil) {
         guard isEnabled else { return }
 
-        // Remove any existing observer before registering a new one. stopListening()
-        // bumps listenGeneration; capture it AFTER, so a concurrent stopListening() (or a
-        // newer startListening()) that runs while we register below bumps it again and our
-        // publication is rejected — otherwise a stop that "wins" the race would leave our
-        // just-registered observer live after teardown.
-        stopListening()
+        // Atomically remove any current observer and claim this start's generation in a
+        // SINGLE critical section. Capturing the generation in a separate lock after
+        // stopListening() would be a TOCTOU: a concurrent stopListening() in the gap would
+        // bump the generation and we'd capture *its* value, so our later equality guard
+        // would wrongly succeed and publish an observer after that stop. Bumping and
+        // capturing together means only a stop/start that runs AFTER this point can
+        // invalidate us — exactly what the store-time guard checks.
         lock.lock()
+        listenGeneration += 1
         let generation = listenGeneration
+        if let observer = kvoObserver {
+            NotificationCenter.default.removeObserver(observer)
+            kvoObserver = nil
+        }
         lock.unlock()
 
         let defaults = suiteName.map { UserDefaults(suiteName: $0) } ?? UserDefaults.standard

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -130,6 +130,11 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
+        // Re-check enabled state UNDER the lock: the `isEnabled` guard above is outside the
+        // lock, so a reset()/setEnabled(false) could have run in the gap between it and
+        // here. Without this, a stale start would install an observer after teardown.
+        guard _isEnabled else { return }
+
         // Remove any existing observer before registering a new one.
         if let existing = kvoObserver {
             NotificationCenter.default.removeObserver(existing)

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -134,6 +134,14 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         }
 
         lock.lock()
+        // A concurrent startListening (two setEnabled(true)/initialize racers can both
+        // pass the `kvoObserver == nil` gate) may have installed an observer between our
+        // stopListening() above and here. Remove it before storing ours so we never leak
+        // a duplicate NotificationCenter observer — which would emit duplicate
+        // storage_changed events forever. Last writer wins; exactly one observer stays.
+        if let existing = kvoObserver {
+            NotificationCenter.default.removeObserver(existing)
+        }
         kvoObserver = observer
         lock.unlock()
     }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -29,19 +29,21 @@ final class SdkHierarchyServer: @unchecked Sendable {
     // MARK: - Lifecycle
 
     func start() {
+        // Hold the lock across the entire start — assign, configure, and `start()` —
+        // so a concurrent `stop()` cannot interleave between the `listener` assignment
+        // and `nwListener.start()`, which would cancel the listener yet leave it
+        // started (and `listener == nil`, so a later `start()` re-binds port 8766). The
+        // handlers only fire asynchronously on `queue`, never synchronously here, so
+        // there is no re-entrancy while the lock is held.
         lock.lock()
-        guard listener == nil else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard listener == nil else { return }
 
         let parameters = NWParameters.tcp
         parameters.allowLocalEndpointReuse = true
 
         do {
             let nwListener = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: Self.port))
-            listener = nwListener
-            lock.unlock()
 
             nwListener.stateUpdateHandler = { state in
                 switch state {
@@ -59,8 +61,8 @@ final class SdkHierarchyServer: @unchecked Sendable {
             }
 
             nwListener.start(queue: queue)
+            listener = nwListener
         } catch {
-            lock.unlock()
             InternalLogger.debug("[SdkHierarchyServer] Failed to create listener: \(error)")
         }
     }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
@@ -28,23 +28,9 @@ final class OsEventsTests: XCTestCase {
         buffer.shutdown()
     }
 
-    /// Observers whose registration completes AFTER a `shutdown()` (the
-    /// register-vs-shutdown race) must not be stored — they would fire after teardown
-    /// and never be removed.
-    func testStoreObserversDroppedWhenNotInitialized() {
-        let osEvents = AutoMobileOsEvents.shared
-        osEvents.reset() // ensure not initialized
-        XCTAssertEqual(osEvents.observerCount, 0)
-
-        let observer = NotificationCenter.default.addObserver(
-            forName: Notification.Name("am.test.notinit"), object: nil, queue: nil
-        ) { _ in }
-        osEvents.storeObservers([observer])
-
-        XCTAssertEqual(osEvents.observerCount, 0, "observers registered while not initialized must be dropped")
-    }
-
-    func testStoreObserversKeptWhileInitializedThenClearedOnShutdown() {
+    /// Observers published with the current init generation are stored; a `shutdown()`
+    /// then removes them.
+    func testStoreObserversKeptForCurrentGenerationThenClearedOnShutdown() {
         let buffer = SdkEventBuffer { _ in }
         buffer.start()
         let osEvents = AutoMobileOsEvents.shared
@@ -52,14 +38,41 @@ final class OsEventsTests: XCTestCase {
         osEvents.initialize(bundleId: "test.bundle", buffer: buffer)
 
         let before = osEvents.observerCount
+        let generation = osEvents.initGeneration
         let observer = NotificationCenter.default.addObserver(
             forName: Notification.Name("am.test.init"), object: nil, queue: nil
         ) { _ in }
-        osEvents.storeObservers([observer])
-        XCTAssertEqual(osEvents.observerCount, before + 1, "observers registered while initialized are stored")
+        osEvents.storeObservers([observer], generation: generation)
+        XCTAssertEqual(osEvents.observerCount, before + 1, "observers published with the current generation are stored")
 
         osEvents.reset()
         XCTAssertEqual(osEvents.observerCount, 0, "shutdown removes all stored observers")
+        buffer.shutdown()
+    }
+
+    /// A→shutdown→B→A: an init A that pauses mid-registration, is shut down, and a NEW
+    /// init B starts, must NOT have A's late-published observers land in B's session. A
+    /// bare `_isInitialized` boolean permits this ABA; the generation token rejects it.
+    func testAbaReinitializeDropsStaleInitObservers() {
+        let buffer = SdkEventBuffer { _ in }
+        buffer.start()
+        let osEvents = AutoMobileOsEvents.shared
+        osEvents.reset()
+
+        osEvents.initialize(bundleId: "A", buffer: buffer) // init A
+        let generationA = osEvents.initGeneration
+        osEvents.reset() // shutdown
+        osEvents.initialize(bundleId: "B", buffer: buffer) // init B — _isInitialized true again
+        let countB = osEvents.observerCount
+
+        // A's late publication carries A's (now stale) generation.
+        let observer = NotificationCenter.default.addObserver(
+            forName: Notification.Name("am.test.aba"), object: nil, queue: nil
+        ) { _ in }
+        osEvents.storeObservers([observer], generation: generationA)
+
+        XCTAssertEqual(osEvents.observerCount, countB, "a stale init's observers must not leak into a newer init's session")
+        osEvents.reset()
         buffer.shutdown()
     }
 }
@@ -91,18 +104,33 @@ final class NotificationObserverTests: XCTestCase {
         buffer.shutdown()
     }
 
-    /// Observers whose registration completes AFTER a `shutdown()` must not be stored.
-    func testStoreObserversDroppedWhenNotInitialized() {
+    /// A→shutdown→B→A: A's late-published observers, carrying A's stale generation, must
+    /// not overwrite B's observers. A bare `_isInitialized` boolean permits this ABA.
+    func testAbaReinitializeDropsStaleInitObservers() {
+        let buffer = SdkEventBuffer { _ in }
+        buffer.start()
         let observerTracker = AutoMobileNotificationObserver.shared
-        observerTracker.reset() // ensure not initialized
-        XCTAssertEqual(observerTracker.observerCount, 0)
+        observerTracker.reset()
+
+        observerTracker.initialize(bundleId: "A", buffer: buffer) // init A
+        let generationA = observerTracker.initGeneration
+        observerTracker.reset() // shutdown
+        observerTracker.initialize(bundleId: "B", buffer: buffer) // init B
+        let countB = observerTracker.observerCount
+        XCTAssertGreaterThan(countB, 0)
 
         let observer = NotificationCenter.default.addObserver(
-            forName: Notification.Name("am.test.obs.notinit"), object: nil, queue: nil
+            forName: Notification.Name("am.test.obs.aba"), object: nil, queue: nil
         ) { _ in }
-        observerTracker.storeObservers([observer])
+        observerTracker.storeObservers([observer], generation: generationA)
 
-        XCTAssertEqual(observerTracker.observerCount, 0, "observers registered while not initialized must be dropped")
+        XCTAssertEqual(
+            observerTracker.observerCount,
+            countB,
+            "a stale init's observers must not overwrite a newer init's session"
+        )
+        observerTracker.reset()
+        buffer.shutdown()
     }
 
     func testInitializeRegistersObserversAndShutdownClearsThem() {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
@@ -27,6 +27,41 @@ final class OsEventsTests: XCTestCase {
 
         buffer.shutdown()
     }
+
+    /// Observers whose registration completes AFTER a `shutdown()` (the
+    /// register-vs-shutdown race) must not be stored — they would fire after teardown
+    /// and never be removed.
+    func testStoreObserversDroppedWhenNotInitialized() {
+        let osEvents = AutoMobileOsEvents.shared
+        osEvents.reset() // ensure not initialized
+        XCTAssertEqual(osEvents.observerCount, 0)
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: Notification.Name("am.test.notinit"), object: nil, queue: nil
+        ) { _ in }
+        osEvents.storeObservers([observer])
+
+        XCTAssertEqual(osEvents.observerCount, 0, "observers registered while not initialized must be dropped")
+    }
+
+    func testStoreObserversKeptWhileInitializedThenClearedOnShutdown() {
+        let buffer = SdkEventBuffer { _ in }
+        buffer.start()
+        let osEvents = AutoMobileOsEvents.shared
+        osEvents.reset()
+        osEvents.initialize(bundleId: "test.bundle", buffer: buffer)
+
+        let before = osEvents.observerCount
+        let observer = NotificationCenter.default.addObserver(
+            forName: Notification.Name("am.test.init"), object: nil, queue: nil
+        ) { _ in }
+        osEvents.storeObservers([observer])
+        XCTAssertEqual(osEvents.observerCount, before + 1, "observers registered while initialized are stored")
+
+        osEvents.reset()
+        XCTAssertEqual(osEvents.observerCount, 0, "shutdown removes all stored observers")
+        buffer.shutdown()
+    }
 }
 
 final class NotificationObserverTests: XCTestCase {
@@ -53,6 +88,34 @@ final class NotificationObserverTests: XCTestCase {
         AutoMobileNotificationObserver.shared.initialize(bundleId: "test.bundle", buffer: buffer)
         AutoMobileNotificationObserver.shared.reset()
 
+        buffer.shutdown()
+    }
+
+    /// Observers whose registration completes AFTER a `shutdown()` must not be stored.
+    func testStoreObserversDroppedWhenNotInitialized() {
+        let observerTracker = AutoMobileNotificationObserver.shared
+        observerTracker.reset() // ensure not initialized
+        XCTAssertEqual(observerTracker.observerCount, 0)
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: Notification.Name("am.test.obs.notinit"), object: nil, queue: nil
+        ) { _ in }
+        observerTracker.storeObservers([observer])
+
+        XCTAssertEqual(observerTracker.observerCount, 0, "observers registered while not initialized must be dropped")
+    }
+
+    func testInitializeRegistersObserversAndShutdownClearsThem() {
+        let buffer = SdkEventBuffer { _ in }
+        buffer.start()
+        let observerTracker = AutoMobileNotificationObserver.shared
+        observerTracker.reset()
+
+        observerTracker.initialize(bundleId: "test.bundle", buffer: buffer)
+        XCTAssertGreaterThan(observerTracker.observerCount, 0, "initialize registers observers")
+
+        observerTracker.reset()
+        XCTAssertEqual(observerTracker.observerCount, 0, "shutdown removes all observers")
         buffer.shutdown()
     }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/OsEventsTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import AutoMobileSDK
 
+// The register-vs-shutdown races these managers had are now closed by construction:
+// observers/path-monitor are registered WHILE the lock is held (see `initialize`), so a
+// `shutdown()` (which also locks) can never interleave between building a resource and
+// storing it. There is therefore no injectable mid-registration seam to drive a race
+// deterministically; these tests pin the observable init/shutdown lifecycle instead.
+
 final class OsEventsTests: XCTestCase {
     func testOsEventsInitializesOnce() {
         let buffer = SdkEventBuffer { _ in }
@@ -28,51 +34,17 @@ final class OsEventsTests: XCTestCase {
         buffer.shutdown()
     }
 
-    /// Observers published with the current init generation are stored; a `shutdown()`
-    /// then removes them.
-    func testStoreObserversKeptForCurrentGenerationThenClearedOnShutdown() {
+    /// After initialize+shutdown the observer set is empty regardless of platform — the
+    /// atomically-registered observers are all removed on teardown.
+    func testInitializeThenShutdownLeavesNoObservers() {
         let buffer = SdkEventBuffer { _ in }
         buffer.start()
         let osEvents = AutoMobileOsEvents.shared
         osEvents.reset()
+
         osEvents.initialize(bundleId: "test.bundle", buffer: buffer)
-
-        let before = osEvents.observerCount
-        let generation = osEvents.initGeneration
-        let observer = NotificationCenter.default.addObserver(
-            forName: Notification.Name("am.test.init"), object: nil, queue: nil
-        ) { _ in }
-        osEvents.storeObservers([observer], generation: generation)
-        XCTAssertEqual(osEvents.observerCount, before + 1, "observers published with the current generation are stored")
-
         osEvents.reset()
-        XCTAssertEqual(osEvents.observerCount, 0, "shutdown removes all stored observers")
-        buffer.shutdown()
-    }
-
-    /// A→shutdown→B→A: an init A that pauses mid-registration, is shut down, and a NEW
-    /// init B starts, must NOT have A's late-published observers land in B's session. A
-    /// bare `_isInitialized` boolean permits this ABA; the generation token rejects it.
-    func testAbaReinitializeDropsStaleInitObservers() {
-        let buffer = SdkEventBuffer { _ in }
-        buffer.start()
-        let osEvents = AutoMobileOsEvents.shared
-        osEvents.reset()
-
-        osEvents.initialize(bundleId: "A", buffer: buffer) // init A
-        let generationA = osEvents.initGeneration
-        osEvents.reset() // shutdown
-        osEvents.initialize(bundleId: "B", buffer: buffer) // init B — _isInitialized true again
-        let countB = osEvents.observerCount
-
-        // A's late publication carries A's (now stale) generation.
-        let observer = NotificationCenter.default.addObserver(
-            forName: Notification.Name("am.test.aba"), object: nil, queue: nil
-        ) { _ in }
-        osEvents.storeObservers([observer], generation: generationA)
-
-        XCTAssertEqual(osEvents.observerCount, countB, "a stale init's observers must not leak into a newer init's session")
-        osEvents.reset()
+        XCTAssertEqual(osEvents.observerCount, 0, "shutdown removes all observers registered under the lock")
         buffer.shutdown()
     }
 }
@@ -104,35 +76,8 @@ final class NotificationObserverTests: XCTestCase {
         buffer.shutdown()
     }
 
-    /// A→shutdown→B→A: A's late-published observers, carrying A's stale generation, must
-    /// not overwrite B's observers. A bare `_isInitialized` boolean permits this ABA.
-    func testAbaReinitializeDropsStaleInitObservers() {
-        let buffer = SdkEventBuffer { _ in }
-        buffer.start()
-        let observerTracker = AutoMobileNotificationObserver.shared
-        observerTracker.reset()
-
-        observerTracker.initialize(bundleId: "A", buffer: buffer) // init A
-        let generationA = observerTracker.initGeneration
-        observerTracker.reset() // shutdown
-        observerTracker.initialize(bundleId: "B", buffer: buffer) // init B
-        let countB = observerTracker.observerCount
-        XCTAssertGreaterThan(countB, 0)
-
-        let observer = NotificationCenter.default.addObserver(
-            forName: Notification.Name("am.test.obs.aba"), object: nil, queue: nil
-        ) { _ in }
-        observerTracker.storeObservers([observer], generation: generationA)
-
-        XCTAssertEqual(
-            observerTracker.observerCount,
-            countB,
-            "a stale init's observers must not overwrite a newer init's session"
-        )
-        observerTracker.reset()
-        buffer.shutdown()
-    }
-
+    /// `initialize` registers its observers atomically under the lock, so they are present
+    /// immediately after it returns; `shutdown` removes them all.
     func testInitializeRegistersObserversAndShutdownClearsThem() {
         let buffer = SdkEventBuffer { _ in }
         buffer.start()
@@ -140,7 +85,7 @@ final class NotificationObserverTests: XCTestCase {
         observerTracker.reset()
 
         observerTracker.initialize(bundleId: "test.bundle", buffer: buffer)
-        XCTAssertGreaterThan(observerTracker.observerCount, 0, "initialize registers observers")
+        XCTAssertGreaterThan(observerTracker.observerCount, 0, "initialize registers observers under the lock")
 
         observerTracker.reset()
         XCTAssertEqual(observerTracker.observerCount, 0, "shutdown removes all observers")


### PR DESCRIPTION
## Summary

Four SDK managers registered observers / started a listener in a check-then-act window OUTSIDE the lock,
so a concurrent `shutdown()`/`stop()` (or a second `startListening`) could interleave and leave an
observer, listener, or side-effect that fires/serves after teardown. This makes registration/setup
**atomic under the lock** so those windows are closed by construction.

- **`AutoMobileNotificationObserver`** and **`AutoMobileOsEvents`** — `initialize()` now builds AND
  stores its observers (and, for OsEvents, its `NWPathMonitor` and the
  `UIDevice.isBatteryMonitoringEnabled` side-effect) **while holding the lock**. A `shutdown()` (which
  also takes the lock) can no longer interleave between building a resource and storing it, so no
  observer / path monitor / battery-monitoring flag can outlive a teardown that races setup, and a
  shutdown+reinitialize (ABA) is impossible. `addObserver` / `NWPathMonitor.start` deliver only
  asynchronously, so holding the lock across them cannot re-enter it.
- **`UserDefaultsInspector.startListening`** now removes the old observer, seeds the baseline, and
  registers+publishes the new observer in ONE critical section. A concurrent `stopListening()` /
  `startListening()` takes the lock and so runs entirely before or after — never leaving an observer live
  past a stop, never leaking a duplicate. With `queue: nil` synchronous delivery, a change notification
  posted during registration blocks on the lock until publication completes rather than firing against a
  half-built state.
- **`SdkHierarchyServer.start()`** holds the lock across the whole assign→configure→`nwListener.start()`,
  so a concurrent `stop()` cannot cancel-then-leave-started the listener (which previously let a later
  `start()` re-bind port 8766).

Approach note: an earlier revision guarded these with re-check-after-register and then initialization
generation tokens; review (Codex/CodeRabbit) surfaced progressively narrower residual windows (callback
firing before store, battery monitoring left enabled, ABA, a TOCTOU on the generation capture), all
instances of the same register-outside-lock gap. The final revision does the root fix — register under
the lock — which eliminates the class and lets the generation tokens be removed. Supersedes and closes
follow-up #5676.

## Linked Issue

Closes #5672

## Validation

- [x] `swift test` for the SDK package: 302/302 pass
- [x] `swift build -c release` clean; SwiftLint clean (pre-existing warnings only, on untouched lines)
- [x] Existing init-once / shutdown-cleanup tests preserved; `initialize` registers observers atomically
      (present immediately after it returns), `shutdown` clears them

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

The register-vs-shutdown races are now closed by construction — there is no injectable mid-registration
seam to drive a race deterministically, so the tests pin the observable init/shutdown lifecycle
(`testInitializeRegistersObserversAndShutdownClearsThem`, `testInitializeThenShutdownLeavesNoObservers`,
plus the existing init-once/shutdown-cleanup tests). `SdkHierarchyServer` (real port bind, DEBUG) remains
verified by reading.

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices via the normal SDK build.
