### PR TITLE
perf(ci): run BATS cross-file-parallel (287s → 63s locally)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -381,8 +381,10 @@ jobs:
 
       - wait: install-bats
 
+      # Cross-file parallel (`--jobs`), within-file serial. See scripts/ci/run-bats.sh.
       - name: "Run BATS Tests"
-        run: bats test/bats/
+        shell: bash
+        run: scripts/ci/run-bats.sh
 
   # Always exercise the real WHIP publisher contract post-merge on main:
   # FFmpeg H.264 -> WebRtcPublisher -> MediaMTX -> headless-Chrome WHEP decode.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1007,8 +1007,10 @@ jobs:
 
       - wait: install-bats
 
+      # Cross-file parallel (`--jobs`), within-file serial. See scripts/ci/run-bats.sh.
       - name: "Run BATS Tests"
-        run: bats test/bats/
+        shell: bash
+        run: scripts/ci/run-bats.sh
 
   installer-minimal:
     timeout-minutes: 20

--- a/scripts/ci/run-bats.sh
+++ b/scripts/ci/run-bats.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Runs the BATS shell-test suite with cross-file parallelism.
+#
+# The suite is ~900 tests across ~125 files and, run serially, dominated the
+# CI wall-clock (~3.5min on the required "Shell Tests" gate). Most files isolate
+# their state in `mktemp -d` temp dirs (temp git repos, temp roots passed to
+# scripts via root-override args), so they are independent and can run
+# concurrently.
+#
+# Two passes:
+#
+#   1. Parallel pass — everything EXCEPT files tagged `serial-boundary`. We
+#      parallelize ACROSS files but keep each file's tests SERIAL
+#      (`--no-parallelize-within-files`): tests inside one file share `setup()`
+#      / `teardown()`, so serializing within a file is the conservative default
+#      while still spreading the files across every core.
+#
+#   2. Serial pass — files tagged `serial`. Two hazard classes carry the tag:
+#      (a) files that write a fixture into the REAL source tree and scan it, so
+#      they race each other (and any tree scan) under parallelism; and (b) files
+#      that spawn real processes and assert timing-bounded reaping, which flakes
+#      under CPU oversubscription. They run one file at a time here, after the
+#      parallel pass, so no fixture is present while an unrelated file scans, and
+#      the process tests get an uncontended CPU. A guard test
+#      (test/scripts/batsSerialTags.test.ts) fails if a new real-tree mutator
+#      lands without the tag.
+#
+# `bats --jobs` requires GNU parallel; this script installs it when missing and
+# suppresses its first-run citation notice so it does not spam CI logs.
+set -euo pipefail
+
+BATS_DIR="${1:-test/bats}"
+SERIAL_TAG="serial"
+
+log() { printf '%s\n' "$*" >&2; }
+
+ensure_gnu_parallel() {
+  if command -v parallel > /dev/null 2>&1; then
+    return 0
+  fi
+  log "GNU parallel not found; installing"
+  if command -v brew > /dev/null 2>&1; then
+    brew install parallel
+  elif command -v apt-get > /dev/null 2>&1; then
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq parallel
+  else
+    log "ERROR: cannot install GNU parallel (no brew or apt-get)"
+    return 1
+  fi
+}
+
+# GNU parallel prints a citation banner to stderr on every invocation until the
+# user acknowledges it. Drop the marker so the suite's output stays readable.
+silence_parallel_citation() {
+  local home_dir="${PARALLEL_HOME:-$HOME/.parallel}"
+  mkdir -p "$home_dir"
+  touch "$home_dir/will-cite"
+}
+
+ensure_gnu_parallel
+silence_parallel_citation
+
+# _NPROCESSORS_ONLN is portable across the Linux and macOS runners; fall back to
+# 2 if the host does not expose it.
+jobs="$(getconf _NPROCESSORS_ONLN 2> /dev/null || echo 2)"
+if ! [[ "$jobs" =~ ^[0-9]+$ ]] || [[ "$jobs" -lt 1 ]]; then
+  jobs=2
+fi
+
+log "Parallel pass: bats --jobs $jobs --no-parallelize-within-files (excluding $SERIAL_TAG) over $BATS_DIR"
+bats --jobs "$jobs" --no-parallelize-within-files --filter-tags "!$SERIAL_TAG" "$BATS_DIR"
+
+log "Serial pass: bats (only $SERIAL_TAG) over $BATS_DIR"
+bats --filter-tags "$SERIAL_TAG" "$BATS_DIR"

