### PR TITLE
fix(snapshot): enforce strictBackupMode all-or-nothing for iOS app data (#5711)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -39,7 +39,7 @@ Capture or restore device snapshots.
 - `includeSettings` (capture only): Include system settings (global/secure/system)
 - `useVmSnapshot` (capture/restore): Use emulator VM snapshot if available (faster for emulators)
 - `vmSnapshotTimeoutMs` (capture/restore): Timeout in milliseconds for emulator VM snapshot commands
-- `strictBackupMode` (capture only, **iOS-only**): If true, fail the snapshot when an iOS app-container backup fails. No effect on Android now that the adb-backup path is gone.
+- `strictBackupMode` (capture only, **iOS-only**): If true, fail the whole snapshot unless every requested bundle is backed up (all-or-nothing) — any bundle that is not-installed, container-less, or fails to copy rejects the capture with an `ActionableError` naming the uncovered bundles (issue #5711). No effect on Android now that the adb-backup path is gone.
 - `appBundleIds` (capture only): iOS bundle IDs to include in app container backups
 - `sessionUuid` (optional): Session UUID for multi-device targeting
 - `device` (optional): Device label for multi-device control

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -936,7 +936,7 @@
           "type": "boolean"
         },
         "strictBackupMode": {
-          "description": "iOS-only: fail if app container backup fails",
+          "description": "iOS-only: fail the whole snapshot unless every requested bundle is backed up (all-or-nothing)",
           "type": "boolean"
         },
         "vmSnapshotTimeoutMs": {

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -47,7 +47,7 @@ export interface CaptureSnapshotArgs {
   includeAppData?: boolean;
   includeSettings?: boolean;
   useVmSnapshot?: boolean;
-  strictBackupMode?: boolean; // iOS-only: if true, fail the snapshot when an app container backup fails
+  strictBackupMode?: boolean; // iOS-only: if true, fail the whole snapshot unless every requested bundle is backed up (all-or-nothing)
   vmSnapshotTimeoutMs?: number; // Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)
   appBundleIds?: string[]; // iOS-only: bundle identifiers to include in app data snapshot
 }
@@ -507,9 +507,16 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
       }
     }
 
-    if (strictBackupMode && failedPackages.length > 0) {
+    // strict = all-or-nothing (#5711): fail the whole snapshot unless every
+    // requested bundle was actually backed up. `failedPackages` alone is not
+    // enough — a bundle with no data container lands in `skippedPackages` yet
+    // still leaves the requested set uncovered, so key the check on coverage.
+    if (strictBackupMode && backedUpPackages.length < sanitized.length) {
+      const backedUp = new Set(backedUpPackages);
+      const notBackedUp = sanitized.filter((bundleId) => !backedUp.has(bundleId));
       throw new ActionableError(
-        `Failed to backup app data for ${failedPackages.length} app(s): ${failedPackages.join(", ")}`,
+        `Failed to backup app data for ${notBackedUp.length} of ${sanitized.length} ` +
+          `requested app(s) in strictBackupMode (all-or-nothing): ${notBackedUp.join(", ")}.`,
       );
     }
 

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -17,7 +17,12 @@ const deviceSnapshotCommonShape = {
     ),
   includeSettings: z.boolean().optional().describe("Include settings"),
   useVmSnapshot: z.boolean().optional().describe("Use emulator VM snapshot"),
-  strictBackupMode: z.boolean().optional().describe("iOS-only: fail if app container backup fails"),
+  strictBackupMode: z
+    .boolean()
+    .optional()
+    .describe(
+      "iOS-only: fail the whole snapshot unless every requested bundle is backed up (all-or-nothing)",
+    ),
   vmSnapshotTimeoutMs: z.number().optional().describe("VM snapshot timeout ms"),
   appBundleIds: z.array(z.string()).optional().describe("iOS bundle IDs for app data snapshot"),
 };

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -732,6 +732,64 @@ describe("CaptureSnapshot (iOS)", () => {
     ).rejects.toThrow("Failed to backup app data");
   });
 
