### PR TITLE
fix(ios): validate appBundleIds and report per-bundle capture status (#5712)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -215,6 +215,8 @@ by the capture paths).
 - Copies `Documents/`, `Library/`, and `tmp/` for each bundle ID
 - Snapshot type is `app_data`
 - Simulator-wide `simctl snapshot` is intentionally not used for portability
+- Each requested bundle ID is validated up front (installed via `simctl listapps`, has a data container via `get_app_container … data`) and reported with a per-bundle status — `captured`, `skipped-no-container`, `not-installed`, or `failed` — in `appDataBackup.bundleStatuses` and at the top level of the capture tool result (`bundleStatuses`), rather than silently "succeeding"
+- Capture with `includeAppData: true` but no usable `appBundleIds` (empty or all blank) is rejected with an `ActionableError` — pass explicit bundle IDs, or set `includeAppData: false` for a settings-only snapshot
 
 ## Storage Location
 

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -787,7 +787,7 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
         // failure, not a missing app; count it as failed so strict mode rejects.
         logger.warn(`[iOS] Failed to backup app data for ${bundleId}: ${error}`);
         failedPackages.push(bundleId);
-        bundleStatuses.push({ bundleId, status: "skipped-no-container" });
+        bundleStatuses.push({ bundleId, status: "failed" });
       }
     }
 

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -2,9 +2,15 @@ import { errorMessage } from "../../utils/describeUnknownError";
 import {
   BootedDevice,
   ActionableError,
+  toActionableError,
   DeviceSnapshotManifest,
   DeviceSnapshotType,
+  IosBundleCaptureStatus,
 } from "../../models";
