### PR TITLE
fix(ios): resolve connected physical devices in iOS device discovery (#5620)

### DIFF
--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -185,7 +185,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         node.name.text === "runExecSeam" ||
         (node.name.text === "execute" &&
           (node.expression.kind === ts.SyntaxKind.ThisKeyword ||
-            /(?:executor|host|process)/i.test(node.expression.getText(sourceFile))))));
+            /(?:executor|host|process|deps)/i.test(node.expression.getText(sourceFile))))));
   const isRunExecSeamReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && runExecSeamAliases.has(node.text)) ||
     (ts.isPropertyAccessExpression(node) && node.name.text === "runExecSeam");

--- a/scripts/oxlint-baseline.txt
+++ b/scripts/oxlint-baseline.txt
@@ -129,7 +129,6 @@
 1	src/utils/android-cmdline-tools/AvdConfigReader.ts	eslint(complexity)
 1	src/utils/android-cmdline-tools/vmSnapshot.ts	eslint(complexity)
 1	src/utils/describeUnknownError.ts	auto-mobile(catch-convention)
-1	src/utils/deviceUtils.ts	auto-mobile(catch-convention)
 1	src/utils/envBootstrap.ts	auto-mobile(catch-convention)
 1	src/utils/fileLock.ts	eslint(complexity)
 1	src/utils/hostAppearance.ts	eslint(complexity)

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -19,6 +19,7 @@ import {
 } from "../../utils/android-cmdline-tools/vmSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import {
   getAppDataContainerPath,
   IOS_APP_DATA_FOLDERS,
@@ -100,6 +101,16 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
       case "android":
         return this.executeAndroid(args);
       case "ios":
