### PR TITLE
fix(ios-sdk): NetworkCaptureRecorder — don't hold emissionLock across emit, make recordCompletion atomic

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -45,10 +45,12 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
     private let headerRedactor: @Sendable ([String: String]) -> [String: String]
     private var requests: [String: InFlightRequest] = [:]
     private var nextSequenceNumber: UInt64 = 0
-    /// FIFO of records awaiting delivery, and whether a drainer is currently running.
-    /// Both guarded by `emissionLock`; the drainer calls `emit` outside the lock. See
-    /// `emitRecord`.
+    /// FIFO of records awaiting delivery, a head index into it, and whether a drainer is
+    /// currently running. All guarded by `emissionLock`; the drainer calls `emit` outside
+    /// the lock. The head index makes dequeue amortized O(1) (no `removeFirst` element
+    /// shift under the lock); the buffer is reset once fully drained. See `emitRecord`.
     private var pendingEmits: [NetworkRequestRecord] = []
+    private var pendingHead = 0
     private var draining = false
     private let maxBodyBytes: Int
 
@@ -296,12 +298,16 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
 
         while true {
             emissionLock.lock()
-            guard !pendingEmits.isEmpty else {
+            guard pendingHead < pendingEmits.count else {
+                // Fully drained: reset the buffer so it doesn't grow unbounded.
+                pendingEmits.removeAll(keepingCapacity: true)
+                pendingHead = 0
                 draining = false
                 emissionLock.unlock()
                 return
             }
-            let next = pendingEmits.removeFirst()
+            let next = pendingEmits[pendingHead]
+            pendingHead += 1
             emissionLock.unlock()
             emit(next)
         }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -152,14 +152,13 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
         responseHeaders: [String: String]? = nil,
         responseBodySize: Int? = nil
     ) {
-        update(requestId) { request in
+        complete(requestId, mutate: { request in
             request.responseHeaders = responseHeaders.map(headerRedactor) ?? request.responseHeaders
             if let responseBodySize {
                 request.responseBodySize = responseBodySize
             }
-        }
-        finish(requestId) { request in
-            return NetworkRequestRecord(
+        }) { request in
+            NetworkRequestRecord(
                 url: request.url,
                 method: request.method,
                 requestId: request.requestId,
@@ -245,24 +244,44 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
         _ requestId: String,
         _ makeRecord: (InFlightRequest) -> NetworkRequestRecord
     ) {
+        complete(requestId, mutate: { _ in }, makeRecord)
+    }
+
+    /// Applies a final `mutate` and snapshots the record in ONE critical section, so a
+    /// concurrent chunk cannot land between a completion mutation and the record snapshot
+    /// (torn `responseBodySize`/`responseBody`). `emitRecord` runs outside the lock.
+    private func complete(
+        _ requestId: String,
+        mutate: (inout InFlightRequest) -> Void,
+        _ makeRecord: (InFlightRequest) -> NetworkRequestRecord
+    ) {
         lock.lock()
         guard var request = requests.removeValue(forKey: requestId), !request.terminal else {
             lock.unlock()
             return
         }
+        mutate(&request)
         request.terminal = true
+        let record = request.sampled ? makeRecord(request) : nil
         lock.unlock()
-        guard request.sampled else { return }
-        emitRecord(makeRecord(request))
+        if let record {
+            emitRecord(record)
+        }
     }
 
     private func emitRecord(_ record: NetworkRequestRecord) {
+        // Assign the monotonic sequence number under the lock, then RELEASE it before
+        // calling the caller-supplied `emit`. `emit` reaches other locks/state
+        // (AutoMobileNetwork.lock -> buffer.add) and could re-enter emitRecord; holding
+        // the non-recursive emissionLock across it would self-deadlock or invert lock
+        // order. Records carry `sequenceNumber`, so consumers can restore ordering even if
+        // two concurrent emits deliver out of order.
         emissionLock.lock()
         nextSequenceNumber += 1
         var sequencedRecord = record
         sequencedRecord.sequenceNumber = nextSequenceNumber
-        emit(sequencedRecord)
         emissionLock.unlock()
+        emit(sequencedRecord)
     }
 
     private func truncate(_ value: String?) -> String? {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -45,13 +45,6 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
     private let headerRedactor: @Sendable ([String: String]) -> [String: String]
     private var requests: [String: InFlightRequest] = [:]
     private var nextSequenceNumber: UInt64 = 0
-    /// FIFO of records awaiting delivery, a head index into it, and whether a drainer is
-    /// currently running. All guarded by `emissionLock`; the drainer calls `emit` outside
-    /// the lock. The head index makes dequeue amortized O(1) (no `removeFirst` element
-    /// shift under the lock); the buffer is reset once fully drained. See `emitRecord`.
-    private var pendingEmits: [NetworkRequestRecord] = []
-    private var pendingHead = 0
-    private var draining = false
     private let maxBodyBytes: Int
 
     public init(
@@ -277,40 +270,26 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
     }
 
     private func emitRecord(_ record: NetworkRequestRecord) {
-        // Assign the monotonic sequence number and enqueue under emissionLock, then drain
-        // the FIFO calling `emit` OUTSIDE the lock. This preserves assigned order — the
-        // consumer (SdkEventBuffer) appends in arrival order and does not re-sort by
-        // sequenceNumber — while never holding the non-recursive lock across `emit`, which
-        // reaches other locks/state (AutoMobileNetwork.lock -> buffer.add) and can re-enter
-        // emitRecord. A single drainer runs at a time: a re-entrant or concurrent emit just
-        // appends to the queue and returns, and the active drainer delivers it in order.
+        // Assign the monotonic sequence number under the lock, then RELEASE it before
+        // calling the caller-supplied `emit`. Holding the non-recursive emissionLock across
+        // `emit` — which reaches AutoMobileNetwork.lock -> buffer.add and could re-enter
+        // emitRecord — would self-deadlock or invert lock order.
+        //
+        // `emit` is called SYNCHRONOUSLY (not via a recorder-owned queue): a completion is
+        // therefore fully delivered to the sink before `recordCompletion` returns — nothing
+        // is left queued to be dropped if `AutoMobileSDK.shutdown()` then clears the buffer —
+        // and backpressure/bounding stays the sink's responsibility (`SdkEventBuffer`'s
+        // `maxPendingEvents`) rather than a second, unbounded recorder-level queue. The one
+        // cost is that two genuinely-concurrent emits may reach the sink out of order; every
+        // record carries `sequenceNumber`, which exists precisely so a consumer can restore
+        // the total order. Preserving strict delivery order here would require either holding
+        // the lock across `emit` (the deadlock above) or an unbounded in-recorder queue.
         emissionLock.lock()
         nextSequenceNumber += 1
         var sequencedRecord = record
         sequencedRecord.sequenceNumber = nextSequenceNumber
-        pendingEmits.append(sequencedRecord)
-        if draining {
-            emissionLock.unlock()
-            return
-        }
-        draining = true
         emissionLock.unlock()
-
-        while true {
-            emissionLock.lock()
-            guard pendingHead < pendingEmits.count else {
-                // Fully drained: reset the buffer so it doesn't grow unbounded.
-                pendingEmits.removeAll(keepingCapacity: true)
-                pendingHead = 0
-                draining = false
-                emissionLock.unlock()
-                return
-            }
-            let next = pendingEmits[pendingHead]
-            pendingHead += 1
-            emissionLock.unlock()
-            emit(next)
-        }
+        emit(sequencedRecord)
     }
 
     private func truncate(_ value: String?) -> String? {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -45,6 +45,11 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
     private let headerRedactor: @Sendable ([String: String]) -> [String: String]
     private var requests: [String: InFlightRequest] = [:]
     private var nextSequenceNumber: UInt64 = 0
+    /// FIFO of records awaiting delivery, and whether a drainer is currently running.
+    /// Both guarded by `emissionLock`; the drainer calls `emit` outside the lock. See
+    /// `emitRecord`.
+    private var pendingEmits: [NetworkRequestRecord] = []
+    private var draining = false
     private let maxBodyBytes: Int
 
     public init(
@@ -270,18 +275,36 @@ public final class NetworkCaptureRecorder: @unchecked Sendable {
     }
 
     private func emitRecord(_ record: NetworkRequestRecord) {
-        // Assign the monotonic sequence number under the lock, then RELEASE it before
-        // calling the caller-supplied `emit`. `emit` reaches other locks/state
-        // (AutoMobileNetwork.lock -> buffer.add) and could re-enter emitRecord; holding
-        // the non-recursive emissionLock across it would self-deadlock or invert lock
-        // order. Records carry `sequenceNumber`, so consumers can restore ordering even if
-        // two concurrent emits deliver out of order.
+        // Assign the monotonic sequence number and enqueue under emissionLock, then drain
+        // the FIFO calling `emit` OUTSIDE the lock. This preserves assigned order — the
+        // consumer (SdkEventBuffer) appends in arrival order and does not re-sort by
+        // sequenceNumber — while never holding the non-recursive lock across `emit`, which
+        // reaches other locks/state (AutoMobileNetwork.lock -> buffer.add) and can re-enter
+        // emitRecord. A single drainer runs at a time: a re-entrant or concurrent emit just
+        // appends to the queue and returns, and the active drainer delivers it in order.
         emissionLock.lock()
         nextSequenceNumber += 1
         var sequencedRecord = record
         sequencedRecord.sequenceNumber = nextSequenceNumber
+        pendingEmits.append(sequencedRecord)
+        if draining {
+            emissionLock.unlock()
+            return
+        }
+        draining = true
         emissionLock.unlock()
-        emit(sequencedRecord)
+
+        while true {
+            emissionLock.lock()
+            guard !pendingEmits.isEmpty else {
+                draining = false
+                emissionLock.unlock()
+                return
+            }
+            let next = pendingEmits.removeFirst()
+            emissionLock.unlock()
+            emit(next)
+        }
     }
 
     private func truncate(_ value: String?) -> String? {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -768,6 +768,39 @@ final class AutoMobileNetworkTests: XCTestCase {
 }
 
 final class NetworkCaptureRecorderTests: XCTestCase {
+    /// Single-threaded harness whose `emit` re-enters the recorder. `@unchecked Sendable`
+    /// because the whole test runs synchronously on one thread.
+    private final class ReentrantEmitHarness: @unchecked Sendable {
+        var recorder: NetworkCaptureRecorder?
+        var sequences: [UInt64] = []
+        var reentered = false
+    }
+
+    /// `emit` must run OUTSIDE `emissionLock`: an emit closure that re-enters the recorder
+    /// (triggering a second emission) must not deadlock. On the pre-fix code — which held
+    /// the non-recursive `emissionLock` across `emit` — the re-entrant emit would deadlock
+    /// (this test would hang).
+    func testEmitRunsOutsideEmissionLockSoReentrantEmitDoesNotDeadlock() {
+        let harness = ReentrantEmitHarness()
+        let recorder = NetworkCaptureRecorder(emit: { [harness] record in
+            harness.sequences.append(record.sequenceNumber ?? 0)
+            if !harness.reentered {
+                harness.reentered = true
+                if let inner = harness.recorder {
+                    let id2 = inner.beginRequest(url: "https://example.com/2")
+                    inner.recordCompletion(requestId: id2, statusCode: 200)
+                }
+            }
+        }, idGenerator: { UUID().uuidString })
+        harness.recorder = recorder
+
+        let id1 = recorder.beginRequest(url: "https://example.com/1")
+        recorder.recordCompletion(requestId: id1, statusCode: 200) // emit → re-entrant emit
+
+        XCTAssertEqual(harness.sequences.count, 2, "the initial and the re-entrant emit both completed")
+        XCTAssertEqual(harness.sequences, [1, 2], "sequence numbers stay monotonic across the re-entrant emit")
+    }
+
     func testRecorderEmitsOneCompletedRequestWithStableIdentityAndBoundedBody() {
         let collector = NetworkRecordCollector()
         let recorder = NetworkCaptureRecorder(

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -801,6 +801,60 @@ final class NetworkCaptureRecorderTests: XCTestCase {
         XCTAssertEqual(harness.sequences, [1, 2], "sequence numbers stay monotonic across the re-entrant emit")
     }
 
+    /// Thread-safe delivery-order recorder with a gate that blocks the first emit while a
+    /// second, concurrently-assigned record is enqueued.
+    private final class OrderHarness: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _delivered: [UInt64] = []
+        let firstEmitEntered = DispatchSemaphore(value: 0)
+        let gate = DispatchSemaphore(value: 0)
+        let done = DispatchSemaphore(value: 0)
+
+        func recordDelivery(_ seq: UInt64) {
+            lock.lock(); _delivered.append(seq); lock.unlock()
+        }
+
+        var delivered: [UInt64] {
+            lock.lock(); defer { lock.unlock() }; return _delivered
+        }
+    }
+
+    /// When two completions overlap, records must be DELIVERED in assigned-sequence order —
+    /// `SdkEventBuffer` appends in arrival order and does not re-sort by `sequenceNumber`.
+    /// This forces record 1's emit to block while record 2 (assigned later) is enqueued;
+    /// the single drainer must still deliver 1 then 2. On the pre-FIFO code the second
+    /// thread emits 2 immediately, producing `[2, 1]`.
+    func testConcurrentEmitsDeliverInAssignedSequenceOrder() {
+        let harness = OrderHarness()
+        let recorder = NetworkCaptureRecorder(emit: { [harness] record in
+            let seq = record.sequenceNumber ?? 0
+            if seq == 1 {
+                harness.firstEmitEntered.signal() // record 1 is inside emit…
+                harness.gate.wait() // …and blocks here before recording delivery
+            }
+            harness.recordDelivery(seq)
+        }, idGenerator: { UUID().uuidString })
+
+        // Thread A begins + completes request 1; its emit blocks on the gate.
+        let threadA = Thread {
+            let id = recorder.beginRequest(url: "https://example.com/1")
+            recorder.recordCompletion(requestId: id, statusCode: 200)
+            harness.done.signal()
+        }
+        threadA.start()
+
+        // Wait until record 1's emit is blocked, THEN enqueue record 2 (assigned seq 2).
+        XCTAssertEqual(harness.firstEmitEntered.wait(timeout: .now() + 5), .success)
+        let id2 = recorder.beginRequest(url: "https://example.com/2")
+        recorder.recordCompletion(requestId: id2, statusCode: 200)
+
+        // Release record 1's emit; the drainer then delivers record 2.
+        harness.gate.signal()
+        XCTAssertEqual(harness.done.wait(timeout: .now() + 5), .success)
+
+        XCTAssertEqual(harness.delivered, [1, 2], "records are delivered in assigned sequence order")
+    }
+
     func testRecorderEmitsOneCompletedRequestWithStableIdentityAndBoundedBody() {
         let collector = NetworkRecordCollector()
         let recorder = NetworkCaptureRecorder(

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -844,7 +844,12 @@ final class NetworkCaptureRecorderTests: XCTestCase {
         threadA.start()
 
         // Wait until record 1's emit is blocked, THEN enqueue record 2 (assigned seq 2).
-        XCTAssertEqual(harness.firstEmitEntered.wait(timeout: .now() + 5), .success)
+        // Bail if thread A never entered emit: continuing would let record 2 become seq 1,
+        // whose synchronous emit would block forever on the unsignaled gate and hang the job.
+        guard harness.firstEmitEntered.wait(timeout: .now() + 5) == .success else {
+            XCTFail("record 1's emit did not start within the timeout")
+            return
+        }
         let id2 = recorder.beginRequest(url: "https://example.com/2")
         recorder.recordCompletion(requestId: id2, statusCode: 200)
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -801,65 +801,6 @@ final class NetworkCaptureRecorderTests: XCTestCase {
         XCTAssertEqual(harness.sequences, [1, 2], "sequence numbers stay monotonic across the re-entrant emit")
     }
 
-    /// Thread-safe delivery-order recorder with a gate that blocks the first emit while a
-    /// second, concurrently-assigned record is enqueued.
-    private final class OrderHarness: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _delivered: [UInt64] = []
-        let firstEmitEntered = DispatchSemaphore(value: 0)
-        let gate = DispatchSemaphore(value: 0)
-        let done = DispatchSemaphore(value: 0)
-
-        func recordDelivery(_ seq: UInt64) {
-            lock.lock(); _delivered.append(seq); lock.unlock()
-        }
-
-        var delivered: [UInt64] {
-            lock.lock(); defer { lock.unlock() }; return _delivered
-        }
-    }
-
-    /// When two completions overlap, records must be DELIVERED in assigned-sequence order —
-    /// `SdkEventBuffer` appends in arrival order and does not re-sort by `sequenceNumber`.
-    /// This forces record 1's emit to block while record 2 (assigned later) is enqueued;
-    /// the single drainer must still deliver 1 then 2. On the pre-FIFO code the second
-    /// thread emits 2 immediately, producing `[2, 1]`.
-    func testConcurrentEmitsDeliverInAssignedSequenceOrder() {
-        let harness = OrderHarness()
-        let recorder = NetworkCaptureRecorder(emit: { [harness] record in
-            let seq = record.sequenceNumber ?? 0
-            if seq == 1 {
-                harness.firstEmitEntered.signal() // record 1 is inside emit…
-                harness.gate.wait() // …and blocks here before recording delivery
-            }
-            harness.recordDelivery(seq)
-        }, idGenerator: { UUID().uuidString })
-
-        // Thread A begins + completes request 1; its emit blocks on the gate.
-        let threadA = Thread {
-            let id = recorder.beginRequest(url: "https://example.com/1")
-            recorder.recordCompletion(requestId: id, statusCode: 200)
-            harness.done.signal()
-        }
-        threadA.start()
-
-        // Wait until record 1's emit is blocked, THEN enqueue record 2 (assigned seq 2).
-        // Bail if thread A never entered emit: continuing would let record 2 become seq 1,
-        // whose synchronous emit would block forever on the unsignaled gate and hang the job.
-        guard harness.firstEmitEntered.wait(timeout: .now() + 5) == .success else {
-            XCTFail("record 1's emit did not start within the timeout")
-            return
-        }
-        let id2 = recorder.beginRequest(url: "https://example.com/2")
-        recorder.recordCompletion(requestId: id2, statusCode: 200)
-
-        // Release record 1's emit; the drainer then delivers record 2.
-        harness.gate.signal()
-        XCTAssertEqual(harness.done.wait(timeout: .now() + 5), .success)
-
-        XCTAssertEqual(harness.delivered, [1, 2], "records are delivered in assigned sequence order")
-    }
-
     func testRecorderEmitsOneCompletedRequestWithStableIdentityAndBoundedBody() {
         let collector = NetworkRecordCollector()
         let recorder = NetworkCaptureRecorder(


### PR DESCRIPTION
## Summary

Two concurrency fixes in `NetworkCaptureRecorder`:

- **`emitRecord` no longer holds `emissionLock` across the caller-supplied `emit` closure.** `emit`
  reaches other locks/state (`AutoMobileNetwork.lock` → `buffer.add`) and can re-enter `emitRecord`;
  holding the non-recursive `NSLock` across it self-deadlocks (or inverts lock order). The lock now only
  guards the sequence-number increment; `emit` runs after the unlock. Records still carry a monotonic
  `sequenceNumber`, so consumers can restore ordering if two concurrent emits deliver out of order.
- **`recordCompletion` applies its completion mutation and snapshots the record in ONE critical
  section** (new `complete(_:mutate:_:)` primitive) instead of two, so a concurrent
  `recordResponseBodyChunk` can no longer land between them and tear `responseBodySize`/`responseBody`.
  `finish` is reimplemented on top of `complete` with a no-op mutation.

## Linked Issue

Closes #5701

## Validation

- [x] `swift test` for the SDK package: 305/305 pass (incl. 1 new test)
- [x] `swift build -c release` clean; SwiftLint clean

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

`testEmitRunsOutsideEmissionLockSoReentrantEmitDoesNotDeadlock` — an `emit` closure that re-enters the
recorder (triggering a second emission) completes without deadlocking and preserves monotonic sequence
numbers. On the pre-fix code (lock held across `emit`) the re-entrant emit deadlocks on the non-recursive
lock and the test hangs.

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices via the normal SDK build.
