### PR TITLE
fix(snapshot): write to ~/.auto-mobile/snapshots not ~/.automobile (#5706)

### DIFF
--- a/docs/design-docs/mcp/storage/index.md
+++ b/docs/design-docs/mcp/storage/index.md
@@ -16,7 +16,7 @@ flowchart TB
 
     subgraph Storage["Persistent Storage"]
         SQLite["🗄️ SQLite<br/>~/.auto-mobile/auto-mobile.db"]
-        Snapshots["📸 Snapshots<br/>~/.automobile/snapshots/"]
+        Snapshots["📸 Snapshots<br/>~/.auto-mobile/snapshots/"]
         Migrations["🔄 Migrations<br/>src/db/migrations/"]
     end
 
@@ -38,7 +38,7 @@ flowchart TB
 | Path                            | Purpose                        |
 | ------------------------------- | ------------------------------ |
 | `~/.auto-mobile/auto-mobile.db` | SQLite database for metadata   |
-| `~/.automobile/snapshots/`      | Device state snapshot payloads |
+| `~/.auto-mobile/snapshots/`     | Device state snapshot payloads |
 | `~/.auto-mobile/*.sock`         | Unix sockets for configuration |
 
 ## Topics
@@ -78,9 +78,9 @@ See [Database Migrations](migrations.md) for details on adding new migrations.
 
 Device snapshots use a hybrid approach:
 
-| Snapshot Type | Metadata | Payload                    |
-| ------------- | -------- | -------------------------- |
-| VM Snapshot   | SQLite   | Emulator AVD directory     |
-| ADB Snapshot  | SQLite   | `~/.automobile/snapshots/` |
+| Snapshot Type | Metadata | Payload                     |
+| ------------- | -------- | --------------------------- |
+| VM Snapshot   | SQLite   | Emulator AVD directory      |
+| ADB Snapshot  | SQLite   | `~/.auto-mobile/snapshots/` |
 
 See [Device Snapshots](snapshots.md) for capture/restore workflows.

--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -23,7 +23,7 @@ The snapshot feature provides deterministic device state management for mobile t
 - **Settings-only Snapshots**: Portable device-settings snapshots for physical Android devices and non-VM emulator captures (no app data)
 - **iOS App Container Backups**: Portable app-scoped snapshots for iOS simulators
 - **Auto-generated Naming**: Automatic timestamp-based snapshot names with optional custom naming
-- **Host-based Storage**: Snapshots stored in `~/.automobile/snapshots/` for fast access and easy management
+- **Host-based Storage**: Snapshots stored in `~/.auto-mobile/snapshots/` for fast access and easy management
 
 ## MCP Tool
 
@@ -163,7 +163,7 @@ compatibility with existing archived snapshots; it no longer carries app data.
 - Emulator replies with `OK` or `KO: <reason>` (missing `OK` is treated as failure)
 - Commands time out after 30000ms by default (configurable via `vmSnapshotTimeoutMs`)
 - Snapshots stored in emulator's AVD directory (typically `~/.android/avd/<avd>.avd/snapshots/`)
-- Metadata stored in `~/.automobile/snapshots/` for management
+- Metadata stored in `~/.auto-mobile/snapshots/` for management
 
 ### Settings-only Snapshots (Non-VM Android)
 
@@ -225,10 +225,10 @@ Used for physical Android devices and for emulator captures with
 
 ## Storage Location
 
-Snapshot payloads are stored in `~/.automobile/snapshots/` (settings-only Android snapshots), and metadata is tracked in SQLite at `~/.auto-mobile/auto-mobile.db`:
+Snapshot payloads are stored in `~/.auto-mobile/snapshots/` (settings-only Android snapshots), and metadata is tracked in SQLite at `~/.auto-mobile/auto-mobile.db`:
 
 ```text
-~/.automobile/snapshots/
+~/.auto-mobile/snapshots/
 ├── Pixel_5_2026-01-08_12-30-45/
 │   └── settings.json          # Device settings (settings-only snapshots)
 └── another-snapshot/
@@ -240,7 +240,7 @@ VM snapshots themselves are stored in the emulator AVD directory and persist acr
 iOS app container backups are stored per simulator device ID:
 
 ```text
-~/.automobile/snapshots/ios/
+~/.auto-mobile/snapshots/ios/
 └── <device-udid>/
     └── <snapshot-name>/
         ├── metadata.json
@@ -369,7 +369,7 @@ still honor `strictBackupMode`.
 - For VM snapshots, ensure emulator console is accessible
 - If VM snapshot commands time out, increase `vmSnapshotTimeoutMs` or restart the emulator
 - If the emulator reports an unknown command, update the emulator to a version that supports snapshots
-- Check available disk space in `~/.automobile/snapshots/`
+- Check available disk space in `~/.auto-mobile/snapshots/`
 
 ### Snapshot Restore Fails
 

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -13,7 +13,7 @@ export class DeviceSnapshotStore {
   private basePath: string;
 
   constructor(customBasePath?: string) {
-    this.basePath = customBasePath || path.join(os.homedir(), ".automobile", "snapshots");
+    this.basePath = customBasePath || path.join(os.homedir(), ".auto-mobile", "snapshots");
   }
 
   getBasePath(): string {

--- a/test/utils/deviceSnapshotStore.test.ts
+++ b/test/utils/deviceSnapshotStore.test.ts
@@ -22,6 +22,18 @@ describe("DeviceSnapshotStore", () => {
     }
   });
 
+  it("should default to the ~/.auto-mobile/snapshots base path", () => {
+    const defaultStore = new DeviceSnapshotStore();
+    expect(defaultStore.getBasePath()).toBe(
+      path.join(os.homedir(), ".auto-mobile", "snapshots"),
+    );
+    // Guard against regressing to the historical hyphen-less ".automobile" typo,
+    // which orphaned snapshot state from the rest of ~/.auto-mobile (issue #5706).
+    expect(defaultStore.getBasePath()).not.toContain(
+      path.join(".automobile", "snapshots"),
+    );
+  });
+
   describe("generateSnapshotName", () => {
     it("should generate a snapshot name with timestamp", () => {
       const name = store.generateSnapshotName();

--- a/test/utils/deviceSnapshotStore.test.ts
+++ b/test/utils/deviceSnapshotStore.test.ts
@@ -24,14 +24,10 @@ describe("DeviceSnapshotStore", () => {
 
   it("should default to the ~/.auto-mobile/snapshots base path", () => {
     const defaultStore = new DeviceSnapshotStore();
-    expect(defaultStore.getBasePath()).toBe(
-      path.join(os.homedir(), ".auto-mobile", "snapshots"),
-    );
+    expect(defaultStore.getBasePath()).toBe(path.join(os.homedir(), ".auto-mobile", "snapshots"));
     // Guard against regressing to the historical hyphen-less ".automobile" typo,
     // which orphaned snapshot state from the rest of ~/.auto-mobile (issue #5706).
-    expect(defaultStore.getBasePath()).not.toContain(
-      path.join(".automobile", "snapshots"),
-    );
+    expect(defaultStore.getBasePath()).not.toContain(path.join(".automobile", "snapshots"));
   });
 
   describe("generateSnapshotName", () => {


### PR DESCRIPTION
## Summary

`DeviceSnapshotStore` defaulted its base path to `~/.automobile/snapshots` — hyphen-less — while the rest of the app uses `~/.auto-mobile` (e.g. the SQLite DB at `~/.auto-mobile`). Snapshot state was therefore orphaned from doctor, device-filter, DB, and logs. This changes the default to `~/.auto-mobile/snapshots`.

Forward-only, per the issue decision: existing `~/.automobile/snapshots` are left orphaned (the user can delete them); no migration is performed.

## Linked Issue

Closes #5706

## Bug / Regression Context

- **Observed symptom:** Snapshots written under `~/.automobile/snapshots`, disconnected from the `~/.auto-mobile` state the rest of the app uses.
- **Repro steps / conditions:** Any `deviceSnapshot` capture with the default base path.

## Changes

- `src/utils/DeviceSnapshotStore.ts`: default base path `.automobile` → `.auto-mobile`.
- `test/utils/deviceSnapshotStore.test.ts`: new test pinning the default `getBasePath()` to `~/.auto-mobile/snapshots` and guarding against the hyphen-less regression.

## Validation

- [x] `bun run lint` clean (no new ratchet violations)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Full `bun test` — 14355 pass (one pre-existing worktree `node_modules/.bin/oxlint` ENOENT artifact, unrelated to this change)
- [x] New test runs in <100ms and injects its base path

## Acceptance Criteria

- [x] Default base path is `~/.auto-mobile/snapshots`
- [x] No migration of existing `~/.automobile/snapshots` (forward-only)
- [x] Tests/fixtures updated — no test pinned the old path; added one pinning the new default