--- a/test/bats/android-kotlin-convention.bats
+++ b/test/bats/android-kotlin-convention.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 #
 # Tests for scripts/android/validate-kotlin-convention.sh (issue #5027).
 

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-android-emulator-boundary.sh"
 FIXTURE="src/utils/EmulatorBoundaryFixture.ts"

--- a/test/bats/check-app-bundle-metadata-boundary.bats
+++ b/test/bats/check-app-bundle-metadata-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-app-bundle-metadata-boundary.sh"
 FIXTURE="src/utils/CodesignBoundaryFixture.ts"

--- a/test/bats/check-daemon-launcher-boundary.bats
+++ b/test/bats/check-daemon-launcher-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-daemon-launcher-boundary.sh"
 FIXTURE="src/daemon/DaemonLauncherBoundaryFixture.ts"

--- a/test/bats/check-ffmpeg-execution-boundary.bats
+++ b/test/bats/check-ffmpeg-execution-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-ffmpeg-execution-boundary.sh"
 FIXTURE="src/utils/FfmpegBoundaryFixture.ts"

--- a/test/bats/check-no-new-direct-git-metadata.bats
+++ b/test/bats/check-no-new-direct-git-metadata.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree (src/utils/GitMetadataBoundaryFixture.ts)
+# and scans the tree, so this file cannot run concurrently with the rest of the
+# suite. scripts/ci/run-bats.sh runs serial-tagged files in a dedicated serial
+# pass; the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 setup() {
   fixture="src/utils/GitMetadataBoundaryFixture.ts"

--- a/test/bats/check-sdkmanager-execution-boundary.bats
+++ b/test/bats/check-sdkmanager-execution-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-sdkmanager-execution-boundary.sh"
 FIXTURE="src/utils/SdkManagerBoundaryFixture.ts"

