### PR TITLE
fix(snapshot): fail iOS capture when 0 requested bundles are backed up (#5710)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -222,6 +222,7 @@ Used for physical Android devices and for emulator captures with
 - Simulator-wide `simctl snapshot` is intentionally not used for portability
 - Each requested bundle ID is validated up front (installed via `simctl listapps`, has a data container via `get_app_container … data`) and reported with a per-bundle status — `captured`, `skipped-no-container`, `not-installed`, or `failed` — in `appDataBackup.bundleStatuses` and at the top level of the capture tool result (`bundleStatuses`), rather than silently "succeeding"
 - Capture with `includeAppData: true` but no usable `appBundleIds` (empty or all blank) is rejected with an `ActionableError` — pass explicit bundle IDs, or set `includeAppData: false` for a settings-only snapshot
+- Capture with `includeAppData: true` where **0** of the requested bundles are actually backed up (every one not-installed, container-less, or failed) is rejected with an `ActionableError` naming the requested set and what failed/was skipped — this holds regardless of `strictBackupMode`, so an empty backup can no longer report "captured successfully" (issue #5710). A mixed set with at least one captured bundle still succeeds; settings-only captures (`includeAppData: false`) are unaffected
 
 ## Storage Location
 

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -499,6 +499,29 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
       );
     }
 
+    // When app data was requested but nothing was actually captured, the
+    // snapshot is empty — reporting "success" hides the failure until the caller
+    // digs into manifest.appDataBackup. Fail loudly instead (issue #5710). This
+    // fires regardless of strictBackupMode: an all-skipped set (e.g. a system app
+    // with no data container) has no failedPackages yet still captures nothing.
+    if (backedUpPackages.length === 0) {
+      const parts = [
+        `iOS app-data capture backed up 0 of ${sanitized.length} requested app(s) ` +
+          `(${sanitized.join(", ")}).`,
+      ];
+      if (failedPackages.length > 0) {
+        parts.push(`Failed: ${failedPackages.join(", ")}.`);
+      }
+      if (skippedPackages.length > 0) {
+        parts.push(`Skipped (no data container): ${skippedPackages.join(", ")}.`);
+      }
+      parts.push(
+        "Pass appBundleIds for installed apps that have a data container, or set " +
+          "includeAppData:false for a settings-only snapshot.",
+      );
+      throw new ActionableError(parts.join(" "));
+    }
+
     return {
       backupMethod: "simctl_copy",
       totalPackages: sanitized.length,

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -722,6 +722,86 @@ describe("CaptureSnapshot (iOS)", () => {
     ).rejects.toThrow("Failed to backup app data");
   });
 
