### PR TITLE
fix(snapshot): drop deprecated adb-backup app-data path on Android (#5708)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -2,7 +2,16 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `deviceSnapshot` MCP tool is fully implemented. VM snapshots (emulators), ADB snapshots (all Android devices), and iOS simulator app container backups are all supported. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `deviceSnapshot` MCP tool is fully implemented. VM snapshots (emulators), settings-only snapshots (all other Android devices), and iOS simulator app container backups are all supported. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+>
+> **App data on Android:** The deprecated `adb backup` app-data path was removed
+> in #5708. `adb backup` is deprecated since Android 12 (API 31), requires
+> interactive on-device confirmation, and produced no `backup.ab` in practice on
+> API 34. App data is now captured only by VM snapshots (emulators, which capture
+> the entire emulator state); for targeted app-data inspection use the DataStore,
+> shared-storage, `sqlQuery`, and preferences tools. **Physical Android devices
+> and non-VM emulator snapshots no longer capture app data** — they capture device
+> settings and foreground-app state only.
 
 ## Overview
 
@@ -10,11 +19,10 @@ The snapshot feature provides deterministic device state management for mobile t
 
 ## Features
 
-- **VM Snapshots for Emulators**: Instant snapshot/restore using Android emulator's built-in snapshot feature
-- **ADB-based Snapshots**: Portable snapshots for both emulators and physical devices
+- **VM Snapshots for Emulators**: Instant snapshot/restore using Android emulator's built-in snapshot feature (captures full app data)
+- **Settings-only Snapshots**: Portable device-settings snapshots for physical Android devices and non-VM emulator captures (no app data)
 - **iOS App Container Backups**: Portable app-scoped snapshots for iOS simulators
 - **Auto-generated Naming**: Automatic timestamp-based snapshot names with optional custom naming
-- **Comprehensive State Capture**: Includes app data, system settings, package list, and foreground app state
 - **Host-based Storage**: Snapshots stored in `~/.automobile/snapshots/` for fast access and easy management
 
 ## MCP Tool
@@ -27,13 +35,11 @@ Capture or restore device snapshots.
 
 - `action` (required): `"capture"` or `"restore"`
 - `snapshotName` (capture: optional, restore: required): Name for the snapshot
-- `includeAppData` (capture only): Include app data directories in snapshot
+- `includeAppData` (capture only): Include app data. Honored by VM snapshots (emulators) and iOS app-container backups. **Ignored on non-VM Android** (physical devices / `useVmSnapshot: false`), which is settings-only — the captured manifest records `includeAppData: false`.
 - `includeSettings` (capture only): Include system settings (global/secure/system)
 - `useVmSnapshot` (capture/restore): Use emulator VM snapshot if available (faster for emulators)
 - `vmSnapshotTimeoutMs` (capture/restore): Timeout in milliseconds for emulator VM snapshot commands
-- `strictBackupMode` (capture only): If true, fail entire snapshot if app data backup fails or times out
-- `backupTimeoutMs` (capture only): Timeout in milliseconds for adb backup user confirmation
-- `userApps` (capture only): Which apps to backup - `"current"` (foreground app only) or `"all"` (all user-installed apps)
+- `strictBackupMode` (capture only, **iOS-only**): If true, fail the snapshot when an iOS app-container backup fails. No effect on Android now that the adb-backup path is gone.
 - `appBundleIds` (capture only): iOS bundle IDs to include in app container backups
 - `sessionUuid` (optional): Session UUID for multi-device targeting
 - `device` (optional): Device label for multi-device control
@@ -125,9 +131,7 @@ Device snapshot defaults can be read or updated via the Unix socket at `~/.auto-
 - `includeAppData`: `true`
 - `includeSettings`: `true`
 - `useVmSnapshot`: `true`
-- `strictBackupMode`: `false`
-- `backupTimeoutMs`: `30000`
-- `userApps`: `"current"`
+- `strictBackupMode`: `false` (iOS-only)
 - `vmSnapshotTimeoutMs`: `30000`
 - `maxArchiveSizeMb`: `100`
 
@@ -135,9 +139,10 @@ Device snapshot defaults can be read or updated via the Unix socket at `~/.auto-
 
 The response `snapshotType` field reflects how the snapshot was taken. The type
 union (`DeviceSnapshotType` in `src/models/DeviceSnapshot.ts`) is `vm` (emulator
-VM snapshot), `adb` (Android app-data via adb), `app_data` (iOS app-container
-copy), and `simctl` (reserved for a simulator-level type; not currently emitted
-by the capture paths).
+VM snapshot), `adb` (non-VM Android settings-only snapshot), `app_data` (iOS
+app-container copy), and `simctl` (reserved for a simulator-level type; not
+currently emitted by the capture paths). The `adb` type is retained for backward
+compatibility with existing archived snapshots; it no longer carries app data.
 
 ### VM Snapshots (Emulators Only)
 
@@ -160,41 +165,41 @@ by the capture paths).
 - Snapshots stored in emulator's AVD directory (typically `~/.android/avd/<avd>.avd/snapshots/`)
 - Metadata stored in `~/.automobile/snapshots/` for management
 
-### ADB Snapshots (All Devices)
+### Settings-only Snapshots (Non-VM Android)
+
+Used for physical Android devices and for emulator captures with
+`useVmSnapshot: false`. The `snapshotType` is `adb`.
 
 **Pros:**
 
 - Works with both emulators and physical devices
 - Portable across device types
-- Fine-grained control over what gets captured
+- Fast — no app-data transfer or user confirmation
 
 **Cons:**
 
-- Slower than VM snapshots
-- Requires clearing app data individually
-- App data backup requires root access or user confirmation
+- Does **not** capture app data (see the note below)
 
 **What Gets Captured:**
 
-- Package list (`pm list packages`)
-- System settings (global/secure/system via `settings list`)
+- System settings (global/secure/system via the CtrlProxy settings namespaces,
+  with a `settings list` ADB fallback)
 - Foreground app state
-- App data via `adb backup`:
-  - Only user-installed apps (system apps excluded)
-  - Only apps that allow backup (`android:allowBackup="true"`)
-  - Defaults to current foreground app only (`userApps: "current"`)
-  - Can backup all user apps with `userApps: "all"`
-  - Requires user confirmation on device (30s timeout by default)
-  - Apps with `android:allowBackup="false"` are automatically skipped
 
 **What Gets Restored:**
 
-- Clears app data for all packages via `pm clear`
-- Restores system settings via `settings put`
-- Restores app data via `adb restore` (if backup was successful)
-  - Requires user confirmation on device (30s timeout by default)
-  - Only restores apps that were successfully backed up
-- Relaunches foreground app
+- Restores system settings via the CtrlProxy `settings put` path (with a
+  `settings put` ADB fallback)
+- Relaunches the foreground app
+
+> **App data is not captured or restored here.** The deprecated `adb backup` /
+> `adb restore` path was removed in #5708 (deprecated since API 31, required
+> interactive on-device confirmation, and produced no `backup.ab` on API 34). No
+> `pm clear`, `adb backup`, or `adb restore` commands are issued. To snapshot app
+> data on an emulator, use a VM snapshot; for targeted app-data inspection use the
+> DataStore, shared-storage, `sqlQuery`, and preferences tools. Legacy archived
+> snapshots that still carry `adb backup` metadata are restored as settings-only —
+> the stale app-data metadata is ignored.
 
 ### iOS App Container Backups (Current)
 
@@ -220,15 +225,12 @@ by the capture paths).
 
 ## Storage Location
 
-Snapshot payloads are stored in `~/.automobile/snapshots/` (ADB snapshots), and metadata is tracked in SQLite at `~/.auto-mobile/auto-mobile.db`:
+Snapshot payloads are stored in `~/.automobile/snapshots/` (settings-only Android snapshots), and metadata is tracked in SQLite at `~/.auto-mobile/auto-mobile.db`:
 
 ```text
 ~/.automobile/snapshots/
 ├── Pixel_5_2026-01-08_12-30-45/
-│   ├── settings.json          # Device settings (ADB snapshots only)
-│   └── app_data/              # App data directory (ADB snapshots only)
-│       ├── packages.txt       # List of installed packages
-│       └── backup.ab          # ADB backup file (if backup succeeded)
+│   └── settings.json          # Device settings (settings-only snapshots)
 └── another-snapshot/
     └── ...
 ```
