### PR TITLE
fix(observe): eagerly abort a hung in-flight CtrlProxy handshake on port change / close (#5656)

### DIFF
--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -77,6 +77,13 @@ export abstract class DeviceServiceClient {
   // Bumped by close() so a connection that opens after close() is discarded
   // instead of installing its socket and restarting the health check.
   protected connectionGeneration: number = 0;
+  // Set while a handshake is mid-flight (socket CONNECTING, this.ws still null)
+  // so close()/updatePort() can eagerly abort a socket stuck in CONNECTING that
+  // emits NEITHER "open" NOR "error". The generation guard alone only fires when
+  // the socket eventually resolves; a wedged handshake would otherwise keep
+  // isConnecting true until connectionTimeoutMs, stalling a fresh-port connect
+  // by up to ~5s. Cleared to null the moment the handshake terminates. (#5656)
+  private pendingConnectAbort: (() => void) | null = null;
 
   // Auto-reconnection state
   protected autoReconnectEnabled: boolean = true;
@@ -251,6 +258,11 @@ export abstract class DeviceServiceClient {
       // Invalidate any in-flight connection whose `open` has not fired yet, so
       // it cannot install its socket / restart the health check after close().
       this.connectionGeneration++;
+      // Eagerly abort a handshake stuck in CONNECTING (no open/error yet): the
+      // generation bump above is only observed inside the socket's open/error
+      // handlers, so without this a wedged socket keeps isConnecting true until
+      // connectionTimeoutMs fires. (#5656)
+      this.abortPendingConnect();
 
       // Clear any pending reconnection timeout
       if (this.reconnectTimeoutId !== null) {
@@ -287,6 +299,26 @@ export abstract class DeviceServiceClient {
       this.onConnectionClosed();
     } catch (error) {
       logger.warn(`[${this.logTag}] Error during close: ${error}`);
+    }
+  }
+
+  /**
+   * Eagerly abort a handshake that is stuck in CONNECTING.
+   *
+   * Called by close() and updatePort() right after bumping
+   * {@link connectionGeneration}. The generation guard alone is re-checked only
+   * inside the socket's `open`/`error` handlers, so a socket that emits neither
+   * would keep {@link isConnecting} true until {@link ConnectionConfig.connectionTimeoutMs}.
+   * Running the stored abort closes+discards that socket, clears isConnecting,
+   * and resolves the pending connect as a failure, so a fresh connect (e.g. to a
+   * new port) proceeds immediately instead of stalling. No-op when no handshake
+   * is in flight. (#5656)
+   */
+  protected abortPendingConnect(): void {
+    const abort = this.pendingConnectAbort;
+    if (abort) {
+      this.pendingConnectAbort = null;
+      abort();
     }
   }
 
@@ -380,11 +412,37 @@ export abstract class DeviceServiceClient {
           new Promise<boolean>((resolve, reject) => {
             const ws = this.webSocketFactory(wsUrl);
             const connectionTimeout = this.timer.setTimeout(() => {
+              this.pendingConnectAbort = null;
               ws.close();
               reject(new Error("WebSocket connection timeout"));
             }, this.config.connectionTimeoutMs);
 
+            // Track this in-flight handshake so a generation change
+            // (close()/updatePort()) can abort it eagerly. A socket stuck in
+            // CONNECTING emits neither "open" nor "error", so the generation
+            // guard in the handlers below would never run for it. (#5656)
+            this.pendingConnectAbort = () => {
+              this.timer.clearTimeout(connectionTimeout);
+              // Detach lifecycle listeners before closing so the aborted
+              // socket's delayed close/error cannot mutate state for the
+              // replacement connect; keep a lone swallowing error listener so a
+              // mid-handshake error cannot throw and crash the daemon.
+              try {
+                ws.removeAllListeners();
+                ws.on("error", (error) => {
+                  logger.debug(`[${this.logTag}] Ignoring error on aborted WebSocket: ${error}`);
+                });
+                ws.close();
+              } catch (error) {
+                // The socket may already be closing; nothing else to clean up.
+                logger.debug(`[${this.logTag}] Error closing aborted WebSocket: ${error}`);
+              }
+              this.isConnecting = false;
+              resolve(false);
+            };
+
             ws.on("open", () => {
+              this.pendingConnectAbort = null;
               this.timer.clearTimeout(connectionTimeout);
               if (generation !== this.connectionGeneration) {
                 // close() or updatePort() ran while this connection was mid-handshake.
@@ -435,6 +493,7 @@ export abstract class DeviceServiceClient {
             });
 
             ws.on("error", (error) => {
+              this.pendingConnectAbort = null;
               this.timer.clearTimeout(connectionTimeout);
               logger.warn(`[${this.logTag}] WebSocket error: ${error.message}`);
               this.isConnecting = false;
@@ -442,6 +501,7 @@ export abstract class DeviceServiceClient {
             });
 
             ws.on("close", () => {
+              this.pendingConnectAbort = null;
               logger.info(`[${this.logTag}] WebSocket connection closed`);
               this.ws = null;
               this.isConnecting = false;

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -955,6 +955,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // makes the base connectWebSocket() open-guard drop that socket and clear
       // isConnecting, leaving a fresh connect free to dial the new port.
       this.connectionGeneration++;
+      // Eagerly abort a handshake still stuck in CONNECTING (this.ws null,
+      // isConnecting true, dialing the now-stale old port): the generation bump
+      // above is only observed inside the socket's open/error handlers, so a
+      // socket emitting neither would keep isConnecting true until
+      // connectionTimeoutMs, stalling the new-port connect by up to ~5s. (#5656)
+      this.abortPendingConnect();
       // The connection-attempt budget is per-endpoint: failures against the old
       // port must not cool down the new one. Without this reset, a port change on
       // the max-th in-flight attempt leaves connectionAttempts at the ceiling, so

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -260,6 +260,71 @@ describe("IOSCtrlProxyClient auto-setup", function () {
     }
   });
 
+  test("updatePort eagerly aborts a hung in-flight handshake so the new-port connect proceeds immediately (#5656)", async function () {
+    // Frozen manual timer: it is NEVER advanced, so neither the 5s connection
+    // timeout nor the "connection already in progress" poll interval can fire.
+    // The new-port connect can therefore only proceed if updatePort() eagerly
+    // aborts the hung handshake and clears isConnecting — not by waiting out the
+    // connectionTimeoutMs.
+    const manualTimer = new FakeTimer();
+    const sockets: { url: string; socket: ManualCloseWebSocket }[] = [];
+    const wsFactory = (url: string): WebSocket => {
+      // "timeout" mode + a never-advanced timer keeps the socket in CONNECTING
+      // forever, emitting NEITHER "open" NOR "error" — a wedged handshake.
+      const socket = new ManualCloseWebSocket(url, "timeout", 60_000, manualTimer);
+      sockets.push({ url, socket });
+      return socket as unknown as WebSocket;
+    };
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      wsFactory,
+      manualTimer,
+      createManagerFactory(),
+    );
+    const connect = (client as unknown as { connectWebSocket: () => Promise<boolean> })
+      .connectWebSocket;
+    const updatePort = (
+      client as unknown as { updatePort: (port: number) => void }
+    ).updatePort.bind(client);
+    try {
+      // Start a connect and let it reach the in-flight state: socket CONNECTING,
+      // this.ws still null, isConnecting true, emitting nothing.
+      const connectPromise = connect.call(client);
+      await flushPromises(8);
+      expect(sockets.length).toBe(1);
+      expect(sockets[0].url).toBe("ws://localhost:8765/ws");
+      expect(client.isConnected()).toBe(false);
+
+      // A port reallocation races the wedged handshake.
+      updatePort(8767);
+      await flushPromises(8);
+
+      // AC1: the hung handshake is aborted eagerly — its connect resolves as a
+      // failure instead of hanging until connectionTimeoutMs (which never fires
+      // here because the timer is frozen).
+      await expect(connectPromise).resolves.toBe(false);
+
+      // AC2: a fresh connect dials the NEW port IMMEDIATELY, without waiting out
+      // any 5s stall. Before the fix, isConnecting stayed true, so this connect
+      // took the "connection already in progress, waiting…" branch and polled a
+      // frozen timer forever — no second socket would ever be created.
+      const secondPromise = connect.call(client);
+      await flushPromises(8);
+      expect(sockets.length).toBe(2);
+      const latest = sockets[sockets.length - 1];
+      expect(latest.url).toBe("ws://localhost:8767/ws");
+
+      latest.socket.readyState = WebSocketState.OPEN;
+      latest.socket.emit("open");
+      await flushPromises(8);
+      expect(await secondPromise).toBe(true);
+      expect(client.isConnected()).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+
   test("a port change resets the per-endpoint attempt budget so the new port is not cooldown-blocked (#5645)", async function () {
     // Frozen manual timer: the cooldown window never elapses on its own, so only a
     // budget reset (not the passage of time) can let the new-port connect through.


### PR DESCRIPTION
## Summary

Follow-up to [#5645](https://github.com/kaeawc/auto-mobile/issues/5645) / [PR #5649](https://github.com/kaeawc/auto-mobile/pull/5649). The `connectionGeneration` guard invalidates an in-flight CtrlProxy connect only *when the socket eventually resolves* — the generation is re-checked inside `ws.on("open")` / `ws.on("error")` in `DeviceServiceClient.connectWebSocket()`. If the old endpoint leaves its WebSocket stuck in `CONNECTING` and emits **neither** `open` nor `error`, the generation bump from `updatePort()` / `close()` is never observed: `this.ws` stays `null` and `isConnecting` stays `true` until the 5s `connectionTimeoutMs` fires — delaying a fresh connect to the new port by up to ~5s.

This tracks the in-flight socket's abort closure on the instance so `close()` and `updatePort()` can eagerly close+discard the wedged socket, clear `isConnecting`, and resolve the pending connect as a failure the moment the generation changes, rather than waiting out `connectionTimeoutMs`. The abort detaches the socket's lifecycle listeners (keeping a lone swallowing `error` listener so a mid-handshake error cannot crash the daemon), mirroring the existing discarded-socket path. The abort closure is nulled the instant the handshake terminates naturally (open/error/close/timeout), so it never runs against a completed attempt.

## Linked Issue

Closes #5656

## Bug / Regression Context

- **Prior attempts:** #5645 / PR #5649 added the `connectionGeneration` guard + discarded-socket handling, but deliberately scoped out the active-abort path (a second invalidation mechanism) for a hung handshake.
- **Observed symptom:** a port change (or close) during a handshake stuck in `CONNECTING` leaves `isConnecting` true; a fresh new-port connect takes the "connection already in progress, waiting…" branch and polls until the 5s connection timeout fires.
- **Repro steps / conditions:** old CtrlProxy endpoint accepts the TCP connect but never completes the WebSocket handshake (emits neither `open` nor `error`); `updatePort()` / `close()` runs while that handshake is in flight. Pre-existing (predates PR #5649), bounded, and self-healing.

## Validation

- [x] `bun run turbo:validate` (lint + build + full `bun test` + boundary checks) passes — 14341 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New test uses an injected `WebSocketFactory` + manual `FakeTimer`; runs in <100ms, no real `getDatabase()`
- [x] Reuses the existing generation-guard mechanism and discarded-socket listener-detach pattern; no new dependencies

## Testing

Added `updatePort eagerly aborts a hung in-flight handshake so the new-port connect proceeds immediately (#5656)` to `CtrlProxyClientAutoSetup.test.ts`: a **frozen** manual `FakeTimer` (never advanced, so neither the 5s connection timeout nor the in-progress poll interval can fire) with a socket wedged in `CONNECTING`. It starts a connect, changes ports mid-handshake, and asserts the hung connect resolves `false` eagerly and a fresh connect dials the **new** port immediately. Confirmed red before the fix (the connect never resolves on the frozen timer) and green after.

## Follow-ups

- None.