### PR TITLE
fix(ios): honor WebSocket FIN bit and reassemble fragmented CtrlProxy messages

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -647,6 +647,15 @@ class WebSocketConnection: WebSocketResponding {
     private var pendingHTTPRequest = Data()
     private static let maximumHTTPRequestLength = 1_000_000
 
+    /// In-progress fragmented-message reassembly state (RFC 6455 §5.4). Both are
+    /// mutated **only** from `connection.receive` completions, which all run on the
+    /// server `queue` (`connection.start(queue:)` binds them there) and are
+    /// therefore serialized — so no lock is needed. `fragmentedOpcode` is the data
+    /// opcode (0x1/0x2) of the message being assembled, or nil when none is open;
+    /// `fragmentBuffer` accumulates the ordered payload bytes (issue #5674).
+    private var fragmentedOpcode: UInt8?
+    private var fragmentBuffer = Data()
+
     init(
         id: Int,
         connection: NWConnection,
@@ -940,6 +949,7 @@ class WebSocketConnection: WebSocketResponding {
         let byte0 = header[0]
         let byte1 = header[1]
 
+        let isFinal = (byte0 & 0x80) != 0
         let opcode = byte0 & 0x0F
         let isMasked = (byte1 & 0x80) != 0
         let payloadLength = UInt64(byte1 & 0x7F)
@@ -965,21 +975,21 @@ class WebSocketConnection: WebSocketResponding {
                 onClose()
                 return
             }
-            readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode)
+            readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
             return
         }
 
         // Read extended length if needed
         if payloadLength == 126 {
-            readExtendedLength(2, isMasked: isMasked, opcode: opcode)
+            readExtendedLength(2, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
         } else if payloadLength == 127 {
-            readExtendedLength(8, isMasked: isMasked, opcode: opcode)
+            readExtendedLength(8, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
         } else {
-            readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode)
+            readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
         }
     }
 
-    private func readExtendedLength(_ bytes: Int, isMasked: Bool, opcode: UInt8) {
+    private func readExtendedLength(_ bytes: Int, isMasked: Bool, opcode: UInt8, isFinal: Bool) {
         connection.receive(minimumIncompleteLength: bytes, maximumLength: bytes) { [weak self] data, _, _, _ in
             guard let self = self, let data = data else {
                 self?.onClose()
@@ -991,7 +1001,7 @@ class WebSocketConnection: WebSocketResponding {
                 length = length << 8 | UInt64(byte)
             }
 
-            self.readPayload(length: length, isMasked: isMasked, opcode: opcode)
+            self.readPayload(length: length, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
         }
     }
 
@@ -1069,15 +1079,90 @@ class WebSocketConnection: WebSocketResponding {
         }
     }
 
-    private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8) {
+    /// The reassembly decision for a data (0x1/0x2) or continuation (0x0) frame —
+    /// control frames are handled before this and never reach it. Pure (state in,
+    /// action out) so the fragmentation semantics can be unit-tested without a
+    /// socket, mirroring `frameAction` (issue #5674).
+    enum FragmentDecision: Equatable {
+        /// The message is complete → deliver these fully-reassembled bytes.
+        case deliver(Data)
+        /// A fragment was stored; more frames are expected. Carries the opcode now
+        /// in progress and the accumulated buffer so the caller can update the
+        /// per-connection reassembly state.
+        case buffered(opcode: UInt8, buffer: Data)
+        /// A malformed fragmentation sequence or an exceeded total-size bound →
+        /// the caller closes the connection rather than mis-delivering (§5.4).
+        case protocolError(String)
+    }
+
+    /// Applies one data/continuation frame to the in-progress reassembly state and
+    /// decides the next action (RFC 6455 §5.4):
+    ///
+    /// - A text/binary frame (0x1/0x2) with FIN=1 and nothing in progress is a
+    ///   complete single-frame message → `.deliver` verbatim (no regression).
+    /// - A text/binary frame with FIN=0 starts a fragmented message → `.buffered`.
+    /// - A continuation frame (0x0) extends the in-progress message; on FIN=1 it
+    ///   completes → `.deliver` the ordered concatenation, otherwise `.buffered`.
+    /// - A continuation with nothing in progress, or a new data frame while a
+    ///   message is still open, is malformed → `.protocolError`.
+    /// - The **total** reassembled size is bounded by `maxTotal` (the per-frame
+    ///   `maxFramePayloadLength` applied cumulatively); exceeding it is a
+    ///   `.protocolError` so the buffer cannot grow unboundedly.
+    static func reassemble(
+        opcode: UInt8,
+        isFinal: Bool,
+        payload: Data,
+        inProgressOpcode: UInt8?,
+        accumulated: Data,
+        maxTotal: UInt64 = maxFramePayloadLength
+    ) -> FragmentDecision {
+        switch opcode {
+        case 0x01, 0x02:
+            // A new data frame is illegal while a fragmented message is still open.
+            if inProgressOpcode != nil {
+                return .protocolError("new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open")
+            }
+            guard UInt64(payload.count) <= maxTotal else {
+                return .protocolError("frame payload exceeds \(maxTotal) bytes")
+            }
+            return isFinal ? .deliver(payload) : .buffered(opcode: opcode, buffer: payload)
+
+        case 0x00:
+            // A continuation frame requires an in-progress message.
+            guard let openOpcode = inProgressOpcode else {
+                return .protocolError("continuation frame with no message in progress")
+            }
+            guard UInt64(accumulated.count) + UInt64(payload.count) <= maxTotal else {
+                return .protocolError("reassembled message exceeds \(maxTotal) bytes")
+            }
+            var combined = accumulated
+            combined.append(payload)
+            return isFinal ? .deliver(combined) : .buffered(opcode: openOpcode, buffer: combined)
+
+        default:
+            // Reserved / unexpected data opcode (control frames never reach here).
+            return .protocolError("unsupported opcode 0x\(String(opcode, radix: 16))")
+        }
+    }
+
+    private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8, isFinal: Bool) {
         guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
             print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
             onClose()
             return
         }
 
+        // A zero-length frame carries no payload/mask bytes to read, but for a
+        // data/continuation frame the FIN bit still matters: an empty final
+        // continuation completes a fragmented message, and an empty non-final data
+        // frame opens one. Route it through reassembly with an empty payload rather
+        // than skipping straight to the next frame.
         guard totalLength > 0 else {
-            receiveWebSocketFrame()
+            if Self.isDataOrContinuation(opcode) {
+                handleDataFrame(opcode: opcode, isFinal: isFinal, payload: Data())
+            } else {
+                receiveWebSocketFrame()
+            }
             return
         }
 
@@ -1090,9 +1175,17 @@ class WebSocketConnection: WebSocketResponding {
 
                 let payload: Data = isMasked ? Self.unmaskFrame(data) : data
 
+                if Self.isDataOrContinuation(opcode) {
+                    self.handleDataFrame(opcode: opcode, isFinal: isFinal, payload: payload)
+                    return
+                }
+
+                // Control frames (ping/pong and any non-data opcode) are handled
+                // independently and never touch the reassembly buffer (§5.4).
                 switch Self.frameAction(opcode: opcode, unmaskedPayload: payload) {
-                case let .deliver(message):
-                    self.onMessage(message)
+                case .deliver:
+                    // Unreachable: data opcodes are handled above via reassembly.
+                    break
                 case let .pong(applicationData):
                     // Echo the ping application data back in the pong (§5.5.3).
                     let pongFrame = Self.createWebSocketFrame(data: applicationData, opcode: 0x0A)
@@ -1103,6 +1196,41 @@ class WebSocketConnection: WebSocketResponding {
 
                 self.receiveWebSocketFrame()
             }
+    }
+
+    /// Whether `opcode` denotes a data (text/binary) or continuation frame — the
+    /// frames that participate in fragmentation reassembly (§5.4).
+    static func isDataOrContinuation(_ opcode: UInt8) -> Bool {
+        opcode == 0x00 || opcode == 0x01 || opcode == 0x02
+    }
+
+    /// Feeds one data/continuation frame through the pure `reassemble` state
+    /// machine, updating the per-connection reassembly state and delivering the
+    /// completed message, buffering, or closing on a malformed sequence. Runs on
+    /// the server `queue` (see `fragmentedOpcode`), so the mutations are serialized.
+    private func handleDataFrame(opcode: UInt8, isFinal: Bool, payload: Data) {
+        switch WebSocketConnection.reassemble(
+            opcode: opcode,
+            isFinal: isFinal,
+            payload: payload,
+            inProgressOpcode: fragmentedOpcode,
+            accumulated: fragmentBuffer
+        ) {
+        case let .deliver(message):
+            fragmentedOpcode = nil
+            fragmentBuffer = Data()
+            onMessage(message)
+            receiveWebSocketFrame()
+        case let .buffered(openOpcode, buffer):
+            fragmentedOpcode = openOpcode
+            fragmentBuffer = buffer
+            receiveWebSocketFrame()
+        case let .protocolError(reason):
+            print("[WebSocketConnection] Fragmentation protocol error: \(reason), closing connection")
+            fragmentedOpcode = nil
+            fragmentBuffer = Data()
+            onClose()
+        }
     }
 
     /// Build an unmasked server→client frame (server frames are never masked,

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1023,6 +1023,22 @@ class WebSocketConnection: WebSocketResponding {
         return Int(payloadLength) + (isMasked ? 4 : 0)
     }
 
+    /// Whether appending a continuation frame of `payloadLength` declared bytes to
+    /// the `alreadyBuffered` accumulated bytes would exceed the total reassembly
+    /// budget. Evaluated from the frame header **before** the payload is received
+    /// and unmasked, so an oversized continuation is rejected without first
+    /// allocating (and copying, when unmasking) its bytes — otherwise a connection
+    /// could transiently hold the prior fragment plus the masked and unmasked
+    /// copies of the new one (~3× the cap) before the post-append bound in
+    /// `accumulate` fires (issue #5674 review).
+    static func continuationExceedsReassemblyBudget(
+        payloadLength: UInt64,
+        alreadyBuffered: Int,
+        maxTotal: UInt64 = maxFramePayloadLength
+    ) -> Bool {
+        UInt64(alreadyBuffered) + payloadLength > maxTotal
+    }
+
     /// Unmask a masked WebSocket frame whose first 4 bytes are the masking key and
     /// whose remaining bytes are the masked payload (RFC 6455 §5.3).
     ///
@@ -1168,6 +1184,21 @@ class WebSocketConnection: WebSocketResponding {
     private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8, isFinal: Bool) {
         guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
             print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
+            onClose()
+            return
+        }
+
+        // Reject a continuation that would overflow the total reassembly budget
+        // from its header, before receiving/unmasking its payload, so a malformed
+        // peer cannot make the runner allocate ~3× the cap per connection (§5.4;
+        // issue #5674 review). The post-append bound in `accumulate` still guards
+        // correctness for the paths that do read.
+        if opcode == 0x00,
+           fragmentedOpcode != nil,
+           Self.continuationExceedsReassemblyBudget(payloadLength: length, alreadyBuffered: fragmentBuffer.count) {
+            print("[WebSocketConnection] Continuation would exceed reassembly budget (\(fragmentBuffer.count) + \(length) > \(Self.maxFramePayloadLength)), closing connection")
+            fragmentedOpcode = nil
+            fragmentBuffer = Data()
             onClose()
             return
         }

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1079,43 +1079,50 @@ class WebSocketConnection: WebSocketResponding {
         }
     }
 
-    /// The reassembly decision for a data (0x1/0x2) or continuation (0x0) frame —
-    /// control frames are handled before this and never reach it. Pure (state in,
-    /// action out) so the fragmentation semantics can be unit-tested without a
-    /// socket, mirroring `frameAction` (issue #5674).
-    enum FragmentDecision: Equatable {
+    /// The outcome of applying one data/continuation frame to the reassembly
+    /// buffer. Kept small so the fragmentation semantics can be unit-tested
+    /// without a socket, mirroring `frameAction` (issue #5674).
+    enum AccumulateResult: Equatable {
         /// The message is complete → deliver these fully-reassembled bytes.
         case deliver(Data)
-        /// A fragment was stored; more frames are expected. Carries the opcode now
-        /// in progress and the accumulated buffer so the caller can update the
-        /// per-connection reassembly state.
-        case buffered(opcode: UInt8, buffer: Data)
+        /// The fragment was appended in place; more frames are expected.
+        case buffered
         /// A malformed fragmentation sequence or an exceeded total-size bound →
         /// the caller closes the connection rather than mis-delivering (§5.4).
         case protocolError(String)
     }
 
-    /// Applies one data/continuation frame to the in-progress reassembly state and
-    /// decides the next action (RFC 6455 §5.4):
+    /// Applies one data/continuation frame to the in-progress reassembly state,
+    /// mutating the caller-owned `buffer` and `inProgressOpcode` **in place**
+    /// (RFC 6455 §5.4):
     ///
     /// - A text/binary frame (0x1/0x2) with FIN=1 and nothing in progress is a
-    ///   complete single-frame message → `.deliver` verbatim (no regression).
-    /// - A text/binary frame with FIN=0 starts a fragmented message → `.buffered`.
-    /// - A continuation frame (0x0) extends the in-progress message; on FIN=1 it
-    ///   completes → `.deliver` the ordered concatenation, otherwise `.buffered`.
+    ///   complete single-frame message → `.deliver` verbatim, untouched buffer
+    ///   (no regression, and no copy).
+    /// - A text/binary frame with FIN=0 starts a fragmented message: the payload
+    ///   becomes the buffer and the opcode is recorded → `.buffered`.
+    /// - A continuation frame (0x0) appends to the buffer; on FIN=1 the buffer is
+    ///   handed off and reset → `.deliver`, otherwise `.buffered`.
     /// - A continuation with nothing in progress, or a new data frame while a
     ///   message is still open, is malformed → `.protocolError`.
     /// - The **total** reassembled size is bounded by `maxTotal` (the per-frame
     ///   `maxFramePayloadLength` applied cumulatively); exceeding it is a
     ///   `.protocolError` so the buffer cannot grow unboundedly.
-    static func reassemble(
+    ///
+    /// Appending into the caller's `buffer` via `inout` (rather than returning a
+    /// freshly concatenated `Data`) keeps reassembly amortized O(total) instead of
+    /// O(total²): a `var combined = accumulated; combined.append(...)` copy-on-write
+    /// -copies the whole message-so-far for every continuation frame, so a legal
+    /// large message split into many small fragments could pin the serial server
+    /// queue and starve `/health` (issue #5674 review).
+    static func accumulate(
+        into buffer: inout Data,
         opcode: UInt8,
         isFinal: Bool,
         payload: Data,
-        inProgressOpcode: UInt8?,
-        accumulated: Data,
+        inProgressOpcode: inout UInt8?,
         maxTotal: UInt64 = maxFramePayloadLength
-    ) -> FragmentDecision {
+    ) -> AccumulateResult {
         switch opcode {
         case 0x01, 0x02:
             // A new data frame is illegal while a fragmented message is still open.
@@ -1125,19 +1132,32 @@ class WebSocketConnection: WebSocketResponding {
             guard UInt64(payload.count) <= maxTotal else {
                 return .protocolError("frame payload exceeds \(maxTotal) bytes")
             }
-            return isFinal ? .deliver(payload) : .buffered(opcode: opcode, buffer: payload)
+            if isFinal {
+                // Single, unfragmented message — deliver directly, no buffering.
+                return .deliver(payload)
+            }
+            // Start a fragmented message: the payload seeds the buffer.
+            inProgressOpcode = opcode
+            buffer = payload
+            return .buffered
 
         case 0x00:
             // A continuation frame requires an in-progress message.
-            guard let openOpcode = inProgressOpcode else {
+            guard inProgressOpcode != nil else {
                 return .protocolError("continuation frame with no message in progress")
             }
-            guard UInt64(accumulated.count) + UInt64(payload.count) <= maxTotal else {
+            guard UInt64(buffer.count) + UInt64(payload.count) <= maxTotal else {
                 return .protocolError("reassembled message exceeds \(maxTotal) bytes")
             }
-            var combined = accumulated
-            combined.append(payload)
-            return isFinal ? .deliver(combined) : .buffered(opcode: openOpcode, buffer: combined)
+            buffer.append(payload)
+            guard isFinal else {
+                return .buffered
+            }
+            // Final continuation — hand off the accumulated bytes and reset.
+            let message = buffer
+            buffer = Data()
+            inProgressOpcode = nil
+            return .deliver(message)
 
         default:
             // Reserved / unexpected data opcode (control frames never reach here).
@@ -1209,21 +1229,17 @@ class WebSocketConnection: WebSocketResponding {
     /// completed message, buffering, or closing on a malformed sequence. Runs on
     /// the server `queue` (see `fragmentedOpcode`), so the mutations are serialized.
     private func handleDataFrame(opcode: UInt8, isFinal: Bool, payload: Data) {
-        switch WebSocketConnection.reassemble(
+        switch WebSocketConnection.accumulate(
+            into: &fragmentBuffer,
             opcode: opcode,
             isFinal: isFinal,
             payload: payload,
-            inProgressOpcode: fragmentedOpcode,
-            accumulated: fragmentBuffer
+            inProgressOpcode: &fragmentedOpcode
         ) {
         case let .deliver(message):
-            fragmentedOpcode = nil
-            fragmentBuffer = Data()
             onMessage(message)
             receiveWebSocketFrame()
-        case let .buffered(openOpcode, buffer):
-            fragmentedOpcode = openOpcode
-            fragmentBuffer = buffer
+        case .buffered:
             receiveWebSocketFrame()
         case let .protocolError(reason):
             print("[WebSocketConnection] Fragmentation protocol error: \(reason), closing connection")

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1023,20 +1023,52 @@ class WebSocketConnection: WebSocketResponding {
         return Int(payloadLength) + (isMasked ? 4 : 0)
     }
 
-    /// Whether appending a continuation frame of `payloadLength` declared bytes to
-    /// the `alreadyBuffered` accumulated bytes would exceed the total reassembly
-    /// budget. Evaluated from the frame header **before** the payload is received
-    /// and unmasked, so an oversized continuation is rejected without first
-    /// allocating (and copying, when unmasking) its bytes — otherwise a connection
-    /// could transiently hold the prior fragment plus the masked and unmasked
-    /// copies of the new one (~3× the cap) before the post-append bound in
-    /// `accumulate` fires (issue #5674 review).
-    static func continuationExceedsReassemblyBudget(
-        payloadLength: UInt64,
+    /// Whether a data/continuation frame may be received, decided from the frame
+    /// header alone.
+    enum FramePreReadDecision: Equatable {
+        /// The frame is admissible — receive its payload, then hand to `accumulate`.
+        case read
+        /// The frame is malformed or would overflow the reassembly budget — close
+        /// the connection without receiving it.
+        case reject(String)
+    }
+
+    /// Decides, from the frame header **before** any payload is received or
+    /// unmasked, whether a data (0x1/0x2) or continuation (0x0) frame can legally
+    /// be accepted into the current reassembly state. This mirrors `accumulate`'s
+    /// rejection conditions but runs pre-read, so a malformed or oversized frame is
+    /// rejected without ever allocating (and, when masked, copying) a payload the
+    /// server would immediately discard — bounding per-connection memory to ~1× the
+    /// cap instead of ~3× (issue #5674 review). Only frames this returns `.read`
+    /// for reach `accumulate`, which stays the post-read authority for the accepted
+    /// paths (defense in depth).
+    static func preReadDataFrameDecision(
+        opcode: UInt8,
+        declaredPayloadLength: UInt64,
+        inProgressOpcode: UInt8?,
         alreadyBuffered: Int,
         maxTotal: UInt64 = maxFramePayloadLength
-    ) -> Bool {
-        UInt64(alreadyBuffered) + payloadLength > maxTotal
+    ) -> FramePreReadDecision {
+        switch opcode {
+        case 0x01, 0x02:
+            if inProgressOpcode != nil {
+                return .reject("new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open")
+            }
+            guard declaredPayloadLength <= maxTotal else {
+                return .reject("frame payload exceeds \(maxTotal) bytes")
+            }
+            return .read
+        case 0x00:
+            guard inProgressOpcode != nil else {
+                return .reject("continuation frame with no message in progress")
+            }
+            guard UInt64(alreadyBuffered) + declaredPayloadLength <= maxTotal else {
+                return .reject("reassembled message exceeds \(maxTotal) bytes")
+            }
+            return .read
+        default:
+            return .reject("unsupported opcode 0x\(String(opcode, radix: 16))")
+        }
     }
 
     /// Unmask a masked WebSocket frame whose first 4 bytes are the masking key and
@@ -1188,15 +1220,19 @@ class WebSocketConnection: WebSocketResponding {
             return
         }
 
-        // Reject a continuation that would overflow the total reassembly budget
-        // from its header, before receiving/unmasking its payload, so a malformed
-        // peer cannot make the runner allocate ~3× the cap per connection (§5.4;
-        // issue #5674 review). The post-append bound in `accumulate` still guards
-        // correctness for the paths that do read.
-        if opcode == 0x00,
-           fragmentedOpcode != nil,
-           Self.continuationExceedsReassemblyBudget(payloadLength: length, alreadyBuffered: fragmentBuffer.count) {
-            print("[WebSocketConnection] Continuation would exceed reassembly budget (\(fragmentBuffer.count) + \(length) > \(Self.maxFramePayloadLength)), closing connection")
+        // Reject any malformed or over-budget data/continuation frame from its
+        // header, before receiving/unmasking its payload, so a malformed peer
+        // cannot make the runner allocate a frame it would immediately discard
+        // (§5.4; issue #5674 review). `accumulate` still enforces the same
+        // conditions post-read as defense in depth for the accepted paths.
+        if Self.isDataOrContinuation(opcode),
+           case let .reject(reason) = Self.preReadDataFrameDecision(
+               opcode: opcode,
+               declaredPayloadLength: length,
+               inProgressOpcode: fragmentedOpcode,
+               alreadyBuffered: fragmentBuffer.count
+           ) {
+            print("[WebSocketConnection] Fragmentation protocol error (pre-read): \(reason), closing connection")
             fragmentedOpcode = nil
             fragmentBuffer = Data()
             onClose()

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -836,6 +836,22 @@ final class WebSocketServerTests: XCTestCase {
         )
     }
 
+    /// AC4: the total-size budget is enforced from the continuation frame's
+    /// declared header length *before* its payload is received/unmasked, so an
+    /// oversized continuation is rejected without allocating ~3× the cap. The cap
+    /// is inclusive (filling it exactly is allowed).
+    func testContinuationBudgetIsCheckedFromHeaderInclusive() {
+        // Exactly filling the remaining budget is allowed.
+        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 10, alreadyBuffered: 0, maxTotal: 10))
+        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 4, alreadyBuffered: 6, maxTotal: 10))
+        // One byte over the remaining budget is rejected.
+        XCTAssertTrue(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 5, alreadyBuffered: 6, maxTotal: 10))
+        // The real vector: a second ~64 MiB continuation on top of a full buffer.
+        let max = WebSocketConnection.maxFramePayloadLength
+        XCTAssertTrue(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: max, alreadyBuffered: Int(max)))
+        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: max, alreadyBuffered: 0))
+    }
+
     /// AC1/AC2/AC3 end-to-end over a real socket: a client command split across
     /// two masked WebSocket fragments — with a ping interleaved between them — is
     /// reassembled by the server and dispatched, so its typed response still comes

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -1183,7 +1183,6 @@ private final class RawWebSocketClient: @unchecked Sendable {
                 }
             }
             // Otherwise (control frame, or non-matching data frame) keep parsing.
-            // Otherwise (control frame, or non-matching data frame) keep parsing.
         }
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -676,142 +676,122 @@ final class WebSocketServerTests: XCTestCase {
 
     // MARK: - Fragmented message reassembly (#5674)
 
-    /// AC2: a single unfragmented frame (FIN=1, text/binary opcode, nothing in
-    /// progress) is delivered verbatim, exactly as before the fragmentation fix.
-    func testSingleUnfragmentedFrameDeliversUnchanged() {
-        let payload = Data("hello".utf8)
-        XCTAssertEqual(
-            WebSocketConnection.reassemble(
-                opcode: 0x01,
-                isFinal: true,
-                payload: payload,
-                inProgressOpcode: nil,
-                accumulated: Data()
-            ),
-            .deliver(payload)
+    /// Drives `WebSocketConnection.accumulate` against local reassembly state,
+    /// mirroring how one connection feeds successive frames (the helper owns the
+    /// `buffer`/`opcode` the production code keeps per-connection). Exposing the
+    /// buffer + opcode lets the tests pin both the result *and* the in-place
+    /// accumulated bytes / carried opcode.
+    private struct FragmentReassembler {
+        var buffer = Data()
+        var opcode: UInt8?
+
+        mutating func feed(
+            opcode: UInt8,
+            isFinal: Bool,
+            payload: Data,
+            maxTotal: UInt64 = WebSocketConnection.maxFramePayloadLength
         )
+            -> WebSocketConnection.AccumulateResult
+        {
+            WebSocketConnection.accumulate(
+                into: &buffer,
+                opcode: opcode,
+                isFinal: isFinal,
+                payload: payload,
+                inProgressOpcode: &self.opcode,
+                maxTotal: maxTotal
+            )
+        }
+    }
+
+    /// AC2: a single unfragmented frame (FIN=1, text/binary opcode, nothing in
+    /// progress) is delivered verbatim and leaves no reassembly state behind,
+    /// exactly as before the fragmentation fix.
+    func testSingleUnfragmentedFrameDeliversUnchanged() {
+        var reassembler = FragmentReassembler()
+        let payload = Data("hello".utf8)
+        XCTAssertEqual(reassembler.feed(opcode: 0x01, isFinal: true, payload: payload), .deliver(payload))
+        XCTAssertNil(reassembler.opcode, "a single frame opens no in-progress message")
+        XCTAssertTrue(reassembler.buffer.isEmpty, "a single frame is delivered without buffering")
     }
 
     /// AC1/AC6: a two-fragment message (initial FIN=0 text, final FIN=1
     /// continuation) buffers the first fragment then delivers the ordered
     /// concatenation once complete.
     func testTwoFragmentMessageReassembles() {
+        var reassembler = FragmentReassembler()
         let first = Data("Hello, ".utf8)
         let second = Data("world!".utf8)
 
-        let initialDecision = WebSocketConnection.reassemble(
-            opcode: 0x01,
-            isFinal: false,
-            payload: first,
-            inProgressOpcode: nil,
-            accumulated: Data()
-        )
-        XCTAssertEqual(initialDecision, .buffered(opcode: 0x01, buffer: first))
+        XCTAssertEqual(reassembler.feed(opcode: 0x01, isFinal: false, payload: first), .buffered)
+        XCTAssertEqual(reassembler.opcode, 0x01)
+        XCTAssertEqual(reassembler.buffer, first)
 
-        let finalDecision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: second,
-            inProgressOpcode: 0x01,
-            accumulated: first
-        )
-        XCTAssertEqual(finalDecision, .deliver(first + second))
+        XCTAssertEqual(reassembler.feed(opcode: 0x00, isFinal: true, payload: second), .deliver(first + second))
+        XCTAssertNil(reassembler.opcode, "delivery clears the in-progress opcode")
+        XCTAssertTrue(reassembler.buffer.isEmpty, "delivery resets the buffer")
     }
 
     /// AC1/AC6: a three-fragment binary message (initial FIN=0 binary, a middle
     /// FIN=0 continuation, a final FIN=1 continuation) reassembles in order and
     /// carries the initial opcode forward through each continuation.
     func testThreeFragmentMessageReassemblesInOrder() {
+        var reassembler = FragmentReassembler()
         let partA = Data("aaa".utf8)
         let partB = Data("bbb".utf8)
         let partC = Data("ccc".utf8)
 
-        let initialDecision = WebSocketConnection.reassemble(
-            opcode: 0x02,
-            isFinal: false,
-            payload: partA,
-            inProgressOpcode: nil,
-            accumulated: Data()
-        )
-        XCTAssertEqual(initialDecision, .buffered(opcode: 0x02, buffer: partA))
+        XCTAssertEqual(reassembler.feed(opcode: 0x02, isFinal: false, payload: partA), .buffered)
+        XCTAssertEqual(reassembler.opcode, 0x02)
+        XCTAssertEqual(reassembler.buffer, partA)
 
-        let middleDecision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: false,
-            payload: partB,
-            inProgressOpcode: 0x02,
-            accumulated: partA
-        )
-        XCTAssertEqual(middleDecision, .buffered(opcode: 0x02, buffer: partA + partB))
+        XCTAssertEqual(reassembler.feed(opcode: 0x00, isFinal: false, payload: partB), .buffered)
+        XCTAssertEqual(reassembler.opcode, 0x02, "the initial opcode is carried through continuations")
+        XCTAssertEqual(reassembler.buffer, partA + partB)
 
-        let finalDecision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: partC,
-            inProgressOpcode: 0x02,
-            accumulated: partA + partB
-        )
-        XCTAssertEqual(finalDecision, .deliver(partA + partB + partC))
+        XCTAssertEqual(reassembler.feed(opcode: 0x00, isFinal: true, payload: partC), .deliver(partA + partB + partC))
     }
 
     /// AC2: a non-final data frame does not trigger delivery — it is buffered
     /// with the in-progress opcode recorded.
     func testNonFinalStartFrameDoesNotDeliver() {
+        var reassembler = FragmentReassembler()
         let payload = Data("partial".utf8)
-        let decision = WebSocketConnection.reassemble(
-            opcode: 0x01,
-            isFinal: false,
-            payload: payload,
-            inProgressOpcode: nil,
-            accumulated: Data()
-        )
-        XCTAssertEqual(decision, .buffered(opcode: 0x01, buffer: payload))
-        if case .deliver = decision {
+        let result = reassembler.feed(opcode: 0x01, isFinal: false, payload: payload)
+        XCTAssertEqual(result, .buffered)
+        XCTAssertEqual(reassembler.opcode, 0x01)
+        XCTAssertEqual(reassembler.buffer, payload)
+        if case .deliver = result {
             XCTFail("a non-final frame must not deliver")
         }
     }
 
     /// AC3: a control frame between fragments is handled independently
-    /// (`frameAction` → pong/ignore) and never fed to `reassemble`, so the
+    /// (`frameAction` → pong/ignore) and never fed to `accumulate`, so the
     /// in-progress opcode + accumulated buffer are untouched and the following
     /// continuation still reassembles into the full message.
     func testControlFrameBetweenFragmentsDoesNotCorruptReassembly() {
+        var reassembler = FragmentReassembler()
         let first = Data("frag-".utf8)
-        let initialDecision = WebSocketConnection.reassemble(
-            opcode: 0x01,
-            isFinal: false,
-            payload: first,
-            inProgressOpcode: nil,
-            accumulated: Data()
-        )
-        XCTAssertEqual(initialDecision, .buffered(opcode: 0x01, buffer: first))
+        XCTAssertEqual(reassembler.feed(opcode: 0x01, isFinal: false, payload: first), .buffered)
 
-        // A ping arriving here routes through frameAction, not reassemble.
+        // A ping arriving here routes through frameAction, not accumulate, and so
+        // does not touch the reassembler's buffer/opcode.
         XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x09, unmaskedPayload: Data()), .pong(Data()))
+        XCTAssertEqual(reassembler.opcode, 0x01)
+        XCTAssertEqual(reassembler.buffer, first)
 
         // The continuation resumes from the unchanged in-progress state.
         let second = Data("done".utf8)
-        let finalDecision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: second,
-            inProgressOpcode: 0x01,
-            accumulated: first
-        )
-        XCTAssertEqual(finalDecision, .deliver(first + second))
+        XCTAssertEqual(reassembler.feed(opcode: 0x00, isFinal: true, payload: second), .deliver(first + second))
     }
 
     /// AC5/AC6: a continuation frame with no message in progress is a protocol
     /// error, so the caller closes the connection rather than mis-delivering.
     func testContinuationWithNoMessageInProgressIsRejected() {
-        let decision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: Data("x".utf8),
-            inProgressOpcode: nil,
-            accumulated: Data()
-        )
-        guard case .protocolError = decision else {
+        var reassembler = FragmentReassembler()
+        let result = reassembler.feed(opcode: 0x00, isFinal: true, payload: Data("x".utf8))
+        guard case .protocolError = result else {
             return XCTFail("a continuation with no in-progress message must be a protocol error")
         }
     }
@@ -819,14 +799,10 @@ final class WebSocketServerTests: XCTestCase {
     /// AC5: a new non-control data frame while a fragmented message is still open
     /// is a protocol error (interleaved data messages are not permitted, §5.4).
     func testNewDataFrameWhileFragmentOpenIsRejected() {
-        let decision = WebSocketConnection.reassemble(
-            opcode: 0x01,
-            isFinal: false,
-            payload: Data("y".utf8),
-            inProgressOpcode: 0x01,
-            accumulated: Data("open".utf8)
-        )
-        guard case .protocolError = decision else {
+        var reassembler = FragmentReassembler()
+        XCTAssertEqual(reassembler.feed(opcode: 0x01, isFinal: false, payload: Data("open".utf8)), .buffered)
+        let result = reassembler.feed(opcode: 0x01, isFinal: false, payload: Data("y".utf8))
+        guard case .protocolError = result else {
             return XCTFail("a new data frame during an open fragment must be a protocol error")
         }
     }
@@ -835,15 +811,13 @@ final class WebSocketServerTests: XCTestCase {
     /// that would push the message past `maxTotal` is a protocol error rather than
     /// growing the buffer unboundedly.
     func testReassemblyTotalSizeBoundExceededIsRejected() {
-        let decision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: Data("world".utf8), // 5
-            inProgressOpcode: 0x01,
-            accumulated: Data("hello".utf8), // 5, total 10
-            maxTotal: 8
+        var reassembler = FragmentReassembler()
+        XCTAssertEqual(
+            reassembler.feed(opcode: 0x01, isFinal: false, payload: Data("hello".utf8), maxTotal: 8), // 5
+            .buffered
         )
-        guard case .protocolError = decision else {
+        let result = reassembler.feed(opcode: 0x00, isFinal: true, payload: Data("world".utf8), maxTotal: 8) // +5 → 10 > 8
+        guard case .protocolError = result else {
             return XCTFail("exceeding the total reassembled size bound must be a protocol error")
         }
     }
@@ -851,15 +825,15 @@ final class WebSocketServerTests: XCTestCase {
     /// AC4: a message whose total lands exactly on the bound is accepted — the
     /// cap is inclusive, matching `frameReadLength`'s per-frame bound.
     func testReassemblyAtExactBoundIsAccepted() {
-        let decision = WebSocketConnection.reassemble(
-            opcode: 0x00,
-            isFinal: true,
-            payload: Data("lo".utf8), // 2
-            inProgressOpcode: 0x01,
-            accumulated: Data("hel".utf8), // 3, total 5
-            maxTotal: 5
+        var reassembler = FragmentReassembler()
+        XCTAssertEqual(
+            reassembler.feed(opcode: 0x01, isFinal: false, payload: Data("hel".utf8), maxTotal: 5), // 3
+            .buffered
         )
-        XCTAssertEqual(decision, .deliver(Data("hello".utf8)))
+        XCTAssertEqual(
+            reassembler.feed(opcode: 0x00, isFinal: true, payload: Data("lo".utf8), maxTotal: 5), // +2 → 5 == 5
+            .deliver(Data("hello".utf8))
+        )
     }
 
     /// AC1/AC2/AC3 end-to-end over a real socket: a client command split across

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -1,4 +1,5 @@
 @testable import CtrlProxy
+import Network
 import XCTest
 
 /// Locks the decode-failure → error-response path #2854 moved *out* of
@@ -673,6 +674,248 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertFalse(WebSocketConnection.isValidControlFramePayloadLength(127))
     }
 
+    // MARK: - Fragmented message reassembly (#5674)
+
+    /// AC2: a single unfragmented frame (FIN=1, text/binary opcode, nothing in
+    /// progress) is delivered verbatim, exactly as before the fragmentation fix.
+    func testSingleUnfragmentedFrameDeliversUnchanged() {
+        let payload = Data("hello".utf8)
+        XCTAssertEqual(
+            WebSocketConnection.reassemble(
+                opcode: 0x01,
+                isFinal: true,
+                payload: payload,
+                inProgressOpcode: nil,
+                accumulated: Data()
+            ),
+            .deliver(payload)
+        )
+    }
+
+    /// AC1/AC6: a two-fragment message (initial FIN=0 text, final FIN=1
+    /// continuation) buffers the first fragment then delivers the ordered
+    /// concatenation once complete.
+    func testTwoFragmentMessageReassembles() {
+        let first = Data("Hello, ".utf8)
+        let second = Data("world!".utf8)
+
+        let initialDecision = WebSocketConnection.reassemble(
+            opcode: 0x01,
+            isFinal: false,
+            payload: first,
+            inProgressOpcode: nil,
+            accumulated: Data()
+        )
+        XCTAssertEqual(initialDecision, .buffered(opcode: 0x01, buffer: first))
+
+        let finalDecision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: second,
+            inProgressOpcode: 0x01,
+            accumulated: first
+        )
+        XCTAssertEqual(finalDecision, .deliver(first + second))
+    }
+
+    /// AC1/AC6: a three-fragment binary message (initial FIN=0 binary, a middle
+    /// FIN=0 continuation, a final FIN=1 continuation) reassembles in order and
+    /// carries the initial opcode forward through each continuation.
+    func testThreeFragmentMessageReassemblesInOrder() {
+        let partA = Data("aaa".utf8)
+        let partB = Data("bbb".utf8)
+        let partC = Data("ccc".utf8)
+
+        let initialDecision = WebSocketConnection.reassemble(
+            opcode: 0x02,
+            isFinal: false,
+            payload: partA,
+            inProgressOpcode: nil,
+            accumulated: Data()
+        )
+        XCTAssertEqual(initialDecision, .buffered(opcode: 0x02, buffer: partA))
+
+        let middleDecision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: false,
+            payload: partB,
+            inProgressOpcode: 0x02,
+            accumulated: partA
+        )
+        XCTAssertEqual(middleDecision, .buffered(opcode: 0x02, buffer: partA + partB))
+
+        let finalDecision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: partC,
+            inProgressOpcode: 0x02,
+            accumulated: partA + partB
+        )
+        XCTAssertEqual(finalDecision, .deliver(partA + partB + partC))
+    }
+
+    /// AC2: a non-final data frame does not trigger delivery — it is buffered
+    /// with the in-progress opcode recorded.
+    func testNonFinalStartFrameDoesNotDeliver() {
+        let payload = Data("partial".utf8)
+        let decision = WebSocketConnection.reassemble(
+            opcode: 0x01,
+            isFinal: false,
+            payload: payload,
+            inProgressOpcode: nil,
+            accumulated: Data()
+        )
+        XCTAssertEqual(decision, .buffered(opcode: 0x01, buffer: payload))
+        if case .deliver = decision {
+            XCTFail("a non-final frame must not deliver")
+        }
+    }
+
+    /// AC3: a control frame between fragments is handled independently
+    /// (`frameAction` → pong/ignore) and never fed to `reassemble`, so the
+    /// in-progress opcode + accumulated buffer are untouched and the following
+    /// continuation still reassembles into the full message.
+    func testControlFrameBetweenFragmentsDoesNotCorruptReassembly() {
+        let first = Data("frag-".utf8)
+        let initialDecision = WebSocketConnection.reassemble(
+            opcode: 0x01,
+            isFinal: false,
+            payload: first,
+            inProgressOpcode: nil,
+            accumulated: Data()
+        )
+        XCTAssertEqual(initialDecision, .buffered(opcode: 0x01, buffer: first))
+
+        // A ping arriving here routes through frameAction, not reassemble.
+        XCTAssertEqual(WebSocketConnection.frameAction(opcode: 0x09, unmaskedPayload: Data()), .pong(Data()))
+
+        // The continuation resumes from the unchanged in-progress state.
+        let second = Data("done".utf8)
+        let finalDecision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: second,
+            inProgressOpcode: 0x01,
+            accumulated: first
+        )
+        XCTAssertEqual(finalDecision, .deliver(first + second))
+    }
+
+    /// AC5/AC6: a continuation frame with no message in progress is a protocol
+    /// error, so the caller closes the connection rather than mis-delivering.
+    func testContinuationWithNoMessageInProgressIsRejected() {
+        let decision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: Data("x".utf8),
+            inProgressOpcode: nil,
+            accumulated: Data()
+        )
+        guard case .protocolError = decision else {
+            return XCTFail("a continuation with no in-progress message must be a protocol error")
+        }
+    }
+
+    /// AC5: a new non-control data frame while a fragmented message is still open
+    /// is a protocol error (interleaved data messages are not permitted, §5.4).
+    func testNewDataFrameWhileFragmentOpenIsRejected() {
+        let decision = WebSocketConnection.reassemble(
+            opcode: 0x01,
+            isFinal: false,
+            payload: Data("y".utf8),
+            inProgressOpcode: 0x01,
+            accumulated: Data("open".utf8)
+        )
+        guard case .protocolError = decision else {
+            return XCTFail("a new data frame during an open fragment must be a protocol error")
+        }
+    }
+
+    /// AC4: reassembly is bounded by the total accumulated size — a continuation
+    /// that would push the message past `maxTotal` is a protocol error rather than
+    /// growing the buffer unboundedly.
+    func testReassemblyTotalSizeBoundExceededIsRejected() {
+        let decision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: Data("world".utf8), // 5
+            inProgressOpcode: 0x01,
+            accumulated: Data("hello".utf8), // 5, total 10
+            maxTotal: 8
+        )
+        guard case .protocolError = decision else {
+            return XCTFail("exceeding the total reassembled size bound must be a protocol error")
+        }
+    }
+
+    /// AC4: a message whose total lands exactly on the bound is accepted — the
+    /// cap is inclusive, matching `frameReadLength`'s per-frame bound.
+    func testReassemblyAtExactBoundIsAccepted() {
+        let decision = WebSocketConnection.reassemble(
+            opcode: 0x00,
+            isFinal: true,
+            payload: Data("lo".utf8), // 2
+            inProgressOpcode: 0x01,
+            accumulated: Data("hel".utf8), // 3, total 5
+            maxTotal: 5
+        )
+        XCTAssertEqual(decision, .deliver(Data("hello".utf8)))
+    }
+
+    /// AC1/AC2/AC3 end-to-end over a real socket: a client command split across
+    /// two masked WebSocket fragments — with a ping interleaved between them — is
+    /// reassembled by the server and dispatched, so its typed response still comes
+    /// back. Pre-fix the first fragment alone is not valid JSON (or is dropped) and
+    /// the continuation payload is discarded, so no `press_back_result` arrives and
+    /// the wait times out.
+    func testFragmentedCommandReassemblesEndToEnd() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        try client.connectAndUpgrade(timeout: 10)
+
+        let command = #"{"type":"request_press_back","requestId":"frag-1"}"#
+        let bytes = Array(command.utf8)
+        let mid = bytes.count / 2
+        let first = Data(bytes[0 ..< mid])
+        let second = Data(bytes[mid ..< bytes.count])
+
+        // Initial text fragment (FIN=0, opcode 0x1), an interleaved ping (a
+        // control frame, FIN=1, opcode 0x9), then the final continuation
+        // (FIN=1, opcode 0x0).
+        client.sendFrame(opcode: 0x01, fin: false, payload: first)
+        client.sendFrame(opcode: 0x09, fin: true, payload: Data("ka".utf8))
+        client.sendFrame(opcode: 0x00, fin: true, payload: second)
+
+        // The command dispatches through `runOnMainThread` (`DispatchQueue.main.sync`),
+        // so the main thread must stay in `wait(for:)` pumping its run loop for the
+        // response to be produced — the frame polling therefore runs on a background
+        // queue and reports back via the expectation (mirroring the ping test).
+        let responseBox = Box<[String: Any]?>(nil)
+        let received = expectation(description: "fragmented command response decodes")
+        DispatchQueue.global().async {
+            let object = try? client.waitForMessage(timeout: 12) { object in
+                object["type"] as? String == "press_back_result"
+            }
+            responseBox.value = object
+            received.fulfill()
+        }
+        wait(for: [received], timeout: 15)
+
+        let response = try XCTUnwrap(responseBox.value, "expected a press_back_result response")
+        XCTAssertEqual(response["requestId"] as? String, "frag-1")
+        XCTAssertEqual(response["success"] as? Bool, true)
+    }
+
     // MARK: - Client presence gating (#5477)
 
     /// Presence tracks only upgraded WebSocket clients and fires the hook exactly
@@ -758,6 +1001,190 @@ final class WebSocketServerTests: XCTestCase {
         let slice = full.suffix(from: 2)
 
         XCTAssertEqual(Array(WebSocketConnection.unmaskFrame(slice)), payload)
+    }
+}
+
+/// A minimal raw-socket WebSocket client for tests that need to drive frame-level
+/// behavior `URLSession.webSocketTask` cannot express — specifically sending a
+/// **fragmented** message (FIN=0 initial + continuation frames) with a control
+/// frame interleaved (issue #5674). It performs the HTTP upgrade by hand, then
+/// sends properly masked client frames (RFC 6455 §5.3) and parses the server's
+/// unmasked reply frames back into JSON objects.
+private final class RawWebSocketClient: @unchecked Sendable {
+    enum ClientError: Error {
+        case timeout(String)
+        case handshake(String)
+    }
+
+    private let connection: NWConnection
+    private let queue = DispatchQueue(label: "test.rawws.client")
+    private let lock = NSLock()
+    private var buffer = Data()
+
+    init(port: UInt16) {
+        let params = NWParameters.tcp
+        connection = NWConnection(
+            host: "127.0.0.1",
+            port: NWEndpoint.Port(integerLiteral: port),
+            using: params
+        )
+    }
+
+    func close() {
+        connection.cancel()
+    }
+
+    /// Opens the TCP connection, sends a WebSocket upgrade request, and blocks
+    /// until the `101` response headers are received. Any bytes after the header
+    /// separator (e.g. the server's `connected` event frame) are retained for
+    /// later frame parsing, then a background receive loop is started.
+    func connectAndUpgrade(timeout: TimeInterval) throws {
+        let ready = DispatchSemaphore(value: 0)
+        connection.stateUpdateHandler = { state in
+            if case .ready = state { ready.signal() }
+        }
+        connection.start(queue: queue)
+        guard ready.wait(timeout: .now() + timeout) == .success else {
+            throw ClientError.timeout("connection not ready")
+        }
+
+        let request = [
+            "GET / HTTP/1.1",
+            "Host: 127.0.0.1",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version: 13",
+            "",
+            "",
+        ].joined(separator: "\r\n")
+        connection.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var httpBuffer = Data()
+        let separator = Data("\r\n\r\n".utf8)
+        while Date() < deadline {
+            let chunk = try receiveOnce(timeout: deadline.timeIntervalSinceNow)
+            httpBuffer.append(chunk)
+            guard let sepRange = httpBuffer.range(of: separator) else { continue }
+
+            let headerData = httpBuffer.subdata(in: httpBuffer.startIndex ..< sepRange.upperBound)
+            guard let header = String(data: headerData, encoding: .utf8), header.contains("101") else {
+                let headerText = String(data: headerData, encoding: .utf8) ?? "<non-utf8 header>"
+                throw ClientError.handshake("expected 101 Switching Protocols, got: \(headerText)")
+            }
+            let leftover = httpBuffer.subdata(in: sepRange.upperBound ..< httpBuffer.endIndex)
+            lock.lock()
+            buffer.append(leftover)
+            lock.unlock()
+            startReceiveLoop()
+            return
+        }
+        throw ClientError.timeout("handshake headers not received")
+    }
+
+    /// Sends one client→server frame, masked as §5.3 requires. Test payloads are
+    /// all < 126 bytes, so only the 7-bit length form is emitted.
+    func sendFrame(opcode: UInt8, fin: Bool, payload: Data) {
+        var frame = Data()
+        frame.append((fin ? 0x80 : 0x00) | opcode)
+        frame.append(0x80 | UInt8(payload.count)) // mask bit set + 7-bit length
+        let mask: [UInt8] = [0x12, 0x34, 0x56, 0x78]
+        frame.append(contentsOf: mask)
+        for (i, byte) in payload.enumerated() {
+            frame.append(byte ^ mask[i % 4])
+        }
+        connection.send(content: frame, completion: .contentProcessed { _ in })
+    }
+
+    /// Polls parsed server frames until one decodes to a JSON object satisfying
+    /// `predicate`, or the timeout elapses.
+    func waitForMessage(
+        timeout: TimeInterval,
+        where predicate: ([String: Any]) -> Bool
+    ) throws -> [String: Any] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let object = nextMatchingMessage(predicate) {
+                return object
+            }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        throw ClientError.timeout("no matching message within \(timeout)s")
+    }
+
+    private func receiveOnce(timeout: TimeInterval) throws -> Data {
+        let sem = DispatchSemaphore(value: 0)
+        var received = Data()
+        var caught: Error?
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, error in
+            if let error = error { caught = error }
+            if let data = data { received = data }
+            sem.signal()
+        }
+        guard sem.wait(timeout: .now() + max(timeout, 0.1)) == .success else {
+            throw ClientError.timeout("receive timed out")
+        }
+        if let caught = caught { throw caught }
+        return received
+    }
+
+    private func startReceiveLoop() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self = self else { return }
+            if let data = data, !data.isEmpty {
+                self.lock.lock()
+                self.buffer.append(data)
+                self.lock.unlock()
+            }
+            if error != nil || isComplete { return }
+            self.startReceiveLoop()
+        }
+    }
+
+    /// Consumes complete frames from the head of the buffer, returning the first
+    /// text/binary frame whose JSON body satisfies `predicate`. Control and
+    /// non-matching frames are skipped. Returns nil when no complete matching
+    /// frame is available yet.
+    private func nextMatchingMessage(_ predicate: ([String: Any]) -> Bool) -> [String: Any]? {
+        while true {
+            lock.lock()
+            // Convert to a 0-based array so indexing is safe regardless of the
+            // Data's start index after prior `removeFirst` calls.
+            let bytes = [UInt8](buffer)
+            lock.unlock()
+            guard bytes.count >= 2 else { return nil }
+
+            let firstByte = bytes[0]
+            let secondByte = bytes[1]
+            let opcode = firstByte & 0x0F
+            var payloadLength = Int(secondByte & 0x7F)
+            var headerLength = 2
+            if payloadLength == 126 {
+                guard bytes.count >= 4 else { return nil }
+                payloadLength = Int(bytes[2]) << 8 | Int(bytes[3])
+                headerLength = 4
+            } else if payloadLength == 127 {
+                return nil // not produced by the server for test-sized payloads
+            }
+            let maskLength = (secondByte & 0x80) != 0 ? 4 : 0
+            let totalLength = headerLength + maskLength + payloadLength
+            guard bytes.count >= totalLength else { return nil }
+
+            let payload = Data(bytes[(headerLength + maskLength) ..< totalLength])
+            lock.lock()
+            buffer.removeFirst(totalLength)
+            lock.unlock()
+
+            if opcode == 0x01 || opcode == 0x02 {
+                if let object = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+                   predicate(object) {
+                    return object
+                }
+            }
+            // Otherwise (control frame, or non-matching data frame) keep parsing.
+            // Otherwise (control frame, or non-matching data frame) keep parsing.
+        }
     }
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -836,20 +836,43 @@ final class WebSocketServerTests: XCTestCase {
         )
     }
 
