### PR TITLE
fix(daemon): bind and heartbeat result-minted device sessions; recover fenced connections

### DIFF
--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -1,6 +1,10 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
-import { getDefaultSessionHeartbeatTimeoutMs, type Session } from "./sessionManager";
+import {
+  getDefaultPreFirstHeartbeatGraceMs,
+  getDefaultSessionHeartbeatTimeoutMs,
+  type Session,
+} from "./sessionManager";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 
 /**
@@ -26,7 +30,6 @@ export interface SessionHeartbeatMonitorConfig {
 }
 
 const DEFAULT_CHECK_INTERVAL_MS = 10_000;
-const DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS = 5_000;
 const DEFAULT_INITIAL_GRACE_MS = 20_000;
 
 function readPositiveMsEnv(primaryName: string, legacyName: string): number | undefined {
@@ -83,12 +86,7 @@ export class SessionHeartbeatMonitor {
       ) ??
       DEFAULT_INITIAL_GRACE_MS;
     this.preFirstHeartbeatGraceMs =
-      config.preFirstHeartbeatGraceMs ??
-      readPositiveMsEnv(
-        "AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
-        "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
-      ) ??
-      DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS;
+      config.preFirstHeartbeatGraceMs ?? getDefaultPreFirstHeartbeatGraceMs();
     this.defaultHeartbeatTimeoutMs =
       config.heartbeatTimeoutMs ??
       readPositiveMsEnv(

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -22,6 +22,10 @@ import type { DaemonNotification, DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBroadcast";
 import {
+  getDeviceSessionIdFromResult,
+  isDeviceSessionAcquisitionTool,
+} from "../server/deviceSessionResult";
+import {
   toolSelectionProfileUuidFromResponse,
   SET_TOOL_ENABLED_TOOL_NAME,
 } from "../features/toolSelection/toolSelectionControl";
@@ -189,6 +193,27 @@ export class DaemonBoundSessionExpiredError extends Error {
     this.sessionUuid = sessionUuid;
     this.reason = reason;
     this.release = release;
+  }
+}
+
+/**
+ * Raised when a call that does NOT reference a specific device session reaches a
+ * connection whose only binding — one MINTED by a device-acquisition RESULT, and
+ * therefore never named by the client — has been terminally released. Naming a
+ * stale UUID the caller never referenced would misattribute the loss; instead
+ * this reports the CURRENT connection state and directs the caller to acquire a
+ * fresh session (issue #5689).
+ */
+export class DaemonConnectionSessionReleasedError extends Error {
+  readonly reason: string;
+
+  constructor(reason: string) {
+    super(
+      `This MCP connection has no active device session (the previous session was released: ${reason}). ` +
+        "Call getAndroid, getApple, or startDevice to acquire a new device session.",
+    );
+    this.name = "DaemonConnectionSessionReleasedError";
+    this.reason = reason;
   }
 }
 
