### PR TITLE
feat(storage): project Android DataStore reads into MCP resources (#5603)

### DIFF
--- a/src/server/dataStoreResources.ts
+++ b/src/server/dataStoreResources.ts
@@ -1,0 +1,353 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
+import { AndroidCtrlProxyClient } from "../features/observe/android";
+import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import { serverConfig } from "../utils/ServerConfig";
+import { BootedDevice } from "../models";
+import { logger } from "../utils/logger";
+import type { PreferenceFile, KeyValueEntry } from "../features/storage/storageTypes";
+import {
+  computeStorageCapabilities,
+  findOperationCapability,
+  type OperationCapability,
+} from "../features/storage/storageCapabilities";
+import { resolveStorageCapabilityContext } from "./storageCapabilityResources";
+
+/**
+ * MCP resources that project delivered Android Jetpack DataStore reads into the
+ * storage resource family (issue #5603).
+ *
+ * DataStore lists and entries reuse the same resource-oriented workflow as
+ * key-value state (`storageResources.ts`), but are keyed by the host-registered
+ * adapter name rather than a file name, and are Android-only (DataStore has no
+ * iOS analog). Every response carries a structured `status` so a client can
+ * distinguish an available read from `unavailable` (device/adapter absent),
+ * `disabled` (embedded SDK off), and `unsupported` (non-Android platform)
+ * without parsing a failed operation. The `key_value` capability from the
+ * storage-capabilities resource (#5602) is echoed as `capability` for the same
+ * diagnostic negotiation.
+ */
+
+// Resource URI templates. The extra `/datastore/` segments keep these distinct
+// from the shorter files (`.../{packageName}/files`) and entries
+// (`.../{packageName}/{fileName}/entries`) templates so neither shadows the other.
+const DATA_STORE_RESOURCE_TEMPLATES = {
+  STORES: "automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/stores",
+  ENTRIES:
+    "automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/{storeName}/entries",
+} as const;
+
+const RESOURCE_KIND = "datastore" as const;
+
+/**
+ * Read seam for DataStore lists and entries. The default implementation routes
+ * through the Android CtrlProxy client; tests inject a fake so routing, typed
+ * diagnostics, and update behavior run without devices or sockets.
+ */
+export interface DataStoreResourceReader {
+  listDataStores(
+    device: BootedDevice,
+    packageName: string,
+    adapterName: string,
+  ): Promise<PreferenceFile[]>;
+  getDataStore(
+    device: BootedDevice,
+    packageName: string,
+    adapterName: string,
+    storeName: string,
+  ): Promise<KeyValueEntry[]>;
+}
+
+const defaultDataStoreReader: DataStoreResourceReader = {
+  listDataStores(device, packageName, adapterName) {
+    const client = AndroidCtrlProxyClient.getInstance(device, defaultAdbClientFactory);
+    return client.listDataStores(packageName, adapterName);
+  },
+  getDataStore(device, packageName, adapterName, storeName) {
+    const client = AndroidCtrlProxyClient.getInstance(device, defaultAdbClientFactory);
+    return client.getDataStore(packageName, adapterName, storeName);
+  },
+};
+
+// Cache entries for change detection (mirrors storageResources.ts).
+interface DataStoreCacheEntry {
+  hash: string;
+}
+
+const cache = {
+  stores: new Map<string, DataStoreCacheEntry>(), // key: `${deviceId}:${packageName}:${adapterName}`
+  entries: new Map<string, DataStoreCacheEntry>(), // key: `${deviceId}:${packageName}:${adapterName}:${storeName}`
+};
+
+/**
+ * Generate a simple hash for change detection.
+ */
+function generateHash(data: unknown): string {
+  const str = JSON.stringify(data);
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return hash.toString(16);
+}
+
+/**
+ * Find a booted device by ID across both platforms.
+ */
+async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
+  try {
+    const manager = PlatformDeviceManagerFactory.getInstance();
+    const androidDevices = await manager.getBootedDevices("android");
+    const android = androidDevices.find((d) => d.deviceId === deviceId);
+    if (android) {
+      return android;
+    }
+    const iosDevices = await manager.getBootedDevices("ios");
+    const ios = iosDevices.find((d) => d.deviceId === deviceId);
+    if (ios) {
+      return ios;
+    }
+    return null;
+  } catch (error) {
+    // Best-effort discovery: an unavailable device manager surfaces as
+    // "device not found" rather than a resource fault.
+    logger.warn(`[DataStoreResources] Failed to find device ${deviceId}: ${error}`);
+    return null;
+  }
+}
+
+function buildStoresUri(deviceId: string, packageName: string, adapterName: string): string {
+  return `automobile:devices/${deviceId}/storage/${encodeURIComponent(packageName)}/datastore/${encodeURIComponent(adapterName)}/stores`;
+}
+
+function buildEntriesUri(
+  deviceId: string,
+  packageName: string,
+  adapterName: string,
+  storeName: string,
+): string {
+  return `automobile:devices/${deviceId}/storage/${encodeURIComponent(packageName)}/datastore/${encodeURIComponent(adapterName)}/${encodeURIComponent(storeName)}/entries`;
+}
+
+function jsonContent(uri: string, body: Record<string, unknown>): ResourceContent {
+  return { uri, mimeType: "application/json", text: JSON.stringify(body, null, 2) };
+}
+
+// Resolve the key_value capability for one operation from the storage-capabilities
+// model (#5602), so DataStore diagnostics stay consistent with the capability
+// resource a client would otherwise negotiate against.
+function keyValueCapability(
+  device: BootedDevice,
+  packageName: string,
+  operation: "list" | "read",
+): OperationCapability | undefined {
+  const report = computeStorageCapabilities(resolveStorageCapabilityContext(device, packageName));
+  return findOperationCapability(report, "key_value", operation);
+}
+
+// Shared pre-read gate: resolve the device and classify any non-available state
+// (unavailable / unsupported / disabled) into a structured diagnostic body.
+// Returns the resolved device when the read may proceed, or a ready-to-serve
+// diagnostic body otherwise.
+async function resolveReadable(
+  deviceId: string,
+  packageName: string,
+  adapterName: string,
+  operation: "list" | "read",
+): Promise<{ device: BootedDevice } | { diagnostic: Record<string, unknown> }> {
+  const device = await findBootedDevice(deviceId);
+  if (!device) {
+    return {
+      diagnostic: {
+        status: "unavailable",
+        kind: RESOURCE_KIND,
+        deviceId,
+        packageName,
+        adapterName,
+        reason: `Device not found or not booted: ${deviceId}`,
+      },
+    };
+  }
+
+  if (device.platform !== "android") {
+    return {
+      diagnostic: {
+        status: "unsupported",
+        kind: RESOURCE_KIND,
+        deviceId,
+        packageName,
+        adapterName,
+        platform: device.platform,
+        reason: `DataStore is Android-only; not available on ${device.platform}.`,
+        capability: keyValueCapability(device, packageName, operation),
+      },
+    };
+  }
+
+  if (!serverConfig.isEmbeddedSdkEnabled()) {
+    const capability = keyValueCapability(device, packageName, operation);
+    return {
+      diagnostic: {
+        status: "disabled",
+        kind: RESOURCE_KIND,
+        deviceId,
+        packageName,
+        adapterName,
+        platform: device.platform,
+        reason:
+          capability?.reason ??
+          "DataStore inspection requires the AutoMobile SDK embedded with storage inspection.",
+        capability,
+      },
+    };
+  }
+
+  return { device };
+}
+
+async function getDataStoresResource(
+  params: Record<string, string>,
+  reader: DataStoreResourceReader,
+): Promise<ResourceContent> {
+  const deviceId = params.deviceId;
+  const packageName = decodeURIComponent(params.packageName);
+  const adapterName = decodeURIComponent(params.adapterName);
+  const uri = buildStoresUri(deviceId, packageName, adapterName);
+
+  const gate = await resolveReadable(deviceId, packageName, adapterName, "list");
+  if ("diagnostic" in gate) {
+    return jsonContent(uri, gate.diagnostic);
+  }
+  const device = gate.device;
+
+  try {
+    const stores = await reader.listDataStores(device, packageName, adapterName);
+    const lastUpdated = new Date().toISOString();
+    const hash = generateHash(stores);
+
+    const cacheKey = `${deviceId}:${packageName}:${adapterName}`;
+    const cached = cache.stores.get(cacheKey);
+    if (cached && cached.hash !== hash) {
+      void ResourceRegistry.notifyResourceUpdated(uri);
+    }
+    cache.stores.set(cacheKey, { hash });
+
+    return jsonContent(uri, {
+      status: "available",
+      kind: RESOURCE_KIND,
+      deviceId,
+      packageName,
+      adapterName,
+      platform: device.platform,
+      stores,
+      totalCount: stores.length,
+      lastUpdated,
+      capability: keyValueCapability(device, packageName, "list"),
+    });
+  } catch (error) {
+    // A registered adapter that fails to answer (absent app integration, no
+    // adapter under this name) surfaces here as a bounded read failure.
+    logger.warn(`[DataStoreResources] Failed to list data stores: ${error}`);
+    return jsonContent(uri, {
+      status: "unavailable",
+      kind: RESOURCE_KIND,
+      deviceId,
+      packageName,
+      adapterName,
+      platform: device.platform,
+      reason: `Failed to list data stores (adapter or app integration may be absent): ${error}`,
+    });
+  }
+}
+
+async function getDataStoreEntriesResource(
+  params: Record<string, string>,
+  reader: DataStoreResourceReader,
+): Promise<ResourceContent> {
+  const deviceId = params.deviceId;
+  const packageName = decodeURIComponent(params.packageName);
+  const adapterName = decodeURIComponent(params.adapterName);
+  const storeName = decodeURIComponent(params.storeName);
+  const uri = buildEntriesUri(deviceId, packageName, adapterName, storeName);
+
+  const gate = await resolveReadable(deviceId, packageName, adapterName, "read");
+  if ("diagnostic" in gate) {
+    return jsonContent(uri, { ...gate.diagnostic, name: storeName });
+  }
+  const device = gate.device;
+
+  try {
+    const entries = await reader.getDataStore(device, packageName, adapterName, storeName);
+    const lastUpdated = new Date().toISOString();
+    const hash = generateHash(entries);
+
+    const cacheKey = `${deviceId}:${packageName}:${adapterName}:${storeName}`;
+    const cached = cache.entries.get(cacheKey);
+    if (cached && cached.hash !== hash) {
+      void ResourceRegistry.notifyResourceUpdated(uri);
+    }
+    cache.entries.set(cacheKey, { hash });
+
+    return jsonContent(uri, {
+      status: "available",
+      kind: RESOURCE_KIND,
+      deviceId,
+      packageName,
+      adapterName,
+      name: storeName,
+      platform: device.platform,
+      entries,
+      totalCount: entries.length,
+      lastUpdated,
+      capability: keyValueCapability(device, packageName, "read"),
+    });
+  } catch (error) {
+    logger.warn(`[DataStoreResources] Failed to get data store entries: ${error}`);
+    return jsonContent(uri, {
+      status: "unavailable",
+      kind: RESOURCE_KIND,
+      deviceId,
+      packageName,
+      adapterName,
+      name: storeName,
+      platform: device.platform,
+      reason: `Failed to read data store (adapter or app integration may be absent): ${error}`,
+    });
+  }
+}
+
+/**
+ * Test-only: drop cached change-detection state so suites sharing the module
+ * singleton stay hermetic.
+ */
+export function clearDataStoreResourceCacheForTesting(): void {
+  cache.stores.clear();
+  cache.entries.clear();
+}
+
+/**
+ * Register Android DataStore list and entry resources (issue #5603).
+ */
+export function registerDataStoreResources(
+  reader: DataStoreResourceReader = defaultDataStoreReader,
+): void {
+  ResourceRegistry.registerTemplate(
+    DATA_STORE_RESOURCE_TEMPLATES.STORES,
+    "App DataStore Instances",
+    "List the Jetpack DataStore instances an app exposes through a host-registered AutoMobile SDK adapter (Android only).",
+    "application/json",
+    (params) => getDataStoresResource(params, reader),
+  );
+
+  ResourceRegistry.registerTemplate(
+    DATA_STORE_RESOURCE_TEMPLATES.ENTRIES,
+    "DataStore Instance Entries",
+    "Read the key-value entries of a named Jetpack DataStore instance via a host-registered AutoMobile SDK adapter (Android only).",
+    "application/json",
+    (params) => getDataStoreEntriesResource(params, reader),
+  );
+
+  logger.info("[DataStoreResources] Registered DataStore resources");
+}