+  it("fails in strictBackupMode when a requested bundle has no data container (all-or-nothing)", async () => {
+    // strict = all-or-nothing (#5711): a skipped-no-container bundle keeps
+    // backedUpPackages from covering the full requested set, so the whole
+    // snapshot must fail even though one bundle captured and none "failed".
+    const captured = "com.example.captured";
+    const noContainer = "com.example.nocontainer";
+
+    const containerRoot = path.join(testBasePath, "containers", captured);
+    await fs.mkdir(path.join(containerRoot, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(containerRoot, "Documents", "data.txt"), "hello");
+
+    simctl.setContainerPath(captured, containerRoot);
+    simctl.setInstalledApps([
+      { CFBundleIdentifier: captured },
+      { CFBundleIdentifier: noContainer },
+    ]);
+
+    const captureSnapshot = makeCapture();
+    const promise = captureSnapshot.execute({
+      snapshotName: "strict-no-container",
+      includeAppData: true,
+      includeSettings: false,
+      strictBackupMode: true,
+      appBundleIds: [captured, noContainer],
+    });
+
+    await expect(promise).rejects.toThrow("Failed to backup app data");
+    // Names the bundle that was not backed up so the failure is actionable.
+    await expect(promise).rejects.toThrow(/com\.example\.nocontainer/);
+  });
+
+  it("fails in strictBackupMode for a mixed valid+invalid set (#5711 AC)", async () => {
+    // Mixed set: one installed-with-container (valid) + one not-installed
+    // (invalid). Strict mode rejects the whole snapshot and names the invalid
+    // bundle; the same set succeeds non-strict (covered above).
+    const captured = "com.example.captured";
+    const notInstalled = "com.example.missing";
+
+    const containerRoot = path.join(testBasePath, "containers", captured);
+    await fs.mkdir(path.join(containerRoot, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(containerRoot, "Documents", "data.txt"), "hello");
+
+    simctl.setContainerPath(captured, containerRoot);
+    simctl.setInstalledApps([{ CFBundleIdentifier: captured }]);
+
+    const captureSnapshot = makeCapture();
+    const promise = captureSnapshot.execute({
+      snapshotName: "strict-mixed",
+      includeAppData: true,
+      includeSettings: false,
+      strictBackupMode: true,
+      appBundleIds: [captured, notInstalled],
+    });
+
+    await expect(promise).rejects.toThrow("Failed to backup app data");
+    await expect(promise).rejects.toThrow(/com\.example\.missing/);
+  });
+
   it("fails the capture when every requested bundle is not installed (0 captured)", async () => {
     // No installed apps: com.fake.doesnotexist resolves to not-installed, so
     // backedUpPackages is empty. Before #5710 this "succeeded" with an empty


### PR DESCRIPTION
## Summary

`strictBackupMode:true` was documented as "fail the entire snapshot if app data backup fails", but the iOS capture path only rejected bundles that landed in `failedPackages`. A requested bundle that is installed but exposes **no data container** lands in `skippedPackages`, so a strict capture where one bundle was captured and another was skipped still reported "captured successfully" — violating the all-or-nothing intent.

This keys the strict check on **coverage**: strict mode now fails the whole snapshot unless `backedUpPackages` covers the full requested set, so any not-backed-up bundle (failed *or* skipped) rejects the snapshot with an `ActionableError` that names the uncovered bundles. Non-strict behavior is unchanged (partial capture, subject to the existing "fail when 0 captured" guard from #5710).

## Linked Issue

Closes #5711

## Bug / Regression Context

- **Observed symptom:** `{ includeAppData:true, strictBackupMode:true }` could return "captured successfully" without fully backing up the requested set (a skipped-no-container bundle did not trip strict mode).
- **Root cause:** strict check was `failedPackages.length > 0` rather than "backedUpPackages doesn't cover the full requested set".
- **Fix:** condition is now `backedUpPackages.length < sanitized.length`; the error names the uncovered bundles.

## Changes

- `src/features/action/CaptureSnapshot.ts` — strict check keyed on coverage; comment + `strictBackupMode` doc updated to "all-or-nothing".
- `src/server/snapshotTools.ts` — schema description updated to reflect all-or-nothing.
- `schemas/tool-definitions.json` — regenerated.
- `test/features/action/CaptureSnapshot.test.ts` — new tests.

## Validation

- [x] `bun run lint` + `bun test` (full suite; only a pre-existing process-lifecycle timing flake, green in isolation)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun x turbo run build` + `bun run format:check` clean
- [x] New tests run in <100ms (fake simctl, no real DB/filesystem services)

## Acceptance Criteria

- [x] Strict mode fails the whole snapshot when `backedUpPackages` doesn't cover the full requested set (all-or-nothing) — new test: strict + skipped-no-container → error.
- [x] Non-strict keeps partial-capture behavior with `failedPackages` populated — existing test unchanged.
- [x] Mixed valid+invalid set: strict → error (names invalid bundle); non-strict → success.
- [x] Android settings-only path treats strict as a no-op — existing test unchanged.

## Device Verification

N/A for this change — iOS simulator behavior is pinned by unit tests against a fake `SimCtlClient`; no on-device gesture/observe surface touched.
