### PR TITLE
fix(daemon): hold concurrent ensureConnected() behind the bound-session first heartbeat (#5643)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -807,7 +807,6 @@ export class DaemonMcpProxy {
       await client.close();
       throw new DaemonUnavailableError("MCP proxy is closing");
     }
-    this.connected = true;
     logger.info("[DaemonMcpProxy] Connected to daemon");
 
     // Deliver the ownership heartbeat FIRST — before the best-effort notification
@@ -817,7 +816,20 @@ export class DaemonMcpProxy {
     // grace edge before the heartbeat is even sent. The notification handler is
     // already registered above (before connect), so a session-released frame is
     // still handled during the heartbeat even without the opt-in subscription.
+    //
+    // On the FIRST establishment mark the proxy `connected` only AFTER the
+    // establishment heartbeat lands (issue #5643). ensureConnected()'s fast path
+    // returns as soon as `connected && client` is true; setting the flag before the
+    // awaited first heartbeat would let a CONCURRENT ensureConnected() (a parallel
+    // listTools/callTool during MCP startup) resolve and forward a request in the
+    // sub-millisecond window before the daemon has recorded ownership. Deferring the
+    // flip holds those concurrent callers on the `connecting` guard until ownership
+    // is recorded; the heartbeat guards key off the live transport (`transportLive`),
+    // not this flag, so the first heartbeat still fires while it is still false. On a
+    // RECONNECT there is no ownership to wait for, so establishBoundSessionHeartbeat
+    // flips `connected` itself before dispatching the keeper heartbeat (see there).
     await this.establishBoundSessionHeartbeat();
+    this.connected = true;
 
     if (supportsNotifications) {
       try {
@@ -1609,8 +1621,27 @@ export class DaemonMcpProxy {
     );
   }
 
+  /**
+   * The daemon transport is live and usable for a heartbeat. Distinct from the
+   * public `connected` flag, which is deferred until AFTER the establishment
+   * heartbeat lands so concurrent ensureConnected() callers block on ownership
+   * (issue #5643). During that window the client has connected but `connected` is
+   * still false; the first-heartbeat / keeper guards must treat the transport as
+   * usable. Everywhere else `this.client !== null` tracks `connected` (both are
+   * set on connect and cleared together on reset/close), so this only widens the
+   * guard across the deliberate establishment window.
+   */
+  private get transportLive(): boolean {
+    return this.client !== null;
+  }
+
   private startBoundSessionHeartbeat(): void {
-    if (this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing) {
+    if (
+      this.boundSessionUuid &&
+      !this.terminalBoundSession &&
+      this.transportLive &&
+      !this.closing
+    ) {
       void this.heartbeatKeeper.run();
       this.heartbeatKeeper.start();
       this.heartbeatKeeperStarted = true;
@@ -1634,7 +1665,9 @@ export class DaemonMcpProxy {
    * emitting a duplicate.
    */
   private async establishBoundSessionHeartbeat(): Promise<void> {
-    if (!(this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing)) {
+    if (
+      !(this.boundSessionUuid && !this.terminalBoundSession && this.transportLive && !this.closing)
+    ) {
       return;
     }
     if (this.heartbeatKeeperStarted) {
@@ -1642,6 +1675,15 @@ export class DaemonMcpProxy {
       // reconnect is itself driven by a keeper tick, run() shares that in-flight
       // tick instead of emitting a duplicate; otherwise it sends a fresh heartbeat
       // on the new transport, exactly as before this change.
+      //
+      // Ownership was already recorded by the first establishment, so — unlike the
+      // first-heartbeat path (issue #5643) — there is nothing to hold concurrent
+      // callers behind. Mark the transport connected BEFORE dispatching the keeper
+      // heartbeat: startBoundSessionHeartbeat void-dispatches run(), which re-enters
+      // ensureConnected() and must short-circuit on the fast path so the heartbeat
+      // lands on the fresh transport before the retried operation (#2737/#4610
+      // ordering). doConnect defers this flip only on the first establishment.
+      this.connected = true;
       this.startBoundSessionHeartbeat();
       return;
     }
@@ -1650,7 +1692,9 @@ export class DaemonMcpProxy {
     // close() landing mid-send may have terminally fenced this binding and stopped
     // the keeper. Restarting it here would leak a no-op interval and desync
     // heartbeatKeeperStarted from the fenced state. Mirrors startBoundSessionHeartbeat's guard.
-    if (!(this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing)) {
+    if (
+      !(this.boundSessionUuid && !this.terminalBoundSession && this.transportLive && !this.closing)
+    ) {
       return;
     }
     // The keeper owns every subsequent tick, its reconnect, and terminal fencing.

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -756,10 +756,14 @@ export class DaemonMcpProxy {
     }
   }
 
-  private async doConnect(): Promise<void> {
+  private throwIfClosing(): void {
     if (this.closing) {
       throw new DaemonUnavailableError("MCP proxy is closing");
     }
+  }
+
+  private async doConnect(): Promise<void> {
+    this.throwIfClosing();
     // Check if daemon is available
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
     // This is an observation-only probe. A daemon from another checkout may own
@@ -785,9 +789,7 @@ export class DaemonMcpProxy {
     }
 
     // Create and connect client
-    if (this.closing) {
-      throw new DaemonUnavailableError("MCP proxy is closing");
-    }
+    this.throwIfClosing();
     this.client = this.clientFactory();
     const client = this.client;
     // Wire daemon-pushed list-changed forwarding (issue #3223) when the client
@@ -829,6 +831,13 @@ export class DaemonMcpProxy {
     // RECONNECT there is no ownership to wait for, so establishBoundSessionHeartbeat
     // flips `connected` itself before dispatching the keeper heartbeat (see there).
     await this.establishBoundSessionHeartbeat();
+    // Re-check closing before the deferred flip: the establishment heartbeat awaits a
+    // real daemon round-trip, and a close() landing during it already set
+    // connected=false and nulled the client. Without this guard doConnect would
+    // resume and set connected=true again — leaving a stale connected flag over a
+    // closed transport (the old pre-await placement flipped before this await, so
+    // close() ran last). Mirrors the closing rechecks above.
+    this.throwIfClosing();
     this.connected = true;
 
     if (supportsNotifications) {

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -224,6 +224,69 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     }
   });
 
+  // issue #5643: a CONCURRENT ensureConnected() (e.g. a parallel listTools/callTool
+  // during MCP startup) that arrives while the establishment heartbeat is still in
+  // flight must not resolve on the `connected` fast path before the daemon has
+  // recorded the first ownership heartbeat. The establishment guarantee must hold
+  // for concurrent callers, not just the one that triggered doConnect().
+  test("holds a concurrent ensureConnected() until the first heartbeat is recorded", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const released = Promise.withResolvers<void>();
+    let heartbeatObserved = false;
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: async (method, params) => {
+        if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+          heartbeatObserved = true;
+          await released.promise;
+          sessionManager.recordHeartbeat(params.sessionId);
+        }
+      },
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      // First caller triggers doConnect(); its establishment heartbeat is gated.
+      const firstConnect = proxy.ensureConnected();
+
+      // Let the connection reach the (gated) first heartbeat.
+      for (let i = 0; i < 50 && !heartbeatObserved; i++) {
+        await Promise.resolve();
+      }
+      expect(heartbeatObserved).toBe(true);
+
+      // A concurrent caller arriving while the first heartbeat is in flight must
+      // NOT short-circuit on the `connected` fast path before ownership is recorded.
+      let concurrentResolved = false;
+      const concurrentConnect = proxy.ensureConnected().then(() => {
+        concurrentResolved = true;
+      });
+
+      // Give any (incorrect) fast-path resolution a chance to land.
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+      expect(concurrentResolved).toBe(false);
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(false);
+
+      released.resolve();
+      await Promise.all([firstConnect, concurrentConnect]);
+      expect(concurrentResolved).toBe(true);
+      expect(sessionManager.getSession(BOUND_SESSION)?.hasReceivedHeartbeat).toBe(true);
+    } finally {
+      released.resolve();
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
   // AC3: connection establishment delivers exactly one first heartbeat — a
   // reconnect must not compound duplicates onto a fresh transport.
   test("delivers exactly one heartbeat on a single establishment", async () => {

--- a/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
+++ b/test/daemon/proxyBoundSessionFirstHeartbeat.test.ts
@@ -287,6 +287,61 @@ describe("proxy-bound session first heartbeat (issue #5637)", () => {
     }
   });
 
+  // issue #5643 (close race): because the `connected` flip is deferred until after
+  // the awaited first heartbeat, a close() landing DURING that round-trip must not be
+  // undone. doConnect() re-checks `closing` before the flip, so the proxy stays
+  // disconnected instead of resuming with a stale connected flag over a nulled client.
+  test("does not resurrect the connected flag when close() lands during the first heartbeat", async () => {
+    await sessionManager.createSession(BOUND_SESSION, "emulator-5554", "android", 60_000);
+
+    const released = Promise.withResolvers<void>();
+    let heartbeatObserved = false;
+    const fakeClient = new FakeDaemonClient({
+      onCallDaemonMethod: async (method, params) => {
+        if (method === "daemon/heartbeat" && typeof params.sessionId === "string") {
+          heartbeatObserved = true;
+          await released.promise;
+          sessionManager.recordHeartbeat(params.sessionId);
+        }
+      },
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      initialSessionUuid: BOUND_SESSION,
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer,
+    });
+
+    try {
+      // The establishing caller rejects when close() tears down the connection; the
+      // detached doConnect() must still not flip connected=true afterwards.
+      const connectResult = proxy.ensureConnected().then(
+        () => "resolved",
+        () => "rejected",
+      );
+
+      for (let i = 0; i < 50 && !heartbeatObserved; i++) {
+        await Promise.resolve();
+      }
+      expect(heartbeatObserved).toBe(true);
+
+      // Close while the first heartbeat is still gated in flight.
+      const closed = proxy.close();
+      released.resolve();
+      await closed;
+      expect(await connectResult).toBe("rejected");
+
+      // The flag must reflect the close, not the resumed establishment.
+      expect(proxy.isConnected()).toBe(false);
+    } finally {
+      released.resolve();
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
   // AC3: connection establishment delivers exactly one first heartbeat — a
   // reconnect must not compound duplicates onto a fresh transport.
   test("delivers exactly one heartbeat on a single establishment", async () => {


### PR DESCRIPTION
## Summary

`DaemonMcpProxy.doConnect()` set `this.connected = true` **before** it awaited the establishment heartbeat (`establishBoundSessionHeartbeat()`). Because `ensureConnected()` checks the `connected && client` fast path before the `connecting` guard, a **concurrent** `ensureConnected()` (e.g. a parallel `listTools`/`callTool` during MCP startup) could resolve and forward a request in the sub-millisecond window while the first ownership heartbeat was still in flight — i.e. before the daemon had recorded ownership. The establishment guarantee from [#5637](https://github.com/kaeawc/auto-mobile/issues/5637) therefore held for the caller that triggered `doConnect()` but not strictly for concurrent callers.

This defers marking the proxy `connected` until **after** the awaited first heartbeat lands, so concurrent callers wait on the `connecting` guard until ownership is recorded. The internal heartbeat guards are switched from `this.connected` to a new `transportLive` getter (`this.client !== null`) so the first heartbeat still fires while `connected` is deliberately still `false` during that window.

The obvious naive fix disturbs the reconnect ordering pinned by [#2737](https://github.com/kaeawc/auto-mobile/issues/2737)/[#4610](https://github.com/kaeawc/auto-mobile/issues/4610): on a **reconnect** the keeper's void-dispatched heartbeat re-enters `ensureConnected()` and must short-circuit on the fast path so it lands on the fresh transport before the retried operation. Since ownership was already recorded by the first establishment, there is nothing to hold concurrent callers behind on a reconnect — so `establishBoundSessionHeartbeat()` flips `connected` early in its keeper-already-started branch, preserving that ordering. Only the **first** establishment defers the flip.

## Linked Issue

Closes #5643

## Bug / Regression Context

- **Prior attempts:** [#5642](https://github.com/kaeawc/auto-mobile/pull/5642) (closes #5637) made the first heartbeat an awaited step of establishment; it fixed the single-caller guarantee but left the concurrent-caller window open (raised by Codex, P1, deferred from that PR).
- **Observed symptom:** a concurrent discovery/tool call during MCP startup could forward to the daemon before the first ownership heartbeat was recorded. The window is sub-millisecond and stays within the pre-first-heartbeat grace, so it did not reproduce the `missing-first-heartbeat` reap #5637 fixed — but the establishment contract was not strictly held for concurrent callers.
- **Repro steps / conditions:** two concurrent `ensureConnected()` (or a first tool/discovery call) racing the in-flight establishment heartbeat.

## Changes

- `src/daemon/daemonMcpProxy.ts`: defer `connected = true` to after `establishBoundSessionHeartbeat()` on first establishment; add `transportLive` getter and key the first-heartbeat/keeper guards off it; flip `connected` early in the reconnect (keeper-started) branch to preserve #2737/#4610 ordering.
- `test/daemon/proxyBoundSessionFirstHeartbeat.test.ts`: new test asserting a concurrent `ensureConnected()` during the in-flight first heartbeat does not resolve until ownership is recorded.

## Validation

- [x] `bun test` — full suite green (only pre-existing `oxlintConfigScoping.test.ts` failure from a missing `node_modules/.bin/oxlint` binary in this worktree, unrelated)
- [x] `bun run lint` — oxlint ratchet: no new violations
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run format:check` — clean
- [x] New test uses interfaces + fakes + FakeTimer; runs in <100ms

## Acceptance Criteria

- [x] A concurrent `ensureConnected()` (or first tool/discovery call) invoked while the establishment heartbeat is in flight does not resolve until the daemon has recorded the first ownership heartbeat.
- [x] Existing reconnect re-seed ordering (#2737, #4610) is preserved.