--- a/src/server/dataStoreResources.ts
+++ b/src/server/dataStoreResources.ts
@@ -1,4 +1,4 @@
-import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { ResourceRegistry, ResourceContent, getRequestedResourceUri } from "./resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
@@ -135,6 +135,32 @@ function jsonContent(uri: string, body: Record<string, unknown>): ResourceConten
   return { uri, mimeType: "application/json", text: JSON.stringify(body, null, 2) };
 }
 
+// Decode a percent-encoded path segment, returning null when the encoding is
+// malformed. A host-defined adapter or store name may contain a literal `%`
+// that is not valid percent-encoding; letting decodeURIComponent's URIError
+// escape would bypass the JSON diagnostic envelope, exactly the failure mode
+// #5686 fixed for query params — here for path params.
+function safeDecodeSegment(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    logger.debug(`[DataStoreResources] Malformed URI segment '${value}': ${error}`);
+    return null;
+  }
+}
+
+// Structured diagnostic for a URI whose path segments are not valid
+// percent-encoding, served on the originally-requested URI so the client still
+// gets a typed JSON envelope rather than a raw MCP error.
+function malformedUriContent(params: Record<string, string>): ResourceContent {
+  return jsonContent(getRequestedResourceUri(params) ?? "", {
+    status: "unavailable",
+    kind: RESOURCE_KIND,
+    deviceId: params.deviceId,
+    reason: "Malformed resource URI: a path segment is not valid percent-encoding.",
+  });
+}
+
 // Resolve the key_value capability for one operation from the storage-capabilities
 // model (#5602), so DataStore diagnostics stay consistent with the capability
 // resource a client would otherwise negotiate against.
