### PR TITLE
perf(ci): pull inline Ubuntu BATS out of Fast Validation (~300s → ~90s)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -824,9 +824,11 @@ jobs:
             --only yaml,xml,bun-version-coherence,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,sharp-matrix,runtime-pins,shell-quote-boundary,security-boundary,app-bundle-metadata-boundary,ios-ctrl-proxy-process-boundary,mkdocs-nav,ktfmt,claude-plugin,codex-skills,github-python-lock \
             --max-parallel 4
 
-      - name: "Run BATS Tests (Ubuntu)"
-        shell: bash
-        run: bats test/bats/
+      # The BATS suite (913 tests, ~3.5min serially) is NOT run here. It ran a
+      # full Ubuntu pass inline and dominated this required gate's wall-clock; the
+      # Ubuntu coverage now lives in the `bats-tests` matrix job (mirroring
+      # merge.yml), gated by the required "Shell Tests" roll-up and running in
+      # parallel instead of on this job's critical path.
 
       # Drift gate for the generated iOS runner version constant (#2814). Pure
       # bash + python3, so it runs on this Ubuntu job rather than the macOS Swift
@@ -948,7 +950,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        # Ubuntu was folded in here (#5643-era Fast Validation split): the Ubuntu
+        # BATS pass used to run inline inside the required Fast Validation job and
+        # dominated its wall-clock. It now runs as a parallel matrix leg, matching
+        # merge.yml, and is gated by the required "Shell Tests" roll-up.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6

--- a/test/scripts/batsInstallHoist.test.ts
+++ b/test/scripts/batsInstallHoist.test.ts
@@ -13,9 +13,9 @@ import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers
 // required check, so the barrier placement is pinned here rather than left to
 // review.
 //
-// Scoped by job id, which matters: pull_request.yml ALSO runs bats inside
-// `fast-validation` (as "Run BATS Tests (Ubuntu)"), and a whole-file search
-// would conflate the two.
+// Scoped by job id, which matters: the `bats-tests` job now runs the suite on
+// both ubuntu-latest and macos-latest (the Ubuntu pass used to run inline inside
+// `fast-validation`), and a whole-file search could conflate jobs.
 
 const JOB_ID = "bats-tests";
 const INSTALL_STEP = "Install BATS";

--- a/test/scripts/fastValidationDepsHoist.test.ts
+++ b/test/scripts/fastValidationDepsHoist.test.ts
@@ -52,19 +52,18 @@ describe("#4125 fast-validation dependency install hoist", () => {
     expect(installIndex).toBeLessThan(npmPackageIndex);
   });
 
-  test("the wait barrier precedes the fast validation checks and the BATS step", () => {
-    // AC2: the aggregator's `xml` check shells out to xmlstarlet, and the BATS
-    // step needs bats — both come from the backgrounded install.
+  test("the wait barrier precedes the fast validation checks", () => {
+    // AC2: the aggregator's `xml` check shells out to xmlstarlet, which comes
+    // from the backgrounded install, so the barrier must sit before it. (The
+    // Ubuntu BATS pass that also consumed this install now runs in the parallel
+    // `bats-tests` matrix job, not inline here.)
     const waitIndex = indexOfWaitOn(steps, INSTALL_ID);
     const checksIndex = indexOfNamed(steps, "Run fast validation checks");
-    const batsIndex = indexOfNamed(steps, "Run BATS Tests (Ubuntu)");
 
     expect(waitIndex).toBeGreaterThanOrEqual(0);
     expect(checksIndex).toBeGreaterThanOrEqual(0);
-    expect(batsIndex).toBeGreaterThanOrEqual(0);
 
     expect(waitIndex).toBeLessThan(checksIndex);
-    expect(waitIndex).toBeLessThan(batsIndex);
   });
 
   test("the JDK setup still precedes the checks that need it", () => {

--- a/test/scripts/miscParallelSteps.test.ts
+++ b/test/scripts/miscParallelSteps.test.ts
@@ -72,11 +72,17 @@ describe("#4130 hadolint hoist (fast-validation)", () => {
   test("the hadolint barrier comes after the job's real work, so a failure still surfaces", () => {
     const waitIndex = indexOfWaitOn(steps, "hadolint");
     const checksIndex = indexOfNamed(steps, "Run fast validation checks");
-    const batsIndex = indexOfNamed(steps, "Run BATS Tests (Ubuntu)");
+    // The iOS version-constant drift gate is the last real step before the
+    // barrier now that the inline Ubuntu BATS pass has moved to the parallel
+    // `bats-tests` matrix job.
+    const versionCheckIndex = indexOfNamed(
+      steps,
+      "Check iOS version constant is in sync with package.json",
+    );
 
     expect(waitIndex).toBeGreaterThanOrEqual(0);
     expect(waitIndex).toBeGreaterThan(checksIndex);
-    expect(waitIndex).toBeGreaterThan(batsIndex);
+    expect(waitIndex).toBeGreaterThan(versionCheckIndex);
   });
 
   test("the documentation lock validation toolchain is ready before fast checks", () => {


### PR DESCRIPTION
## Problem

The **Fast Validation** required check runs ~5 min. Measuring per-step timing across three recent runs, one step is **70% of the wall-clock**: the full 913-test BATS suite (`Run BATS Tests (Ubuntu)`, ~212s) ran serially, inline, on the critical path.

| Step | Time |
|---|---|
| Run BATS Tests (Ubuntu) | **212s** |
| Run fast validation checks (yaml/ktfmt/shellcheck/boundaries) | 42s |
| All setup | ~50s |

It was also **redundant**: BATS already runs in the `bats-tests` job (gated by the required "Shell Tests" roll-up), and `merge.yml` already runs it on `[ubuntu-latest, macos-latest]` at merge time.

## Change

- Remove the inline `Run BATS Tests (Ubuntu)` step from `fast-validation`.
- Add `ubuntu-latest` to the `bats-tests` matrix (`[ubuntu-latest, macos-latest]`), mirroring `merge.yml`, so the Ubuntu pass runs in parallel under the required "Shell Tests" gate.
- Update the workflow-shape tests that anchored the hadolint/deps `wait` barriers on the removed step.

**Result: Fast Validation ~300s → ~90s (~3.3×)**, zero coverage loss, no branch-protection change (both "Fast Validation" and "Shell Tests" are already required).

## Validation

- `bun test` on the 4 affected workflow-shape tests — 33 pass
- `bats test/bats/pr-gate-wiring.bats` — 11 pass
- `scripts/all_fast_validate_checks.sh --only yaml` — OK
- `oxfmt --check` on touched files — clean

## Follow-up (separate PR)

Parallelizing BATS itself with `bats --jobs N` needs `validate-no-desktop-core-unified.bats` made hermetic first (it writes a fixture into the real tree and would race under `--jobs`). Tracked separately.