### PR TITLE
fix(daemon): route fresh screenshot reads to the owning session (#5663)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -60,6 +60,14 @@ function isFreshSessionScreenshotUri(uri: string, sessionUuid: string): boolean 
   return uri === `automobile:device-session/${sessionUuid}/screenshot`;
 }
 
+// The session UUID embedded in a fresh-session-screenshot resource URI
+// (`automobile:device-session/<uuid>/screenshot`), or undefined for any other
+// URI. Kept in lockstep with {@link isFreshSessionScreenshotUri}.
+function freshSessionScreenshotUriSessionUuid(uri: string): string | undefined {
+  const match = uri.match(/^automobile:device-session\/([^/]+)\/screenshot$/);
+  return match?.[1];
+}
+
 function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
   const configuredTimeout = config.heartbeatTimeoutMs;
   const configuredInterval = config.heartbeatIntervalMs;
@@ -615,6 +623,16 @@ export class DaemonMcpProxy {
   // result-minted one reports the connection state instead of a stale UUID the
   // caller never referenced (issue #5689).
   private boundSessionFromResultMint = false;
+  // Every device session this connection has bound over its lifetime and not yet
+  // seen released. `boundSessionUuid` only tracks the LATEST binding, so acquiring
+  // a second device (e.g. getApple after getAndroid) moves it off the first
+  // session. A fresh-screenshot resource read names its session in the URI, and it
+  // must route to that owning session — not the latest binding — or the daemon
+  // seeds the loopback with the wrong session and denies the just-established
+  // owner with SCREENSHOT_ACCESS_DENIED (issue #5663). Membership here is what
+  // authorizes owner-routing; a session this connection never bound is absent, so
+  // a foreign read still forwards this connection's own binding and stays denied.
+  private readonly ownedDeviceSessions = new Set<string>();
   // Once the daemon confirms this transport's bound session is gone, preserve
   // that terminal identity instead of clearing it and allowing the same UUID to
   // acquire another device. `fromResultMint` records the binding's provenance at
@@ -698,6 +716,7 @@ export class DaemonMcpProxy {
       this.boundSessionUuid = config.initialSessionUuid.trim();
       this.boundSessionUuidAt = this.timer.now();
       this.initialSessionBindingConfigured = true;
+      this.ownedDeviceSessions.add(this.boundSessionUuid);
     }
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
@@ -874,6 +893,11 @@ export class DaemonMcpProxy {
       return;
     }
     this.recordSessionReleased(releasedSessionUuid, notification.reason);
+    // A released session is no longer owned: drop it so a later fresh-screenshot
+    // read stops owner-routing to it and falls back to the live binding (which the
+    // daemon denies), matching the "released session remains denied" guarantee
+    // (issue #5663).
+    this.ownedDeviceSessions.delete(releasedSessionUuid);
     if (
       releasedSessionUuid === this.boundSessionUuid ||
       releasedSessionUuid === this.terminalBoundSession?.sessionUuid
@@ -1788,6 +1812,7 @@ export class DaemonMcpProxy {
     this.terminalBoundSession = undefined;
     this.boundSessionUuid = mintedSessionUuid;
     this.boundSessionUuidAt = this.timer.now();
+    this.ownedDeviceSessions.add(mintedSessionUuid);
     this.boundSessionFromResultMint = true;
     this.initialSessionBindingConfigured = false;
     // Deliver the first ownership heartbeat as part of the acquisition so the
@@ -1842,6 +1867,7 @@ export class DaemonMcpProxy {
     }
     this.boundSessionUuid = sessionUuid;
     this.boundSessionUuidAt = this.timer.now();
+    this.ownedDeviceSessions.add(sessionUuid);
   }
 
   // Refresh the replay lease for a call that was ADMITTED and forwarded to the
@@ -1964,6 +1990,33 @@ export class DaemonMcpProxy {
     }
   }
 
+  // Route a fresh-session-screenshot read to the session named in its URI when
+  // this connection owns that session but has since bound a newer one (e.g.
+  // getApple after getAndroid). Forwarding the URI's session — not the latest
+  // binding — makes the daemon seed the loopback SessionToolBinding with the
+  // owning session, so the just-established owner is authorized instead of denied
+  // with SCREENSHOT_ACCESS_DENIED (issue #5663). Returns undefined for any other
+  // URI, a foreign/unowned session (which must keep forwarding this connection's
+  // own binding and stay denied), or the current binding / a fenced connection
+  // (both already handled by withBoundSessionUuid and the released-session path).
+  private freshScreenshotOwnerForwardParams(uri: string): Record<string, unknown> | undefined {
+    if (this.terminalBoundSession) {
+      return undefined;
+    }
+    const uriSessionUuid = freshSessionScreenshotUriSessionUuid(uri);
+    if (
+      !uriSessionUuid ||
+      uriSessionUuid === this.boundSessionUuid ||
+      !this.ownedDeviceSessions.has(uriSessionUuid)
+    ) {
+      return undefined;
+    }
+    return {
+      sessionUuid: uriSessionUuid,
+      [DAEMON_BOUND_SESSION_PARAM]: uriSessionUuid,
+    };
+  }
+
   /**
    * Read a resource from the daemon
    */
@@ -1977,7 +2030,7 @@ export class DaemonMcpProxy {
           [DAEMON_BOUND_SESSION_PARAM]: terminalSessionUuid,
           [DAEMON_RELEASED_SESSION_PARAM]: terminalSessionUuid,
         }
-      : this.withBoundSessionUuid({});
+      : (this.freshScreenshotOwnerForwardParams(uri) ?? this.withBoundSessionUuid({}));
     return await this.withRecoverableReconnect(
       () => this.client!.readResource(uri, forwardedParams),
       this.sessionUuidFromArgs(forwardedParams),
@@ -2016,6 +2069,7 @@ export class DaemonMcpProxy {
     this.notificationUnsubscribe = null;
     this.connected = false;
     this.clearBoundSessionUuid();
+    this.ownedDeviceSessions.clear();
     this.terminalBoundSession = undefined;
     // Drain the per-UUID release-tracking maps at the close/reconnect boundary.
     // Ordinary completion already evicts each entry when its last in-flight

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -3130,6 +3130,152 @@ describe("DaemonMcpProxy", () => {
     });
   });
 
+  describe("fresh session screenshot binding (#5663)", () => {
+    // A device-session acquisition tool mints its session id in the RESULT. This
+    // models getAndroid/getApple returning `{ sessionId }`.
+    const mintingResult = (sessionUuid: string) => ({
+      content: [{ type: "text", text: JSON.stringify({ sessionId: sessionUuid }) }],
+    });
+
+    test("routes a fresh screenshot read to the owning session, not the latest binding", async () => {
+      // AC1: acquire an Android and an iOS device session over one connection,
+      // then read each session's fresh screenshot. The read for the FIRST
+      // (now non-current) session must still route to its owner rather than the
+      // latest binding — otherwise the daemon denies the just-established owner
+      // with SCREENSHOT_ACCESS_DENIED.
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolResultFor: (toolName) =>
+          toolName === "getAndroid"
+            ? mintingResult("session-android")
+            : mintingResult("session-ios"),
+        resourceResult: { contents: [{ uri: "x", blob: "x" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("getAndroid", {});
+        await proxy.callTool("getApple", {});
+
+        await proxy.readResource("automobile:device-session/session-android/screenshot");
+        await proxy.readResource("automobile:device-session/session-ios/screenshot");
+
+        expect(fakeClient.readResourceParams).toEqual([
+          { sessionUuid: "session-android" },
+          { sessionUuid: "session-ios" },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("routes concurrent fresh screenshot reads each to their owning session", async () => {
+      // AC2: concurrent reads during/after acquisition (concurrent MCP init) must
+      // each carry their own owner session, independent of ordering or a delayed
+      // first heartbeat.
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolResultFor: (toolName) =>
+          toolName === "getAndroid"
+            ? mintingResult("session-android")
+            : mintingResult("session-ios"),
+        resourceResult: { contents: [{ uri: "x", blob: "x" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("getAndroid", {});
+        await proxy.callTool("getApple", {});
+
+        await Promise.all([
+          proxy.readResource("automobile:device-session/session-android/screenshot"),
+          proxy.readResource("automobile:device-session/session-ios/screenshot"),
+        ]);
+
+        const forwarded = fakeClient.readResourceParams.map((params) => params.sessionUuid).sort();
+        expect(forwarded).toEqual(["session-android", "session-ios"]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does not route a fresh screenshot read for a session this connection never acquired", async () => {
+      // AC3: a different connection (bound to its own session) reading another
+      // connection's fresh screenshot must NOT borrow the URI's session — it
+      // forwards its own binding, so the daemon keeps denying it.
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolResultFor: () => mintingResult("session-mine"),
+        resourceResult: { contents: [{ uri: "x", blob: "x" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("getAndroid", {});
+
+        await proxy.readResource("automobile:device-session/session-foreign/screenshot");
+
+        // The connection owns session-mine, so a read for a foreign session
+        // forwards the connection's own binding — never the foreign URI session.
+        expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "session-mine" }]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("stops owner-routing a fresh screenshot read after its session is released", async () => {
+      // AC3: once a session is released it is no longer owner-routed; the read
+      // falls back to the connection's current binding and the daemon denies it.
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolResultFor: (toolName) =>
+          toolName === "getAndroid"
+            ? mintingResult("session-android")
+            : mintingResult("session-ios"),
+        resourceResult: { contents: [{ uri: "x", blob: "x" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("getAndroid", {});
+        await proxy.callTool("getApple", {});
+        // Release the non-current owned session.
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-android");
+
+        await proxy.readResource("automobile:device-session/session-android/screenshot");
+
+        // No longer owner-routed to session-android; forwards the live binding.
+        expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "session-ios" }]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+  });
+
   describe("cache invalidation", () => {
     test("invalidateCache clears all caches", async () => {
       const fakeClient = new FakeDaemonClient({


### PR DESCRIPTION
## Summary

A device-session acquisition tool (`getAndroid`/`getApple`/`startDevice`) mints its session id in the tool **result**, and `DaemonMcpProxy` binds it. The proxy only tracked the **latest** binding, so acquiring a second device (e.g. `getApple` after `getAndroid`) moved `boundSessionUuid` off the first session. `readResource` then injected that current binding into **every** fresh-session-screenshot read (`automobile:device-session/<uuid>/screenshot`), ignoring the session named in the URI. The daemon seeded the loopback `SessionToolBinding` with the wrong session, the resource handler saw `context.sessionUuid !== <uri uuid>`, and it returned `SCREENSHOT_ACCESS_DENIED` to the connection that actually owned the session.

The fix tracks every device session a connection has bound (`ownedDeviceSessions`) and, for a fresh-screenshot read whose URI session is owned but no longer the current binding, forwards that session so the daemon routes and seeds the correct owner. A session the connection never bound is absent from the set, so a foreign read still forwards the connection's own binding and stays denied; released sessions are pruned from the set, and the fenced / released-session read paths are unchanged.

## Linked Issue

Closes #5663

## Bug / Regression Context

- **Prior attempts:** builds on the result-minted session binding from #5694 (#5689) and the establishment-heartbeat work in #5637; relates to the typed failures from #5571 and the concurrency follow-up #5643 without regressing them.
- **Observed symptom:** an immediate read of `automobile:device-session/<session>/screenshot` on the connection that just acquired the session intermittently failed with `SCREENSHOT_ACCESS_DENIED: This resource can only be read by its bound device session.`
- **Repro conditions:** one MCP connection acquires more than one device session (Android then iOS); the fresh-screenshot read for the first, now non-current, session is misrouted to the latest binding and denied. Reproduced deterministically at the proxy level (a read for `session-android` forwarded `session-ios`).

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — full suite green (`test/daemon` + `test/server`: 3595 pass; `daemonMcpProxy` 114 pass incl. 4 new)
- [x] `bun run typecheck` reports no new errors (baseline gate: 174 known)
- [x] `bun run format:check` clean
- [x] New tests use interfaces + fakes; unit tests run in <100ms
- [x] Reuses existing proxy/session-binding seams; no new dependency

## Acceptance criteria

- [x] Deterministic regression test acquires an Android and an iOS session and reads each `automobile:device-session/<session>/screenshot` over the same connection — each is authorized (owner-routed).
- [x] Covers concurrent reads (concurrent MCP initialization) and is independent of a delayed first heartbeat — the owned set is populated at bind time, not at heartbeat time.
- [x] A different connection remains denied (forwards its own binding, not the URI's session); a released/expired session is no longer owner-routed and stays denied.
- [x] Real capture failures retain their existing typed failure code and retryability (resource handler unchanged; covered by existing `observationResources` tests).