@@ -315,95 +317,45 @@ const v1 = await loadManifest("v1.0-baseline");
 const v2 = await loadManifest("v1.1-baseline");
 ```
 
-## App Data Backup Details
+## App Data on Android
 
-### How It Works
+App data on Android is captured **only** by VM snapshots (emulators), which
+snapshot the entire emulator state as a superset of app data. The previous
+`adb backup` / `adb restore` app-data path for non-VM Android was removed in
+#5708:
 
-The ADB snapshot feature uses Android's native `adb backup` and `adb restore` commands to capture and restore app data:
+- `adb backup` is deprecated since Android 12 (API 31) and requires interactive
+  on-device confirmation, so it cannot be automated.
+- In practice it produced no `backup.ab` on API 34 while still reporting success.
+- It is redundant with VM snapshots and with the targeted app-data tools
+  (DataStore, shared-storage resources, `sqlQuery`, preferences).
 
-1. **Filtering**: Only user-installed apps are backed up (system apps are excluded)
-2. **Backup Eligibility**: Apps must have `android:allowBackup="true"` in their manifest
-3. **Scope**: By default, only the current foreground app is backed up (`userApps: "current"`)
-4. **User Confirmation**: The device will prompt the user to confirm the backup/restore operation
-5. **Timeout**: If the user doesn't confirm within 30 seconds (configurable), the backup continues without app data
+**Consequence:** physical Android devices, and emulator captures taken with
+`useVmSnapshot: false`, no longer snapshot app data — they capture device
+settings and foreground-app state only. To capture app data, take a VM snapshot
+on an emulator; to inspect a specific app's data, use the targeted tools above.
 
-### Backup Metadata
-
-The snapshot manifest includes detailed backup information:
-
-```json
-{
-  "appDataBackup": {
-    "backupFile": "backup.ab",
-    "backupMethod": "adb_backup",
-    "totalPackages": 150,
-    "backedUpPackages": ["com.example.app"],
-    "skippedPackages": ["com.example.nobackup"],
-    "failedPackages": [],
-    "backupTimedOut": false
-  }
-}
-```
-
-### Backup Modes
-
-**Current App Only (default)**:
-
-```javascript
-await deviceSnapshot({
-  action: "capture",
-  userApps: "current", // Only backup foreground app
-  includeAppData: true,
-});
-```
-
-**All User Apps**:
-
-```javascript
-await deviceSnapshot({
-  action: "capture",
-  userApps: "all", // Backup all user-installed apps
-  includeAppData: true,
-});
-```
-
-**Strict Mode** (fail if backup times out):
-
-```javascript
-await deviceSnapshot({
-  action: "capture",
-  strictBackupMode: true, // Fail entire snapshot if backup fails
-  backupTimeoutMs: 60000, // Wait 60 seconds for user confirmation
-});
-```
-
-### Limitations
-
-- **User Confirmation Required**: Cannot automate without user interaction
-- **allowBackup Flag**: Apps with `android:allowBackup="false"` cannot be backed up
-- **APKs Not Included**: Only app data is backed up, not the APK files themselves
-- **Timeout**: If user doesn't confirm, snapshot continues without app data (unless strictBackupMode is enabled)
+The iOS app-container backups (`snapshotType: "app_data"`) are unaffected and
+still honor `strictBackupMode`.
 
 ## Limitations
 
 - **Android + iOS Simulator Only**: iOS snapshots are app container backups for simulators
-- **App Data Backup**: Requires user confirmation on device for each backup/restore operation
+- **App Data on Android**: Captured only by VM snapshots (emulators); non-VM Android snapshots are settings-only (#5708)
 - **VM Snapshots**: Only available for emulators, not physical devices
 - **Storage Space**: Snapshots can be large (especially VM snapshots), manage storage accordingly
-- **Backup Scope**: By default, only current app is backed up (set `userApps: "all"` for all apps)
 - **iOS Simulator Snapshot**: `simctl snapshot` is intentionally not used; app container backups are the current choice
 
 ## Performance
 
 - **VM Snapshot Capture**: ~2-5 seconds
 - **VM Snapshot Restore**: ~3-8 seconds (includes emulator stabilization)
-- **ADB Snapshot Capture**: ~10-30 seconds (depends on number of apps and settings)
-- **ADB Snapshot Restore**: ~15-45 seconds (depends on number of apps to clear)
+- **Settings-only Snapshot Capture/Restore**: ~1-3 seconds (settings only, no app data)
 - **iOS App Container Backup**: Varies with app data size
 
 ## Best Practices
 
-1. **Use VM Snapshots for Emulators**: Significantly faster than ADB snapshots
+1. **Use VM Snapshots for Emulators**: Significantly faster, and the only way to snapshot app data on Android
 2. **Manage Archive Size**: Automatic cleanup enforces `maxArchiveSizeMb` (adjust via the device snapshot socket config)
 3. **Descriptive Names**: Use meaningful snapshot names for easier management
 4. **Base Snapshots**: Create a "golden" base snapshot and restore from it
@@ -428,6 +380,5 @@ await deviceSnapshot({
 
 ### Snapshot Too Large
 
-- Disable `includeAppData` for smaller snapshots
-- Use ADB snapshots instead of VM snapshots
+- Use a settings-only (non-VM) snapshot instead of a VM snapshot when app data is not needed
 - Adjust `maxArchiveSizeMb` to control archive size

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -924,7 +924,7 @@
           "minLength": 1
         },
         "includeAppData": {
-          "description": "Include app data",
+          "description": "Include app data (iOS app containers; ignored on non-VM Android, which is settings-only)",
           "type": "boolean"
         },
         "includeSettings": {
@@ -936,17 +936,8 @@
           "type": "boolean"
         },
         "strictBackupMode": {
-          "description": "Fail if app data backup fails",
+          "description": "iOS-only: fail if app container backup fails",
           "type": "boolean"
-        },
-        "backupTimeoutMs": {
-          "description": "adb backup confirmation timeout ms",
-          "type": "number"
-        },
-        "userApps": {
-          "description": "Apps to back up: current or all",
-          "type": "string",
-          "enum": ["current", "all"]
         },
         "vmSnapshotTimeoutMs": {
           "description": "VM snapshot timeout ms",

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -47,9 +47,7 @@ export interface CaptureSnapshotArgs {
   includeAppData?: boolean;
   includeSettings?: boolean;
   useVmSnapshot?: boolean;
-  strictBackupMode?: boolean; // If true, fail entire snapshot if app data backup fails
-  backupTimeoutMs?: number; // Timeout in milliseconds for adb backup (default: 30000ms)
-  userApps?: "current" | "all"; // Which apps to backup: "current" (foreground app only) or "all" (all user apps)
+  strictBackupMode?: boolean; // iOS-only: if true, fail the snapshot when an app container backup fails
   vmSnapshotTimeoutMs?: number; // Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)
   appBundleIds?: string[]; // iOS-only: bundle identifiers to include in app data snapshot
 }
@@ -64,7 +62,8 @@ export interface CaptureSnapshotResult {
 /**
  * Capture device state snapshot, dispatching on device platform.
  *
- * - **Android**: VM snapshots for emulators, ADB-based capture otherwise.
+ * - **Android**: VM snapshots for emulators; settings-only snapshots otherwise
+ *   (the deprecated `adb backup` app-data path was dropped in #5708).
  * - **iOS**: app container backups via `simctl` (portable across restores).
  */
 export class CaptureSnapshot implements SnapshotCaptureProvider {
@@ -72,14 +71,13 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
   private adb: AdbExecutor;
   private emulator: AndroidEmulatorClient;
   private store: DeviceSnapshotStore;
-  private timer: Timer;
   private simctl: SimCtlClient;
 
   constructor(
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     emulator?: AndroidEmulatorClient,
-    timer: Timer = defaultTimer,
+    _timer: Timer = defaultTimer,
     store: DeviceSnapshotStore = new DeviceSnapshotStore(),
     simctl?: SimCtlClient,
   ) {
@@ -87,7 +85,6 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     this.adb = adbFactory.create(device);
     this.emulator = emulator || new AndroidEmulatorClient();
     this.store = store;
-    this.timer = timer;
     this.simctl = simctl || new SimCtlClient(device);
   }
 
@@ -131,9 +128,6 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
       includeAppData = true,
       includeSettings = true,
       useVmSnapshot = true,
-      strictBackupMode = false,
-      backupTimeoutMs = 30000,
-      userApps = "current",
       vmSnapshotTimeoutMs = 30000,
     } = args;
 
@@ -148,14 +142,7 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     if (shouldUseVmSnapshot) {
       manifest = await this.captureVmSnapshot(snapshotName, includeSettings, vmSnapshotTimeoutMs);
     } else {
-      manifest = await this.captureAdbSnapshot(
-        snapshotName,
-        includeAppData,
-        includeSettings,
-        strictBackupMode,
-        backupTimeoutMs,
-        userApps,
-      );
+      manifest = await this.captureSettingsSnapshot(snapshotName, includeAppData, includeSettings);
     }
 
     logger.info(
@@ -231,25 +218,33 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
   }
 
   /**
-   * Capture ADB-based snapshot
+   * Capture a settings-only Android snapshot.
+   *
+   * The deprecated `adb backup` app-data path was dropped in #5708 — it is
+   * deprecated since API 31, requires interactive on-device confirmation, and
+   * produced no `backup.ab` in practice on API 34. VM snapshots (emulators)
+   * remain the way to capture app data; targeted app-data inspection is covered
+   * by the DataStore / shared-storage / `sqlQuery` tools. Non-VM Android
+   * (physical devices and emulators with `useVmSnapshot: false`) therefore
+   * captures device settings and foreground-app state only, using the CtrlProxy
+   * settings namespaces (with an ADB fallback) — never `adb backup`.
    */
-  private async captureAdbSnapshot(
+  private async captureSettingsSnapshot(
     snapshotName: string,
     includeAppData: boolean,
     includeSettings: boolean,
-    strictBackupMode: boolean,
-    backupTimeoutMs: number,
-    userApps: "current" | "all",
   ): Promise<DeviceSnapshotManifest> {
-    logger.info(`Using ADB-based snapshot for device ${this.device.deviceId}`);
+    logger.info(`Using settings-only snapshot for device ${this.device.deviceId}`);
+
+    if (includeAppData) {
+      logger.warn(
+        "App-data snapshots are not supported on non-VM Android (the adb backup path was removed in #5708); capturing settings only. Use a VM snapshot on an emulator to capture app data.",
+      );
+    }
 
     try {
-      // Get foreground app first (needed if userApps is "current")
+      // Foreground-app state is cheap metadata and drives restore's relaunch.
       const foregroundApp = await this.getForegroundApp();
-
-      // Get list of installed packages
-      const packages = await this.getInstalledPackages();
-      logger.info(`Found ${packages.length} installed packages`);
 
       // Capture settings if requested
       let settings;
@@ -258,20 +253,8 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
         await this.saveSettings(snapshotName, settings);
       }
 
-      // Capture app data if requested
-      let appDataBackup;
-      if (includeAppData) {
-        appDataBackup = await this.captureAppData(
-          snapshotName,
-          packages,
-          strictBackupMode,
-          backupTimeoutMs,
-          userApps,
-          foregroundApp,
-        );
-      }
-
-      // Create manifest
+      // Create manifest. includeAppData is always false: non-VM Android no
+      // longer captures app data, so the manifest must reflect what was taken.
       const manifest: DeviceSnapshotManifest = {
         snapshotName,
         timestamp: new Date().toISOString(),
@@ -279,40 +262,17 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
         deviceName: this.device.name,
         platform: "android",
         snapshotType: "adb",
-        includeAppData,
+        includeAppData: false,
         includeSettings,
-        packages,
         foregroundApp,
         settings,
-        appDataBackup,
       };
 
       return manifest;
     } catch (error) {
-      logger.error(`Failed to capture ADB snapshot: ${error}`);
-      throw new ActionableError(`Failed to capture ADB snapshot: ${error}`);
+      logger.error(`Failed to capture settings snapshot: ${error}`);
+      throw new ActionableError(`Failed to capture settings snapshot: ${error}`);
     }
-  }
-
-  /**
-   * Get list of installed packages
-   */
-  private async getInstalledPackages(): Promise<string[]> {
-    try {
-      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-      const result = await a11y.requestInstalledPackages(true, undefined, 4000);
-      if (result.success) {
-        return result.packages.map((p) => p.packageName);
-      }
-    } catch (error) {
-      logger.debug(`[CaptureSnapshot] a11y package list failed, falling back to ADB: ${error}`);
-    }
-    const result = await this.adb.executeCommand("shell pm list packages");
-    return result.stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.startsWith("package:"))
-      .map((line) => line.replace("package:", ""));
   }
 
   /**
@@ -400,275 +360,6 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     const settingsPath = this.store.getSettingsPath(snapshotName);
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
     logger.info(`Saved settings to ${settingsPath}`);
-  }
-
-  /**
-   * Capture app data using adb backup
-   */
-  private async captureAppData(
-    snapshotName: string,
-    packages: string[],
-    strictBackupMode: boolean,
-    backupTimeoutMs: number,
-    userApps: "current" | "all",
-    foregroundApp: string | undefined,
-  ): Promise<DeviceSnapshotManifest["appDataBackup"]> {
-    logger.info(`Capturing app data (scope: ${userApps})`);
-
-    const appDataPath = this.store.getAppDataPath(snapshotName);
-    await fs.mkdir(appDataPath, { recursive: true });
-
-    // Save package list for reference
-    const packageListPath = path.join(appDataPath, "packages.txt");
-    await fs.writeFile(packageListPath, packages.join("\n"), "utf-8");
-
-    // Filter to user apps only (exclude system apps)
-    let userPackages = await this.filterUserPackages(packages);
-    logger.info(
-      `Found ${userPackages.length} user-installed apps (excluding ${packages.length - userPackages.length} system apps)`,
-    );
-
-    // If userApps is "current", only backup the foreground app
-    if (userApps === "current") {
-      if (!foregroundApp) {
-        logger.warn("No foreground app detected, cannot backup current app");
-        return {
-          backupMethod: "none",
-          totalPackages: packages.length,
-          backedUpPackages: [],
-          skippedPackages: [],
-          failedPackages: [],
-        };
-      }
-
-      if (userPackages.includes(foregroundApp)) {
-        userPackages = [foregroundApp];
-        logger.info(`Backing up current foreground app: ${foregroundApp}`);
-      } else {
-        logger.warn(`Foreground app ${foregroundApp} is not a user app, skipping backup`);
-        return {
-          backupMethod: "none",
-          totalPackages: packages.length,
-          backedUpPackages: [],
-          skippedPackages: [],
-          failedPackages: [],
-        };
-      }
-    }
-
-    // Filter out packages that don't allow backup
-    const { allowedPackages, skippedPackages } =
-      await this.filterBackupAllowedPackages(userPackages);
-    logger.info(
-      `${allowedPackages.length} apps allow backup, ${skippedPackages.length} apps disallow backup`,
-    );
-
-    if (skippedPackages.length > 0) {
-      logger.info(
-        `Skipped apps (android:allowBackup="false"): ${skippedPackages.slice(0, 10).join(", ")}${skippedPackages.length > 10 ? "..." : ""}`,
-      );
-    }
-
-    if (allowedPackages.length === 0) {
-      logger.warn("No apps available for backup");
-      return {
-        backupMethod: "none",
-        totalPackages: packages.length,
-        backedUpPackages: [],
-        skippedPackages,
-        failedPackages: [],
-      };
-    }
-
-    // Attempt adb backup
-    const backupFilePath = this.store.getBackupFilePath(snapshotName);
-    const backupResult = await this.performAdbBackup(
-      allowedPackages,
-      backupFilePath,
-      backupTimeoutMs,
-    );
-
-    // Check if backup succeeded
-    let backupSucceeded = false;
-    try {
-      const stats = await fs.stat(backupFilePath);
-      backupSucceeded = stats.size > 0;
-    } catch {
-      backupSucceeded = false;
-    }
-
-    if (!backupSucceeded) {
-      const errorMessage = `App data backup failed or timed out. User may need to confirm backup on device. ${allowedPackages.length} apps were attempted.`;
-      logger.warn(errorMessage);
-
-      if (strictBackupMode) {
-        throw new ActionableError(errorMessage);
-      }
-
-      return {
-        backupMethod: "adb_backup",
-        totalPackages: packages.length,
-        backedUpPackages: [],
-        skippedPackages,
-        failedPackages: allowedPackages,
-        backupTimedOut: backupResult.timedOut,
-      };
-    }
-
-    logger.info(`Successfully backed up ${allowedPackages.length} apps to ${backupFilePath}`);
-
-    return {
-      backupFile: path.basename(backupFilePath),
-      backupMethod: "adb_backup",
-      totalPackages: packages.length,
-      backedUpPackages: allowedPackages,
-      skippedPackages,
-      failedPackages: [],
-      backupTimedOut: false,
-    };
-  }
-
-  /**
-   * Filter packages to only include user-installed apps
-   */
-  private async filterUserPackages(packages: string[]): Promise<string[]> {
-    // Try WebSocket-backed PackageManager once and partition.
-    try {
-      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-      const result = await a11y.requestInstalledPackages(true, undefined, 4000);
-      if (result.success) {
-        const userSet = new Set(
-          result.packages.filter((p) => !p.isSystem).map((p) => p.packageName),
-        );
-        return packages.filter((p) => userSet.has(p));
-      }
-    } catch (error) {
-      logger.debug(
-        `[CaptureSnapshot] a11y filterUserPackages failed, falling back to ADB: ${error}`,
-      );
-    }
-
-    const userPackages: string[] = [];
-
-    for (const packageName of packages) {
-      try {
-        const result = await this.adb.executeCommand(`shell pm list packages -3 ${packageName}`);
-        if (result.stdout.includes(packageName)) {
-          userPackages.push(packageName);
-        }
-      } catch (error) {
-        logger.debug(`Failed to check if ${packageName} is user app: ${error}`);
-      }
-    }
-
-    return userPackages;
-  }
-
-  /**
-   * Filter packages to only include those that allow backup
-   */
-  private async filterBackupAllowedPackages(packages: string[]): Promise<{
-    allowedPackages: string[];
-    skippedPackages: string[];
-  }> {
-    const allowedPackages: string[] = [];
-    const skippedPackages: string[] = [];
-    const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-
-    for (const packageName of packages) {
-      let resolved = false;
-      try {
-        const info = await a11y.requestPackageInfo(
-          packageName,
-          { includePermissions: false },
-          2000,
-        );
-        if (info.success && info.allowBackup !== undefined) {
-          if (info.allowBackup === false) {
-            skippedPackages.push(packageName);
-          } else {
-            allowedPackages.push(packageName);
-          }
-          resolved = true;
-        }
-      } catch {
-        // fall through to ADB
-      }
-      if (resolved) {
-        continue;
-      }
-
-      try {
-        const result = await this.adb.executeCommand(`shell dumpsys package ${packageName}`);
-        if (result.stdout.includes("ALLOW_BACKUP=false")) {
-          skippedPackages.push(packageName);
-        } else {
-          allowedPackages.push(packageName);
-        }
-      } catch (error) {
-        logger.debug(`Failed to check backup flag for ${packageName}, assuming allowed: ${error}`);
-        allowedPackages.push(packageName);
-      }
-    }
-
-    return { allowedPackages, skippedPackages };
-  }
-
-  /**
-   * Perform adb backup with timeout
-   */
-  private async performAdbBackup(
-    packages: string[],
-    backupFilePath: string,
-    timeoutMs: number,
-  ): Promise<{ timedOut: boolean }> {
-    logger.info(`Starting adb backup for ${packages.length} packages (timeout: ${timeoutMs}ms)`);
-    logger.info("Please confirm the backup on your device if prompted");
-
-    // Declared outside try so the catch block can clear a pending timeout.
-    let timeoutHandle: NodeJS.Timeout | null = null;
-
-    try {
-      // Build adb backup command
-      // -f: file path, -noapk: don't backup APK files, -obb: include OBB files
-      // -shared: include shared storage, -all: backup all data
-      const packageList = packages.join(" ");
-      const command = `backup -f "${backupFilePath}" -noapk ${packageList}`;
-
-      // Execute backup with timeout using timer
-      let timedOut = false;
-
-      const result = await Promise.race([
-        this.adb.executeCommand(command),
-        new Promise<{ stdout: string; stderr: string; timedOut: true }>((resolve) => {
-          timeoutHandle = this.timer.setTimeout(() => {
-            timedOut = true;
-            resolve({ stdout: "", stderr: "Backup timed out", timedOut: true });
-          }, timeoutMs);
-        }),
-      ]);
-
-      // Clear timeout if command completed first
-      if (timeoutHandle && !timedOut) {
-        this.timer.clearTimeout(timeoutHandle);
-      }
-
-      if ("timedOut" in result && result.timedOut) {
-        logger.warn(
-          `Backup timed out after ${timeoutMs}ms - user may not have confirmed on device`,
-        );
-        return { timedOut: true };
-      }
-
-      return { timedOut: false };
-    } catch (error) {
-      // Clear timeout to avoid keeping process alive
-      if (timeoutHandle) {
-        this.timer.clearTimeout(timeoutHandle);
-      }
-      logger.error(`Backup failed: ${error}`);
-      return { timedOut: false };
-    }
   }
 
   private async executeIos(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -50,8 +50,9 @@ export interface RestoreSnapshotResult {
 /**
  * Restore device state from snapshot, dispatching on device platform.
  *
- * - **Android**: VM snapshot restoration for emulators, ADB-based restore
- *   otherwise.
+ * - **Android**: VM snapshot restoration for emulators; settings-only restore
+ *   otherwise (the deprecated `adb backup`/`adb restore` app-data path was
+ *   dropped in #5708).
  * - **iOS**: app container restore via `simctl` (app_data snapshots only).
  */
 export class RestoreSnapshot implements SnapshotRestoreProvider {
@@ -133,7 +134,7 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
     if (shouldUseVmSnapshot) {
       await this.restoreVmSnapshot(snapshotName, manifest, vmSnapshotTimeoutMs);
     } else {
-      await this.restoreAdbSnapshot(snapshotName, manifest);
+      await this.restoreSettingsSnapshot(manifest);
     }
 
     logger.info(`Snapshot '${snapshotName}' restored successfully`);
@@ -185,38 +186,19 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
   }
 
   /**
-   * Restore ADB-based snapshot
+   * Restore a settings-only Android snapshot.
+   *
+   * The deprecated `adb backup`/`adb restore` app-data path was dropped in
+   * #5708, so non-VM Android restore reapplies captured device settings and
+   * relaunches the foreground app only. There is no app-data clear/restore
+   * phase — `pm clear` and `adb restore` are never issued.
    */
-  private async restoreAdbSnapshot(
-    snapshotName: string,
-    manifest: DeviceSnapshotManifest,
-  ): Promise<void> {
-    logger.info(`Restoring ADB-based snapshot for device ${this.device.deviceId}`);
+  private async restoreSettingsSnapshot(manifest: DeviceSnapshotManifest): Promise<void> {
+    logger.info(`Restoring settings-only snapshot for device ${this.device.deviceId}`);
 
     try {
-      // Restore settings first: it is fast, independent of app data, and must not
-      // be lost if the app-data phase is slow or cannot complete (#4236).
       if (manifest.includeSettings && manifest.settings) {
         await this.restoreSettings(manifest.settings);
-      }
-
-      // Clear only the packages whose data was actually captured.
-      //
-      // manifest.packages is every installed package (CaptureSnapshot populates it
-      // from getInstalledPackages -- ~244 on a stock emulator), but only
-      // appDataBackup.backedUpPackages was backed up. Clearing all of them wiped
-      // data that could never be restored, and awaiting ~244 sequential `pm clear`
-      // calls exhausted the request budget so the restore timed out before app
-      // data or the foreground app were restored (#4236). Scoping to the backed-up
-      // set makes the default restore finish inside the budget.
-      const restorablePackages = manifest.appDataBackup?.backedUpPackages ?? [];
-      if (manifest.includeAppData && restorablePackages.length > 0) {
-        await this.clearCurrentAppData(restorablePackages);
-      }
-
-      // Restore app data if it was captured
-      if (manifest.includeAppData) {
-        await this.restoreAppData(snapshotName, manifest);
       }
 
       // Restore foreground app if captured
@@ -224,41 +206,11 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
         await this.restoreForegroundApp(manifest.foregroundApp);
       }
 
-      logger.info("ADB snapshot restoration complete");
+      logger.info("Settings snapshot restoration complete");
     } catch (error) {
-      logger.error(`Failed to restore ADB snapshot: ${error}`);
-      throw new ActionableError(`Failed to restore ADB snapshot: ${error}`);
+      logger.error(`Failed to restore settings snapshot: ${error}`);
+      throw new ActionableError(`Failed to restore settings snapshot: ${error}`);
     }
-  }
-
-  /**
-   * Clear app data for all packages
-   */
-  private async clearCurrentAppData(packages: string[]): Promise<void> {
-    logger.info(`Clearing app data for ${packages.length} packages`);
-
-    let successCount = 0;
-    let failureCount = 0;
-
-    for (const packageName of packages) {
-      try {
-        // Use pm clear to reset app data
-        const result = await this.adb.executeCommand(`shell pm clear ${packageName}`);
-
-        if (result.stdout.includes("Success")) {
-          successCount++;
-          logger.debug(`Cleared data for ${packageName}`);
-        } else {
-          failureCount++;
-          logger.warn(`Failed to clear data for ${packageName}: ${result.stdout}`);
-        }
-      } catch (error) {
-        failureCount++;
-        logger.warn(`Error clearing data for ${packageName}: ${error}`);
-      }
-    }
-
-    logger.info(`App data cleared: ${successCount} succeeded, ${failureCount} failed`);
   }
 
   /**
@@ -315,117 +267,6 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
       logger.info(
         `${settingsType} settings restored: ${successCount} succeeded, ${failureCount} failed`,
       );
-    }
-  }
-
-  /**
-   * Restore app data from snapshot
-   */
-  private async restoreAppData(
-    snapshotName: string,
-    manifest: DeviceSnapshotManifest,
-  ): Promise<void> {
-    logger.info("Restoring app data");
-
-    // Check if backup metadata exists
-    if (!manifest.appDataBackup) {
-      logger.warn("No app data backup metadata found in manifest");
-      return;
-    }
-
-    const { backupFile, backupMethod, backedUpPackages } = manifest.appDataBackup;
-
-    // If no backup was performed, skip restore
-    if (
-      backupMethod === "none" ||
-      !backupFile ||
-      !backedUpPackages ||
-      backedUpPackages.length === 0
-    ) {
-      logger.info(`No app data backup available (method: ${backupMethod || "none"})`);
-      return;
-    }
-
-    // Get backup file path
-    const backupFilePath = path.join(this.store.getAppDataPath(snapshotName), backupFile);
-
-    try {
-      // Check if backup file exists
-      await fs.access(backupFilePath);
-
-      const stats = await fs.stat(backupFilePath);
-      if (stats.size === 0) {
-        logger.warn("Backup file is empty, skipping restore");
-        return;
-      }
-
-      logger.info(
-        `Found backup file: ${backupFilePath} (${(stats.size / 1024 / 1024).toFixed(2)} MB)`,
-      );
-      logger.info(`Restoring ${backedUpPackages.length} apps using adb restore`);
-      logger.info("Please confirm the restore on your device if prompted");
-
-      // Perform adb restore
-      const restoreResult = await this.performAdbRestore(backupFilePath);
-
-      if (restoreResult.success) {
-        logger.info(`Successfully restored app data for ${backedUpPackages.length} apps`);
-      } else if (restoreResult.timedOut) {
-        logger.warn("App data restore timed out - user may not have confirmed on device");
-      } else {
-        logger.warn("App data restore may have failed - check device");
-      }
-    } catch (error) {
-      logger.warn(`Could not restore app data: ${error}`);
-    }
-  }
-
-  /**
-   * Perform adb restore with timeout
-   */
-  private async performAdbRestore(
-    backupFilePath: string,
-    timeoutMs: number = 30000,
-  ): Promise<{ success: boolean; timedOut: boolean }> {
-    // Declared outside try so the catch block can clear a pending timeout.
-    let timeoutHandle: NodeJS.Timeout | null = null;
-
-    try {
-      // Execute restore with timeout using timer
-      let timedOut = false;
-
-      const result = await Promise.race([
-        this.adb.executeCommand(`restore "${backupFilePath}"`),
-        new Promise<{ stdout: string; stderr: string; timedOut: true }>((resolve) => {
-          timeoutHandle = this.timer.setTimeout(() => {
-            timedOut = true;
-            resolve({ stdout: "", stderr: "Restore timed out", timedOut: true });
-          }, timeoutMs);
-        }),
-      ]);
-
-      // Clear timeout if command completed first
-      if (timeoutHandle && !timedOut) {
-        this.timer.clearTimeout(timeoutHandle);
-      }
-
-      if ("timedOut" in result && result.timedOut) {
-        logger.warn(
-          `Restore timed out after ${timeoutMs}ms - user may not have confirmed on device`,
-        );
-        return { success: false, timedOut: true };
-      }
-
-      // Check if restore was successful
-      // adb restore doesn't provide clear success/failure output, so we assume success
-      return { success: true, timedOut: false };
-    } catch (error) {
-      // Clear timeout to avoid keeping process alive
-      if (timeoutHandle) {
-        this.timer.clearTimeout(timeoutHandle);
-      }
-      logger.error(`Restore failed: ${error}`);
-      return { success: false, timedOut: false };
     }
   }
 

--- a/src/features/snapshot/DeviceSnapshotConfig.ts
+++ b/src/features/snapshot/DeviceSnapshotConfig.ts
@@ -5,13 +5,9 @@ export const DEFAULT_DEVICE_SNAPSHOT_CONFIG: DeviceSnapshotConfig = {
   includeSettings: true,
   useVmSnapshot: true,
   strictBackupMode: false,
-  backupTimeoutMs: 30000,
-  userApps: "current",
   vmSnapshotTimeoutMs: 30000,
   maxArchiveSizeMb: 100,
 };
-
-const USER_APPS_VALUES = new Set(["current", "all"]);
 
 function parseBoolean(value: boolean | string | undefined, fallback: boolean): boolean {
   if (typeof value === "boolean") {
@@ -50,17 +46,6 @@ function parsePositiveNumber(
   return result > 0 ? result : fallback;
 }
 
-function parseUserApps(value: string | undefined, fallback: "current" | "all"): "current" | "all" {
-  if (!value) {
-    return fallback;
-  }
-  const normalized = value.trim().toLowerCase();
-  if (USER_APPS_VALUES.has(normalized)) {
-    return normalized as "current" | "all";
-  }
-  return fallback;
-}
-
 export function parseDeviceSnapshotConfig(
   input: DeviceSnapshotConfigInput | null | undefined,
 ): DeviceSnapshotConfig {
@@ -82,15 +67,6 @@ export function parseDeviceSnapshotConfig(
     strictBackupMode: parseBoolean(
       safeInput.strictBackupMode,
       DEFAULT_DEVICE_SNAPSHOT_CONFIG.strictBackupMode,
-    ),
-    backupTimeoutMs: parsePositiveNumber(
-      safeInput.backupTimeoutMs,
-      DEFAULT_DEVICE_SNAPSHOT_CONFIG.backupTimeoutMs,
-      false,
-    ),
-    userApps: parseUserApps(
-      typeof safeInput.userApps === "string" ? safeInput.userApps : undefined,
-      DEFAULT_DEVICE_SNAPSHOT_CONFIG.userApps,
     ),
     vmSnapshotTimeoutMs: parsePositiveNumber(
       safeInput.vmSnapshotTimeoutMs,

--- a/src/models/DeviceSnapshot.ts
+++ b/src/models/DeviceSnapshot.ts
@@ -54,7 +54,7 @@ export interface DeviceSnapshotManifest {
     failedPackages?: string[];
     totalPackages?: number;
     backupTimedOut?: boolean;
-    backupMethod?: "adb_backup" | "root_pull" | "none" | "simctl_copy";
+    backupMethod?: "root_pull" | "none" | "simctl_copy";
     /**
      * iOS-only per-bundle outcome for each requested `appBundleIds` entry, so a
      * caller can tell an installed-and-captured app apart from one that was
@@ -72,8 +72,6 @@ export interface DeviceSnapshotConfig {
   includeSettings: boolean;
   useVmSnapshot: boolean;
   strictBackupMode: boolean;
-  backupTimeoutMs: number;
-  userApps: "current" | "all";
   vmSnapshotTimeoutMs: number;
   maxArchiveSizeMb: number;
 }
@@ -83,8 +81,6 @@ export interface DeviceSnapshotConfigInput {
   includeSettings?: boolean | string;
   useVmSnapshot?: boolean | string;
   strictBackupMode?: boolean | string;
-  backupTimeoutMs?: number | string;
-  userApps?: "current" | "all" | string;
   vmSnapshotTimeoutMs?: number | string;
   maxArchiveSizeMb?: number | string;
 }

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -36,8 +36,6 @@ interface DeviceSnapshotCaptureArgs {
   includeSettings?: boolean;
   useVmSnapshot?: boolean;
   strictBackupMode?: boolean;
-  backupTimeoutMs?: number;
-  userApps?: "current" | "all";
   vmSnapshotTimeoutMs?: number;
   appBundleIds?: string[];
 }
@@ -134,8 +132,6 @@ function configToInput(config: DeviceSnapshotConfig): DeviceSnapshotConfigInput 
     includeSettings: config.includeSettings,
     useVmSnapshot: config.useVmSnapshot,
     strictBackupMode: config.strictBackupMode,
-    backupTimeoutMs: config.backupTimeoutMs,
-    userApps: config.userApps,
     vmSnapshotTimeoutMs: config.vmSnapshotTimeoutMs,
     maxArchiveSizeMb: config.maxArchiveSizeMb,
   };
@@ -150,8 +146,6 @@ function mergeConfigInput(
     includeSettings: overrides.includeSettings ?? base.includeSettings,
     useVmSnapshot: overrides.useVmSnapshot ?? base.useVmSnapshot,
     strictBackupMode: overrides.strictBackupMode ?? base.strictBackupMode,
-    backupTimeoutMs: overrides.backupTimeoutMs ?? base.backupTimeoutMs,
-    userApps: overrides.userApps ?? base.userApps,
     vmSnapshotTimeoutMs: overrides.vmSnapshotTimeoutMs ?? base.vmSnapshotTimeoutMs,
     maxArchiveSizeMb: overrides.maxArchiveSizeMb ?? base.maxArchiveSizeMb,
   };
@@ -491,8 +485,6 @@ export async function captureDeviceSnapshot(
     includeSettings: args.includeSettings ?? baseConfig.includeSettings,
     useVmSnapshot: args.useVmSnapshot ?? baseConfig.useVmSnapshot,
     strictBackupMode: args.strictBackupMode ?? baseConfig.strictBackupMode,
-    backupTimeoutMs: args.backupTimeoutMs ?? baseConfig.backupTimeoutMs,
-    userApps: args.userApps ?? baseConfig.userApps,
     vmSnapshotTimeoutMs: args.vmSnapshotTimeoutMs ?? baseConfig.vmSnapshotTimeoutMs,
   };
 
@@ -503,8 +495,6 @@ export async function captureDeviceSnapshot(
     includeSettings: mergedConfig.includeSettings,
     useVmSnapshot: mergedConfig.useVmSnapshot,
     strictBackupMode: mergedConfig.strictBackupMode,
-    backupTimeoutMs: mergedConfig.backupTimeoutMs,
-    userApps: mergedConfig.userApps,
     vmSnapshotTimeoutMs: mergedConfig.vmSnapshotTimeoutMs,
     appBundleIds: args.appBundleIds,
   });

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -9,12 +9,15 @@ const snapshotNameRequiredMessage = "snapshotName is required when action is res
 const optionalSnapshotNameSchema = z.string().min(1).optional().describe("Snapshot name");
 
 const deviceSnapshotCommonShape = {
-  includeAppData: z.boolean().optional().describe("Include app data"),
+  includeAppData: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include app data (iOS app containers; ignored on non-VM Android, which is settings-only)",
+    ),
   includeSettings: z.boolean().optional().describe("Include settings"),
   useVmSnapshot: z.boolean().optional().describe("Use emulator VM snapshot"),
-  strictBackupMode: z.boolean().optional().describe("Fail if app data backup fails"),
-  backupTimeoutMs: z.number().optional().describe("adb backup confirmation timeout ms"),
-  userApps: z.enum(["current", "all"]).optional().describe("Apps to back up: current or all"),
+  strictBackupMode: z.boolean().optional().describe("iOS-only: fail if app container backup fails"),
   vmSnapshotTimeoutMs: z.number().optional().describe("VM snapshot timeout ms"),
   appBundleIds: z.array(z.string()).optional().describe("iOS bundle IDs for app data snapshot"),
 };

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -54,10 +54,6 @@ export class DeviceSnapshotStore {
     return path.join(this.getSnapshotPathWithOptions(snapshotName, options), folderName);
   }
 
-  getBackupFilePath(snapshotName: string, options?: SnapshotPathOptions): string {
-    return path.join(this.getAppDataPath(snapshotName, options), "backup.ab");
-  }
-
   async snapshotDirectoryExists(
     snapshotName: string,
     options?: SnapshotPathOptions,

--- a/src/utils/interfaces/SnapshotProvider.ts
+++ b/src/utils/interfaces/SnapshotProvider.ts
@@ -11,9 +11,9 @@ import type {
  * Captures a device-state snapshot. Implemented by `CaptureSnapshot`,
  * which dispatches on device platform (Android and iOS).
  *
- * Platform-specific fields on {@link CaptureSnapshotArgs} (`appBundleIds`
- * iOS-only, `userApps` Android-only) are ignored on the platform that
- * doesn't understand them — see the concrete implementation.
+ * Platform-specific fields on {@link CaptureSnapshotArgs} (`appBundleIds` and
+ * `strictBackupMode` are iOS-only) are ignored on the platform that doesn't
+ * understand them — see the concrete implementation.
  */
 export interface SnapshotCaptureProvider {
   capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult>;

--- a/test/db/keyedJsonConfigRepository.test.ts
+++ b/test/db/keyedJsonConfigRepository.test.ts
@@ -105,8 +105,6 @@ describe("KeyedJsonConfigRepository", () => {
       includeSettings: true,
       useVmSnapshot: false,
       strictBackupMode: true,
-      backupTimeoutMs: 12000,
-      userApps: "all",
       vmSnapshotTimeoutMs: 34000,
       maxArchiveSizeMb: 12,
     });

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -42,16 +42,6 @@ describe("CaptureSnapshot", () => {
     captureSnapshot = new CaptureSnapshot(device, fakeAdbFactory, undefined, fakeTimer, store);
 
     // Setup default command results
-    fakeAdb.setCommandResult(
-      "shell pm list packages",
-      "package:com.example.app\npackage:com.system.app",
-    );
-    fakeAdb.setCommandResult(
-      "shell pm list packages -3 com.example.app",
-      "package:com.example.app",
-    );
-    fakeAdb.setCommandResult("shell pm list packages -3 com.system.app", ""); // system app
-    fakeAdb.setCommandResult("shell dumpsys package com.example.app", "flags=0x1234 ALLOW_BACKUP");
     fakeAdb.setCommandResult("shell settings list global", "airplane_mode_on=0");
     fakeAdb.setCommandResult("shell settings list secure", "android_id=abc123");
     fakeAdb.setCommandResult("shell settings list system", "screen_brightness=128");
@@ -253,7 +243,7 @@ describe("CaptureSnapshot", () => {
       expect(call?.timeoutMs).toBe(vmSnapshotTimeoutMs);
     });
 
-    it("should use ADB snapshot for non-emulator device even with useVmSnapshot=true", async () => {
+    it("should use settings-only snapshot for non-emulator device even with useVmSnapshot=true", async () => {
       const snapshotName = "test-physical-device";
 
       // Create physical device
@@ -273,23 +263,115 @@ describe("CaptureSnapshot", () => {
       );
       fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
 
-      // Create backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
       const result = await capturePhysical.execute({
         snapshotName,
         includeAppData: true,
         includeSettings: false,
         useVmSnapshot: true,
-        userApps: "current",
       });
 
-      // Should use ADB snapshot for physical device
+      // Physical devices cannot take a VM snapshot; they fall back to the
+      // settings-only ADB path (VM snapshot command is never issued).
       expect(result.snapshotType).toBe("adb");
       expect(fakeAdb.wasCommandExecuted("emu avd snapshot save")).toBe(false);
+    });
+  });
+
+  // #5708: the deprecated `adb backup` app-data path was dropped. Non-VM Android
+  // (physical devices, or emulators with useVmSnapshot:false) now captures device
+  // settings and foreground-app state only -- never `adb backup`.
+  describe("settings-only Android snapshot (#5708)", () => {
+    it("captures settings and foreground app without ever invoking adb backup", async () => {
+      const snapshotName = "test-settings-only";
+
+      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+
+      const result = await captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: true,
+        useVmSnapshot: false,
+      });
+
+      // snapshotType stays "adb" for backward compatibility with the archive.
+      expect(result.snapshotType).toBe("adb");
+      expect(result.manifest.foregroundApp).toBe("com.example.app");
+
+      // Settings are captured via `settings list` (CtrlProxy falls back to ADB).
+      expect(result.manifest.settings?.global).toEqual({ airplane_mode_on: "0" });
+
+      // No app-data machinery: no adb backup command, no appDataBackup metadata,
+      // no package enumeration for backup, and includeAppData recorded as false.
+      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(false);
+      expect(result.manifest.appDataBackup).toBeUndefined();
+      expect(result.manifest.packages).toBeUndefined();
+      expect(result.manifest.includeAppData).toBe(false);
+    });
+
+    it("records includeAppData:false even when the caller requested app data", async () => {
+      const snapshotName = "test-settings-only-requested-appdata";
+
+      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+
+      const result = await captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: false,
+      });
+
+      expect(result.manifest.includeAppData).toBe(false);
+      expect(result.manifest.appDataBackup).toBeUndefined();
+      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(false);
+    });
+
+    it("does not throw when strictBackupMode is set (it is iOS-only, a no-op on Android)", async () => {
+      const snapshotName = "test-strict-mode-noop";
+
+      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+
+      const result = await captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: false,
+        strictBackupMode: true,
+      });
+
+      // strictBackupMode used to fail the whole Android snapshot when adb backup
+      // failed; with the adb-backup path gone it can no longer fail here.
+      expect(result.snapshotType).toBe("adb");
+      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(false);
+    });
+
+    it("captures a settings-only snapshot on a physical device without adb backup", async () => {
+      const snapshotName = "test-physical-settings-only";
+      const physicalDevice: BootedDevice = {
+        deviceId: "ABC123DEF",
+        name: "Pixel_5_Physical",
+        platform: "android",
+        isEmulator: false,
+      };
+      const capturePhysical = new CaptureSnapshot(
+        physicalDevice,
+        fakeAdbFactory,
+        undefined,
+        fakeTimer,
+        store,
+      );
+      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+
+      const result = await capturePhysical.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: true,
+        useVmSnapshot: false,
+      });
+
+      expect(result.snapshotType).toBe("adb");
+      expect(result.manifest.includeAppData).toBe(false);
+      expect(result.manifest.settings?.secure).toEqual({ android_id: "abc123" });
+      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(false);
     });
   });
 
@@ -300,18 +382,11 @@ describe("CaptureSnapshot", () => {
       // Mock getForegroundApp
       fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
 
-      // Create backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
       const result = await captureSnapshot.execute({
         snapshotName,
-        includeAppData: true,
+        includeAppData: false,
         includeSettings: true,
         useVmSnapshot: false,
-        userApps: "current",
       });
 
       expect(result.manifest.includeSettings).toBe(true);
@@ -340,18 +415,11 @@ describe("CaptureSnapshot", () => {
       // Mock getForegroundApp
       fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
 
-      // Create backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
       const result = await captureSnapshot.execute({
         snapshotName,
-        includeAppData: true,
+        includeAppData: false,
         includeSettings: true,
         useVmSnapshot: false,
-        userApps: "current",
       });
 
       expect(result.manifest.settings?.global).toEqual({
@@ -370,18 +438,11 @@ describe("CaptureSnapshot", () => {
       // Mock getForegroundApp
       fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
 
-      // Create backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
       const result = await captureSnapshot.execute({
         snapshotName,
-        includeAppData: true,
+        includeAppData: false,
         includeSettings: true,
         useVmSnapshot: false,
-        userApps: "current",
       });
 
       expect(result.manifest.settings?.global).toEqual({});
@@ -395,18 +456,11 @@ describe("CaptureSnapshot", () => {
       // Mock getForegroundApp
       fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
 
-      // Create backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
       const result = await captureSnapshot.execute({
         snapshotName,
-        includeAppData: true,
+        includeAppData: false,
         includeSettings: false,
         useVmSnapshot: false,
-        userApps: "current",
       });
 
       expect(result.manifest.includeSettings).toBe(false);
@@ -414,28 +468,6 @@ describe("CaptureSnapshot", () => {
 
       // Verify settings commands were not called
       expect(fakeAdb.wasCommandExecuted("shell settings list")).toBe(false);
-    });
-  });
-
-  describe("error scenarios", () => {
-    it("should throw error in strictBackupMode when backup fails", async () => {
-      const snapshotName = "test-strict-mode";
-
-      // Mock getForegroundApp
-      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-
-      // Don't create backup file to simulate failure
-
-      await expect(
-        captureSnapshot.execute({
-          snapshotName,
-          includeAppData: true,
-          includeSettings: false,
-          useVmSnapshot: false,
-          userApps: "current",
-          strictBackupMode: true,
-        }),
-      ).rejects.toThrow("App data backup failed");
     });
   });
 
@@ -451,318 +483,10 @@ describe("CaptureSnapshot", () => {
         includeAppData: true,
         includeSettings: false,
         useVmSnapshot: false,
-        userApps: "current",
       });
 
       expect(result.manifest.foregroundApp).toBeUndefined();
-      expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
-    });
-
-    it("should handle empty package list", async () => {
-      const snapshotName = "test-empty-packages";
-
-      fakeAdb.setCommandResult("shell pm list packages", "");
-
-      // Mock getForegroundApp
-      fakeAdb.setForegroundApp(null);
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "all",
-      });
-
-      expect(result.manifest.packages).toEqual([]);
-      expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
-    });
-
-    it("should handle foreground app that is not a user app", async () => {
-      const snapshotName = "test-system-foreground";
-
-      // Mock getForegroundApp to return a system app
-      fakeAdb.setForegroundApp({ packageName: "com.system.app", userId: 0 });
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "current",
-      });
-
-      expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
-      expect(result.manifest.appDataBackup?.backedUpPackages).toEqual([]);
-    });
-
-    it("should handle all apps disallowing backup", async () => {
-      const snapshotName = "test-all-disallow-backup";
-
-      fakeAdb.setCommandResult(
-        "shell pm list packages",
-        "package:com.example.app1\npackage:com.example.app2",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app1",
-        "package:com.example.app1",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app2",
-        "package:com.example.app2",
-      );
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app1",
-        "flags=0x1234 ALLOW_BACKUP=false",
-      );
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app2",
-        "flags=0x1234 ALLOW_BACKUP=false",
-      );
-
-      // Mock getForegroundApp
-      fakeAdb.setForegroundApp({ packageName: "com.example.app1", userId: 0 });
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "all",
-      });
-
-      expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
-      expect(result.manifest.appDataBackup?.skippedPackages?.length).toBe(2);
-    });
-  });
-
-  describe("app data backup with timeout", () => {
-    it("should backup successfully when user confirms within timeout", async () => {
-      // Setup: Create a fake backup file to simulate successful backup
-      const snapshotName = "test-snapshot";
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-
-      // Mock getForegroundApp to return the test app
-      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-
-      // Create backup file first to simulate successful backup
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      // Simulate successful backup
-      fakeAdb.setCommandResult(`backup -f "${backupFilePath}" -noapk com.example.app`, "Success");
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "current",
-      });
-
-      expect(result.snapshotName).toBe(snapshotName);
-      expect(result.manifest.appDataBackup).toBeDefined();
-      expect(result.manifest.appDataBackup?.backupMethod).toBe("adb_backup");
-      expect(result.manifest.appDataBackup?.backedUpPackages).toContain("com.example.app");
-
-      // Verify timer was used for timeout
-      expect(fakeTimer.getPendingTimeoutCount()).toBe(0); // Should be cleared after completion
-    });
-
-    it("should clear the pending timeout when the backup command throws (regression #2866)", async () => {
-      // Regression guard: timeoutHandle used to be declared inside the try block
-      // but referenced in the catch block, causing a ReferenceError instead of a
-      // graceful failure when adb executeCommand throws mid-backup.
-      const backupFilePath = store.getBackupFilePath("test-throw");
-      fakeAdb.setCommandError(
-        `backup -f "${backupFilePath}" -noapk com.example.app`,
-        new Error("adb connection dropped"),
-      );
-
-      const result = await (captureSnapshot as any).performAdbBackup(
-        ["com.example.app"],
-        backupFilePath,
-        30000,
-      );
-
-      // Catch path returns a graceful failure, no ReferenceError thrown.
-      expect(result).toEqual({ timedOut: false });
-      // The timeout scheduled before the throw must be cleared to avoid a leak.
-      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
-    });
-
-    it("records the failed backup in the manifest when no backup file is produced", async () => {
-      const snapshotName = "test-snapshot-no-file";
-
-      // Drive the real foreground-app path rather than stubbing the subject.
-      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-
-      // The backup command returns without creating a file (backup not confirmed).
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "current",
-        strictBackupMode: false,
-        backupTimeoutMs: 30000,
-      });
-
-      // A failed backup must pin: adb_backup attempted, package moved to
-      // failedPackages, NO backupFile recorded (item 11), and not-timed-out.
-      const backup = result.manifest.appDataBackup;
-      expect(backup?.backupMethod).toBe("adb_backup");
-      expect(backup?.backedUpPackages).toEqual([]);
-      expect(backup?.failedPackages).toEqual(["com.example.app"]);
-      expect(backup?.backupFile).toBeUndefined();
-      expect(backup?.backupTimedOut).toBe(false);
-    });
-
-    it("records backupTimedOut when the adb backup never completes", async () => {
-      const snapshotName = "test-snapshot-timeout";
-
-      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-      // The backup command hangs; the FakeTimer timeout wins the race.
-      fakeAdb.setHangingCommand("backup -f");
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "current",
-        strictBackupMode: false,
-        backupTimeoutMs: 30000,
-      });
-
-      const backup = result.manifest.appDataBackup;
-      expect(backup?.backupMethod).toBe("adb_backup");
-      expect(backup?.backupTimedOut).toBe(true);
-      expect(backup?.failedPackages).toEqual(["com.example.app"]);
-      expect(backup?.backupFile).toBeUndefined();
-    });
-
-    it("should backup only current foreground app by default", async () => {
-      const snapshotName = "test-current-app";
-
-      // Setup getForegroundApp to return a specific app
-      fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-
-      // Create dummy backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "current",
-      });
-
-      // Verify backup command was called with only the foreground app
-      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(true);
-      const backupCommand = fakeAdb.getAllCommands().find((cmd) => cmd.includes("backup -f"));
-      expect(backupCommand).toContain("com.example.app");
-      expect(backupCommand).not.toContain("com.system.app");
-    });
-
-    it("should backup all user apps when userApps is 'all'", async () => {
-      const snapshotName = "test-all-apps";
-
-      // Add more user apps
-      fakeAdb.setCommandResult(
-        "shell pm list packages",
-        "package:com.example.app1\npackage:com.example.app2\npackage:com.system.app",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app1",
-        "package:com.example.app1",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app2",
-        "package:com.example.app2",
-      );
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app1",
-        "flags=0x1234 ALLOW_BACKUP",
-      );
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app2",
-        "flags=0x1234 ALLOW_BACKUP",
-      );
-
-      // Create dummy backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "all",
-      });
-
-      // Verify backup command was called with all user apps
-      expect(fakeAdb.wasCommandExecuted("backup -f")).toBe(true);
-      const backupCommand = fakeAdb.getAllCommands().find((cmd) => cmd.includes("backup -f"));
-      expect(backupCommand).toContain("com.example.app1");
-      expect(backupCommand).toContain("com.example.app2");
-    });
-
-    it("should skip apps with android:allowBackup=false", async () => {
-      const snapshotName = "test-skip-nobackup";
-
-      fakeAdb.setCommandResult(
-        "shell pm list packages",
-        "package:com.example.app1\npackage:com.example.app2",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app1",
-        "package:com.example.app1",
-      );
-      fakeAdb.setCommandResult(
-        "shell pm list packages -3 com.example.app2",
-        "package:com.example.app2",
-      );
-
-      // app1 allows backup, app2 doesn't
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app1",
-        "flags=0x1234 ALLOW_BACKUP",
-      );
-      fakeAdb.setCommandResult(
-        "shell dumpsys package com.example.app2",
-        "flags=0x1234 ALLOW_BACKUP=false",
-      );
-
-      // Create dummy backup file
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      const result = await captureSnapshot.execute({
-        snapshotName,
-        includeAppData: true,
-        includeSettings: false,
-        useVmSnapshot: false,
-        userApps: "all",
-      });
-
-      // Verify only app1 was backed up
-      const backupCommand = fakeAdb.getAllCommands().find((cmd) => cmd.includes("backup -f"));
-      expect(backupCommand).toContain("com.example.app1");
-      expect(backupCommand).not.toContain("com.example.app2");
-
-      // Check manifest contains skipped packages
-      expect(result.manifest.appDataBackup?.skippedPackages).toContain("com.example.app2");
+      expect(result.manifest.appDataBackup).toBeUndefined();
     });
   });
 

--- a/test/features/action/RestoreSnapshot.test.ts
+++ b/test/features/action/RestoreSnapshot.test.ts
@@ -476,542 +476,91 @@ describe("RestoreSnapshot", () => {
         }),
       ).rejects.toThrow("Snapshot platform 'ios' does not match device platform 'android'");
     });
-
-    it("should handle app clear failures gracefully", async () => {
-      const snapshotName = "test-clear-fail";
-
-      // Create manifest with packages
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app1", "com.example.app2"],
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 2,
-          backedUpPackages: ["com.example.app1", "com.example.app2"],
-          skippedPackages: [],
-          failedPackages: [],
-        },
-      };
-
-      // Setup clear commands - one succeeds, one fails
-      fakeAdb.setCommandResult("shell pm clear com.example.app1", "Success");
-      fakeAdb.setCommandResult("shell pm clear com.example.app2", "Failed");
-
-      // Should not throw, just log warnings
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      expect(fakeAdb.wasCommandExecuted("shell pm clear com.example.app1")).toBe(true);
-      expect(fakeAdb.wasCommandExecuted("shell pm clear com.example.app2")).toBe(true);
-    });
   });
 
-  describe("edge cases", () => {
-    it("should not clear app data when includeAppData is false", async () => {
-      const snapshotName = "test-no-clear";
-
-      // Create manifest without app data
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: false,
-        includeSettings: false,
-        packages: ["com.example.app"],
-      };
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      // Verify pm clear was not called
-      expect(fakeAdb.wasCommandExecuted("shell pm clear")).toBe(false);
-    });
-
-    it("should not clear app data when packages list is empty", async () => {
-      const snapshotName = "test-empty-packages";
-
-      // Create manifest with empty packages
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: [],
-      };
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      // Verify pm clear was not called
-      expect(fakeAdb.wasCommandExecuted("shell pm clear")).toBe(false);
-    });
-
-    it("should skip foreground app restore when not in manifest", async () => {
-      const snapshotName = "test-no-foreground";
-
-      // Create manifest without foreground app
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: false,
-        includeSettings: false,
-      };
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      // Verify app launch was not called
-      expect(fakeAdb.wasCommandExecuted("shell am start")).toBe(false);
-    });
-
-    it("should handle missing backup file gracefully", async () => {
-      const snapshotName = "test-missing-backup";
-
-      // Create manifest with backup metadata but no actual file
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app"],
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 1,
-          backedUpPackages: ["com.example.app"],
-          skippedPackages: [],
-          failedPackages: [],
-        },
-      };
-
-      // Should not throw, just skip restore
-      const result = await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      expect(result.snapshotType).toBe("adb");
-      expect(fakeAdb.wasCommandExecuted("restore")).toBe(false);
-    });
-
-    it("should skip restore for empty backup file", async () => {
-      const snapshotName = "test-empty-backup";
-
-      // Create manifest with backup
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app"],
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 1,
-          backedUpPackages: ["com.example.app"],
-          skippedPackages: [],
-          failedPackages: [],
-        },
-      };
-
-      // Create empty backup file
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      await fs.writeFile(backupFilePath, "", "utf-8"); // Empty file
-
-      const result = await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      expect(result.snapshotType).toBe("adb");
-      expect(fakeAdb.wasCommandExecuted("restore")).toBe(false);
-    });
-  });
-
-  describe("app data restore with timeout", () => {
-    it("should clear the pending timeout when the restore command throws (regression #2866)", async () => {
-      // Regression guard: timeoutHandle used to be declared inside the try block
-      // but referenced in the catch block, causing a ReferenceError instead of a
-      // graceful failure when adb executeCommand throws mid-restore.
-      const backupFilePath = "/tmp/backup.ab";
-      fakeAdb.setCommandError(`restore "${backupFilePath}"`, new Error("adb connection dropped"));
-
-      const result = await (restoreSnapshot as any).performAdbRestore(backupFilePath, 30000);
-
-      // Catch path returns a graceful failure, no ReferenceError thrown.
-      expect(result).toEqual({ success: false, timedOut: false });
-      // The timeout scheduled before the throw must be cleared to avoid a leak.
-      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
-    });
-
-    it("should restore successfully when user confirms within timeout", async () => {
-      const snapshotName = "test-snapshot";
-
-      // Create manifest with backup data
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app"],
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 1,
-          backedUpPackages: ["com.example.app"],
-          skippedPackages: [],
-          failedPackages: [],
-          backupTimedOut: false,
-        },
-      };
-
-      // Create backup file
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      // Setup restore command result
-      fakeAdb.setCommandResult(`restore "${backupFilePath}"`, "");
-
-      const result = await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      expect(result.snapshotType).toBe("adb");
-      expect(result.restoredAt).toBeDefined();
-
-      // Verify restore command was called
-      expect(fakeAdb.wasCommandExecuted(`restore "${backupFilePath}"`)).toBe(true);
-
-      // Verify timer was used for timeout
-      expect(fakeTimer.getPendingTimeoutCount()).toBe(0); // Should be cleared after completion
-    });
-
-    it("should skip restore if no backup file exists", async () => {
-      const snapshotName = "test-no-backup";
-
-      // Create manifest without backup data
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app"],
-        appDataBackup: {
-          backupMethod: "none",
-          totalPackages: 1,
-          backedUpPackages: [],
-          skippedPackages: [],
-          failedPackages: [],
-        },
-      };
-
-      // Create app data directory but no backup file
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-
-      const result = await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      expect(result.snapshotType).toBe("adb");
-
-      // Verify restore command was not called
-      expect(fakeAdb.wasCommandExecuted("restore")).toBe(false);
-    });
-
-    it("should clear app data before restore", async () => {
-      const snapshotName = "test-clear";
-
-      // Create manifest with packages
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: ["com.example.app1", "com.example.app2"],
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 2,
-          backedUpPackages: ["com.example.app1"],
-          skippedPackages: [],
-          failedPackages: [],
-          backupTimedOut: false,
-        },
-      };
-
-      // Create backup file
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      // Setup clear commands
-      fakeAdb.setCommandResult("shell pm clear com.example.app1", "Success");
-      fakeAdb.setCommandResult("shell pm clear com.example.app2", "Success");
-      fakeAdb.setCommandResult(`restore "${backupFilePath}"`, "");
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      // Only the backed-up package is cleared. app2 was never captured
-      // (backedUpPackages is [app1]), so clearing it would wipe data that
-      // cannot be restored (#4236).
-      expect(fakeAdb.wasCommandExecuted("shell pm clear com.example.app1")).toBe(true);
-      expect(fakeAdb.wasCommandExecuted("shell pm clear com.example.app2")).toBe(false);
-    });
-
-    it("should restore foreground app after data restore", async () => {
-      const snapshotName = "test-foreground";
-      const foregroundApp = "com.example.app";
-
-      // Create manifest with foreground app
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "adb",
-        includeAppData: true,
-        includeSettings: false,
-        packages: [foregroundApp],
-        foregroundApp,
-        appDataBackup: {
-          backupFile: "backup.ab",
-          backupMethod: "adb_backup",
-          totalPackages: 1,
-          backedUpPackages: [foregroundApp],
-          skippedPackages: [],
-          failedPackages: [],
-          backupTimedOut: false,
-        },
-      };
-
-      // Create backup file
-      const appDataPath = store.getAppDataPath(snapshotName);
-      await fs.mkdir(appDataPath, { recursive: true });
-      const backupFilePath = store.getBackupFilePath(snapshotName);
-      await fs.writeFile(backupFilePath, "backup data", "utf-8");
-
-      fakeAdb.setCommandResult(`restore "${backupFilePath}"`, "");
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: false,
-      });
-
-      // Verify foreground app was launched
-      expect(
-        fakeAdb.wasCommandExecuted(
-          `shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER ${foregroundApp}`,
-        ),
-      ).toBe(true);
-    });
-
-    it("should restore VM snapshot with timer sleep", async () => {
-      const snapshotName = "test-vm";
-
-      // Create VM snapshot manifest
-      const manifest: DeviceSnapshotManifest = {
-        snapshotName,
-        timestamp: new Date().toISOString(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        platform: "android",
-        snapshotType: "vm",
-        includeAppData: true,
-        includeSettings: false,
-      };
-
-      // Setup VM snapshot load command
-      fakeAdb.setCommandResult(`emu avd snapshot load ${snapshotName}`, "OK");
-
-      await restoreSnapshot.execute({
-        snapshotName,
-        manifest,
-        useVmSnapshot: true,
-      });
-
-      // Verify sleep was called for stabilization
-      expect(fakeTimer.wasSleepCalled(2000)).toBe(true);
-
-      // Verify VM restore command was called
-      expect(fakeAdb.wasCommandExecuted(`emu avd snapshot load ${snapshotName}`)).toBe(true);
-    });
-  });
-});
-
-describe("RestoreSnapshot restores settings before the slow app-data phase (#4236)", () => {
-  let device: BootedDevice;
-  let fakeAdb: FakeAdbClient;
-  let fakeAdbFactory: AdbClientFactory;
-  let fakeTimer: FakeTimer;
-  let restoreSnapshot: RestoreSnapshot;
-  let store: DeviceSnapshotStore;
-  let basePath: string;
-
-  beforeEach(async () => {
-    device = {
-      deviceId: "emulator-5554",
-      name: "Pixel_5",
-      platform: "android",
-      isEmulator: true,
-    } as BootedDevice;
-    fakeAdb = new FakeAdbClient();
-    fakeAdbFactory = { create: () => fakeAdb as any };
-    fakeTimer = new FakeTimer();
-    fakeTimer.enableAutoAdvance();
-    basePath = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-scope-test-"));
-    store = new DeviceSnapshotStore(basePath);
-    restoreSnapshot = new RestoreSnapshot(device, fakeAdbFactory, undefined, fakeTimer, store);
-  });
-
-  afterEach(async () => {
-    try {
-      await fs.rm(basePath, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
-    fakeTimer.reset();
-  });
-
-  // manifest.packages is every installed package (getInstalledPackages), while
-  // only appDataBackup.backedUpPackages was actually captured. Clearing the
-  // former wipes data that can never be restored, and the volume of pm clear
-  // calls is what exhausted the request budget before restoreSettings ran.
-  const manifestWith = (allPackages: string[], backedUp: string[]): DeviceSnapshotManifest =>
-    ({
-      snapshotName: "scope-test",
+  // #5708: the deprecated adb backup/restore app-data path was dropped. Non-VM
+  // Android restore now reapplies settings and relaunches the foreground app
+  // only -- `pm clear` and `adb restore` are never issued.
+  describe("settings-only Android restore (#5708)", () => {
+    const androidManifest = (
+      overrides: Partial<DeviceSnapshotManifest> = {},
+    ): DeviceSnapshotManifest => ({
+      snapshotName: "settings-only",
       timestamp: new Date().toISOString(),
       deviceId: device.deviceId,
       deviceName: device.name,
       platform: "android",
       snapshotType: "adb",
-      includeAppData: true,
+      includeAppData: false,
       includeSettings: true,
-      packages: allPackages,
-      settings: { system: { screen_off_timeout: "60000" }, global: {}, secure: {} },
-      appDataBackup: {
-        backedUpPackages: backedUp,
-        skippedPackages: [],
-        totalPackages: allPackages.length,
-      },
-    }) as unknown as DeviceSnapshotManifest;
+      ...overrides,
+    });
 
-  it("clears only the backed-up packages, not every installed package (#4236 P1)", async () => {
-    // The default restore path: manifest.packages is every installed package but
-    // only a subset was backed up. Clearing all of them is what exhausted the
-    // request budget before the restore could finish.
-    const manifest = manifestWith(
-      ["com.example.app", "com.android.systemui", "com.google.android.gms"],
-      ["com.example.app"],
-    );
+    it("restores settings and relaunches the foreground app, never clearing app data", async () => {
+      const manifest = androidManifest({
+        settings: { global: { airplane_mode_on: "1" }, secure: {}, system: {} },
+        foregroundApp: "com.example.app",
+      });
+      fakeAdb.setCommandResult("shell settings put global airplane_mode_on '1'", "");
 
-    await restoreSnapshot
-      .execute({ snapshotName: "scope-test", manifest, useVmSnapshot: false })
-      .catch(() => undefined);
+      const result = await restoreSnapshot.execute({
+        snapshotName: "settings-only",
+        manifest,
+        useVmSnapshot: false,
+      });
 
-    expect(fakeAdb.getCommandCount("pm clear com.example.app")).toBeGreaterThan(0);
-    expect(fakeAdb.getCommandCount("pm clear com.android.systemui")).toBe(0);
-    expect(fakeAdb.getCommandCount("pm clear com.google.android.gms")).toBe(0);
-  });
+      expect(result.snapshotType).toBe("adb");
+      expect(fakeAdb.wasCommandExecuted("shell settings put global airplane_mode_on '1'")).toBe(
+        true,
+      );
+      expect(
+        fakeAdb.wasCommandExecuted(
+          "shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER com.example.app",
+        ),
+      ).toBe(true);
 
-  it("clears nothing when no packages were backed up (#4236 P1)", async () => {
-    const manifest = manifestWith(["com.example.app", "com.android.systemui"], []);
+      // No app-data phase: neither `pm clear` nor `adb restore` is issued, even
+      // if a legacy manifest still carries backup metadata.
+      expect(fakeAdb.wasCommandExecuted("pm clear")).toBe(false);
+      expect(fakeAdb.wasCommandExecuted("restore")).toBe(false);
+    });
 
-    await restoreSnapshot
-      .execute({ snapshotName: "scope-test", manifest, useVmSnapshot: false })
-      .catch(() => undefined);
+    it("ignores legacy app-data backup metadata without clearing or restoring", async () => {
+      // A snapshot captured before #5708 may still carry appDataBackup with a
+      // backedUpPackages list. Restore must not act on it.
+      const manifest = androidManifest({
+        includeAppData: true,
+        foregroundApp: "com.example.app",
+        packages: ["com.example.app", "com.android.systemui"],
+        appDataBackup: {
+          backupFile: "backup.ab",
+          backedUpPackages: ["com.example.app"],
+          skippedPackages: [],
+          totalPackages: 2,
+        },
+      });
 
-    expect(fakeAdb.getCommandCount("pm clear")).toBe(0);
-  });
+      await restoreSnapshot.execute({
+        snapshotName: "settings-only",
+        manifest,
+        useVmSnapshot: false,
+      });
 
-  it("restores settings before clearing app data, so a slow clear cannot cost the settings", async () => {
-    // Ordering is the fix: on a real device the clear phase spans every installed
-    // package and exhausts the request budget, so settings restored afterwards
-    // never happened. Fakes are instant, so assert the command *sequence* rather
-    // than timing -- otherwise the test passes with either order.
-    const manifest = manifestWith(["com.example.app"], ["com.example.app"]);
+      expect(fakeAdb.wasCommandExecuted("pm clear")).toBe(false);
+      expect(fakeAdb.wasCommandExecuted("restore")).toBe(false);
+    });
 
-    await restoreSnapshot
-      .execute({ snapshotName: "scope-test", manifest, useVmSnapshot: false })
-      .catch(() => undefined);
+    it("skips foreground relaunch when the manifest has no foreground app", async () => {
+      const manifest = androidManifest({ includeSettings: false });
 
-    const commands = fakeAdb.getAllCommands();
-    const settingsAt = commands.findIndex((c) =>
-      c.includes("settings put system screen_off_timeout"),
-    );
-    const clearAt = commands.findIndex((c) => c.includes("pm clear"));
+      await restoreSnapshot.execute({
+        snapshotName: "settings-only",
+        manifest,
+        useVmSnapshot: false,
+      });
 
-    expect(settingsAt).toBeGreaterThanOrEqual(0);
-    expect(clearAt).toBeGreaterThanOrEqual(0);
-    expect(settingsAt).toBeLessThan(clearAt);
+      expect(fakeAdb.wasCommandExecuted("shell am start")).toBe(false);
+    });
   });
 });
 

--- a/test/features/snapshot/DeviceSnapshotConfig.property.test.ts
+++ b/test/features/snapshot/DeviceSnapshotConfig.property.test.ts
@@ -21,9 +21,6 @@ const positiveNumber = fc.oneof(
 
 describe("parseDeviceSnapshotConfig (property-based)", () => {
   test("the (0, 0.5) rounding-to-zero repro no longer returns 0", () => {
-    expect(parseDeviceSnapshotConfig({ backupTimeoutMs: 0.3 }).backupTimeoutMs).toBe(
-      DEFAULT_DEVICE_SNAPSHOT_CONFIG.backupTimeoutMs,
-    );
     expect(parseDeviceSnapshotConfig({ vmSnapshotTimeoutMs: 0.3 }).vmSnapshotTimeoutMs).toBe(
       DEFAULT_DEVICE_SNAPSHOT_CONFIG.vmSnapshotTimeoutMs,
     );
@@ -31,17 +28,11 @@ describe("parseDeviceSnapshotConfig (property-based)", () => {
 
   test("integer timeout fields are always positive integers for positive input", () => {
     fc.assert(
-      fc.property(positiveNumber, positiveNumber, (backup, vm) => {
+      fc.property(positiveNumber, (vm) => {
         const config = parseDeviceSnapshotConfig({
-          backupTimeoutMs: backup,
           vmSnapshotTimeoutMs: vm,
         });
-        return (
-          Number.isInteger(config.backupTimeoutMs) &&
-          config.backupTimeoutMs > 0 &&
-          Number.isInteger(config.vmSnapshotTimeoutMs) &&
-          config.vmSnapshotTimeoutMs > 0
-        );
+        return Number.isInteger(config.vmSnapshotTimeoutMs) && config.vmSnapshotTimeoutMs > 0;
       }),
       RUN_OPTIONS,
     );
@@ -58,15 +49,13 @@ describe("parseDeviceSnapshotConfig (property-based)", () => {
 
   test("parsing is idempotent: parse(parse(x)) === parse(x)", () => {
     fc.assert(
-      fc.property(positiveNumber, positiveNumber, positiveNumber, (backup, vm, size) => {
+      fc.property(positiveNumber, positiveNumber, (vm, size) => {
         const once = parseDeviceSnapshotConfig({
-          backupTimeoutMs: backup,
           vmSnapshotTimeoutMs: vm,
           maxArchiveSizeMb: size,
         });
         const twice = parseDeviceSnapshotConfig(once);
         return (
-          twice.backupTimeoutMs === once.backupTimeoutMs &&
           twice.vmSnapshotTimeoutMs === once.vmSnapshotTimeoutMs &&
           twice.maxArchiveSizeMb === once.maxArchiveSizeMb
         );
@@ -83,12 +72,10 @@ describe("parseDeviceSnapshotConfig (property-based)", () => {
     fc.assert(
       fc.property(nonPositive, (value) => {
         const config = parseDeviceSnapshotConfig({
-          backupTimeoutMs: value,
           vmSnapshotTimeoutMs: value,
           maxArchiveSizeMb: value,
         });
         return (
-          config.backupTimeoutMs === DEFAULT_DEVICE_SNAPSHOT_CONFIG.backupTimeoutMs &&
           config.vmSnapshotTimeoutMs === DEFAULT_DEVICE_SNAPSHOT_CONFIG.vmSnapshotTimeoutMs &&
           config.maxArchiveSizeMb === DEFAULT_DEVICE_SNAPSHOT_CONFIG.maxArchiveSizeMb
         );

--- a/test/server/configManagerDefaultRepositories.test.ts
+++ b/test/server/configManagerDefaultRepositories.test.ts
@@ -71,8 +71,6 @@ describe("config manager default repositories", () => {
       includeSettings: true,
       useVmSnapshot: false,
       strictBackupMode: true,
-      backupTimeoutMs: 12000,
-      userApps: "all",
       vmSnapshotTimeoutMs: 34000,
       maxArchiveSizeMb: 12,
     };

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -89,8 +89,6 @@ describe("deviceSnapshotManager", () => {
       includeSettings: true,
       useVmSnapshot: true,
       strictBackupMode: false,
-      backupTimeoutMs: 10000,
-      userApps: "current",
       vmSnapshotTimeoutMs: 12000,
       maxArchiveSizeMb: 1,
     };
@@ -327,8 +325,6 @@ describe("deviceSnapshotManager", () => {
       includeSettings: true,
       useVmSnapshot: true,
       strictBackupMode: false,
-      backupTimeoutMs: 0,
-      userApps: "current",
       vmSnapshotTimeoutMs: 0,
       maxArchiveSizeMb: 100,
     };
@@ -336,9 +332,7 @@ describe("deviceSnapshotManager", () => {
 
     const config = await getDeviceSnapshotConfig();
 
-    expect(config.backupTimeoutMs).toBeGreaterThan(0);
     expect(config.vmSnapshotTimeoutMs).toBeGreaterThan(0);
-    expect(config.backupTimeoutMs).toBe(30000);
     expect(config.vmSnapshotTimeoutMs).toBe(30000);
   });
 });

--- a/test/utils/deviceSnapshotStore.test.ts
+++ b/test/utils/deviceSnapshotStore.test.ts
@@ -50,9 +50,6 @@ describe("DeviceSnapshotStore", () => {
     expect(store.getAppDataPath("test-snapshot")).toBe(
       path.join(testBasePath, "test-snapshot", "app_data"),
     );
-    expect(store.getBackupFilePath("test-snapshot")).toBe(
-      path.join(testBasePath, "test-snapshot", "app_data", "backup.ab"),
-    );
   });
 
   it("should return iOS snapshot paths scoped by device", () => {


### PR DESCRIPTION
## Summary

The Android non-VM `deviceSnapshot` path captured app data with `adb backup`.
`adb backup` is deprecated since Android 12 (API 31), requires interactive
on-device confirmation (so it cannot be automated), and in testing on API 34
produced **no `backup.ab`** — only `settings.json` + `packages.txt` — while still
reporting "captured successfully". It is redundant with VM snapshots (full
emulator state) and the targeted app-data tools (DataStore, shared-storage
resources, `sqlQuery`, preferences).

This drops the `adb backup`/`adb restore` app-data path and reduces non-VM
Android to a **settings-only** snapshot (the endorsed alternative in the issue):

- **Capture** — device settings (CtrlProxy settings namespaces, ADB fallback) +
  foreground-app state. `snapshotType` stays `"adb"` for archive compatibility;
  the manifest records `includeAppData: false`. No `adb backup` is issued.
- **Restore** — reapplies settings and relaunches the foreground app. No
  `pm clear` and no `adb restore`. Legacy snapshots that still carry app-data
  metadata restore as settings-only (stale metadata ignored).
- Removed the adb-backup-only knobs `backupTimeoutMs` and `userApps` and the
  `adb_backup` `backupMethod` from the model, config, parser, and tool schema
  (`schemas/tool-definitions.json` regenerated). Removing the two tool params is
  non-breaking — zod strips unknown keys.
- `strictBackupMode` is retained but is now **iOS-only** (its Android relevance
  disappears — coordinates with #5711).
- VM (emulator) and iOS app-container paths are unchanged.

Physical Android devices lose app-data snapshotting — which never worked via
adb backup anyway. Documented in `docs/design-docs/mcp/storage/snapshots.md`.

## Linked Issue

Closes #5708

## Bug / Regression Context

- **Prior attempts:** n/a — chore/removal of a non-functional path.
- **Observed symptom:** on API 34, `adb backup` yielded no `backup.ab` yet the
  snapshot reported success; on physical devices it required manual confirmation.
- **Repro steps / conditions:** `deviceSnapshot` capture on non-VM Android with
  `includeAppData: true`.

## Validation

- [x] `bun test` — full suite green (the one failing test, `test/lint/oxlintConfigScoping.test.ts`, only fails because this worktree has no local `node_modules/.bin/oxlint`; the real oxlint ratchet passes via `bun run lint`)
- [x] `bun run lint` — ratchet gate: no new violations; boundary-checks pass
- [x] `bun run typecheck` — no new type errors (baseline gate)
- [x] `bunx oxfmt --check` on touched files — clean
- [x] `schemas/tool-definitions.json` regenerated; registration tests pass
- [x] New/updated unit tests use interfaces + fakes + FakeTimer and run <100ms

### Acceptance criteria

- [x] **AC1** — adb backup capture/restore path and the app-data branch removed; non-VM Android is settings-only.
- [x] **AC2** — physical Android app-data loss documented in the snapshots design doc.
- [x] **AC3** — `strictBackupMode` no longer affects Android (iOS-only); coordinates with #5711.

## Follow-ups

- [ ] None. #5710 / #5711 (strictBackupMode / 0-captured enforcement) are tracked separately.
