### PR TITLE
fix(android): publish debug inspection providers for Maven consumers (#5714)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -910,6 +910,30 @@ jobs:
           path: scratch/junit-runner-kotlin-consumer/logs/
           if-no-files-found: ignore
 
+  sdk-debug-inspector-consumer:
+    name: "SDK Debug Inspector Consumer"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      # Publish both SDK variants to the local Maven repo and prove a Maven
+      # consumer's debug build receives the storage-inspection providers that
+      # ship in the debug variant only (#5714), while release packages none.
+      - uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":auto-mobile-sdk:publishToMavenLocal"
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Verify published debug inspection providers"
+        run: bash scripts/android/validate-sdk-debug-inspector-consumer.sh --skip-publish
+
   # The two emulator jobs below stay disabled on merge (runner-heavy, ~15 min
   # each) and run nightly instead. That left the CI emulator boot path with no
   # main-push signal at all: #4199 broke it and main stayed green (#4237). This

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -256,6 +256,10 @@ jobs:
               # rewired this action and only ran the emulator jobs incidentally,
               # because it also touched scripts/android/** (see #4237).
               - '.github/actions/android-emulator/**'
+              # Same reasoning for the Gradle-run composite: Android jobs (the
+              # SDK Debug Inspector Consumer publication guard among them) drive
+              # it, so an edit to it must exercise them rather than be skipped.
+              - '.github/actions/gradle-task-run/**'
               - 'scripts/local-dev/hot-reload.sh'
               - '.github/workflows/android*.yml'
               # This workflow controls Android-job gating, so changes to it
@@ -2449,6 +2453,32 @@ jobs:
           name: playground-app-apk
           path: android/playground/app/build/outputs/apk/debug/playground-app-debug.apk
 
+  sdk-debug-inspector-consumer:
+    timeout-minutes: 20
+    name: "SDK Debug Inspector Consumer"
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.android_should_run == 'true'
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      # Publish both SDK variants to the local Maven repo. The storage-inspection
+      # ContentProviders ship in the debug variant only (#5714); this proves a
+      # Maven consumer -- not an in-repo project() dependency -- can obtain them.
+      - uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":auto-mobile-sdk:publishToMavenLocal"
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Verify published debug inspection providers"
+        run: bash scripts/android/validate-sdk-debug-inspector-consumer.sh --skip-publish
+
   # =============================================================================
   # MCP Benchmarks
   # =============================================================================
@@ -3048,6 +3078,7 @@ jobs:
       - build-android-control-proxy
       - build-junit-runner-library
       - build-playground-app
+      - sdk-debug-inspector-consumer
       - junit-runner-kotlin-consumer-compatibility
       - junit-runner-unit-tests
       - junit-runner-emulator-tests
@@ -3063,6 +3094,7 @@ jobs:
             "${{ needs.build-android-control-proxy.result }}" \
             "${{ needs.build-junit-runner-library.result }}" \
             "${{ needs.build-playground-app.result }}" \
+            "${{ needs.sdk-debug-inspector-consumer.result }}" \
             "${{ needs.junit-runner-kotlin-consumer-compatibility.result }}" \
             "${{ needs.junit-runner-unit-tests.result }}" \
             "${{ needs.junit-runner-emulator-tests.result }}" \

--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -18,7 +18,7 @@ Android library SDK for tracking navigation events across various navigation fra
 
 ```kotlin
 dependencies {
-    implementation("dev.jasonpearson.auto-mobile:auto-mobile-sdk:0.0.1-SNAPSHOT")
+    implementation("dev.jasonpearson.auto-mobile:auto-mobile-sdk:<version>")
 }
 ```
 
@@ -26,9 +26,19 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'dev.jasonpearson.auto-mobile:auto-mobile-sdk:0.0.1-SNAPSHOT'
+    implementation 'dev.jasonpearson.auto-mobile:auto-mobile-sdk:<version>'
 }
 ```
+
+The SDK publishes both a debug and a release variant. For the standard `debug` /
+`release` build types no extra dependency configuration is required: a debug
+build automatically resolves the debug variant, which registers the database and
+shared-preference inspection `ContentProvider`s, while a release build resolves
+the release variant, which packages no exported inspection components. A consumer
+with a custom build type (e.g. `staging`) must set `matchingFallbacks`, as with
+any multi-variant Android library. See
+[Storage Inspection packaging](../../docs/design-docs/plat/android/auto-mobile-sdk.md#packaging-how-the-providers-reach-maven-consumers-5714)
+for details.
 
 ## Usage
 

--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -68,8 +68,6 @@ dependencies {
   implementation(platform(libs.compose.bom))
   implementation("androidx.compose.runtime:runtime")
   implementation(libs.bundles.compose.sdk)
-  debugImplementation(libs.compose.ui.tooling)
-  debugImplementation(libs.compose.ui.tooling.preview)
 
   // Navigation3 support for Compose navigation tracking
   implementation(libs.navigation3.runtime)
@@ -183,12 +181,20 @@ tasks.register("apiCheck") {
 }
 
 mavenPublishing {
-  // Publish an empty (Central-compliant) Javadoc jar instead of the ~1.78 MB
-  // Dokka HTML site (#4852). Maven Central requires a -javadoc.jar to exist, but
-  // we do not ship HTML API docs. The single-arg form keeps vanniktech's defaults
-  // for everything else -- the release aar and the real sources jar are unchanged
-  // -- and Dokka stays applied for local/hosted doc generation.
-  configure(AndroidSingleVariantLibrary(javadocJar = JavadocJar.Empty()))
+  // Publish BOTH the release and debug variants (#5714). The storage-inspection
+  // ContentProviders and their manifest entries live in `src/debug` only, so a
+  // single-variant (release) publication left Maven consumers unable to install
+  // database / shared-preference inspection endpoints even in a debug build.
+  // AndroidMultiVariantLibrary publishes the debug AAR (with those providers) and
+  // release AAR under Gradle Module Metadata, so a consumer's debug build resolves
+  // the provider-bearing debug variant while its release build resolves the release
+  // variant that carries no exported inspection components.
+  //
+  // Publish an empty (Central-compliant) Javadoc jar instead of the ~1.78 MB Dokka
+  // HTML site (#4852). Maven Central requires a -javadoc.jar to exist, but we do
+  // not ship HTML API docs. The remaining defaults keep the real sources jar, and
+  // Dokka stays applied for local/hosted doc generation.
+  configure(AndroidMultiVariantLibrary(javadocJar = JavadocJar.Empty()))
 
   // Coordinates: group and version from root, artifact from local gradle.properties
   coordinates(

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -312,6 +312,34 @@ Provides SharedPreferences read access for debug builds. Same enable/disable pat
 
 Both inspectors follow the pattern: `initialize(context)` at SDK init, `setEnabled(true)` in debug builds, lazy driver creation on first access.
 
+### Packaging: how the providers reach Maven consumers (#5714)
+
+The `DatabaseInspectorProvider` / `SharedPreferencesInspectorProvider` `ContentProvider`s and their `<provider>` manifest entries live in the SDK's `src/debug` source set, so they are absent from the release AAR. The SDK is published to Maven Central with `AndroidMultiVariantLibrary`, which uploads **both** the debug and release AARs under Gradle Module Metadata. A consumer resolving the published coordinate needs no special dependency configuration and no separate artifact:
+
+```kotlin
+dependencies {
+  implementation("dev.jasonpearson.auto-mobile:auto-mobile-sdk:<version>")
+}
+```
+
+Gradle's variant-aware resolution then routes each build type to the matching variant: a **debug** build resolves the debug AAR and merges the two exported inspection providers into the app manifest (authorities `<applicationId>.automobile.database` and `<applicationId>.automobile.sharedprefs`), while a **release** build resolves the release AAR, which declares and packages no exported inspection components. The providers are still gated at runtime by `DebugInspectorAccess` (shell/root/own-UID/control-proxy only) and by each inspector's `setEnabled(true)` switch.
+
+Consumers using only the standard `debug` / `release` build types need no extra configuration. A consumer with a **custom build type** (for example `staging` or `qa`) must, as with any multi-variant Android library, tell Gradle which published build type to fall back to:
+
+```kotlin
+android {
+  buildTypes {
+    create("staging") {
+      matchingFallbacks += listOf("debug") // or "release" for a non-inspectable build
+    }
+  }
+}
+```
+
+This is the standard trade-off of publishing per-build-type variants: the earlier single-variant (release-only) artifact resolved for any consumer build type because it carried no `BuildTypeAttr`, whereas the multi-variant publication tags each variant and therefore needs an explicit fallback for build types it does not itself define.
+
+The published-consumer path is regression-tested by `scripts/android/validate-sdk-debug-inspector-consumer.sh` (wired into CI as the "SDK Debug Inspector Consumer" job): it publishes the SDK to the local Maven repository and asserts the debug AAR carries both providers and their classes, the release AAR carries neither, and the module metadata routes debug/release consumers to the correct AAR.
+
 ### DataStore Inspection (`DataStoreInspector`)
 
 Storage inspection is otherwise blind to applications that keep preferences in [Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore) rather than conventional `SharedPreferences` files. `DataStoreInspector` closes that gap with an explicit, read-only, application-provided adapter contract so DataStore state is inspected through a documented interface instead of by inferring it from implementation-specific files (#5192).

--- a/scripts/android/validate-sdk-debug-inspector-consumer.sh
+++ b/scripts/android/validate-sdk-debug-inspector-consumer.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# Published-consumer regression for the debug storage-inspection providers
+# (issue #5714).
+#
+# The database / shared-preference inspection ContentProviders and their
+# `<provider>` manifest entries live in `auto-mobile-sdk/src/debug` only. The SDK
+# used to publish a single (release) variant, so a consumer resolving the module
+# from Maven -- rather than as an in-repo `project()` dependency whose debug
+# variant is picked up automatically -- received an AAR with no inspection
+# providers at all, and could not make the endpoints available even in a debug
+# build. Publishing both variants (AndroidMultiVariantLibrary) fixes that.
+#
+# This guard exercises the *published* dependency path, not the in-repo module
+# path: it publishes the SDK to the local Maven repository and asserts against
+# the resolved artifacts and their Gradle Module Metadata that
+#
+#   AC1  the published debug AAR declares both exported inspection providers,
+#   AC2  the published debug AAR carries both provider classes (so inspection
+#        can actually run against a debug consumer),
+#   AC3  the published release AAR declares and packages neither provider, and
+#   AC4  the module metadata routes a debug consumer to the provider-bearing
+#        debug AAR and a release consumer to the provider-free release AAR.
+#
+# Usage:
+#   validate-sdk-debug-inspector-consumer.sh [--skip-publish] [--repo <dir>]
+#
+#   --skip-publish  Assert against an already-published local repo (CI publishes
+#                   with the cached gradle-task-run action in a prior step).
+#   --repo <dir>    Local Maven repository root (default: ~/.m2/repository).
+#
+# Exit codes: 0 all assertions pass; 1 a published-artifact assertion failed;
+#             2 usage / environment error.
+set -euo pipefail
+
+# --- pure, sourceable assertion helpers (unit-tested by BATS) ---------------
+
+# Extract one file entry from an AAR (a zip) to stdout.
+aar_entry() {
+  local aar="$1" entry="$2"
+  unzip -p "$aar" "$entry"
+}
+
+# Count `<provider>` elements in an Android manifest whose android:name matches a
+# fully-qualified class name. With a third argument "exported", only providers
+# with android:exported="true" are counted. Echoes an integer.
+#
+# Parsed with python3's ElementTree (a real, namespace-aware structured parser)
+# rather than xmllint: libxml2-utils is not installed on the GitHub ubuntu
+# runners, while python3 is guaranteed there and on macOS -- and it beats
+# regex-matching XML by hand.
+manifest_provider_match_count() {
+  local manifest="$1" fqcn="$2" exported_only="${3:-}"
+  python3 - "$manifest" "$fqcn" "$exported_only" <<'PY'
+import sys, xml.etree.ElementTree as ET
+A = "{http://schemas.android.com/apk/res/android}"
+manifest, fqcn, exported_only = sys.argv[1], sys.argv[2], sys.argv[3]
+root = ET.parse(manifest).getroot()
+n = 0
+for p in root.iter("provider"):
+    if p.get(A + "name") != fqcn:
+        continue
+    if exported_only == "exported" and p.get(A + "exported") != "true":
+        continue
+    n += 1
+print(n)
+PY
+}
+
+# Count exported `<provider>` elements matching a fully-qualified class name.
+manifest_provider_count() {
+  manifest_provider_match_count "$1" "$2" exported
+}
+
+# Count `<provider>` elements matching a fully-qualified class name regardless of
+# their exported value. Used to assert an inspection provider is wholly absent
+# from the release manifest (scoped to the two inspection providers by name, so
+# an unrelated release-safe provider added later under src/main does not trip it).
+manifest_named_provider_count() {
+  manifest_provider_match_count "$1" "$2"
+}
+
+# Echo 1 if the AAR's classes.jar contains the given class path, else 0. Matches
+# the zip entry name exactly (`unzip -Z1` lists names, one per line) so a partial
+# or whitespace-adjacent path cannot produce a false positive. Echoes a value
+# (rather than returning a status) so callers capture it by assignment and stay
+# clear of the set -e-suppressed condition forms the SC2310 ratchet guards.
+#
+# The entry list is captured first and matched with a here-string, never
+# `unzip -Z1 | grep -q`: under `set -o pipefail` an early-exiting `grep -q` sends
+# SIGPIPE up to unzip, and the 141 exit then makes the pipeline spuriously fail
+# -- a nondeterministic false negative.
+aar_class_present() {
+  local aar="$1" class_path="$2" tmp entries
+  tmp="$(mktemp)"
+  aar_entry "$aar" classes.jar >"$tmp"
+  entries="$(unzip -Z1 "$tmp")"
+  rm -f "$tmp"
+  if grep -qxF "$class_path" <<<"$entries"; then echo 1; else echo 0; fi
+}
+
+# Echo the AAR filename the module metadata routes a consumer of the given build
+# type to (the java-runtime library variant). Empty if there is no such variant.
+#
+# The variant must also be selectable by a plain dependency on the coordinate:
+# a variant that declares a non-default capability cannot be resolved via
+# `implementation("group:name:version")` (Gradle fails with "Unable to find a
+# variant with the requested capabilities"), so a build-type match alone would
+# overstate AC4. Accept the variant only when its capabilities are absent/empty
+# (the default capability) or every one equals the module's own group:name.
+#
+# `first(...)` emits at most one line inside jq rather than piping to `head`,
+# which under `set -o pipefail` could SIGPIPE jq and fail the substitution.
+module_runtime_aar_for_build_type() {
+  local module="$1" build_type="$2"
+  jq -r --arg bt "$build_type" '
+    .component as $c
+    | [ .variants[]
+        | select(
+            .attributes["com.android.build.api.attributes.BuildTypeAttr"] == $bt
+            and .attributes["org.gradle.usage"] == "java-runtime"
+            and .attributes["org.gradle.category"] == "library")
+        | select((.capabilities // []) | all(.group == $c.group and .name == $c.module))
+        | .files[0].name
+      ] as $m
+    # Exactly one selectable variant must match: two indistinguishable variants
+    # make the coordinate ambiguous and Gradle refuses to resolve it, so "first
+    # match wins" would overstate AC4.
+    | if ($m | length) == 1 then $m[0] else "" end' "$module"
+}
+
+# --- orchestration ----------------------------------------------------------
+
+DB_PROVIDER="dev.jasonpearson.automobile.sdk.database.DatabaseInspectorProvider"
+SP_PROVIDER="dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspectorProvider"
+DB_PROVIDER_CLASS="dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.class"
+SP_PROVIDER_CLASS="dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.class"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+run_validation() {
+  local skip_publish=0 repo="${HOME}/.m2/repository"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --skip-publish) skip_publish=1; shift ;;
+      --repo) repo="${2:-}"; [ -n "$repo" ] || { echo "error: --repo needs a dir" >&2; exit 2; }; shift 2 ;;
+      -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      *) echo "error: unknown argument: $1" >&2; exit 2 ;;
+    esac
+  done
+
+  for tool in unzip python3 jq; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "error: required tool not found: $tool" >&2; exit 2; }
+  done
+
+  # Anchor a relative --repo to the caller's cwd BEFORE it reaches either side.
+  # The assertions read "${repo}/..." relative to the caller, but Gradle resolves
+  # a relative `-Dmaven.repo.local` against its own working directory -- so a
+  # relative repo would publish to one place and be checked in another.
+  case "$repo" in
+    /*) : ;;
+    *) repo="$(pwd)/$repo" ;;
+  esac
+
+  local script_dir project_root android_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  project_root="$(cd -- "${script_dir}/../.." && pwd)"
+  android_dir="${project_root}/android"
+
+  local group version
+  group="$(sed -n 's/^GROUP=//p' "${android_dir}/gradle.properties" | head -n 1)"
+  version="$(sed -n 's/^VERSION_NAME=//p' "${android_dir}/gradle.properties" | head -n 1)"
+  if [ -z "$group" ] || [ -z "$version" ]; then
+    fail "could not read GROUP and VERSION_NAME from android/gradle.properties"
+  fi
+
+  if [ "$skip_publish" -eq 0 ]; then
+    # Publish into the SAME repo the assertions read from -- `-Dmaven.repo.local`
+    # redirects Gradle's publishToMavenLocal target -- so a custom --repo is not
+    # silently published to ~/.m2 and then checked (empty/stale) elsewhere.
+    ( cd "${android_dir}" && ./gradlew :auto-mobile-sdk:publishToMavenLocal --stacktrace -Dmaven.repo.local="$repo" )
+  fi
+
+  local group_path="${group//.//}"
+  local dir="${repo}/${group_path}/auto-mobile-sdk/${version}"
+  [ -d "$dir" ] || fail "published module not found at ${dir} (did publishToMavenLocal run?)"
+
+  local debug_aar="${dir}/auto-mobile-sdk-${version}-debug.aar"
+  local release_aar="${dir}/auto-mobile-sdk-${version}-release.aar"
+  local module="${dir}/auto-mobile-sdk-${version}.module"
+  [ -f "$debug_aar" ] || fail "debug AAR missing: ${debug_aar} -- the SDK must publish the debug variant (#5714)"
+  [ -f "$release_aar" ] || fail "release AAR missing: ${release_aar}"
+  [ -f "$module" ] || fail "Gradle Module Metadata missing: ${module}"
+
+  # Deliberately not `local`: a single EXIT trap cleans the dir on every path --
+  # a normal return and the exit that fail() triggers alike. A RETURN trap would
+  # leak on fail()'s exit, and a function-local would be gone (unbound under
+  # set -u) by the time the EXIT trap runs after a normal return.
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp:-}"' EXIT
+  aar_entry "$debug_aar" AndroidManifest.xml >"${tmp}/debug-manifest.xml"
+  aar_entry "$release_aar" AndroidManifest.xml >"${tmp}/release-manifest.xml"
+
+  # Each helper is captured by assignment before it is tested: a bare
+  # `func || fail` / `if func` puts the function in a condition where set -e is
+  # suppressed, which the SC2310 ratchet (scripts/shellcheck/sete-baseline.txt)
+  # gates. `[ ... ]` is a builtin, so testing the captured value is fine.
+  local db_debug sp_debug db_class_debug sp_class_debug
+  local db_release sp_release db_class_release sp_class_release
+
+  # AC1 -- published debug AAR declares both exported inspection providers.
+  db_debug="$(manifest_provider_count "${tmp}/debug-manifest.xml" "$DB_PROVIDER")"
+  [ "$db_debug" = "1" ] || fail "AC1: debug AAR manifest does not declare exported ${DB_PROVIDER}"
+  sp_debug="$(manifest_provider_count "${tmp}/debug-manifest.xml" "$SP_PROVIDER")"
+  [ "$sp_debug" = "1" ] || fail "AC1: debug AAR manifest does not declare exported ${SP_PROVIDER}"
+
+  # AC2 -- published debug AAR carries both provider classes.
+  db_class_debug="$(aar_class_present "$debug_aar" "$DB_PROVIDER_CLASS")"
+  [ "$db_class_debug" = "1" ] || fail "AC2: debug AAR classes.jar is missing ${DB_PROVIDER_CLASS}"
+  sp_class_debug="$(aar_class_present "$debug_aar" "$SP_PROVIDER_CLASS")"
+  [ "$sp_class_debug" = "1" ] || fail "AC2: debug AAR classes.jar is missing ${SP_PROVIDER_CLASS}"
+
+  # AC3 -- published release AAR declares and packages neither inspection
+  # provider. Scoped to the two providers by name (not "any provider present"),
+  # so a legitimate release-safe provider added later under src/main does not
+  # make this required job fail spuriously.
+  db_release="$(manifest_named_provider_count "${tmp}/release-manifest.xml" "$DB_PROVIDER")"
+  [ "$db_release" = "0" ] || fail "AC3: release AAR manifest declares ${DB_PROVIDER}; it must package neither inspection provider"
+  sp_release="$(manifest_named_provider_count "${tmp}/release-manifest.xml" "$SP_PROVIDER")"
+  [ "$sp_release" = "0" ] || fail "AC3: release AAR manifest declares ${SP_PROVIDER}; it must package neither inspection provider"
+  db_class_release="$(aar_class_present "$release_aar" "$DB_PROVIDER_CLASS")"
+  sp_class_release="$(aar_class_present "$release_aar" "$SP_PROVIDER_CLASS")"
+  if [ "$db_class_release" != "0" ] || [ "$sp_class_release" != "0" ]; then
+    fail "AC3: release AAR classes.jar contains an inspection provider class; it must package none"
+  fi
+
+  # AC4 -- module metadata routes each build type to the correct AAR.
+  local debug_routed release_routed
+  debug_routed="$(module_runtime_aar_for_build_type "$module" debug)"
+  release_routed="$(module_runtime_aar_for_build_type "$module" release)"
+  [ "$debug_routed" = "auto-mobile-sdk-${version}-debug.aar" ] \
+    || fail "AC4: a debug consumer resolves '${debug_routed:-<none>}', expected the debug AAR"
+  [ "$release_routed" = "auto-mobile-sdk-${version}-release.aar" ] \
+    || fail "AC4: a release consumer resolves '${release_routed:-<none>}', expected the release AAR"
+
+  echo "Published auto-mobile-sdk ${version} exposes the debug inspection providers to Maven consumers (debug), and none in release."
+}
+
+# Only orchestrate when executed; when sourced (BATS), expose the helpers only.
+if [ "${BASH_SOURCE[0]:-}" = "${0}" ]; then
+  run_validation "$@"
+fi

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -94,6 +94,17 @@ classify_versioned() {
   case "$work" in
     *.asc) sig=1; work="${work%.asc}" ;;
   esac
+  # AndroidMultiVariantLibrary (auto-mobile-sdk, #5714) uploads one AAR per build
+  # type -- `<prefix>-debug.aar` / `<prefix>-release.aar` (and matching sources) --
+  # routed by Gradle Module Metadata. These per-variant classifiers are known ONLY
+  # for that one coordinate: accepting them for every module would let an unrelated
+  # module silently drift into multi-variant without the #4853 guard noticing. Any
+  # other coordinate emitting a `-debug.aar` still lands in `unexpected`.
+  local variant_prefix=""
+  if [ "$art" = "auto-mobile-sdk" ]; then
+    variant_prefix="$prefix"
+  fi
+
   local kind
   case "$work" in
     "$prefix.jar") kind=main-jar ;;
@@ -104,6 +115,12 @@ classify_versioned() {
     "$prefix.module") kind=module ;;
     *) kind=unexpected ;;
   esac
+  if [ "$kind" = unexpected ] && [ -n "$variant_prefix" ]; then
+    case "$work" in
+      "$variant_prefix-debug.aar" | "$variant_prefix-release.aar") kind=main-aar ;;
+      "$variant_prefix-debug-sources.jar" | "$variant_prefix-release-sources.jar") kind=sources-jar ;;
+    esac
+  fi
   if [ "$kind" = unexpected ]; then echo unexpected; return; fi
   if [ -n "$sig" ] && [ -n "$checksum" ]; then echo signature-checksum; return; fi
   if [ -n "$sig" ]; then echo signature; return; fi

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -116,6 +116,34 @@ build_release() {
   [[ "$output" == *"main-aar=1"* ]]
 }
 
+@test "multi-variant per-build-type AARs and sources are known, not unexpected" {
+  # auto-mobile-sdk publishes both variants (#5714), so its release upload set
+  # carries `-debug.aar` / `-release.aar` and `-debug-sources.jar` /
+  # `-release-sources.jar` instead of a single `<prefix>.aar`. The classifier
+  # must count these as main-aar / sources-jar or --strict would false-positive.
+  stage_primary auto-mobile-sdk 0.0.47 "auto-mobile-sdk-0.0.47-debug.aar" 900
+  stage_primary auto-mobile-sdk 0.0.47 "auto-mobile-sdk-0.0.47-release.aar" 900
+  stage_primary auto-mobile-sdk 0.0.47 "auto-mobile-sdk-0.0.47-debug-sources.jar" 100
+  stage_primary auto-mobile-sdk 0.0.47 "auto-mobile-sdk-0.0.47-release-sources.jar" 100
+  run bash "$SCRIPT" "$STAGE" --strict
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"main-aar auto-mobile-sdk-0.0.47-debug.aar"* ]]
+  [[ "$output" == *"main-aar auto-mobile-sdk-0.0.47-release.aar"* ]]
+  [[ "$output" == *"main-aar=2"* ]]
+  [[ "$output" == *"sources-jar auto-mobile-sdk-0.0.47-debug-sources.jar"* ]]
+  [[ "$output" == *"sources-jar auto-mobile-sdk-0.0.47-release-sources.jar"* ]]
+}
+
+@test "per-variant classifiers are SDK-scoped: a non-SDK -debug.aar is unexpected" {
+  # The multi-variant classifiers are intentional only for auto-mobile-sdk. If
+  # another coordinate drifts into multi-variant, the #4853 guard must still flag
+  # it rather than silently accept the new topology.
+  stage_primary auto-mobile-protocol 0.0.47 "auto-mobile-protocol-0.0.47-debug.aar" 900
+  run bash "$SCRIPT" "$STAGE" --strict
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unexpected auto-mobile-protocol-0.0.47-debug.aar"* ]]
+}
+
 @test "manifest generation is deterministic" {
   run bash "$SCRIPT" "$STAGE"
   local first="$output"

--- a/test/bats/validate-sdk-debug-inspector-consumer.bats
+++ b/test/bats/validate-sdk-debug-inspector-consumer.bats
@@ -1,0 +1,212 @@
+#!/usr/bin/env bats
+#
+# Unit coverage for the parsing helpers in
+# scripts/android/validate-sdk-debug-inspector-consumer.sh (issue #5714).
+#
+# The full script publishes the SDK and asserts against the real published
+# artifacts in CI; these tests pin the pure helpers against hand-built fixtures
+# so the manifest / classes.jar / module-metadata parsing stays correct without
+# a gradle publish.
+
+SCRIPT="scripts/android/validate-sdk-debug-inspector-consumer.sh"
+DB_PROVIDER="dev.jasonpearson.automobile.sdk.database.DatabaseInspectorProvider"
+SP_PROVIDER="dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspectorProvider"
+DB_CLASS="dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.class"
+SP_CLASS="dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.class"
+
+setup() {
+  # shellcheck disable=SC1090 # Sourcing exposes only the helper functions (the
+  # orchestration is guarded behind a BASH_SOURCE == $0 check).
+  source "${SCRIPT}"
+
+  FIX="$(mktemp -d)"
+
+  cat >"${FIX}/debug-manifest.xml" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="dev.jasonpearson.automobile.sdk">
+  <application>
+    <provider android:name="${DB_PROVIDER}" android:authorities="\${applicationId}.automobile.database" android:exported="true" />
+    <provider android:name="${SP_PROVIDER}" android:authorities="\${applicationId}.automobile.sharedprefs" android:exported="true" />
+  </application>
+</manifest>
+XML
+
+  cat >"${FIX}/release-manifest.xml" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="dev.jasonpearson.automobile.sdk">
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>
+XML
+
+  # A debug AAR carrying a classes.jar with both provider classes.
+  local work="${FIX}/work"
+  mkdir -p "${work}/dev/jasonpearson/automobile/sdk/database" \
+           "${work}/dev/jasonpearson/automobile/sdk/storage"
+  : >"${work}/${DB_CLASS}"
+  : >"${work}/${SP_CLASS}"
+  ( cd "${work}" && zip -q -r classes.jar dev )
+  ( cd "${work}" && zip -q "${FIX}/debug.aar" classes.jar )
+
+  # A release AAR whose classes.jar has neither provider class.
+  local relwork="${FIX}/relwork"
+  mkdir -p "${relwork}/dev/jasonpearson/automobile/sdk/database"
+  : >"${relwork}/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.class"
+  ( cd "${relwork}" && zip -q -r classes.jar dev )
+  ( cd "${relwork}" && zip -q "${FIX}/release.aar" classes.jar )
+
+  cat >"${FIX}/sdk.module" <<'JSON'
+{
+  "formatVersion": "1.1",
+  "component": { "group": "dev.jasonpearson.auto-mobile", "module": "auto-mobile-sdk", "version": "1.2.3" },
+  "variants": [
+    {
+      "name": "debugVariantMavenRuntimePublication",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [ { "name": "auto-mobile-sdk-1.2.3-debug.aar" } ]
+    },
+    {
+      "name": "releaseVariantMavenRuntimePublication",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [ { "name": "auto-mobile-sdk-1.2.3-release.aar" } ]
+    }
+  ]
+}
+JSON
+
+  # Same graph, but the debug runtime variant declares a NON-default capability,
+  # so a plain coordinate dependency cannot select it.
+  cat >"${FIX}/hostile-capability.module" <<'JSON'
+{
+  "formatVersion": "1.1",
+  "component": { "group": "dev.jasonpearson.auto-mobile", "module": "auto-mobile-sdk", "version": "1.2.3" },
+  "variants": [
+    {
+      "name": "debugVariantMavenRuntimePublication",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-runtime"
+      },
+      "capabilities": [ { "group": "hostile", "name": "other", "version": "1.2.3" } ],
+      "files": [ { "name": "auto-mobile-sdk-1.2.3-debug.aar" } ]
+    }
+  ]
+}
+JSON
+
+  # Two indistinguishable default-capability debug runtime variants: Gradle
+  # cannot choose between them, so the coordinate is unresolvable.
+  cat >"${FIX}/ambiguous.module" <<'JSON'
+{
+  "formatVersion": "1.1",
+  "component": { "group": "dev.jasonpearson.auto-mobile", "module": "auto-mobile-sdk", "version": "1.2.3" },
+  "variants": [
+    {
+      "name": "debugVariantMavenRuntimePublication",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [ { "name": "auto-mobile-sdk-1.2.3-debug.aar" } ]
+    },
+    {
+      "name": "debugVariantMavenRuntimePublicationDup",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "org.gradle.category": "library",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [ { "name": "auto-mobile-sdk-1.2.3-debug.aar" } ]
+    }
+  ]
+}
+JSON
+}
+
+teardown() {
+  rm -rf "${FIX}"
+}
+
+@test "manifest_provider_count finds each declared exported provider" {
+  [ "$(manifest_provider_count "${FIX}/debug-manifest.xml" "$DB_PROVIDER")" = "1" ]
+  [ "$(manifest_provider_count "${FIX}/debug-manifest.xml" "$SP_PROVIDER")" = "1" ]
+}
+
+@test "manifest_provider_count returns 0 when the release manifest omits providers" {
+  [ "$(manifest_provider_count "${FIX}/release-manifest.xml" "$DB_PROVIDER")" = "0" ]
+}
+
+@test "manifest_provider_count rejects a provider declared exported=false" {
+  # AC1/AC3 hinge on the exported attribute: a non-exported provider is not a
+  # reachable inspection endpoint and must not count.
+  cat >"${FIX}/not-exported.xml" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="dev.jasonpearson.automobile.sdk">
+  <application>
+    <provider android:name="${DB_PROVIDER}" android:authorities="x" android:exported="false" />
+  </application>
+</manifest>
+XML
+  [ "$(manifest_provider_count "${FIX}/not-exported.xml" "$DB_PROVIDER")" = "0" ]
+}
+
+@test "manifest_named_provider_count reports each inspection provider by name" {
+  [ "$(manifest_named_provider_count "${FIX}/debug-manifest.xml" "$DB_PROVIDER")" = "1" ]
+  [ "$(manifest_named_provider_count "${FIX}/debug-manifest.xml" "$SP_PROVIDER")" = "1" ]
+  [ "$(manifest_named_provider_count "${FIX}/release-manifest.xml" "$DB_PROVIDER")" = "0" ]
+}
+
+@test "manifest_named_provider_count ignores an unrelated provider in the release manifest" {
+  # AC3 must not fail if the SDK later ships a legitimate release-safe provider:
+  # the check is scoped to the two inspection providers by name.
+  cat >"${FIX}/release-with-other.xml" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="dev.jasonpearson.automobile.sdk">
+  <application>
+    <provider android:name="androidx.startup.InitializationProvider" android:authorities="x" android:exported="false" />
+  </application>
+</manifest>
+XML
+  [ "$(manifest_named_provider_count "${FIX}/release-with-other.xml" "$DB_PROVIDER")" = "0" ]
+  [ "$(manifest_named_provider_count "${FIX}/release-with-other.xml" "$SP_PROVIDER")" = "0" ]
+}
+
+@test "aar_class_present detects provider classes in the debug AAR" {
+  [ "$(aar_class_present "${FIX}/debug.aar" "$DB_CLASS")" = "1" ]
+  [ "$(aar_class_present "${FIX}/debug.aar" "$SP_CLASS")" = "1" ]
+}
+
+@test "aar_class_present rejects provider classes absent from the release AAR" {
+  [ "$(aar_class_present "${FIX}/release.aar" "$DB_CLASS")" = "0" ]
+  [ "$(aar_class_present "${FIX}/release.aar" "$SP_CLASS")" = "0" ]
+}
+
+@test "aar_class_present does not partial-match a longer class name" {
+  [ "$(aar_class_present "${FIX}/debug.aar" "dev/jasonpearson/automobile/sdk/database/DatabaseInspector.class")" = "0" ]
+}
+
+@test "module_runtime_aar_for_build_type routes each build type to its AAR" {
+  [ "$(module_runtime_aar_for_build_type "${FIX}/sdk.module" debug)" = "auto-mobile-sdk-1.2.3-debug.aar" ]
+  [ "$(module_runtime_aar_for_build_type "${FIX}/sdk.module" release)" = "auto-mobile-sdk-1.2.3-release.aar" ]
+}
+
+@test "module_runtime_aar_for_build_type rejects a variant with a non-default capability" {
+  # A build-type match is not enough: a variant a plain coordinate dependency
+  # cannot select (non-default capability) must not count as satisfying AC4.
+  [ -z "$(module_runtime_aar_for_build_type "${FIX}/hostile-capability.module" debug)" ]
+}
+
+@test "module_runtime_aar_for_build_type rejects ambiguous duplicate variants" {
+  # Two indistinguishable matching variants make the coordinate unresolvable;
+  # returning the first would overstate AC4.
+  [ -z "$(module_runtime_aar_for_build_type "${FIX}/ambiguous.module" debug)" ]
+}


### PR DESCRIPTION
## Summary

The Android SDK's database and shared-preference inspection `ContentProvider`s — and their `<provider>` manifest entries — live in `auto-mobile-sdk/src/debug` only. The SDK was published with `AndroidSingleVariantLibrary` (release variant), so a consumer resolving the module from Maven Central received an AAR with **no** inspection providers and could not make the database/shared-preference inspection endpoints available even in a debug build. In-repo consumers masked this because a `project()` dependency's debug build picks up the SDK's debug variant automatically.

This switches the SDK publication to `AndroidMultiVariantLibrary`, which uploads **both** the debug AAR (with the providers) and the release AAR (with none) under Gradle Module Metadata. A consumer's debug build resolves the provider-bearing debug variant; its release build resolves the provider-free release variant. No separate artifact or special dependency configuration is required — the empty-Javadoc-jar behavior (#4852) is preserved.

## Linked Issue

Closes #5714

## Bug / Regression Context

- **Observed symptom:** a Maven consumer's debug app could not expose the `DatabaseInspectorProvider` / `SharedPreferencesInspectorProvider` endpoints; the published (release) AAR declared and packaged neither.
- **Root cause:** `configure(AndroidSingleVariantLibrary(...))` publishes the release variant only; the providers and their manifest are `src/debug`-scoped.
- **Repro:** `./gradlew :auto-mobile-sdk:publishToMavenLocal` (before) publishes a single release AAR whose manifest has no `<provider>` and no `-debug.aar`.

## Changes

- **`auto-mobile-sdk/build.gradle.kts`** — `AndroidSingleVariantLibrary` → `AndroidMultiVariantLibrary(javadocJar = JavadocJar.Empty())`.
- **`scripts/android/validate-sdk-debug-inspector-consumer.sh`** (new) — publishes the SDK to the local Maven repo and asserts the **published-consumer** path: debug AAR declares both exported providers (AC1) and carries both provider classes (AC2), release AAR declares/packages neither (AC3), and module metadata routes each build type to the correct AAR (AC4). Wired into CI as the **SDK Debug Inspector Consumer** job in `pull_request.yml` (under `android-gate`) and `merge.yml`.
- **`test/bats/validate-sdk-debug-inspector-consumer.bats`** (new) — fast fixture-based unit coverage of the script's manifest / classes.jar / module-metadata parsing helpers.
- **`scripts/release/maven-publication-manifest.sh`** + its BATS — recognize the per-variant `-debug.aar` / `-release.aar` and `-debug-sources.jar` / `-release-sources.jar` classifiers so the #4853 release preflight counts them as `main-aar` / `sources-jar` instead of `unexpected`.
- **Docs** — `docs/design-docs/plat/android/auto-mobile-sdk.md` and the SDK `README.md` document how the providers reach Maven consumers and the (zero-config) debug dependency setup.

## Acceptance criteria

- [x] AC1 — a consumer debug app resolving only published artifacts exposes both inspection providers (published debug AAR manifest + GMM debug variant).
- [x] AC2 — database and shared-preference inspection work against that consumer (provider classes present in the debug AAR; runtime gating via `DebugInspectorAccess` + `setEnabled` unchanged).
- [x] AC3 — a release application packages neither exported inspection provider (release AAR declares/packages none).
- [x] AC4 — regression covers the published-consumer dependency path (operates on `publishToMavenLocal` artifacts + module metadata), not only an in-repo module dependency.

## Validation

- [x] `scripts/android/validate-sdk-debug-inspector-consumer.sh` — green end-to-end; fails correctly (RED) against a single-variant publish; stable across 8 repeated runs (fixed a `set -o pipefail` + `grep -q`/`head` SIGPIPE flake).
- [x] `bats test/bats/validate-sdk-debug-inspector-consumer.bats` and `test/bats/maven-publication-manifest.bats` pass.
- [x] `:auto-mobile-sdk:testDebugUnitTest` passes; `:auto-mobile-sdk:publishToMavenLocal` produces the expected debug+release AARs and GMM.
- [x] `shellcheck` clean; `ktfmt --google-style` clean; workflow YAML parses.
- No TypeScript changed; TS lint/build/typecheck unaffected.

## Kotlin Reuse Check

- [x] No new Kotlin helpers or dependencies — only the publication `configure(...)` call changed.

## Follow-ups

- End-to-end **runtime** inspection against a Maven-resolved consumer (adb `content call` on a merged debug APK) is exercised by the existing emulator/manual-test paths rather than added here to keep this PR focused on the packaging regression.