@@ -212,8 +238,11 @@ async function getDataStoresResource(
   reader: DataStoreResourceReader,
 ): Promise<ResourceContent> {
   const deviceId = params.deviceId;
-  const packageName = decodeURIComponent(params.packageName);
-  const adapterName = decodeURIComponent(params.adapterName);
+  const packageName = safeDecodeSegment(params.packageName);
+  const adapterName = safeDecodeSegment(params.adapterName);
+  if (packageName === null || adapterName === null) {
+    return malformedUriContent(params);
+  }
   const uri = buildStoresUri(deviceId, packageName, adapterName);
 
   const gate = await resolveReadable(deviceId, packageName, adapterName, "list");
@@ -267,9 +296,12 @@ async function getDataStoreEntriesResource(
   reader: DataStoreResourceReader,
 ): Promise<ResourceContent> {
   const deviceId = params.deviceId;
-  const packageName = decodeURIComponent(params.packageName);
-  const adapterName = decodeURIComponent(params.adapterName);
-  const storeName = decodeURIComponent(params.storeName);
+  const packageName = safeDecodeSegment(params.packageName);
+  const adapterName = safeDecodeSegment(params.adapterName);
+  const storeName = safeDecodeSegment(params.storeName);
+  if (packageName === null || adapterName === null || storeName === null) {
+    return malformedUriContent(params);
+  }
   const uri = buildEntriesUri(deviceId, packageName, adapterName, storeName);
 
   const gate = await resolveReadable(deviceId, packageName, adapterName, "read");

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -81,6 +81,7 @@ import { registerDatabaseResources } from "./databaseResources";
 import { registerFailuresResources } from "./failuresResources";
 import { registerStorageResources } from "./storageResources";
 import { registerStorageCapabilityResources } from "./storageCapabilityResources";
+import { registerDataStoreResources } from "./dataStoreResources";
 import { registerAppFileResources } from "./appFileResources";
 import { registerSharedStorageResources } from "./sharedStorageResources";
 import { registerFeatureFlagResources } from "./featureFlagResources";
@@ -325,6 +326,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerFailuresResources();
   registerStorageResources();
   registerStorageCapabilityResources();
+  registerDataStoreResources();
   registerAppFileResources();
   registerSharedStorageResources();
   registerFeatureFlagResources();

--- a/test/server/dataStoreResources.test.ts
+++ b/test/server/dataStoreResources.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  registerDataStoreResources,
+  clearDataStoreResourceCacheForTesting,
+  type DataStoreResourceReader,
+} from "../../src/server/dataStoreResources";
+import { registerStorageResources } from "../../src/server/storageResources";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import type { BootedDevice } from "../../src/models";
+import type { PreferenceFile, KeyValueEntry } from "../../src/features/storage/storageTypes";
+
+// DataStore resources project the existing Android DataStore CtrlProxy chain
+// (AndroidCtrlProxyClient.listDataStores / getDataStore) into the MCP storage
+// resource family (issue #5603). The read path is injected via a
+// DataStoreResourceReader so routing, typed diagnostics, and update behavior are
+// exercised with only a FakeDeviceManager + fake reader — no DB, clock, or socket.
+describe("dataStoreResources", () => {
+  const androidEmulator: BootedDevice = {
+    name: "Pixel_7",
+    platform: "android",
+    deviceId: "emulator-5554",
+  };
+  const iosSimulator: BootedDevice = {
+    name: "iPhone",
+    platform: "ios",
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+  };
+
+  const LIST_URI =
+    "automobile:devices/emulator-5554/storage/com.example.app/datastore/settings/stores";
+  const ENTRIES_URI =
+    "automobile:devices/emulator-5554/storage/com.example.app/datastore/settings/user_prefs/entries";
+
+  afterEach(() => {
+    PlatformDeviceManagerFactory.setInstance(null);
+    ResourceRegistry.clearResources();
+    clearDataStoreResourceCacheForTesting();
+    serverConfig.setEmbeddedSdkEnabled(false);
+  });
+
+  function setup(devices: BootedDevice[], reader?: Partial<DataStoreResourceReader>): void {
+    PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], devices));
+    const fullReader: DataStoreResourceReader = {
+      listDataStores: reader?.listDataStores ?? (async () => []),
+      getDataStore: reader?.getDataStore ?? (async () => []),
+    };
+    registerDataStoreResources(fullReader);
+  }
+
+  function readResource(uri: string) {
+    const match = ResourceRegistry.matchTemplate(uri);
+    if (!match) {
+      throw new Error(`no template matched: ${uri}`);
+    }
+    return match.template.handler(match.params);
+  }
+
+  async function readBody(uri: string): Promise<Record<string, unknown>> {
+    const content = await readResource(uri);
+    expect(content.mimeType).toBe("application/json");
+    return JSON.parse(content.text ?? "{}");
+  }
+
+  // --- Routing (AC3) ---------------------------------------------------------
+
+  test("registers both DataStore templates and routes their URIs", () => {
+    setup([]);
+    const templates = ResourceRegistry.getAllTemplates()
+      .map((t) => t.uriTemplate)
+      .filter((t) => t.includes("/datastore/"));
+    expect(templates).toEqual([
+      "automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/stores",
+      "automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/{storeName}/entries",
+    ]);
+    expect(ResourceRegistry.matchTemplate(LIST_URI)).toBeDefined();
+    expect(ResourceRegistry.matchTemplate(ENTRIES_URI)).toBeDefined();
+  });
+
+  test("DataStore URIs are not shadowed by the sibling storage files/entries templates", () => {
+    // Register the key-value storage resources first (as src/server/index.ts
+    // does), then the DataStore resources. The extra /datastore/ segments must
+    // keep DataStore URIs from matching the shorter files/entries templates.
+    PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], []));
+    registerStorageResources();
+    registerDataStoreResources();
+    const listMatch = ResourceRegistry.matchTemplate(LIST_URI);
+    const entriesMatch = ResourceRegistry.matchTemplate(ENTRIES_URI);
+    expect(listMatch?.template.uriTemplate).toContain("/datastore/");
+    expect(entriesMatch?.template.uriTemplate).toContain("/datastore/");
+  });
+
+  test("params are percent-decoded and the canonical URI round-trips", async () => {
+    setup([]);
+    const uri =
+      "automobile:devices/dev1/storage/com.example%20app/datastore/my%20adapter/my%20store/entries";
+    const content = await readResource(uri);
+    expect(content.uri).toBe(uri);
+  });
+
+  // --- Enumerate + read happy path (AC1) -------------------------------------
+
+  test("enumerates DataStore instances for a booted Android device", async () => {
+    serverConfig.setEmbeddedSdkEnabled(true);
+    const stores: PreferenceFile[] = [
+      { name: "user_prefs", path: "", entryCount: 3 },
+      { name: "flags", path: "", entryCount: 1 },
+    ];
+    setup([androidEmulator], { listDataStores: async () => stores });
+    const body = await readBody(LIST_URI);
+    expect(body.status).toBe("available");
+    expect(body.kind).toBe("datastore");
+    expect(body.deviceId).toBe("emulator-5554");
+    expect(body.packageName).toBe("com.example.app");
+    expect(body.adapterName).toBe("settings");
+    expect(body.platform).toBe("android");
+    expect(body.stores).toEqual(stores);
+    expect(body.totalCount).toBe(2);
+    // Capability integration: key_value list is supported once the SDK is present.
+    expect((body.capability as { state: string }).state).toBe("supported");
+  });
+
+  test("reads entries from a named DataStore instance", async () => {
+    serverConfig.setEmbeddedSdkEnabled(true);
+    const entries: KeyValueEntry[] = [
+      { key: "theme", value: '"dark"', type: "STRING" },
+      { key: "count", value: "5", type: "INT" },
+    ];
+    const captured: string[] = [];
+    setup([androidEmulator], {
+      getDataStore: async (_device, packageName, adapterName, storeName) => {
+        captured.push(packageName, adapterName, storeName);
+        return entries;
+      },
+    });
+    const body = await readBody(ENTRIES_URI);
+    expect(body.status).toBe("available");
+    expect(body.kind).toBe("datastore");
+    expect(body.adapterName).toBe("settings");
+    expect(body.name).toBe("user_prefs");
+    expect(body.entries).toEqual(entries);
+    expect(body.totalCount).toBe(2);
+    expect(captured).toEqual(["com.example.app", "settings", "user_prefs"]);
+  });
+
+  // --- Typed diagnostics (AC2 + AC3) -----------------------------------------
+
+  test("reports unavailable when the device is not booted", async () => {
+    setup([]);
+    const body = await readBody(LIST_URI);
+    expect(body.status).toBe("unavailable");
+    expect(body.kind).toBe("datastore");
+    expect(body.reason).toContain("emulator-5554");
+  });
+
+  test("reports unsupported on iOS (DataStore is Android-only)", async () => {
+    serverConfig.setEmbeddedSdkEnabled(true);
+    setup([iosSimulator]);
+    const body = await readBody(
+      "automobile:devices/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/storage/com.example.app/datastore/settings/stores",
+    );
+    expect(body.status).toBe("unsupported");
+    expect(body.kind).toBe("datastore");
+    expect(String(body.reason)).toContain("Android");
+  });
+
+  test("reports disabled when the embedded SDK is not enabled", async () => {
+    serverConfig.setEmbeddedSdkEnabled(false);
+    // The reader must never be called when the SDK is disabled.
+    let called = false;
+    setup([androidEmulator], {
+      listDataStores: async () => {
+        called = true;
+        return [];
+      },
+    });
+    const body = await readBody(LIST_URI);
+    expect(body.status).toBe("disabled");
+    expect(body.kind).toBe("datastore");
+    expect(called).toBe(false);
+    expect(body.capability).toBeDefined();
+  });
+
+  test("reports unavailable when the adapter/app integration is absent (read throws)", async () => {
+    serverConfig.setEmbeddedSdkEnabled(true);
+    setup([androidEmulator], {
+      listDataStores: async () => {
+        throw new Error("No DataStore adapter registered under 'settings'");
+      },
+    });
+    const body = await readBody(LIST_URI);
+    expect(body.status).toBe("unavailable");
+    expect(body.kind).toBe("datastore");
+    expect(String(body.reason)).toContain("adapter");
+  });
+
+  // --- Update behavior (AC3) -------------------------------------------------
+
+  test("notifies subscribers when the DataStore listing changes between reads", async () => {
+    serverConfig.setEmbeddedSdkEnabled(true);
+    let call = 0;
+    setup([androidEmulator], {
+      listDataStores: async () => {
+        call += 1;
+        return call === 1
+          ? [{ name: "user_prefs", path: "", entryCount: 1 }]
+          : [{ name: "user_prefs", path: "", entryCount: 2 }];
+      },
+    });
+
+    const notify = [] as string[];
+    const original = ResourceRegistry.notifyResourceUpdated;
+    ResourceRegistry.notifyResourceUpdated = (async (uri: string) => {
+      notify.push(uri);
+    }) as typeof ResourceRegistry.notifyResourceUpdated;
+    try {
+      await readResource(LIST_URI); // seeds cache, no notify
+      expect(notify).toEqual([]);
+      await readResource(LIST_URI); // changed data -> notify
+      expect(notify).toEqual([LIST_URI]);
+    } finally {
+      ResourceRegistry.notifyResourceUpdated = original;
+    }
+  });
+});

