### PR TITLE
fix(snapshot): scope Android snapshots by AVD name (#5707)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -227,12 +227,20 @@ Used for physical Android devices and for emulator captures with
 
 Snapshot payloads are stored in `~/.auto-mobile/snapshots/` (settings-only Android snapshots), and metadata is tracked in SQLite at `~/.auto-mobile/auto-mobile.db`:
 
+Android emulator settings-only snapshots are scoped by AVD name — unique
+(avdmanager enforces one AVD per name) and stable across reboots, unlike the
+port-based emulator serial — so the same snapshot name can be reused across
+AVDs without a filesystem collision. Physical Android devices have no AVD name
+and keep the unscoped path.
+
 ```text
 ~/.auto-mobile/snapshots/
-├── Pixel_5_2026-01-08_12-30-45/
-│   └── settings.json          # Device settings (settings-only snapshots)
-└── another-snapshot/
-    └── ...
+├── android/
+│   └── <avd-name>/             # e.g. Pixel_5
+│       └── <snapshot-name>/
+│           └── settings.json   # Device settings (settings-only snapshots)
+└── <snapshot-name>/            # physical Android (no AVD name) — unscoped
+    └── settings.json
 ```
 
 VM snapshots themselves are stored in the emulator AVD directory and persist across emulator restarts. Automatic cleanup removes AutoMobile metadata and host snapshot payloads, but does not delete the emulator's VM snapshot.

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -353,13 +353,27 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
    * Save settings to snapshot directory
    */
   private async saveSettings(snapshotName: string, settings: any): Promise<void> {
-    // Ensure snapshot directory exists before writing
-    const snapshotDir = this.store.getSnapshotPath(snapshotName);
+    // Ensure snapshot directory exists before writing. Android emulator
+    // snapshots are scoped by AVD name so the same name can be reused across
+    // AVDs without colliding on disk (#5707).
+    const pathOptions = this.getAndroidPathOptions();
+    const snapshotDir = this.store.getSnapshotPathWithOptions(snapshotName, pathOptions);
     await fs.mkdir(snapshotDir, { recursive: true });
 
-    const settingsPath = this.store.getSettingsPath(snapshotName);
+    const settingsPath = this.store.getSettingsPath(snapshotName, pathOptions);
     await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
     logger.info(`Saved settings to ${settingsPath}`);
+  }
+
+  /**
+   * AVD-scoped path options for Android emulator snapshots. Returns undefined
+   * for physical Android devices (no AVD name), which keep the unscoped path.
+   */
+  private getAndroidPathOptions(): SnapshotPathOptions | undefined {
+    if (this.device.deviceId.startsWith("emulator-")) {
+      return { platform: "android", avdName: this.device.name };
+    }
+    return undefined;
   }
 
   private async executeIos(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -78,11 +78,23 @@ interface DeviceSnapshotManagerDependencies {
 let moduleDependencies: DeviceSnapshotManagerDependencies | null = null;
 const LEGACY_MANIFEST_FILENAME = "manifest.json";
 
-function getSnapshotPathOptions(
-  context: Pick<BootedDevice, "platform" | "deviceId">,
-): SnapshotPathOptions | undefined {
+function getSnapshotPathOptions(context: {
+  platform?: string;
+  deviceId?: string;
+  avdName?: string;
+}): SnapshotPathOptions | undefined {
   if (context.platform === "ios") {
     return { platform: "ios", deviceId: context.deviceId };
+  }
+  // Android emulator snapshots are scoped on disk by AVD name (stable + unique),
+  // never the port-based serial. Physical Android devices have no AVD name and
+  // fall through to the unscoped path (#5707).
+  if (
+    context.platform === "android" &&
+    context.deviceId?.startsWith("emulator-") &&
+    context.avdName
+  ) {
+    return { platform: "android", avdName: context.avdName };
   }
   return undefined;
 }
@@ -370,7 +382,12 @@ async function ensureSnapshotAvailable(
 
 async function deleteDeviceSnapshotRecord(record: DeviceSnapshotRecord): Promise<boolean> {
   const { snapshotRepository, snapshotStore } = await getDeviceSnapshotDependencies();
-  const pathOptions = getSnapshotPathOptions(record);
+  const pathOptions = getSnapshotPathOptions({
+    platform: record.platform,
+    deviceId: record.deviceId,
+    // For Android, deviceName holds the AVD name (see the capture manifest).
+    avdName: record.deviceName,
+  });
   await snapshotStore.deleteSnapshotData(record.snapshotName, pathOptions);
   const deleted = await snapshotRepository.deleteSnapshot(record.snapshotName);
   return deleted;
@@ -475,7 +492,13 @@ export async function captureDeviceSnapshot(
 
   const baseConfig = await getDeviceSnapshotConfig();
   const snapshotName = args.snapshotName ?? snapshotStore.generateSnapshotName(device.name);
-  const pathOptions = getSnapshotPathOptions(device);
+  const pathOptions = getSnapshotPathOptions({
+    platform: device.platform,
+    deviceId: device.deviceId,
+    // For an Android emulator, BootedDevice.name is the AVD name resolved via
+    // `adb emu avd name` during discovery.
+    avdName: device.name,
+  });
 
   await ensureSnapshotAvailable(snapshotName, snapshotStore, snapshotRepository, pathOptions);
 

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -389,8 +389,28 @@ async function deleteDeviceSnapshotRecord(record: DeviceSnapshotRecord): Promise
     avdName: record.deviceName,
   });
   await snapshotStore.deleteSnapshotData(record.snapshotName, pathOptions);
+  // Snapshots captured before AVD-scoping (#5707) — including any created in the
+  // ~/.auto-mobile base-path window between #5716 and this change — keep their
+  // data at the unscoped flat path. Eviction now computes the scoped path, which
+  // misses that data: the row would be deleted and its bytes reported reclaimed
+  // while the flat directory survives (and, if it holds a legacy manifest.json,
+  // listDeviceSnapshots re-imports it, so the archive limit can never evict it).
+  // When scoping applied, also clear the flat path — but never a reserved scope
+  // root (a snapshot literally named "android"/"ios", whose flat path IS the
+  // scope tree); name sanitization is tracked separately (#5705).
+  if (pathOptions && !isReservedScopeSegment(record.snapshotName)) {
+    await snapshotStore.deleteSnapshotData(record.snapshotName);
+  }
   const deleted = await snapshotRepository.deleteSnapshot(record.snapshotName);
   return deleted;
+}
+
+// Top-level segments the store uses to scope snapshots by platform/device. A
+// snapshot whose name equals one of these resolves its flat path to the scope
+// root, so the legacy flat-path cleanup must skip it to avoid deleting the whole
+// scope tree.
+function isReservedScopeSegment(snapshotName: string): boolean {
+  return snapshotName === "android" || snapshotName === "ios";
 }
 
 async function enforceDeviceSnapshotArchiveLimit(

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -366,6 +366,17 @@ async function ensureSnapshotAvailable(
   snapshotRepository: DeviceSnapshotRepository,
   pathOptions?: SnapshotPathOptions,
 ): Promise<void> {
+  // "android"/"ios" are the platform scope roots under the snapshots dir. An
+  // unscoped (physical / fallback) snapshot with one of those names would take
+  // the scope directory itself, so deleting it later would recursively remove
+  // every scoped snapshot nested under it. Reject the collision at the source
+  // (#5707); broader snapshotName sanitization is tracked in #5705.
+  if (isReservedScopeSegment(snapshotName)) {
+    throw new ActionableError(
+      `Snapshot name '${snapshotName}' is reserved. Please choose a different name.`,
+    );
+  }
+
   const existing = await snapshotRepository.getSnapshot(snapshotName);
   if (existing) {
     throw new ActionableError(

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -7,6 +7,13 @@ import type { Platform } from "../models";
 export interface SnapshotPathOptions {
   platform?: Platform;
   deviceId?: string;
+  /**
+   * Android AVD name. Android snapshots are keyed by AVD name — unique
+   * (avdmanager enforces one AVD per name) and stable across reboots, unlike the
+   * port-based emulator serial. Only set for emulator snapshots; physical
+   * Android devices have no AVD name and fall back to the unscoped path (#5707).
+   */
+  avdName?: string;
 }
 
 export class DeviceSnapshotStore {
@@ -36,6 +43,12 @@ export class DeviceSnapshotStore {
   getSnapshotPathWithOptions(snapshotName: string, options?: SnapshotPathOptions): string {
     if (options?.platform === "ios" && options.deviceId) {
       return path.join(this.basePath, "ios", options.deviceId, snapshotName);
+    }
+
+    // Android emulators scope by AVD name so the same snapshot name can be
+    // reused across AVDs without a filesystem collision (#5707).
+    if (options?.platform === "android" && options.avdName) {
+      return path.join(this.basePath, "android", options.avdName, snapshotName);
     }
 
     return this.getSnapshotPath(snapshotName);

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -395,8 +395,18 @@ describe("CaptureSnapshot", () => {
       expect(result.manifest.settings?.secure).toEqual({ android_id: "abc123" });
       expect(result.manifest.settings?.system).toEqual({ screen_brightness: "128" });
 
-      // Verify settings were written to file
-      const settingsPath = store.getSettingsPath(snapshotName);
+      // Verify settings were written to the AVD-scoped path (#5707): the
+      // emulator's AVD name (device.name) keys the on-disk directory.
+      expect(device.name).toBe("Pixel_5");
+      const settingsPath = store.getSettingsPath(snapshotName, {
+        platform: "android",
+        avdName: device.name,
+      });
+      // Literal AVD segment (not `device.name`) so the native-source cache guard
+      // does not read this as a reference to the on-disk `android/` tree (#4351).
+      expect(settingsPath).toBe(
+        path.join(testBasePath, "android", "Pixel_5", snapshotName, "settings.json"),
+      );
       const settingsContent = await fs.readFile(settingsPath, "utf-8");
       const settings = JSON.parse(settingsContent);
       expect(settings.global).toEqual({ airplane_mode_on: "0" });

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -393,4 +393,107 @@ describe("deviceSnapshotManager", () => {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  test("evicting a legacy FLAT Android emulator snapshot reclaims the flat directory (#5707/#5724)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-legacy-flat-"));
+    try {
+      const realStore = new DeviceSnapshotStore(tempRoot);
+      await realStore.ensureSnapshotsDirectory();
+      await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+      const snapshotName = "legacy-flat";
+      const avdName = "Pixel_5";
+      const emulatorDeviceId = "emulator-5554";
+
+      // Pre-scoping data lives at the UNSCOPED flat path. Eviction computes the
+      // scoped path from the record; without the flat-path fallback it would
+      // fs.rm a nonexistent dir, delete the row, report bytes reclaimed, and
+      // leave this directory (and its re-importable manifest) on disk.
+      const flatDir = realStore.getSnapshotPath(snapshotName);
+      await fs.mkdir(flatDir, { recursive: true });
+      await fs.writeFile(path.join(flatDir, "settings.json"), "{}");
+
+      const timestamp = new Date(fakeTimer.now()).toISOString();
+      const manifest: DeviceSnapshotManifest = {
+        snapshotName,
+        timestamp,
+        deviceId: emulatorDeviceId,
+        deviceName: avdName,
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+      };
+      await repository.insertSnapshot({
+        snapshotName,
+        deviceId: emulatorDeviceId,
+        deviceName: avdName,
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+        createdAt: timestamp,
+        lastAccessedAt: timestamp,
+        sizeBytes: 5 * 1024 * 1024,
+        manifest,
+      });
+
+      await updateDeviceSnapshotConfig({ maxArchiveSizeMb: 1 });
+
+      // The flat directory is actually gone — eviction did not silently under-reclaim.
+      expect(await realStore.snapshotDirectoryExists(snapshotName)).toBe(false);
+      expect(await repository.getSnapshot(snapshotName)).toBeNull();
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("legacy flat-path cleanup never deletes a reserved scope root (#5707)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-reserved-"));
+    try {
+      const realStore = new DeviceSnapshotStore(tempRoot);
+      await realStore.ensureSnapshotsDirectory();
+      await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+      // A different AVD's real snapshot living under the "android" scope root.
+      const other = { platform: "android" as const, avdName: "Pixel_7" };
+      const otherDir = realStore.getSnapshotPathWithOptions("keep-me", other);
+      await fs.mkdir(otherDir, { recursive: true });
+      await fs.writeFile(path.join(otherDir, "settings.json"), "{}");
+
+      // A pathological snapshot literally named "android": its flat path is the
+      // scope root that holds `otherDir`. Evicting it must not wipe that tree.
+      const timestamp = new Date(fakeTimer.now()).toISOString();
+      const manifest: DeviceSnapshotManifest = {
+        snapshotName: "android",
+        timestamp,
+        deviceId: "emulator-5554",
+        deviceName: "Pixel_5",
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+      };
+      await repository.insertSnapshot({
+        snapshotName: "android",
+        deviceId: "emulator-5554",
+        deviceName: "Pixel_5",
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+        createdAt: timestamp,
+        lastAccessedAt: timestamp,
+        sizeBytes: 5 * 1024 * 1024,
+        manifest,
+      });
+
+      await updateDeviceSnapshotConfig({ maxArchiveSizeMb: 1 });
+
+      // The unrelated AVD's snapshot under the scope root survives.
+      expect(await realStore.snapshotDirectoryExists("keep-me", other)).toBe(true);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -448,6 +448,14 @@ describe("deviceSnapshotManager", () => {
     }
   });
 
+  test("captureDeviceSnapshot rejects a reserved scope-root name (#5707)", async () => {
+    for (const reserved of ["android", "ios"]) {
+      await expect(captureDeviceSnapshot(TEST_DEVICE, { snapshotName: reserved })).rejects.toThrow(
+        /reserved/i,
+      );
+    }
+  });
+
   test("legacy flat-path cleanup never deletes a reserved scope root (#5707)", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-reserved-"));
     try {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -10,6 +10,7 @@ import {
   resetDeviceSnapshotManagerDependencies,
   restoreDeviceSnapshot,
   setDeviceSnapshotManagerDependencies,
+  updateDeviceSnapshotConfig,
 } from "../../src/server/deviceSnapshotManager";
 import { DeviceSnapshotStore } from "../../src/utils/DeviceSnapshotStore";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -334,5 +335,62 @@ describe("deviceSnapshotManager", () => {
 
     expect(config.vmSnapshotTimeoutMs).toBeGreaterThan(0);
     expect(config.vmSnapshotTimeoutMs).toBe(30000);
+  });
+
+  test("evicting an Android emulator snapshot deletes its AVD-scoped directory (#5707)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-avd-"));
+    try {
+      const realStore = new DeviceSnapshotStore(tempRoot);
+      await realStore.ensureSnapshotsDirectory();
+      await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+      const snapshotName = "evict-me";
+      const avdName = "Pixel_5";
+      const emulatorDeviceId = "emulator-5554";
+      const androidOptions = { platform: "android" as const, avdName };
+
+      // Write the snapshot on disk at the AVD-scoped path — where capture puts it.
+      const scopedDir = realStore.getSnapshotPathWithOptions(snapshotName, androidOptions);
+      await fs.mkdir(scopedDir, { recursive: true });
+      await fs.writeFile(path.join(scopedDir, "settings.json"), "{}");
+      // The legacy flat path must NOT be where this snapshot lives.
+      const flatDir = realStore.getSnapshotPath(snapshotName);
+      expect(scopedDir).not.toBe(flatDir);
+
+      const timestamp = new Date(fakeTimer.now()).toISOString();
+      const manifest: DeviceSnapshotManifest = {
+        snapshotName,
+        timestamp,
+        deviceId: emulatorDeviceId,
+        deviceName: avdName,
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+      };
+      await repository.insertSnapshot({
+        snapshotName,
+        deviceId: emulatorDeviceId,
+        deviceName: avdName,
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+        createdAt: timestamp,
+        lastAccessedAt: timestamp,
+        sizeBytes: 5 * 1024 * 1024,
+        manifest,
+      });
+
+      // Force eviction by lowering the archive limit below the record size.
+      await updateDeviceSnapshotConfig({ maxArchiveSizeMb: 1 });
+
+      // The AVD-scoped directory is deleted — the manager resolved the path from
+      // the record's deviceName (the AVD name), not the flat/legacy path.
+      expect(await realStore.snapshotDirectoryExists(snapshotName, androidOptions)).toBe(false);
+      expect(await repository.getSnapshot(snapshotName)).toBeNull();
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/utils/deviceSnapshotStore.test.ts
+++ b/test/utils/deviceSnapshotStore.test.ts
@@ -73,6 +73,50 @@ describe("DeviceSnapshotStore", () => {
     );
   });
 
+  it("should return Android snapshot paths scoped by AVD name (#5707)", () => {
+    const options = { platform: "android" as const, avdName: "Pixel_5" };
+    expect(store.getSnapshotPathWithOptions("test-snapshot", options)).toBe(
+      path.join(testBasePath, "android", "Pixel_5", "test-snapshot"),
+    );
+    expect(store.getSettingsPath("test-snapshot", options)).toBe(
+      path.join(testBasePath, "android", "Pixel_5", "test-snapshot", "settings.json"),
+    );
+    expect(store.getMetadataPath("test-snapshot", options)).toBe(
+      path.join(testBasePath, "android", "Pixel_5", "test-snapshot", "metadata.json"),
+    );
+    expect(store.getAppDataPath("test-snapshot", options)).toBe(
+      path.join(testBasePath, "android", "Pixel_5", "test-snapshot", "app_data"),
+    );
+  });
+
+  it("falls back to the unscoped path for Android without an AVD name (physical device) (#5707)", () => {
+    const options = { platform: "android" as const };
+    expect(store.getSnapshotPathWithOptions("test-snapshot", options)).toBe(
+      path.join(testBasePath, "test-snapshot"),
+    );
+  });
+
+  it("isolates same-named Android snapshots across two AVDs on disk (#5707)", async () => {
+    const snapshotName = "shared-name";
+    const avdA = { platform: "android" as const, avdName: "Pixel_5" };
+    const avdB = { platform: "android" as const, avdName: "Pixel_7" };
+
+    // Capture "shared-name" on AVD A only.
+    await fs.mkdir(store.getSnapshotPathWithOptions(snapshotName, avdA), { recursive: true });
+
+    // AVD A sees it; AVD B does not — the name is reusable across devices.
+    expect(await store.snapshotDirectoryExists(snapshotName, avdA)).toBe(true);
+    expect(await store.snapshotDirectoryExists(snapshotName, avdB)).toBe(false);
+
+    // Deleting AVD B's (nonexistent) snapshot must not remove AVD A's data.
+    await store.deleteSnapshotData(snapshotName, avdB);
+    expect(await store.snapshotDirectoryExists(snapshotName, avdA)).toBe(true);
+
+    // Deleting AVD A's snapshot removes only AVD A's data.
+    await store.deleteSnapshotData(snapshotName, avdA);
+    expect(await store.snapshotDirectoryExists(snapshotName, avdA)).toBe(false);
+  });
+
   it("should detect snapshot directories", async () => {
     const snapshotName = "snapshot-exists";
     expect(await store.snapshotDirectoryExists(snapshotName)).toBe(false);


### PR DESCRIPTION
## Summary

Android device snapshots were stored flat by name (`~/.auto-mobile/snapshots/<name>`) — **not scoped by device** — whereas iOS was already scoped (`snapshots/ios/<deviceId>/<name>`). As a result the same snapshot name could not be reused across two Android devices without an on-disk collision.

This scopes Android **emulator** snapshots by **AVD name**, which is unique (avdmanager enforces one AVD per name in `~/.android/avd/`) and stable across reboots — unlike the port-based emulator serial, which changes each boot. The store path becomes `snapshots/android/<avdName>/<name>`, mirroring the iOS layout. This also matches VM-snapshot semantics: the VM snapshot lives inside the AVD (`adb emu avd snapshot save`), so it only restores onto the same AVD anyway.

The AVD name is the value already resolved via `adb emu avd name` during device discovery and carried as `BootedDevice.name` (`AndroidEmulatorClient.getRunningAVDName`); at delete/evict time it is recovered from the snapshot record's `deviceName`. Physical Android devices have no AVD name and keep the unscoped path.

## Linked Issue

Closes #5707

## Changes

- `DeviceSnapshotStore`: add `avdName` to `SnapshotPathOptions`; `getSnapshotPathWithOptions` returns `android/<avdName>/<name>` for Android emulator snapshots (settings/metadata/app-data paths derive from it).
- `deviceSnapshotManager.getSnapshotPathOptions`: resolve the Android AVD name from `device.name` (capture) / `record.deviceName` (delete/evict), gated on an `emulator-` serial so physical devices fall through to the unscoped path.
- `CaptureSnapshot`: the settings-only Android path writes to the AVD-scoped directory.

## Bug / Regression Context

- **Observed symptom:** capturing the same snapshot name on a second Android device failed with an on-disk "already exists" collision; the flat path could not distinguish two AVDs.
- **Conditions:** two Android emulators (different AVDs) sharing a snapshot name.

## Validation

- [x] `bun test` — whole suite green (14402 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` ratchet — no new violations; `oxfmt --check` clean
- [x] `turbo run build` succeeds
- [x] New tests use interfaces + fakes + FakeTimer; run in <100ms

### Acceptance criteria → tests

- **Android keyed by AVD name; path `snapshots/android/<avdName>/<name>`** → `test/utils/deviceSnapshotStore.test.ts` ("android paths scoped by AVD name").
- **Same name reusable across two AVDs without on-disk collision** → `deviceSnapshotStore.test.ts` ("isolates same-named Android snapshots across two AVDs") + `deviceSnapshotManager.test.ts` (evict deletes the AVD-scoped dir, not the flat path).
- **Capture writes to the scoped path; physical devices keep the unscoped path** → `test/features/action/CaptureSnapshot.test.ts` + `deviceSnapshotStore.test.ts` fallback case.

## Notes

The cross-device **database** collision (`snapshot_name` primary key rejecting a reused name regardless of device) is a separate milestone-35 item ("auto-overwrite existing snapshot names") and is intentionally out of scope here — this PR fixes only the filesystem store-path scoping. No DB schema/migration change; legacy flat snapshots remain importable.
