### PR TITLE
fix(ios): CtrlProxy WebSocket close paths should cancel NWConnection, not just onClose()

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -665,6 +665,16 @@ class WebSocketConnection: WebSocketResponding {
     private var fragmentedOpcode: UInt8?
     private var fragmentBuffer = Data()
 
+    /// Whether `onClose` has already fired for this connection. Every error/close
+    /// path now cancels the `NWConnection` and lets the `.cancelled` state
+    /// transition invoke `onClose`, but Network.framework can deliver both
+    /// `.failed` and `.cancelled` for one socket, so this guard keeps the callback
+    /// — which removes the connection from the registry and updates presence
+    /// bookkeeping — firing exactly once (issue #5677). Touched only from the state
+    /// handler and receive/send completions, all of which run on the server
+    /// `queue`, so it needs no lock (same invariant as the reassembly state).
+    private var didFireClose = false
+
     init(
         id: Int,
         connection: NWConnection,
@@ -693,7 +703,7 @@ class WebSocketConnection: WebSocketResponding {
             case .ready:
                 self?.receiveHTTPUpgrade()
             case .failed, .cancelled:
-                self?.onClose()
+                self?.fireOnClose()
             default:
                 break
             }
@@ -704,6 +714,32 @@ class WebSocketConnection: WebSocketResponding {
 
     func close() {
         connection.cancel()
+    }
+
+    /// Deterministically tears the socket down on an error/close path by
+    /// cancelling the `NWConnection`, mirroring how `close()` / `stop()` already
+    /// release the socket. The `.cancelled` state transition then invokes `onClose`
+    /// exactly once via `fireOnClose()`, so no error/close path is left calling
+    /// `onClose` directly and leaking a half-open connection whose file descriptor
+    /// lingers until the peer disconnects (issue #5677). `NWConnection.cancel()` is
+    /// idempotent, so a path that cancels and then also observes `.failed` /
+    /// `.cancelled` stays safe. Runs on the server `queue` (every receive/send
+    /// completion does), so it needs no lock.
+    private func closeConnection() {
+        connection.cancel()
+    }
+
+    /// Invokes the `onClose` callback at most once per connection. Called only from
+    /// the `.failed` / `.cancelled` state handler now that every error/close path
+    /// cancels the connection rather than calling `onClose` inline; the
+    /// `didFireClose` guard collapses a `.failed`-then-`.cancelled` pair (or any
+    /// repeat) into a single `onClose` (issue #5677 AC2). Internal, not private, so
+    /// `WebSocketServerTests` can pin the exactly-once contract without a live
+    /// socket. Runs on the server `queue`, so the guard needs no lock.
+    func fireOnClose() {
+        guard !didFireClose else { return }
+        didFireClose = true
+        onClose()
     }
 
     func send(_ data: Data) {
@@ -723,12 +759,12 @@ class WebSocketConnection: WebSocketResponding {
 
             if let error = error {
                 print("[WebSocketConnection] Error: \(error)")
-                self.onClose()
+                self.closeConnection()
                 return
             }
 
             if isComplete {
-                self.onClose()
+                self.closeConnection()
                 return
             }
 
@@ -910,7 +946,7 @@ class WebSocketConnection: WebSocketResponding {
         connection.send(content: response.data(using: .utf8), completion: .contentProcessed { [weak self] error in
             if let error = error {
                 print("[WebSocketConnection] Upgrade send error: \(error)")
-                self?.onClose()
+                self?.closeConnection()
                 return
             }
 
@@ -973,7 +1009,7 @@ class WebSocketConnection: WebSocketResponding {
 
             if let error = error {
                 print("[WebSocketConnection] Frame error: \(error)")
-                self.onClose()
+                self.closeConnection()
                 return
             }
 
@@ -1014,7 +1050,7 @@ class WebSocketConnection: WebSocketResponding {
             // Still short of a full frame. EOF here means the peer closed
             // mid-frame, so nothing more is coming — close.
             if isComplete {
-                self.onClose()
+                self.closeConnection()
                 return
             }
 
@@ -1053,10 +1089,11 @@ class WebSocketConnection: WebSocketResponding {
         let isMasked = (byte1 & 0x80) != 0
         let payloadLength = UInt64(byte1 & 0x7F)
 
-        // Handle close frame
+        // Handle close frame. Send the close frame back, then cancel the socket
+        // from the send completion so the peer receives the close before the TCP
+        // teardown; the `.cancelled` transition fires `onClose` once (issue #5677).
         if opcode == 0x08 {
             sendCloseFrame()
-            onClose()
             return
         }
 
@@ -1071,7 +1108,7 @@ class WebSocketConnection: WebSocketResponding {
         if opcode == 0x09 {
             guard Self.isValidControlFramePayloadLength(payloadLength) else {
                 print("[WebSocketConnection] Ping payload too large (\(payloadLength) bytes), closing connection")
-                onClose()
+                closeConnection()
                 return
             }
             readPayload(length: payloadLength, isMasked: isMasked, opcode: opcode, isFinal: isFinal)
@@ -1312,7 +1349,7 @@ class WebSocketConnection: WebSocketResponding {
     private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8, isFinal: Bool) {
         guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
             print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
-            onClose()
+            closeConnection()
             return
         }
 
@@ -1331,7 +1368,7 @@ class WebSocketConnection: WebSocketResponding {
             print("[WebSocketConnection] Fragmentation protocol error (pre-read): \(reason), closing connection")
             fragmentedOpcode = nil
             fragmentBuffer = Data()
-            onClose()
+            closeConnection()
             return
         }
 
@@ -1404,7 +1441,7 @@ class WebSocketConnection: WebSocketResponding {
             print("[WebSocketConnection] Fragmentation protocol error: \(reason), closing connection")
             fragmentedOpcode = nil
             fragmentBuffer = Data()
-            onClose()
+            closeConnection()
         }
     }
 
@@ -1437,7 +1474,12 @@ class WebSocketConnection: WebSocketResponding {
 
     private func sendCloseFrame() {
         let frame = Self.createWebSocketFrame(data: Data(), opcode: 0x08)
-        connection.send(content: frame, completion: .contentProcessed { _ in })
+        // Cancel from the send completion — as the HTTP responders do — so the
+        // close frame reaches the peer before the TCP teardown; the resulting
+        // `.cancelled` transition fires `onClose` exactly once (issue #5677).
+        connection.send(content: frame, completion: .contentProcessed { [weak self] _ in
+            self?.connection.cancel()
+        })
     }
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -929,6 +929,93 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertEqual(response["success"] as? Bool, true)
     }
 
+    // MARK: - Close paths cancel the NWConnection (#5677)
+
+    /// AC2: `onClose` fires **exactly once** per connection even when the close
+    /// machinery is triggered more than once. Every error/close path now cancels
+    /// the `NWConnection`, and Network.framework can deliver both `.failed` and
+    /// `.cancelled` for one socket, so the state handler routes through the guarded
+    /// `fireOnClose()`. Calling it twice must still invoke the `onClose` callback —
+    /// which removes the connection from the registry and updates presence — only
+    /// once. Pre-fix (a bare `onClose()` with no guard) this would report 2.
+    func testFireOnCloseIsIdempotent() {
+        var onCloseCount = 0
+        // An NWConnection that is never started: `fireOnClose` is driven directly.
+        let nwConnection = NWConnection(host: "127.0.0.1", port: 1, using: .tcp)
+        let connection = WebSocketConnection(
+            id: 1,
+            connection: nwConnection,
+            queue: DispatchQueue(label: "test.ws.fireclose"),
+            boundPort: 8765,
+            onMessage: { _ in },
+            onClose: { onCloseCount += 1 }
+        )
+
+        connection.fireOnClose()
+        connection.fireOnClose()
+
+        XCTAssertEqual(onCloseCount, 1, "onClose must fire exactly once per connection (issue #5677 AC2)")
+    }
+
+    /// AC1/AC3: a client close frame (0x08) makes the server deterministically tear
+    /// the socket down — not merely stop reading — so the peer observes the
+    /// connection close (EOF). Pre-fix the close handler called `onClose()` without
+    /// `connection.cancel()`, leaving a half-open socket whose file descriptor
+    /// lingered until the peer disconnected, so `waitForServerClose` times out.
+    func testCloseFrameCancelsConnectionSoPeerObservesClose() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        try client.connectAndUpgrade(timeout: 10)
+
+        // A client→server close frame is masked (§5.3); an empty payload is fine.
+        client.sendFrame(opcode: 0x08, fin: true, payload: Data())
+
+        XCTAssertTrue(
+            client.waitForServerClose(timeout: 10),
+            "server must cancel the NWConnection after a close frame so the peer observes EOF (issue #5677)"
+        )
+    }
+
+    /// AC1/AC3: a fragmentation protocol error also cancels the socket, so the peer
+    /// observes the close. A continuation frame (0x00) with no message in progress
+    /// is rejected pre-read in `readPayload` and, pre-fix, called `onClose()` alone
+    /// — leaving the socket half-open. Post-fix the connection is cancelled and the
+    /// peer sees EOF.
+    func testFragmentationProtocolErrorCancelsConnection() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer { server.stop() }
+
+        let client = RawWebSocketClient(port: port)
+        defer { client.close() }
+        try client.connectAndUpgrade(timeout: 10)
+
+        // Continuation (0x00), FIN=1, with no fragmented message open → protocol
+        // error rejected before the payload is accumulated.
+        client.sendFrame(opcode: 0x00, fin: true, payload: Data("orphan".utf8))
+
+        XCTAssertTrue(
+            client.waitForServerClose(timeout: 10),
+            "server must cancel the NWConnection after a fragmentation protocol error so the peer observes EOF (issue #5677)"
+        )
+    }
+
     // MARK: - Frame pipelined with the upgrade handshake (#5678)
 
     /// AC5 deterministic: a complete masked text frame already sitting in the
@@ -1203,6 +1290,11 @@ private final class RawWebSocketClient: @unchecked Sendable {
     private let queue = DispatchQueue(label: "test.rawws.client")
     private let lock = NSLock()
     private var buffer = Data()
+    /// Signalled once the background receive loop observes the server closing its
+    /// write side (EOF via `isComplete`, or a receive error). Lets a test assert
+    /// the peer deterministically saw the socket close after a server-side
+    /// error/close path cancelled the `NWConnection` (issue #5677).
+    private let serverClosed = DispatchSemaphore(value: 0)
 
     init(port: UInt16) {
         let params = NWParameters.tcp
@@ -1335,9 +1427,20 @@ private final class RawWebSocketClient: @unchecked Sendable {
                 self.buffer.append(data)
                 self.lock.unlock()
             }
-            if error != nil || isComplete { return }
+            if error != nil || isComplete {
+                self.serverClosed.signal()
+                return
+            }
             self.startReceiveLoop()
         }
+    }
+
+    /// Blocks until the background receive loop observes the server closing the
+    /// connection (EOF/error), or the timeout elapses. Returns `true` only if the
+    /// peer actually saw the socket close — the property issue #5677 requires of
+    /// every server-side error/close path.
+    func waitForServerClose(timeout: TimeInterval) -> Bool {
+        serverClosed.wait(timeout: .now() + timeout) == .success
     }
 
     /// Consumes complete frames from the head of the buffer, returning the first


### PR DESCRIPTION
## Summary

Follow-up from [PR #5679](https://github.com/kaeawc/auto-mobile/pull/5679)'s review. Every "close the connection" path in `ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift` invoked the `onClose` callback alone. `onClose` removes the connection from the registry and updates presence bookkeeping, but does **not** call `connection.cancel()` — so the receive loop stops while the TCP socket can remain half-open until the peer disconnects, its file descriptor pinned indefinitely.

This makes every error/close path cancel the underlying `NWConnection`, consistent with how graceful teardown (`close()` / `stop()`) already releases the socket.

## Linked Issue

Closes #5677

## Bug / Regression Context

- **Prior attempts:** the ping (#5671), FIN/fragmentation (#5675), and pipelined-buffer (#5679) fixes each added `onClose()` call sites following the pre-existing convention; a CodeRabbit review on #5675 flagged the missing cancel.
- **Observed symptom:** after a close-frame, oversized-frame, ping-too-large, fragmentation protocol error, or EOF, the server stopped reading but left the socket half-open — the peer never observed the close.
- **Repro conditions:** any of those close paths; the peer's socket receives no FIN.

## Changes

- New private `closeConnection()` calls `connection.cancel()`; every error/close path (close-frame `0x08`, oversized-frame guard, ping length guard, fragmentation pre-read reject, `handleDataFrame` `.protocolError`, receive error/EOF, upgrade-send error) routes through it instead of calling `onClose()` directly.
- The `.failed` / `.cancelled` state handler is now the sole `onClose` invoker, via a guarded `fireOnClose()` (a `didFireClose` flag collapses a `.failed`-then-`.cancelled` pair into one `onClose`).
- The close-frame path sends the close frame, then cancels from the send completion so the peer receives it before the TCP teardown (mirroring the HTTP responders).

## Acceptance criteria

1. Each error/close path that called `onClose()` alone now cancels the `NWConnection`. ✅
2. `onClose()` fires exactly once per connection — no double-invocation via both a direct call and the `.cancelled` handler. ✅ (`testFireOnCloseIsIdempotent`)
3. Tests assert the peer observes a closed socket after a fragmentation protocol error and after a close frame. ✅ (`testFragmentationProtocolErrorCancelsConnection`, `testCloseFrameCancelsConnectionSoPeerObservesClose` — both drive a real loopback socket and observe server-initiated EOF; pre-fix they time out)

## Validation

- [x] `./scripts/ios/swift-build.sh` + `./scripts/ios/swift-test.sh` green (all Swift packages)
- [x] `bun run turbo:validate` green (7/7 tasks; 14341 pass / 0 fail)
- [x] `bun run typecheck` — no new type errors (baseline gate)
- [x] SwiftLint: 0 serious (force_unwrapping clean; 2 pre-existing warnings untouched)
- [x] No XcodeGen drift (existing files edited only)

## Notes

Runner-side source change; reaches production only when the iOS control-proxy runner is re-cut. That re-cut is tracked separately as #5681 and is **out of scope** for this PR.