+  it("fails the capture when every requested bundle is not installed (0 captured)", async () => {
+    // No installed apps: com.fake.doesnotexist resolves to not-installed, so
+    // backedUpPackages is empty. Before #5710 this "succeeded" with an empty
+    // backup; now it must be an ActionableError that names what failed.
+    simctl.setInstalledApps([{ CFBundleIdentifier: "com.example.other" }]);
+    const captureSnapshot = makeCapture();
+
+    const promise = captureSnapshot.execute({
+      snapshotName: "all-failed",
+      includeAppData: true,
+      appBundleIds: ["com.fake.doesnotexist"],
+    });
+
+    await expect(promise).rejects.toThrow(/com\.fake\.doesnotexist/);
+    // Names what was requested vs. what failed (AC3).
+    await expect(promise).rejects.toThrow(/backed up 0 of 1/i);
+  });
+
+  it("fails the capture when the only requested bundle has no data container (0 captured)", async () => {
+    // A system app that is installed but exposes no simctl-accessible container
+    // (e.g. com.apple.Preferences). It is skipped, not failed, but 0 packages
+    // are captured, so the capture must fail rather than report success.
+    simctl.setInstalledApps([{ CFBundleIdentifier: "com.apple.Preferences" }]);
+    const captureSnapshot = makeCapture();
+
+    const promise = captureSnapshot.execute({
+      snapshotName: "no-container",
+      includeAppData: true,
+      appBundleIds: ["com.apple.Preferences"],
+    });
+
+    await expect(promise).rejects.toThrow(/com\.apple\.Preferences/);
+    await expect(promise).rejects.toThrow(/backed up 0 of 1/i);
+  });
+
+  it("succeeds when at least one bundle is captured in a mixed set", async () => {
+    // Mixed/partial policy (non-strict): one captured, one skipped-no-container,
+    // one not-installed. backedUpPackages is non-empty, so the capture succeeds.
+    const captured = "com.example.captured";
+    const noContainer = "com.example.nocontainer";
+    const notInstalled = "com.example.missing";
+
+    const containerRoot = path.join(testBasePath, "containers", captured);
+    await fs.mkdir(path.join(containerRoot, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(containerRoot, "Documents", "data.txt"), "hello");
+
+    simctl.setContainerPath(captured, containerRoot);
+    simctl.setInstalledApps([
+      { CFBundleIdentifier: captured },
+      { CFBundleIdentifier: noContainer },
+    ]);
+
+    const captureSnapshot = makeCapture();
+    const result = await captureSnapshot.execute({
+      snapshotName: "mixed",
+      includeAppData: true,
+      includeSettings: false,
+      appBundleIds: [captured, noContainer, notInstalled],
+    });
+
+    expect(result.manifest.appDataBackup?.backedUpPackages).toEqual([captured]);
+    expect(result.manifest.appDataBackup?.failedPackages).toEqual([notInstalled]);
+  });
+
+  it("succeeds for a settings-only capture even when no app data would back up", async () => {
+    // includeAppData:false never touches captureIosAppData, so the 0-captured
+    // guard must not fire for legitimate settings-only snapshots (AC2).
+    simctl.setInstalledApps([]);
+    const captureSnapshot = makeCapture();
+
+    const result = await captureSnapshot.execute({
+      snapshotName: "settings-only",
+      includeAppData: false,
+      includeSettings: true,
+    });
+
+    expect(result.manifest.includeAppData).toBe(false);
+    expect(result.manifest.appDataBackup).toBeUndefined();
+  });
+
   it("captures iOS settings (locale + UI) into the manifest when includeSettings", async () => {
     simctl.setCommandArgsResult(
       ["spawn", device.deviceId, "defaults", "read", ".GlobalPreferences", "AppleLocale"],

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -152,9 +152,9 @@ describe("deviceSnapshotManager", () => {
       }),
     });
 
-    await expect(
-      captureDeviceSnapshot(TEST_DEVICE, { includeAppData: true }),
-    ).rejects.toThrow(/backed up 0 of 1/i);
+    await expect(captureDeviceSnapshot(TEST_DEVICE, { includeAppData: true })).rejects.toThrow(
+      /backed up 0 of 1/i,
+    );
 
     expect(await repository.getSnapshot("doomed-snapshot")).toBeNull();
     const listed = await repository.listSnapshots();

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import * as os from "os";
 import type { BootedDevice, DeviceSnapshotConfig, DeviceSnapshotManifest } from "../../src/models";
+import { ActionableError } from "../../src/models";
 import {
   captureDeviceSnapshot,
   getDeviceSnapshotConfig,
@@ -137,6 +138,27 @@ describe("deviceSnapshotManager", () => {
 
     const inserted = await repository.getSnapshot("new-snapshot");
     expect(inserted?.sizeBytes).toBe(700 * 1024);
+  });
+
+  test("captureDeviceSnapshot inserts no record when the capture fails (#5710)", async () => {
+    // A capture that fails (e.g. iOS 0-packages-captured) throws before the
+    // manager shapes a result, so no snapshot record must be persisted.
+    store.queueGeneratedName("doomed-snapshot");
+    await setDeviceSnapshotManagerDependencies({
+      createCaptureProvider: () => ({
+        capture: async () => {
+          throw new ActionableError("iOS app-data capture backed up 0 of 1 requested app(s)");
+        },
+      }),
+    });
+
+    await expect(
+      captureDeviceSnapshot(TEST_DEVICE, { includeAppData: true }),
+    ).rejects.toThrow(/backed up 0 of 1/i);
+
+    expect(await repository.getSnapshot("doomed-snapshot")).toBeNull();
+    const listed = await repository.listSnapshots();
+    expect(listed).toEqual([]);
   });
 
   test("restoreDeviceSnapshot touches lastAccessedAt and forwards manifest", async () => {


### PR DESCRIPTION
## Summary

`deviceSnapshot capture` reported "captured successfully" even when nothing was actually backed up — the failure was only visible if the caller dug into `manifest.appDataBackup`. When `includeAppData` is requested with a non-empty `appBundleIds` set but **0** of those bundles are actually captured (every one not-installed, container-less, or failed to copy), `captureIosAppData` now throws an `ActionableError` that names the requested set and what failed/was skipped, instead of shaping a success result over an empty backup.

This holds regardless of `strictBackupMode` — an all-skipped set (e.g. a system app like `com.apple.Preferences` with no simctl-accessible container) has no `failedPackages` yet still captures nothing, so it must fail too. A mixed set with at least one captured bundle still succeeds (partial policy), and settings-only captures (`includeAppData:false`) are unaffected.

## Linked Issue

Closes #5710

## Bug / Regression Context

- **Prior attempts:** #5712 rejected empty/blank `appBundleIds` up front; this closes the remaining gap where a non-empty request still captured nothing.
- **Observed symptom:** iOS `appBundleIds:["com.fake.doesnotexist"]` → `{backedUpPackages:[], failedPackages:["com.fake.doesnotexist"]}` but tool message = "captured successfully". Same for `com.apple.Preferences` (0 B `app-data/`).
- **Repro steps / conditions:** `deviceSnapshot capture` with `includeAppData:true` and only uninstalled / container-less bundles.

## Changes

- `src/features/action/CaptureSnapshot.ts` — after the strict-mode check, throw `ActionableError` when `backedUpPackages.length === 0`, naming requested/failed/skipped bundles.
- `docs/design-docs/mcp/storage/snapshots.md` — documented the new failure condition.
- Tests: all-failed bundles, a system app with no container, a mixed set that still succeeds, a settings-only capture that still succeeds, and a manager-level test asserting no snapshot record is persisted on capture failure.

## Validation

- [x] `bun test` — new + existing snapshot suites green (the one repo-wide failure is `test/lint/oxlintConfigScoping.test.ts`, a pre-existing `.claude/worktrees` `node_modules/.bin/oxlint` ENOENT artifact, unrelated to this diff)
- [x] `bun run lint` — ratchet gate: no new violations
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Acceptance Criteria

- [x] `includeAppData` requested + 0 captured (non-empty requested set) → `ActionableError` instead of success
- [x] Settings-only captures (`includeAppData:false`) still succeed
- [x] Error names what was requested vs. what failed (surfaces `failedPackages`)
- [x] Tests cover all-failed bundles, a system app with no container, and a mixed set
