### PR TITLE
test(ios): deterministic byte-receive seam for CtrlProxy WebSocket framing tests

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -628,12 +628,97 @@ public class WebSocketServer: WebSocketServing {
     }
 }
 
+// MARK: - Byte transport seam
+
+/// The lifecycle transitions `WebSocketConnection` reacts to, distilled from the
+/// `NWConnection.State` cases it actually acts on (`.ready` starts the handshake
+/// read; `.failed`/`.cancelled` fire the one-shot close). Modeling only these
+/// keeps the test seam small while preserving the exact behavior.
+enum ByteChannelState {
+    case ready
+    case failed
+    case cancelled
+}
+
+/// The minimal byte-transport surface `WebSocketConnection` needs from its
+/// socket: start, a state callback, length-bounded receive, framed send, and
+/// cancel. `NWByteChannel` is the production implementation (a 1:1 forward to
+/// `NWConnection`); `WebSocketServerTests` injects a scripted fake so framing
+/// tests can drive the handshake→frame handoff, the EOF-coalescing path, ping
+/// consume, fragmentation reassembly, and close-path teardown with exact byte
+/// chunks — without a live `NWConnection` or any dependence on TCP segmentation
+/// (issue #5680). The `receive` signature mirrors `NWConnection.receive`'s
+/// completion shape (data, isComplete, error), dropping only the unused
+/// `ContentContext`.
+protocol ByteChannel: AnyObject {
+    /// Invoked on each lifecycle transition the connection cares about. Set
+    /// before `start` and delivered on the channel's queue in production.
+    var onState: ((ByteChannelState) -> Void)? { get set }
+    func start(queue: DispatchQueue)
+    func receive(
+        minimumIncompleteLength: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, Error?) -> Void
+    )
+    func send(_ data: Data, completion: @escaping (Error?) -> Void)
+    func cancel()
+}
+
+/// Production `ByteChannel` backed by a real `NWConnection`. Forwards every call
+/// unchanged so the wire behavior is identical to talking to `NWConnection`
+/// directly; the only reason it exists is to let tests substitute a scripted
+/// channel at the same seam (issue #5680).
+final class NWByteChannel: ByteChannel {
+    private let connection: NWConnection
+    var onState: ((ByteChannelState) -> Void)?
+
+    init(_ connection: NWConnection) {
+        self.connection = connection
+    }
+
+    func start(queue: DispatchQueue) {
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.onState?(.ready)
+            case .failed:
+                self?.onState?(.failed)
+            case .cancelled:
+                self?.onState?(.cancelled)
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    func receive(
+        minimumIncompleteLength: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, Error?) -> Void
+    ) {
+        connection.receive(minimumIncompleteLength: minimumIncompleteLength, maximumLength: maximumLength) { data, _, isComplete, error in
+            completion(data, isComplete, error)
+        }
+    }
+
+    func send(_ data: Data, completion: @escaping (Error?) -> Void) {
+        connection.send(content: data, completion: .contentProcessed { error in
+            completion(error)
+        })
+    }
+
+    func cancel() {
+        connection.cancel()
+    }
+}
+
 // MARK: - WebSocket Connection
 
 /// Handles a single WebSocket connection with handshake and framing
 class WebSocketConnection: WebSocketResponding {
     let id: Int
-    private let connection: NWConnection
+    private let channel: ByteChannel
     private let queue: DispatchQueue
     private let onMessage: (Data) -> Void
     private let onClose: () -> Void
@@ -675,7 +760,35 @@ class WebSocketConnection: WebSocketResponding {
     /// `queue`, so it needs no lock (same invariant as the reassembly state).
     private var didFireClose = false
 
+    /// Designated initializer over the `ByteChannel` seam. Production wraps a real
+    /// `NWConnection` (see the `connection:` convenience init); tests inject a
+    /// scripted channel to drive framing deterministically (issue #5680).
     init(
+        id: Int,
+        channel: ByteChannel,
+        queue: DispatchQueue,
+        boundPort: UInt16,
+        sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
+        onSdkHierarchyUpdated: (() -> Void)? = nil,
+        onUpgrade: (() -> Void)? = nil,
+        onMessage: @escaping (Data) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.id = id
+        self.channel = channel
+        self.queue = queue
+        self.boundPort = boundPort
+        self.sdkHierarchyCache = sdkHierarchyCache
+        self.onSdkHierarchyUpdated = onSdkHierarchyUpdated
+        self.onUpgrade = onUpgrade
+        self.onMessage = onMessage
+        self.onClose = onClose
+    }
+
+    /// Production convenience initializer: wraps a real `NWConnection` in an
+    /// `NWByteChannel`. Keeps the call site in `handleNewConnection` (and the
+    /// existing socket-free tests that pass an unstarted `NWConnection`) unchanged.
+    convenience init(
         id: Int,
         connection: NWConnection,
         queue: DispatchQueue,
@@ -686,34 +799,34 @@ class WebSocketConnection: WebSocketResponding {
         onMessage: @escaping (Data) -> Void,
         onClose: @escaping () -> Void
     ) {
-        self.id = id
-        self.connection = connection
-        self.queue = queue
-        self.boundPort = boundPort
-        self.sdkHierarchyCache = sdkHierarchyCache
-        self.onSdkHierarchyUpdated = onSdkHierarchyUpdated
-        self.onUpgrade = onUpgrade
-        self.onMessage = onMessage
-        self.onClose = onClose
+        self.init(
+            id: id,
+            channel: NWByteChannel(connection),
+            queue: queue,
+            boundPort: boundPort,
+            sdkHierarchyCache: sdkHierarchyCache,
+            onSdkHierarchyUpdated: onSdkHierarchyUpdated,
+            onUpgrade: onUpgrade,
+            onMessage: onMessage,
+            onClose: onClose
+        )
     }
 
     func start() {
-        connection.stateUpdateHandler = { [weak self] state in
+        channel.onState = { [weak self] state in
             switch state {
             case .ready:
                 self?.receiveHTTPUpgrade()
             case .failed, .cancelled:
                 self?.fireOnClose()
-            default:
-                break
             }
         }
 
-        connection.start(queue: queue)
+        channel.start(queue: queue)
     }
 
     func close() {
-        connection.cancel()
+        channel.cancel()
     }
 
     /// Deterministically tears the socket down on an error/close path by
@@ -726,7 +839,7 @@ class WebSocketConnection: WebSocketResponding {
     /// `.cancelled` stays safe. Runs on the server `queue` (every receive/send
     /// completion does), so it needs no lock.
     private func closeConnection() {
-        connection.cancel()
+        channel.cancel()
     }
 
     /// Invokes the `onClose` callback at most once per connection. Called only from
@@ -744,17 +857,17 @@ class WebSocketConnection: WebSocketResponding {
 
     func send(_ data: Data) {
         let frame = Self.createWebSocketFrame(data: data, opcode: 0x01) // Text frame
-        connection.send(content: frame, completion: .contentProcessed { error in
+        channel.send(frame) { error in
             if let error = error {
                 print("[WebSocketConnection] Send error: \(error)")
             }
-        })
+        }
     }
 
     // MARK: - WebSocket Handshake
 
     private func receiveHTTPUpgrade() {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: Self.maximumHTTPRequestLength) { [weak self] data, _, isComplete, error in
+        channel.receive(minimumIncompleteLength: 1, maximumLength: Self.maximumHTTPRequestLength) { [weak self] data, isComplete, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -776,7 +889,7 @@ class WebSocketConnection: WebSocketResponding {
             self.inboundBuffer.append(data)
             guard self.inboundBuffer.count <= Self.maximumHTTPRequestLength else {
                 print("[WebSocketConnection] HTTP request exceeds maximum length")
-                self.connection.cancel()
+                self.channel.cancel()
                 return
             }
 
@@ -788,7 +901,7 @@ class WebSocketConnection: WebSocketResponding {
             let requestData = Data(self.inboundBuffer.prefix(requestLength))
             self.inboundBuffer.removeFirst(requestLength)
             guard let request = String(data: requestData, encoding: .utf8) else {
-                self.connection.cancel()
+                self.channel.cancel()
                 return
             }
 
@@ -864,9 +977,9 @@ class WebSocketConnection: WebSocketResponding {
         let header = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(body.count)\r\n\r\n"
         var response = Data(header.utf8)
         response.append(body)
-        connection.send(content: response, completion: .contentProcessed { [weak self] _ in
-            self?.connection.cancel()
-        })
+        channel.send(response) { [weak self] _ in
+            self?.channel.cancel()
+        }
     }
 
     private static func currentDeviceId() -> String? {
@@ -895,9 +1008,9 @@ class WebSocketConnection: WebSocketResponding {
             print("[CtrlProxy] POST /sdk-events: no header separator found in \(request.count) chars")
         }
         let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n{\"ok\":true}\r\n"
-        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { [weak self] _ in
-            self?.connection.cancel()
-        })
+        channel.send(Data(response.utf8)) { [weak self] _ in
+            self?.channel.cancel()
+        }
     }
 
     private func handleSdkEventsGet() {
@@ -912,9 +1025,9 @@ class WebSocketConnection: WebSocketResponding {
         let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(bodyData.count)\r\n\r\n"
         var responseData = response.data(using: .utf8) ?? Data()
         responseData.append(bodyData)
-        connection.send(content: responseData, completion: .contentProcessed { [weak self] _ in
-            self?.connection.cancel()
-        })
+        channel.send(responseData) { [weak self] _ in
+            self?.channel.cancel()
+        }
     }
 
     private func handleWebSocketUpgrade(_ request: String) {
@@ -924,7 +1037,7 @@ class WebSocketConnection: WebSocketResponding {
             let key = keyLine.split(separator: ":").last?.trimmingCharacters(in: .whitespaces)
         else {
             print("[WebSocketConnection] Missing Sec-WebSocket-Key")
-            connection.cancel()
+            channel.cancel()
             return
         }
 
@@ -943,7 +1056,7 @@ class WebSocketConnection: WebSocketResponding {
 
         """
 
-        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { [weak self] error in
+        channel.send(Data(response.utf8)) { [weak self] error in
             if let error = error {
                 print("[WebSocketConnection] Upgrade send error: \(error)")
                 self?.closeConnection()
@@ -954,7 +1067,7 @@ class WebSocketConnection: WebSocketResponding {
             self?.onUpgrade?()
             self?.sendConnectedEvent()
             self?.receiveWebSocketFrame()
-        })
+        }
     }
 
     private func sendConnectedEvent() {
@@ -1004,7 +1117,7 @@ class WebSocketConnection: WebSocketResponding {
         }
 
         let needed = count - inboundBuffer.count
-        connection.receive(minimumIncompleteLength: needed, maximumLength: needed) { [weak self] data, _, isComplete, error in
+        channel.receive(minimumIncompleteLength: needed, maximumLength: needed) { [weak self] data, isComplete, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -1405,7 +1518,7 @@ class WebSocketConnection: WebSocketResponding {
             case let .pong(applicationData):
                 // Echo the ping application data back in the pong (§5.5.3).
                 let pongFrame = Self.createWebSocketFrame(data: applicationData, opcode: 0x0A)
-                self.connection.send(content: pongFrame, completion: .contentProcessed { _ in })
+                self.channel.send(pongFrame) { _ in }
             case .ignore:
                 break
             }
@@ -1477,9 +1590,9 @@ class WebSocketConnection: WebSocketResponding {
         // Cancel from the send completion — as the HTTP responders do — so the
         // close frame reaches the peer before the TCP teardown; the resulting
         // `.cancelled` transition fires `onClose` exactly once (issue #5677).
-        connection.send(content: frame, completion: .contentProcessed { [weak self] _ in
-            self?.connection.cancel()
-        })
+        channel.send(frame) { [weak self] _ in
+            self?.channel.cancel()
+        }
     }
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -1272,6 +1272,321 @@ final class WebSocketServerTests: XCTestCase {
 
         XCTAssertEqual(Array(WebSocketConnection.unmaskFrame(slice)), payload)
     }
+
+    // MARK: - Deterministic byte-receive seam (#5680)
+
+    /// A well-formed WebSocket upgrade request, byte-for-byte as a client sends it.
+    /// Used to drive `WebSocketConnection` through the real handshake with a
+    /// scripted channel, so framing tests reach the upgraded frame-reading state
+    /// without a live socket (issue #5680).
+    private static func upgradeRequestBytes() -> Data {
+        let request = [
+            "GET / HTTP/1.1",
+            "Host: 127.0.0.1",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version: 13",
+            "",
+            "",
+        ].joined(separator: "\r\n")
+        return Data(request.utf8)
+    }
+
+    /// Wires a `WebSocketConnection` to a `ScriptedByteChannel` playing `segments`,
+    /// so a test can feed exact bytes and observe framing behavior via `onMessage`
+    /// / `onClose` and the channel's captured `sent` / `didCancel`.
+    private func makeScriptedConnection(
+        segments: [ScriptedByteChannel.Segment],
+        onMessage: @escaping (Data) -> Void,
+        onClose: @escaping () -> Void = {}
+    )
+        -> (connection: WebSocketConnection, channel: ScriptedByteChannel)
+    {
+        let channel = ScriptedByteChannel(segments: segments)
+        let connection = WebSocketConnection(
+            id: 1,
+            channel: channel,
+            queue: DispatchQueue(label: "test.ws.scripted.conn"),
+            boundPort: 8765,
+            onMessage: onMessage,
+            onClose: onClose
+        )
+        return (connection, channel)
+    }
+
+    /// AC (deterministic handshake→frame handoff): a masked data frame pipelined in
+    /// the **same** receive as the upgrade request is carried past the handshake
+    /// slice and delivered — pinned without any dependence on TCP segmentation. The
+    /// scripted channel returns `request + frame` in one `receive`, exactly the
+    /// residual case #5678 fixed; pre-fix (`receiveWebSocketFrame` starting a fresh
+    /// socket read that ignores the buffered residual) `onMessage` never fires and
+    /// this times out. This is the deterministic counterpart to the real-socket
+    /// `testFramePipelinedWithUpgradeIsDelivered`, which can false-pass if the
+    /// stack splits the segment.
+    func testHandshakeWithPipelinedFrameDeliveredThroughByteChannelSeam() {
+        let command = #"{"type":"request_press_back","requestId":"seam-pipe-1"}"#
+        let frame = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+        var pipelined = Self.upgradeRequestBytes()
+        pipelined.append(frame)
+
+        let delivered = expectation(description: "pipelined frame delivered via onMessage")
+        let payloadBox = Box<Data?>(nil)
+        let (connection, _) = makeScriptedConnection(
+            segments: [.init(bytes: pipelined, isComplete: false)],
+            onMessage: { data in
+                payloadBox.value = data
+                delivered.fulfill()
+            }
+        )
+        connection.start()
+
+        wait(for: [delivered], timeout: 3)
+        XCTAssertEqual(payloadBox.value, Data(command.utf8), "the pipelined frame must be delivered verbatim")
+    }
+
+    /// AC (EOF-coalescing, #5679): a complete final frame delivered by the socket
+    /// **together with** `isComplete` must still be parsed and delivered, not
+    /// dropped as EOF. The scripted channel hands the frame's payload bytes back on
+    /// the same `receive` callback that reports `isComplete=true` — the exact
+    /// coalescing PR #5679 fixed, which cannot be forced reliably over a real
+    /// socket. Against a pre-#5679 frame reader that acts on `isComplete` before
+    /// consuming the delivered bytes, `onMessage` never fires and this times out.
+    func testFinalFrameDeliveredWhenReceivedTogetherWithEOF() {
+        let command = #"{"type":"request_press_back","requestId":"seam-eof-1"}"#
+        let frame = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+
+        let delivered = expectation(description: "final frame delivered despite coincident EOF")
+        let payloadBox = Box<Data?>(nil)
+        let (connection, _) = makeScriptedConnection(
+            segments: [
+                .init(bytes: Self.upgradeRequestBytes(), isComplete: false),
+                // The frame's remaining bytes (mask + payload) are handed over on the
+                // same callback that reports isComplete — the coalesced-EOF case.
+                .init(bytes: frame, isComplete: true),
+            ],
+            onMessage: { data in
+                payloadBox.value = data
+                delivered.fulfill()
+            }
+        )
+        connection.start()
+
+        wait(for: [delivered], timeout: 3)
+        XCTAssertEqual(
+            payloadBox.value,
+            Data(command.utf8),
+            "a complete frame delivered together with isComplete must still be parsed (issue #5679)"
+        )
+    }
+
+    /// AC (ping consume, #5669): a masked ping frame's mask + payload bytes are
+    /// consumed and a pong is echoed, so the **following** data frame still decodes
+    /// on the re-synced wire. Scripted deterministically: ping segment, then data
+    /// segment. Pre-fix the ping branch read the next 2 bytes as a header, mis-read
+    /// the mask bytes, and the data frame never decodes.
+    func testPingConsumedThenDataFrameStillDecodesThroughSeam() {
+        let ping = RawWebSocketClient.maskedFrame(opcode: 0x09, fin: true, payload: Data("ka".utf8))
+        let command = #"{"type":"request_press_back","requestId":"seam-ping-1"}"#
+        let dataFrame = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: true, payload: Data(command.utf8))
+
+        let delivered = expectation(description: "data frame after ping delivered")
+        let payloadBox = Box<Data?>(nil)
+        let (connection, channel) = makeScriptedConnection(
+            segments: [
+                .init(bytes: Self.upgradeRequestBytes(), isComplete: false),
+                .init(bytes: ping, isComplete: false),
+                .init(bytes: dataFrame, isComplete: false),
+            ],
+            onMessage: { data in
+                payloadBox.value = data
+                delivered.fulfill()
+            }
+        )
+        connection.start()
+
+        wait(for: [delivered], timeout: 3)
+        XCTAssertEqual(
+            payloadBox.value,
+            Data(command.utf8),
+            "the data frame after a ping must still decode once the ping's mask/payload are consumed (#5669)"
+        )
+        let expectedPong = WebSocketConnection.createWebSocketFrame(data: Data("ka".utf8), opcode: 0x0A)
+        XCTAssertTrue(channel.sent.contains(expectedPong), "the server must reply to the ping with a pong echo")
+    }
+
+    /// AC (fragmentation reassembly, #5674): a command split across a non-final
+    /// text fragment and a final continuation — with a ping interleaved — is
+    /// reassembled and delivered. Scripted deterministically frame-by-frame, no
+    /// socket. Pre-fix the continuation payload is discarded and no message is
+    /// delivered.
+    func testFragmentedMessageReassemblesThroughByteChannelSeam() {
+        let command = #"{"type":"request_press_back","requestId":"seam-frag-1"}"#
+        let bytes = Array(command.utf8)
+        let mid = bytes.count / 2
+        let first = RawWebSocketClient.maskedFrame(opcode: 0x01, fin: false, payload: Data(bytes[0 ..< mid]))
+        let ping = RawWebSocketClient.maskedFrame(opcode: 0x09, fin: true, payload: Data("ka".utf8))
+        let second = RawWebSocketClient.maskedFrame(opcode: 0x00, fin: true, payload: Data(bytes[mid ..< bytes.count]))
+
+        let delivered = expectation(description: "fragmented message reassembled")
+        let payloadBox = Box<Data?>(nil)
+        let (connection, _) = makeScriptedConnection(
+            segments: [
+                .init(bytes: Self.upgradeRequestBytes(), isComplete: false),
+                .init(bytes: first, isComplete: false),
+                .init(bytes: ping, isComplete: false),
+                .init(bytes: second, isComplete: false),
+            ],
+            onMessage: { data in
+                payloadBox.value = data
+                delivered.fulfill()
+            }
+        )
+        connection.start()
+
+        wait(for: [delivered], timeout: 3)
+        XCTAssertEqual(payloadBox.value, Data(command.utf8), "the reassembled command must be delivered verbatim")
+    }
+
+    /// AC (close-path cancel, #5677): a client close frame makes the server echo a
+    /// close frame, cancel the channel (so the peer observes EOF), and fire
+    /// `onClose` exactly once. Scripted deterministically; the fake channel's
+    /// `cancel()` drives the `.cancelled` transition just as `NWConnection` does.
+    func testCloseFrameCancelsChannelAndFiresCloseOnceThroughSeam() {
+        let close = RawWebSocketClient.maskedFrame(opcode: 0x08, fin: true, payload: Data())
+
+        let closed = expectation(description: "onClose fired after close frame")
+        let closeCount = Box<Int>(0)
+        let (connection, channel) = makeScriptedConnection(
+            segments: [
+                .init(bytes: Self.upgradeRequestBytes(), isComplete: false),
+                .init(bytes: close, isComplete: false),
+            ],
+            onMessage: { _ in XCTFail("a close frame must not surface as an application message") },
+            onClose: {
+                closeCount.value += 1
+                closed.fulfill()
+            }
+        )
+        connection.start()
+
+        wait(for: [closed], timeout: 3)
+        XCTAssertTrue(channel.didCancel, "a close frame must cancel the channel so the peer observes EOF (#5677)")
+        XCTAssertEqual(closeCount.value, 1, "onClose must fire exactly once")
+        let serverClose = WebSocketConnection.createWebSocketFrame(data: Data(), opcode: 0x08)
+        XCTAssertTrue(channel.sent.contains(serverClose), "the server must echo a close frame before teardown")
+    }
+}
+
+/// A deterministic `ByteChannel` for framing tests (issue #5680). It plays a
+/// scripted list of receive segments back to the connection's readers — each
+/// segment delivered honoring the caller's `maximumLength`, exactly as
+/// `NWConnection` does, and a `receive` never reads across a segment boundary
+/// (mirroring one TCP segment). A segment may carry `isComplete`, so a test can
+/// land EOF on the very callback that hands over the segment's final bytes — the
+/// coalesced-EOF case (#5679) that cannot be forced over a real socket. It
+/// captures every outbound `send` and records `cancel()`, driving the
+/// `.cancelled` transition once so the connection's guarded `fireOnClose` runs
+/// just as production does. Feeding exact bytes pins the handshake→frame handoff,
+/// EOF coalescing, ping consume, fragmentation reassembly, and close-path
+/// teardown without a live socket or any dependence on TCP segmentation.
+private final class ScriptedByteChannel: ByteChannel, @unchecked Sendable {
+    /// One scripted receive segment: up to `maximumLength` of `bytes` is returned
+    /// per `receive`, and `isComplete` is reported only when the segment's final
+    /// bytes are handed over.
+    struct Segment {
+        var bytes: Data
+        var isComplete: Bool
+    }
+
+    var onState: ((ByteChannelState) -> Void)?
+
+    private let lock = NSLock()
+    private var segments: [Segment]
+    private var _sent: [Data] = []
+    private var _didCancel = false
+    /// The connection's serial queue, adopted in `start` so every completion runs
+    /// there — matching the no-lock, single-queue invariant the real code relies on.
+    private var queue = DispatchQueue(label: "test.scripted.channel.placeholder")
+
+    init(segments: [Segment]) {
+        self.segments = segments
+    }
+
+    /// Outbound frames the connection handed to `send`, in order.
+    var sent: [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _sent
+    }
+
+    /// Whether `cancel()` was called at least once.
+    var didCancel: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _didCancel
+    }
+
+    func start(queue: DispatchQueue) {
+        lock.lock()
+        self.queue = queue
+        lock.unlock()
+        // Mirror NWConnection reaching `.ready`, which kicks off the handshake read.
+        queue.async { [weak self] in self?.onState?(.ready) }
+    }
+
+    func receive(
+        minimumIncompleteLength _: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, Error?) -> Void
+    ) {
+        lock.lock()
+        let deliveryQueue = queue
+        let data: Data?
+        let isComplete: Bool
+        if segments.isEmpty {
+            // Stream exhausted — model the peer having closed its write side (EOF).
+            data = nil
+            isComplete = true
+        } else {
+            var head = segments[0]
+            let take = min(head.bytes.count, maximumLength)
+            let chunk = Data(head.bytes.prefix(take))
+            head.bytes.removeFirst(take)
+            if head.bytes.isEmpty {
+                segments.removeFirst()
+                data = chunk.isEmpty ? nil : chunk
+                isComplete = head.isComplete
+            } else {
+                segments[0] = head
+                data = chunk
+                isComplete = false
+            }
+        }
+        lock.unlock()
+        deliveryQueue.async { completion(data, isComplete, nil) }
+    }
+
+    func send(_ data: Data, completion: @escaping (Error?) -> Void) {
+        lock.lock()
+        _sent.append(data)
+        let deliveryQueue = queue
+        lock.unlock()
+        deliveryQueue.async { completion(nil) }
+    }
+
+    func cancel() {
+        lock.lock()
+        let firstCancel = !_didCancel
+        _didCancel = true
+        let deliveryQueue = queue
+        lock.unlock()
+        // A real NWConnection.cancel() eventually drives a `.cancelled` transition;
+        // deliver it once so the connection's guarded `fireOnClose` runs.
+        if firstCancel {
+            deliveryQueue.async { [weak self] in self?.onState?(.cancelled) }
+        }
+    }
 }
 
 /// A minimal raw-socket WebSocket client for tests that need to drive frame-level


### PR DESCRIPTION
## Summary

Introduces a deterministic byte-receive seam (`ByteChannel`) for `WebSocketConnection` so CtrlProxy's WebSocket framing behavior can be pinned by feeding **exact byte sequences**, instead of depending on a real loopback socket and TCP delivering one `NWConnection.send` in a single `receive` callback.

As raised in review of PR #5679, the wire-framing regression tests drove a real loopback socket and relied on TCP coalescing. On loopback with small sends that is reliable in practice, but not *guaranteed*: if the stack split the bytes after the handshake headers, a pre-fix path could read the frame normally and the test could pass without exercising the regression (a false negative), making it network-stack-dependent. This affected `testDataFrameAfterPingStillDecodes` (#5669), `testFragmentedCommandReassemblesEndToEnd` (#5674), and `testFramePipelinedWithUpgradeIsDelivered` (#5678).

This is a runner source change; like #5678 it does not reach production until the iOS control-proxy runner is re-cut (tracked separately in #5681, out of scope here).

## Linked Issue

Closes #5680

## Changes

- **Seam (WebSocketServer.swift):** add `ByteChannel` (protocol), `ByteChannelState`, and `NWByteChannel` (production adapter — a 1:1 forward to `NWConnection`). `WebSocketConnection` now depends on `ByteChannel`; a convenience initializer keeps the `NWConnection` call site in `handleNewConnection` (and the existing socket-free tests) unchanged. **Runtime wire behavior is unchanged** — the adapter forwards receive/send/cancel/state verbatim, reusing the existing single serial `queue`, `inboundBuffer`, and `receiveFrameBytes` (no parallel parse path).
- **Test fake:** `ScriptedByteChannel` plays back exact receive *segments* — honoring the caller's `maximumLength` exactly as `NWConnection` does, never reading across a segment boundary (one TCP segment), and able to land `isComplete` on the same callback that hands over a segment's final bytes (the coalesced-EOF case). It captures every `send` and records `cancel()`, driving the `.cancelled` transition once so the connection's guarded `fireOnClose` runs just as production does.
- **Deterministic tests** (through the real handshake→frame path, no socket):
  - handshake + frame pipelined in one receive (#5678)
  - **EOF-coalescing** — a complete final frame delivered together with `isComplete` (#5679), which cannot be forced reliably over a real socket
  - ping consume then data frame still decodes (#5669)
  - fragmentation reassembly with an interleaved ping (#5674)
  - close-frame cancels the channel and fires `onClose` exactly once (#5677)

The real-socket loopback tests are **kept** as integration coverage.

## Bug / Regression Context

- **Observed symptom:** framing regression tests could false-pass against pre-fix code if the TCP stack split the segment after the handshake headers (network-stack-dependent false negatives).
- **Repro / conditions:** the seam's EOF-coalescing test was verified **red** against a pre-#5679 frame reader (acting on `isComplete` before consuming the coalesced final bytes) — it times out — and green against the current implementation.

## Validation

- [x] `./scripts/ios/swift-build.sh` and `./scripts/ios/swift-test.sh` green (all 4 Swift packages; `WebSocketServerTests` 55 tests pass, new tests ~3ms total)
- [x] `bun run turbo:validate` green (lint + build + 14348 TS tests + boundary checks)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] No XcodeGen project drift (only existing files edited)
- [x] SwiftLint clean (no new violations; `force_unwrapping` avoided via `Data(string.utf8)`)
- [x] New tests use interfaces + fakes; unit tests run in <100ms

## Device Verification

N/A — test-infrastructure + runtime-neutral dependency-injection seam; no on-device behavior change.

## Follow-ups

- iOS control-proxy runner re-cut is tracked in #5681 (out of scope for this PR).