### PR TITLE
fix(ios-sdk): cancel the delayed network fault on stopLoading (no client re-entry after stop)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -475,6 +475,11 @@ public class AutoMobileURLProtocol: URLProtocol {
     private var receivedResponse: URLResponse?
     private var receivedData = Data()
     private var totalBytesReceived = 0
+    /// Guards the delayed-fault lifecycle across `stopLoading()` (called by the URL
+    /// loading system) and the global-queue timer block that serves a delayed fault.
+    private let faultLock = NSLock()
+    private var stopped = false
+    private var faultWorkItem: DispatchWorkItem?
 
     private static let supportedSchemes: Set<String> = ["http", "https"]
 
@@ -516,9 +521,16 @@ public class AutoMobileURLProtocol: URLProtocol {
            !fault.dryRun
         {
             if let delayMs = fault.delayMs, delayMs > 0 {
-                DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(delayMs)) { [weak self] in
+                // Schedule as a cancellable work item stored on the protocol so
+                // stopLoading() can cancel it — otherwise the timer fires serveFault()
+                // (client callbacks) after the protocol has been torn down.
+                let workItem = DispatchWorkItem { [weak self] in
                     self?.serveFault(fault, url: url)
                 }
+                faultLock.lock()
+                faultWorkItem = workItem
+                faultLock.unlock()
+                DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(delayMs), execute: workItem)
             } else {
                 serveFault(fault, url: url)
             }
@@ -597,6 +609,15 @@ public class AutoMobileURLProtocol: URLProtocol {
     }
 
     public override func stopLoading() {
+        // Cancel a pending delayed fault and mark the protocol stopped so neither the
+        // timer block (if not yet started) nor an already-running serveFault invokes the
+        // client after teardown.
+        faultLock.lock()
+        stopped = true
+        faultWorkItem?.cancel()
+        faultWorkItem = nil
+        faultLock.unlock()
+
         dataTask?.cancel()
         // Invalidate session to break the retain cycle (session -> delegate -> self)
         urlSession?.invalidateAndCancel()
@@ -606,6 +627,13 @@ public class AutoMobileURLProtocol: URLProtocol {
 
     #if DEBUG
     private func serveFault(_ fault: NetworkMockRuleStore.FaultDecision, url: URL) {
+        // If the protocol was stopped (e.g. the delayed-fault timer began executing just
+        // as stopLoading() ran), do not invoke the client on a torn-down protocol.
+        faultLock.lock()
+        let isStopped = stopped
+        faultLock.unlock()
+        if isStopped { return }
+
         let method = request.httpMethod ?? "GET"
         let error: URLError
         switch fault.errorType {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -463,12 +463,32 @@ public final class AutoMobileNetwork: @unchecked Sendable {
 
 // MARK: - URLProtocol Implementation
 
+#if DEBUG
+/// Seam for scheduling a delayed network fault (issue #5697), so tests can fire it
+/// deterministically instead of waiting on a real timer. Production schedules the work
+/// item on a global queue via `asyncAfter`.
+protocol FaultScheduling {
+    func schedule(delayMs: Int, work: DispatchWorkItem)
+}
+
+struct RealFaultScheduler: FaultScheduling {
+    func schedule(delayMs: Int, work: DispatchWorkItem) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(delayMs), execute: work)
+    }
+}
+#endif
+
 /// A URLProtocol subclass that intercepts network requests for monitoring.
 ///
 /// This is an implementation detail -- consumers should register it via
 /// ``AutoMobileNetwork/protocolClass()`` rather than referencing this type directly.
 public class AutoMobileURLProtocol: URLProtocol {
     private static let handledKey = "dev.jasonpearson.automobile.sdk.handled"
+    #if DEBUG
+    /// Injectable delayed-fault scheduler; tests override it to fire the fault on demand
+    /// (no real timer). Reset to `RealFaultScheduler()` in `tearDown`.
+    static var faultScheduler: FaultScheduling = RealFaultScheduler()
+    #endif
     private var startTime: Date?
     private var urlSession: URLSession?
     private var dataTask: URLSessionDataTask?
@@ -477,9 +497,10 @@ public class AutoMobileURLProtocol: URLProtocol {
     private var totalBytesReceived = 0
     /// Guards the delayed-fault lifecycle across `stopLoading()` (called by the URL
     /// loading system) and the global-queue timer block that serves a delayed fault.
+    /// `serveFault` checks `stopped` under this lock and delivers under it too, so the
+    /// check is atomic with delivery: stopLoading() cannot slip in between.
     private let faultLock = NSLock()
     private var stopped = false
-    private var faultWorkItem: DispatchWorkItem?
 
     private static let supportedSchemes: Set<String> = ["http", "https"]
 
@@ -521,16 +542,14 @@ public class AutoMobileURLProtocol: URLProtocol {
            !fault.dryRun
         {
             if let delayMs = fault.delayMs, delayMs > 0 {
-                // Schedule as a cancellable work item stored on the protocol so
-                // stopLoading() can cancel it — otherwise the timer fires serveFault()
-                // (client callbacks) after the protocol has been torn down.
+                // The delayed serveFault checks `stopped` under faultLock before delivering,
+                // so a fault whose timer fires after stopLoading() never touches the client
+                // (the guard also covers the case where the timer already began executing —
+                // which a work-item cancel could not). No cancellation needed.
                 let workItem = DispatchWorkItem { [weak self] in
                     self?.serveFault(fault, url: url)
                 }
-                faultLock.lock()
-                faultWorkItem = workItem
-                faultLock.unlock()
-                DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(delayMs), execute: workItem)
+                Self.faultScheduler.schedule(delayMs: delayMs, work: workItem)
             } else {
                 serveFault(fault, url: url)
             }
@@ -609,13 +628,10 @@ public class AutoMobileURLProtocol: URLProtocol {
     }
 
     public override func stopLoading() {
-        // Cancel a pending delayed fault and mark the protocol stopped so neither the
-        // timer block (if not yet started) nor an already-running serveFault invokes the
-        // client after teardown.
+        // Mark the protocol stopped so a delayed fault whose timer fires later (or is
+        // mid-serveFault) sees it under faultLock and does not invoke the client.
         faultLock.lock()
         stopped = true
-        faultWorkItem?.cancel()
-        faultWorkItem = nil
         faultLock.unlock()
 
         dataTask?.cancel()
@@ -627,12 +643,15 @@ public class AutoMobileURLProtocol: URLProtocol {
 
     #if DEBUG
     private func serveFault(_ fault: NetworkMockRuleStore.FaultDecision, url: URL) {
-        // If the protocol was stopped (e.g. the delayed-fault timer began executing just
-        // as stopLoading() ran), do not invoke the client on a torn-down protocol.
+        // Hold faultLock across the whole delivery so the stopped-check is ATOMIC with the
+        // client callbacks: stopLoading() (which sets `stopped` under the same lock) can no
+        // longer slip in between the check and the callbacks. Safe against deadlock — this
+        // body never re-enters faultLock, and the URL loading system does not synchronously
+        // call stopLoading() from a completion callback (didFinish/didFail), so the client
+        // calls here cannot re-enter this lock on the same thread.
         faultLock.lock()
-        let isStopped = stopped
-        faultLock.unlock()
-        if isStopped { return }
+        defer { faultLock.unlock() }
+        if stopped { return }
 
         let method = request.httpMethod ?? "GET"
         let error: URLError

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -643,15 +643,18 @@ public class AutoMobileURLProtocol: URLProtocol {
 
     #if DEBUG
     private func serveFault(_ fault: NetworkMockRuleStore.FaultDecision, url: URL) {
-        // Hold faultLock across the whole delivery so the stopped-check is ATOMIC with the
-        // client callbacks: stopLoading() (which sets `stopped` under the same lock) can no
-        // longer slip in between the check and the callbacks. Safe against deadlock — this
-        // body never re-enters faultLock, and the URL loading system does not synchronously
-        // call stopLoading() from a completion callback (didFinish/didFail), so the client
-        // calls here cannot re-enter this lock on the same thread.
+        // Snapshot `stopped` under the lock, then RELEASE the lock before any client
+        // callbacks. The lock must NOT be held across the callouts: a client whose
+        // didFailWithError synchronously calls stopLoading() would deadlock on this
+        // non-recursive lock. The stopped-check drops the delayed fault once stopLoading()
+        // has run; a callback that races an in-progress stopLoading() (delivered in the
+        // sub-microsecond window after this check) is the ordinary "response arrives as the
+        // task is cancelled" race the URL loading system already tolerates — making it
+        // fully atomic is not possible without reintroducing the deadlock above.
         faultLock.lock()
-        defer { faultLock.unlock() }
-        if stopped { return }
+        let isStopped = stopped
+        faultLock.unlock()
+        if isStopped { return }
 
         let method = request.httpMethod ?? "GET"
         let error: URLError

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -922,7 +922,7 @@ final class NetworkCaptureRecorderTests: XCTestCase {
     }
 
     #if DEBUG
-    func testDelayedFaultCancelledByStopLoadingDoesNotCallClient() {
+    private func makeDelayedFaultProtocol(client: RecordingURLProtocolClient) -> AutoMobileURLProtocol {
         AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: SdkEventBuffer { _ in })
         NetworkMockRuleStore.shared.setFaultRules([
             NetworkFaultRuleDTO(
@@ -934,29 +934,61 @@ final class NetworkCaptureRecorderTests: XCTestCase {
                 expiresAtEpochMs: nil, scope: nil, dryRun: false
             ),
         ])
-        defer { NetworkMockRuleStore.shared.setFaultRules([]) }
-
         let request = URLRequest(url: URL(string: "https://api.example.com/v1/x")!)
+        return AutoMobileURLProtocol(request: request, cachedResponse: nil, client: client)
+    }
+
+    // The delayed fault fires normally when the protocol has NOT been stopped.
+    func testDelayedFaultFiresWhenNotStopped() {
+        let scheduler = FakeFaultScheduler()
+        AutoMobileURLProtocol.faultScheduler = scheduler
+        defer {
+            AutoMobileURLProtocol.faultScheduler = RealFaultScheduler()
+            NetworkMockRuleStore.shared.setFaultRules([])
+        }
+
         let client = RecordingURLProtocolClient()
-        let proto = AutoMobileURLProtocol(request: request, cachedResponse: nil, client: client)
+        let proto = makeDelayedFaultProtocol(client: client)
+        proto.startLoading() // schedules the fault via the fake scheduler (captured, not fired)
 
-        proto.startLoading() // schedules the 100ms-delayed fault as a work item
-        proto.stopLoading() // synchronously cancels the work item + marks the protocol stopped
+        scheduler.captured?.perform() // fire the delayed fault
 
-        // The cancelled work item must never fire serveFault, so the client stays untouched.
-        // Deterministic: stopLoading ran synchronously well before the 100ms delay, so the
-        // work item is cancelled; we wait past the delay only to prove nothing fired.
-        let waited = expectation(description: "past the fault delay")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) { waited.fulfill() }
-        wait(for: [waited], timeout: 1.0)
+        XCTAssertEqual(client.calls, ["didFail"], "an un-stopped delayed fault serves the client")
+    }
+
+    // A fault whose work item fires AFTER stopLoading — the already-running interleaving —
+    // must not invoke the client, because serveFault's stopped-check is atomic with delivery.
+    func testDelayedFaultFiringAfterStopDoesNotCallClient() {
+        let scheduler = FakeFaultScheduler()
+        AutoMobileURLProtocol.faultScheduler = scheduler
+        defer {
+            AutoMobileURLProtocol.faultScheduler = RealFaultScheduler()
+            NetworkMockRuleStore.shared.setFaultRules([])
+        }
+
+        let client = RecordingURLProtocolClient()
+        let proto = makeDelayedFaultProtocol(client: client)
+        proto.startLoading() // captures the work item
+        proto.stopLoading() // marks the protocol stopped (and cancels the work item)
+
+        scheduler.captured?.perform() // fire the (now stale) work item anyway
 
         XCTAssertTrue(
             client.calls.isEmpty,
-            "a delayed fault cancelled by stopLoading() must not invoke the client after stop"
+            "a delayed fault that fires after stopLoading() must not invoke the client"
         )
     }
     #endif
 }
+
+#if DEBUG
+/// Captures the delayed-fault work item so a test can fire it deterministically, instead
+/// of waiting on the real timer.
+private final class FakeFaultScheduler: FaultScheduling {
+    var captured: DispatchWorkItem?
+    func schedule(delayMs _: Int, work: DispatchWorkItem) { captured = work }
+}
+#endif
 
 /// Records `URLProtocolClient` callbacks so a test can assert a stopped protocol makes none.
 private final class RecordingURLProtocolClient: NSObject, URLProtocolClient {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -920,4 +920,62 @@ final class NetworkCaptureRecorderTests: XCTestCase {
         XCTAssertNil(collector.records.first?.requestBodySize)
         XCTAssertEqual(collector.records.first?.responseBodySize, 13)
     }
+
+    #if DEBUG
+    func testDelayedFaultCancelledByStopLoadingDoesNotCallClient() {
+        AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: SdkEventBuffer { _ in })
+        NetworkMockRuleStore.shared.setFaultRules([
+            NetworkFaultRuleDTO(
+                faultId: "delayed-error", transport: .urlSession, host: nil, port: nil,
+                scheme: nil, path: nil, method: nil, headers: nil, origin: nil,
+                connectionId: nil, sessionId: nil, action: .error, statusCode: nil,
+                responseHeaders: nil, responseBody: nil, contentType: nil, errorType: "timeout",
+                delayMs: 100, bandwidthBytesPerSecond: nil, dropBytes: nil, limit: nil,
+                expiresAtEpochMs: nil, scope: nil, dryRun: false
+            ),
+        ])
+        defer { NetworkMockRuleStore.shared.setFaultRules([]) }
+
+        let request = URLRequest(url: URL(string: "https://api.example.com/v1/x")!)
+        let client = RecordingURLProtocolClient()
+        let proto = AutoMobileURLProtocol(request: request, cachedResponse: nil, client: client)
+
+        proto.startLoading() // schedules the 100ms-delayed fault as a work item
+        proto.stopLoading() // synchronously cancels the work item + marks the protocol stopped
+
+        // The cancelled work item must never fire serveFault, so the client stays untouched.
+        // Deterministic: stopLoading ran synchronously well before the 100ms delay, so the
+        // work item is cancelled; we wait past the delay only to prove nothing fired.
+        let waited = expectation(description: "past the fault delay")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) { waited.fulfill() }
+        wait(for: [waited], timeout: 1.0)
+
+        XCTAssertTrue(
+            client.calls.isEmpty,
+            "a delayed fault cancelled by stopLoading() must not invoke the client after stop"
+        )
+    }
+    #endif
+}
+
+/// Records `URLProtocolClient` callbacks so a test can assert a stopped protocol makes none.
+private final class RecordingURLProtocolClient: NSObject, URLProtocolClient {
+    private let lock = NSLock()
+    private var _calls: [String] = []
+    var calls: [String] {
+        lock.lock(); defer { lock.unlock() }; return _calls
+    }
+
+    private func record(_ name: String) {
+        lock.lock(); _calls.append(name); lock.unlock()
+    }
+
+    func urlProtocol(_: URLProtocol, wasRedirectedTo _: URLRequest, redirectResponse _: URLResponse) { record("redirect") }
+    func urlProtocol(_: URLProtocol, cachedResponseIsValid _: CachedURLResponse) { record("cached") }
+    func urlProtocol(_: URLProtocol, didReceive _: URLResponse, cacheStoragePolicy _: URLCache.StoragePolicy) { record("didReceive") }
+    func urlProtocol(_: URLProtocol, didLoad _: Data) { record("didLoad") }
+    func urlProtocolDidFinishLoading(_: URLProtocol) { record("finish") }
+    func urlProtocol(_: URLProtocol, didFailWithError _: Error) { record("didFail") }
+    func urlProtocol(_: URLProtocol, didReceive _: URLAuthenticationChallenge) { record("challenge") }
+    func urlProtocol(_: URLProtocol, didCancel _: URLAuthenticationChallenge) { record("cancelChallenge") }
 }


### PR DESCRIPTION
## Summary

`AutoMobileURLProtocol` scheduled a delayed network fault via `DispatchQueue.global().asyncAfter` with no
cancellation token, so `stopLoading()` (which cancels the data task and invalidates the session) did NOT
cancel the delayed block — when the URL loading system tore the protocol down, the timer still fired
`serveFault(...)`, calling `client?.urlProtocol(...)` on an already-stopped protocol from a concurrent
global-queue block.

Fix: schedule the delayed fault as a cancellable `DispatchWorkItem` stored on the protocol; `stopLoading()`
cancels it and sets a `stopped` flag under a lock, and `serveFault` returns early if stopped. So a fault
whose delay has not elapsed is cancelled, and a block that already began executing when `stopLoading()`
runs does not touch the client.

This path is `#if DEBUG`-gated (network-mock infrastructure), so it is a test-infra correctness/UB
concern (client re-entry after stop), not a production-traffic bug.

## Linked Issue

Closes #5697

## Validation

- [x] `swift test` for the SDK package: 303/303 pass (incl. 1 new test)
- [x] `swift build -c release` clean; SwiftLint clean
- [x] No behavior change with no delay (synchronous `serveFault`) or no fault

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

`testDelayedFaultCancelledByStopLoadingDoesNotCallClient` (DEBUG) instantiates the protocol directly with
a recording `URLProtocolClient` fake, calls `startLoading()` (schedules a 100ms-delayed fault) then
`stopLoading()` synchronously, waits past the delay, and asserts the client received no callbacks.
Deterministic — the synchronous stop cancels the work item before its delay elapses — and verified to
FAIL without the cancellation (serveFault fires at 100ms and calls `didFailWithError`).

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices via the normal SDK build.