@@ -582,11 +607,25 @@ export class DaemonMcpProxy {
   // refreshing it, the remembered UUID is treated as retired so a sessionless
   // call is not rewritten to a released session (issue #4610).
   private boundSessionUuidAt: number | undefined;
+  // Whether the current binding was minted by a device-acquisition RESULT
+  // (getAndroid/getApple/startDevice), i.e. never named by the client, versus
+  // client-declared (an explicit `sessionUuid` arg, or a startup
+  // `initialSessionUuid`). Governs how a fenced sessionless call is reported: a
+  // client-declared binding keeps the ownership-lost-for-UUID error, while a
+  // result-minted one reports the connection state instead of a stale UUID the
+  // caller never referenced (issue #5689).
+  private boundSessionFromResultMint = false;
   // Once the daemon confirms this transport's bound session is gone, preserve
   // that terminal identity instead of clearing it and allowing the same UUID to
-  // acquire another device.
+  // acquire another device. `fromResultMint` records the binding's provenance at
+  // fence time (see boundSessionFromResultMint).
   private terminalBoundSession:
-    | { sessionUuid: string; reason: string; release?: SessionReleaseSnapshot }
+    | {
+        sessionUuid: string;
+        reason: string;
+        fromResultMint: boolean;
+        release?: SessionReleaseSnapshot;
+      }
     | undefined;
   // Startup bindings remain authoritative until the daemon signals release.
   // Replay expiration only protects bindings inferred from ordinary calls.
@@ -1273,11 +1312,19 @@ export class DaemonMcpProxy {
    * Call a tool on the daemon
    */
   async callTool(name: string, args: Record<string, unknown>): Promise<any> {
+    // Device-session acquisition (getAndroid/getApple/startDevice) mints a NEW
+    // session in its RESULT and is never routed to — or fenced by — the connection's
+    // bound session: it must be admitted even on a terminally fenced connection so
+    // the client can recover in-band (issue #5689). Forward its raw args and bind
+    // the minted session from the result afterwards.
+    const isSessionAcquisition = isDeviceSessionAcquisitionTool(name);
     // An omitted `sessionUuid` on the control tool means the connection profile,
     // not the proxy's retained device-routing session. Preserve that distinction
     // after a device has been bound.
     const routingArgs =
-      name === SET_TOOL_ENABLED_TOOL_NAME ? args : this.withBoundSessionUuid(args);
+      name === SET_TOOL_ENABLED_TOOL_NAME || isSessionAcquisition
+        ? args
+        : this.withBoundSessionUuid(args);
     const forwardedArgs = this.withToolSelectionProfile(routingArgs);
     const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     this.retainReleaseEpochReference(forwardedSessionUuid);
@@ -1289,11 +1336,21 @@ export class DaemonMcpProxy {
     // so it does not block remembering the session this call forwarded.
     const callReleaseEpoch = this.releaseEpoch;
     try {
-      const result = await this.withRecoverableReconnect(() => {
-        this.throwIfForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch);
-        return this.client!.callTool(name, forwardedArgs);
-      }, forwardedSessionUuid);
+      const result = await this.withRecoverableReconnect(
+        () => {
+          this.throwIfForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch);
+          return this.client!.callTool(name, forwardedArgs);
+        },
+        forwardedSessionUuid,
+        // Acquisition is admitted while fenced; the terminal fence is cleared once
+        // the result-minted session establishes a fresh binding.
+        isSessionAcquisition,
+      );
       this.rememberToolSelectionProfile(name, args, result);
+      if (isSessionAcquisition) {
+        await this.bindResultMintedDeviceSession(name, result);
+        return result;
+      }
       // Remember what was actually forwarded, not the caller's raw args. An
       // implicit sessionless call injects the bound UUID into forwardedArgs and
       // extends the live daemon session in getOrCreateSession(); refreshing the
@@ -1332,7 +1389,6 @@ export class DaemonMcpProxy {
   }
 
   private withBoundSessionUuid(args: Record<string, unknown>): Record<string, unknown> {
-    this.throwIfBoundSessionUnavailable();
     // A daemon session released by ordinary heartbeat/idle expiry leaves this
     // remembered binding dangling; replaying its UUID on a later sessionless call
     // would silently recreate the session and reacquire a device without the
@@ -1340,6 +1396,7 @@ export class DaemonMcpProxy {
     // no forwarded call (explicit or implicit) refreshing the binding, treat it
     // as retired.
     const explicitSessionUuid = this.sessionUuidFromArgs(args);
+    this.throwIfBoundSessionUnavailable(explicitSessionUuid);
     const normalizedArgs =
       explicitSessionUuid && explicitSessionUuid !== args.sessionUuid
         ? { ...args, sessionUuid: explicitSessionUuid }
@@ -1369,13 +1426,33 @@ export class DaemonMcpProxy {
     };
   }
 
-  private throwIfBoundSessionUnavailable(): void {
-    this.throwIfBoundSessionFenced();
+  private throwIfBoundSessionUnavailable(explicitSessionUuid?: string): void {
+    this.throwIfFencedForCaller(explicitSessionUuid);
     if (!this.isBoundSessionReplayExpired()) {
       return;
     }
     this.fenceBoundSessionUuid(this.boundSessionUuid!, "replay-lease-expired");
-    throw this.boundSessionExpiredError();
+    this.throwIfFencedForCaller(explicitSessionUuid);
+  }
+
+  // Surface a terminal fence to a caller, distinguishing whether the caller
+  // referenced the fenced session. A client-declared binding (explicit
+  // `sessionUuid`, or the same UUID named again) — or any explicit reference to
+  // the fenced UUID — yields the ownership-lost-for-UUID error. A call that never
+  // named the session and whose binding was minted by a device-acquisition RESULT
+  // instead gets the current connection state, not a stale UUID (issue #5689).
+  private throwIfFencedForCaller(explicitSessionUuid?: string): void {
+    const terminal = this.terminalBoundSession;
+    if (!terminal) {
+      return;
+    }
+    const callerReferencedTerminal =
+      !terminal.fromResultMint ||
+      (explicitSessionUuid !== undefined && explicitSessionUuid === terminal.sessionUuid);
+    if (callerReferencedTerminal) {
+      throw this.boundSessionExpiredError();
+    }
+    throw new DaemonConnectionSessionReleasedError(terminal.reason);
   }
 
   private sessionUuidFromArgs(args: Record<string, unknown>): string | undefined {
@@ -1428,6 +1505,7 @@ export class DaemonMcpProxy {
     this.boundSessionUuid = undefined;
     this.boundSessionUuidAt = undefined;
     this.initialSessionBindingConfigured = false;
+    this.boundSessionFromResultMint = false;
   }
 
   private fenceBoundSessionUuid(
@@ -1444,7 +1522,12 @@ export class DaemonMcpProxy {
       }
       return;
     }
-    this.terminalBoundSession = { sessionUuid, reason, ...(release ? { release } : {}) };
+    this.terminalBoundSession = {
+      sessionUuid,
+      reason,
+      fromResultMint: this.boundSessionFromResultMint,
+      ...(release ? { release } : {}),
+    };
     // A terminal release changes the scope of in-flight discovery and prevents
     // its stale response from repopulating a cleared cache.
     this.discoveryEpoch += 1;
@@ -1674,6 +1757,37 @@ export class DaemonMcpProxy {
     throw new DaemonBoundSessionExpiredError(forwardedUuid, reason);
   }
 
+  // Bind and heartbeat the device session a getAndroid/getApple/startDevice call
+  // minted in its RESULT — the proxy equivalent of the direct-path bind in
+  // src/server/index.ts. Without this the daemon never sees an ownership heartbeat
+  // for a result-minted session and reaps it under the pre-first-heartbeat grace
+  // (issue #5689). Acquisition also clears any terminal fence: the connection is
+  // usable again once a fresh session is established (AC2).
+  private async bindResultMintedDeviceSession(name: string, result: unknown): Promise<void> {
+    if (!isDeviceSessionAcquisitionTool(name)) {
+      return;
+    }
+    const mintedSessionUuid = getDeviceSessionIdFromResult(result);
+    if (!mintedSessionUuid || mintedSessionUuid === this.boundSessionUuid) {
+      return;
+    }
+    // A prior binding's keeper must not outlive the rebind to a fresh session.
+    // (A terminal fence already stopped it; this covers re-acquiring over a live
+    // binding.)
+    if (this.heartbeatKeeperStarted) {
+      await this.stopBoundSessionHeartbeat();
+    }
+    this.terminalBoundSession = undefined;
+    this.boundSessionUuid = mintedSessionUuid;
+    this.boundSessionUuidAt = this.timer.now();
+    this.boundSessionFromResultMint = true;
+    this.initialSessionBindingConfigured = false;
+    // Deliver the first ownership heartbeat as part of the acquisition so the
+    // daemon records ownership before the pre-first-heartbeat grace fires
+    // (mirrors the establishment guarantee in issue #5637).
+    await this.establishBoundSessionHeartbeat();
+  }
+
   // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit
   // sessionless call that had the bound UUID injected refreshes the replay lease
   // just like an explicit-sessionUuid call, matching the daemon session it just
@@ -1705,10 +1819,21 @@ export class DaemonMcpProxy {
     }
     const rememberedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     if (rememberedSessionUuid) {
-      this.boundSessionUuid = rememberedSessionUuid;
-      this.boundSessionUuidAt = this.timer.now();
+      this.updateBoundSessionUuid(rememberedSessionUuid);
       this.startBoundSessionHeartbeat();
     }
+  }
+
+  // Bind `sessionUuid`, refreshing the replay lease. A change to a different UUID
+  // marks the binding client-declared: the new UUID came from a call's args, not
+  // a device-acquisition result. A sessionless refresh re-binds the same
+  // result-minted UUID and preserves its provenance (issue #5689).
+  private updateBoundSessionUuid(sessionUuid: string): void {
+    if (sessionUuid !== this.boundSessionUuid) {
+      this.boundSessionFromResultMint = false;
+    }
+    this.boundSessionUuid = sessionUuid;
+    this.boundSessionUuidAt = this.timer.now();
   }
 
   // Refresh the replay lease for a call that was ADMITTED and forwarded to the
@@ -1749,8 +1874,7 @@ export class DaemonMcpProxy {
     }
     const admittedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     if (admittedSessionUuid) {
-      this.boundSessionUuid = admittedSessionUuid;
-      this.boundSessionUuidAt = this.timer.now();
+      this.updateBoundSessionUuid(admittedSessionUuid);
       this.startBoundSessionHeartbeat();
     }
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1441,6 +1441,14 @@ export class DaemonMcpProxy {
   // the fenced UUID — yields the ownership-lost-for-UUID error. A call that never
   // named the session and whose binding was minted by a device-acquisition RESULT
   // instead gets the current connection state, not a stale UUID (issue #5689).
+  //
+  // This is the entry-gate check for calls arriving at an ALREADY-fenced
+  // connection. A session released WHILE a call is actively holding it (the
+  // narrow mid-flight-release race) still surfaces the generic ownership-lost
+  // error for that UUID via the in-flight fence checks in
+  // withRecoverableReconnect — consistent with the established mid-flight-release
+  // semantics for every binding — and self-heals: the next call reaches this gate
+  // and gets the provenance-aware error.
   private throwIfFencedForCaller(explicitSessionUuid?: string): void {
     const terminal = this.terminalBoundSession;
     if (!terminal) {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -949,7 +949,11 @@ export class SessionManager {
           hasReceivedHeartbeat: session.hasReceivedHeartbeat,
           // A missing-first-heartbeat reap fires on the pre-first-heartbeat grace,
           // not the session's heartbeat timeout; report the deadline that actually
-          // governed the release so `ageMs` stays coherent (issue #5689).
+          // governed the release so `ageMs` stays coherent (issue #5689). The grace
+          // is resolved from the shared env/default here — matching the daemon's
+          // monitor, which is constructed with default config. (A monitor given an
+          // explicit `preFirstHeartbeatGraceMs`, as in tests, would diverge; drive
+          // the grace via env to keep the snapshot consistent.)
           timeoutMs:
             releaseReason === "missing-first-heartbeat"
               ? getDefaultPreFirstHeartbeatGraceMs()

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -188,6 +188,24 @@ export function getDefaultSessionHeartbeatTimeoutMs(): number {
     : SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS;
 }
 
+/** Default grace before a never-heartbeated default-policy session is reaped. */
+export const DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS = 5_000;
+
+/**
+ * The grace `SessionHeartbeatMonitor` applies before reaping a default-policy
+ * session that never sent its first heartbeat. Single-sourced here so the
+ * `missing-first-heartbeat` release snapshot reports the deadline that actually
+ * fired — the grace, not the (longer) heartbeat timeout — instead of leaving a
+ * reader to conclude the daemon reaped early (issue #5689).
+ */
+export function getDefaultPreFirstHeartbeatGraceMs(): number {
+  const rawValue =
+    process.env.AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS ??
+    process.env.AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS;
+  const parsed = rawValue ? Number.parseInt(rawValue, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS;
+}
+
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private sessionDeviceMap: Map<string, string> = new Map(); // sessionId -> deviceId
@@ -396,7 +414,12 @@ export class SessionManager {
       heartbeat: {
         lastHeartbeatMs: persisted.last_used_at_ms,
         hasReceivedHeartbeat: persisted.has_received_heartbeat === 1,
-        timeoutMs: persisted.heartbeat_timeout_ms,
+        // Match the live snapshot: a missing-first-heartbeat reap is governed by
+        // the pre-first-heartbeat grace, not the stored heartbeat timeout.
+        timeoutMs:
+          persisted.release_reason === "missing-first-heartbeat"
+            ? getDefaultPreFirstHeartbeatGraceMs()
+            : persisted.heartbeat_timeout_ms,
         ageMs: Math.max(0, releasedAtMs - persisted.last_used_at_ms),
       },
     };
@@ -924,7 +947,13 @@ export class SessionManager {
         heartbeat: {
           lastHeartbeatMs: session.lastHeartbeat,
           hasReceivedHeartbeat: session.hasReceivedHeartbeat,
-          timeoutMs: session.heartbeatTimeoutMs,
+          // A missing-first-heartbeat reap fires on the pre-first-heartbeat grace,
+          // not the session's heartbeat timeout; report the deadline that actually
+          // governed the release so `ageMs` stays coherent (issue #5689).
+          timeoutMs:
+            releaseReason === "missing-first-heartbeat"
+              ? getDefaultPreFirstHeartbeatGraceMs()
+              : session.heartbeatTimeoutMs,
           ageMs: Math.max(0, releasedAtMs - session.lastHeartbeat),
         },
       };

--- a/src/server/deviceSessionResult.ts
+++ b/src/server/deviceSessionResult.ts
@@ -1,0 +1,55 @@
+import { logger } from "../utils/logger";
+
+/**
+ * The tools that acquire a device and mint a device session, returning its
+ * `sessionId` in the tool RESULT (not the request args). Both the direct MCP
+ * server (`src/server/index.ts`) and the daemon proxy (`DaemonMcpProxy`) must
+ * bind the session these tools mint — the proxy additionally heartbeats it so
+ * the daemon does not reap a result-minted session (issue #5689).
+ */
+export const DEVICE_SESSION_ACQUISITION_TOOLS = [
+  "getAndroid",
+  "getApple",
+  "startDevice",
+] as const;
+
+/** Whether `name` is a device-session acquisition tool (see above). */
+export function isDeviceSessionAcquisitionTool(name: string): boolean {
+  return (DEVICE_SESSION_ACQUISITION_TOOLS as readonly string[]).includes(name);
+}
+
+/**
+ * Extract the `sessionId` a device-start tool minted, from its MCP tool result.
+ * The id rides in the first `text` content item as JSON `{ "sessionId": "..." }`.
+ * Returns undefined when the result is not a device-start envelope.
+ */
+export function getDeviceSessionIdFromResult(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || !("content" in result)) {
+    return undefined;
+  }
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content.find(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      "type" in item &&
+      (item as { type?: unknown }).type === "text" &&
+      "text" in item &&
+      typeof (item as { text?: unknown }).text === "string",
+  ) as { text: string } | undefined;
+  if (!text) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(text.text) as { sessionId?: unknown };
+    return typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
+      ? payload.sessionId
+      : undefined;
+  } catch (error) {
+    logger.debug("[MCP] Device-start response did not contain JSON", { error });
+    return undefined;
+  }
+}

--- a/src/server/deviceSessionResult.ts
+++ b/src/server/deviceSessionResult.ts
@@ -7,11 +7,7 @@ import { logger } from "../utils/logger";
  * bind the session these tools mint — the proxy additionally heartbeats it so
  * the daemon does not reap a result-minted session (issue #5689).
  */
-export const DEVICE_SESSION_ACQUISITION_TOOLS = [
-  "getAndroid",
-  "getApple",
-  "startDevice",
-] as const;
+export const DEVICE_SESSION_ACQUISITION_TOOLS = ["getAndroid", "getApple", "startDevice"] as const;
 
 /** Whether `name` is a device-session acquisition tool (see above). */
 export function isDeviceSessionAcquisitionTool(name: string): boolean {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,6 +58,10 @@ import { registerAccessibilityTools } from "./accessibilityTools";
 import { registerAccessibilityFocusTools } from "./accessibilityFocusTools";
 import { registerNetworkTools } from "./networkTools";
 import { registerToolSelectionTools, SET_TOOL_ENABLED_TOOL_NAME } from "./toolSelectionTools";
+import {
+  getDeviceSessionIdFromResult,
+  isDeviceSessionAcquisitionTool,
+} from "./deviceSessionResult";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
@@ -177,37 +181,6 @@ function stripInternalToolParams(params: unknown): unknown {
   delete rest[INTERNAL_EXECUTION_START_TIME_PARAM];
   delete rest[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
   return rest;
-}
-
-function getDeviceSessionIdFromResult(result: unknown): string | undefined {
-  if (!result || typeof result !== "object" || !("content" in result)) {
-    return undefined;
-  }
-  const content = (result as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-  const text = content.find(
-    (item) =>
-      item &&
-      typeof item === "object" &&
-      "type" in item &&
-      (item as { type?: unknown }).type === "text" &&
-      "text" in item &&
-      typeof (item as { text?: unknown }).text === "string",
-  ) as { text: string } | undefined;
-  if (!text) {
-    return undefined;
-  }
-  try {
-    const payload = JSON.parse(text.text) as { sessionId?: unknown };
-    return typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
-      ? payload.sessionId
-      : undefined;
-  } catch (error) {
-    logger.debug("[MCP] Device-start response did not contain JSON", { error });
-    return undefined;
-  }
 }
 
 function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
@@ -725,7 +698,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         ),
       );
       if (
-        (name === "getAndroid" || name === "getApple" || name === "startDevice") &&
+        isDeviceSessionAcquisitionTool(name) &&
         sessionToolBinding.bind(sessionId, getDeviceSessionIdFromResult(result))
       ) {
         ToolRegistry.notifyToolListChanged();

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -88,7 +88,11 @@ function noActiveDeviceSessionResult(error: DaemonConnectionSessionReleasedError
 }
 
 function noActiveDeviceSessionError(error: DaemonConnectionSessionReleasedError): McpError {
-  return new McpError(-32603, noActiveDeviceSessionMessage(error), noActiveDeviceSessionPayload(error));
+  return new McpError(
+    -32603,
+    noActiveDeviceSessionMessage(error),
+    noActiveDeviceSessionPayload(error),
+  );
 }
 
 function deviceControlTransportFailureResult(error: DeviceControlTransportError): CallToolResult {

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from "../utils/logger";
 import {
   DaemonBoundSessionExpiredError,
+  DaemonConnectionSessionReleasedError,
   DaemonMcpProxy,
   type DaemonMcpProxyConfig,
 } from "../daemon/daemonMcpProxy";
@@ -63,6 +64,31 @@ function sessionOwnershipLostResult(error: DaemonBoundSessionExpiredError): Call
 function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): McpError {
   const payload = sessionOwnershipLostPayload(error);
   return new McpError(-32603, sessionOwnershipLostMessage(error), payload);
+}
+
+function noActiveDeviceSessionPayload(error: DaemonConnectionSessionReleasedError) {
+  return {
+    error: {
+      code: "no_active_device_session",
+      message: error.message,
+      reason: error.reason,
+    },
+  };
+}
+
+function noActiveDeviceSessionMessage(error: DaemonConnectionSessionReleasedError): string {
+  return JSON.stringify(noActiveDeviceSessionPayload(error));
+}
+
+function noActiveDeviceSessionResult(error: DaemonConnectionSessionReleasedError): CallToolResult {
+  return {
+    content: [{ type: "text", text: noActiveDeviceSessionMessage(error) }],
+    isError: true,
+  };
+}
+
+function noActiveDeviceSessionError(error: DaemonConnectionSessionReleasedError): McpError {
+  return new McpError(-32603, noActiveDeviceSessionMessage(error), noActiveDeviceSessionPayload(error));
 }
 
 function deviceControlTransportFailureResult(error: DeviceControlTransportError): CallToolResult {
@@ -161,6 +187,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       if (error instanceof DaemonBoundSessionExpiredError) {
         throw sessionOwnershipLostError(error);
       }
+      if (error instanceof DaemonConnectionSessionReleasedError) {
+        throw noActiveDeviceSessionError(error);
+      }
       logger.error(`[ProxyServer] Failed to list tools: ${error}`);
       throw new ActionableError(`Failed to list tools from daemon: ${errorMessage(error)}`);
     }
@@ -186,6 +215,10 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
           `[ProxyServer] Session ownership lost for ${error.sessionUuid}: ${error.reason}`,
         );
         return sessionOwnershipLostResult(error);
+      }
+      if (error instanceof DaemonConnectionSessionReleasedError) {
+        logger.warn(`[ProxyServer] No active device session (released: ${error.reason})`);
+        return noActiveDeviceSessionResult(error);
       }
       if (error instanceof DeviceControlTransportError) {
         logger.warn(
@@ -216,6 +249,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       if (error instanceof DaemonBoundSessionExpiredError) {
         throw sessionOwnershipLostError(error);
       }
+      if (error instanceof DaemonConnectionSessionReleasedError) {
+        throw noActiveDeviceSessionError(error);
+      }
       logger.error(`[ProxyServer] Failed to list resources: ${error}`);
       throw new ActionableError(`Failed to list resources from daemon: ${errorMessage(error)}`);
     }
@@ -229,6 +265,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {
         throw sessionOwnershipLostError(error);
+      }
+      if (error instanceof DaemonConnectionSessionReleasedError) {
+        throw noActiveDeviceSessionError(error);
       }
       logger.error(`[ProxyServer] Failed to list resource templates: ${error}`);
       throw new ActionableError(
@@ -253,6 +292,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {
         throw sessionOwnershipLostError(error);
+      }
+      if (error instanceof DaemonConnectionSessionReleasedError) {
+        throw noActiveDeviceSessionError(error);
       }
       logger.error(`[ProxyServer] Resource read failed: ${uri} - ${error}`);
       throw new ActionableError(`Failed to read resource from daemon: ${errorMessage(error)}`);

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
+import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../src/daemon/client";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+
+// Issue #5689: `getAndroid` / `getApple` / `startDevice` mint a device session in
+// the tool RESULT. The proxy only ever bound a session from a call's request
+// args, so a result-minted session was never bound or heartbeated — the daemon
+// reaped it after the pre-first-heartbeat grace, and the first later reference to
+// the dead id fenced the connection permanently, including re-acquisition.
+
+const HEARTBEAT_ENV_KEYS = [
+  "AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+] as const;
+
+function clearHeartbeatEnv(): void {
+  for (const key of HEARTBEAT_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function matchingDaemonManager(): FakeDaemonManager {
+  const manager = new FakeDaemonManager();
+  manager.statusResult = { ...manager.statusResult, version: DAEMON_VERSION };
+  return manager;
+}
+
+function deviceStartResult(sessionId: string): { content: Array<{ type: string; text: string }> } {
+  return { content: [{ type: "text", text: JSON.stringify({ sessionId }) }] };
+}
+
+// A FakeDaemonClient standing in for a daemon that mints a fresh device session
+// on each getAndroid call (recorded in a real SessionManager), returns its id in
+// the RESULT, and forwards daemon/heartbeat to the same SessionManager.
+function acquiringClient(
+  sessionManager: SessionManager,
+  mintedIds: string[],
+): { client: FakeDaemonClient; nextIndex: () => number } {
+  let acquired = 0;
+  const client = new FakeDaemonClient({
+    onCallTool: async (toolName) => {
+      if (toolName === "getAndroid") {
+        const sessionId = mintedIds[acquired];
+        acquired += 1;
+        await sessionManager.createSession(sessionId, "emulator-5554", "android", 60_000);
+      }
+    },
+    toolResultFor: (toolName) =>
+      toolName === "getAndroid" ? deviceStartResult(mintedIds[acquired - 1]) : undefined,
+    onCallDaemonMethod: (method, params) => {
+      if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+        sessionManager.recordHeartbeat(params.sessionId);
+      }
+    },
+  });
+  return { client, nextIndex: () => acquired };
+}
+
+describe("proxy binds and heartbeats a result-minted device session (issue #5689)", () => {
+  let timer: FakeTimer;
+  let sessionManager: SessionManager;
+  let reaped: Array<{ sessionId: string; reason: string }>;
+  let monitor: SessionHeartbeatMonitor;
+  let isAvailableSpy: ReturnType<typeof spyOn> | null;
+
+  beforeEach(() => {
+    clearHeartbeatEnv();
+    timer = new FakeTimer();
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    reaped = [];
+    monitor = new SessionHeartbeatMonitor(
+      sessionManager,
+      () => false,
+      async (sessionId, reason) => {
+        reaped.push({ sessionId, reason });
+        await sessionManager.releaseSession(sessionId, reason);
+      },
+      timer,
+    );
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    await monitor.stop();
+    sessionManager.stopCleanupTimer();
+    isAvailableSpy?.mockRestore();
+    isAvailableSpy = null;
+    clearHeartbeatEnv();
+  });
+
+  // AC1: a getAndroid RESULT-minted session is bound AND heartbeated by the proxy
+  // (as src/server/index.ts does on the direct path), so the daemon has recorded
+  // ownership and never reaps it under the pre-first-heartbeat grace.
+  test("delivers the first heartbeat for a getAndroid result-minted session", async () => {
+    const MINTED = "minted-session-a";
+    const { client } = acquiringClient(sessionManager, [MINTED]);
+    monitor.start();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      const result = await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      expect(result).toEqual(deviceStartResult(MINTED));
+
+      // The guarantee: the daemon has already recorded the first ownership
+      // heartbeat for the minted session.
+      expect(sessionManager.getSession(MINTED)?.hasReceivedHeartbeat).toBe(true);
+
+      // Past the pre-first-heartbeat grace, the keeper keeps ownership fresh.
+      await timer.advanceTimeAsync(20_000);
+      await monitor.tick();
+
+      expect(reaped).toEqual([]);
+      expect(sessionManager.getSession(MINTED)).not.toBeNull();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  // AC1 (regression of the exact repro): without binding, the minted session is
+  // reaped after ~5s idle. With the fix it survives a 20s idle window and a later
+  // sessionless call still routes to it.
+  test("a sessionless call after a 20s idle window still reaches the minted session", async () => {
+    const MINTED = "minted-session-b";
+    const { client } = acquiringClient(sessionManager, [MINTED]);
+    monitor.start();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      // Idle 20s, issuing no tool calls (monitor ticks throughout).
+      await timer.advanceTimeAsync(20_000);
+      await monitor.tick();
+      expect(reaped).toEqual([]);
+
+      const observe = await proxy.callTool("observe", { platform: "android", project: "skeleton" });
+      expect(observe).toEqual({ content: [{ type: "text", text: "success" }] });
+      // The sessionless call routed to the minted session, not a released id.
+      expect(client.callToolCalls.at(-1)).toEqual({
+        toolName: "observe",
+        params: { platform: "android", project: "skeleton", sessionUuid: MINTED },
+      });
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  // AC2: a terminal fence must NOT fence session acquisition. After the bound
+  // session is genuinely released, getAndroid is admitted, mints a fresh session,
+  // establishes a new binding, and clears the fence so the connection is usable.
+  test("getAndroid is admitted on a fenced connection and re-establishes a binding", async () => {
+    const M1 = "minted-session-1";
+    const M2 = "minted-session-2";
+    const { client } = acquiringClient(sessionManager, [M1, M2]);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      // The daemon terminally releases the first minted session.
+      client.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, M1, "heartbeat-timeout");
+
+      // Re-acquisition is admitted (not fenced) and mints a new session.
+      const reacquired = await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      expect(reacquired).toEqual(deviceStartResult(M2));
+      expect(sessionManager.getSession(M2)?.hasReceivedHeartbeat).toBe(true);
+
+      // The fence is cleared: a subsequent sessionless call routes to M2.
+      await proxy.callTool("observe", { deviceId: "device-a" });
+      expect(client.callToolCalls.at(-1)).toEqual({
+        toolName: "observe",
+        params: { deviceId: "device-a", sessionUuid: M2 },
+      });
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  // AC3: a sessionless call on a fenced connection whose binding was result-minted
+  // (never named by the client) fails naming the CURRENT state — directing to
+  // re-acquire — rather than reporting the stale uuid the caller never referenced.
+  test("a sessionless call on a result-mint fenced connection names the current state", async () => {
+    const M1 = "minted-session-x";
+    const { client } = acquiringClient(sessionManager, [M1]);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => client,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      await proxy.callTool("getAndroid", { avdName: "am-api34-ga-arm64" });
+      client.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, M1, "heartbeat-timeout");
+
+      // Sessionless call: the error must direct to re-acquire and must NOT present
+      // the stale minted uuid as the caller's own ownership loss.
+      const sessionless = proxy.callTool("observe", { deviceId: "device-a" });
+      await expect(sessionless).rejects.toThrow(/acquire a new device session/i);
+      await expect(sessionless).rejects.not.toThrow(new RegExp(M1));
+
+      // A caller that DOES name the released session still gets ownership-lost.
+      await expect(
+        proxy.callTool("observe", { sessionUuid: M1, deviceId: "device-a" }),
+      ).rejects.toThrow(new RegExp(`${M1}.*(?:expired|released)`, "i"));
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/test/daemon/sessionReleaseGraceSnapshot.test.ts
+++ b/test/daemon/sessionReleaseGraceSnapshot.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+
+// Issue #5689 (Evidence): a session reaped for `missing-first-heartbeat` is
+// released under the pre-first-heartbeat grace (5s), NOT its heartbeat timeout
+// (10s). The release snapshot previously reported `timeoutMs` as the heartbeat
+// timeout, so a reader saw `ageMs < timeoutMs` and concluded the daemon reaped
+// early. The snapshot must report the grace that actually fired.
+
+const GRACE_ENV_KEYS = [
+  "AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+] as const;
+
+function clearGraceEnv(): void {
+  for (const key of GRACE_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+describe("release snapshot reports the deadline that fired (issue #5689)", () => {
+  afterEach(() => {
+    clearGraceEnv();
+  });
+
+  test("a missing-first-heartbeat release reports the pre-first-heartbeat grace, not the heartbeat timeout", async () => {
+    clearGraceEnv();
+    const timer = new FakeTimer();
+    const manager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    try {
+      // Default heartbeat policy: heartbeat timeout defaults to 10s.
+      await manager.createSession("session-nfh", "emulator-5554", "android", 60_000);
+      // Reaped after the 5s pre-first-heartbeat grace elapsed.
+      timer.advanceTime(5_963);
+      await manager.releaseSession("session-nfh", "missing-first-heartbeat");
+
+      const snapshot = manager.getTerminalReleaseSnapshot("session-nfh");
+      expect(snapshot?.releaseReason).toBe("missing-first-heartbeat");
+      expect(snapshot?.heartbeat.hasReceivedHeartbeat).toBe(false);
+      // The operative deadline is the 5s grace, not the 10s heartbeat timeout.
+      expect(snapshot?.heartbeat.timeoutMs).toBe(5_000);
+      // The reported deadline is now coherent with the reaping age.
+      expect(snapshot!.heartbeat.ageMs).toBeGreaterThan(snapshot!.heartbeat.timeoutMs);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("honors an overridden pre-first-heartbeat grace", async () => {
+    process.env.AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS = "3000";
+    const timer = new FakeTimer();
+    const manager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    try {
+      await manager.createSession("session-nfh2", "emulator-5554", "android", 60_000);
+      timer.advanceTime(3_500);
+      await manager.releaseSession("session-nfh2", "missing-first-heartbeat");
+
+      expect(manager.getTerminalReleaseSnapshot("session-nfh2")?.heartbeat.timeoutMs).toBe(3_000);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("a heartbeat-timeout release still reports the session heartbeat timeout", async () => {
+    clearGraceEnv();
+    const timer = new FakeTimer();
+    const manager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    try {
+      // Explicit heartbeat timeout of 2s (custom source).
+      await manager.createSession("session-hbt", "emulator-5554", "android", 60_000, 2_000);
+      timer.advanceTime(3_000);
+      await manager.releaseSession("session-hbt", "heartbeat-timeout");
+
+      expect(manager.getTerminalReleaseSnapshot("session-hbt")?.heartbeat.timeoutMs).toBe(2_000);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+});

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -5,6 +5,11 @@ import type { DaemonNotification } from "../../src/daemon/types";
 
 export interface FakeDaemonClientOptions {
   toolResult?: any;
+  // Per-tool result override. When it returns a value for a given call, that
+  // value is the tool result instead of `toolResult`; returning undefined falls
+  // back to `toolResult`. Lets a test model a device-acquisition tool minting a
+  // session id in its RESULT (issue #5689) while other tools return "success".
+  toolResultFor?: (toolName: string, params: Record<string, any>) => any;
   resourceResult?: any;
   daemonMethodResults?: Map<string, any>;
   // Invoked inside callTool AFTER the call is recorded but BEFORE it resolves, so
@@ -25,6 +30,7 @@ export class FakeDaemonClient implements DaemonClientLike {
   readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
   private connected = false;
   private toolResult: any;
+  private readonly toolResultFor?: (toolName: string, params: Record<string, any>) => any;
   private resourceResult: any;
   private daemonMethodResults: Map<string, any>;
   private readonly onCallTool?: (
@@ -42,6 +48,7 @@ export class FakeDaemonClient implements DaemonClientLike {
 
   constructor(options: FakeDaemonClientOptions = {}) {
     this.toolResult = options.toolResult ?? { content: [{ type: "text", text: "success" }] };
+    this.toolResultFor = options.toolResultFor;
     this.resourceResult = options.resourceResult ?? { contents: [{ uri: "test", text: "test" }] };
     this.daemonMethodResults = options.daemonMethodResults ?? new Map();
     this.onCallTool = options.onCallTool;
@@ -66,7 +73,8 @@ export class FakeDaemonClient implements DaemonClientLike {
     if (this.onCallTool) {
       await this.onCallTool(toolName, params);
     }
-    return this.toolResult;
+    const perToolResult = this.toolResultFor?.(toolName, params);
+    return perToolResult ?? this.toolResult;
   }
 
   async readResource(uri: string, params: Record<string, any> = {}): Promise<any> {


### PR DESCRIPTION
## Summary

`getAndroid` / `getApple` / `startDevice` mint a device session in the tool
**result**, but the daemon proxy (`DaemonMcpProxy`) only ever bound a session
from a call's **request args** (`sessionUuidFromArgs`). A result-minted session
was therefore never bound or heartbeated by the proxy: the daemon reaped it under
the 5s pre-first-heartbeat grace, and the first later reference to the dead id
fenced the MCP connection permanently (`terminalBoundSession`, cleared only in
`close()`) — including the `getAndroid` that is the only in-band way to acquire a
replacement.

This fix binds and heartbeats the result-minted session on the proxy path
(mirroring the direct-path bind in `src/server/index.ts`), keeps device
acquisition admissible on a fenced connection, reports a clearer state for
sessionless calls on a fenced result-mint connection, and corrects the
release-snapshot's reported deadline.

## Linked Issue

Closes #5689

## Bug / Regression Context

- **Prior attempts:** #5637 fixed the analogous race for a session supplied by
  the client at connection startup (`initialSessionUuid`). This one is minted
  *mid-connection* by a tool result, which the proxy had no bind path for.
- **Observed symptom:** after `getAndroid`, a ~20s idle window let the daemon
  reap the never-heartbeated session; the next call fenced the connection and
  every subsequent call — including re-acquisition — failed
  `session_ownership_lost` citing the original dead uuid.
- **Repro steps / conditions:** standalone MCP stdio client, one booted Android
  emulator: `getAndroid` → idle 20s → `observe` (explicit id) → `observe`
  (sessionless) → `getAndroid`. Per the issue, all later calls reported the
  original dead uuid.

## What changed (acceptance criteria)

- **AC1 — result-minted session is bound and heartbeated.**
  `DaemonMcpProxy.callTool` now binds the session id parsed from a
  `getAndroid`/`getApple`/`startDevice` result and delivers the establishment
  heartbeat + starts the keeper, so the daemon records ownership before the
  pre-first-heartbeat grace. The result-parser and acquisition-tool predicate are
  extracted to `src/server/deviceSessionResult.ts` and shared with the direct
  path in `src/server/index.ts`.
- **AC2 — a terminal fence must not fence acquisition.**
  Acquisition tools are admitted while `terminalBoundSession` is set (forwarded
  with raw args, bypassing bound-session routing); a successful result-bind
  clears the fence and establishes a fresh binding.
- **AC3 — a sessionless call on a fenced connection names the current state.**
  Fence errors now discriminate on binding *provenance*: a result-minted binding
  (never named by the client) surfaces `DaemonConnectionSessionReleasedError` →
  `no_active_device_session`, directing the caller to re-acquire, instead of a
  stale uuid the caller never referenced. Client-declared bindings (explicit
  `sessionUuid`, or startup `initialSessionUuid`) keep the existing
  ownership-lost-for-uuid error.
- **AC4 — the release snapshot reports the deadline that fired.**
  A `missing-first-heartbeat` release now reports the pre-first-heartbeat grace
  (5s) as `heartbeat.timeoutMs` instead of the 10s heartbeat timeout, so a reader
  no longer sees `ageMs < timeoutMs` and concludes the daemon reaped early. The
  grace is single-sourced via `getDefaultPreFirstHeartbeatGraceMs`, shared by the
  snapshot and `SessionHeartbeatMonitor`.

## Validation

- [x] `bun run lint` (ratchet gate: no new violations) + `bun test` (full suite
  green; the sole failure is `test/lint/oxlintConfigScoping.test.ts`, which
  spawns the worktree's absent `node_modules/.bin/oxlint` — a `.claude/worktrees`
  env artifact unrelated to this change)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; new unit tests run in <100ms
- [x] New generic code reuses existing helpers (shared result-parser; no new deps)

No public MCP tool schema changes; no DB migration (AC4 reuses existing snapshot
fields).

## Follow-ups

- [ ] None required. AC1–AC4 are all covered here.
