### PR TITLE
fix(ios-sdk): enforce main-thread on public UIKit/WebKit entry points

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -14,9 +14,21 @@
         // MARK: - Public API
 
         /// Walk the entire view hierarchy and return a snapshot.
-        /// Must be called on the main thread.
+        ///
+        /// Reads UIKit (`UIApplication`/`UIScreen`/the view tree), which is main-thread
+        /// only. Host apps may call this SDK from any thread, so this enforces the
+        /// requirement rather than doing undefined off-main UIKit work: a debug build
+        /// asserts (surfacing the misuse in development), and any build called off the
+        /// main thread hops onto it synchronously. A main-thread caller runs inline
+        /// (the `Thread.isMainThread` guard avoids a `DispatchQueue.main.sync` self-deadlock).
         public static func walk(bundleId: String? = nil) -> SdkViewHierarchy {
-            walk(in: visibleKeyWindow(), bundleId: bundleId)
+            assert(Thread.isMainThread, "ViewHierarchyWalker.walk(bundleId:) must be called on the main thread")
+            if Thread.isMainThread {
+                return walk(in: visibleKeyWindow(), bundleId: bundleId)
+            }
+            return DispatchQueue.main.sync {
+                walk(in: visibleKeyWindow(), bundleId: bundleId)
+            }
         }
 
         /// Testability seam: snapshot an explicit window rather than resolving the

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
@@ -316,6 +316,16 @@ public final class AutoMobileWebViewBridge: NSObject, WKScriptMessageHandler, WK
     }
 
     public func perform(_ action: AutoMobileWebAction, completion: @escaping (Result<Void, Error>) -> Void) {
+        // WKWebView (evaluateJavaScript, url, navigationDelegate) is main-thread only, but a
+        // host app may call this from any thread. Assert in debug to surface the misuse, and
+        // in any build re-dispatch to the main thread when off it rather than touching WebKit
+        // off-main. `perform` is already completion-based, so an async hop preserves its
+        // contract and cannot deadlock.
+        assert(Thread.isMainThread, "AutoMobileWebViewBridge.perform must be called on the main thread")
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { self.perform(action, completion: completion) }
+            return
+        }
         guard policy.validates(action) || (ifEvaluate(action) && policy.allows(url: webView?.url, frameId: nil)) else {
             completion(.failure(NSError(domain: "AutoMobileWebViewBridge", code: 1, userInfo: [NSLocalizedDescriptionKey: "Stale or disallowed web action"])))
             return


### PR DESCRIPTION
## Summary

Two `public` SDK entry points touched main-thread-only UIKit/WebKit APIs but could be called from any
thread by a host app. This enforces the main-thread requirement: a debug `assert(Thread.isMainThread)`
surfaces the misuse in development, and any build hops onto the main thread when called off it rather
than doing undefined off-main UIKit/WebKit work.

- **`ViewHierarchyWalker.walk(bundleId:)`** — reads `UIApplication`/`UIScreen`/the view tree. Returns a
  value synchronously, so an off-main call hops via `DispatchQueue.main.sync`, guarded by
  `Thread.isMainThread` so a main-thread caller runs inline (no self-deadlock).
- **`AutoMobileWebViewBridge.perform(_:completion:)`** — drives `webView.evaluateJavaScript`. It is
  completion-based, so an off-main call re-dispatches with `DispatchQueue.main.async` (preserves the
  contract, cannot deadlock).

The SDK's only internal `walk()` caller (`ViewHierarchyTracker`) already hops to main first, so it runs
inline and the assert never fires for the SDK's own use.

## Linked Issue

Closes #5719

## Validation

- [x] `swift test` for the SDK package: 305/305 pass (on-main path, incl. existing `WebViewBridgeTests`)
- [x] `swift build -c release` clean; SwiftLint clean

Not applicable: pure Swift/`ios/` change, no TypeScript touched.

## Tests

The on-main path (the normal case) is exercised by the existing `WebViewBridgeTests`. The off-main hop is
a release safety net that is inherently not unit-testable — the debug `assert` fires first, and
`ViewHierarchyWalker` is `#if canImport(UIKit)` (iOS-only, not compiled on the macOS test host) — so it
is verified by reading and the CI iOS build.

## Note on delivery

The SDK ships in host apps; like other SDK-source PRs this reaches devices via the normal SDK build.