-    /// AC4: the total-size budget is enforced from the continuation frame's
-    /// declared header length *before* its payload is received/unmasked, so an
-    /// oversized continuation is rejected without allocating ~3× the cap. The cap
-    /// is inclusive (filling it exactly is allowed).
-    func testContinuationBudgetIsCheckedFromHeaderInclusive() {
-        // Exactly filling the remaining budget is allowed.
-        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 10, alreadyBuffered: 0, maxTotal: 10))
-        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 4, alreadyBuffered: 6, maxTotal: 10))
-        // One byte over the remaining budget is rejected.
-        XCTAssertTrue(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: 5, alreadyBuffered: 6, maxTotal: 10))
-        // The real vector: a second ~64 MiB continuation on top of a full buffer.
+    /// AC4/AC5: malformed or over-budget data/continuation frames are rejected
+    /// from the header, *before* the payload is received/unmasked, so a malformed
+    /// peer cannot make the runner allocate a frame it will immediately discard.
+    /// This mirrors `accumulate`'s rejections but pre-read, and covers every
+    /// admissible/inadmissible header combination.
+    func testPreReadDataFrameDecisionRejectsBeforeAllocating() {
+        typealias Decision = WebSocketConnection.FramePreReadDecision
         let max = WebSocketConnection.maxFramePayloadLength
-        XCTAssertTrue(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: max, alreadyBuffered: Int(max)))
-        XCTAssertFalse(WebSocketConnection.continuationExceedsReassemblyBudget(payloadLength: max, alreadyBuffered: 0))
+
+        // Admissible: a fresh single/opening data frame within the cap.
+        XCTAssertEqual(
+            WebSocketConnection.preReadDataFrameDecision(opcode: 0x01, declaredPayloadLength: 100, inProgressOpcode: nil, alreadyBuffered: 0),
+            Decision.read
+        )
+        // Admissible: a continuation that fits the remaining budget exactly.
+        XCTAssertEqual(
+            WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 4, inProgressOpcode: 0x01, alreadyBuffered: 6, maxTotal: 10),
+            Decision.read
+        )
+
+        // The Codex vector: a new data frame declared while a fragment is open —
+        // illegal, and must be rejected before its ~64 MiB payload is read.
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x02, declaredPayloadLength: max, inProgressOpcode: 0x01, alreadyBuffered: Int(max)) else {
+            return XCTFail("a new data frame while a fragment is open must be rejected pre-read")
+        }
+        // A continuation that would overflow the total budget — rejected pre-read.
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 5, inProgressOpcode: 0x01, alreadyBuffered: 6, maxTotal: 10) else {
+            return XCTFail("an over-budget continuation must be rejected pre-read")
+        }
+        // A continuation with no message in progress — rejected pre-read.
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 1, inProgressOpcode: nil, alreadyBuffered: 0) else {
+            return XCTFail("an orphan continuation must be rejected pre-read")
+        }
+        // A single data frame larger than the whole cap — rejected pre-read.
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x01, declaredPayloadLength: max + 1, inProgressOpcode: nil, alreadyBuffered: 0) else {
+            return XCTFail("an over-cap opening frame must be rejected pre-read")
+        }
     }
 
     /// AC1/AC2/AC3 end-to-end over a real socket: a client command split across


