### PR TITLE
ci(lychee): harden doc-link checker against transient network flakes (#5622)

### DIFF
--- a/.lycherc.toml
+++ b/.lycherc.toml
@@ -17,9 +17,11 @@ exclude = [
   "^https://hub\\.docker\\.com/",
   # WebAIM contrast checker has unreliable uptime / timeouts in CI
   "^https://webaim\\.org/",
-  # Contributor Covenant pages intermittently reset CI connections
-  "^https://www\\.contributor-covenant\\.org/?$",
-  "^https://www\\.contributor-covenant\\.org/translations/?$",
+  # Contributor Covenant intermittently resets CI connections; exclude every
+  # path under the host (the /faq page reset On Merge run 32703978446, #5622),
+  # not just the root and /translations pages that the old narrow patterns
+  # covered.
+  "^https://www\\.contributor-covenant\\.org/",
 ]
 
 # Exclude specific paths
@@ -46,11 +48,19 @@ accept = [
   "503", # Service Unavailable (temporary for Anthropic URLs under load)
 ]
 
-# Timeout for each request in seconds
-timeout = 20
+# Timeout for each request in seconds. Raised from 20 to give slow, rate-limited
+# responses (e.g. github.com's own issue URLs) headroom before they time out and
+# redden the merge workflow (#5622).
+timeout = 30
 
 # Number of retries per link
 max_retries = 3
+
+# Minimum wait (seconds) between retries. Without a backoff, max_retries fires
+# immediately against a rate-limited/slow endpoint and still fails; the wait lets
+# a transient timeout or connection reset recover before the final verdict
+# (#5622).
+retry_wait_time = 2
 
 # HTTP method to use for checking links
 method = "get"

--- a/test/bats/lychee-flake-resilience.bats
+++ b/test/bats/lychee-flake-resilience.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Regression guard for #5622: the "Validate Documentation Links" (lychee) job
+# reddened `main` on `On Merge` from purely transient network failures — 10
+# timeouts against github.com's own `issues/*` URLs and a "Connection reset by
+# server" against https://www.contributor-covenant.org/faq — not real broken
+# links.
+#
+# This pins the `.lycherc.toml` hardening so the flake signature cannot recur
+# silently:
+#   - a retry backoff (`retry_wait_time`) so a rate-limited/slow endpoint is
+#     re-tried after a wait instead of hammered and failed immediately, plus a
+#     roomier per-request `timeout` for the slow responses that stalled the run;
+#   - a contributor-covenant.org exclusion that covers *all* paths under that
+#     host (the prior narrow `/?$` + `/translations/?$` patterns let `/faq`
+#     through, which is exactly the URL that reset the connection).
+#
+# github.com `issues/*` links are deliberately NOT excluded: they are legitimate
+# references we want validated, routed through the authenticated GitHub API
+# (GITHUB_TOKEN, #5405) rather than throttled HTTP scraping; the backoff above is
+# the correct lever for their transient timeouts.
+#
+# TOML is parsed with yq (the repo's canonical config/workflow parser), not
+# grepped, so a value in a comment cannot satisfy these assertions. The
+# behavioral exclusion check drives the real lychee binary; the bats CI job does
+# not install lychee, so that test skips there and runs in local pre-PR
+# validation where lychee is present.
+
+CONFIG=".lycherc.toml"
+
+requires_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if [[ -n "${CI:-}" ]]; then
+    echo "yq is required in CI to verify .lycherc.toml hardening" >&2
+    return 1
+  fi
+  skip "yq not installed"
+}
+
+requires_lychee() {
+  command -v lychee >/dev/null 2>&1 && return 0
+  # The bats CI job does not install lychee (only the dedicated doc-links job
+  # does), so skip rather than fail when the binary is absent.
+  skip "lychee not installed"
+}
+
+@test "lychee retries failed requests with a backoff (retry_wait_time)" {
+  requires_yq
+  run yq -p toml -o json '.retry_wait_time' "$CONFIG"
+  [ "$status" -eq 0 ]
+  # Must be a positive number: retrying immediately (no wait) against a
+  # rate-limited endpoint is what let the timeouts fail the run.
+  [[ "$output" =~ ^[0-9]+$ ]]
+  [ "$output" -gt 0 ]
+}
+
+@test "lychee allows a roomier per-request timeout for slow responses" {
+  requires_yq
+  run yq -p toml -o json '.timeout' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+$ ]]
+  # The stalled requests in run 32703978446 needed more headroom than the prior
+  # 20s ceiling.
+  [ "$output" -ge 30 ]
+}
+
+@test "contributor-covenant.org is excluded for all paths, not just the root" {
+  requires_lychee
+
+  local fixture
+  fixture="$(mktemp -t lychee-fixture.XXXXXX.md)"
+  cat > "$fixture" <<'EOF'
+# fixture
+[faq](https://www.contributor-covenant.org/faq)
+[root](https://www.contributor-covenant.org/)
+[issue](https://github.com/kaeawc/auto-mobile/issues/50)
+EOF
+
+  # `--dump` extracts and filters links through the config WITHOUT hitting the
+  # network, so this is fast and deterministic.
+  run lychee --config "$CONFIG" --dump "$fixture"
+  rm -f "$fixture"
+
+  [ "$status" -eq 0 ]
+  # The connection-reset URL from the flake must now be excluded.
+  [[ "$output" != *"contributor-covenant.org/faq"* ]]
+  # Sanity: github issue links are still checked (not over-excluded), so we keep
+  # validating real references.
+  [[ "$output" == *"github.com/kaeawc/auto-mobile/issues/50"* ]]
+}

--- a/test/bats/lychee-flake-resilience.bats
+++ b/test/bats/lychee-flake-resilience.bats
@@ -68,7 +68,9 @@ requires_lychee() {
   requires_lychee
 
   local fixture
-  fixture="$(mktemp -t lychee-fixture.XXXXXX.md)"
+  # Plain mktemp (no -t template) for GNU/BSD portability; lychee parses markdown
+  # link syntax from the file content, so no .md extension is required.
+  fixture="$(mktemp)"
   cat > "$fixture" <<'EOF'
 # fixture
 [faq](https://www.contributor-covenant.org/faq)


### PR DESCRIPTION
## Summary

The `Validate Documentation Links` (lychee) job reddened `main` on `On Merge`
([run 32703978446](https://github.com/kaeawc/auto-mobile/actions/runs/32703978446))
from purely transient network failures — 10 timeouts against github.com's own
`issues/*` URLs and a `Connection reset by server` on
`https://www.contributor-covenant.org/faq` — not any real broken link. This
hardens `.lycherc.toml` so that flake signature (`lychee-doc-links-network-timeout`)
cannot silently recur.

## Linked Issue

Closes #5622

## Bug / Regression Context

- **Prior attempts:** [#5405](https://github.com/kaeawc/auto-mobile/pull/5405) routed github.com links through the authenticated GitHub API to dodge unauthenticated rate limits; the Aug-24 failure shows that alone did not stop transient timeouts.
- **Observed symptom:** `Validate Documentation Links` exits 2 on `[TIMEOUT]` results (github.com `issues/*`) and an `[ERROR] ... Connection reset by server` (`contributor-covenant.org/faq`), turning the merge workflow red. All URLs resolve on retry.
- **Repro conditions:** slow / rate-limited HTTP from the runner (the run took 6m 41s); `max_retries` was set but with **no wait between retries**, so a stalled endpoint was retried immediately and still failed, and the contributor-covenant exclude only matched the root + `/translations`, letting `/faq` through.

## Changes

- **`retry_wait_time = 2`** — retries now back off instead of hammering a rate-limited/slow endpoint and failing immediately.
- **`timeout` 20 → 30** — headroom for the slow responses that stalled the run.
- **Broaden the contributor-covenant.org exclude** to `^https://www\.contributor-covenant\.org/` (all paths), replacing the narrow `/?$` + `/translations/?$` patterns that let `/faq` slip through.
- github.com `issues/*` links are deliberately **not** excluded — they are legitimate references we want validated via the GitHub API ([#5405](https://github.com/kaeawc/auto-mobile/pull/5405)); backoff is the correct lever for their transient timeouts.

## Validation

- [x] `test/bats/lychee-flake-resilience.bats` — new regression guard, red before / green after (drives the real `lychee` binary via offline `--dump` for the exclusion, `yq`-parses the TOML for the retry/timeout knobs).
- [x] Offline `lychee --dump` over the real `docs/` + root `*.md` with the new config: **0** contributor-covenant links still checked, github `issues/*` still checked (no over-exclusion).
- [x] Config is valid TOML (`yq -p toml`), and lychee loads it without error (proves `retry_wait_time` is a recognized key).
- No TypeScript/lint surface touched (config + BATS only), so the TS gate is unaffected.

## Follow-ups

- The issue also suggested adding `lychee-doc-links-network-timeout` to the **flake sentinel's known-flake catalog**. That sentinel is an external Claude routine ("Filed automatically by the CI flake sentinel routine"), not an in-repo artifact, so it is out of scope for this PR.

_Generated with [Claude Code](https://claude.ai/code)_