--- a/test/server/dataStoreResources.test.ts
+++ b/test/server/dataStoreResources.test.ts
@@ -196,6 +196,21 @@ describe("dataStoreResources", () => {
     expect(String(body.reason)).toContain("adapter");
   });
 
+  test("returns a structured envelope for a malformed percent-encoded segment (not a raw throw)", async () => {
+    // A host-defined adapter name with a literal `%` that is not valid
+    // percent-encoding must yield a typed JSON diagnostic, not a URIError that
+    // escapes the resource handler (cf. #5686 for query params).
+    setup([androidEmulator]);
+    const uri = "automobile:devices/emulator-5554/storage/com.example.app/datastore/wei%rd/stores";
+    const content = await readResource(uri);
+    expect(content.mimeType).toBe("application/json");
+    expect(content.uri).toBe(uri);
+    const body = JSON.parse(content.text ?? "{}");
+    expect(body.status).toBe("unavailable");
+    expect(body.kind).toBe("datastore");
+    expect(String(body.reason)).toContain("percent-encoding");
+  });
+
   // --- Update behavior (AC3) -------------------------------------------------
 
   test("notifies subscribers when the DataStore listing changes between reads", async () => {


### PR DESCRIPTION
## Summary

Projects delivered Android Jetpack DataStore reads into the MCP storage
resource family, so clients discover and read DataStore instances with the
same resource-oriented workflow used for key-value state. Backed by the
already-merged Android DataStore CtrlProxy chain (`AndroidCtrlProxyClient.listDataStores` / `getDataStore`, #5573/#5594); this PR adds only the missing MCP **resource** layer over it.

New URI templates:
- `automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/stores`
- `automobile:devices/{deviceId}/storage/{packageName}/datastore/{adapterName}/{storeName}/entries`

The extra `/datastore/` segments keep these distinct from the shorter
files/entries key-value templates, so neither shadows the other.

## Linked Issue

Closes #5603

## Changes

- `src/server/dataStoreResources.ts` (new): two resource templates backed by an
  injectable `DataStoreResourceReader` (default routes through the Android
  CtrlProxy client). Every response carries a structured `status`:
  - `available` — stores/entries returned, with `kind: "datastore"`, `adapterName`, and store `name` metadata preserved.
  - `unavailable` — device not booted, or the adapter / app integration is absent (the bounded read failed).
  - `disabled` — the embedded AutoMobile SDK with storage inspection is off.
  - `unsupported` — non-Android platform (DataStore has no iOS analog).
  Reads are bounded (client timeout), and the handlers notify subscribers on
  change, mirroring the key-value read handlers.
- Integrates with the storage-capabilities resource (#5602): each response
  echoes the resolved `key_value` `OperationCapability` as `capability` for
  consistent diagnostic negotiation.
- `src/server/index.ts`: register the new resources alongside the sibling
  storage resources.

## Acceptance criteria

- [x] A registered DataStore can be enumerated and read through MCP resources on a device — list + entry templates return `status: "available"` with stores/entries.
- [x] Clients receive deterministic diagnostics when the app integration or adapter is absent — structured `unavailable` / `disabled` / `unsupported` statuses plus the echoed capability.
- [x] Tests cover resource routing, typed failures, and update behavior — `test/server/dataStoreResources.test.ts` (10 tests).

## Validation

- [x] `bun test` — new suite green (10 tests); full suite green except one
  pre-existing worktree env artifact (`test/lint/oxlintConfigScoping.test.ts`
  fails on `ENOENT` spawning `node_modules/.bin/oxlint`, absent in this
  worktree; unrelated to this change, which touches no lint tooling).
- [x] `bun run lint` — no new ratchet violations; boundary checks pass.
- [x] `bun run typecheck` — no new type errors (baseline gate).
- [x] `bun run build` — succeeds.
- [x] New code uses an interface + fake seam; unit tests run in <100ms and touch no DB/clock/sockets.

## Device Verification

- [ ] Not run here — no device attached in this environment. The read path
  reuses the existing, device-verified DataStore CtrlProxy chain (#5594); this
  PR adds only the resource projection over it. Manual on-device verification
  can confirm the end-to-end resource read.