### PR DESCRIPTION
## Summary

The iOS CtrlProxy WebSocket server ignored the frame FIN bit and did not handle continuation frames (opcode `0x0`), so a fragmented message (RFC 6455 §5.4) was silently truncated to its first fragment and continuation payloads were read then discarded — with no reassembly and no error signal.

This threads the FIN bit through the frame path and adds per-connection reassembly, built on top of the control-frame refactor from #5671 (the pure `frameAction` helper and `isValidControlFramePayloadLength`).

## Linked Issue

Closes #5674

## Bug / Regression Context

- **Observed symptom:** any peer that fragments a message (large payloads, a proxy, a future streaming client) got a truncated/dropped message with no error. Latent today because the current TS `ws` client sends unfragmented frames.
- **Root cause:** `parseWebSocketFrame` extracted `opcode` but never inspected the FIN bit; delivery happened per-frame for opcode `0x1`/`0x2` only, so continuation frames were dropped.

## Changes

- New pure `WebSocketConnection.reassemble(...)` state machine (mirrors #5671's `frameAction`): decides `deliver` / `buffered` / `protocolError` from opcode + FIN + in-progress state. Unit-testable without a socket.
- Per-connection reassembly state (`fragmentedOpcode`, `fragmentBuffer`) mutated only on the serialized server `queue` — no new locks.
- FIN threaded from `parseWebSocketFrame` → `readExtendedLength` → `readPayload`; data/continuation frames route through reassembly, control frames stay on the independent `frameAction` path and never touch the buffer.
- Total reassembled size bounded by the existing `maxFramePayloadLength` (64 MiB) applied cumulatively; overflow and malformed sequences close the connection with a trace.

## Acceptance criteria

1. Fragmented message reassembled in order, delivered once — `testTwoFragmentMessageReassembles`, `testThreeFragmentMessageReassemblesInOrder`, `testFragmentedCommandReassemblesEndToEnd` (real socket).
2. FIN honored; single-frame unchanged; non-final does not deliver — `testSingleUnfragmentedFrameDeliversUnchanged`, `testNonFinalStartFrameDoesNotDeliver`.
3. Interleaved control frames don't corrupt reassembly — `testControlFrameBetweenFragmentsDoesNotCorruptReassembly` + interleaved ping in the end-to-end test.
4. Total-size bound applied to the whole message — `testReassemblyTotalSizeBoundExceededIsRejected`, `testReassemblyAtExactBoundIsAccepted`.
5. Malformed sequence closes the connection — `testContinuationWithNoMessageInProgressIsRejected`, `testNewDataFrameWhileFragmentOpenIsRejected`.
6. Unit tests pin 2-/3-fragment, single-frame, and out-of-sequence — covered above.

## Validation

- [x] `./scripts/ios/swift-build.sh` and `./scripts/ios/swift-test.sh` green (all 4 Swift packages)
- [x] `bun run turbo:validate` green (lint/build/test + boundary checks; 14340 pass / 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] SwiftLint clean for the changed files (no `force_unwrapping`)
- [x] New unit tests are pure/deterministic and run in <1ms each; the one real-socket test runs in ~30ms

## Notes

Runner-side source change only. The runner ships as a pinned, checksummed release artifact, so this fix does not reach production until the runner is re-cut — tracked as a separate follow-on, out of scope here.