--- a/test/bats/check-simulator-tcc-sqlite-boundary.bats
+++ b/test/bats/check-simulator-tcc-sqlite-boundary.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Writes a fixture into the real source tree and scans it, so this file cannot
+# run concurrently with the rest of the suite. scripts/ci/run-bats.sh runs all
+# serial-tagged files in a dedicated serial pass (scripts/ci/run-bats.sh);
+# the tag is enforced by test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-simulator-tcc-sqlite-boundary.sh"
 FIXTURE="src/utils/ios-cmdline-tools/SimulatorTccSqliteBoundaryFixture.ts"

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Spawns real (sometimes SIGTERM-ignoring, CPU-spinning) helper processes and
+# asserts they are reaped within a bounded time. Under parallel CPU
+# oversubscription the reap misses its deadline and the test flakes, so
+# scripts/ci/run-bats.sh runs this file in the serial pass.
 
 setup() {
   TEST_DIR="$(mktemp -d)"

--- a/test/bats/run-bats.bats
+++ b/test/bats/run-bats.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/run-bats.sh — the CI BATS runner that runs the suite in
+# two passes: a cross-file-parallel pass (everything but `serial`-tagged files)
+# and a serial pass (the `serial`-tagged files).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ci/run-bats.sh"
+
+  # Isolated PATH shim so the script exec's our fake `bats` (which appends each
+  # invocation's args) instead of the real one, and finds a fake `parallel` so
+  # it never tries to install anything.
+  STUB_BIN="$(mktemp -d)"
+  ARGS_FILE="$(mktemp)"
+  FAKE_HOME="$(mktemp -d)"
+
+  # The runner calls bats twice; record every invocation on its own line.
+  cat > "$STUB_BIN/bats" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$ARGS_FILE"
+EOF
+  chmod +x "$STUB_BIN/bats"
+
+  cat > "$STUB_BIN/parallel" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$STUB_BIN/parallel"
+}
+
+teardown() {
+  rm -rf "$STUB_BIN" "$FAKE_HOME"
+  rm -f "$ARGS_FILE"
+}
+
+run_runner() {
+  run env HOME="$FAKE_HOME" PATH="$STUB_BIN:$PATH" bash "$SCRIPT" "${1:-test/bats}"
+}
+
+# The parallel pass is the invocation carrying --jobs; the serial pass is the
+# one without it.
+parallel_pass_args() { grep -- '--jobs' "$ARGS_FILE"; }
+serial_pass_args() { grep -v -- '--jobs' "$ARGS_FILE"; }
+
+@test "the parallel pass runs cross-file-parallel and excludes serial-tagged files" {
+  run_runner
+  [ "$status" -eq 0 ]
+
+  local args
+  args="$(parallel_pass_args)"
+  [[ "$args" == *"--jobs "* ]]
+  [[ "$args" == *"--no-parallelize-within-files"* ]]
+  [[ "$args" == *"--filter-tags !serial"* ]]
+  [[ "$args" == *"test/bats"* ]]
+}
+
+@test "the serial pass runs only serial-tagged files without --jobs" {
+  run_runner
+  [ "$status" -eq 0 ]
+
+  local args
+  args="$(serial_pass_args)"
+  [[ "$args" == *"--filter-tags serial"* ]]
+  [[ "$args" != *"--jobs"* ]]
+  [[ "$args" == *"test/bats"* ]]
+}
+
+@test "passes a positive integer job count to --jobs" {
+  run_runner
+  [ "$status" -eq 0 ]
+
+  local jobs
+  jobs="$(sed -nE 's/.*--jobs ([0-9]+).*/\1/p' "$ARGS_FILE")"
+  [ -n "$jobs" ]
+  [ "$jobs" -ge 1 ]
+}
+
+@test "acknowledges the GNU parallel citation to keep logs clean" {
+  run_runner
+  [ "$status" -eq 0 ]
+  [ -f "$FAKE_HOME/.parallel/will-cite" ]
+}
+
+@test "defaults the target directory to test/bats when no argument is given" {
+  run env HOME="$FAKE_HOME" PATH="$STUB_BIN:$PATH" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$ARGS_FILE")" == *"test/bats"* ]]
+}

--- a/test/scripts/batsInstallHoist.test.ts
+++ b/test/scripts/batsInstallHoist.test.ts
@@ -78,5 +78,14 @@ for (const workflow of WORKFLOWS) {
       expect(bunDepsIndex).toBeGreaterThanOrEqual(0);
       expect(bunDepsIndex).toBeLessThan(consumerIndex);
     });
+
+    test("the suite runs through the parallel runner, not a bare serial `bats`", () => {
+      // The ~900-test suite runs cross-file-parallel via scripts/ci/run-bats.sh.
+      // Guard against a regression back to serial `bats test/bats/`, which is
+      // what dominated the required "Shell Tests" gate's wall-clock.
+      const consumer = stepNamed(steps, CONSUMER_STEP);
+      expect(consumer?.run).toContain("scripts/ci/run-bats.sh");
+      expect(consumer?.run).not.toContain("bats test/bats/");
+    });
   });
 }

