### PR TITLE
feat(desktop): key Android↔iOS compare diff on cross-platform structural roles (#4872)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -399,11 +399,24 @@ private fun pathKey(
  *   pairs with Android's `CheckBox`. The promotion is gated on the generic roles so a `UISwitch`
  *   (also checkable, but already keyed [StructuralRole.Switch] by class) is left alone (issue #4872
  *   review).
+ * - A non-interactive generic node that carries visible `text` is promoted to
+ *   [StructuralRole.Text]. Android's `ViewHierarchyExtractor` blanks `android.widget.TextView` to a
+ *   class-less node (it is in `GENERIC_CLASS_NAMES`), which `HierarchyParser` then defaults to
+ *   `android.view.View` — so an ordinary Android label reaches here as a generic Container and
+ *   would never pair with the iOS runner's `UILabel -> Text`, leaving ubiquitous labels and their
+ *   whole subtrees as OnlyIn. The promotion recovers the label the producer erased. It is gated on
+ *   non-empty text and on the node being neither clickable nor scrollable, so a genuine interactive
+ *   control or scroll container that merely happens to carry text is left in its structural role
+ *   (issue #4872 review).
  */
 private fun structuralRoleOf(node: UIElementInfo): StructuralRole {
   val byClass = structuralRole(node.className)
   val isGeneric = byClass == StructuralRole.Container || byClass == StructuralRole.Other
-  return if (node.isCheckable && isGeneric) StructuralRole.Checkbox else byClass
+  if (!isGeneric) return byClass
+  if (node.isCheckable) return StructuralRole.Checkbox
+  val hasVisibleText = !node.text.isNullOrEmpty()
+  if (hasVisibleText && !node.isClickable && !node.isScrollable) return StructuralRole.Text
+  return byClass
 }
 
 /**
@@ -441,9 +454,12 @@ private fun nodeAttributesDiffer(
 }
 
 /**
- * The cross-platform accessible name of a node: its visible `text` if present, otherwise its
+ * The cross-platform accessible name of a node: its visible `text` if non-empty, otherwise its
  * `contentDescription`. Collapses the Android convention (icon controls carry the label in
  * `content-desc`, text controls in `text`) onto the iOS convention (every label in `text`) so the
- * same control reads the same across platforms (issue #4872 review).
+ * same control reads the same across platforms. An empty `text` is treated as absent so an Android
+ * icon control (`text = ""`, `content-desc = "Add"`) still falls back to its content-desc and reads
+ * the same as an iOS `text = "Add"` instead of comparing `""` against `"Add"` (issue #4872 review).
  */
-private fun accessibleName(node: UIElementInfo): String? = node.text ?: node.contentDescription
+private fun accessibleName(node: UIElementInfo): String? =
+  node.text?.takeIf { it.isNotEmpty() } ?: node.contentDescription

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -98,8 +98,12 @@ fun diffHierarchies(
   val windowsA = windowsOf(a)
   val windowsB = windowsOf(b)
   val (slotsA, slotsB) = alignWindowSlots(windowsA, windowsB, keyMode)
-  val mapA = indexWindows(windowsA, slotsA, keyMode)
-  val mapB = indexWindows(windowsB, slotsB, keyMode)
+  val (mapA, mapB) =
+    if (keyMode == DiffKeyMode.StructuralRole) {
+      indexAlignedWindows(windowsA, slotsA, windowsB, slotsB, keyMode)
+    } else {
+      indexWindows(windowsA, slotsA, keyMode) to indexWindows(windowsB, slotsB, keyMode)
+    }
   val entries = ArrayList<HierarchyDiffEntry>(mapA.size + mapB.size)
   for ((key, nodeA) in mapA) {
     val nodeB = mapB[key]
@@ -167,6 +171,118 @@ private fun indexWindows(
     )
   }
   return map
+}
+
+/** Index role-mode trees with order-preserving, cross-side child slots. */
+private fun indexAlignedWindows(
+  windowsA: List<UIElementInfo>,
+  slotsA: IntArray,
+  windowsB: List<UIElementInfo>,
+  slotsB: IntArray,
+  keyMode: DiffKeyMode,
+): Pair<LinkedHashMap<String, UIElementInfo>, LinkedHashMap<String, UIElementInfo>> {
+  val mapA = LinkedHashMap<String, UIElementInfo>()
+  val mapB = LinkedHashMap<String, UIElementInfo>()
+  addAlignedChildren(mapA, mapB, windowsA, slotsA, windowsB, slotsB, "", null, null, keyMode)
+  return mapA to mapB
+}
+
+private fun addAlignedChildren(
+  mapA: LinkedHashMap<String, UIElementInfo>,
+  mapB: LinkedHashMap<String, UIElementInfo>,
+  childrenA: List<UIElementInfo>,
+  slotsA: IntArray,
+  childrenB: List<UIElementInfo>,
+  slotsB: IntArray,
+  parentKey: String,
+  parentRoleA: StructuralRole?,
+  parentRoleB: StructuralRole?,
+  keyMode: DiffKeyMode,
+) {
+  val bySlotA = childrenA.indices.associateBy { slotsA[it] }
+  val bySlotB = childrenB.indices.associateBy { slotsB[it] }
+  (bySlotA.keys + bySlotB.keys).sorted().forEach { slot ->
+    val nodeA = bySlotA[slot]?.let(childrenA::get)
+    val nodeB = bySlotB[slot]?.let(childrenB::get)
+    val roleA = nodeA?.let { roleFor(it, keyMode, parentRoleA) }
+    val roleB = nodeB?.let { roleFor(it, keyMode, parentRoleB) }
+    nodeA?.let { mapA[pathKey(parentKey, it, slot, keyMode, roleA)] = it }
+    nodeB?.let { mapB[pathKey(parentKey, it, slot, keyMode, roleB)] = it }
+    val key =
+      nodeA?.let { pathKey(parentKey, it, slot, keyMode, roleA) }
+        ?: nodeB?.let { pathKey(parentKey, it, slot, keyMode, roleB) }
+        ?: return@forEach
+    val (childSlotsA, childSlotsB) =
+      alignChildSlots(nodeA?.children.orEmpty(), nodeB?.children.orEmpty(), roleA, roleB)
+    addAlignedChildren(
+      mapA,
+      mapB,
+      nodeA?.children.orEmpty(),
+      childSlotsA,
+      nodeB?.children.orEmpty(),
+      childSlotsB,
+      key,
+      roleA,
+      roleB,
+      keyMode,
+    )
+  }
+}
+
+/** Needleman-Wunsch alignment that only pairs siblings with the same structural role. */
+private fun alignChildSlots(
+  childrenA: List<UIElementInfo>,
+  childrenB: List<UIElementInfo>,
+  parentRoleA: StructuralRole?,
+  parentRoleB: StructuralRole?,
+): Pair<IntArray, IntArray> {
+  val slotsA = IntArray(childrenA.size)
+  val slotsB = IntArray(childrenB.size)
+  fun similarity(a: UIElementInfo, b: UIElementInfo): Double {
+    if (structuralRoleOf(a, parentRoleA) != structuralRoleOf(b, parentRoleB)) {
+      return Double.NEGATIVE_INFINITY
+    }
+    return if (accessibleName(a) == accessibleName(b)) 2.0 else 1.0
+  }
+  val score = Array(childrenA.size + 1) { DoubleArray(childrenB.size + 1) }
+  for (i in 1..childrenA.size) for (j in 1..childrenB.size) {
+    score[i][j] =
+      maxOf(
+        score[i - 1][j - 1] + similarity(childrenA[i - 1], childrenB[j - 1]),
+        score[i - 1][j],
+        score[i][j - 1],
+      )
+  }
+  val columnsA = ArrayList<Int>()
+  val columnsB = ArrayList<Int>()
+  var i = childrenA.size
+  var j = childrenB.size
+  while (i > 0 || j > 0) {
+    val diagonal =
+      if (i > 0 && j > 0) score[i - 1][j - 1] + similarity(childrenA[i - 1], childrenB[j - 1])
+      else Double.NEGATIVE_INFINITY
+    when {
+      i > 0 && j > 0 && diagonal >= score[i - 1][j] && diagonal >= score[i][j - 1] -> {
+        columnsA.add(--i)
+        columnsB.add(--j)
+      }
+      i > 0 && (j == 0 || score[i - 1][j] >= score[i][j - 1]) -> {
+        columnsA.add(--i)
+        columnsB.add(-1)
+      }
+      else -> {
+        columnsA.add(-1)
+        columnsB.add(--j)
+      }
+    }
+  }
+  var slot = 0
+  for (column in columnsA.indices.reversed()) {
+    columnsA[column].takeIf { it >= 0 }?.let { slotsA[it] = slot }
+    columnsB[column].takeIf { it >= 0 }?.let { slotsB[it] = slot }
+    slot++
+  }
+  return slotsA to slotsB
 }
 
 /**
@@ -442,15 +558,15 @@ private fun pathKey(
  *   Container` whose collection-item metadata `HierarchyParser` drops, so inferring `ListItem` from
  *   the `List` parent is what pairs the two rows (and thus their descendants) instead of leaving
  *   every row as OnlyIn (issue #4872 review).
- * - A non-interactive generic node that carries visible `text` is promoted to
+ * - A non-interactive generic node that carries an accessible name is promoted to
  *   [StructuralRole.Text]. Android's `ViewHierarchyExtractor` blanks `android.widget.TextView` to a
  *   class-less node (it is in `GENERIC_CLASS_NAMES`), which `HierarchyParser` then defaults to
  *   `android.view.View` — so an ordinary Android label reaches here as a generic Container and
  *   would never pair with the iOS runner's `UILabel -> Text`, leaving ubiquitous labels and their
  *   whole subtrees as OnlyIn. The promotion recovers the label the producer erased. It is gated on
- *   non-empty text and on the node being neither clickable nor scrollable, so a genuine interactive
- *   control or scroll container that merely happens to carry text is left in its structural role
- *   (issue #4872 review).
+ *   non-empty accessible name and on the node being neither clickable nor scrollable, so a genuine
+ *   interactive control or scroll container that merely happens to carry a label is left in its
+ *   structural role (issue #4872 review).
  * - A generic scrollable node is promoted to [StructuralRole.ScrollView]. Android's extractor also
  *   clears `android.widget.ScrollView`, but retains `isScrollable`; without this recovery it
  *   remains a Container and cannot pair with iOS's `UIScrollView -> ScrollView` role.
@@ -465,8 +581,8 @@ private fun structuralRoleOf(node: UIElementInfo, parentRole: StructuralRole?): 
   if (!isGeneric) return byClass
   if (parentRole == StructuralRole.List) return StructuralRole.ListItem
   if (node.isScrollable) return StructuralRole.ScrollView
-  val hasVisibleText = !node.text.isNullOrEmpty()
-  if (hasVisibleText && !node.isClickable && !node.isScrollable) return StructuralRole.Text
+  val hasAccessibleName = !accessibleName(node).isNullOrEmpty()
+  if (hasAccessibleName && !node.isClickable && !node.isScrollable) return StructuralRole.Text
   return byClass
 }
 
@@ -505,12 +621,11 @@ private fun nodeAttributesDiffer(
 }
 
 /**
- * The cross-platform accessible name of a node: its visible `text` if non-empty, otherwise its
- * `contentDescription`. Collapses the Android convention (icon controls carry the label in
- * `content-desc`, text controls in `text`) onto the iOS convention (every label in `text`) so the
- * same control reads the same across platforms. An empty `text` is treated as absent so an Android
- * icon control (`text = ""`, `content-desc = "Add"`) still falls back to its content-desc and reads
- * the same as an iOS `text = "Add"` instead of comparing `""` against `"Add"` (issue #4872 review).
+ * The cross-platform accessible name of a node. Android's explicit content description is its
+ * accessibility label even when visible text is also present; iOS serializes that label in `text`
+ * and leaves `contentDescription` empty. Prefer the former when available, then fall back to text,
+ * so a production Android label such as `content-desc="Predicted app: AutoMobile Playground"` pairs
+ * with the equivalent iOS text instead of comparing the Android's separate visible label.
  */
 private fun accessibleName(node: UIElementInfo): String? =
-  node.text?.takeIf { it.isNotEmpty() } ?: node.contentDescription
+  node.contentDescription?.takeIf { it.isNotEmpty() } ?: node.text?.takeIf { it.isNotEmpty() }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -157,7 +157,14 @@ private fun indexWindows(
 ): LinkedHashMap<String, UIElementInfo> {
   val map = LinkedHashMap<String, UIElementInfo>()
   windows.forEachIndexed { index, window ->
-    addSubtree(map, window, parentKey = "", siblingIndex = slots[index], keyMode = keyMode)
+    addSubtree(
+      map,
+      window,
+      parentKey = "",
+      siblingIndex = slots[index],
+      keyMode = keyMode,
+      parentRole = null,
+    )
   }
   return map
 }
@@ -288,7 +295,14 @@ private fun alignWindowSlots(
  */
 private fun signatureKeys(window: UIElementInfo, keyMode: DiffKeyMode): Set<String> {
   val keys = LinkedHashSet<String>()
-  collectSignatureKeys(keys, window, parentKey = "", siblingIndex = 0, keyMode = keyMode)
+  collectSignatureKeys(
+    keys,
+    window,
+    parentKey = "",
+    siblingIndex = 0,
+    keyMode = keyMode,
+    parentRole = null,
+  )
   return keys
 }
 
@@ -309,11 +323,13 @@ private fun collectSignatureKeys(
   parentKey: String,
   siblingIndex: Int,
   keyMode: DiffKeyMode,
+  parentRole: StructuralRole?,
 ) {
-  val structural = pathKey(parentKey, node, siblingIndex, keyMode)
+  val role = roleFor(node, keyMode, parentRole)
+  val structural = pathKey(parentKey, node, siblingIndex, keyMode, role)
   keys.add("$structural::${semanticDigest(node, keyMode)}")
   node.children.forEachIndexed { index, child ->
-    collectSignatureKeys(keys, child, structural, index, keyMode)
+    collectSignatureKeys(keys, child, structural, index, keyMode, role)
   }
 }
 
@@ -367,38 +383,65 @@ private fun addSubtree(
   parentKey: String,
   siblingIndex: Int,
   keyMode: DiffKeyMode,
+  parentRole: StructuralRole?,
 ) {
-  val key = pathKey(parentKey, node, siblingIndex, keyMode)
+  val role = roleFor(node, keyMode, parentRole)
+  val key = pathKey(parentKey, node, siblingIndex, keyMode, role)
   map[key] = node
-  node.children.forEachIndexed { index, child -> addSubtree(map, child, key, index, keyMode) }
+  node.children.forEachIndexed { index, child ->
+    addSubtree(map, child, key, index, keyMode, role)
+  }
 }
+
+/**
+ * The resolved [StructuralRole] for a node in role mode, threaded to children as their parent role;
+ * null in class-name mode where roles are unused. Computed once per node so [pathKey] and the
+ * recursion share the value (and the [structuralRoleOf] parent-context inference).
+ */
+private fun roleFor(
+  node: UIElementInfo,
+  keyMode: DiffKeyMode,
+  parentRole: StructuralRole?,
+): StructuralRole? =
+  if (keyMode == DiffKeyMode.StructuralRole) structuralRoleOf(node, parentRole) else null
 
 private fun pathKey(
   parentKey: String,
   node: UIElementInfo,
   siblingIndex: Int,
   keyMode: DiffKeyMode,
+  role: StructuralRole?,
 ): String {
   val segment =
     when (keyMode) {
       DiffKeyMode.ClassName -> "${node.className}:${node.resourceId ?: ""}#$siblingIndex"
       // Role mode drops the platform-specific resourceId: it never matches across Android↔iOS, so
-      // keeping it would defeat the whole point of role keying.
-      DiffKeyMode.StructuralRole -> "${structuralRoleOf(node)}#$siblingIndex"
+      // keeping it would defeat the whole point of role keying. [role] is the pre-resolved
+      // [roleFor] value (non-null in this mode).
+      DiffKeyMode.StructuralRole -> "${role}#$siblingIndex"
     }
   return if (parentKey.isEmpty()) segment else "$parentKey$PATH_SEPARATOR$segment"
 }
 
 /**
- * The cross-platform [StructuralRole] of a full node. Starts from the class-name mapping, then
- * applies the semantic signals a class name alone cannot carry:
- * - A checkable node whose class maps only to a generic [StructuralRole.Container] or
- *   [StructuralRole.Other] is promoted to [StructuralRole.Checkbox]. The live iOS runner reports a
- *   checkbox as the bare `UIView` class (`ElementLocator.mapElementType` has no `.checkBox` case)
- *   while still setting `isCheckable`, so without this an iOS checkbox keys as Container and never
- *   pairs with Android's `CheckBox`. The promotion is gated on the generic roles so a `UISwitch`
- *   (also checkable, but already keyed [StructuralRole.Switch] by class) is left alone (issue #4872
- *   review).
+ * The cross-platform [StructuralRole] of a full node, given its [parentRole] (the resolved role of
+ * its parent, or null at a window root). Starts from the class-name mapping, then applies the
+ * semantic and positional signals a class name alone cannot carry:
+ * - A checkable node is promoted to [StructuralRole.Checkbox] unless its class already keyed it to
+ *   the sibling checkable role [StructuralRole.Switch]. The live iOS runner reports a checkbox as
+ *   the bare `UIView` class (`ElementLocator.mapElementType` has no `.checkBox` case) while still
+ *   setting `isCheckable`, so an iOS checkbox arrives as a generic Container; Android's
+ *   `CheckedTextView` instead keys as [StructuralRole.Text] by class (it contains the `TextView`
+ *   substring) yet is a standard checkable control. Promoting on `isCheckable` regardless of the
+ *   class-derived role — not only the generic ones — pairs both against Android's `CheckBox`
+ *   instead of leaving them as OnlyIn. `Switch` is exempt so a `UISwitch`/`SwitchCompat`/
+ *   `ToggleButton` (also checkable) keeps its own distinct role (issue #4872 review).
+ * - A generic node whose [parentRole] is [StructuralRole.List] is promoted to
+ *   [StructuralRole.ListItem]: it is the list's row wrapper. iOS emits a row as a `UITableViewCell
+ *   -> ListItem` by class, but an Android row is an ordinary `LinearLayout`/`ViewGroup ->
+ *   Container` whose collection-item metadata `HierarchyParser` drops, so inferring `ListItem` from
+ *   the `List` parent is what pairs the two rows (and thus their descendants) instead of leaving
+ *   every row as OnlyIn (issue #4872 review).
  * - A non-interactive generic node that carries visible `text` is promoted to
  *   [StructuralRole.Text]. Android's `ViewHierarchyExtractor` blanks `android.widget.TextView` to a
  *   class-less node (it is in `GENERIC_CLASS_NAMES`), which `HierarchyParser` then defaults to
@@ -412,11 +455,15 @@ private fun pathKey(
  *   clears `android.widget.ScrollView`, but retains `isScrollable`; without this recovery it
  *   remains a Container and cannot pair with iOS's `UIScrollView -> ScrollView` role.
  */
-private fun structuralRoleOf(node: UIElementInfo): StructuralRole {
+private fun structuralRoleOf(node: UIElementInfo, parentRole: StructuralRole?): StructuralRole {
   val byClass = structuralRole(node.className)
+  // Checkable controls key as Checkbox even when the class name mapped them elsewhere (e.g.
+  // CheckedTextView -> Text), so a checkable control pairs across platforms. Switch is left alone:
+  // it is a distinct checkable role that must not collapse into Checkbox.
+  if (node.isCheckable && byClass != StructuralRole.Switch) return StructuralRole.Checkbox
   val isGeneric = byClass == StructuralRole.Container || byClass == StructuralRole.Other
   if (!isGeneric) return byClass
-  if (node.isCheckable) return StructuralRole.Checkbox
+  if (parentRole == StructuralRole.List) return StructuralRole.ListItem
   if (node.isScrollable) return StructuralRole.ScrollView
   val hasVisibleText = !node.text.isNullOrEmpty()
   if (hasVisibleText && !node.isClickable && !node.isScrollable) return StructuralRole.Text

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -49,6 +49,20 @@ data class HierarchyDiff(val entries: List<HierarchyDiffEntry>) {
 private const val PATH_SEPARATOR = "/"
 
 /**
+ * How [diffHierarchies] forms a node's structural key segment.
+ * - [ClassName]: the raw platform-specific `className` (plus `resourceId`). The honest identity for
+ *   a **same-platform** diff, where classes and ids line up.
+ * - [StructuralRole]: the cross-platform [structuralRole] of the class, with `resourceId` dropped
+ *   (ids are platform-specific and never match across Android↔iOS). Lets an Android and an iOS
+ *   rendering of the same screen pair by role + tree position and produce a meaningful diff instead
+ *   of two disjoint OnlyIn trees (issue #4872).
+ */
+enum class DiffKeyMode {
+  ClassName,
+  StructuralRole,
+}
+
+/**
  * Diff two view hierarchies into a flat, deterministic classification.
  *
  * Node identity is a **structural path key**: each node contributes the segment
@@ -67,13 +81,25 @@ private const val PATH_SEPARATOR = "/"
  * The result is deterministic (stable pre-order) and symmetric in classification: `diffHierarchies(
  * a, b)` and `diffHierarchies(b, a)` agree once A/B roles are swapped (an `OnlyInA` key in one is
  * exactly an `OnlyInB` key in the other; `Changed`/`Equal` key sets are identical).
+ *
+ * [keyMode] selects how each key segment is formed. The default [DiffKeyMode.ClassName] keeps the
+ * raw platform-specific identity for a same-platform diff; [DiffKeyMode.StructuralRole] keys on the
+ * cross-platform [structuralRole] instead so an Android↔iOS pair diffs meaningfully. The mode only
+ * changes the *segment* (className/resourceId → role); every other property above — window
+ * alignment, pre-order determinism, the attribute-only Changed test, and the A/B symmetry — is
+ * mode-independent because it is threaded identically through both the diff index and the
+ * window-alignment signatures.
  */
-fun diffHierarchies(a: UIElementInfo, b: UIElementInfo): HierarchyDiff {
+fun diffHierarchies(
+  a: UIElementInfo,
+  b: UIElementInfo,
+  keyMode: DiffKeyMode = DiffKeyMode.ClassName,
+): HierarchyDiff {
   val windowsA = windowsOf(a)
   val windowsB = windowsOf(b)
-  val (slotsA, slotsB) = alignWindowSlots(windowsA, windowsB)
-  val mapA = indexWindows(windowsA, slotsA)
-  val mapB = indexWindows(windowsB, slotsB)
+  val (slotsA, slotsB) = alignWindowSlots(windowsA, windowsB, keyMode)
+  val mapA = indexWindows(windowsA, slotsA, keyMode)
+  val mapB = indexWindows(windowsB, slotsB, keyMode)
   val entries = ArrayList<HierarchyDiffEntry>(mapA.size + mapB.size)
   for ((key, nodeA) in mapA) {
     val nodeB = mapB[key]
@@ -123,10 +149,11 @@ private fun windowsOf(root: UIElementInfo): List<UIElementInfo> =
 private fun indexWindows(
   windows: List<UIElementInfo>,
   slots: IntArray,
+  keyMode: DiffKeyMode,
 ): LinkedHashMap<String, UIElementInfo> {
   val map = LinkedHashMap<String, UIElementInfo>()
   windows.forEachIndexed { index, window ->
-    addSubtree(map, window, parentKey = "", siblingIndex = slots[index])
+    addSubtree(map, window, parentKey = "", siblingIndex = slots[index], keyMode = keyMode)
   }
   return map
 }
@@ -160,6 +187,7 @@ private fun indexWindows(
 private fun alignWindowSlots(
   windowsA: List<UIElementInfo>,
   windowsB: List<UIElementInfo>,
+  keyMode: DiffKeyMode,
 ): Pair<IntArray, IntArray> {
   val n = windowsA.size
   val m = windowsB.size
@@ -171,8 +199,8 @@ private fun alignWindowSlots(
     return slotsA to slotsB
   }
 
-  val signaturesA = windowsA.map { signatureKeys(it) }
-  val signaturesB = windowsB.map { signatureKeys(it) }
+  val signaturesA = windowsA.map { signatureKeys(it, keyMode) }
+  val signaturesB = windowsB.map { signatureKeys(it, keyMode) }
   // A canonical, side-independent ordering key per window (its sorted signature). Used only to
   // break a skipA-vs-skipB tie deterministically by window *content* rather than by side, so the
   // choice is transposition-invariant (see the backtrack below).
@@ -254,9 +282,9 @@ private fun alignWindowSlots(
  * (structure **and** compared attributes) produce identical key sets, so [jaccard] overlap measures
  * subtree similarity for [alignWindowSlots]. See [collectSignatureKeys].
  */
-private fun signatureKeys(window: UIElementInfo): Set<String> {
+private fun signatureKeys(window: UIElementInfo, keyMode: DiffKeyMode): Set<String> {
   val keys = LinkedHashSet<String>()
-  collectSignatureKeys(keys, window, parentKey = "", siblingIndex = 0)
+  collectSignatureKeys(keys, window, parentKey = "", siblingIndex = 0, keyMode = keyMode)
   return keys
 }
 
@@ -276,11 +304,12 @@ private fun collectSignatureKeys(
   node: UIElementInfo,
   parentKey: String,
   siblingIndex: Int,
+  keyMode: DiffKeyMode,
 ) {
-  val structural = pathKey(parentKey, node, siblingIndex)
+  val structural = pathKey(parentKey, node, siblingIndex, keyMode)
   keys.add("$structural::${semanticDigest(node)}")
   node.children.forEachIndexed { index, child ->
-    collectSignatureKeys(keys, child, structural, index)
+    collectSignatureKeys(keys, child, structural, index, keyMode)
   }
 }
 
@@ -323,14 +352,26 @@ private fun addSubtree(
   node: UIElementInfo,
   parentKey: String,
   siblingIndex: Int,
+  keyMode: DiffKeyMode,
 ) {
-  val key = pathKey(parentKey, node, siblingIndex)
+  val key = pathKey(parentKey, node, siblingIndex, keyMode)
   map[key] = node
-  node.children.forEachIndexed { index, child -> addSubtree(map, child, key, index) }
+  node.children.forEachIndexed { index, child -> addSubtree(map, child, key, index, keyMode) }
 }
 
-private fun pathKey(parentKey: String, node: UIElementInfo, siblingIndex: Int): String {
-  val segment = "${node.className}:${node.resourceId ?: ""}#$siblingIndex"
+private fun pathKey(
+  parentKey: String,
+  node: UIElementInfo,
+  siblingIndex: Int,
+  keyMode: DiffKeyMode,
+): String {
+  val segment =
+    when (keyMode) {
+      DiffKeyMode.ClassName -> "${node.className}:${node.resourceId ?: ""}#$siblingIndex"
+      // Role mode drops the platform-specific resourceId: it never matches across Android↔iOS, so
+      // keeping it would defeat the whole point of role keying.
+      DiffKeyMode.StructuralRole -> "${structuralRole(node.className)}#$siblingIndex"
+    }
   return if (parentKey.isEmpty()) segment else "$parentKey$PATH_SEPARATOR$segment"
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -103,7 +103,7 @@ fun diffHierarchies(
   val entries = ArrayList<HierarchyDiffEntry>(mapA.size + mapB.size)
   for ((key, nodeA) in mapA) {
     val nodeB = mapB[key]
-    entries.add(HierarchyDiffEntry(key, classifyMatched(nodeA, nodeB), nodeA, nodeB))
+    entries.add(HierarchyDiffEntry(key, classifyMatched(nodeA, nodeB, keyMode), nodeA, nodeB))
   }
   for ((key, nodeB) in mapB) {
     if (!mapA.containsKey(key)) {
@@ -114,10 +114,14 @@ fun diffHierarchies(
 }
 
 /** Classify a node from A against its same-key counterpart in B (null when absent from B). */
-private fun classifyMatched(nodeA: UIElementInfo, nodeB: UIElementInfo?): NodeDiffStatus =
+private fun classifyMatched(
+  nodeA: UIElementInfo,
+  nodeB: UIElementInfo?,
+  keyMode: DiffKeyMode,
+): NodeDiffStatus =
   when {
     nodeB == null -> NodeDiffStatus.OnlyInA
-    nodeAttributesDiffer(nodeA, nodeB) -> NodeDiffStatus.Changed
+    nodeAttributesDiffer(nodeA, nodeB, keyMode) -> NodeDiffStatus.Changed
     else -> NodeDiffStatus.Equal
   }
 
@@ -307,17 +311,26 @@ private fun collectSignatureKeys(
   keyMode: DiffKeyMode,
 ) {
   val structural = pathKey(parentKey, node, siblingIndex, keyMode)
-  keys.add("$structural::${semanticDigest(node)}")
+  keys.add("$structural::${semanticDigest(node, keyMode)}")
   node.children.forEachIndexed { index, child ->
     collectSignatureKeys(keys, child, structural, index, keyMode)
   }
 }
 
-/** The compared semantic attributes of a node, joined — the [nodeAttributesDiffer] surface. */
-private fun semanticDigest(node: UIElementInfo): String =
-  listOf(
-      node.text ?: "",
-      node.contentDescription ?: "",
+/**
+ * The compared semantic attributes of a node, joined — the [nodeAttributesDiffer] surface, and it
+ * must track that surface per [keyMode]. Same-platform keeps `text` and `contentDescription` as two
+ * fields; cross-platform collapses them to the single normalized [accessibleName] so the alignment
+ * signatures agree with the role-mode Changed test.
+ */
+private fun semanticDigest(node: UIElementInfo, keyMode: DiffKeyMode): String {
+  val label =
+    when (keyMode) {
+      DiffKeyMode.ClassName -> "${node.text ?: ""}|${node.contentDescription ?: ""}"
+      DiffKeyMode.StructuralRole -> accessibleName(node) ?: ""
+    }
+  return listOf(
+      label,
       node.isClickable,
       node.isEnabled,
       node.isFocused,
@@ -327,6 +340,7 @@ private fun semanticDigest(node: UIElementInfo): String =
       node.isChecked,
     )
     .joinToString("|")
+}
 
 /**
  * A canonical, order-independent string for a window's signature key set: its keys sorted and
@@ -370,19 +384,53 @@ private fun pathKey(
       DiffKeyMode.ClassName -> "${node.className}:${node.resourceId ?: ""}#$siblingIndex"
       // Role mode drops the platform-specific resourceId: it never matches across Android↔iOS, so
       // keeping it would defeat the whole point of role keying.
-      DiffKeyMode.StructuralRole -> "${structuralRole(node.className)}#$siblingIndex"
+      DiffKeyMode.StructuralRole -> "${structuralRoleOf(node)}#$siblingIndex"
     }
   return if (parentKey.isEmpty()) segment else "$parentKey$PATH_SEPARATOR$segment"
+}
+
+/**
+ * The cross-platform [StructuralRole] of a full node. Starts from the class-name mapping, then
+ * applies the semantic signals a class name alone cannot carry:
+ * - A checkable node whose class maps only to a generic [StructuralRole.Container] or
+ *   [StructuralRole.Other] is promoted to [StructuralRole.Checkbox]. The live iOS runner reports a
+ *   checkbox as the bare `UIView` class (`ElementLocator.mapElementType` has no `.checkBox` case)
+ *   while still setting `isCheckable`, so without this an iOS checkbox keys as Container and never
+ *   pairs with Android's `CheckBox`. The promotion is gated on the generic roles so a `UISwitch`
+ *   (also checkable, but already keyed [StructuralRole.Switch] by class) is left alone (issue #4872
+ *   review).
+ */
+private fun structuralRoleOf(node: UIElementInfo): StructuralRole {
+  val byClass = structuralRole(node.className)
+  val isGeneric = byClass == StructuralRole.Container || byClass == StructuralRole.Other
+  return if (node.isCheckable && isGeneric) StructuralRole.Checkbox else byClass
 }
 
 /**
  * Whether two same-key nodes differ in a compared semantic attribute. Bounds and children are
  * deliberately excluded (see [diffHierarchies]); className and resourceId are already equal because
  * they are part of the key.
+ *
+ * [keyMode] governs the label comparison. A same-platform diff ([DiffKeyMode.ClassName]) compares
+ * `text` and `contentDescription` field-by-field, the honest identity where both platforms fill the
+ * same fields. A cross-platform diff ([DiffKeyMode.StructuralRole]) compares a single normalized
+ * [accessibleName] instead: Android puts an icon control's label in `content-desc` and a visible
+ * label in `text`, whereas iOS puts every accessibility label in `text` and leaves `content-desc`
+ * null — so comparing the fields separately reports equivalent controls (an Android
+ * `content-desc="Add"` vs an iOS `text="Add"`) as Changed. The boolean state flags are compared
+ * identically in both modes (issue #4872 review).
  */
-private fun nodeAttributesDiffer(a: UIElementInfo, b: UIElementInfo): Boolean =
-  a.text != b.text ||
-    a.contentDescription != b.contentDescription ||
+private fun nodeAttributesDiffer(
+  a: UIElementInfo,
+  b: UIElementInfo,
+  keyMode: DiffKeyMode,
+): Boolean {
+  val labelsDiffer =
+    when (keyMode) {
+      DiffKeyMode.ClassName -> a.text != b.text || a.contentDescription != b.contentDescription
+      DiffKeyMode.StructuralRole -> accessibleName(a) != accessibleName(b)
+    }
+  return labelsDiffer ||
     a.isClickable != b.isClickable ||
     a.isEnabled != b.isEnabled ||
     a.isFocused != b.isFocused ||
@@ -390,3 +438,12 @@ private fun nodeAttributesDiffer(a: UIElementInfo, b: UIElementInfo): Boolean =
     a.isScrollable != b.isScrollable ||
     a.isCheckable != b.isCheckable ||
     a.isChecked != b.isChecked
+}
+
+/**
+ * The cross-platform accessible name of a node: its visible `text` if present, otherwise its
+ * `contentDescription`. Collapses the Android convention (icon controls carry the label in
+ * `content-desc`, text controls in `text`) onto the iOS convention (every label in `text`) so the
+ * same control reads the same across platforms (issue #4872 review).
+ */
+private fun accessibleName(node: UIElementInfo): String? = node.text ?: node.contentDescription

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -408,12 +408,16 @@ private fun pathKey(
  *   non-empty text and on the node being neither clickable nor scrollable, so a genuine interactive
  *   control or scroll container that merely happens to carry text is left in its structural role
  *   (issue #4872 review).
+ * - A generic scrollable node is promoted to [StructuralRole.ScrollView]. Android's extractor also
+ *   clears `android.widget.ScrollView`, but retains `isScrollable`; without this recovery it
+ *   remains a Container and cannot pair with iOS's `UIScrollView -> ScrollView` role.
  */
 private fun structuralRoleOf(node: UIElementInfo): StructuralRole {
   val byClass = structuralRole(node.className)
   val isGeneric = byClass == StructuralRole.Container || byClass == StructuralRole.Other
   if (!isGeneric) return byClass
   if (node.isCheckable) return StructuralRole.Checkbox
+  if (node.isScrollable) return StructuralRole.ScrollView
   val hasVisibleText = !node.text.isNullOrEmpty()
   if (hasVisibleText && !node.isClickable && !node.isScrollable) return StructuralRole.Text
   return byClass

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
@@ -1,0 +1,99 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+/**
+ * A cross-platform, structural role for a UI node, abstracting away the platform-specific
+ * `className`. The role captures *what kind of thing* a node is (a button, a text label, a
+ * scrollable list, …) so an Android and an iOS rendering of the same screen can be diffed by role
+ * instead of by raw class (issue #4872).
+ *
+ * The set is deliberately coarse — it covers the widget families a two-device compare cares about
+ * and folds everything unrecognised into [Other]. Grow it when a real screen needs a finer role,
+ * not ahead of need.
+ */
+enum class StructuralRole {
+  Container,
+  Text,
+  TextField,
+  Button,
+  Image,
+  List,
+  ListItem,
+  Checkbox,
+  Switch,
+  Toolbar,
+  ScrollView,
+  WebView,
+  Other,
+}
+
+/**
+ * Map a platform-specific view `className` to its cross-platform [StructuralRole].
+ *
+ * Recognises both Android class names (`android.widget.*`, `androidx.*`, Compose, custom
+ * `*View`/`*Layout` classes) and iOS XCUITest element types (`XCUIElementType*`). Matching is by
+ * substring so vendor-prefixed or `Compat`/`Material` variants (e.g. `SwitchCompat`,
+ * `MaterialButton`, `AppCompatImageView`) fall into the right role without an exhaustive table.
+ *
+ * Order matters: more specific families are tested before broader ones. In particular toggles and
+ * checkboxes are matched before [Button] because Android's `ToggleButton`/`CompoundButton` contain
+ * the substring `Button`, and editable text is matched before static [Text] because iOS's
+ * `XCUIElementTypeTextView` (an editable field) contains `TextView` (Android's static label).
+ * Unrecognised classes map to [Other].
+ */
+fun structuralRole(className: String): StructuralRole =
+  when {
+    // Editable text entry. iOS TextView is an editable multiline field, so it belongs here rather
+    // than with the static Text below (Android's TextView, matched later, is a static label).
+    className.contains("EditText") ||
+      className.contains("XCUIElementTypeTextField") ||
+      className.contains("XCUIElementTypeSecureTextField") ||
+      className.contains("XCUIElementTypeSearchField") ||
+      className.contains("XCUIElementTypeTextView") -> StructuralRole.TextField
+    // Checkboxes and toggles/switches — before Button, since ToggleButton/CompoundButton contain
+    // the "Button" substring.
+    className.contains("CheckBox") || className.contains("XCUIElementTypeCheckBox") ->
+      StructuralRole.Checkbox
+    className.contains("Switch") ||
+      className.contains("ToggleButton") ||
+      className.contains("XCUIElementTypeSwitch") ||
+      className.contains("XCUIElementTypeToggle") -> StructuralRole.Switch
+    // Buttons: Android Button/ImageButton/MaterialButton, iOS Button.
+    className.contains("Button") || className.contains("XCUIElementTypeButton") ->
+      StructuralRole.Button
+    // Static text labels.
+    className.contains("TextView") || className.contains("XCUIElementTypeStaticText") ->
+      StructuralRole.Text
+    // Images.
+    className.contains("ImageView") || className.contains("XCUIElementTypeImage") ->
+      StructuralRole.Image
+    // List / collection containers.
+    className.contains("RecyclerView") ||
+      className.contains("ListView") ||
+      className.contains("GridView") ||
+      className.contains("XCUIElementTypeTable") ||
+      className.contains("XCUIElementTypeCollectionView") -> StructuralRole.List
+    // A single row/cell within a list.
+    className.contains("XCUIElementTypeCell") -> StructuralRole.ListItem
+    // Top/bottom chrome: toolbars, action/nav bars, tab bars.
+    className.contains("Toolbar") ||
+      className.contains("ActionBar") ||
+      className.contains("XCUIElementTypeNavigationBar") ||
+      className.contains("XCUIElementTypeToolbar") ||
+      className.contains("XCUIElementTypeTabBar") -> StructuralRole.Toolbar
+    // Scroll containers (Android ScrollView/HorizontalScrollView/NestedScrollView, iOS ScrollView).
+    className.contains("ScrollView") || className.contains("XCUIElementTypeScrollView") ->
+      StructuralRole.ScrollView
+    // Web content.
+    className.contains("WebView") || className.contains("XCUIElementTypeWebView") ->
+      StructuralRole.WebView
+    // Generic containers: layouts, view groups, Compose host, and iOS structural wrappers.
+    className.contains("Layout") ||
+      className.contains("ViewGroup") ||
+      className.contains("ComposeView") ||
+      className.contains("XCUIElementTypeApplication") ||
+      className.contains("XCUIElementTypeWindow") ||
+      className.contains("XCUIElementTypeGroup") ||
+      className.contains("XCUIElementTypeOther") ||
+      className == MULTI_WINDOW_ROOT_CLASS_NAME -> StructuralRole.Container
+    else -> StructuralRole.Other
+  }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
@@ -22,6 +22,7 @@ enum class StructuralRole {
   Switch,
   Toolbar,
   ScrollView,
+  Progress,
   WebView,
   Other,
 }
@@ -97,6 +98,11 @@ fun structuralRole(className: String): StructuralRole =
       className.contains("ActionBar") ||
       className.contains("NavigationBar") ||
       className.contains("TabBar") -> StructuralRole.Toolbar
+    // Progress indicators: Android ProgressBar, iOS UIProgressView/UIActivityIndicatorView.
+    className.contains("ProgressBar") ||
+      className.contains("UIProgressView") ||
+      className.contains("UIActivityIndicatorView") ||
+      className.contains("XCUIElementTypeActivityIndicator") -> StructuralRole.Progress
     // Scroll containers: Android ScrollView/NestedScrollView, iOS UIScrollView, XCUITest
     // ScrollView.
     className.contains("ScrollView") || className.contains("XCUIElementTypeScrollView") ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
@@ -39,11 +39,12 @@ enum class StructuralRole {
  * vendor-prefixed or `Compat`/`Material` variants (e.g. `SwitchCompat`, `MaterialButton`,
  * `AppCompatImageView`) fall into the right role without an exhaustive table.
  *
- * Order matters: more specific families are tested before broader ones. In particular toggles and
- * checkboxes are matched before [Button] because Android's `ToggleButton`/`CompoundButton` contain
- * the substring `Button`; a list cell is matched before [List] because `UITableViewCell` contains
- * `TableView`; and iOS's editable `UITextView` is matched before static [Text] because it contains
- * `TextView` (Android's static label). Unrecognised classes map to [Other].
+ * Order matters: more specific families are tested before broader ones. In particular toggles,
+ * checkboxes, and radio buttons are matched before [Button] because Android's
+ * `ToggleButton`/`CompoundButton`/`RadioButton` contain the substring `Button`; a list cell is
+ * matched before [List] because `UITableViewCell` contains `TableView`; and iOS's editable
+ * `UITextView` is matched before static [Text] because it contains `TextView` (Android's static
+ * label). Unrecognised classes map to [Other].
  */
 fun structuralRole(className: String): StructuralRole =
   when {
@@ -56,10 +57,14 @@ fun structuralRole(className: String): StructuralRole =
       className.contains("SearchBar") ||
       className.contains("UITextView") ||
       className.contains("XCUIElementTypeTextView") -> StructuralRole.TextField
-    // Checkboxes and toggles/switches — before Button, since ToggleButton/CompoundButton contain
-    // the "Button" substring.
-    className.contains("CheckBox") || className.contains("XCUIElementTypeCheckBox") ->
-      StructuralRole.Checkbox
+    // Checkboxes, radio buttons, and toggles/switches — before Button, since
+    // ToggleButton/CompoundButton/RadioButton all contain the "Button" substring. Android's
+    // RadioButton folds into Checkbox: the iOS runner reports a radio as a checkable `UIView` with
+    // no distinct class, which structuralRoleOf promotes to Checkbox, so a shared checkable role is
+    // the only one that pairs the two (issue #4872 review).
+    className.contains("CheckBox") ||
+      className.contains("XCUIElementTypeCheckBox") ||
+      className.contains("RadioButton") -> StructuralRole.Checkbox
     // "Switch" also matches iOS UISwitch and XCUIElementTypeSwitch.
     className.contains("Switch") ||
       className.contains("ToggleButton") ||
@@ -123,6 +128,14 @@ fun structuralRole(className: String): StructuralRole =
       className.contains("XCUIElementTypeWindow") ||
       className.contains("XCUIElementTypeGroup") ||
       className.contains("XCUIElementTypeOther") ||
+      // Catch-all for custom Android View subclasses (e.g. `com.example.ProfileView`) and iOS
+      // structural views like `UIStackView`: the specific `*View` families (TextView, ImageView,
+      // ScrollView, WebView, RecyclerView, …) are matched above, so anything else ending in `View`
+      // is a bespoke container. It lands in Container to mirror the iOS runner, which reports an
+      // equivalent custom `.other` element as `UIView -> Container`; otherwise the custom subtree
+      // keys as Other on one side and Container on the other and reads as disjoint (issue #4872
+      // review).
+      className.endsWith("View") ||
       className == MULTI_WINDOW_ROOT_CLASS_NAME -> StructuralRole.Container
     else -> StructuralRole.Other
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
@@ -30,66 +30,85 @@ enum class StructuralRole {
  * Map a platform-specific view `className` to its cross-platform [StructuralRole].
  *
  * Recognises both Android class names (`android.widget.*`, `androidx.*`, Compose, custom
- * `*View`/`*Layout` classes) and iOS XCUITest element types (`XCUIElementType*`). Matching is by
- * substring so vendor-prefixed or `Compat`/`Material` variants (e.g. `SwitchCompat`,
- * `MaterialButton`, `AppCompatImageView`) fall into the right role without an exhaustive table.
+ * `*View`/`*Layout` classes) and the iOS vocabulary. On iOS the class the runner reports is the
+ * UIKit class name that `ElementLocator.mapElementType` emits (`XCUIApplication`, `UIWindow`,
+ * `UIButton`, `UILabel`, `UITextField`, `UITableView`, `UITableViewCell`, `WKWebView`, `UIView`,
+ * …), which `CtrlProxyHierarchy.convertNode` forwards unchanged — so the UIKit names are the ones
+ * that must match on live trees. The XCUITest-native `XCUIElementType*` names are also recognised
+ * defensively (they are what a raw XCUITest snapshot uses). Matching is by substring so
+ * vendor-prefixed or `Compat`/`Material` variants (e.g. `SwitchCompat`, `MaterialButton`,
+ * `AppCompatImageView`) fall into the right role without an exhaustive table.
  *
  * Order matters: more specific families are tested before broader ones. In particular toggles and
  * checkboxes are matched before [Button] because Android's `ToggleButton`/`CompoundButton` contain
- * the substring `Button`, and editable text is matched before static [Text] because iOS's
- * `XCUIElementTypeTextView` (an editable field) contains `TextView` (Android's static label).
- * Unrecognised classes map to [Other].
+ * the substring `Button`; a list cell is matched before [List] because `UITableViewCell` contains
+ * `TableView`; and iOS's editable `UITextView` is matched before static [Text] because it contains
+ * `TextView` (Android's static label). Unrecognised classes map to [Other].
  */
 fun structuralRole(className: String): StructuralRole =
   when {
-    // Editable text entry. iOS TextView is an editable multiline field, so it belongs here rather
-    // than with the static Text below (Android's TextView, matched later, is a static label).
+    // Editable text entry. Android EditText; iOS UITextField/UISecureTextField/UISearchBar and the
+    // editable UITextView (matched explicitly here — before the static Text branch — so it is not
+    // mistaken for Android's static TextView); plus the XCUITest-native equivalents.
     className.contains("EditText") ||
-      className.contains("XCUIElementTypeTextField") ||
-      className.contains("XCUIElementTypeSecureTextField") ||
-      className.contains("XCUIElementTypeSearchField") ||
+      className.contains("TextField") ||
+      className.contains("SearchField") ||
+      className.contains("SearchBar") ||
+      className.contains("UITextView") ||
       className.contains("XCUIElementTypeTextView") -> StructuralRole.TextField
     // Checkboxes and toggles/switches — before Button, since ToggleButton/CompoundButton contain
     // the "Button" substring.
     className.contains("CheckBox") || className.contains("XCUIElementTypeCheckBox") ->
       StructuralRole.Checkbox
+    // "Switch" also matches iOS UISwitch and XCUIElementTypeSwitch.
     className.contains("Switch") ||
       className.contains("ToggleButton") ||
-      className.contains("XCUIElementTypeSwitch") ||
       className.contains("XCUIElementTypeToggle") -> StructuralRole.Switch
-    // Buttons: Android Button/ImageButton/MaterialButton, iOS Button.
+    // Buttons: Android Button/ImageButton/MaterialButton, iOS UIButton / XCUIElementTypeButton.
     className.contains("Button") || className.contains("XCUIElementTypeButton") ->
       StructuralRole.Button
-    // Static text labels.
-    className.contains("TextView") || className.contains("XCUIElementTypeStaticText") ->
-      StructuralRole.Text
-    // Images.
+    // Static text labels: Android TextView, iOS UILabel / XCUIElementTypeStaticText.
+    className.contains("TextView") ||
+      className.contains("UILabel") ||
+      className.contains("XCUIElementTypeStaticText") -> StructuralRole.Text
+    // Images: Android ImageView, iOS UIImageView / XCUIElementTypeImage.
     className.contains("ImageView") || className.contains("XCUIElementTypeImage") ->
       StructuralRole.Image
-    // List / collection containers.
+    // A single row/cell within a list — before List, since UITableViewCell contains "TableView".
+    // Catches iOS UITableViewCell/UICollectionViewCell and XCUIElementTypeCell.
+    className.contains("Cell") -> StructuralRole.ListItem
+    // List / collection containers: Android RecyclerView/ListView/GridView, iOS UITableView/
+    // UICollectionView, and the XCUITest-native XCUIElementTypeTable.
     className.contains("RecyclerView") ||
       className.contains("ListView") ||
       className.contains("GridView") ||
-      className.contains("XCUIElementTypeTable") ||
-      className.contains("XCUIElementTypeCollectionView") -> StructuralRole.List
-    // A single row/cell within a list.
-    className.contains("XCUIElementTypeCell") -> StructuralRole.ListItem
-    // Top/bottom chrome: toolbars, action/nav bars, tab bars.
+      className.contains("TableView") ||
+      className.contains("CollectionView") ||
+      className.contains("XCUIElementTypeTable") -> StructuralRole.List
+    // Top/bottom chrome: toolbars, action/nav bars, tab bars. Android Toolbar/ActionBar; iOS
+    // UIToolbar/UINavigationBar/UITabBar and the XCUITest-native equivalents (all covered by the
+    // "Toolbar"/"NavigationBar"/"TabBar" substrings).
     className.contains("Toolbar") ||
       className.contains("ActionBar") ||
-      className.contains("XCUIElementTypeNavigationBar") ||
-      className.contains("XCUIElementTypeToolbar") ||
-      className.contains("XCUIElementTypeTabBar") -> StructuralRole.Toolbar
-    // Scroll containers (Android ScrollView/HorizontalScrollView/NestedScrollView, iOS ScrollView).
+      className.contains("NavigationBar") ||
+      className.contains("TabBar") -> StructuralRole.Toolbar
+    // Scroll containers: Android ScrollView/NestedScrollView, iOS UIScrollView, XCUITest
+    // ScrollView.
     className.contains("ScrollView") || className.contains("XCUIElementTypeScrollView") ->
       StructuralRole.ScrollView
-    // Web content.
+    // Web content: Android WebView, iOS WKWebView / XCUIElementTypeWebView.
     className.contains("WebView") || className.contains("XCUIElementTypeWebView") ->
       StructuralRole.WebView
-    // Generic containers: layouts, view groups, Compose host, and iOS structural wrappers.
+    // Generic containers: Android layouts/view groups/Compose host; iOS structural wrappers. The
+    // runner emits XCUIApplication + UIWindow for the mandatory root and window and UIView for any
+    // non-semantic wrapper, so these must land in the same role as Android's FrameLayout/ViewGroup
+    // or the two roots would never pair. The XCUIElementType* names are the XCUITest-native forms.
     className.contains("Layout") ||
       className.contains("ViewGroup") ||
       className.contains("ComposeView") ||
+      className.contains("XCUIApplication") ||
+      className.contains("UIWindow") ||
+      className.contains("UIView") ||
       className.contains("XCUIElementTypeApplication") ||
       className.contains("XCUIElementTypeWindow") ||
       className.contains("XCUIElementTypeGroup") ||

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt
@@ -103,7 +103,17 @@ fun structuralRole(className: String): StructuralRole =
     // runner emits XCUIApplication + UIWindow for the mandatory root and window and UIView for any
     // non-semantic wrapper, so these must land in the same role as Android's FrameLayout/ViewGroup
     // or the two roots would never pair. The XCUIElementType* names are the XCUITest-native forms.
-    className.contains("Layout") ||
+    //
+    // The bare `android.view.View` (and its short `View` form) is folded in here too: both Android
+    // extraction paths wrap the capture in a class-less synthetic root, and `HierarchyParser`
+    // defaults a class-less node to `android.view.View` — so that is the class the live Android
+    // compare root actually carries. Without this it would map to Other while the iOS root maps to
+    // Container, and since every descendant key includes the root segment the two live trees would
+    // stay wholly disjoint (issue #4872 review). A plain `View` is a generic wrapper regardless, so
+    // this also mirrors iOS's `UIView -> Container` for non-root spacers.
+    className == "android.view.View" ||
+      className == "View" ||
+      className.contains("Layout") ||
       className.contains("ViewGroup") ||
       className.contains("ComposeView") ||
       className.contains("XCUIApplication") ||

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -36,6 +36,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.layout.DiffKeyMode
 import dev.jasonpearson.automobile.desktop.core.layout.HierarchyDiff
 import dev.jasonpearson.automobile.desktop.core.layout.HierarchyDiffEntry
 import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
@@ -97,10 +98,15 @@ fun TwoDeviceCompareView(
   var hierarchyA by remember(columnA.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
   var hierarchyB by remember(columnB.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
   val diff =
-    remember(hierarchyA, hierarchyB) {
+    remember(hierarchyA, hierarchyB, columnA.platform, columnB.platform) {
       val a = hierarchyA
       val b = hierarchyB
-      if (a != null && b != null) diffHierarchies(a.root, b.root) else null
+      // A cross-platform pair keys by structural role (issue #4872); a same-platform pair keeps the
+      // raw-class identity, which lines up class names and resource ids exactly.
+      val keyMode =
+        if (columnA.platform == columnB.platform) DiffKeyMode.ClassName
+        else DiffKeyMode.StructuralRole
+      if (a != null && b != null) diffHierarchies(a.root, b.root, keyMode) else null
     }
 
   Column(modifier.fillMaxSize().semantics { contentDescription = "Two-device compare" }) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -212,26 +212,23 @@ fun WorkspaceShell(
 }
 
 /**
- * Pick the two device columns to compare: the focused column plus the first other observed column
- * **of the same platform**. Returns null when there is no same-platform second device, so the ⧉
- * Compare entry stays hidden and the overlay never opens with an incomparable pair. If more than
- * two same-platform devices are observed, only the focused device and one other are compared (N-way
- * compare is deferred).
+ * Pick the two device columns to compare: the focused column plus the first other observed column.
+ * Returns null when there is no second device, so the ⧉ Compare entry stays hidden. If more than
+ * two devices are observed, only the focused device and one other are compared (N-way compare is
+ * deferred).
  *
- * Same-platform only because the structural diff key embeds `className`, which is platform-specific
- * (`android.widget.FrameLayout` vs `XCUIElementTypeApplication`): an Android-to-iOS pair would
- * share no keys and every node would read as only-in-one, a meaningless diff. Cross-platform
- * structural-role normalization is deferred to issue #4872.
+ * A cross-platform (Android↔iOS) pair is allowed: [TwoDeviceCompareView] keys such a diff by the
+ * cross-platform [structuralRole][dev.jasonpearson.automobile.desktop.core.layout.structuralRole]
+ * of each node (issue #4872) rather than by the platform-specific `className`, so the two trees
+ * pair by role + tree position and produce a meaningful diff instead of two disjoint only-in trees.
+ * A same-platform pair keeps the raw-class identity.
  */
 internal fun compareColumns(content: WorkspaceUiState.Content): Pair<DeviceColumn, DeviceColumn>? {
   val focused =
     content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
       ?: content.columns.firstOrNull()
       ?: return null
-  val other =
-    content.columns.firstOrNull {
-      it.deviceId != focused.deviceId && it.platform == focused.platform
-    } ?: return null
+  val other = content.columns.firstOrNull { it.deviceId != focused.deviceId } ?: return null
   return focused to other
 }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -426,4 +426,130 @@ class HierarchyDiffTest {
     assertEquals(0, diff.onlyInA)
     assertEquals(0, diff.onlyInB)
   }
+
+  // --- Cross-platform structural-role keying (issue #4872) ---
+
+  /** An Android screen: content frame → list → [title label, action button]. */
+  private fun androidScreen(title: String, action: String): UIElementInfo =
+    node(
+      "android.widget.FrameLayout",
+      "android:id/content",
+      children =
+        listOf(
+          node(
+            "androidx.recyclerview.widget.RecyclerView",
+            "com.app:id/list",
+            children =
+              listOf(
+                node("android.widget.TextView", "com.app:id/title", text = title),
+                node("androidx.appcompat.widget.AppCompatButton", "com.app:id/cta", text = action),
+              ),
+          )
+        ),
+    )
+
+  /** The iOS rendering of the same screen: application → table → [static text, button]. */
+  private fun iosScreen(title: String, action: String): UIElementInfo =
+    node(
+      "XCUIElementTypeApplication",
+      children =
+        listOf(
+          node(
+            "XCUIElementTypeTable",
+            children =
+              listOf(
+                node("XCUIElementTypeStaticText", text = title),
+                node("XCUIElementTypeButton", text = action),
+              ),
+          )
+        ),
+    )
+
+  @Test
+  fun `class-name mode makes a cross-platform pair a meaningless all-OnlyIn diff`() {
+    val diff = diffHierarchies(androidScreen("Inbox", "Compose"), iosScreen("Inbox", "Compose"))
+
+    // Disjoint class names: every Android node is OnlyInA and every iOS node is OnlyInB, with no
+    // Equal/Changed — the very failure #4872 describes.
+    assertEquals(4, diff.onlyInA)
+    assertEquals(4, diff.onlyInB)
+    assertEquals(0, diff.equal)
+    assertEquals(0, diff.changed)
+  }
+
+  @Test
+  fun `role mode pairs a structurally-equal cross-platform screen as all-equal`() {
+    val diff =
+      diffHierarchies(
+        androidScreen("Inbox", "Compose"),
+        iosScreen("Inbox", "Compose"),
+        DiffKeyMode.StructuralRole,
+      )
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(4, diff.equal)
+    assertFalse(diff.hasDifferences)
+    // Keys are keyed by role, not raw class.
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Button#"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "List#"))
+  }
+
+  @Test
+  fun `role mode reports a differing label as Changed, not OnlyIn`() {
+    val diff =
+      diffHierarchies(
+        androidScreen("Inbox", "Compose"),
+        iosScreen("Sent", "Compose"),
+        DiffKeyMode.StructuralRole,
+      )
+
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "Text#"))
+    assertEquals(1, diff.changed)
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(3, diff.equal)
+  }
+
+  @Test
+  fun `role mode isolates a genuinely-extra node as OnlyIn`() {
+    // The Android side has an extra image trailing the button; the rest still pairs by role.
+    val android =
+      node(
+        "android.widget.FrameLayout",
+        "android:id/content",
+        children =
+          listOf(
+            node("android.widget.TextView", "com.app:id/title", text = "Inbox"),
+            node("android.widget.ImageView", "com.app:id/avatar"),
+          ),
+      )
+    val ios =
+      node(
+        "XCUIElementTypeApplication",
+        children = listOf(node("XCUIElementTypeStaticText", text = "Inbox")),
+      )
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(NodeDiffStatus.OnlyInA, statusOf(diff, "Image#"))
+    assertEquals(1, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+  }
+
+  @Test
+  fun `role mode is symmetric under A-B swap`() {
+    val android = androidScreen("Inbox", "Compose")
+    val ios = iosScreen("Sent", "Compose")
+
+    val forward = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+    val backward = diffHierarchies(ios, android, DiffKeyMode.StructuralRole)
+
+    assertEquals(forward.onlyInA, backward.onlyInB)
+    assertEquals(forward.onlyInB, backward.onlyInA)
+    assertEquals(forward.changed, backward.changed)
+    assertEquals(forward.equal, backward.equal)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -17,6 +17,7 @@ class HierarchyDiffTest {
     contentDescription: String? = null,
     bounds: ElementBounds = ElementBounds(0, 0, 10, 10),
     isClickable: Boolean = false,
+    isScrollable: Boolean = false,
     isCheckable: Boolean = false,
     isChecked: Boolean = false,
     children: List<UIElementInfo> = emptyList(),
@@ -32,7 +33,7 @@ class HierarchyDiffTest {
       isEnabled = true,
       isFocused = false,
       isSelected = false,
-      isScrollable = false,
+      isScrollable = isScrollable,
       isCheckable = isCheckable,
       isChecked = isChecked,
       children = children,
@@ -706,6 +707,29 @@ class HierarchyDiffTest {
     assertEquals(2, diff.equal)
     assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Container#"))
     assertNull(statusOf(diff, "Text#"))
+  }
+
+  /**
+   * Production Android also blanks `android.widget.ScrollView` to `android.view.View`, while
+   * retaining its scrollable state. Role mode must recover ScrollView from that state so its
+   * subtree aligns with the iOS runner's `UIScrollView` instead of becoming OnlyIn entries.
+   */
+  @Test
+  fun `role mode promotes a class-erased android scroll container to ScrollView`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.view.View", isScrollable = true)),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIScrollView", isScrollable = true)))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "ScrollView#"))
   }
 
   /**

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -659,4 +659,134 @@ class HierarchyDiffTest {
     assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Switch#"))
     assertNull(statusOf(diff, "Checkbox#"))
   }
+
+  /**
+   * Production Android blanks `android.widget.TextView` (it is in the extractor's
+   * `GENERIC_CLASS_NAMES`) to a class-less node that `HierarchyParser` defaults to
+   * `android.view.View`, so an ordinary label arrives as a generic node — not the idealized
+   * `TextView` the earlier tests use. Role mode must still promote a non-interactive text-bearing
+   * generic node to Text so it pairs with the iOS `UILabel`; otherwise ubiquitous labels and their
+   * subtrees read as OnlyIn (issue #4872 review).
+   */
+  @Test
+  fun `role mode promotes a class-erased android label to Text so it pairs with an ios UILabel`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.view.View", "com.app:id/title", text = "Inbox")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UILabel", text = "Inbox")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Text#"))
+  }
+
+  /**
+   * The text promotion is gated on the node being non-interactive: a clickable generic node that
+   * carries text is left in its structural Container role on both sides rather than mis-promoted to
+   * Text, so an interactive control is never keyed as a static label (issue #4872 review).
+   */
+  @Test
+  fun `role mode leaves a clickable text-bearing generic node keyed as Container`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.view.View", text = "Go", isClickable = true)),
+      )
+    val ios =
+      node("XCUIApplication", children = listOf(node("UIView", text = "Go", isClickable = true)))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Container#"))
+    assertNull(statusOf(diff, "Text#"))
+  }
+
+  /**
+   * Android keeps `android.widget.RadioButton` (it is not erased), which contains the `Button`
+   * substring, while the iOS runner reports a radio as a checkable generic `UIView`. Role mode
+   * folds the Android radio into Checkbox so it pairs with iOS's promoted checkable node instead of
+   * surfacing as two OnlyIn entries (issue #4872 review).
+   */
+  @Test
+  fun `role mode pairs an android RadioButton with an ios checkable radio view`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.RadioButton", isCheckable = true)),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIView", isCheckable = true)))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Checkbox#"))
+  }
+
+  /**
+   * A custom Android View subclass (`com.example.ProfileView`) and its whole subtree must pair with
+   * the iOS runner's custom `.other -> UIView` container. Without the `*View` container catch-all
+   * the Android node keys as Other and the iOS node as Container, making the entire custom subtree
+   * disjoint (issue #4872 review).
+   */
+  @Test
+  fun `role mode pairs a custom android View container with an ios UIView container`() {
+    val android =
+      node(
+        "android.view.View",
+        children =
+          listOf(
+            node(
+              "com.example.ProfileView",
+              children = listOf(node("android.widget.TextView", text = "Name")),
+            )
+          ),
+      )
+    val ios =
+      node(
+        "XCUIApplication",
+        children = listOf(node("UIView", children = listOf(node("UILabel", text = "Name")))),
+      )
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(3, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Container#"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Text#"))
+  }
+
+  /**
+   * An Android icon control can carry an empty `text` alongside a real `content-desc`. The
+   * normalized accessible name treats empty text as absent and falls back to `content-desc`, so it
+   * reads the same as the iOS `text` label instead of comparing `""` against the label and
+   * reporting Changed (issue #4872 review).
+   */
+  @Test
+  fun `role mode treats empty android text as absent and falls back to content-desc`() {
+    val android =
+      node(
+        "android.view.View",
+        children =
+          listOf(node("android.widget.ImageButton", text = "", contentDescription = "Add")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIButton", text = "Add")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.changed)
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Button#"))
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -185,7 +185,7 @@ class HierarchyDiffTest {
   fun `same-platform trees with realistic class names yield a mixed non-disjoint diff`() {
     // Real Android class names on BOTH sides: the shared structure matches by key, so the diff is a
     // meaningful mix of equal/changed/only-in rather than the all-disjoint result a cross-platform
-    // pair (android.widget.* vs XCUIElementType*) would produce.
+    // pair (android.widget.* vs the iOS runner's UIKit names) would produce.
     val a =
       node(
         "android.widget.FrameLayout",
@@ -448,19 +448,20 @@ class HierarchyDiffTest {
         ),
     )
 
-  /** The iOS rendering of the same screen: application → table → [static text, button]. */
+  /**
+   * The iOS rendering of the same screen: application → table → [static text, button]. Uses the
+   * UIKit class names the runner actually reports (`ElementLocator.mapElementType`), not the
+   * fabricated `XCUIElementType*` forms, so the cross-platform role diff is exercised on the live
+   * vocabulary.
+   */
   private fun iosScreen(title: String, action: String): UIElementInfo =
     node(
-      "XCUIElementTypeApplication",
+      "XCUIApplication",
       children =
         listOf(
           node(
-            "XCUIElementTypeTable",
-            children =
-              listOf(
-                node("XCUIElementTypeStaticText", text = title),
-                node("XCUIElementTypeButton", text = action),
-              ),
+            "UITableView",
+            children = listOf(node("UILabel", text = title), node("UIButton", text = action)),
           )
         ),
     )
@@ -525,11 +526,7 @@ class HierarchyDiffTest {
             node("android.widget.ImageView", "com.app:id/avatar"),
           ),
       )
-    val ios =
-      node(
-        "XCUIElementTypeApplication",
-        children = listOf(node("XCUIElementTypeStaticText", text = "Inbox")),
-      )
+    val ios = node("XCUIApplication", children = listOf(node("UILabel", text = "Inbox")))
 
     val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -17,11 +17,12 @@ class HierarchyDiffTest {
     contentDescription: String? = null,
     bounds: ElementBounds = ElementBounds(0, 0, 10, 10),
     isClickable: Boolean = false,
+    isCheckable: Boolean = false,
     isChecked: Boolean = false,
     children: List<UIElementInfo> = emptyList(),
   ): UIElementInfo =
     UIElementInfo(
-      id = "$className:${resourceId ?: ""}:${text ?: ""}",
+      id = "$className:${resourceId ?: ""}:${text ?: ""}:${contentDescription ?: ""}",
       className = className,
       resourceId = resourceId,
       text = text,
@@ -32,7 +33,7 @@ class HierarchyDiffTest {
       isFocused = false,
       isSelected = false,
       isScrollable = false,
-      isCheckable = false,
+      isCheckable = isCheckable,
       isChecked = isChecked,
       children = children,
       depth = 0,
@@ -548,5 +549,114 @@ class HierarchyDiffTest {
     assertEquals(forward.onlyInB, backward.onlyInA)
     assertEquals(forward.changed, backward.changed)
     assertEquals(forward.equal, backward.equal)
+  }
+
+  // --- Production-shaped cross-platform pairing (issue #4872 review) ---
+
+  /**
+   * The Android compare root as `HierarchyParser` actually produces it: a class-less synthetic
+   * wrapper defaulting to `android.view.View`, not the idealized `FrameLayout`. It must pair with
+   * the iOS `XCUIApplication` root, or the shared root segment diverges and every descendant key is
+   * disjoint — the two live trees would read as wholly OnlyIn.
+   */
+  @Test
+  fun `role mode pairs the production class-less android root with the ios root`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.TextView", "com.app:id/title", text = "Inbox")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UILabel", text = "Inbox")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Container#"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Text#"))
+  }
+
+  /**
+   * An icon button carries its label in Android's `content-desc` but in iOS's `text`. Role mode
+   * normalizes to a single accessible name, so the equivalent controls read Equal instead of being
+   * flagged Changed by a field-by-field text/content-desc comparison.
+   */
+  @Test
+  fun `role mode treats an android content-desc and an ios text label as the same accessible name`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.ImageButton", contentDescription = "Add")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIButton", text = "Add")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.changed)
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Button#"))
+  }
+
+  /** A genuinely different accessible name is still Changed under the normalized comparison. */
+  @Test
+  fun `role mode still reports a differing accessible name as Changed`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.ImageButton", contentDescription = "Add")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIButton", text = "Remove")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(1, diff.changed)
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "Button#"))
+  }
+
+  /**
+   * The live iOS runner reports a checkbox as the bare `UIView` class (its `mapElementType` has no
+   * `.checkBox` case) while still setting `isCheckable`. Role mode promotes that checkable generic
+   * node to Checkbox so it pairs with Android's `CheckBox` instead of surfacing as OnlyIn on each
+   * side.
+   */
+  @Test
+  fun `role mode pairs an ios checkbox reported as a checkable UIView with an android CheckBox`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.CheckBox", isCheckable = true)),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIView", isCheckable = true)))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Checkbox#"))
+  }
+
+  /**
+   * The checkable promotion is gated on generic roles: a `UISwitch` is checkable too but already
+   * keys as Switch by class, so it must not be pulled into Checkbox and mis-pair with a checkbox.
+   */
+  @Test
+  fun `role mode leaves a checkable switch keyed as Switch`() {
+    val androidSwitch =
+      node(
+        "android.view.View",
+        children = listOf(node("androidx.appcompat.widget.SwitchCompat", isCheckable = true)),
+      )
+    val iosSwitch = node("XCUIApplication", children = listOf(node("UISwitch", isCheckable = true)))
+
+    val diff = diffHierarchies(androidSwitch, iosSwitch, DiffKeyMode.StructuralRole)
+
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Switch#"))
+    assertNull(statusOf(diff, "Checkbox#"))
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -914,4 +914,76 @@ class HierarchyDiffTest {
     assertEquals(2, diff.equal)
     assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Button#"))
   }
+
+  @Test
+  fun `role mode aligns later siblings after a platform-specific node`() {
+    val android =
+      node(
+        "android.view.View",
+        children =
+          listOf(
+            node("android.widget.TextView", text = "First"),
+            node("android.widget.ImageView"),
+            node("android.widget.TextView", text = "Second"),
+          ),
+      )
+    val ios =
+      node(
+        "XCUIApplication",
+        children = listOf(node("UILabel", text = "First"), node("UILabel", text = "Second")),
+      )
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(1, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(3, diff.equal)
+  }
+
+  @Test
+  fun `role mode promotes a content-description-only generic node to Text`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.view.View", contentDescription = "Home")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIView", text = "Home")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Text#"))
+  }
+
+  @Test
+  fun `role mode prefers an Android content description over visible text`() {
+    val android =
+      node(
+        "android.view.View",
+        children =
+          listOf(
+            node(
+              "android.widget.Button",
+              text = "AutoMobile Playground",
+              contentDescription = "Predicted app: AutoMobile Playground",
+            )
+          ),
+      )
+    val ios =
+      node(
+        "XCUIApplication",
+        children = listOf(node("UIButton", text = "Predicted app: AutoMobile Playground")),
+      )
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.changed)
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -790,6 +790,107 @@ class HierarchyDiffTest {
   }
 
   /**
+   * `android.widget.CheckedTextView` is a standard checkable control, but its class name contains
+   * the `TextView` substring so the class mapping keys it as [StructuralRole.Text] — before any
+   * generic-role checkable promotion could fire. The iOS runner reports the equivalent checkbox as
+   * a checkable bare `UIView -> Container`. Promoting on `isCheckable` regardless of the
+   * class-derived role folds the CheckedTextView into Checkbox too, so the two pair instead of
+   * surfacing as OnlyIn on each side (issue #4872 review).
+   */
+  @Test
+  fun `role mode pairs a checkable android CheckedTextView with an ios checkable view`() {
+    val android =
+      node(
+        "android.view.View",
+        children =
+          listOf(node("android.widget.CheckedTextView", text = "Wifi", isCheckable = true)),
+      )
+    val ios =
+      node("XCUIApplication", children = listOf(node("UIView", text = "Wifi", isCheckable = true)))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Checkbox#"))
+  }
+
+  /**
+   * A production Android list row is an ordinary `LinearLayout`/`ViewGroup -> Container` whose
+   * collection-item metadata `HierarchyParser` drops, while the iOS runner emits the matching row
+   * as a `UITableViewCell -> ListItem` by class. Keying the Android row by its class alone would
+   * make every row (and its whole subtree) OnlyIn against the iOS cells. Inferring [ListItem] for a
+   * generic direct child of a [List] parent pairs the rows so their contents diff (issue #4872
+   * review).
+   */
+  @Test
+  fun `role mode infers ListItem for an android list-row wrapper so it pairs with an ios cell`() {
+    val android =
+      node(
+        "android.widget.FrameLayout",
+        "android:id/content",
+        children =
+          listOf(
+            node(
+              "androidx.recyclerview.widget.RecyclerView",
+              "com.app:id/list",
+              children =
+                listOf(
+                  node(
+                    "android.widget.LinearLayout",
+                    "com.app:id/row",
+                    children = listOf(node("android.widget.TextView", text = "Inbox")),
+                  )
+                ),
+            )
+          ),
+      )
+    val ios =
+      node(
+        "XCUIApplication",
+        children =
+          listOf(
+            node(
+              "UITableView",
+              children =
+                listOf(node("UITableViewCell", children = listOf(node("UILabel", text = "Inbox")))),
+            )
+          ),
+      )
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    // Root(Container) + List + row(ListItem) + label(Text) all pair.
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(4, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "List#"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "ListItem#"))
+  }
+
+  /**
+   * The ListItem inference is scoped to a [List] parent: a generic container that is *not* a list
+   * row keeps its Container role, so an ordinary nested wrapper is never mis-keyed as a list item.
+   */
+  @Test
+  fun `role mode does not infer ListItem for a generic container outside a list`() {
+    val android =
+      node(
+        "android.view.View",
+        children = listOf(node("android.widget.LinearLayout", "com.app:id/panel")),
+      )
+    val ios = node("XCUIApplication", children = listOf(node("UIView")))
+
+    val diff = diffHierarchies(android, ios, DiffKeyMode.StructuralRole)
+
+    assertEquals(2, diff.equal)
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Container#"))
+    assertNull(statusOf(diff, "ListItem#"))
+  }
+
+  /**
    * An Android icon control can carry an empty `text` alongside a real `content-desc`. The
    * normalized accessible name treats empty text as absent and falls back to `content-desc`, so it
    * reads the same as the iOS `text` label instead of comparing `""` against the label and

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
@@ -52,6 +52,35 @@ class StructuralRoleTest {
     assertEquals(StructuralRole.ScrollView, structuralRole("XCUIElementTypeScrollView"))
   }
 
+  /**
+   * The class names the live iOS runner actually reports are the UIKit names emitted by
+   * `ElementLocator.mapElementType` (e.g. `XCUIApplication`, `UILabel`, `UITableView`), not the
+   * `XCUIElementType*` forms tested above. These must map to the same roles or a live Android↔iOS
+   * diff keys on mismatched roots and reads as two disjoint trees (issue #4872).
+   */
+  @Test
+  fun `ios UIKit class names emitted by the runner map to their roles`() {
+    assertEquals(StructuralRole.Container, structuralRole("XCUIApplication"))
+    assertEquals(StructuralRole.Container, structuralRole("UIWindow"))
+    assertEquals(StructuralRole.Container, structuralRole("UIView"))
+    assertEquals(StructuralRole.Text, structuralRole("UILabel"))
+    assertEquals(StructuralRole.TextField, structuralRole("UITextField"))
+    assertEquals(StructuralRole.TextField, structuralRole("UISecureTextField"))
+    assertEquals(StructuralRole.TextField, structuralRole("UITextView"))
+    assertEquals(StructuralRole.TextField, structuralRole("UISearchBar"))
+    assertEquals(StructuralRole.Button, structuralRole("UIButton"))
+    assertEquals(StructuralRole.Image, structuralRole("UIImageView"))
+    assertEquals(StructuralRole.List, structuralRole("UITableView"))
+    assertEquals(StructuralRole.List, structuralRole("UICollectionView"))
+    assertEquals(StructuralRole.ListItem, structuralRole("UITableViewCell"))
+    assertEquals(StructuralRole.Switch, structuralRole("UISwitch"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("UIToolbar"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("UINavigationBar"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("UITabBar"))
+    assertEquals(StructuralRole.ScrollView, structuralRole("UIScrollView"))
+    assertEquals(StructuralRole.WebView, structuralRole("WKWebView"))
+  }
+
   @Test
   fun `android and ios classes for the same widget share a role`() {
     assertEquals(structuralRole("android.widget.Button"), structuralRole("XCUIElementTypeButton"))
@@ -67,6 +96,20 @@ class StructuralRoleTest {
       structuralRole("android.widget.EditText"),
       structuralRole("XCUIElementTypeTextField"),
     )
+  }
+
+  /** The same widget families align on the UIKit names the runner actually emits. */
+  @Test
+  fun `android and ios UIKit classes for the same widget share a role`() {
+    assertEquals(structuralRole("android.widget.FrameLayout"), structuralRole("XCUIApplication"))
+    assertEquals(structuralRole("android.widget.Button"), structuralRole("UIButton"))
+    assertEquals(structuralRole("android.widget.TextView"), structuralRole("UILabel"))
+    assertEquals(structuralRole("android.widget.EditText"), structuralRole("UITextField"))
+    assertEquals(
+      structuralRole("androidx.recyclerview.widget.RecyclerView"),
+      structuralRole("UITableView"),
+    )
+    assertEquals(structuralRole("android.widget.ImageView"), structuralRole("UIImageView"))
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
@@ -27,6 +27,7 @@ class StructuralRoleTest {
     assertEquals(StructuralRole.Switch, structuralRole("android.widget.ToggleButton"))
     assertEquals(StructuralRole.Toolbar, structuralRole("androidx.appcompat.widget.Toolbar"))
     assertEquals(StructuralRole.ScrollView, structuralRole("android.widget.NestedScrollView"))
+    assertEquals(StructuralRole.Progress, structuralRole("android.widget.ProgressBar"))
     assertEquals(StructuralRole.WebView, structuralRole("android.webkit.WebView"))
   }
 
@@ -78,6 +79,8 @@ class StructuralRoleTest {
     assertEquals(StructuralRole.Toolbar, structuralRole("UINavigationBar"))
     assertEquals(StructuralRole.Toolbar, structuralRole("UITabBar"))
     assertEquals(StructuralRole.ScrollView, structuralRole("UIScrollView"))
+    assertEquals(StructuralRole.Progress, structuralRole("UIProgressView"))
+    assertEquals(StructuralRole.Progress, structuralRole("UIActivityIndicatorView"))
     assertEquals(StructuralRole.WebView, structuralRole("WKWebView"))
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
@@ -1,0 +1,84 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Pure, fast tests for the cross-platform class-name → [StructuralRole] mapping (issue #4872). */
+class StructuralRoleTest {
+
+  @Test
+  fun `android widgets map to their roles`() {
+    assertEquals(StructuralRole.Container, structuralRole("android.widget.FrameLayout"))
+    assertEquals(StructuralRole.Container, structuralRole("android.view.ViewGroup"))
+    assertEquals(
+      StructuralRole.Container,
+      structuralRole("androidx.compose.ui.platform.ComposeView"),
+    )
+    assertEquals(StructuralRole.Text, structuralRole("android.widget.TextView"))
+    assertEquals(StructuralRole.TextField, structuralRole("android.widget.EditText"))
+    assertEquals(StructuralRole.Button, structuralRole("android.widget.Button"))
+    assertEquals(StructuralRole.Button, structuralRole("androidx.appcompat.widget.AppCompatButton"))
+    assertEquals(StructuralRole.Button, structuralRole("android.widget.ImageButton"))
+    assertEquals(StructuralRole.Image, structuralRole("android.widget.ImageView"))
+    assertEquals(StructuralRole.List, structuralRole("androidx.recyclerview.widget.RecyclerView"))
+    assertEquals(StructuralRole.List, structuralRole("android.widget.ListView"))
+    assertEquals(StructuralRole.Checkbox, structuralRole("android.widget.CheckBox"))
+    assertEquals(StructuralRole.Switch, structuralRole("androidx.appcompat.widget.SwitchCompat"))
+    assertEquals(StructuralRole.Switch, structuralRole("android.widget.ToggleButton"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("androidx.appcompat.widget.Toolbar"))
+    assertEquals(StructuralRole.ScrollView, structuralRole("android.widget.NestedScrollView"))
+    assertEquals(StructuralRole.WebView, structuralRole("android.webkit.WebView"))
+  }
+
+  @Test
+  fun `ios element types map to their roles`() {
+    assertEquals(StructuralRole.Container, structuralRole("XCUIElementTypeApplication"))
+    assertEquals(StructuralRole.Container, structuralRole("XCUIElementTypeWindow"))
+    assertEquals(StructuralRole.Container, structuralRole("XCUIElementTypeOther"))
+    assertEquals(StructuralRole.Container, structuralRole("XCUIElementTypeGroup"))
+    assertEquals(StructuralRole.Text, structuralRole("XCUIElementTypeStaticText"))
+    assertEquals(StructuralRole.TextField, structuralRole("XCUIElementTypeTextField"))
+    assertEquals(StructuralRole.TextField, structuralRole("XCUIElementTypeSecureTextField"))
+    assertEquals(StructuralRole.TextField, structuralRole("XCUIElementTypeSearchField"))
+    assertEquals(StructuralRole.TextField, structuralRole("XCUIElementTypeTextView"))
+    assertEquals(StructuralRole.Button, structuralRole("XCUIElementTypeButton"))
+    assertEquals(StructuralRole.Image, structuralRole("XCUIElementTypeImage"))
+    assertEquals(StructuralRole.List, structuralRole("XCUIElementTypeTable"))
+    assertEquals(StructuralRole.List, structuralRole("XCUIElementTypeCollectionView"))
+    assertEquals(StructuralRole.ListItem, structuralRole("XCUIElementTypeCell"))
+    assertEquals(StructuralRole.Switch, structuralRole("XCUIElementTypeSwitch"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("XCUIElementTypeNavigationBar"))
+    assertEquals(StructuralRole.Toolbar, structuralRole("XCUIElementTypeTabBar"))
+    assertEquals(StructuralRole.ScrollView, structuralRole("XCUIElementTypeScrollView"))
+  }
+
+  @Test
+  fun `android and ios classes for the same widget share a role`() {
+    assertEquals(structuralRole("android.widget.Button"), structuralRole("XCUIElementTypeButton"))
+    assertEquals(
+      structuralRole("android.widget.TextView"),
+      structuralRole("XCUIElementTypeStaticText"),
+    )
+    assertEquals(
+      structuralRole("androidx.recyclerview.widget.RecyclerView"),
+      structuralRole("XCUIElementTypeTable"),
+    )
+    assertEquals(
+      structuralRole("android.widget.EditText"),
+      structuralRole("XCUIElementTypeTextField"),
+    )
+  }
+
+  @Test
+  fun `toggles and checkboxes win over the button substring`() {
+    // ToggleButton / CompoundButton contain "Button" but must not classify as Button.
+    assertEquals(StructuralRole.Switch, structuralRole("android.widget.ToggleButton"))
+    assertEquals(StructuralRole.Checkbox, structuralRole("android.widget.CheckBox"))
+  }
+
+  @Test
+  fun `unknown classes fall back to Other`() {
+    assertEquals(StructuralRole.Other, structuralRole("com.example.CustomThing"))
+    assertEquals(StructuralRole.Other, structuralRole(""))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
@@ -134,6 +134,40 @@ class StructuralRoleTest {
     assertEquals(structuralRole("android.view.View"), structuralRole("UIView"))
   }
 
+  /**
+   * A radio button contains the `Button` substring but is a single-choice checkable control. It
+   * folds into [StructuralRole.Checkbox] so it pairs with the iOS runner's radio, which arrives as
+   * a checkable generic node that `structuralRoleOf` promotes to Checkbox (issue #4872 review).
+   */
+  @Test
+  fun `radio buttons win over the button substring and fold into Checkbox`() {
+    assertEquals(StructuralRole.Checkbox, structuralRole("android.widget.RadioButton"))
+    assertEquals(
+      StructuralRole.Checkbox,
+      structuralRole("androidx.appcompat.widget.AppCompatRadioButton"),
+    )
+    assertEquals(
+      structuralRole("android.widget.RadioButton"),
+      structuralRole("android.widget.CheckBox"),
+    )
+  }
+
+  /**
+   * Custom Android View subclasses (and iOS structural views like `UIStackView`) fold into
+   * [StructuralRole.Container] via the `*View` suffix catch-all, mirroring the iOS runner's custom
+   * `.other -> UIView -> Container`, so a bespoke container subtree is not disjoint (issue #4872
+   * review).
+   */
+  @Test
+  fun `custom View subclasses map to Container`() {
+    assertEquals(StructuralRole.Container, structuralRole("com.example.ProfileView"))
+    assertEquals(StructuralRole.Container, structuralRole("UIStackView"))
+    assertEquals(structuralRole("com.example.ProfileView"), structuralRole("UIView"))
+    // The specific *View families are still matched first, not swallowed by the catch-all.
+    assertEquals(StructuralRole.Text, structuralRole("com.example.BannerTextView"))
+    assertEquals(StructuralRole.Image, structuralRole("com.example.AvatarImageView"))
+  }
+
   @Test
   fun `unknown classes fall back to Other`() {
     assertEquals(StructuralRole.Other, structuralRole("com.example.CustomThing"))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt
@@ -119,6 +119,21 @@ class StructuralRoleTest {
     assertEquals(StructuralRole.Checkbox, structuralRole("android.widget.CheckBox"))
   }
 
+  /**
+   * The live Android compare root is a class-less synthetic wrapper: both extraction paths wrap the
+   * capture in a class-less node and `HierarchyParser` defaults that to `android.view.View`. It
+   * must map to [StructuralRole.Container] like the iOS `XCUIApplication`/`UIView` root, or every
+   * descendant key (which includes the root segment) would be disjoint across a live Android↔iOS
+   * pair (issue #4872 review).
+   */
+  @Test
+  fun `the class-less android root maps to Container like the ios root`() {
+    assertEquals(StructuralRole.Container, structuralRole("android.view.View"))
+    assertEquals(StructuralRole.Container, structuralRole("View"))
+    assertEquals(structuralRole("android.view.View"), structuralRole("XCUIApplication"))
+    assertEquals(structuralRole("android.view.View"), structuralRole("UIView"))
+  }
+
   @Test
   fun `unknown classes fall back to Other`() {
     assertEquals(StructuralRole.Other, structuralRole("com.example.CustomThing"))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -37,10 +37,12 @@ class TwoDeviceCompareViewTest {
   private fun columnB() = DeviceColumn(deviceId = "dev-b", name = "iPhone", platform = Platform.Ios)
 
   /**
-   * A minimal two-child hierarchy: a shared `title` node plus a second child whose resource-id
-   * distinguishes the two devices, yielding one only-in-A and one only-in-B node in the diff.
+   * The Android side's minimal hierarchy: a shared `title` label plus a **Button** whose
+   * resource-id distinguishes it. Paired against [iosHierarchyJson], whose second child is a
+   * different structural role, so the compare's cross-platform role diff (issue #4872) surfaces the
+   * button as only-in-A.
    */
-  private fun hierarchyJson(secondChildResourceId: String): JsonElement {
+  private fun androidHierarchyJson(secondChildResourceId: String): JsonElement {
     val raw =
       """
       {"hierarchy":{"node":{
@@ -58,10 +60,35 @@ class TwoDeviceCompareViewTest {
     return Json.parseToJsonElement(raw)
   }
 
+  /**
+   * The iOS side's counterpart, emitting real `XCUIElementType*` classes. Its `title` maps to the
+   * same `Text` role as Android's `TextView` (so those pair and stay Equal), while its second child
+   * is an **Image** (a different role than Android's Button) so the role diff reports it as
+   * only-in-B rather than pairing it against the button.
+   */
+  private fun iosHierarchyJson(secondChildResourceId: String): JsonElement {
+    val raw =
+      """
+      {"hierarchy":{"node":{
+        "class":"XCUIElementTypeApplication","resource-id":"root",
+        "bounds":{"left":0,"top":0,"right":100,"bottom":200},
+        "node":[
+          {"class":"XCUIElementTypeStaticText","resource-id":"title","text":"Hi",
+           "bounds":{"left":0,"top":0,"right":50,"bottom":20}},
+          {"class":"XCUIElementTypeImage","resource-id":"$secondChildResourceId",
+           "bounds":{"left":0,"top":30,"right":50,"bottom":60}}
+        ]
+      }}}
+      """
+        .trimIndent()
+    return Json.parseToJsonElement(raw)
+  }
+
+  // dev-b is the iOS column ([columnB]); every other device emits the Android hierarchy.
   private fun emit(fake: FakeObservationStream, deviceId: String, resourceId: String) {
-    fake.emitHierarchy(
-      HierarchyStreamUpdate(deviceId = deviceId, timestamp = 1L, data = hierarchyJson(resourceId))
-    )
+    val data =
+      if (deviceId == "dev-b") iosHierarchyJson(resourceId) else androidHierarchyJson(resourceId)
+    fake.emitHierarchy(HierarchyStreamUpdate(deviceId = deviceId, timestamp = 1L, data = data))
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -61,21 +61,25 @@ class TwoDeviceCompareViewTest {
   }
 
   /**
-   * The iOS side's counterpart, emitting real `XCUIElementType*` classes. Its `title` maps to the
-   * same `Text` role as Android's `TextView` (so those pair and stay Equal), while its second child
-   * is an **Image** (a different role than Android's Button) so the role diff reports it as
-   * only-in-B rather than pairing it against the button.
+   * The iOS side's counterpart, emitting the **UIKit** class names the runner actually reports
+   * (`ElementLocator.mapElementType` → `XCUIApplication`, `UILabel`, `UIImageView`, …), not the
+   * fabricated `XCUIElementType*` forms — so this exercises the live cross-platform path. Its
+   * `title` (`UILabel`) maps to the same `Text` role as Android's `TextView` (so those pair and
+   * stay Equal), while its second child is an **Image** (`UIImageView`, a different role than
+   * Android's Button) so the role diff reports it as only-in-B rather than pairing it against the
+   * button. The `XCUIApplication` root maps to the same `Container` role as Android's
+   * `FrameLayout`, so the roots pair instead of leaving the whole tree disjoint (issue #4872).
    */
   private fun iosHierarchyJson(secondChildResourceId: String): JsonElement {
     val raw =
       """
       {"hierarchy":{"node":{
-        "class":"XCUIElementTypeApplication","resource-id":"root",
+        "class":"XCUIApplication","resource-id":"root",
         "bounds":{"left":0,"top":0,"right":100,"bottom":200},
         "node":[
-          {"class":"XCUIElementTypeStaticText","resource-id":"title","text":"Hi",
+          {"class":"UILabel","resource-id":"title","text":"Hi",
            "bounds":{"left":0,"top":0,"right":50,"bottom":20}},
-          {"class":"XCUIElementTypeImage","resource-id":"$secondChildResourceId",
+          {"class":"UIImageView","resource-id":"$secondChildResourceId",
            "bounds":{"left":0,"top":30,"right":50,"bottom":60}}
         ]
       }}}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
@@ -26,7 +26,7 @@ class WorkspaceCompareEntryTest {
   }
 
   @Test
-  fun `compareColumns pairs the focused device with the first same-platform other`() {
+  fun `compareColumns pairs the focused device with the first other`() {
     val content =
       WorkspaceUiState.Content(
         columns =
@@ -38,34 +38,36 @@ class WorkspaceCompareEntryTest {
         focusedDeviceId = "a",
       )
     val pair = compareColumns(content)
-    // Skips the iOS device b (cross-platform diff is meaningless) and pairs with the Android c.
+    // The first other device wins regardless of platform — the cross-platform iOS b, not the
+    // same-platform Android c — because the compare keys by structural role (issue #4872).
     assertEquals("a", pair?.first?.deviceId)
-    assertEquals("c", pair?.second?.deviceId)
+    assertEquals("b", pair?.second?.deviceId)
   }
 
   @Test
-  fun `compareColumns is null when the only other device is a different platform`() {
+  fun `compareColumns pairs a cross-platform other`() {
     val content =
       WorkspaceUiState.Content(
         columns = listOf(col("a", "Pixel", Platform.Android), col("b", "iPhone", Platform.Ios)),
         focusedDeviceId = "a",
       )
-    assertNull(compareColumns(content))
+    val pair = compareColumns(content)
+    assertEquals("a", pair?.first?.deviceId)
+    assertEquals("b", pair?.second?.deviceId)
   }
 
   @Test
-  fun `compare glyph is hidden when the only other device is a different platform`() =
-    runComposeUiTest {
-      val state =
-        WorkspaceUiState.Content(
-          columns = listOf(col("a", "Pixel", Platform.Android), col("b", "iPhone", Platform.Ios)),
-          focusedDeviceId = "a",
-        )
-      setContent {
-        MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
-      }
-      onNodeWithContentDescription("Compare two devices").assertDoesNotExist()
+  fun `compare glyph is shown for a cross-platform pair`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel", Platform.Android), col("b", "iPhone", Platform.Ios)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
     }
+    onNodeWithContentDescription("Compare two devices").assertIsDisplayed()
+  }
 
   @Test
   fun `compare glyph is hidden with a single device`() = runComposeUiTest {


### PR DESCRIPTION
## What

The two-device compare's hierarchy diff keyed node identity on the raw, platform-specific `className`. An **Android↔iOS** pair therefore had entirely disjoint key sets (`android.widget.FrameLayout` vs `XCUIElementTypeApplication`), producing two complete OnlyInA/OnlyInB trees with no Equal/Changed — the meaningless diff described in [#4872](https://github.com/kaeawc/auto-mobile/issues/4872).

## How

- **New `StructuralRole` taxonomy + `structuralRole(className)` mapping** ([`StructuralRole.kt`](android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRole.kt)) folds both Android class names (`android.widget.*`, `androidx.*`, Compose, custom `*View`/`*Layout`) and iOS `XCUIElementType*` into cross-platform roles: container / text / text-field / button / image / list / list-item / checkbox / switch / toolbar / scroll-view / web-view, with everything unrecognised → `Other`. Matching is by substring so `Compat`/`Material` variants land correctly; ordering resolves the two real ambiguities (toggles/checkboxes before `Button`; iOS `TextView` — an editable field — before Android's static `TextView`).
- **`diffHierarchies` gains a `DiffKeyMode`.** The default `ClassName` keeps the raw same-platform identity (`className:resourceId#siblingIndex`); `StructuralRole` keys each segment on the role and **drops `resourceId`** (platform-specific, never matches cross-platform). The mode threads identically through the diff index *and* the window-alignment signatures, so pre-order determinism and the A/B symmetry contract are preserved.
- **`TwoDeviceCompareView` auto-selects** role mode when the two columns are on different platforms, `ClassName` otherwise.

## Design choices (noted, no clarification needed)

- The role set is deliberately coarse — the widget families a compare cares about — and grows when a real screen needs a finer role.
- Role mode changes only the key *segment*; the attribute-only `Changed` test, bounds exclusion, and window alignment are all mode-independent.

## Tests (all pure, fast, local)

- [`StructuralRoleTest`](android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StructuralRoleTest.kt) — the Android + iOS mapping tables, cross-platform role equivalence, the toggle-vs-button ordering, and the `Other` fallback.
- [`HierarchyDiffTest`](android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt) — class-name mode yields the all-OnlyIn baseline for a cross-platform pair; role mode pairs a structurally-equal cross-platform screen as all-Equal, reports a differing label as `Changed`, isolates a genuinely-extra node as `OnlyIn`, and stays symmetric under A/B swap.
- [`TwoDeviceCompareViewTest`](android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt) — updated to emit a realistic iOS hierarchy on the iOS side so the compare UI exercises the new cross-platform role diff end-to-end.

Validated locally: `:desktop-core:test` (full module) green, `:desktop-core:detektMain` clean, project-wide ktfmt clean.

## Note

Labeled `needs-human` and auto-merge left off — this changes runtime diff behavior in `android/`, so it warrants human review rather than mechanical auto-merge.

Closes #4872