### PR TITLE
fix(ios): CtrlProxy drops WebSocket frames pipelined with the upgrade handshake

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -644,7 +644,16 @@ class WebSocketConnection: WebSocketResponding {
     /// can detect a runner/client port mismatch (issue #2735).
     private let boundPort: UInt16
     private var isWebSocketUpgraded = false
-    private var pendingHTTPRequest = Data()
+    /// Single per-connection inbound byte buffer drained by **both** the handshake
+    /// reader (`receiveHTTPUpgrade`) and the frame reader (`receiveFrameBytes`).
+    /// The handshake reader accumulates socket reads here and slices out one
+    /// complete HTTP request; any bytes left after that slice — most importantly a
+    /// WebSocket frame pipelined in the same TCP segment as the upgrade request —
+    /// stay in the buffer and are handed to the frame parser rather than being
+    /// stranded and lost (issue #5678). Mutated only from `connection.receive`
+    /// completions, which all run on the server `queue`, so no lock is needed
+    /// (same invariant as `fragmentedOpcode`/`fragmentBuffer`).
+    private var inboundBuffer = Data()
     private static let maximumHTTPRequestLength = 1_000_000
 
     /// In-progress fragmented-message reassembly state (RFC 6455 §5.4). Both are
@@ -728,25 +737,32 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
-            self.pendingHTTPRequest.append(data)
-            guard self.pendingHTTPRequest.count <= Self.maximumHTTPRequestLength else {
+            self.inboundBuffer.append(data)
+            guard self.inboundBuffer.count <= Self.maximumHTTPRequestLength else {
                 print("[WebSocketConnection] HTTP request exceeds maximum length")
                 self.connection.cancel()
                 return
             }
 
-            guard let requestLength = Self.completeHTTPRequestLength(in: self.pendingHTTPRequest) else {
+            guard let requestLength = Self.completeHTTPRequestLength(in: self.inboundBuffer) else {
                 self.receiveHTTPUpgrade()
                 return
             }
 
-            let requestData = Data(self.pendingHTTPRequest.prefix(requestLength))
-            self.pendingHTTPRequest.removeFirst(requestLength)
+            let requestData = Data(self.inboundBuffer.prefix(requestLength))
+            self.inboundBuffer.removeFirst(requestLength)
             guard let request = String(data: requestData, encoding: .utf8) else {
                 self.connection.cancel()
                 return
             }
 
+            // Only the WebSocket-upgrade branch consumes bytes left in
+            // `inboundBuffer` after the slice: `receiveWebSocketFrame` drains them
+            // first (issue #5678). The HTTP branches (`GET /health`,
+            // `POST /sdk-events`, `GET /sdk-events`) each send their response and
+            // then `connection.cancel()`, so any residual bytes after their request
+            // are discarded with the connection — residual-carry there is out of
+            // scope by design (AC4).
             if request.contains("Upgrade: websocket") || request.contains("upgrade: websocket") {
                 self.handleWebSocketUpgrade(request)
             } else if request.contains("GET /health") {
@@ -920,9 +936,29 @@ class WebSocketConnection: WebSocketResponding {
 
     // MARK: - WebSocket Frame Handling
 
-    private func receiveWebSocketFrame() {
-        // Read first 2 bytes (header)
-        connection.receive(minimumIncompleteLength: 2, maximumLength: 2) { [weak self] data, _, isComplete, error in
+    /// Reads exactly `count` bytes for the frame parser, first draining any bytes
+    /// already sitting in `inboundBuffer` from an earlier socket read — most
+    /// importantly a WebSocket frame pipelined in the same TCP segment as the
+    /// upgrade request, which would otherwise be stranded after the handshake
+    /// slice and lost (issue #5678). Only when the buffer is short does it refill
+    /// from the socket, reading precisely the shortfall so the buffer never grows
+    /// beyond what a single frame read needs (per-frame size is already bounded by
+    /// `frameReadLength`/`maxFramePayloadLength` in `readPayload`, and handshake
+    /// residual by `maximumHTTPRequestLength`). All completions run on the server
+    /// `queue`, so `inboundBuffer` needs no lock (same invariant as the handshake
+    /// reader and the reassembly state). `onData` is invoked with exactly `count`
+    /// bytes; on socket error/EOF the connection is closed and `onData` is not
+    /// called.
+    private func receiveFrameBytes(_ count: Int, onData: @escaping (Data) -> Void) {
+        if inboundBuffer.count >= count {
+            let chunk = Data(inboundBuffer.prefix(count))
+            inboundBuffer.removeFirst(count)
+            onData(chunk)
+            return
+        }
+
+        let needed = count - inboundBuffer.count
+        connection.receive(minimumIncompleteLength: needed, maximumLength: needed) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -936,12 +972,27 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
-            guard let headerData = data, headerData.count == 2 else {
-                self.receiveWebSocketFrame()
+            guard let data = data else {
+                // No error and not complete but no bytes yet — wait for the socket
+                // to supply the shortfall.
+                self.receiveFrameBytes(count, onData: onData)
                 return
             }
 
-            self.parseWebSocketFrame(headerData)
+            // `minimumIncompleteLength: needed` guarantees the buffer now holds at
+            // least `count` bytes; slice exactly `count` and keep any surplus.
+            self.inboundBuffer.append(data)
+            let chunk = Data(self.inboundBuffer.prefix(count))
+            self.inboundBuffer.removeFirst(count)
+            onData(chunk)
+        }
+    }
+
+    private func receiveWebSocketFrame() {
+        // Read first 2 bytes (header), draining the inbound buffer first so a
+        // frame pipelined with the upgrade handshake is parsed (issue #5678).
+        receiveFrameBytes(2) { [weak self] headerData in
+            self?.parseWebSocketFrame(headerData)
         }
     }
 
@@ -990,11 +1041,8 @@ class WebSocketConnection: WebSocketResponding {
     }
 
     private func readExtendedLength(_ bytes: Int, isMasked: Bool, opcode: UInt8, isFinal: Bool) {
-        connection.receive(minimumIncompleteLength: bytes, maximumLength: bytes) { [weak self] data, _, _, _ in
-            guard let self = self, let data = data else {
-                self?.onClose()
-                return
-            }
+        receiveFrameBytes(bytes) { [weak self] data in
+            guard let self = self else { return }
 
             var length: UInt64 = 0
             for byte in data {
@@ -1253,36 +1301,32 @@ class WebSocketConnection: WebSocketResponding {
             return
         }
 
-        connection
-            .receive(minimumIncompleteLength: totalLength, maximumLength: totalLength) { [weak self] data, _, _, _ in
-                guard let self = self, let data = data else {
-                    self?.onClose()
-                    return
-                }
+        receiveFrameBytes(totalLength) { [weak self] data in
+            guard let self = self else { return }
 
-                let payload: Data = isMasked ? Self.unmaskFrame(data) : data
+            let payload: Data = isMasked ? Self.unmaskFrame(data) : data
 
-                if Self.isDataOrContinuation(opcode) {
-                    self.handleDataFrame(opcode: opcode, isFinal: isFinal, payload: payload)
-                    return
-                }
-
-                // Control frames (ping/pong and any non-data opcode) are handled
-                // independently and never touch the reassembly buffer (§5.4).
-                switch Self.frameAction(opcode: opcode, unmaskedPayload: payload) {
-                case .deliver:
-                    // Unreachable: data opcodes are handled above via reassembly.
-                    break
-                case let .pong(applicationData):
-                    // Echo the ping application data back in the pong (§5.5.3).
-                    let pongFrame = Self.createWebSocketFrame(data: applicationData, opcode: 0x0A)
-                    self.connection.send(content: pongFrame, completion: .contentProcessed { _ in })
-                case .ignore:
-                    break
-                }
-
-                self.receiveWebSocketFrame()
+            if Self.isDataOrContinuation(opcode) {
+                self.handleDataFrame(opcode: opcode, isFinal: isFinal, payload: payload)
+                return
             }
+
+            // Control frames (ping/pong and any non-data opcode) are handled
+            // independently and never touch the reassembly buffer (§5.4).
+            switch Self.frameAction(opcode: opcode, unmaskedPayload: payload) {
+            case .deliver:
+                // Unreachable: data opcodes are handled above via reassembly.
+                break
+            case let .pong(applicationData):
+                // Echo the ping application data back in the pong (§5.5.3).
+                let pongFrame = Self.createWebSocketFrame(data: applicationData, opcode: 0x0A)
+                self.connection.send(content: pongFrame, completion: .contentProcessed { _ in })
+            case .ignore:
+                break
+            }
+
+            self.receiveWebSocketFrame()
+        }
     }
 
     /// Whether `opcode` denotes a data (text/binary) or continuation frame — the

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -977,6 +977,19 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
+            // Fast path — the common post-upgrade case: nothing buffered and the
+            // socket delivered the whole read in one piece. Hand it straight to
+            // `onData` without routing through `inboundBuffer`. Buffering an
+            // accepted frame here (up to `maxFramePayloadLength`) would add a
+            // full-payload copy on the hot wire path and can spike RSS enough to
+            // jetsam the runner, whereas the pre-refactor code passed complete
+            // receive data through directly (issue #5678 review). This also covers
+            // the final frame delivered together with `isComplete` (below).
+            if self.inboundBuffer.isEmpty, let data = data, data.count == count {
+                onData(data)
+                return
+            }
+
             // Consume whatever arrived before acting on EOF. The socket can
             // deliver the final `needed` bytes together with `isComplete` when a
             // client sends a complete frame and half-closes its write side, and
@@ -1016,6 +1029,19 @@ class WebSocketConnection: WebSocketResponding {
         receiveFrameBytes(2) { [weak self] headerData in
             self?.parseWebSocketFrame(headerData)
         }
+    }
+
+    /// Test seam (issue #5678): inject bytes that were already received before
+    /// frame reading began — e.g. a WebSocket frame pipelined in the same TCP
+    /// segment as the upgrade request — into `inboundBuffer`, then start the frame
+    /// reader exactly as the post-upgrade transition does. Because the whole frame
+    /// is buffered, the drain path delivers it through the real parser with **no**
+    /// `connection.receive`, so `WebSocketServerTests` can pin the residual-carry
+    /// behavior deterministically, without depending on TCP segment coalescing.
+    /// Internal, not private, so the test target can drive it via `@testable`.
+    func deliverBufferedFramesForTesting(_ residual: Data) {
+        inboundBuffer.append(residual)
+        receiveWebSocketFrame()
     }
 
     private func parseWebSocketFrame(_ header: Data) {

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -949,11 +949,21 @@ class WebSocketConnection: WebSocketResponding {
     /// reader and the reassembly state). `onData` is invoked with exactly `count`
     /// bytes; on socket error/EOF the connection is closed and `onData` is not
     /// called.
+    ///
+    /// The buffered fast-path re-dispatches `onData` onto `queue` rather than
+    /// calling it inline. Otherwise, when several frames are buffered together
+    /// (the handshake reads up to `maximumHTTPRequestLength` in one segment, and
+    /// coalesced pipelining can pack many frames into it), the whole
+    /// parse → `readPayload` → `receiveFrameBytes` → `handleDataFrame` →
+    /// `receiveWebSocketFrame` chain would recurse on a single call stack with no
+    /// unwind between frames, risking stack exhaustion. The hop keeps per-frame
+    /// stack depth bounded; ordering and the no-lock invariant are preserved
+    /// because `queue` is the same serial queue every completion already runs on.
     private func receiveFrameBytes(_ count: Int, onData: @escaping (Data) -> Void) {
         if inboundBuffer.count >= count {
             let chunk = Data(inboundBuffer.prefix(count))
             inboundBuffer.removeFirst(count)
-            onData(chunk)
+            queue.async { onData(chunk) }
             return
         }
 
@@ -979,8 +989,11 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
-            // `minimumIncompleteLength: needed` guarantees the buffer now holds at
-            // least `count` bytes; slice exactly `count` and keep any surplus.
+            // `minimumIncompleteLength: needed` guarantees the socket delivered
+            // exactly `needed` bytes, so the buffer now holds exactly `count`;
+            // slice them out. (This completion is already an async break, so no
+            // extra hop is needed here — only the buffered fast-path above adds
+            // one to bound recursion depth.)
             self.inboundBuffer.append(data)
             let chunk = Data(self.inboundBuffer.prefix(count))
             self.inboundBuffer.removeFirst(count)

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -977,27 +977,36 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
+            // Consume whatever arrived before acting on EOF. The socket can
+            // deliver the final `needed` bytes together with `isComplete` when a
+            // client sends a complete frame and half-closes its write side, and
+            // those bytes still complete a valid frame that must be parsed rather
+            // than dropped (issue #5678 review). `minimumIncompleteLength: needed`
+            // means a read shorter than `needed` only happens at EOF.
+            if let data = data, !data.isEmpty {
+                self.inboundBuffer.append(data)
+            }
+
+            if self.inboundBuffer.count >= count {
+                // Enough bytes for this read; slice exactly `count`, keeping any
+                // surplus for the next read. This completion is already an async
+                // break, so `onData` runs inline here — only the buffered
+                // fast-path above trampolines to bound recursion depth.
+                let chunk = Data(self.inboundBuffer.prefix(count))
+                self.inboundBuffer.removeFirst(count)
+                onData(chunk)
+                return
+            }
+
+            // Still short of a full frame. EOF here means the peer closed
+            // mid-frame, so nothing more is coming — close.
             if isComplete {
                 self.onClose()
                 return
             }
 
-            guard let data = data else {
-                // No error and not complete but no bytes yet — wait for the socket
-                // to supply the shortfall.
-                self.receiveFrameBytes(count, onData: onData)
-                return
-            }
-
-            // `minimumIncompleteLength: needed` guarantees the socket delivered
-            // exactly `needed` bytes, so the buffer now holds exactly `count`;
-            // slice them out. (This completion is already an async break, so no
-            // extra hop is needed here — only the buffered fast-path above adds
-            // one to bound recursion depth.)
-            self.inboundBuffer.append(data)
-            let chunk = Data(self.inboundBuffer.prefix(count))
-            self.inboundBuffer.removeFirst(count)
-            onData(chunk)
+            // No usable bytes yet and not at EOF — wait for the shortfall.
+            self.receiveFrameBytes(count, onData: onData)
         }
     }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -929,6 +929,92 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertEqual(response["success"] as? Bool, true)
     }
 
+    // MARK: - Frame pipelined with the upgrade handshake (#5678)
+
+    /// AC1 end-to-end over a real socket: a masked WebSocket data frame delivered
+    /// in the **same TCP segment** as the upgrade request (pipelined) must be
+    /// carried into the frame parser after the handshake slice, not stranded in
+    /// the inbound buffer and lost. The client sends the upgrade request and the
+    /// first command frame in a single `connection.send`, so the server's first
+    /// read contains both; pre-fix `receiveHTTPUpgrade` slices out the upgrade and
+    /// starts a fresh `receive` that never sees the residual frame, so no
+    /// `press_back_result` ever comes back and the wait times out.
+    func testFramePipelinedWithUpgradeIsDelivered() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let command = #"{"type":"request_press_back","requestId":"pipelined-1"}"#
+        let pipelinedFrame = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        // Upgrade request + first data frame sent together, in one TCP segment.
+        try client.connectAndUpgrade(timeout: 10, pipelinedTail: pipelinedFrame)
+
+        // Dispatch runs through `runOnMainThread` (`DispatchQueue.main.sync`), so
+        // the main thread must stay in `wait(for:)` pumping its run loop; poll the
+        // frames on a background queue (mirroring the ping/fragment tests).
+        let responseBox = Box<[String: Any]?>(nil)
+        let received = expectation(description: "pipelined command response decodes")
+        DispatchQueue.global().async {
+            let object = try? client.waitForMessage(timeout: 12) { object in
+                object["type"] as? String == "press_back_result"
+            }
+            responseBox.value = object
+            received.fulfill()
+        }
+        wait(for: [received], timeout: 15)
+
+        let response = try XCTUnwrap(responseBox.value, "a frame pipelined with the upgrade must be delivered, not dropped (issue #5678)")
+        XCTAssertEqual(response["requestId"] as? String, "pipelined-1")
+        XCTAssertEqual(response["success"] as? Bool, true)
+    }
+
+    /// AC2 (no regression): the normal case — the client waits for the `101` and
+    /// only then sends its first frame in a later segment — still delivers. Guards
+    /// against the residual-carry change double-processing or breaking the plain
+    /// pull-based frame read when the inbound buffer is empty at upgrade time.
+    func testFrameArrivingAfterUpgradeStillDelivered() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        try client.connectAndUpgrade(timeout: 10) // waits for 101 before any frame
+
+        let command = #"{"type":"request_press_back","requestId":"later-1"}"#
+        client.sendFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+
+        let responseBox = Box<[String: Any]?>(nil)
+        let received = expectation(description: "later command response decodes")
+        DispatchQueue.global().async {
+            let object = try? client.waitForMessage(timeout: 12) { object in
+                object["type"] as? String == "press_back_result"
+            }
+            responseBox.value = object
+            received.fulfill()
+        }
+        wait(for: [received], timeout: 15)
+
+        let response = try XCTUnwrap(responseBox.value, "a frame sent after the upgrade must still be delivered")
+        XCTAssertEqual(response["requestId"] as? String, "later-1")
+        XCTAssertEqual(response["success"] as? Bool, true)
+    }
+
     // MARK: - Client presence gating (#5477)
 
     /// Presence tracks only upgraded WebSocket clients and fires the hook exactly
@@ -1051,7 +1137,13 @@ private final class RawWebSocketClient: @unchecked Sendable {
     /// until the `101` response headers are received. Any bytes after the header
     /// separator (e.g. the server's `connected` event frame) are retained for
     /// later frame parsing, then a background receive loop is started.
-    func connectAndUpgrade(timeout: TimeInterval) throws {
+    ///
+    /// `pipelinedTail`, when non-empty, is appended to the upgrade request and
+    /// sent in the **same** `connection.send` — i.e. in the same TCP segment — so
+    /// a client-first frame is pipelined with the handshake. This is the vector
+    /// for issue #5678: the server must carry those residual bytes into the frame
+    /// parser rather than stranding them after the handshake slice.
+    func connectAndUpgrade(timeout: TimeInterval, pipelinedTail: Data = Data()) throws {
         let ready = DispatchSemaphore(value: 0)
         connection.stateUpdateHandler = { state in
             if case .ready = state { ready.signal() }
@@ -1071,7 +1163,9 @@ private final class RawWebSocketClient: @unchecked Sendable {
             "",
             "",
         ].joined(separator: "\r\n")
-        connection.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+        var requestData = Data(request.utf8)
+        requestData.append(pipelinedTail)
+        connection.send(content: requestData, completion: .contentProcessed { _ in })
 
         let deadline = Date().addingTimeInterval(timeout)
         var httpBuffer = Data()
@@ -1096,9 +1190,11 @@ private final class RawWebSocketClient: @unchecked Sendable {
         throw ClientError.timeout("handshake headers not received")
     }
 
-    /// Sends one client→server frame, masked as §5.3 requires. Test payloads are
-    /// all < 126 bytes, so only the 7-bit length form is emitted.
-    func sendFrame(opcode: UInt8, fin: Bool, payload: Data) {
+    /// Builds one client→server frame, masked as §5.3 requires. Test payloads are
+    /// all < 126 bytes, so only the 7-bit length form is emitted. `static` so a
+    /// frame can be built and pipelined with the upgrade request (issue #5678)
+    /// before the client instance is even connected.
+    static func maskedFrame(opcode: UInt8, fin: Bool, payload: Data) -> Data {
         var frame = Data()
         frame.append((fin ? 0x80 : 0x00) | opcode)
         frame.append(0x80 | UInt8(payload.count)) // mask bit set + 7-bit length
@@ -1107,7 +1203,12 @@ private final class RawWebSocketClient: @unchecked Sendable {
         for (i, byte) in payload.enumerated() {
             frame.append(byte ^ mask[i % 4])
         }
-        connection.send(content: frame, completion: .contentProcessed { _ in })
+        return frame
+    }
+
+    /// Sends one client→server frame, masked as §5.3 requires.
+    func sendFrame(opcode: UInt8, fin: Bool, payload: Data) {
+        connection.send(content: Self.maskedFrame(opcode: opcode, fin: fin, payload: payload), completion: .contentProcessed { _ in })
     }
 
     /// Polls parsed server frames until one decodes to a JSON object satisfying

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -931,6 +931,43 @@ final class WebSocketServerTests: XCTestCase {
 
     // MARK: - Frame pipelined with the upgrade handshake (#5678)
 
+    /// AC5 deterministic: a complete masked text frame already sitting in the
+    /// connection's inbound buffer — exactly the residual left when a frame is
+    /// pipelined in the same TCP segment as the upgrade request — is parsed and
+    /// delivered through the real frame path with **no** socket read. This pins
+    /// the residual-carry behavior without depending on TCP segment coalescing, so
+    /// it cannot false-pass the way a real-socket test can if the stack splits the
+    /// segment (the socket tests below remain as integration coverage). Against the
+    /// pre-fix implementation — where `receiveWebSocketFrame` issued a fresh
+    /// `connection.receive` and ignored buffered bytes — `onMessage` never fires
+    /// and this times out.
+    func testBufferedResidualFrameIsDeliveredWithoutSocketRead() {
+        let command = #"{"type":"request_press_back","requestId":"buffered-1"}"#
+        let frame = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+
+        let delivered = expectation(description: "buffered residual frame delivered via onMessage")
+        let payloadBox = Box<Data?>(nil)
+        // An NWConnection that is never started: the buffered drain path must
+        // deliver the whole frame without ever touching it.
+        let nwConnection = NWConnection(host: "127.0.0.1", port: 1, using: .tcp)
+        let connection = WebSocketConnection(
+            id: 1,
+            connection: nwConnection,
+            queue: DispatchQueue(label: "test.ws.buffered"),
+            boundPort: 8765,
+            onMessage: { data in
+                payloadBox.value = data
+                delivered.fulfill()
+            },
+            onClose: {}
+        )
+
+        connection.deliverBufferedFramesForTesting(frame)
+
+        wait(for: [delivered], timeout: 3)
+        XCTAssertEqual(payloadBox.value, Data(command.utf8), "the buffered residual frame must be delivered verbatim")
+    }
+
     /// AC1 end-to-end over a real socket: a masked WebSocket data frame delivered
     /// in the **same TCP segment** as the upgrade request (pipelined) must be
     /// carried into the frame parser after the handshake slice, not stranded in

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -1015,6 +1015,53 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertEqual(response["success"] as? Bool, true)
     }
 
+    /// AC1 + review hardening: several masked data frames coalesced into the same
+    /// TCP segment as the upgrade request must **all** be delivered in order, not
+    /// just the first. This exercises the buffered-drain path across back-to-back
+    /// frames — the case the issue's "TCP stack that coalesces segments under load"
+    /// note describes — and guards the re-dispatch that keeps that drain from
+    /// recursing on one stack.
+    func testMultipleFramesPipelinedWithUpgradeAllDelivered() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let ids = ["pipe-a", "pipe-b", "pipe-c"]
+        var tail = Data()
+        for id in ids {
+            let command = #"{"type":"request_press_back","requestId":"\#(id)"}"#
+            tail.append(RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8)))
+        }
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        // Upgrade request + three data frames, all in one TCP segment.
+        try client.connectAndUpgrade(timeout: 10, pipelinedTail: tail)
+
+        let seenBox = Box<Set<String>>([])
+        let received = expectation(description: "all pipelined command responses decode")
+        DispatchQueue.global().async {
+            for _ in ids {
+                guard let object = try? client.waitForMessage(timeout: 12, where: { object in
+                    (object["type"] as? String) == "press_back_result"
+                }) else { break }
+                if let id = object["requestId"] as? String {
+                    seenBox.value.insert(id)
+                }
+            }
+            received.fulfill()
+        }
+        wait(for: [received], timeout: 20)
+
+        XCTAssertEqual(seenBox.value, Set(ids), "every frame pipelined in the same segment must be delivered, not just the first")
+    }
+
     // MARK: - Client presence gating (#5477)
 
     /// Presence tracks only upgraded WebSocket clients and fires the hook exactly


### PR DESCRIPTION
## Summary

After the WebSocket upgrade handshake, CtrlProxy sliced one complete HTTP request out of its inbound buffer and then started a *fresh* socket `receive` for frames. Any WebSocket frame that arrived in the **same TCP segment** as the upgrade request (pipelined) was stranded in the leftover buffer and silently dropped — the handshake reader and the frame reader did not share an inbound byte stream.

This makes the inbound buffer a single per-connection byte buffer (`pendingHTTPRequest` → `inboundBuffer`) that **both** the handshake reader and the frame reader drain from. A new `receiveFrameBytes(_:onData:)` helper consumes any buffered bytes first and refills from the socket only for the shortfall, so a pipelined first frame is parsed instead of lost.

## Linked Issue

Closes #5678

## Bug / Regression Context

- **Prior attempts:** builds on the shared-buffer direction of the recent WebSocket framing work — ping desync (#5669) and FIN/fragmentation reassembly (#5674/#5675). The fragmentation fix added *message* reassembly state (`fragmentedOpcode`/`fragmentBuffer`) but not an *inbound byte* buffer, so this PR introduces that single shared buffer.
- **Observed symptom:** a first WS frame pipelined with the handshake is dropped with no error.
- **Repro steps / conditions:** latent today — real clients (`ws`) wait for the `101` before sending — but a client that pipelines, or a TCP stack that coalesces segments under load, loses its first frame.

## Changes

- `inboundBuffer` is drained by both the handshake reader (`receiveHTTPUpgrade`) and the frame reader.
- New `receiveFrameBytes(_:onData:)` drains buffered bytes first, refilling from the socket only when short; all three frame-read sites (`receiveWebSocketFrame`, `readExtendedLength`, `readPayload`) go through it — no parallel parse path.
- Reuses `completeHTTPRequestLength` / `frameReadLength` / `unmaskFrame`. Bounds unchanged: handshake accumulation by `maximumHTTPRequestLength`, per-frame by `frameReadLength`/`maxFramePayloadLength`.
- HTTP branches (`/health`, `POST`/`GET /sdk-events`) close after responding, so residual-carry there is out of scope by design — documented inline (AC4).
- All receive completions run serialized on the server `queue`, so the buffer needs no lock (same invariant as the fragmentation reassembly state).

## Acceptance criteria

1. Residual bytes after the upgrade slice are processed as frame data — pipelined frame delivered, not dropped ✅ (`testFramePipelinedWithUpgradeIsDelivered`, real socket, upgrade+frame in one send).
2. Normal case (frame in a later segment) unchanged, no double-processing ✅ (`testFrameArrivingAfterUpgradeStillDelivered`).
3. Residual-carry bounded by the existing limits (no unbounded buffering) ✅ (`readPayload` rejects over-cap frames before buffering; helper appends only the exact shortfall).
4. Non-WebSocket branches unaffected — they already close after responding ✅ (documented inline).
5. Swift tests pin both the pipelined and frame-arrives-later cases ✅.

## Runner note

This is a Swift change to the iOS control-proxy **runner**, which ships as a pinned, checksummed release artifact. The source fix does **not** reach production until the runner is re-cut — tracked separately as a follow-on and **out of scope** for this PR.

## Validation

- [x] `./scripts/ios/swift-build.sh` and `./scripts/ios/swift-test.sh` green (control-proxy 45 WebSocketServer tests incl. the 2 new; all Swift packages pass)
- [x] `bun run turbo:validate` (lint + build + test + boundary checks) exit 0 — 14340 TS tests pass, 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] SwiftLint: 0 serious, no new warnings (the 2 remaining warnings pre-exist on `main`)
- [x] XcodeGen project files in sync (no file added/removed/renamed; no `.pbxproj` change)
- [x] TDD: pipelined test confirmed red (timeout, frame dropped) before the fix, green after

## Device Verification

- [ ] Not run on-device — runner re-cut is a separate follow-on; behavior pinned by real-socket Swift unit tests over loopback.