--- a/test/scripts/batsSerialTags.test.ts
+++ b/test/scripts/batsSerialTags.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// scripts/ci/run-bats.sh runs the BATS suite cross-file-parallel, except files
+// tagged `serial`, which it runs one at a time. A file that writes a fixture
+// into the REAL source tree (src/ | android/ | ios/) and then runs a scanner
+// over that tree races every other file under parallelism (that is exactly the
+// class of flake that motivated this: an unrelated file scans the tree while a
+// fixture is present). This guard fails if such a file lands without the tag,
+// so a new boundary/convention check cannot silently reintroduce the race.
+
+const BATS_DIR = join(import.meta.dir, "..", "..", "test", "bats");
+const REAL_TREE = /^(src|android|ios)\//;
+
+interface BatsFile {
+  name: string;
+  text: string;
+}
+
+function loadBatsFiles(): BatsFile[] {
+  return readdirSync(BATS_DIR)
+    .filter((f) => f.endsWith(".bats"))
+    .map((name) => ({ name, text: readFileSync(join(BATS_DIR, name), "utf8") }));
+}
+
+// A file mutates the real tree when it assigns a variable to a real-tree path
+// and then uses that variable as a redirection target (printf/cat/echo > "$VAR").
+// Copies FROM a real path INTO a temp dir assign the real path but redirect to a
+// different (temp) target, so they are not flagged.
+function mutatesRealTree(text: string): boolean {
+  const realVars = new Set<string>();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)=["']?([^"'\s]+)/);
+    if (m && REAL_TREE.test(m[2])) {
+      realVars.add(m[1]);
+    }
+  }
+  for (const varName of realVars) {
+    // A redirection whose target is this variable: `> "$VAR"` / `>"${VAR}"`.
+    const redirect = new RegExp(`>\\s*"?\\$\\{?${varName}\\}?"?`);
+    if (redirect.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasSerialTag(text: string): boolean {
+  // `# bats file_tags=serial` or a comma list that includes `serial`.
+  return text
+    .split("\n")
+    .some(
+      (line) =>
+        /^#\s*bats\s+file_tags=/.test(line) &&
+        /(^|=|,)\s*serial\s*(,|$)/.test(line.replace(/^#\s*bats\s+file_tags=/, "=")),
+    );
+}
+
+describe("bats serial-pass tagging (scripts/ci/run-bats.sh)", () => {
+  const files = loadBatsFiles();
+
+  test("the suite has bats files to scan", () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  test("every real-tree-mutating bats file carries the `serial` tag", () => {
+    const offenders = files
+      .filter((f) => mutatesRealTree(f.text))
+      .filter((f) => !hasSerialTag(f.text))
+      .map((f) => f.name);
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("the tag detector actually recognizes a known mutator (guards against a no-op regex)", () => {
+    const known = files.find((f) => f.name === "check-android-emulator-boundary.bats");
+    expect(known).toBeDefined();
+    expect(mutatesRealTree(known!.text)).toBe(true);
+    expect(hasSerialTag(known!.text)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #5725 (now merged). Second lever from the "make Fast Validation faster" investigation.

## Problem

The ~900-test / ~125-file BATS suite runs **serially** and, at ~3.5min, dominates the required "Shell Tests" gate (and dominated Fast Validation until #5725 split it out). Most files isolate state in `mktemp -d` temp dirs, so they can run concurrently.

## Change

New `scripts/ci/run-bats.sh` runs the suite in **two passes**, and both the PR and merge workflows call it instead of bare `bats test/bats/`:

1. **Parallel pass** — `bats --jobs $(nproc) --no-parallelize-within-files` over every file *except* those tagged `serial`. Cross-file parallel; within-file serial (tests in one file share `setup()`/`teardown()`).
2. **Serial pass** — `bats --filter-tags serial`, one file at a time.

It installs GNU parallel when missing and drops the `will-cite` marker to keep logs clean.

## What must stay serial (and why)

Two hazard classes flake under parallelism and carry `# bats file_tags=serial`:

- **Real-tree mutators** — write a fixture into `src/`/`android/` and run a scanner over the tree, racing any concurrent scan: `android-kotlin-convention`, the `check-*-boundary` family, `check-no-new-direct-git-metadata`.
- **Process-timing** — `install-background-work` spawns CPU-spinning, SIGTERM-ignoring helpers and asserts bounded reaping, which misses its deadline under CPU oversubscription.

`test/scripts/batsSerialTags.test.ts` fails if a new real-tree mutator lands without the tag (it auto-detects the `var=<real-tree-path>` + `> "$var"` pattern — this is how it caught `check-no-new-direct-git-metadata`). `test/bats/run-bats.bats` pins the two-pass invocation.

## Validation

Local, 16 cores:

| | time | failures |
|---|---|---|
| serial `bats test/bats/` | 287s | 1 (pre-existing env: `verify-runtime-deps`) |
| two-pass runner | **63s** | same 1, **no new failures** |

CI runners have 4 cores, so the speedup is smaller but real. Also ran: shellcheck, shell-portability/sete/quote-boundary, yaml, oxfmt, oxlint ratchet (no new violations), typecheck gate (no new errors), and all affected TS tests (38 pass).