### PR TITLE
fix(daemon): wait for socket publication while a daemon is starting (#5664)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1172,7 +1172,30 @@ export class DaemonMcpProxy {
         );
       }
       logger.info("[DaemonMcpProxy] Daemon started successfully");
+      return;
     }
+
+    // The daemon reports running but startDaemon is only reached when the
+    // observation-only socket probe (DaemonClient.isAvailable) failed — i.e. the
+    // socket is not connectable yet. A daemon in-progress startup writes its
+    // early-owner PID record (daemon.ts writeEarlyOwnerRecord) BEFORE publishing
+    // the Unix socket, which appears seconds later once DB init, device-pool
+    // discovery, and iOS services complete. Treat that missing socket as pending
+    // readiness, not a terminal error: wait behind the same bounded readiness
+    // path so publication can complete instead of letting the subsequent
+    // client.connect() fail immediately with "Daemon socket not found" (issue
+    // #5664). waitForReady polls the socket + verifyDaemonConnection and never
+    // unlinks a live daemon's socket, so stale-socket / dead-daemon handling and
+    // the "do not replace a live daemon's socket" contract are preserved. A
+    // genuinely wedged daemon that never publishes still fails promptly at the
+    // deadline with an actionable error.
+    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+    if (!ready) {
+      throw new DaemonUnavailableError(
+        `Daemon failed to start within ${DAEMON_STARTUP_TIMEOUT_MS}ms`,
+      );
+    }
+    logger.info("[DaemonMcpProxy] Daemon reported running; socket became ready");
   }
 
   private async withRecoverableReconnect<T>(

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -466,6 +466,152 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    describe("in-progress daemon startup (issue #5664)", () => {
+      // The daemon writes an "early owner" PID record (daemon.ts writeEarlyOwnerRecord)
+      // BEFORE publishing its Unix socket — the socket appears seconds later after DB
+      // init, device-pool discovery, and iOS services come up. During that window
+      // status().running is true but the socket does not exist yet, so a client's
+      // first request must WAIT for socket publication behind the bounded readiness
+      // path instead of failing immediately with "Daemon socket not found".
+      class StartingDaemonManager extends FakeDaemonManager {
+        socketPublished = false;
+        waitForReadyCalls = 0;
+        publishOnWaitForReady = true;
+
+        override async waitForReady(_timeout: number): Promise<boolean> {
+          this.waitForReadyCalls++;
+          if (this.publishOnWaitForReady) {
+            // Model the bounded readiness path observing the socket become
+            // connectable once the starting daemon finishes publishing it.
+            this.socketPublished = true;
+            return true;
+          }
+          return false;
+        }
+      }
+
+      // A client that mirrors the real DaemonClient: connecting before the socket is
+      // published throws the terminal "Daemon socket not found" error.
+      class SocketGatedClient implements DaemonClientLike {
+        connectCallCount = 0;
+        closeCallCount = 0;
+        constructor(private readonly manager: StartingDaemonManager) {}
+        async connect(): Promise<void> {
+          this.connectCallCount++;
+          if (!this.manager.socketPublished) {
+            throw new DaemonUnavailableError("Daemon socket not found: /tmp/test.sock");
+          }
+        }
+        async close(): Promise<void> {
+          this.closeCallCount++;
+        }
+        async callTool(): Promise<any> {
+          return { content: [{ type: "text", text: "success" }] };
+        }
+        async readResource(): Promise<any> {
+          return { contents: [] };
+        }
+        async callDaemonMethod(): Promise<any> {
+          return { tools: [] };
+        }
+      }
+
+      test("waits for socket publication when the daemon reports running but the socket is not yet published", async () => {
+        const fakeManager = new StartingDaemonManager();
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+        };
+        const client = new SocketGatedClient(fakeManager);
+        // The socket is not published yet, so the observation-only availability
+        // probe fails and auto-start engages.
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
+
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => client,
+          daemonManager: fakeManager,
+          autoStartDaemon: true,
+        });
+
+        try {
+          await proxy.listTools();
+
+          // The bounded readiness path was consulted before connecting, and the
+          // client connected successfully once the socket was published.
+          expect(fakeManager.waitForReadyCalls).toBeGreaterThanOrEqual(1);
+          expect(client.connectCallCount).toBe(1);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("throws an actionable startup error when the socket is never published", async () => {
+        const fakeManager = new StartingDaemonManager();
+        fakeManager.publishOnWaitForReady = false;
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+        };
+        const client = new SocketGatedClient(fakeManager);
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
+
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => client,
+          daemonManager: fakeManager,
+          autoStartDaemon: true,
+        });
+
+        try {
+          await expect(proxy.listTools()).rejects.toThrow(/failed to start within \d+ms/);
+          // The readiness deadline gates the connect: the client is never asked to
+          // connect against a socket that was never published.
+          expect(fakeManager.waitForReadyCalls).toBeGreaterThanOrEqual(1);
+          expect(client.connectCallCount).toBe(0);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("coalesces concurrent first requests through a single readiness wait", async () => {
+        const fakeManager = new StartingDaemonManager();
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+        };
+        const client = new SocketGatedClient(fakeManager);
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
+
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => client,
+          daemonManager: fakeManager,
+          autoStartDaemon: true,
+        });
+
+        try {
+          // Two concurrent first requests must share one readiness wait rather than
+          // racing independent launches or probes.
+          await Promise.all([proxy.listTools(), proxy.listTools()]);
+
+          expect(fakeManager.waitForReadyCalls).toBe(1);
+          expect(client.connectCallCount).toBe(1);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+    });
+
     describe("version-mismatch handling", () => {
       function makeProxy(
         opts: {


### PR DESCRIPTION
## Summary

When a daemon is still starting, a client's first request could fail immediately with `Daemon socket not found: /tmp/auto-mobile-daemon-<uid>.sock`, turning a recoverable cold-start race into a terminal error.

The daemon writes its **early-owner PID record** (`daemon.ts` `writeEarlyOwnerRecord`) *before* publishing its Unix socket — the socket appears seconds later, after DB init, device-pool discovery, and iOS service bring-up complete. During that window `DaemonManager.status().running` is `true` but the socket does not exist yet. `DaemonMcpProxy.startDaemon()` returned early on `status.running === true`, skipping `waitForReady()`, so the subsequent `client.connect()` hit the missing socket and threw the terminal error.

The fix: `startDaemon()` is only ever reached when the observation-only socket probe (`DaemonClient.isAvailable`) already failed, so a "running" daemon with an unconnectable socket is a verified in-progress startup (or a wedged daemon). Treat the missing socket as **pending readiness** and wait behind the existing bounded readiness path `waitForReady(DAEMON_STARTUP_TIMEOUT_MS)` for publication, throwing the actionable timeout error only if the socket never appears.

`waitForReady` polls the socket + `verifyDaemonConnection` and never unlinks a live daemon's socket, so stale-socket / dead-daemon handling and the "do not replace a live daemon's socket" contract are preserved unchanged.

## Linked Issue

Closes #5664

## Bug / Regression Context

- **Observed symptom:** first request after a cold start fails with `Daemon socket not found` even though the daemon becomes healthy a few seconds later.
- **Repro steps / conditions:** a client connects during the window between the daemon writing its early-owner PID record and publishing its Unix socket (DB init + device-pool + iOS services, up to several seconds — longer for cold iOS startup).

## Acceptance Criteria

- ✅ A deterministic test delays socket publication after the daemon reports running; a concurrent client request waits and succeeds once the socket is available.
- ✅ The wait is bounded by an explicit deadline (`DAEMON_STARTUP_TIMEOUT_MS`) and returns an actionable `failed to start within Nms` error if publication never occurs.
- ✅ Multiple concurrent clients share the same readiness work (the existing `ensureConnected` single-flight coalesces to one `waitForReady` + one connect).
- ✅ A stale socket and a dead daemon still recover or fail per the existing lifecycle contract (`status()` reports `running: false` and routes through `manager.start()`, untouched).
- ✅ Coverage includes cold Android and iOS startup: the wait is at the platform-agnostic socket layer; iOS's longer cold-startup budget is precisely the publication delay this handles.

## Validation

- [x] `bun run lint` — no new ratchet violations
- [x] `bun run build`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test` — full suite green (one pre-existing worktree-only env failure in `test/lint/oxlintConfigScoping.test.ts`: this worktree has no `node_modules/.bin/oxlint` to spawn; passes in CI)
- [x] New tests use interfaces + fakes; unit tests run in <100ms

## Follow-ups

- During the sub-second window between the socket starting to listen and `writePidFile()` overwriting the early record with the full build identity, `ensureBuildMatches` can read a record with no `buildId`. Pre-existing and cooldown-guarded (retryable), out of scope here — will file if it proves to matter.