+        // Physical iOS devices are discoverable now, but iOS snapshot capture uses
+        // simctl for metadata/settings/app-container operations, which only works on a
+        // Simulator. Reject a physical iPhone with an actionable error rather than
+        // producing a partial, simctl-transport-failed snapshot.
+        if (isIosPhysicalUdid(this.device.deviceId)) {
+          throw new ActionableError(
+            `Device snapshots are not supported on physical iOS devices (${this.device.deviceId}); ` +
+              "they require a Simulator (simctl).",
+          );
+        }
         return this.executeIos(args);
       default:
         throw new ActionableError(

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -19,6 +19,7 @@ import {
 } from "../../utils/android-cmdline-tools/vmSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import {
   getAppDataContainerPath,
   IOS_APP_DATA_FOLDERS,
@@ -93,6 +94,16 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
       case "android":
         return this.executeAndroid(args);
       case "ios":
+        // Physical iOS devices are discoverable now, but iOS snapshot restore drives
+        // simctl for settings and app-container operations, which only works on a
+        // Simulator. Reject a physical iPhone with an actionable error rather than
+        // half-applying a restore over a failing simctl transport.
+        if (isIosPhysicalUdid(this.device.deviceId)) {
+          throw new ActionableError(
+            `Device snapshots are not supported on physical iOS devices (${this.device.deviceId}); ` +
+              "they require a Simulator (simctl).",
+          );
+        }
         return this.executeIos(args);
       default:
         throw new ActionableError(

--- a/src/features/video/HybridVideoCaptureBackend.ts
+++ b/src/features/video/HybridVideoCaptureBackend.ts
@@ -1,5 +1,6 @@
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
+import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import type {
   RecordingHandle,
   RecordingResult,
@@ -31,6 +32,18 @@ export class HybridVideoCaptureBackend implements VideoCaptureBackend {
     const device = config.device;
     if (!device) {
       throw new ActionableError("Device is required to start video recording.");
+    }
+
+    // Physical iOS devices are now discoverable and assignable through DevicePool, but the
+    // iOS video path routes every iOS device to FfmpegVideoProcessingBackend.startIos →
+    // `simctl io <deviceId> recordVideo`, which only drives Simulators. Reject a physical
+    // iPhone here (branching on the UDID type before backend selection) with an actionable
+    // error, rather than surfacing a confusing simctl transport failure.
+    if (device.platform === "ios" && isIosPhysicalUdid(device.deviceId)) {
+      throw new ActionableError(
+        `Video recording is not supported on physical iOS devices (${device.deviceId}); ` +
+          "it currently requires a Simulator (simctl io recordVideo).",
+      );
     }
 
     const backend = this.selectBackend(device);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3663,7 +3663,7 @@ export function registerDeviceTools() {
         "RUNNING DEVICES (booted/active):\n" +
         `  - automobile:devices/booted - All running devices\n` +
         `  - automobile:devices/booted/android - Android devices only\n` +
-        `  - automobile:devices/booted/ios - iOS simulators only\n\n` +
+        `  - automobile:devices/booted/ios - Booted iOS simulators and connected physical iOS devices\n\n` +
         "AVAILABLE DEVICE IMAGES (can be started):\n" +
         `  - automobile:devices/images - All available images\n` +
         `  - automobile:devices/images/android - Android AVDs\n` +

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -556,21 +556,18 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     const physical = await this.listPhysicalIosDevices();
     try {
       const simulators = await this.simctl.getBootedSimulatorsChecked();
-      const devices = mergeIosDevices(simulators, physical.devices);
-      // An incomplete physical sweep leaves iOS un-discovered even though simctl
-      // answered: the disconnect monitor prunes on this flag, and a devicectl
-      // blip must not evict a still-connected iPhone.
-      return physical.complete
-        ? { devices, succeeded: true }
-        : {
-            devices,
-            succeeded: false,
-            error: {
-              code: "failed",
-              message:
-                "iOS physical-device discovery failed; retaining tracked physical iOS devices.",
-            },
-          };
+      // `succeeded` stays tied to simctl alone. It is a per-platform flag with
+      // no room for "simulators are authoritative but physical devices are
+      // not", and clearing it on a devicectl blip would make every idle
+      // simulator unassignable. The lister keeps a failing sweep from dropping a
+      // connected device by retaining its last-known devices instead.
+      if (!physical.complete) {
+        logger.warn(
+          "[DeviceManager] iOS physical-device discovery was incomplete; " +
+            "reporting last-known physical devices alongside authoritative simulators.",
+        );
+      }
+      return { devices: mergeIosDevices(simulators, physical.devices), succeeded: true };
     } catch (error) {
       logger.warn(
         `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`,

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -4,6 +4,10 @@ import { DeviceInfo, ActionableError, SomePlatform, BootedDevice, Platform } fro
 import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
+import {
+  DevicectlDeviceLister,
+  type IosPhysicalDeviceLister,
+} from "./ios-cmdline-tools/DevicectlDeviceLister";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import { deleteAvd } from "./android-cmdline-tools/avdmanager";
 import { logger } from "./logger";
@@ -276,10 +280,22 @@ export async function waitForDeviceReadyOrCancel(
   }
 }
 
+/**
+ * Combine booted simulators with connected physical devices into one iOS device
+ * list. Simulator and physical UDID shapes are disjoint, but de-duplicating by
+ * deviceId keeps the merge idempotent if a future discovery source overlaps;
+ * the simulator entry wins because it carries richer runtime metadata.
+ */
+function mergeIosDevices(simulators: BootedDevice[], physical: BootedDevice[]): BootedDevice[] {
+  const seen = new Set(simulators.map((device) => device.deviceId));
+  return [...simulators, ...physical.filter((device) => !seen.has(device.deviceId))];
+}
+
 export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   private adb: AdbExecutor;
   private emulator: AndroidEmulatorClient;
   private simctl: SimCtlClient;
+  private readonly physicalIosDevices: IosPhysicalDeviceLister;
   private readonly lifecycleCoordinator: VirtualDeviceLifecycleCoordinator;
   private readonly timer: Pick<Timer, "now">;
 
@@ -288,6 +304,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
    * @param adb - An instance of AdbExecutor for interacting with Android Debug Bridge
    * @param simctl - An instance of SimCtlClient for interacting with iOS simulator controls
    * @param emulator - An instance of AndroidEmulatorClient for managing Android emulators
+   * @param physicalIosDevices - Discovery seam for connected physical iOS devices (devicectl)
    */
   constructor(
     adb: AdbExecutor | null = null,
@@ -295,10 +312,12 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     emulator: AndroidEmulatorClient | null = null,
     lifecycleCoordinator: VirtualDeviceLifecycleCoordinator = getVirtualDeviceLifecycleCoordinator(),
     timer: Pick<Timer, "now"> = defaultTimer,
+    physicalIosDevices: IosPhysicalDeviceLister | null = null,
   ) {
     this.adb = adb || defaultAdbClientFactory.create(null);
     this.simctl = simctl || new SimCtlClient();
     this.emulator = emulator || new AndroidEmulatorClient();
+    this.physicalIosDevices = physicalIosDevices || new DevicectlDeviceLister();
     this.lifecycleCoordinator = lifecycleCoordinator;
     this.timer = timer;
   }
@@ -334,15 +353,31 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     }
   }
 
+  /**
+   * Connected physical iOS devices, or an empty list when devicectl cannot
+   * answer. Additive to simulator discovery and never throws, so a host with no
+   * Xcode/hardware still resolves its simulators (issue #5620).
+   */
+  private async listPhysicalIosDevices(): Promise<BootedDevice[]> {
+    try {
+      return await this.physicalIosDevices.listConnectedDevices();
+    } catch (error) {
+      // The lister contract is non-throwing; a misbehaving implementation must
+      // still not take simulator discovery down with it.
+      logger.debug(`[DeviceManager] physical iOS device discovery failed: ${errorMessage(error)}`);
+      return [];
+    }
+  }
+
   private async getBootedIosDevicesIfAvailable(): Promise<BootedDevice[]> {
     if (!(await this.canDiscoverIosLocally())) {
       return [];
     }
-    try {
-      return await this.simctl.getBootedSimulators();
-    } catch {
-      return [];
-    }
+    const simulators = await this.simctl.getBootedSimulators().catch((error: unknown) => {
+      logger.debug(`[DeviceManager] booted simulator discovery failed: ${errorMessage(error)}`);
+      return [] as BootedDevice[];
+    });
+    return mergeIosDevices(simulators, await this.listPhysicalIosDevices());
   }
 
   /**
@@ -434,8 +469,11 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
 
     if (platform === "ios" || platform === "either") {
       const ios = await this.discoverBootedIosDevices();
+      // Physical devices that devicectl confirmed are reported even when
+      // simulator discovery failed; `succeeded` still gates pruning, because a
+      // failed simctl sweep cannot prove a tracked simulator is gone.
+      devices.push(...ios.devices);
       if (ios.succeeded) {
-        devices.push(...ios.devices);
         succeededPlatforms.add("ios");
       } else if (ios.error) {
         discoveryErrors.ios = ios.error;
@@ -510,15 +548,18 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         },
       };
     }
+    // Physical-device discovery runs regardless of the simulator outcome and
+    // cannot fail the sweep: it is best-effort by contract.
+    const physical = await this.listPhysicalIosDevices();
     try {
-      const devices = await this.simctl.getBootedSimulatorsChecked();
-      return { devices, succeeded: true };
+      const simulators = await this.simctl.getBootedSimulatorsChecked();
+      return { devices: mergeIosDevices(simulators, physical), succeeded: true };
     } catch (error) {
       logger.warn(
         `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`,
       );
       return {
-        devices: [],
+        devices: physical,
         succeeded: false,
         error: {
           code: "failed",

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -7,7 +7,9 @@ import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import {
   DevicectlDeviceLister,
   type IosPhysicalDeviceLister,
+  type PhysicalIosDeviceDiscovery,
 } from "./ios-cmdline-tools/DevicectlDeviceLister";
+import { isIosPhysicalUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import { deleteAvd } from "./android-cmdline-tools/avdmanager";
 import { logger } from "./logger";
@@ -358,14 +360,15 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
    * answer. Additive to simulator discovery and never throws, so a host with no
    * Xcode/hardware still resolves its simulators (issue #5620).
    */
-  private async listPhysicalIosDevices(): Promise<BootedDevice[]> {
+  private async listPhysicalIosDevices(): Promise<PhysicalIosDeviceDiscovery> {
     try {
       return await this.physicalIosDevices.listConnectedDevices();
     } catch (error) {
       // The lister contract is non-throwing; a misbehaving implementation must
-      // still not take simulator discovery down with it.
-      logger.debug(`[DeviceManager] physical iOS device discovery failed: ${errorMessage(error)}`);
-      return [];
+      // still not take simulator discovery down with it. `complete: false` so a
+      // devicectl blip cannot be read as "the physical device disconnected".
+      logger.warn(`[DeviceManager] physical iOS device discovery failed: ${errorMessage(error)}`);
+      return { devices: [], complete: false };
     }
   }
 
@@ -377,7 +380,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       logger.debug(`[DeviceManager] booted simulator discovery failed: ${errorMessage(error)}`);
       return [] as BootedDevice[];
     });
-    return mergeIosDevices(simulators, await this.listPhysicalIosDevices());
+    return mergeIosDevices(simulators, (await this.listPhysicalIosDevices()).devices);
   }
 
   /**
@@ -553,13 +556,27 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     const physical = await this.listPhysicalIosDevices();
     try {
       const simulators = await this.simctl.getBootedSimulatorsChecked();
-      return { devices: mergeIosDevices(simulators, physical), succeeded: true };
+      const devices = mergeIosDevices(simulators, physical.devices);
+      // An incomplete physical sweep leaves iOS un-discovered even though simctl
+      // answered: the disconnect monitor prunes on this flag, and a devicectl
+      // blip must not evict a still-connected iPhone.
+      return physical.complete
+        ? { devices, succeeded: true }
+        : {
+            devices,
+            succeeded: false,
+            error: {
+              code: "failed",
+              message:
+                "iOS physical-device discovery failed; retaining tracked physical iOS devices.",
+            },
+          };
     } catch (error) {
       logger.warn(
         `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`,
       );
       return {
-        devices: physical,
+        devices: physical.devices,
         succeeded: false,
         error: {
           code: "failed",
@@ -700,6 +717,20 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
           signal,
         );
       case "ios":
+        // A connected physical device has no simulator lifecycle: `simctl
+        // bootstatus` cannot answer for its UDID, and discovery already proved
+        // it reachable. Treat successful discovery as readiness rather than
+        // shelling out to a tool that would only fail (issue #5620).
+        if (device.deviceId && isIosPhysicalUdid(device.deviceId)) {
+          return {
+            name: device.name,
+            platform: "ios",
+            deviceId: device.deviceId,
+            ...(device.iosVersion ? { iosVersion: device.iosVersion } : {}),
+            ...(device.osVersion ? { osVersion: device.osVersion } : {}),
+            ...(device.formFactor ? { formFactor: device.formFactor } : {}),
+          };
+        }
         // A `childProcess` is only supplied on the cold-boot path, where
         // `startSimulator` has already run `bootstatus -b`. Signal that so the
         // wait doesn't redundantly repeat the full boot-readiness wait; the

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -626,6 +626,16 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.killDevice(device, options);
       case "ios":
+        // Physical devices are discoverable now (issue #5620), so a kill request
+        // can reach one. `simctl shutdown` cannot act on a physical UDID — it
+        // would fail with an opaque CoreSimulator error — and there is no
+        // devicectl equivalent of shutting a device down, so say so plainly.
+        if (device.deviceId && isIosPhysicalUdid(device.deviceId)) {
+          throw new ActionableError(
+            `Cannot shut down physical iOS device ${device.deviceId}: only simulators have a ` +
+              `remote shutdown path. Disconnect or power the device off manually.`,
+          );
+        }
         return this.simctl.killSimulator(device, options);
     }
   }

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -5,7 +5,6 @@ import type { ExecResult } from "../../models";
 import type { BootedDevice } from "../../models/DeviceInfo";
 import { errorMessage } from "../describeUnknownError";
 import { DefaultHostCommandExecutor, type HostCommandOptions } from "../HostCommandExecutor";
-import { getAbortSignal } from "../AbortContext";
 import { logger, type Logger } from "../logger";
 import { defaultTimer, type Timer } from "../SystemTimer";
 import { inferIosFormFactor, isIosPhysicalUdid } from "./iosDeviceType";
@@ -83,17 +82,20 @@ function asString(value: unknown): string | undefined {
  * a top-level array so a future envelope change degrades to "no devices" rather
  * than a crash.
  */
-function extractDeviceEntries(data: unknown): unknown[] {
+function extractDeviceEntries(data: unknown): unknown[] | null {
   if (Array.isArray(data)) {
     return data;
   }
   const root = asRecord(data);
   if (!root) {
-    return [];
+    return null;
   }
-  const result = asRecord(root.result);
-  const devices = result?.devices ?? root.devices;
-  return Array.isArray(devices) ? devices : [];
+  const outcome = asString(asRecord(root.info)?.outcome)?.toLowerCase();
+  if (outcome && outcome !== "success") {
+    return null;
+  }
+  const devices = asRecord(root.result)?.devices ?? root.devices;
+  return Array.isArray(devices) ? devices : null;
 }
 
 /**
@@ -189,15 +191,25 @@ function toBootedDevice(entry: unknown): BootedDevice | null {
  * physical iOS devices it reports, sorted by UDID to match
  * `SimCtlClient.getBootedSimulatorsChecked`'s stable ordering.
  *
+ * `complete` separates a *recognized* empty listing ("nothing is plugged in",
+ * authoritative) from an envelope this parser does not understand — a failed
+ * `info.outcome`, a missing/non-array `devices`, or a future rename. Reporting
+ * the latter as an authoritative empty list is what would let the disconnect
+ * monitor drop a still-connected iPhone.
+ *
  * Exported separately from the client so the payload shape can be pinned by
  * fast unit tests with no host tooling involved.
  */
-export function parseDevicectlDeviceList(data: unknown): BootedDevice[] {
-  const devices = extractDeviceEntries(data)
+export function parseDevicectlDeviceList(data: unknown): PhysicalIosDeviceDiscovery {
+  const entries = extractDeviceEntries(data);
+  if (!entries) {
+    return { devices: [], complete: false };
+  }
+  const devices = entries
     .map(toBootedDevice)
     .filter((device): device is BootedDevice => device !== null);
   devices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
-  return devices;
+  return { devices, complete: true };
 }
 
 /**
@@ -218,6 +230,19 @@ const DEVICE_LIST_CACHE_TTL_MS = 3_000;
  * wedge each later sweep behind it.
  */
 const DEVICE_LIST_TIMEOUT_MS = 15_000;
+
+/**
+ * How long a failing sweep keeps reporting the devices the last good sweep
+ * found.
+ *
+ * Without this, a single devicectl blip makes a connected iPhone vanish from
+ * discovery, and the daemon's disconnect monitor starts counting misses against
+ * a device that never went anywhere. Retaining last-known devices keeps the
+ * iPhone in the discovered list while `complete: false` still tells callers the
+ * sweep was not authoritative. The window is bounded so a permanently broken
+ * devicectl eventually stops asserting hardware that may well be unplugged.
+ */
+const LAST_GOOD_RETENTION_MS = 60_000;
 
 interface DevicectlDeviceListerDependencies {
   platform: () => NodeJS.Platform;
@@ -254,6 +279,7 @@ const defaultDependencies: DevicectlDeviceListerDependencies = {
 export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
   private readonly deps: DevicectlDeviceListerDependencies;
   private cache: { discovery: PhysicalIosDeviceDiscovery; expiresAt: number } | null = null;
+  private lastGood: { devices: BootedDevice[]; staleAfter: number } | null = null;
   private inFlight: Promise<PhysicalIosDeviceDiscovery> | null = null;
 
   constructor(dependencies: Partial<DevicectlDeviceListerDependencies> = {}) {
@@ -282,13 +308,14 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
       await this.deps.execute(
         "xcrun",
         ["devicectl", "list", "devices", "--json-output", jsonPath, "--quiet"],
-        { timeoutMs: DEVICE_LIST_TIMEOUT_MS, signal: getAbortSignal() },
+        // Deliberately NOT wired to the ambient abort signal: this listing is
+        // shared across concurrent callers, so honoring one caller's
+        // cancellation would cancel the process out from under the others. The
+        // timeout is what bounds it.
+        { timeoutMs: DEVICE_LIST_TIMEOUT_MS },
       );
       const raw = await this.deps.readFile(jsonPath);
-      return this.remember({
-        devices: parseDevicectlDeviceList(JSON.parse(raw) as unknown),
-        complete: true,
-      });
+      return this.remember(parseDevicectlDeviceList(JSON.parse(raw) as unknown));
     } catch (error) {
       // A host without Xcode 15+, without paired hardware, or with a devicectl
       // that failed still has working simulator discovery; degrade to
@@ -296,9 +323,8 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
       this.deps.logger.debug(
         `[DevicectlDeviceLister] physical iOS device discovery unavailable: ${errorMessage(error)}`,
       );
-      // Cache the empty result too: a host with no Xcode must not pay for a
-      // failing process spawn on every sweep. `complete: false` keeps callers
-      // from reading the emptiness as "the iPhone went away".
+      // Cache the failure too: a host with no Xcode must not pay for a failing
+      // process spawn on every sweep.
       return this.remember({ devices: [], complete: false });
     } finally {
       if (tempDir) {
@@ -314,7 +340,28 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
   }
 
   private remember(discovery: PhysicalIosDeviceDiscovery): PhysicalIosDeviceDiscovery {
-    this.cache = { discovery, expiresAt: this.deps.timer.now() + DEVICE_LIST_CACHE_TTL_MS };
+    const now = this.deps.timer.now();
+    const resolved = discovery.complete
+      ? this.recordLastGood(discovery, now)
+      : { devices: this.retainedDevices(now), complete: false };
+    this.cache = { discovery: resolved, expiresAt: now + DEVICE_LIST_CACHE_TTL_MS };
+    return resolved;
+  }
+
+  private recordLastGood(
+    discovery: PhysicalIosDeviceDiscovery,
+    now: number,
+  ): PhysicalIosDeviceDiscovery {
+    this.lastGood = { devices: discovery.devices, staleAfter: now + LAST_GOOD_RETENTION_MS };
     return discovery;
+  }
+
+  /** Devices the last good sweep found, while still inside the retention window. */
+  private retainedDevices(now: number): BootedDevice[] {
+    if (!this.lastGood || now >= this.lastGood.staleAfter) {
+      this.lastGood = null;
+      return [];
+    }
+    return this.lastGood.devices;
   }
 }

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -1,0 +1,260 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { ExecResult } from "../../models";
+import type { BootedDevice } from "../../models/DeviceInfo";
+import { errorMessage } from "../describeUnknownError";
+import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
+import { logger, type Logger } from "../logger";
+import { defaultTimer, type Timer } from "../SystemTimer";
+import { inferIosFormFactor, isIosPhysicalUdid } from "./iosDeviceType";
+
+/**
+ * Discovery seam for *physical* iOS devices attached to this host.
+ *
+ * Simulators come from `SimCtlClient`; this is the devicectl-backed other half,
+ * so `MultiPlatformDeviceManager` can resolve a physical UDID to a
+ * `BootedDevice` instead of rejecting it as "not booted" (issue #5620).
+ *
+ * Implementations must never throw: a host with no Xcode, no devicectl, or no
+ * attached hardware degrades to an empty list.
+ */
+export interface IosPhysicalDeviceLister {
+  listConnectedDevices(): Promise<BootedDevice[]>;
+}
+
+/**
+ * `connectionProperties.tunnelState` values that mean "this device is known to
+ * Xcode but is not reachable right now". Everything else — including a missing
+ * or unrecognized state — is treated as connected.
+ *
+ * The bias is deliberate and asymmetric: the bug being fixed is a physical
+ * device being wrongly rejected, so an unknown state must not re-introduce that
+ * rejection. Only states devicectl documents as unreachable filter a device out.
+ */
+const UNREACHABLE_TUNNEL_STATES = new Set(["unavailable", "disconnected"]);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Pull the device array out of a `devicectl list devices --json-output` payload.
+ * devicectl nests it under `result.devices`; tolerate a bare `devices` array and
+ * a top-level array so a future envelope change degrades to "no devices" rather
+ * than a crash.
+ */
+function extractDeviceEntries(data: unknown): unknown[] {
+  if (Array.isArray(data)) {
+    return data;
+  }
+  const root = asRecord(data);
+  if (!root) {
+    return [];
+  }
+  const result = asRecord(root.result);
+  const devices = result?.devices ?? root.devices;
+  return Array.isArray(devices) ? devices : [];
+}
+
+/**
+ * The physical-device UDID a devicectl record identifies, or null when the
+ * record is not a reachable physical iOS device.
+ *
+ * The UDID is validated with the canonical {@link isIosPhysicalUdid} predicate
+ * rather than trusted, so a simulator entry, a paired-Watch record, or a renamed
+ * field can never be surfaced as a physical iOS device.
+ */
+function reachablePhysicalUdid(
+  hardware: Record<string, unknown> | null,
+  connection: Record<string, unknown> | null,
+  identifier: unknown,
+): string | null {
+  const udid = asString(hardware?.udid) ?? asString(identifier);
+  if (!udid || !isIosPhysicalUdid(udid)) {
+    return null;
+  }
+  const tunnelState = asString(connection?.tunnelState)?.toLowerCase();
+  return tunnelState && UNREACHABLE_TUNNEL_STATES.has(tunnelState) ? null : udid;
+}
+
+/**
+ * Best available human-readable name for a device record, falling back to the
+ * UDID so a device is never surfaced nameless.
+ */
+function deviceDisplayName(
+  deviceProperties: Record<string, unknown> | null,
+  hardware: Record<string, unknown> | null,
+  udid: string,
+): string {
+  return (
+    asString(deviceProperties?.name) ??
+    asString(hardware?.marketingName) ??
+    asString(hardware?.deviceType) ??
+    udid
+  );
+}
+
+/**
+ * Convert one devicectl device record into a `BootedDevice`, or null when the
+ * record is not a reachable physical iOS device.
+ */
+function toBootedDevice(entry: unknown): BootedDevice | null {
+  const record = asRecord(entry);
+  if (!record) {
+    return null;
+  }
+
+  const hardware = asRecord(record.hardwareProperties);
+  const udid = reachablePhysicalUdid(
+    hardware,
+    asRecord(record.connectionProperties),
+    record.identifier,
+  );
+  if (!udid) {
+    return null;
+  }
+
+  const deviceProperties = asRecord(record.deviceProperties);
+  const osVersion = asString(deviceProperties?.osVersionNumber);
+  const formFactor = inferIosFormFactor(asString(hardware?.productType));
+
+  return {
+    name: deviceDisplayName(deviceProperties, hardware, udid),
+    platform: "ios",
+    deviceId: udid,
+    ...(osVersion ? { iosVersion: osVersion, osVersion } : {}),
+    ...(formFactor ? { formFactor } : {}),
+  };
+}
+
+/**
+ * Parse a `devicectl list devices --json-output` payload into the reachable
+ * physical iOS devices it reports, sorted by UDID to match
+ * `SimCtlClient.getBootedSimulatorsChecked`'s stable ordering.
+ *
+ * Exported separately from the client so the payload shape can be pinned by
+ * fast unit tests with no host tooling involved.
+ */
+export function parseDevicectlDeviceList(data: unknown): BootedDevice[] {
+  const devices = extractDeviceEntries(data)
+    .map(toBootedDevice)
+    .filter((device): device is BootedDevice => device !== null);
+  devices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
+  return devices;
+}
+
+/**
+ * How long a devicectl listing is reused before re-shelling out.
+ *
+ * `getBootedDevices("ios")` is a hot path — the app resources and the daemon's
+ * device sweep both call it — while `devicectl list devices` costs on the order
+ * of a second. The window is short enough that a freshly-plugged device shows up
+ * within one sweep, and long enough that a burst of resource reads spawns one
+ * process rather than one per read.
+ */
+const DEVICE_LIST_CACHE_TTL_MS = 3_000;
+
+interface DevicectlDeviceListerDependencies {
+  platform: () => NodeJS.Platform;
+  timer: Pick<Timer, "now">;
+  execute: (file: string, args: string[]) => Promise<ExecResult>;
+  readFile: (path: string) => Promise<string>;
+  mkdtemp: (prefix: string) => Promise<string>;
+  rm: (path: string) => Promise<void>;
+  tmpdir: () => string;
+  logger: Pick<Logger, "debug" | "warn">;
+}
+
+const defaultDependencies: DevicectlDeviceListerDependencies = {
+  platform: () => process.platform,
+  execute: (file, args) => new DefaultHostCommandExecutor().executeCommand(file, args),
+  readFile: async (path) => fs.readFile(path, "utf-8"),
+  mkdtemp: async (prefix) => fs.mkdtemp(prefix),
+  rm: async (path) => fs.rm(path, { recursive: true, force: true }),
+  tmpdir,
+  logger,
+  timer: defaultTimer,
+};
+
+/**
+ * Lists connected physical iOS devices via `xcrun devicectl list devices`.
+ *
+ * macOS-only and entirely best-effort: every failure path (non-darwin host,
+ * missing Xcode, devicectl error, unreadable JSON) logs and returns an empty
+ * list. Physical-device discovery is additive to the simulator list, so a
+ * failure here must degrade iOS discovery to "simulators only" rather than
+ * failing the whole sweep.
+ */
+export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
+  private readonly deps: DevicectlDeviceListerDependencies;
+  private cache: { devices: BootedDevice[]; expiresAt: number } | null = null;
+  private inFlight: Promise<BootedDevice[]> | null = null;
+
+  constructor(dependencies: Partial<DevicectlDeviceListerDependencies> = {}) {
+    this.deps = { ...defaultDependencies, ...dependencies };
+  }
+
+  async listConnectedDevices(): Promise<BootedDevice[]> {
+    if (this.deps.platform() !== "darwin") {
+      return [];
+    }
+    if (this.cache && this.deps.timer.now() < this.cache.expiresAt) {
+      return this.cache.devices;
+    }
+    // Concurrent sweeps share one devicectl process rather than racing two.
+    this.inFlight ??= this.runListing().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  private async runListing(): Promise<BootedDevice[]> {
+    let tempDir: string | null = null;
+    try {
+      tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-devices-"));
+      const jsonPath = join(tempDir, "devices.json");
+      await this.deps.execute("xcrun", [
+        "devicectl",
+        "list",
+        "devices",
+        "--json-output",
+        jsonPath,
+        "--quiet",
+      ]);
+      const raw = await this.deps.readFile(jsonPath);
+      return this.remember(parseDevicectlDeviceList(JSON.parse(raw) as unknown));
+    } catch (error) {
+      // A host without Xcode 15+, without paired hardware, or with a devicectl
+      // that failed still has working simulator discovery; degrade to
+      // "no physical devices" rather than breaking the iOS sweep.
+      this.deps.logger.debug(
+        `[DevicectlDeviceLister] physical iOS device discovery unavailable: ${errorMessage(error)}`,
+      );
+      // Cache the empty result too: a host with no Xcode must not pay for a
+      // failing process spawn on every sweep.
+      return this.remember([]);
+    } finally {
+      if (tempDir) {
+        try {
+          await this.deps.rm(tempDir);
+        } catch (cleanupError) {
+          this.deps.logger.warn(
+            `[DevicectlDeviceLister] Failed to remove temporary device listing directory ${tempDir}: ${errorMessage(cleanupError)}`,
+          );
+        }
+      }
+    }
+  }
+
+  private remember(devices: BootedDevice[]): BootedDevice[] {
+    this.cache = { devices, expiresAt: this.deps.timer.now() + DEVICE_LIST_CACHE_TTL_MS };
+    return devices;
+  }
+}

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -4,7 +4,8 @@ import { join } from "path";
 import type { ExecResult } from "../../models";
 import type { BootedDevice } from "../../models/DeviceInfo";
 import { errorMessage } from "../describeUnknownError";
-import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
+import { DefaultHostCommandExecutor, type HostCommandOptions } from "../HostCommandExecutor";
+import { getAbortSignal } from "../AbortContext";
 import { logger, type Logger } from "../logger";
 import { defaultTimer, type Timer } from "../SystemTimer";
 import { inferIosFormFactor, isIosPhysicalUdid } from "./iosDeviceType";
@@ -20,7 +21,25 @@ import { inferIosFormFactor, isIosPhysicalUdid } from "./iosDeviceType";
  * attached hardware degrades to an empty list.
  */
 export interface IosPhysicalDeviceLister {
-  listConnectedDevices(): Promise<BootedDevice[]>;
+  listConnectedDevices(): Promise<PhysicalIosDeviceDiscovery>;
+}
+
+/**
+ * Outcome of one physical-device sweep.
+ *
+ * `complete` is the load-bearing half: it is false ONLY when devicectl was
+ * reachable but its listing failed, so callers can tell "no physical devices are
+ * attached" from "we could not find out". The daemon's disconnect monitor prunes
+ * on that distinction, and pruning a still-connected iPhone because devicectl
+ * blipped would evict a device mid-session.
+ *
+ * A host that cannot run devicectl at all (non-darwin, no Xcode) reports
+ * `complete: true`: no physical device can ever be tracked there, so their
+ * absence is authoritative.
+ */
+export interface PhysicalIosDeviceDiscovery {
+  devices: BootedDevice[];
+  complete: boolean;
 }
 
 /**
@@ -33,6 +52,20 @@ export interface IosPhysicalDeviceLister {
  * rejection. Only states devicectl documents as unreachable filter a device out.
  */
 const UNREACHABLE_TUNNEL_STATES = new Set(["unavailable", "disconnected"]);
+
+/**
+ * `hardwareProperties.platform` values this lister accepts as an iOS device.
+ *
+ * A paired Apple Watch, Apple TV, or Vision Pro is a CoreDevice too, and they
+ * use the same physical-UDID shapes — so the UDID pattern alone cannot tell them
+ * apart. Without this gate they would be published as `platform: "ios"` and
+ * route iOS operations to hardware that cannot serve them.
+ *
+ * A record with NO platform field is still accepted, keeping the same
+ * degrade-toward-inclusion policy as {@link UNREACHABLE_TUNNEL_STATES}: older
+ * devicectl payloads that omit the field must not lose their iPhones.
+ */
+const IOS_PLATFORM_VALUES = new Set(["ios", "ipados"]);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -76,12 +109,29 @@ function reachablePhysicalUdid(
   connection: Record<string, unknown> | null,
   identifier: unknown,
 ): string | null {
-  const udid = asString(hardware?.udid) ?? asString(identifier);
-  if (!udid || !isIosPhysicalUdid(udid)) {
+  if (!isIosPlatform(hardware) || !isReachable(connection)) {
     return null;
   }
+  const udid = asString(hardware?.udid) ?? asString(identifier);
+  return udid && isIosPhysicalUdid(udid) ? udid : null;
+}
+
+/**
+ * False only when the record names a platform that is not iOS. A missing field
+ * passes, per the degrade-toward-inclusion policy on {@link IOS_PLATFORM_VALUES}.
+ */
+function isIosPlatform(hardware: Record<string, unknown> | null): boolean {
+  const devicePlatform = asString(hardware?.platform)?.toLowerCase();
+  return !devicePlatform || IOS_PLATFORM_VALUES.has(devicePlatform);
+}
+
+/**
+ * False only when devicectl names a tunnel state it documents as unreachable.
+ * A missing or unrecognized state passes; see {@link UNREACHABLE_TUNNEL_STATES}.
+ */
+function isReachable(connection: Record<string, unknown> | null): boolean {
   const tunnelState = asString(connection?.tunnelState)?.toLowerCase();
-  return tunnelState && UNREACHABLE_TUNNEL_STATES.has(tunnelState) ? null : udid;
+  return !tunnelState || !UNREACHABLE_TUNNEL_STATES.has(tunnelState);
 }
 
 /**
@@ -161,10 +211,18 @@ export function parseDevicectlDeviceList(data: unknown): BootedDevice[] {
  */
 const DEVICE_LIST_CACHE_TTL_MS = 3_000;
 
+/**
+ * Ceiling on one `devicectl list devices` invocation. Unbounded, a stalled
+ * devicectl would hang every caller awaiting iOS discovery — including
+ * simulator-only app-resource reads — and the shared in-flight promise would
+ * wedge each later sweep behind it.
+ */
+const DEVICE_LIST_TIMEOUT_MS = 15_000;
+
 interface DevicectlDeviceListerDependencies {
   platform: () => NodeJS.Platform;
   timer: Pick<Timer, "now">;
-  execute: (file: string, args: string[]) => Promise<ExecResult>;
+  execute: (file: string, args: string[], options: HostCommandOptions) => Promise<ExecResult>;
   readFile: (path: string) => Promise<string>;
   mkdtemp: (prefix: string) => Promise<string>;
   rm: (path: string) => Promise<void>;
@@ -174,7 +232,8 @@ interface DevicectlDeviceListerDependencies {
 
 const defaultDependencies: DevicectlDeviceListerDependencies = {
   platform: () => process.platform,
-  execute: (file, args) => new DefaultHostCommandExecutor().executeCommand(file, args),
+  execute: (file, args, options) =>
+    new DefaultHostCommandExecutor().executeCommand(file, args, options),
   readFile: async (path) => fs.readFile(path, "utf-8"),
   mkdtemp: async (prefix) => fs.mkdtemp(prefix),
   rm: async (path) => fs.rm(path, { recursive: true, force: true }),
@@ -194,19 +253,19 @@ const defaultDependencies: DevicectlDeviceListerDependencies = {
  */
 export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
   private readonly deps: DevicectlDeviceListerDependencies;
-  private cache: { devices: BootedDevice[]; expiresAt: number } | null = null;
-  private inFlight: Promise<BootedDevice[]> | null = null;
+  private cache: { discovery: PhysicalIosDeviceDiscovery; expiresAt: number } | null = null;
+  private inFlight: Promise<PhysicalIosDeviceDiscovery> | null = null;
 
   constructor(dependencies: Partial<DevicectlDeviceListerDependencies> = {}) {
     this.deps = { ...defaultDependencies, ...dependencies };
   }
 
-  async listConnectedDevices(): Promise<BootedDevice[]> {
+  async listConnectedDevices(): Promise<PhysicalIosDeviceDiscovery> {
     if (this.deps.platform() !== "darwin") {
-      return [];
+      return { devices: [], complete: true };
     }
     if (this.cache && this.deps.timer.now() < this.cache.expiresAt) {
-      return this.cache.devices;
+      return this.cache.discovery;
     }
     // Concurrent sweeps share one devicectl process rather than racing two.
     this.inFlight ??= this.runListing().finally(() => {
@@ -215,21 +274,21 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
     return this.inFlight;
   }
 
-  private async runListing(): Promise<BootedDevice[]> {
+  private async runListing(): Promise<PhysicalIosDeviceDiscovery> {
     let tempDir: string | null = null;
     try {
       tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-devices-"));
       const jsonPath = join(tempDir, "devices.json");
-      await this.deps.execute("xcrun", [
-        "devicectl",
-        "list",
-        "devices",
-        "--json-output",
-        jsonPath,
-        "--quiet",
-      ]);
+      await this.deps.execute(
+        "xcrun",
+        ["devicectl", "list", "devices", "--json-output", jsonPath, "--quiet"],
+        { timeoutMs: DEVICE_LIST_TIMEOUT_MS, signal: getAbortSignal() },
+      );
       const raw = await this.deps.readFile(jsonPath);
-      return this.remember(parseDevicectlDeviceList(JSON.parse(raw) as unknown));
+      return this.remember({
+        devices: parseDevicectlDeviceList(JSON.parse(raw) as unknown),
+        complete: true,
+      });
     } catch (error) {
       // A host without Xcode 15+, without paired hardware, or with a devicectl
       // that failed still has working simulator discovery; degrade to
@@ -238,8 +297,9 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
         `[DevicectlDeviceLister] physical iOS device discovery unavailable: ${errorMessage(error)}`,
       );
       // Cache the empty result too: a host with no Xcode must not pay for a
-      // failing process spawn on every sweep.
-      return this.remember([]);
+      // failing process spawn on every sweep. `complete: false` keeps callers
+      // from reading the emptiness as "the iPhone went away".
+      return this.remember({ devices: [], complete: false });
     } finally {
       if (tempDir) {
         try {
@@ -253,8 +313,8 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
     }
   }
 
-  private remember(devices: BootedDevice[]): BootedDevice[] {
-    this.cache = { devices, expiresAt: this.deps.timer.now() + DEVICE_LIST_CACHE_TTL_MS };
-    return devices;
+  private remember(discovery: PhysicalIosDeviceDiscovery): PhysicalIosDeviceDiscovery {
+    this.cache = { discovery, expiresAt: this.deps.timer.now() + DEVICE_LIST_CACHE_TTL_MS };
+    return discovery;
   }
 }

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -27,8 +27,9 @@ export interface IosPhysicalDeviceLister {
  * Outcome of one physical-device sweep.
  *
  * `complete` is the load-bearing half: it is false ONLY when devicectl was
- * reachable but its listing failed, so callers can tell "no physical devices are
- * attached" from "we could not find out". The daemon's disconnect monitor prunes
+ * reachable but its listing could not be read in full — the invocation failed, or
+ * the payload drifted — so callers can tell "no physical devices are attached"
+ * from "we could not find out". The daemon's disconnect monitor prunes
  * on that distinction, and pruning a still-connected iPhone because devicectl
  * blipped would evict a device mid-session.
  *
@@ -99,24 +100,22 @@ function extractDeviceEntries(data: unknown): unknown[] | null {
 }
 
 /**
- * The physical-device UDID a devicectl record identifies, or null when the
- * record is not a reachable physical iOS device.
+ * What one devicectl record turned out to be.
  *
- * The UDID is validated with the canonical {@link isIosPhysicalUdid} predicate
- * rather than trusted, so a simulator entry, a paired-Watch record, or a renamed
- * field can never be surfaced as a physical iOS device.
+ * `filtered` and `malformed` both yield no device, but they mean opposite things
+ * for completeness. `filtered` is a record this lister *understands* and does not
+ * want — a paired Watch, an unreachable phone — so the sweep still knows exactly
+ * which iPhones are attached. `malformed` is a record it cannot identify at all,
+ * which means the payload no longer matches what this parser reads and the
+ * resulting device list may be missing hardware that is physically present.
  */
-function reachablePhysicalUdid(
-  hardware: Record<string, unknown> | null,
-  connection: Record<string, unknown> | null,
-  identifier: unknown,
-): string | null {
-  if (!isIosPlatform(hardware) || !isReachable(connection)) {
-    return null;
-  }
-  const udid = asString(hardware?.udid) ?? asString(identifier);
-  return udid && isIosPhysicalUdid(udid) ? udid : null;
-}
+type DeviceEntryOutcome =
+  | { kind: "device"; device: BootedDevice }
+  | { kind: "filtered" }
+  | { kind: "malformed" };
+
+const FILTERED: DeviceEntryOutcome = { kind: "filtered" };
+const MALFORMED: DeviceEntryOutcome = { kind: "malformed" };
 
 /**
  * False only when the record names a platform that is not iOS. A missing field
@@ -154,23 +153,34 @@ function deviceDisplayName(
 }
 
 /**
- * Convert one devicectl device record into a `BootedDevice`, or null when the
- * record is not a reachable physical iOS device.
+ * Classify one devicectl device record.
+ *
+ * The order matters: the two *understood* rejections — a non-iOS platform and a
+ * documented-unreachable tunnel state — are checked first, so everything that
+ * survives them is a record devicectl says is a reachable iOS CoreDevice. Those
+ * are physical hardware by definition, so failing to read a physical UDID out of
+ * one is schema drift rather than a device we meant to skip, and it must make the
+ * whole listing non-authoritative.
+ *
+ * The UDID is validated with the canonical {@link isIosPhysicalUdid} predicate
+ * rather than trusted, so a simulator-shaped entry or a renamed field can never
+ * be surfaced as a physical iOS device.
  */
-function toBootedDevice(entry: unknown): BootedDevice | null {
+function classifyDeviceEntry(entry: unknown): DeviceEntryOutcome {
   const record = asRecord(entry);
   if (!record) {
-    return null;
+    // A non-record entry inside a recognized envelope is drift, not a device.
+    return MALFORMED;
   }
 
   const hardware = asRecord(record.hardwareProperties);
-  const udid = reachablePhysicalUdid(
-    hardware,
-    asRecord(record.connectionProperties),
-    record.identifier,
-  );
-  if (!udid) {
-    return null;
+  if (!isIosPlatform(hardware) || !isReachable(asRecord(record.connectionProperties))) {
+    return FILTERED;
+  }
+
+  const udid = asString(hardware?.udid) ?? asString(record.identifier);
+  if (!udid || !isIosPhysicalUdid(udid)) {
+    return MALFORMED;
   }
 
   const deviceProperties = asRecord(record.deviceProperties);
@@ -178,11 +188,14 @@ function toBootedDevice(entry: unknown): BootedDevice | null {
   const formFactor = inferIosFormFactor(asString(hardware?.productType));
 
   return {
-    name: deviceDisplayName(deviceProperties, hardware, udid),
-    platform: "ios",
-    deviceId: udid,
-    ...(osVersion ? { iosVersion: osVersion, osVersion } : {}),
-    ...(formFactor ? { formFactor } : {}),
+    kind: "device",
+    device: {
+      name: deviceDisplayName(deviceProperties, hardware, udid),
+      platform: "ios",
+      deviceId: udid,
+      ...(osVersion ? { iosVersion: osVersion, osVersion } : {}),
+      ...(formFactor ? { formFactor } : {}),
+    },
   };
 }
 
@@ -191,11 +204,13 @@ function toBootedDevice(entry: unknown): BootedDevice | null {
  * physical iOS devices it reports, sorted by UDID to match
  * `SimCtlClient.getBootedSimulatorsChecked`'s stable ordering.
  *
- * `complete` separates a *recognized* empty listing ("nothing is plugged in",
- * authoritative) from an envelope this parser does not understand — a failed
- * `info.outcome`, a missing/non-array `devices`, or a future rename. Reporting
- * the latter as an authoritative empty list is what would let the disconnect
- * monitor drop a still-connected iPhone.
+ * `complete` separates a *recognized* listing (authoritative — an empty one means
+ * "nothing is plugged in") from one this parser could not fully read. That covers
+ * both halves of the payload: an envelope it does not understand — a failed
+ * `info.outcome`, a missing/non-array `devices`, or a future rename — and an
+ * individual entry devicectl calls a reachable iOS device but which yields no
+ * physical UDID. Reporting either as authoritative is what would let the
+ * disconnect monitor drop a still-connected iPhone.
  *
  * Exported separately from the client so the payload shape can be pinned by
  * fast unit tests with no host tooling involved.
@@ -205,11 +220,26 @@ export function parseDevicectlDeviceList(data: unknown): PhysicalIosDeviceDiscov
   if (!entries) {
     return { devices: [], complete: false };
   }
-  const devices = entries
-    .map(toBootedDevice)
-    .filter((device): device is BootedDevice => device !== null);
+  const outcomes = entries.map(classifyDeviceEntry);
+  const devices = outcomes
+    .filter((outcome) => outcome.kind === "device")
+    .map((outcome) => outcome.device);
   devices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
-  return { devices, complete: true };
+  // The devices that did resolve are still reported: the caller needs both the
+  // iPhone it found and the signal that something in the payload was unreadable.
+  return { devices, complete: !outcomes.some((outcome) => outcome.kind === "malformed") };
+}
+
+/**
+ * Union two device listings by UDID, preferring the first list's record for a
+ * device both report, and keeping the UDID ordering `parseDevicectlDeviceList`
+ * establishes.
+ */
+function mergeById(preferred: BootedDevice[], fallback: BootedDevice[]): BootedDevice[] {
+  const seen = new Set(preferred.map((device) => device.deviceId));
+  const merged = [...preferred, ...fallback.filter((device) => !seen.has(device.deviceId))];
+  merged.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
+  return merged;
 }
 
 /**
@@ -343,7 +373,14 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
     const now = this.deps.timer.now();
     const resolved = discovery.complete
       ? this.recordLastGood(discovery, now)
-      : { devices: this.retainedDevices(now), complete: false };
+      : {
+          // A partial sweep and the retained listing are both incomplete views of
+          // the same hardware, so neither may evict the other's device: union
+          // them. When the sweep failed outright its half is empty and this
+          // degrades to pure retention.
+          devices: mergeById(discovery.devices, this.retainedDevices(now)),
+          complete: false,
+        };
     this.cache = { discovery: resolved, expiresAt: now + DEVICE_LIST_CACHE_TTL_MS };
     return resolved;
   }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -15,7 +15,7 @@ import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
-import { isIosSimulatorUdid } from "./iosDeviceType";
+import { inferIosFormFactor, isIosSimulatorUdid } from "./iosDeviceType";
 import { getAbortSignal } from "../AbortContext";
 import { Mutex } from "async-mutex";
 
@@ -444,19 +444,6 @@ function pickHighestRuntime(
     .filter((runtime) => typeof runtime.version === "string" && runtime.version.startsWith(prefix))
     .sort((a, b) => compareVersions(a.version, b.version))
     .pop();
-}
-
-function inferIosFormFactor(deviceTypeId: string | undefined): "phone" | "tablet" | undefined {
-  if (!deviceTypeId) {
-    return undefined;
-  }
-  if (deviceTypeId.includes("iPad")) {
-    return "tablet";
-  }
-  if (deviceTypeId.includes("iPhone")) {
-    return "phone";
-  }
-  return undefined;
 }
 
 function isAlreadyBootedCoreSimulator405(error: unknown, udid: string): boolean {

--- a/src/utils/ios-cmdline-tools/iosDeviceType.ts
+++ b/src/utils/ios-cmdline-tools/iosDeviceType.ts
@@ -61,3 +61,27 @@ export function isIosPhysicalUdid(deviceId: string): boolean {
 export function isIosUdid(deviceId: string): boolean {
   return isIosSimulatorUdid(deviceId) || isIosPhysicalUdid(deviceId);
 }
+
+/**
+ * Infer an iOS form factor from any Apple device-model string.
+ *
+ * Deliberately substring-based so a single implementation covers both device
+ * vocabularies: simulator device-type identifiers
+ * (`com.apple.CoreSimulator.SimDeviceType.iPhone-15`) and the product types
+ * physical devices report through devicectl (`iPhone16,1`, `iPad14,3`).
+ * Anything else — Apple TV, Watch, Vision — has no form factor here.
+ */
+export function inferIosFormFactor(
+  deviceTypeId: string | undefined,
+): "phone" | "tablet" | undefined {
+  if (!deviceTypeId) {
+    return undefined;
+  }
+  if (deviceTypeId.includes("iPad")) {
+    return "tablet";
+  }
+  if (deviceTypeId.includes("iPhone")) {
+    return "phone";
+  }
+  return undefined;
+}

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -827,6 +827,19 @@ describe("CaptureSnapshot (iOS)", () => {
     return new CaptureSnapshot(device, undefined, undefined, undefined, store, simctl as any);
   }
 
+  it("rejects a physical iOS device instead of driving simctl against it", async () => {
+    // Physical iOS devices became discoverable/assignable in #5620, but every iOS
+    // capture path routes through SimCtlClient (metadata, settings, app containers),
+    // which only drives Simulators. Reject the physical UDID up front so the caller
+    // gets an actionable error rather than a "captured successfully" over failed simctl.
+    device = { deviceId: "00008030-001C2D3E1234567A", name: "iPhone 15 Pro", platform: "ios" };
+
+    await expect(makeCapture().execute({ snapshotName: "physical" })).rejects.toThrow(
+      /physical iOS device/i,
+    );
+    expect(simctl.getMethodCalls("getDeviceInfo").length).toBe(0);
+  });
+
   it("captures app data and writes metadata", async () => {
     const snapshotName = "ios-snapshot";
     const bundleId = "com.example.app";

--- a/test/features/action/RestoreSnapshot.test.ts
+++ b/test/features/action/RestoreSnapshot.test.ts
@@ -1045,6 +1045,18 @@ describe("RestoreSnapshot (iOS)", () => {
     return new RestoreSnapshot(device, undefined, undefined, undefined, store, simctl as any);
   }
 
+  it("rejects a physical iOS device instead of driving simctl against it", async () => {
+    // iOS restore drives simctl for settings/app-container operations, which only works
+    // on a Simulator. Reject a physical iPhone up front rather than half-applying a
+    // restore over a failing simctl transport (#5620).
+    device = { deviceId: "00008030-001C2D3E1234567A", name: "iPhone 15 Pro", platform: "ios" };
+
+    await expect(makeRestore().execute({ snapshotName: "physical" })).rejects.toThrow(
+      /physical iOS device/i,
+    );
+    expect(simctl.getMethodCalls("launchApp").length).toBe(0);
+  });
+
   it("restores app data using fallback device path", async () => {
     const snapshotName = "restore-snapshot";
     const bundleId = "com.example.app";

--- a/test/features/video/HybridVideoCaptureBackend.test.ts
+++ b/test/features/video/HybridVideoCaptureBackend.test.ts
@@ -130,6 +130,35 @@ describe("HybridVideoCaptureBackend - Unit Tests", function () {
     await expect(backend.start(configWithoutDevice)).rejects.toThrow("Device is required");
   });
 
+  // Physical iOS devices are discoverable now, but the iOS video path is simctl-only.
+  test("start rejects a physical iOS device (simctl recordVideo is simulator-only)", async function () {
+    const physicalConfig: VideoCaptureConfig = {
+      ...baseConfig,
+      device: {
+        platform: "ios",
+        deviceId: "00008030-001C2D3E1234567A", // physical UDID (8-hex + 16-hex)
+      } as BootedDevice,
+    };
+    await expect(backend.start(physicalConfig)).rejects.toThrow(
+      "not supported on physical iOS devices",
+    );
+    expect(ffmpegBackend.startCalls.length).toBe(0);
+    expect(platformBackend.startCalls.length).toBe(0);
+  });
+
+  test("start routes a Simulator iOS device to the ffmpeg backend", async function () {
+    const simulatorConfig: VideoCaptureConfig = {
+      ...baseConfig,
+      device: {
+        platform: "ios",
+        deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890", // simulator UUID
+      } as BootedDevice,
+    };
+    await backend.start(simulatorConfig);
+    expect(ffmpegBackend.startCalls.length).toBe(1);
+    expect(platformBackend.startCalls.length).toBe(0);
+  });
+
   test("stop rejects when the backend handle is missing or not a hybrid handle", async function () {
     await expect(
       backend.stop({

--- a/test/lint/devicectlExecutionBoundary.test.ts
+++ b/test/lint/devicectlExecutionBoundary.test.ts
@@ -129,7 +129,9 @@ describe("devicectl execution boundary (issue #4053)", () => {
       }
       const source = readFileSync(file, "utf8");
       return directlyExecutesDevicectl(source)
-        ? [`${repoPath} directly executes devicectl; route it through ${PRIMARY_OWNER} (or another sanctioned owner) instead.`]
+        ? [
+            `${repoPath} directly executes devicectl; route it through ${PRIMARY_OWNER} (or another sanctioned owner) instead.`,
+          ]
         : [];
     });
 
@@ -165,9 +167,9 @@ describe("devicectl execution boundary (issue #4053)", () => {
       ),
     ).toBe(true);
     // Benign non-devicectl calls through the same seam stay off the offender list.
-    expect(
-      directlyExecutesDevicectl('await this.deps.execute("xcrun", ["simctl", "list"]);'),
-    ).toBe(false);
+    expect(directlyExecutesDevicectl('await this.deps.execute("xcrun", ["simctl", "list"]);')).toBe(
+      false,
+    );
   });
 
   test("detects Bun.spawn devicectl launches", () => {

--- a/test/lint/devicectlExecutionBoundary.test.ts
+++ b/test/lint/devicectlExecutionBoundary.test.ts
@@ -4,11 +4,20 @@ import { join, relative } from "node:path";
 import { executionBoundaryAst } from "../../scripts/lib/executionBoundaryAst";
 
 const ROOT = join(import.meta.dir, "..", "..");
-const OWNER = "src/utils/ios-cmdline-tools/DeviceAppManager.ts";
+// Files sanctioned to execute `xcrun devicectl` directly. Each is a distinct,
+// coherent devicectl domain kept deliberately narrow (issue #4053):
+//   - DeviceAppManager: app lifecycle (launch/terminate/info apps).
+//   - DevicectlDeviceLister: physical-device discovery (`devicectl list devices`, #5620).
+// Any OTHER file that reaches devicectl directly must route through one of these.
+const OWNERS = [
+  "src/utils/ios-cmdline-tools/DeviceAppManager.ts",
+  "src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts",
+];
+const PRIMARY_OWNER = OWNERS[0];
 
 /**
  * True when `source` hands `devicectl` to a subprocess directly — i.e. a
- * production call that bypasses the single {@link OWNER} boundary. Two shapes
+ * production call that bypasses the sanctioned {@link OWNERS} boundary. Two shapes
  * are caught:
  *
  * 1. A launcher primitive (exec/execFile/spawn family, promisified or not, plus
@@ -20,7 +29,7 @@ const OWNER = "src/utils/ios-cmdline-tools/DeviceAppManager.ts";
  *    Requiring the `xcrun` literal keeps benign `executeCommand("adb", ...)` /
  *    `executeCommand("xcrun", ["simctl", ...])` calls off the offender list.
  *
- * DeviceAppManager itself is excluded as the owner. Elsewhere, an injected
+ * The sanctioned owners are excluded. Elsewhere, an injected
  * `execute(file, args)` seam is treated as a launch boundary too, so a refactor
  * cannot hide a literal xcrun/devicectl call behind that indirection.
  */
@@ -109,18 +118,18 @@ function sourceFiles(directory: string): string[] {
 }
 
 describe("devicectl execution boundary (issue #4053)", () => {
-  test("only DeviceAppManager directly executes xcrun devicectl", () => {
+  test("only sanctioned owners directly execute xcrun devicectl", () => {
     const exceptions = new Map<string, string>([
       // Diagnostic-only references are allowed only with a concrete reason here.
     ]);
     const offenders = sourceFiles(join(ROOT, "src")).flatMap((file) => {
       const repoPath = relative(ROOT, file).replace(/\\/g, "/");
-      if (repoPath === OWNER || exceptions.has(repoPath)) {
+      if (OWNERS.includes(repoPath) || exceptions.has(repoPath)) {
         return [];
       }
       const source = readFileSync(file, "utf8");
       return directlyExecutesDevicectl(source)
-        ? [`${repoPath} directly executes devicectl; route it through ${OWNER} instead.`]
+        ? [`${repoPath} directly executes devicectl; route it through ${PRIMARY_OWNER} (or another sanctioned owner) instead.`]
         : [];
     });
 
@@ -145,6 +154,20 @@ describe("devicectl execution boundary (issue #4053)", () => {
     expect(
       directlyExecutesDevicectl('execFile("xcrun" as const, ["devicectl", "device", "list"]);'),
     ).toBe(true);
+  });
+
+  test("detects the injected this.deps.execute devicectl seam", () => {
+    // DevicectlDeviceLister runs devicectl through a `this.deps.execute(file, args)` seam;
+    // the boundary must recognize it so a stray call via that indirection cannot hide.
+    expect(
+      directlyExecutesDevicectl(
+        'await this.deps.execute("xcrun", ["devicectl", "list", "devices"], { timeoutMs: 5000 });',
+      ),
+    ).toBe(true);
+    // Benign non-devicectl calls through the same seam stay off the offender list.
+    expect(
+      directlyExecutesDevicectl('await this.deps.execute("xcrun", ["simctl", "list"]);'),
+    ).toBe(false);
   });
 
   test("detects Bun.spawn devicectl launches", () => {

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -42,6 +42,7 @@ describe("MultiPlatformDeviceManager", () => {
     function makeManager(options: {
       simulators?: BootedDevice[] | Error;
       physical?: BootedDevice[] | Error;
+      physicalComplete?: boolean;
     }): MultiPlatformDeviceManager {
       const resolve = <T>(value: T | Error): Promise<T> =>
         value instanceof Error ? Promise.reject(value) : Promise.resolve(value);
@@ -51,7 +52,10 @@ describe("MultiPlatformDeviceManager", () => {
         getBootedSimulatorsChecked: () => resolve(options.simulators ?? []),
       } as unknown as SimCtlClient;
       const fakeLister: IosPhysicalDeviceLister = {
-        listConnectedDevices: () => resolve(options.physical ?? []),
+        listConnectedDevices: async () => ({
+          devices: await resolve(options.physical ?? []),
+          complete: options.physicalComplete ?? true,
+        }),
       };
 
       return new MultiPlatformDeviceManager(
@@ -125,6 +129,62 @@ describe("MultiPlatformDeviceManager", () => {
         expect(discovery.devices).toEqual([physicalDevice]);
         expect(discovery.succeededPlatforms.has("ios")).toBe(false);
         expect(discovery.discoveryErrors.ios?.code).toBe("failed");
+      });
+    });
+
+    test("an incomplete physical sweep keeps iOS out of succeededPlatforms", async () => {
+      await withProcessPlatform("darwin", async () => {
+        // A devicectl blip must not let the disconnect monitor prune a
+        // still-connected iPhone just because simctl answered.
+        const manager = makeManager({
+          simulators: [simulator],
+          physical: [],
+          physicalComplete: false,
+        });
+
+        const discovery = await manager.getBootedDevicesDetailed("ios");
+
+        expect(discovery.devices).toEqual([simulator]);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+        expect(discovery.discoveryErrors.ios?.code).toBe("failed");
+      });
+    });
+
+    test("a lister that throws is reported as an incomplete sweep, not an empty one", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({
+          simulators: [simulator],
+          physical: new Error("lister broke its non-throwing contract"),
+        });
+
+        const discovery = await manager.getBootedDevicesDetailed("ios");
+
+        expect(discovery.devices).toEqual([simulator]);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+      });
+    });
+
+    test("waitForDeviceReady adopts a connected physical device without simctl", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const fakeSimctl = {
+          isAvailable: async () => true,
+          waitForSimulatorReady: async () => {
+            throw new Error("simctl bootstatus must not run for a physical UDID");
+          },
+        } as unknown as SimCtlClient;
+        const manager = new MultiPlatformDeviceManager(
+          new FakeAdbClient() as unknown as AdbClient,
+          fakeSimctl,
+          {} as unknown as AndroidEmulatorClient,
+        );
+
+        await expect(
+          manager.waitForDeviceReady({
+            name: physicalDevice.name,
+            platform: "ios",
+            deviceId: physicalDevice.deviceId,
+          } as DeviceInfo),
+        ).resolves.toEqual(physicalDevice);
       });
     });
 

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -128,7 +128,7 @@ describe("MultiPlatformDeviceManager", () => {
 
         expect(discovery.devices).toEqual([physicalDevice]);
         expect(discovery.succeededPlatforms.has("ios")).toBe(false);
-        expect(discovery.discoveryErrors.ios?.code).toBe("failed");
+        expect(discovery.discoveryErrors?.ios?.code).toBe("failed");
       });
     });
 

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -8,6 +8,7 @@ import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tool
 import { runWithAbortSignal } from "../../src/utils/AbortContext";
 import type { VirtualDeviceLifecycleCoordinator } from "../../src/utils/virtualDeviceLifecycleCoordinator";
 import { FakeTimer } from "../fakes/FakeTimer";
+import type { IosPhysicalDeviceLister } from "../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
 
 async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
   const original = process.platform;
@@ -26,6 +27,135 @@ async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promi
 }
 
 describe("MultiPlatformDeviceManager", () => {
+  describe("physical iOS device discovery (#5620)", () => {
+    const physicalDevice: BootedDevice = {
+      name: "Jason's iPhone",
+      platform: "ios",
+      deviceId: "00008120-001C2D3E1234567A",
+    };
+    const simulator: BootedDevice = {
+      name: "iPhone 16",
+      platform: "ios",
+      deviceId: "1B2C3D4E-5F60-4718-8293-A1B2C3D4E5F6",
+    };
+
+    function makeManager(options: {
+      simulators?: BootedDevice[] | Error;
+      physical?: BootedDevice[] | Error;
+    }): MultiPlatformDeviceManager {
+      const resolve = <T>(value: T | Error): Promise<T> =>
+        value instanceof Error ? Promise.reject(value) : Promise.resolve(value);
+      const fakeSimctl = {
+        isAvailable: async () => true,
+        getBootedSimulators: () => resolve(options.simulators ?? []),
+        getBootedSimulatorsChecked: () => resolve(options.simulators ?? []),
+      } as unknown as SimCtlClient;
+      const fakeLister: IosPhysicalDeviceLister = {
+        listConnectedDevices: () => resolve(options.physical ?? []),
+      };
+
+      return new MultiPlatformDeviceManager(
+        new FakeAdbClient() as unknown as AdbClient,
+        fakeSimctl,
+        { getBootedDevices: async () => [] } as unknown as AndroidEmulatorClient,
+        undefined,
+        undefined,
+        fakeLister,
+      );
+    }
+
+    test("a simulator-only host still lists only its simulators", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({ simulators: [simulator], physical: [] });
+
+        expect(await manager.getBootedDevices("ios")).toEqual([simulator]);
+      });
+    });
+
+    test("a physical-only host resolves the physical device as a booted iOS device", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({ simulators: [], physical: [physicalDevice] });
+
+        const devices = await manager.getBootedDevices("ios");
+
+        expect(devices).toEqual([physicalDevice]);
+        expect(devices[0].platform).toBe("ios");
+      });
+    });
+
+    test("a host with both reports simulators and physical devices together", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({ simulators: [simulator], physical: [physicalDevice] });
+
+        expect(await manager.getBootedDevices("ios")).toEqual([simulator, physicalDevice]);
+      });
+    });
+
+    test("a host where devicectl is unavailable degrades instead of throwing", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({
+          simulators: [simulator],
+          physical: new Error('xcrun: error: unable to find utility "devicectl"'),
+        });
+
+        expect(await manager.getBootedDevices("ios")).toEqual([simulator]);
+      });
+    });
+
+    test("getBootedDevicesDetailed includes physical devices and still succeeds", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({ simulators: [simulator], physical: [physicalDevice] });
+
+        const discovery = await manager.getBootedDevicesDetailed("ios");
+
+        expect(discovery.devices).toEqual([simulator, physicalDevice]);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(true);
+      });
+    });
+
+    test("a simulator discovery failure still surfaces connected physical devices", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const manager = makeManager({
+          simulators: new Error("simctl exploded"),
+          physical: [physicalDevice],
+        });
+
+        const discovery = await manager.getBootedDevicesDetailed("ios");
+
+        expect(discovery.devices).toEqual([physicalDevice]);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+        expect(discovery.discoveryErrors.ios?.code).toBe("failed");
+      });
+    });
+
+    test("physical discovery is not attempted when iOS tooling is unavailable", async () => {
+      await withProcessPlatform("linux", async () => {
+        let listerCalls = 0;
+        const fakeSimctl = {
+          isAvailable: async () => false,
+          getBootedSimulators: async () => [],
+          getBootedSimulatorsChecked: async () => [],
+        } as unknown as SimCtlClient;
+        const manager = new MultiPlatformDeviceManager(
+          new FakeAdbClient() as unknown as AdbClient,
+          fakeSimctl,
+          { getBootedDevices: async () => [] } as unknown as AndroidEmulatorClient,
+          undefined,
+          undefined,
+          {
+            listConnectedDevices: async () => {
+              listerCalls++;
+              return [physicalDevice];
+            },
+          },
+        );
+
+        expect(await manager.getBootedDevices("ios")).toEqual([]);
+        expect(listerCalls).toBe(0);
+      });
+    });
+  });
+
   test("forwards ambient cancellation to Android detailed discovery", async () => {
     const controller = new AbortController();
     let receivedSignal: AbortSignal | undefined;

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -188,6 +188,25 @@ describe("MultiPlatformDeviceManager", () => {
       });
     });
 
+    test("killDevice refuses a physical UDID instead of shelling out to simctl", async () => {
+      await withProcessPlatform("darwin", async () => {
+        const fakeSimctl = {
+          killSimulator: async () => {
+            throw new Error("simctl shutdown must not run for a physical UDID");
+          },
+        } as unknown as SimCtlClient;
+        const manager = new MultiPlatformDeviceManager(
+          new FakeAdbClient() as unknown as AdbClient,
+          fakeSimctl,
+          {} as unknown as AndroidEmulatorClient,
+        );
+
+        await expect(manager.killDevice(physicalDevice)).rejects.toThrow(
+          /Cannot shut down physical iOS device/,
+        );
+      });
+    });
+
     test("physical discovery is not attempted when iOS tooling is unavailable", async () => {
       await withProcessPlatform("linux", async () => {
         let listerCalls = 0;

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -132,25 +132,25 @@ describe("MultiPlatformDeviceManager", () => {
       });
     });
 
-    test("an incomplete physical sweep keeps iOS out of succeededPlatforms", async () => {
+    test("an incomplete physical sweep still leaves simulators authoritative", async () => {
       await withProcessPlatform("darwin", async () => {
-        // A devicectl blip must not let the disconnect monitor prune a
-        // still-connected iPhone just because simctl answered.
+        // `succeededPlatforms` has no room for "simulators yes, physical no", and
+        // clearing it on a devicectl blip would make every idle simulator
+        // unassignable. The lister retains last-known physical devices instead.
         const manager = makeManager({
           simulators: [simulator],
-          physical: [],
+          physical: [physicalDevice],
           physicalComplete: false,
         });
 
         const discovery = await manager.getBootedDevicesDetailed("ios");
 
-        expect(discovery.devices).toEqual([simulator]);
-        expect(discovery.succeededPlatforms.has("ios")).toBe(false);
-        expect(discovery.discoveryErrors.ios?.code).toBe("failed");
+        expect(discovery.devices).toEqual([simulator, physicalDevice]);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(true);
       });
     });
 
-    test("a lister that throws is reported as an incomplete sweep, not an empty one", async () => {
+    test("a lister that throws does not take simulator discovery down", async () => {
       await withProcessPlatform("darwin", async () => {
         const manager = makeManager({
           simulators: [simulator],
@@ -160,7 +160,7 @@ describe("MultiPlatformDeviceManager", () => {
         const discovery = await manager.getBootedDevicesDetailed("ios");
 
         expect(discovery.devices).toEqual([simulator]);
-        expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+        expect(discovery.succeededPlatforms.has("ios")).toBe(true);
       });
     });
 

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -142,7 +142,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("rejects records whose udid is not a physical iOS udid", () => {
-    const { devices } = parseDevicectlDeviceList(
+    const discovery = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({ hardwareProperties: { udid: SIMULATOR_UDID } }),
         connectedIphone({ hardwareProperties: { udid: "emulator-5554" } }),
@@ -151,7 +151,11 @@ describe("parseDevicectlDeviceList", () => {
       ]),
     );
 
-    expect(devices).toEqual([]);
+    expect(discovery.devices).toEqual([]);
+    // None of these are records this lister understands and skips — devicectl
+    // reports physical hardware, so each is unreadable rather than filtered, and
+    // the listing must not claim to be authoritative.
+    expect(discovery.complete).toBe(false);
   });
 
   test("falls back through name sources when deviceProperties has no name", () => {
@@ -182,6 +186,56 @@ describe("parseDevicectlDeviceList", () => {
     expect(
       parseDevicectlDeviceList({ info: { outcome: "failure" }, result: { devices: [] } }),
     ).toEqual({ devices: [], complete: false });
+  });
+
+  test("an iOS record it cannot identify makes the listing incomplete", () => {
+    // devicectl enumerates CoreDevices — physical hardware — so a reachable iOS
+    // record that yields no physical UDID is schema drift, not a device we meant
+    // to filter. Reporting the survivors as an authoritative listing is what lets
+    // the disconnect monitor count misses against a phone that never moved.
+    expect(
+      parseDevicectlDeviceList(
+        devicectlPayload([connectedIphone({ hardwareProperties: { platform: "iOS" } })]),
+      ),
+    ).toEqual({ devices: [], complete: false });
+
+    expect(
+      parseDevicectlDeviceList(
+        devicectlPayload([connectedIphone({ hardwareProperties: { udid: 42, platform: "iOS" } })]),
+      ),
+    ).toEqual({ devices: [], complete: false });
+
+    expect(parseDevicectlDeviceList(devicectlPayload(["not-an-object"]))).toEqual({
+      devices: [],
+      complete: false,
+    });
+  });
+
+  test("a healthy device alongside an unidentifiable one is still reported", () => {
+    // Incompleteness must not swallow the devices the sweep did resolve: the
+    // daemon needs the iPhone it found AND the signal that the list is partial.
+    const discovery = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone(),
+        connectedIphone({ hardwareProperties: { platform: "iOS" } }),
+      ]),
+    );
+
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.complete).toBe(false);
+  });
+
+  test("records it deliberately filters keep the listing authoritative", () => {
+    // A paired Watch and an unreachable phone are understood, not drifted: the
+    // sweep still knows exactly which physical iOS devices are attached.
+    expect(
+      parseDevicectlDeviceList(
+        devicectlPayload([
+          connectedIphone({ hardwareProperties: { udid: PHYSICAL_UDID, platform: "watchOS" } }),
+          connectedIphone({ connectionProperties: { tunnelState: "unavailable" } }),
+        ]),
+      ),
+    ).toEqual({ devices: [], complete: true });
   });
 
   test("a recognized empty listing is authoritative", () => {
@@ -261,6 +315,52 @@ describe("DevicectlDeviceLister", () => {
     // the first caller's cancellation; the timeout is what bounds it.
     expect(options?.timeoutMs).toBe(15_000);
     expect(options?.signal).toBeUndefined();
+  });
+
+  test("a partially unreadable sweep still surfaces the devices it did resolve", async () => {
+    // The sweep is non-authoritative because one entry drifted, but the iPhone it
+    // *did* resolve is real. Falling back to last-known would report nothing at
+    // all on a cold start, hiding hardware that is plugged in right now.
+    const lister = makeLister({
+      readFile: async () =>
+        JSON.stringify(
+          devicectlPayload([
+            connectedIphone(),
+            connectedIphone({ hardwareProperties: { platform: "iOS" } }),
+          ]),
+        ),
+    });
+
+    const discovery = await lister.listConnectedDevices();
+
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.complete).toBe(false);
+  });
+
+  test("a partial sweep unions its devices with the ones it retained", async () => {
+    // The drifted entry may well be the second phone: retention and this sweep
+    // are both partial views, so neither may evict the other's device.
+    const timer = new FakeTimer();
+    let payload = devicectlPayload([
+      connectedIphone({ hardwareProperties: { udid: LEGACY_UDID } }),
+    ]);
+    const lister = makeLister({ timer, readFile: async () => JSON.stringify(payload) });
+
+    expect((await lister.listConnectedDevices()).devices.map((d) => d.deviceId)).toEqual([
+      LEGACY_UDID,
+    ]);
+
+    payload = devicectlPayload([
+      connectedIphone(),
+      connectedIphone({ hardwareProperties: { platform: "iOS" } }),
+    ]);
+    timer.advanceTime(DEVICE_LIST_CACHE_TTL_MS);
+    const partial = await lister.listConnectedDevices();
+
+    expect(partial.devices.map((device) => device.deviceId).sort()).toEqual(
+      [LEGACY_UDID, PHYSICAL_UDID].sort(),
+    );
+    expect(partial.complete).toBe(false);
   });
 
   test("retains the last good listing across a failing sweep, then lets it go stale", async () => {

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
 import type { ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { join } from "path";
 
 const PHYSICAL_UDID = "00008120-001C2D3E1234567A";
 const LEGACY_UDID = "a".repeat(40);
@@ -28,6 +29,11 @@ function connectedIphone(overrides: Record<string, unknown> = {}): Record<string
     ...overrides,
   };
 }
+
+// Built with `join` rather than literal "/" so the assertions hold on Windows,
+// where the production code's `join(tmpdir(), ...)` yields backslashes.
+const TEMP_DIR = join("/tmp", "automobile-devicectl-devices-abc123");
+const JSON_PATH = join(TEMP_DIR, "devices.json");
 
 const okExec: ExecResult = { stdout: "", stderr: "", toString: () => "" } as ExecResult;
 
@@ -162,7 +168,7 @@ describe("DevicectlDeviceLister", () => {
         return okExec;
       },
       readFile: async (path: string) => {
-        expect(path).toBe("/tmp/automobile-devicectl-devices-abc123/devices.json");
+        expect(path).toBe(JSON_PATH);
         return JSON.stringify(devicectlPayload([connectedIphone()]));
       },
     });
@@ -171,7 +177,7 @@ describe("DevicectlDeviceLister", () => {
 
     expect(devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
     expect(args.slice(0, 3)).toEqual(["devicectl", "list", "devices"]);
-    expect(args).toContain("/tmp/automobile-devicectl-devices-abc123/devices.json");
+    expect(args).toContain(JSON_PATH);
   });
 
   test("degrades to an empty list when devicectl is unavailable", async () => {
@@ -210,10 +216,7 @@ describe("DevicectlDeviceLister", () => {
     await succeeding.listConnectedDevices();
     await failing.listConnectedDevices();
 
-    expect(removed).toEqual([
-      "/tmp/automobile-devicectl-devices-abc123",
-      "/tmp/automobile-devicectl-devices-abc123",
-    ]);
+    expect(removed).toEqual([TEMP_DIR, TEMP_DIR]);
   });
 
   test("reuses a listing within the cache window and re-shells out after it", async () => {

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -36,6 +36,8 @@ function connectedIphone(overrides: Record<string, unknown> = {}): Record<string
 const TEMP_DIR = join("/tmp", "automobile-devicectl-devices-abc123");
 const JSON_PATH = join(TEMP_DIR, "devices.json");
 
+const DEVICE_LIST_CACHE_TTL_MS = 3_000;
+
 const okExec: ExecResult = { stdout: "", stderr: "", toString: () => "" } as ExecResult;
 
 function makeLister(overrides: Record<string, unknown>): DevicectlDeviceLister {
@@ -53,7 +55,7 @@ function makeLister(overrides: Record<string, unknown>): DevicectlDeviceLister {
 
 describe("parseDevicectlDeviceList", () => {
   test("maps a connected physical device to a BootedDevice", () => {
-    expect(parseDevicectlDeviceList(devicectlPayload([connectedIphone()]))).toEqual([
+    expect(parseDevicectlDeviceList(devicectlPayload([connectedIphone()])).devices).toEqual([
       {
         name: "Jason's iPhone",
         platform: "ios",
@@ -66,7 +68,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("infers the tablet form factor from an iPad product type", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({
           deviceProperties: { name: "Test iPad" },
@@ -81,7 +83,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("drops devices devicectl reports as unreachable", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({ connectionProperties: { tunnelState: "unavailable" } }),
         connectedIphone({
@@ -95,7 +97,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("keeps devices whose tunnel state is missing or unrecognized", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({ connectionProperties: {} }),
         connectedIphone({
@@ -110,7 +112,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("rejects connected non-iOS CoreDevices (Watch, TV, Vision)", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({
           hardwareProperties: { udid: LEGACY_UDID, platform: "watchOS", productType: "Watch7,1" },
@@ -125,7 +127,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("keeps iPadOS records and records that omit the platform field", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({
           hardwareProperties: { udid: LEGACY_UDID, platform: "iPadOS", productType: "iPad14,3" },
@@ -140,7 +142,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("rejects records whose udid is not a physical iOS udid", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({ hardwareProperties: { udid: SIMULATOR_UDID } }),
         connectedIphone({ hardwareProperties: { udid: "emulator-5554" } }),
@@ -153,7 +155,7 @@ describe("parseDevicectlDeviceList", () => {
   });
 
   test("falls back through name sources when deviceProperties has no name", () => {
-    const devices = parseDevicectlDeviceList(
+    const { devices } = parseDevicectlDeviceList(
       devicectlPayload([
         connectedIphone({ deviceProperties: {} }),
         connectedIphone({
@@ -168,11 +170,23 @@ describe("parseDevicectlDeviceList", () => {
     );
   });
 
-  test("returns an empty list for payload shapes it does not understand", () => {
-    expect(parseDevicectlDeviceList(null)).toEqual([]);
-    expect(parseDevicectlDeviceList({ result: {} })).toEqual([]);
-    expect(parseDevicectlDeviceList({ result: { devices: "nope" } })).toEqual([]);
-    expect(parseDevicectlDeviceList([connectedIphone()])).toHaveLength(1);
+  test("marks payload shapes it does not understand as incomplete, not empty", () => {
+    // An unrecognized envelope reported as an authoritative empty list is what
+    // would let the disconnect monitor drop a still-connected iPhone.
+    expect(parseDevicectlDeviceList(null)).toEqual({ devices: [], complete: false });
+    expect(parseDevicectlDeviceList({ result: {} })).toEqual({ devices: [], complete: false });
+    expect(parseDevicectlDeviceList({ result: { devices: "nope" } })).toEqual({
+      devices: [],
+      complete: false,
+    });
+    expect(
+      parseDevicectlDeviceList({ info: { outcome: "failure" }, result: { devices: [] } }),
+    ).toEqual({ devices: [], complete: false });
+  });
+
+  test("a recognized empty listing is authoritative", () => {
+    expect(parseDevicectlDeviceList(devicectlPayload([]))).toEqual({ devices: [], complete: true });
+    expect(parseDevicectlDeviceList([connectedIphone()]).devices).toHaveLength(1);
   });
 });
 
@@ -230,7 +244,7 @@ describe("DevicectlDeviceLister", () => {
     expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
   });
 
-  test("bounds the devicectl invocation and forwards the ambient abort signal", async () => {
+  test("bounds the devicectl invocation without binding it to one caller's abort", async () => {
     let options: { timeoutMs?: number; signal?: AbortSignal } | undefined;
     const controller = new AbortController();
     const lister = makeLister({
@@ -243,8 +257,43 @@ describe("DevicectlDeviceLister", () => {
 
     await runWithAbortSignal(controller.signal, () => lister.listConnectedDevices());
 
+    // The listing is shared between concurrent callers, so it must not inherit
+    // the first caller's cancellation; the timeout is what bounds it.
     expect(options?.timeoutMs).toBe(15_000);
-    expect(options?.signal).toBe(controller.signal);
+    expect(options?.signal).toBeUndefined();
+  });
+
+  test("retains the last good listing across a failing sweep, then lets it go stale", async () => {
+    const timer = new FakeTimer();
+    let shouldFail = false;
+    const lister = makeLister({
+      timer,
+      execute: async () => {
+        if (shouldFail) {
+          throw new Error("devicectl blipped");
+        }
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    expect((await lister.listConnectedDevices()).devices).toHaveLength(1);
+
+    shouldFail = true;
+    timer.advanceTime(DEVICE_LIST_CACHE_TTL_MS);
+    const blipped = await lister.listConnectedDevices();
+
+    // The iPhone did not go anywhere, so it stays in the discovered list; the
+    // sweep is still flagged non-authoritative.
+    expect(blipped.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(blipped.complete).toBe(false);
+
+    timer.advanceTime(60_000);
+    const stale = await lister.listConnectedDevices();
+
+    // A permanently broken devicectl must eventually stop asserting hardware
+    // that may well have been unplugged.
+    expect(stale).toEqual({ devices: [], complete: false });
   });
 
   test("removes its temp directory on both success and failure", async () => {

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
 import type { ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 import { join } from "path";
 
 const PHYSICAL_UDID = "00008120-001C2D3E1234567A";
@@ -108,6 +109,36 @@ describe("parseDevicectlDeviceList", () => {
     expect(devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID, LEGACY_UDID].sort());
   });
 
+  test("rejects connected non-iOS CoreDevices (Watch, TV, Vision)", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({
+          hardwareProperties: { udid: LEGACY_UDID, platform: "watchOS", productType: "Watch7,1" },
+        }),
+        connectedIphone({
+          hardwareProperties: { udid: PHYSICAL_UDID, platform: "xrOS" },
+        }),
+      ]),
+    );
+
+    expect(devices).toEqual([]);
+  });
+
+  test("keeps iPadOS records and records that omit the platform field", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({
+          hardwareProperties: { udid: LEGACY_UDID, platform: "iPadOS", productType: "iPad14,3" },
+        }),
+        connectedIphone({ hardwareProperties: { udid: PHYSICAL_UDID } }),
+      ]),
+    );
+
+    expect(devices.map((device) => device.deviceId).sort()).toEqual(
+      [LEGACY_UDID, PHYSICAL_UDID].sort(),
+    );
+  });
+
   test("rejects records whose udid is not a physical iOS udid", () => {
     const devices = parseDevicectlDeviceList(
       devicectlPayload([
@@ -156,7 +187,7 @@ describe("DevicectlDeviceLister", () => {
       },
     });
 
-    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: true });
     expect(executed).toBe(0);
   });
 
@@ -173,27 +204,47 @@ describe("DevicectlDeviceLister", () => {
       },
     });
 
-    const devices = await lister.listConnectedDevices();
+    const discovery = await lister.listConnectedDevices();
 
-    expect(devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.complete).toBe(true);
     expect(args.slice(0, 3)).toEqual(["devicectl", "list", "devices"]);
     expect(args).toContain(JSON_PATH);
   });
 
-  test("degrades to an empty list when devicectl is unavailable", async () => {
+  test("degrades to an incomplete empty list when devicectl is unavailable", async () => {
     const lister = makeLister({
       execute: async () => {
         throw new Error('xcrun: error: unable to find utility "devicectl"');
       },
     });
 
-    expect(await lister.listConnectedDevices()).toEqual([]);
+    // `complete: false` is what stops the daemon reading this as "the iPhone
+    // disconnected" and pruning a device that is still plugged in.
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
   });
 
-  test("degrades to an empty list when the JSON output is unreadable", async () => {
+  test("degrades to an incomplete empty list when the JSON output is unreadable", async () => {
     const lister = makeLister({ readFile: async () => "{not json" });
 
-    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
+  });
+
+  test("bounds the devicectl invocation and forwards the ambient abort signal", async () => {
+    let options: { timeoutMs?: number; signal?: AbortSignal } | undefined;
+    const controller = new AbortController();
+    const lister = makeLister({
+      execute: async (_file: string, _args: string[], execOptions: typeof options) => {
+        options = execOptions;
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([])),
+    });
+
+    await runWithAbortSignal(controller.signal, () => lister.listConnectedDevices());
+
+    expect(options?.timeoutMs).toBe(15_000);
+    expect(options?.signal).toBe(controller.signal);
   });
 
   test("removes its temp directory on both success and failure", async () => {
@@ -240,7 +291,7 @@ describe("DevicectlDeviceLister", () => {
     expect(executions).toBe(1);
 
     timer.advanceTime(2);
-    expect((await lister.listConnectedDevices()).map((device) => device.deviceId)).toEqual([
+    expect((await lister.listConnectedDevices()).devices.map((device) => device.deviceId)).toEqual([
       PHYSICAL_UDID,
     ]);
     expect(executions).toBe(2);
@@ -255,8 +306,8 @@ describe("DevicectlDeviceLister", () => {
       },
     });
 
-    expect(await lister.listConnectedDevices()).toEqual([]);
-    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
     expect(executions).toBe(1);
   });
 
@@ -287,7 +338,7 @@ describe("DevicectlDeviceLister", () => {
       readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
     });
 
-    expect((await lister.listConnectedDevices()).map((device) => device.deviceId)).toEqual([
+    expect((await lister.listConnectedDevices()).devices.map((device) => device.deviceId)).toEqual([
       PHYSICAL_UDID,
     ]);
   });

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DevicectlDeviceLister,
+  parseDevicectlDeviceList,
+} from "../../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
+import type { ExecResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const PHYSICAL_UDID = "00008120-001C2D3E1234567A";
+const LEGACY_UDID = "a".repeat(40);
+const SIMULATOR_UDID = "1B2C3D4E-5F60-4718-8293-A1B2C3D4E5F6";
+
+function devicectlPayload(devices: unknown[]): unknown {
+  return { info: { outcome: "success" }, result: { devices } };
+}
+
+function connectedIphone(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    identifier: "8FB0A5A4-0000-0000-0000-000000000000",
+    deviceProperties: { name: "Jason's iPhone", osVersionNumber: "18.6" },
+    hardwareProperties: {
+      udid: PHYSICAL_UDID,
+      platform: "iOS",
+      productType: "iPhone16,1",
+      marketingName: "iPhone 15 Pro",
+    },
+    connectionProperties: { tunnelState: "connected", pairingState: "paired" },
+    ...overrides,
+  };
+}
+
+const okExec: ExecResult = { stdout: "", stderr: "", toString: () => "" } as ExecResult;
+
+function makeLister(overrides: Record<string, unknown>): DevicectlDeviceLister {
+  return new DevicectlDeviceLister({
+    platform: () => "darwin",
+    tmpdir: () => "/tmp",
+    mkdtemp: async (prefix) => `${prefix}abc123`,
+    rm: async () => {},
+    execute: async () => okExec,
+    logger: { debug: () => {}, warn: () => {} },
+    timer: new FakeTimer(),
+    ...overrides,
+  } as ConstructorParameters<typeof DevicectlDeviceLister>[0]);
+}
+
+describe("parseDevicectlDeviceList", () => {
+  test("maps a connected physical device to a BootedDevice", () => {
+    expect(parseDevicectlDeviceList(devicectlPayload([connectedIphone()]))).toEqual([
+      {
+        name: "Jason's iPhone",
+        platform: "ios",
+        deviceId: PHYSICAL_UDID,
+        iosVersion: "18.6",
+        osVersion: "18.6",
+        formFactor: "phone",
+      },
+    ]);
+  });
+
+  test("infers the tablet form factor from an iPad product type", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({
+          deviceProperties: { name: "Test iPad" },
+          hardwareProperties: { udid: LEGACY_UDID, productType: "iPad14,3" },
+        }),
+      ]),
+    );
+
+    expect(devices).toEqual([
+      { name: "Test iPad", platform: "ios", deviceId: LEGACY_UDID, formFactor: "tablet" },
+    ]);
+  });
+
+  test("drops devices devicectl reports as unreachable", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({ connectionProperties: { tunnelState: "unavailable" } }),
+        connectedIphone({
+          hardwareProperties: { udid: LEGACY_UDID },
+          connectionProperties: { tunnelState: "disconnected" },
+        }),
+      ]),
+    );
+
+    expect(devices).toEqual([]);
+  });
+
+  test("keeps devices whose tunnel state is missing or unrecognized", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({ connectionProperties: {} }),
+        connectedIphone({
+          deviceProperties: { name: "Second" },
+          hardwareProperties: { udid: LEGACY_UDID },
+          connectionProperties: { tunnelState: "someFutureState" },
+        }),
+      ]),
+    );
+
+    expect(devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID, LEGACY_UDID].sort());
+  });
+
+  test("rejects records whose udid is not a physical iOS udid", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({ hardwareProperties: { udid: SIMULATOR_UDID } }),
+        connectedIphone({ hardwareProperties: { udid: "emulator-5554" } }),
+        connectedIphone({ hardwareProperties: {} }),
+        "not-an-object",
+      ]),
+    );
+
+    expect(devices).toEqual([]);
+  });
+
+  test("falls back through name sources when deviceProperties has no name", () => {
+    const devices = parseDevicectlDeviceList(
+      devicectlPayload([
+        connectedIphone({ deviceProperties: {} }),
+        connectedIphone({
+          deviceProperties: {},
+          hardwareProperties: { udid: LEGACY_UDID },
+        }),
+      ]),
+    );
+
+    expect(devices.map((device) => device.name).sort()).toEqual(
+      [LEGACY_UDID, "iPhone 15 Pro"].sort(),
+    );
+  });
+
+  test("returns an empty list for payload shapes it does not understand", () => {
+    expect(parseDevicectlDeviceList(null)).toEqual([]);
+    expect(parseDevicectlDeviceList({ result: {} })).toEqual([]);
+    expect(parseDevicectlDeviceList({ result: { devices: "nope" } })).toEqual([]);
+    expect(parseDevicectlDeviceList([connectedIphone()])).toHaveLength(1);
+  });
+});
+
+describe("DevicectlDeviceLister", () => {
+  test("does not invoke devicectl off macOS", async () => {
+    let executed = 0;
+    const lister = makeLister({
+      platform: () => "linux",
+      execute: async () => {
+        executed++;
+        return okExec;
+      },
+    });
+
+    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(executed).toBe(0);
+  });
+
+  test("reads the devicectl JSON output it asked for", async () => {
+    let args: string[] = [];
+    const lister = makeLister({
+      execute: async (_file: string, execArgs: string[]) => {
+        args = execArgs;
+        return okExec;
+      },
+      readFile: async (path: string) => {
+        expect(path).toBe("/tmp/automobile-devicectl-devices-abc123/devices.json");
+        return JSON.stringify(devicectlPayload([connectedIphone()]));
+      },
+    });
+
+    const devices = await lister.listConnectedDevices();
+
+    expect(devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(args.slice(0, 3)).toEqual(["devicectl", "list", "devices"]);
+    expect(args).toContain("/tmp/automobile-devicectl-devices-abc123/devices.json");
+  });
+
+  test("degrades to an empty list when devicectl is unavailable", async () => {
+    const lister = makeLister({
+      execute: async () => {
+        throw new Error('xcrun: error: unable to find utility "devicectl"');
+      },
+    });
+
+    expect(await lister.listConnectedDevices()).toEqual([]);
+  });
+
+  test("degrades to an empty list when the JSON output is unreadable", async () => {
+    const lister = makeLister({ readFile: async () => "{not json" });
+
+    expect(await lister.listConnectedDevices()).toEqual([]);
+  });
+
+  test("removes its temp directory on both success and failure", async () => {
+    const removed: string[] = [];
+    const succeeding = makeLister({
+      rm: async (path: string) => {
+        removed.push(path);
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([])),
+    });
+    const failing = makeLister({
+      rm: async (path: string) => {
+        removed.push(path);
+      },
+      execute: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await succeeding.listConnectedDevices();
+    await failing.listConnectedDevices();
+
+    expect(removed).toEqual([
+      "/tmp/automobile-devicectl-devices-abc123",
+      "/tmp/automobile-devicectl-devices-abc123",
+    ]);
+  });
+
+  test("reuses a listing within the cache window and re-shells out after it", async () => {
+    const timer = new FakeTimer();
+    let executions = 0;
+    const lister = makeLister({
+      timer,
+      execute: async () => {
+        executions++;
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    await lister.listConnectedDevices();
+    await lister.listConnectedDevices();
+    expect(executions).toBe(1);
+
+    timer.advanceTime(2_999);
+    await lister.listConnectedDevices();
+    expect(executions).toBe(1);
+
+    timer.advanceTime(2);
+    expect((await lister.listConnectedDevices()).map((device) => device.deviceId)).toEqual([
+      PHYSICAL_UDID,
+    ]);
+    expect(executions).toBe(2);
+  });
+
+  test("caches an unavailable host so every sweep does not respawn devicectl", async () => {
+    let executions = 0;
+    const lister = makeLister({
+      execute: async () => {
+        executions++;
+        throw new Error("devicectl missing");
+      },
+    });
+
+    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(await lister.listConnectedDevices()).toEqual([]);
+    expect(executions).toBe(1);
+  });
+
+  test("concurrent sweeps share a single devicectl invocation", async () => {
+    let executions = 0;
+    const lister = makeLister({
+      execute: async () => {
+        executions++;
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    const [first, second] = await Promise.all([
+      lister.listConnectedDevices(),
+      lister.listConnectedDevices(),
+    ]);
+
+    expect(executions).toBe(1);
+    expect(first).toEqual(second);
+  });
+
+  test("a cleanup failure does not turn a good listing into an empty one", async () => {
+    const lister = makeLister({
+      rm: async () => {
+        throw new Error("EBUSY");
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    expect((await lister.listConnectedDevices()).map((device) => device.deviceId)).toEqual([
+      PHYSICAL_UDID,
+    ]);
+  });
+});

--- a/test/utils/physicalIosDeviceResolution.test.ts
+++ b/test/utils/physicalIosDeviceResolution.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { ListInstalledApps } from "../../src/features/observe/ListInstalledApps";
+import type { BootedDevice } from "../../src/models";
+import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeSimctl } from "../fakes/FakeSimctl";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const PHYSICAL_UDID = "00008130-000A1B2C3D4E5F60";
+
+/**
+ * Issue #5620: the app resources resolve a deviceId through
+ * `PlatformDeviceManager.getBootedDevices("ios")` before constructing
+ * `ListInstalledApps`. This pins the whole chain — a connected physical UDID
+ * must survive resolution and land on the devicectl listing path — with fakes
+ * only, so it holds on hosts with no iOS tooling at all.
+ */
+describe("physical iOS device resolution reaches ListInstalledApps", () => {
+  test("a physical UDID resolves to an iOS BootedDevice that lists apps via devicectl", async () => {
+    const physical: BootedDevice = {
+      name: "Jason's iPhone",
+      platform: "ios",
+      deviceId: PHYSICAL_UDID,
+      iosVersion: "18.6",
+      osVersion: "18.6",
+      formFactor: "phone",
+    };
+    const manager = new MultiPlatformDeviceManager(
+      null,
+      {
+        isAvailable: async () => true,
+        getBootedSimulators: async () => [],
+      } as unknown as SimCtlClient,
+      { getBootedDevices: async () => [] } as unknown as AndroidEmulatorClient,
+      undefined,
+      undefined,
+      { listConnectedDevices: async () => [physical] },
+    );
+
+    // Exactly the lookup src/server/appResources.ts performs.
+    const booted = await manager.getBootedDevices("ios");
+    const resolved = booted.find((device) => device.deviceId === PHYSICAL_UDID);
+
+    expect(resolved).toBeDefined();
+    expect(resolved!.platform).toBe("ios");
+
+    const devicectlUdids: string[] = [];
+    const simctl = new FakeSimctl();
+    simctl.setInstalledApps([{ bundleId: "com.example.simulator-only" }]);
+    const list = new ListInstalledApps(
+      resolved!,
+      new FakeAdbClientFactory(new FakeAdbExecutor()),
+      simctl,
+      {
+        cacheEnabled: false,
+        installedAppsRepository: new FakeInstalledAppsRepository(),
+        timer: new FakeTimer(),
+        iosPhysicalAppLister: {
+          listInstalledApps: async (udid: string) => {
+            devicectlUdids.push(udid);
+            return [{ bundleIdentifier: "com.example.onhardware" }];
+          },
+        },
+      },
+    );
+
+    await expect(list.execute()).resolves.toEqual(["com.example.onhardware"]);
+    expect(devicectlUdids).toEqual([PHYSICAL_UDID]);
+  });
+});

--- a/test/utils/physicalIosDeviceResolution.test.ts
+++ b/test/utils/physicalIosDeviceResolution.test.ts
@@ -38,7 +38,7 @@ describe("physical iOS device resolution reaches ListInstalledApps", () => {
       { getBootedDevices: async () => [] } as unknown as AndroidEmulatorClient,
       undefined,
       undefined,
-      { listConnectedDevices: async () => [physical] },
+      { listConnectedDevices: async () => ({ devices: [physical], complete: true }) },
     );
 
     // Exactly the lookup src/server/appResources.ts performs.


### PR DESCRIPTION
Closes [#5620](https://github.com/kaeawc/auto-mobile/issues/5620).

[#5619](https://github.com/kaeawc/auto-mobile/pull/5619) gave `ListInstalledApps` a real physical-device listing via `devicectl device info apps`, but a client following the public `listApps` workflow still could not reach it. `src/server/appTools.ts` directs clients to the app resources; `findBootedDevice` in `src/server/appResources.ts` resolves the deviceId through `PlatformDeviceManager.getBootedDevices("ios")`; and that returned `simctl.getBootedSimulators()` alone. A physical UDID was rejected as "not booted" before `ListInstalledApps` was ever constructed — the direct feature path worked, the resource path did not.

## What changed

- **New discovery seam** `src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts`, backed by `xcrun devicectl list devices --json-output`. `IosPhysicalDeviceLister` is the narrow interface `MultiPlatformDeviceManager` depends on, so tests inject a fake instead of a host. It returns `{ devices, complete }` — `complete` separates "nothing is plugged in" from "we could not find out", which is the distinction the daemon's pruning logic needs.
- **Merged into iOS discovery** in `getBootedIosDevicesIfAvailable` and `discoverBootedIosDevices`. Physical discovery is *additive and best-effort by contract*: non-darwin host, missing Xcode, devicectl error, or unreadable JSON all degrade rather than failing the sweep. `succeededPlatforms` stays tied to simctl — it is one flag per platform, and clearing it on a devicectl blip would make every idle simulator unassignable. A failing sweep instead retains the lister's last-known devices (bounded to 60s), so a blip cannot make a connected iPhone look disconnected while a permanently broken devicectl eventually stops asserting hardware that may have been unplugged.
- **Defensive parsing.** The UDID is validated with the canonical `isIosPhysicalUdid` predicate rather than trusted, and `hardwareProperties.platform` rejects paired Watch/TV/Vision CoreDevices, which share the same UDID shapes. Only `tunnelState` values devicectl documents as unreachable filter a device out; unknown or missing values keep the device, deliberately biased so a field rename cannot re-introduce the very rejection this fixes. An envelope the parser does not recognize (`{ "result": {} }`, a non-array `devices`, a failed `info.outcome`) reports `complete: false` rather than authoritative absence.
- **Bounded and shared.** `getBootedDevices("ios")` is a hot path and `devicectl list devices` costs about a second, so listings are cached for 3s behind an injected `Timer` and concurrent sweeps share one process. The exec carries a 15s timeout; it deliberately does *not* inherit the ambient abort signal, since one caller cancelling a shared listing would cancel it out from under the others.
- **Closed the surfaces this newly exposes.** Making physical devices resolvable widens what the existing iOS switch arms can be handed. `waitForDeviceReady` no longer runs `simctl bootstatus` against a physical UDID (discovery already proved it reachable); `killDevice` refuses one with an actionable message instead of running `simctl shutdown`; and the `listDevices` guidance no longer tells MCP clients that `automobile:devices/booted/ios` is "iOS simulators only".
- **Reuse.** `inferIosFormFactor` moved from `SimCtlClient` into `iosDeviceType` so simulator device-type identifiers (`…SimDeviceType.iPhone-15`) and devicectl product types (`iPhone16,1`) share one implementation.

## Acceptance criteria

| AC | Covered by |
| --- | --- |
| iOS discovery resolves connected physical devices in addition to booted simulators | `DevicectlDeviceLister` merged in `deviceUtils.ts` |
| A physical UDID resolves to a `BootedDevice` with `platform: "ios"` and reaches `ListInstalledApps` | `test/utils/physicalIosDeviceResolution.test.ts` — pins the whole chain and asserts the devicectl listing path receives the UDID |
| Simulator-only host | `deviceUtils.test.ts` |
| Physical-only host | `deviceUtils.test.ts` |
| Both | `deviceUtils.test.ts` |
| devicectl unavailable — must not throw | `deviceUtils.test.ts` + the degradation and last-good-retention cases in `DevicectlDeviceLister.test.ts` |

All new tests use fakes and `FakeTimer`; the three files run in ~140ms combined and need no iOS tooling, so they pass on Linux and Windows CI.

## Validation

- `turbo run lint build test` — 14373 pass, 0 fail
- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- `scripts/oxlint-baseline.txt` shrinks by one line: the pre-existing traceless `catch` in `deviceUtils.ts` now logs.

## Deferred

Per-source liveness — when simctl fails but devicectl positively reports a connected iPhone, `getIosLivenessSnapshot()` discards it, because `succeededPlatforms` is one flag per platform. Not a regression (the device was previously not discovered at all); filed as [#5683](https://github.com/kaeawc/auto-mobile/issues/5683).

## Manual verification needed

The devicectl `list devices` **JSON field names are not verified against real hardware** — that is exactly what open issue #3055 tracks for the sibling `device info processes` payload. `hardwareProperties.udid` / `.platform` / `.productType`, `deviceProperties.name` / `.osVersionNumber`, and `connectionProperties.tunnelState` are taken from Apple's documented envelope, and every one of them degrades safely if wrong (an unrecognized record is skipped; an unknown tunnel state or absent platform keeps the device; an unrecognized envelope reports incomplete rather than empty). Worth confirming on a connected iPhone that:

1. `listApps` via the `automobile:devices/{udid}/apps` resource now returns apps for a physical UDID.
2. An unplugged-but-paired device does *not* appear as booted.
3. A paired Apple Watch does not appear as an iOS device.