### PR TITLE
fix: three bot-filed regressions (#5686 appId decode, #5618 owner windows, #5617 safeStringify)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -402,8 +402,12 @@ export class TapOnElement extends BaseVisualChange {
     if (!viewHierarchy) {
       return false;
     }
+    // The owner is resolved (ElementFinder) and natively activated across every
+    // window subtree, so the uniqueness count must span the same node set. Flatten
+    // with includeWindows to match — otherwise an owner in a dialog/popup/overlay is
+    // miscounted: an ambiguous owner reads as unique, a valid one as absent. See #5618.
     const elements = this.elementParser
-      .flattenViewHierarchy(viewHierarchy)
+      .flattenViewHierarchy(viewHierarchy, { includeWindows: true })
       .map(({ element }) => element);
     if (this.device.platform === "ios") {
       const ownerResourceId = owner["resource-id"];

--- a/src/server/storageCapabilityResources.ts
+++ b/src/server/storageCapabilityResources.ts
@@ -84,7 +84,11 @@ export async function getStorageCapabilitiesResource(
   params: Record<string, string>,
 ): Promise<ResourceContent> {
   const { deviceId } = params;
-  const appId = params.appId ? decodeURIComponent(params.appId) : undefined;
+  // The resource registry already percent-decodes query params via URLSearchParams
+  // (resourceRegistry.ts), so appId arrives decoded. Decoding again here would be a
+  // double-decode: it corrupts %-bearing ids and throws URIError on a literal `%`
+  // (which, being outside the try/catch, would bypass the JSON error envelope). See #5686.
+  const appId = params.appId ? params.appId : undefined;
   const uri = buildUri(deviceId, appId);
 
   try {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -299,14 +299,24 @@ const safeStringify = (obj: any): string => {
     return String(obj);
   }
 
-  const seen = new WeakSet<object>();
+  // Track only the current ancestor path (not every object ever visited) so a
+  // shared child referenced from two sibling positions — a DAG/diamond, which is
+  // NOT a cycle — renders fully at both, instead of the second occurrence being
+  // mis-flagged as "[circular]". Each entry pairs the filtered object we return
+  // (which becomes `this`, the holder, in the child calls) with the original value
+  // it was built from (whose identity a true cycle repeats on the path). See #5617.
+  const ancestors: Array<{ holder: object; original: object }> = [];
   try {
-    return JSON.stringify(obj, (_key, value) => {
+    return JSON.stringify(obj, function (this: unknown, _key, value) {
       if (typeof value === "object" && value !== null) {
-        if (seen.has(value)) {
+        // Unwind the path back to this value's holder before testing/pushing, so
+        // siblings don't inherit each other's descendants as false ancestors.
+        while (ancestors.length > 0 && ancestors[ancestors.length - 1].holder !== this) {
+          ancestors.pop();
+        }
+        if (ancestors.some((entry) => entry.original === value)) {
           return "[circular]";
         }
-        seen.add(value);
         // Filter sensitive environment-like keys
         const filtered: any = {};
         for (const [k, v] of Object.entries(value)) {
@@ -314,6 +324,7 @@ const safeStringify = (obj: any): string => {
             filtered[k] = v;
           }
         }
+        ancestors.push({ holder: filtered, original: value });
         return filtered;
       }
       return value;

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -72,6 +72,54 @@ describe("TapOnElement selectedElement metadata", () => {
     expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
   });
 
+  // Regression: the uniqueness count must span window subtrees, because the owner
+  // is resolved and natively activated across every window — not just the main
+  // hierarchy. Counting only the main tree both mis-passes an ambiguous owner and
+  // rejects a valid owner that lives inside a dialog/popup/overlay window (#5618).
+  test("rejects an owner duplicated in another window (ambiguous across windows)", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Account B",
+      "resource-id": "com.example:id/account_row",
+    });
+    const duplicateInWindow = ResultFaker.element({
+      text: "Account A",
+      "resource-id": "com.example:id/account_row",
+    });
+    const hierarchy = {
+      hierarchy: { node: [{ ...owner, children: [] }] },
+      windows: [
+        {
+          isActive: true,
+          isFocused: true,
+          hierarchy: { node: [{ ...duplicateInWindow, children: [] }] },
+        },
+      ],
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(false);
+  });
+
+  test("accepts a unique owner that lives inside a window subtree", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Terms and privacy",
+      "resource-id": "com.example:id/legal_row",
+    });
+    const hierarchy = {
+      hierarchy: { node: [] },
+      windows: [
+        {
+          isActive: true,
+          isFocused: true,
+          hierarchy: { node: [{ ...owner, children: [] }] },
+        },
+      ],
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
+  });
+
   test("uses Android's complete stable selector for duplicate resource IDs", () => {
     const tapOnElement = createTapOnElement();
     const owner = ResultFaker.element({

--- a/test/server/storageCapabilityResources.test.ts
+++ b/test/server/storageCapabilityResources.test.ts
@@ -158,4 +158,46 @@ describe("storageCapabilityResources", () => {
       serverConfig.setEmbeddedSdkEnabled(previous);
     }
   });
+
+  // Regression: the resource registry already percent-decodes query params via
+  // URLSearchParams, so the handler must NOT decode appId a second time (#5686).
+  describe("appId query param is not double-decoded (#5686)", () => {
+    test("registry hands the handler an already-decoded query param (mechanism)", () => {
+      setDevices([androidEmulator]);
+      const match = ResourceRegistry.matchTemplate(
+        "automobile:devices/emulator-5554/storage/capabilities?appId=%2541",
+      );
+      // URI value %2541 → registry decodes once → "%41". A handler decode would
+      // wrongly turn this into "A".
+      expect(match?.params.appId).toBe("%41");
+    });
+
+    test("a %-bearing appId round-trips through the report (identity contract)", async () => {
+      const previous = serverConfig.isEmbeddedSdkEnabled();
+      serverConfig.setEmbeddedSdkEnabled(true);
+      try {
+        setDevices([androidEmulator]);
+        const intended = "%41";
+        const content = await readResource(
+          `automobile:devices/emulator-5554/storage/capabilities?appId=${encodeURIComponent(intended)}`,
+        );
+        const body = JSON.parse(content.text ?? "{}");
+        expect(body.appId).toBe(intended);
+      } finally {
+        serverConfig.setEmbeddedSdkEnabled(previous);
+      }
+    });
+
+    test("a literal-% appId returns a graceful JSON envelope, not an unhandled throw", async () => {
+      setDevices([androidEmulator]);
+      // URI value 100%25 → registry decodes → "100%". A second decodeURIComponent
+      // would throw URIError outside the try/catch, bypassing the error envelope.
+      const content = await readResource(
+        "automobile:devices/emulator-5554/storage/capabilities?appId=100%25",
+      );
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text ?? "{}");
+      expect(body.appId).toBe("100%");
+    });
+  });
 });

--- a/test/utils/logger-redaction.test.ts
+++ b/test/utils/logger-redaction.test.ts
@@ -67,6 +67,29 @@ describe("safeStringify redacts sensitive data", () => {
     circular.self = circular;
     expect(safeStringify(circular)).toBe('{"self":"[circular]"}');
   });
+
+  // Regression: cycle detection tracked every visited object instead of just the
+  // ancestor path, so a shared (non-cyclic) child was mis-flagged "[circular]" at
+  // its second sibling position, dropping real log data (#5617).
+  test("renders a shared child fully at both sibling positions (diamond, not a cycle)", () => {
+    const shared = { x: 1 };
+    expect(safeStringify({ a: shared, b: shared })).toBe('{"a":{"x":1},"b":{"x":1}}');
+  });
+
+  test("renders a shared child fully across array elements", () => {
+    const shared = { x: 1 };
+    // Arrays serialize as index-keyed objects (see above); both entries keep the child.
+    expect(safeStringify([shared, shared])).toBe('{"0":{"x":1},"1":{"x":1}}');
+  });
+
+  test("still detects a true cycle nested under a shared sibling", () => {
+    const shared: { x: number } = { x: 1 };
+    const cyclic: { child?: unknown; self?: unknown } = { child: shared };
+    cyclic.self = cyclic;
+    expect(safeStringify({ a: shared, b: cyclic })).toBe(
+      '{"a":{"x":1},"b":{"child":{"x":1},"self":"[circular]"}}',
+    );
+  });
 });
 
 describe("SENSITIVE_ENV_KEYS", () => {


### PR DESCRIPTION
Fixes three bot-filed `needs-human` regressions, one per commit.

> **Note:** [#5622](https://github.com/kaeawc/auto-mobile/issues/5622) (lychee doc-link flake) was originally the 4th commit here, but a fix already landed on `main` during rebase — with the same `timeout`/`retry_wait_time` bump **plus** a broader `contributor-covenant.org` host exclusion. My redundant commit was dropped; nothing to do here for #5622.

## [#5686](https://github.com/kaeawc/auto-mobile/issues/5686) — storage-capabilities `appId` double-decode (regression in #5665)
The resource registry already percent-decodes query params via `URLSearchParams`, so the handler's extra `decodeURIComponent(appId)` was a double-decode: it corrupted `%`-bearing ids (`%41`→`A`, breaking the echo contract) and threw `URIError` on a literal `%` **outside** the `try/catch`, bypassing the JSON error envelope. Fix drops the second decode. Tests cover the mechanism, the round-trip identity, and the graceful-envelope path.

## [#5618](https://github.com/kaeawc/auto-mobile/issues/5618) — semantic-link owner uniqueness ignores windows (regression in #5548)
`hasUniqueSemanticLinkOwner` flattened without `includeWindows`, counting only the main hierarchy — but the owner is resolved (`ElementFinder`) and natively activated across every window. That both mis-passed an ambiguous owner duplicated in a window and rejected a valid unique owner inside a dialog/popup/overlay. Fix flattens with `includeWindows: true` to match. Tests cover both directions.

## [#5617](https://github.com/kaeawc/auto-mobile/issues/5617) — `safeStringify` false-positive `[circular]` (regression in #5556)
The cycle-detection `WeakSet` was added-to but never pruned on DFS unwind, so a shared (non-cyclic) child referenced from two siblings — a diamond — was dropped as `[circular]`. Fix tracks only the current ancestor path (a stack pairing each returned filtered object with its original value); true cycles are still detected. Tests cover diamonds (object + array) and a real cycle nested under a shared sibling.

---
### Validation (post-rebase onto latest `main`)
- Affected tests: `bun test` green (38 tests across the 3 touched suites).
- `bun run lint` — no new ratchet violations; `bun run typecheck` — no new type errors; `bun run build` — ok; `oxfmt --check` on changed files — clean.

### Follow-up (out of scope, per #5686's aside)
`src/server/navigationResources.ts` appears to decode its own `{?appId}` query param the same way — a likely latent instance of the same double-decode, left for a separate change.

Closes #5686. Closes #5618. Closes #5617.