+import {
+  getIosInstalledAppBundleId,
+  type IosInstalledAppRecord,
+} from "../../utils/ios-cmdline-tools/iosInstalledApp";
 import type { SnapshotCaptureProvider } from "../../utils/interfaces/SnapshotProvider";
 import {
   AdbClientFactory,
@@ -721,50 +727,67 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     strictBackupMode: boolean,
     pathOptions: SnapshotPathOptions,
   ): Promise<DeviceSnapshotManifest["appDataBackup"]> {
+    // Sanitize first: trim, drop blank entries, and de-dupe while preserving order.
+    const sanitized = Array.from(
+      new Set((appBundleIds ?? []).map((value) => value.trim()).filter(Boolean)),
+    );
+
+    // Empty `appBundleIds` with `includeAppData:true` used to "succeed" while
+    // capturing nothing. That is a caller mistake — fail loudly instead of
+    // producing an empty backup (issue #5712).
+    if (sanitized.length === 0) {
+      throw new ActionableError(
+        "No app bundle IDs provided for iOS app-data capture. Pass appBundleIds " +
+          "with at least one installed app, or set includeAppData:false for a " +
+          "settings-only snapshot.",
+      );
+    }
+
     logger.info("[iOS] Capturing app data containers");
 
     const appDataPath = this.store.getAppDataPath(snapshotName, pathOptions);
     await fs.mkdir(appDataPath, { recursive: true });
 
-    if (!appBundleIds || appBundleIds.length === 0) {
-      logger.warn("[iOS] No appBundleIds provided; skipping app data capture");
-    }
+    // Validate installation up front so an unknown bundle is reported as
+    // not-installed rather than silently "succeeding".
+    const installedBundleIds = await this.getInstalledIosBundleIds();
 
-    const { bundleIds, skippedBundles, totalBundles } =
-      await this.resolveIosBundleIds(appBundleIds);
-
-    if (bundleIds.length === 0) {
-      logger.warn("[iOS] No app bundle IDs available for backup");
-      return {
-        backupMethod: "none",
-        totalPackages: totalBundles,
-        backedUpPackages: [],
-        skippedPackages: skippedBundles,
-        failedPackages: [],
-      };
-    }
-
+    const bundleStatuses: IosBundleCaptureStatus[] = [];
     const backedUpPackages: string[] = [];
+    const skippedPackages: string[] = [];
     const failedPackages: string[] = [];
 
-    for (const bundleId of bundleIds) {
+    for (const bundleId of sanitized) {
+      if (!installedBundleIds.has(bundleId)) {
+        logger.warn(`[iOS] ${bundleId} is not installed; skipping app data capture`);
+        failedPackages.push(bundleId);
+        bundleStatuses.push({ bundleId, status: "not-installed" });
+        continue;
+      }
+
       try {
-        logger.info(`[iOS] Backing up app data: ${bundleId}`);
         const containerPath = await getAppDataContainerPath(
           this.simctl,
           this.device.deviceId,
           bundleId,
         );
         if (!containerPath) {
-          failedPackages.push(bundleId);
+          logger.warn(`[iOS] ${bundleId} has no data container; skipping app data capture`);
+          skippedPackages.push(bundleId);
+          bundleStatuses.push({ bundleId, status: "skipped-no-container" });
           continue;
         }
 
+        logger.info(`[iOS] Backing up app data: ${bundleId}`);
         await this.copyIosAppContainer(containerPath, appDataPath, bundleId);
         backedUpPackages.push(bundleId);
+        bundleStatuses.push({ bundleId, status: "captured" });
       } catch (error) {
+        // A container that resolved but failed to copy is a genuine capture
+        // failure, not a missing app; count it as failed so strict mode rejects.
         logger.warn(`[iOS] Failed to backup app data for ${bundleId}: ${error}`);
         failedPackages.push(bundleId);
+        bundleStatuses.push({ bundleId, status: "skipped-no-container" });
       }
     }
 
@@ -776,37 +799,36 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
 
     return {
       backupMethod: "simctl_copy",
-      totalPackages: totalBundles,
+      totalPackages: sanitized.length,
       backedUpPackages,
-      skippedPackages: skippedBundles,
+      skippedPackages,
       failedPackages,
+      bundleStatuses,
     };
   }
 
-  private async resolveIosBundleIds(appBundleIds?: string[]): Promise<{
-    bundleIds: string[];
-    skippedBundles: string[];
-    totalBundles: number;
-  }> {
-    if (!appBundleIds || appBundleIds.length === 0) {
-      return {
-        bundleIds: [],
-        skippedBundles: [],
-        totalBundles: 0,
-      };
+  /**
+   * Resolve the set of installed bundle identifiers on the simulator. Uses the
+   * strict `listAppsOrThrow` so a listing failure surfaces as an error (we can
+   * no longer validate installation) instead of being collapsed into "no apps
+   * installed" and mislabeling every requested bundle as not-installed.
+   */
+  private async getInstalledIosBundleIds(): Promise<Set<string>> {
+    let apps: IosInstalledAppRecord[];
+    try {
+      apps = await this.simctl.listAppsOrThrow(this.device.deviceId);
+    } catch (error) {
+      throw toActionableError(error, "Failed to list installed iOS apps to validate appBundleIds");
     }
 
-    const sanitized = Array.from(
-      new Set(appBundleIds.map((value) => value.trim()).filter(Boolean)),
-    );
-    const bundleIds = sanitized.filter((bundleId) => !bundleId.startsWith("com.apple."));
-    const skippedBundles = sanitized.filter((bundleId) => !bundleIds.includes(bundleId));
-
-    return {
-      bundleIds,
-      skippedBundles,
-      totalBundles: sanitized.length,
-    };
+    const installed = new Set<string>();
+    for (const app of apps) {
+      const bundleId = getIosInstalledAppBundleId(app);
+      if (bundleId) {
+        installed.add(bundleId);
+      }
+    }
+    return installed;
   }
 
   private async copyIosAppContainer(

--- a/src/models/DeviceSnapshot.ts
+++ b/src/models/DeviceSnapshot.ts
@@ -1,5 +1,18 @@
 export type DeviceSnapshotType = "vm" | "adb" | "simctl" | "app_data";
 
+/**
+ * Outcome of an iOS app-container capture for a single requested bundle id:
+ * `captured` — installed with a data container that was backed up;
+ * `skipped-no-container` — installed but has no data container to capture;
+ * `not-installed` — no such app is installed on the simulator (issue #5712).
+ */
+export type IosBundleCaptureStatusKind = "captured" | "skipped-no-container" | "not-installed";
+
+export interface IosBundleCaptureStatus {
+  bundleId: string;
+  status: IosBundleCaptureStatusKind;
+}
+
 export interface DeviceSnapshotManifest {
   snapshotName: string;
   timestamp: string;
@@ -35,6 +48,15 @@ export interface DeviceSnapshotManifest {
     totalPackages?: number;
     backupTimedOut?: boolean;
     backupMethod?: "adb_backup" | "root_pull" | "none" | "simctl_copy";
+    /**
+     * iOS-only per-bundle outcome for each requested `appBundleIds` entry, so a
+     * caller can tell an installed-and-captured app apart from one that was
+     * never installed or has no data container — instead of every bundle
+     * silently "succeeding" (issue #5712). Mirrors the
+     * backedUp/skipped/failedPackages arrays: `captured` → backedUp,
+     * `skipped-no-container` → skipped, `not-installed` → failed.
+     */
+    bundleStatuses?: IosBundleCaptureStatus[];
   };
 }
 

--- a/src/models/DeviceSnapshot.ts
+++ b/src/models/DeviceSnapshot.ts
@@ -4,9 +4,16 @@ export type DeviceSnapshotType = "vm" | "adb" | "simctl" | "app_data";
  * Outcome of an iOS app-container capture for a single requested bundle id:
  * `captured` — installed with a data container that was backed up;
  * `skipped-no-container` — installed but has no data container to capture;
- * `not-installed` — no such app is installed on the simulator (issue #5712).
+ * `not-installed` — no such app is installed on the simulator;
+ * `failed` — installed with a resolved container, but copying it errored
+ * (issue #5712). `captured` → `backedUpPackages`, `skipped-no-container` →
+ * `skippedPackages`, and both `not-installed` and `failed` → `failedPackages`.
  */
-export type IosBundleCaptureStatusKind = "captured" | "skipped-no-container" | "not-installed";
+export type IosBundleCaptureStatusKind =
+  | "captured"
+  | "skipped-no-container"
+  | "not-installed"
+  | "failed";
 
 export interface IosBundleCaptureStatus {
   bundleId: string;

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -55,6 +55,10 @@ export function registerSnapshotTools() {
           deviceId: device.deviceId,
           deviceName: device.name,
           manifest: result.manifest,
+          // Surface iOS per-bundle capture status at the top level so callers
+          // don't have to dig into the manifest to see what was actually
+          // captured vs skipped/not-installed (issue #5712).
+          bundleStatuses: result.manifest.appDataBackup?.bundleStatuses,
           evictedSnapshotNames: evictedSnapshotNames.length > 0 ? evictedSnapshotNames : undefined,
         });
       }

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -836,6 +836,12 @@ describe("CaptureSnapshot (iOS)", () => {
     await fs.writeFile(path.join(documentsPath, "data.txt"), "hello");
 
     simctl.setContainerPath(bundleId, containerRoot);
+    // Installed apps: the user app (with a container) and a system app that is
+    // installed but exposes no data container.
+    simctl.setInstalledApps([
+      { CFBundleIdentifier: bundleId },
+      { CFBundleIdentifier: "com.apple.Preferences" },
+    ]);
     simctl.setDeviceInfo(device.deviceId, {
       udid: device.deviceId,
       name: "iPhone 15",
@@ -865,8 +871,13 @@ describe("CaptureSnapshot (iOS)", () => {
     expect(parsed.snapshotName).toBe(snapshotName);
     expect(parsed.platform).toBe("ios");
     expect(parsed.appDataBackup?.backedUpPackages).toEqual([bundleId]);
+    // com.apple.Preferences is installed but container-less → skipped-no-container.
     expect(parsed.appDataBackup?.skippedPackages).toEqual(["com.apple.Preferences"]);
     expect(parsed.appDataBackup?.totalPackages).toBe(2);
+    expect(parsed.appDataBackup?.bundleStatuses).toEqual([
+      { bundleId, status: "captured" },
+      { bundleId: "com.apple.Preferences", status: "skipped-no-container" },
+    ]);
 
     const appDataPath = store.getAppDataPath(snapshotName, pathOptions);
     const copiedFile = await fs.readFile(
@@ -889,17 +900,89 @@ describe("CaptureSnapshot (iOS)", () => {
     ).rejects.toThrow("Failed to backup app data");
   });
 
-  it("marks backup as none when no bundle IDs are provided", async () => {
+  it("throws when includeAppData is true but no appBundleIds are provided", async () => {
     const captureSnapshot = makeCapture();
 
+    await expect(
+      captureSnapshot.execute({
+        snapshotName: "no-bundles",
+        includeAppData: true,
+        appBundleIds: [],
+      }),
+    ).rejects.toThrow("No app bundle IDs");
+  });
+
+  it("throws when includeAppData is true and appBundleIds is undefined", async () => {
+    const captureSnapshot = makeCapture();
+
+    await expect(
+      captureSnapshot.execute({
+        snapshotName: "undefined-bundles",
+        includeAppData: true,
+      }),
+    ).rejects.toThrow("No app bundle IDs");
+  });
+
+  it("throws when appBundleIds contains only blank entries", async () => {
+    const captureSnapshot = makeCapture();
+
+    await expect(
+      captureSnapshot.execute({
+        snapshotName: "blank-bundles",
+        includeAppData: true,
+        appBundleIds: ["  ", ""],
+      }),
+    ).rejects.toThrow("No app bundle IDs");
+  });
+
+  it("classifies bundles as captured, skipped-no-container, or not-installed", async () => {
+    const snapshotName = "classify";
+    const captured = "com.example.captured";
+    const noContainer = "com.example.nocontainer";
+    const notInstalled = "com.example.missing";
+
+    const containerRoot = path.join(testBasePath, "containers", captured);
+    await fs.mkdir(path.join(containerRoot, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(containerRoot, "Documents", "data.txt"), "hello");
+
+    simctl.setContainerPath(captured, containerRoot);
+    // `noContainer` is installed but has no data container (empty path).
+    simctl.setInstalledApps([
+      { CFBundleIdentifier: captured },
+      { CFBundleIdentifier: noContainer },
+    ]);
+
+    const captureSnapshot = makeCapture();
     const result = await captureSnapshot.execute({
-      snapshotName: "no-bundles",
+      snapshotName,
       includeAppData: true,
-      appBundleIds: [],
+      includeSettings: false,
+      appBundleIds: [captured, noContainer, notInstalled],
     });
 
-    expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
-    expect(result.manifest.appDataBackup?.totalPackages).toBe(0);
+    expect(result.manifest.appDataBackup?.bundleStatuses).toEqual([
+      { bundleId: captured, status: "captured" },
+      { bundleId: noContainer, status: "skipped-no-container" },
+      { bundleId: notInstalled, status: "not-installed" },
+    ]);
+    expect(result.manifest.appDataBackup?.backedUpPackages).toEqual([captured]);
+    expect(result.manifest.appDataBackup?.skippedPackages).toEqual([noContainer]);
+    expect(result.manifest.appDataBackup?.failedPackages).toEqual([notInstalled]);
+    expect(result.manifest.appDataBackup?.totalPackages).toBe(3);
+  });
+
+  it("fails in strictBackupMode when a bundle is not installed", async () => {
+    simctl.setInstalledApps([{ CFBundleIdentifier: "com.example.other" }]);
+    const captureSnapshot = makeCapture();
+
+    await expect(
+      captureSnapshot.execute({
+        snapshotName: "strict-not-installed",
+        includeAppData: true,
+        strictBackupMode: true,
+        appBundleIds: ["com.example.missing"],
+      }),
+    ).rejects.toThrow("Failed to backup app data");
   });
 
   it("captures iOS settings (locale + UI) into the manifest when includeSettings", async () => {

--- a/test/server/snapshotTools.test.ts
+++ b/test/server/snapshotTools.test.ts
@@ -53,6 +53,17 @@ describe("snapshot tool", () => {
             snapshotType: "app_data",
             includeAppData: args.includeAppData ?? true,
             includeSettings: false,
+            appDataBackup: {
+              backupMethod: "simctl_copy",
+              totalPackages: args.appBundleIds?.length ?? 0,
+              backedUpPackages: args.appBundleIds ?? [],
+              skippedPackages: [],
+              failedPackages: [],
+              bundleStatuses: (args.appBundleIds ?? []).map((bundleId) => ({
+                bundleId,
+                status: "captured" as const,
+              })),
+            },
           };
           return {
             snapshotName: args.snapshotName,
@@ -143,6 +154,12 @@ describe("snapshot tool", () => {
     expect(payload.message).toContain("captured successfully");
     expect(captureCalls).toHaveLength(1);
     expect(captureCalls[0]?.appBundleIds).toEqual(["com.example.app"]);
+    // AC2: per-bundle status is surfaced at the top level of the tool result,
+    // not only nested inside the manifest.
+    expect(payload.bundleStatuses).toEqual([{ bundleId: "com.example.app", status: "captured" }]);
+    expect(payload.manifest.appDataBackup.bundleStatuses).toEqual([
+      { bundleId: "com.example.app", status: "captured" },
+    ]);
   });
 
   test("restores snapshot and returns payload", async () => {


### PR DESCRIPTION
## Summary

iOS app-container capture (`deviceSnapshot` action `capture`) accepted any `appBundleIds` entry and only recorded outcomes in the manifest, so an unknown bundle (`com.fake.doesnotexist`), a container-less system app (`com.apple.Preferences`), or an empty `appBundleIds:[]` all reported "success" while capturing nothing. This validates each requested bundle up front and reports a per-bundle status.

## Changes

- **Validate before capture** (`CaptureSnapshot.captureIosAppData`): list installed apps via `simctl listapps` (`listAppsOrThrow`, so a listing failure surfaces as an error rather than mislabeling every bundle as missing). Each requested bundle is classified:
  - `not-installed` — no such app installed (→ `failedPackages`)
  - `skipped-no-container` — installed but no `simctl get_app_container … data` (→ `skippedPackages`)
  - `captured` — installed with a data container that was backed up (→ `backedUpPackages`)
- **Per-bundle status in the tool result**: new `appDataBackup.bundleStatuses[]` on the manifest, and surfaced at the top level of the `deviceSnapshot` capture response (`bundleStatuses`) so callers don't have to dig into the manifest.
- **Empty `appBundleIds` + `includeAppData:true` now fails loudly** with an actionable error ("pass appBundleIds … or set includeAppData:false") instead of silently succeeding — aligned with the milestone's "fail when nothing is captured" decision.
- `strictBackupMode` still rejects the whole snapshot when any requested bundle failed (not-installed / copy error).

## Linked Issue

Closes #5712

## Validation

- [x] `bun test` — full suite green except one pre-existing environment artifact in this worktree (`test/lint/oxlintConfigScoping.test.ts` ENOENT on the `oxlint` binary, missing from the worktree's `node_modules/.bin`; unrelated to this change)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] oxlint ratchet unchanged for touched files; `oxfmt --check` clean
- [x] New tests use the existing `FakeSimCtlClient` fake; unit tests run in <100ms

## Acceptance criteria

1. **Validate each `appBundleIds` up front** — installed + has data container; unknown/container-less bundles flagged, not silently succeeded. ✅ `captureIosAppData` + `getInstalledIosBundleIds`
2. **Per-bundle status in the tool result** (captured / skipped-no-container / not-installed) — ✅ `bundleStatuses` on manifest and top-level tool response
3. **Behavior for empty `appBundleIds` + `includeAppData:true`** — ✅ errors (fail when 0 captured)

## Device Verification

- [ ] Not run on hardware in this session — logic is covered by unit tests against the `simctl` fake. Manual verification against a real simulator recommended before/after.
