### PR TITLE
fix(snapshot): reject path-traversal snapshotName before filesystem/adb use (#5705)

### DIFF
--- a/docs/design-docs/mcp/storage/snapshots.md
+++ b/docs/design-docs/mcp/storage/snapshots.md
@@ -34,7 +34,7 @@ Capture or restore device snapshots.
 **Parameters:**
 
 - `action` (required): `"capture"` or `"restore"`
-- `snapshotName` (capture: optional, restore: required): Name for the snapshot
+- `snapshotName` (capture: optional, restore: required): Name for the snapshot. Must be a single path segment: names containing a path separator (`/` or `\`), a `.`/`..` traversal segment, or an absolute path are rejected with an `ActionableError` before any filesystem or `adb emu avd snapshot save`/`simctl` use, so a name can never escape the snapshots directory (issue #5705)
 - `includeAppData` (capture only): Include app data. Honored by VM snapshots (emulators) and iOS app-container backups. **Ignored on non-VM Android** (physical devices / `useVmSnapshot: false`), which is settings-only — the captured manifest records `includeAppData: false`.
 - `includeSettings` (capture only): Include system settings (global/secure/system)
 - `useVmSnapshot` (capture/restore): Use emulator VM snapshot if available (faster for emulators)

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -24,6 +24,7 @@ import {
   formatVmSnapshotExecutionError,
 } from "../../utils/android-cmdline-tools/vmSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
+import { assertSafeSnapshotName } from "../../utils/snapshotNameValidation";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import {
@@ -100,6 +101,10 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
    * Execute snapshot capture
    */
   async execute(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
+    // Reject a traversal/absolute snapshotName before any filesystem write or
+    // `adb emu avd snapshot save`/`simctl` call can act on it (issue #5705).
+    assertSafeSnapshotName(args.snapshotName);
+
     switch (this.device.platform) {
       case "android":
         return this.executeAndroid(args);

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -18,6 +18,7 @@ import {
   formatVmSnapshotExecutionError,
 } from "../../utils/android-cmdline-tools/vmSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
+import { assertSafeSnapshotName } from "../../utils/snapshotNameValidation";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import {
@@ -91,6 +92,10 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
    * Execute snapshot restoration
    */
   async execute(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
+    // Reject a traversal/absolute snapshotName before any filesystem read or
+    // `adb emu avd snapshot load`/`simctl` call resolves a path from it (#5705).
+    assertSafeSnapshotName(args.snapshotName);
+
     switch (this.device.platform) {
       case "android":
         return this.executeAndroid(args);

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -17,6 +17,7 @@ import {
   type ConfigRepository,
 } from "../db/keyedJsonConfigRepository";
 import { DeviceSnapshotStore, type SnapshotPathOptions } from "../utils/DeviceSnapshotStore";
+import { assertSafeSnapshotName } from "../utils/snapshotNameValidation";
 import { parseDeviceSnapshotConfig } from "../features/snapshot";
 import { serverConfig } from "../utils/ServerConfig";
 import { ResourceRegistry } from "./resourceRegistry";
@@ -523,6 +524,9 @@ export async function captureDeviceSnapshot(
 
   const baseConfig = await getDeviceSnapshotConfig();
   const snapshotName = args.snapshotName ?? snapshotStore.generateSnapshotName(device.name);
+  // Reject a traversal/absolute name before any filesystem probe (this runs
+  // `fs.access` via ensureSnapshotAvailable) or capture command (issue #5705).
+  assertSafeSnapshotName(snapshotName);
   const pathOptions = getSnapshotPathOptions({
     platform: device.platform,
     deviceId: device.deviceId,
@@ -585,6 +589,10 @@ export async function restoreDeviceSnapshot(
 }> {
   const { snapshotRepository, snapshotStore, timer, now, createRestoreProvider } =
     await getDeviceSnapshotDependencies();
+
+  // Reject a traversal/absolute name before any snapshot lookup or legacy
+  // manifest read resolves a path from it (issue #5705).
+  assertSafeSnapshotName(args.snapshotName);
 
   let record = await snapshotRepository.getSnapshot(args.snapshotName);
   if (!record) {

--- a/src/utils/snapshotNameValidation.ts
+++ b/src/utils/snapshotNameValidation.ts
@@ -1,0 +1,59 @@
+import * as path from "path";
+import { ActionableError } from "../models";
+
+/**
+ * Reject a `snapshotName` that could escape the snapshots directory before it
+ * reaches any filesystem path or emulator/simulator command.
+ *
+ * `DeviceSnapshotStore` builds every on-disk path with `path.join(basePath,
+ * snapshotName, …)`, and the Android VM path forwards the raw name to
+ * `adb emu avd snapshot save <name>`. A name containing a path separator, a `.`
+ * or `..` segment, or an absolute path therefore writes (or saves a VM snapshot)
+ * outside the intended directory (issue #5705). We reject rather than silently
+ * slugify: a silent rename would hide the caller's mistake and could still
+ * collide with an existing snapshot.
+ *
+ * The snapshot name must be a single, non-empty path segment made of ordinary
+ * characters — no separators, no `.`/`..`, no NUL, no absolute path.
+ */
+export function assertSafeSnapshotName(snapshotName: string): void {
+  const reject = (reason: string): never => {
+    throw new ActionableError(
+      `Invalid snapshot name '${snapshotName}': ${reason}. Use a single name segment ` +
+        "without path separators, '.'/'..', or an absolute path.",
+    );
+  };
+
+  if (typeof snapshotName !== "string" || snapshotName.trim().length === 0) {
+    reject("name must be a non-empty string");
+    return;
+  }
+
+  // NUL can truncate a path in native syscalls, hiding the real target.
+  if (snapshotName.includes("\0")) {
+    reject("name contains a NUL byte");
+    return;
+  }
+
+  // Any separator (POSIX '/' or Windows '\\') makes the name more than one path
+  // segment — this catches 'a/b' and the leading separator of most absolute
+  // paths — so joining it can descend into or escape the snapshots directory.
+  if (snapshotName.includes("/") || snapshotName.includes("\\")) {
+    reject("name contains a path separator");
+    return;
+  }
+
+  // '.' and '..' as the whole name are the traversal primitives that have no
+  // separator of their own; '..' escapes the snapshots directory outright.
+  if (snapshotName === "." || snapshotName === "..") {
+    reject("name is a path traversal segment");
+    return;
+  }
+
+  // Absolute paths (including Windows drive-letter forms like 'C:\\x' that
+  // survive the separator check on POSIX) must never be joined onto basePath.
+  if (path.isAbsolute(snapshotName) || path.win32.isAbsolute(snapshotName)) {
+    reject("name is an absolute path");
+    return;
+  }
+}

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -859,3 +859,52 @@ describe("CaptureSnapshot (iOS)", () => {
     expect(settingsCommands).toEqual([]);
   });
 });
+
+describe("CaptureSnapshot snapshotName path-traversal rejection (#5705)", () => {
+  let device: BootedDevice;
+  let fakeAdb: FakeAdbClient;
+  let fakeAdbFactory: AdbClientFactory;
+  let fakeTimer: FakeTimer;
+  let store: DeviceSnapshotStore;
+  let testBasePath: string;
+
+  beforeEach(async () => {
+    device = {
+      deviceId: "emulator-5554",
+      name: "Pixel_5",
+      platform: "android",
+      isEmulator: true,
+    };
+    fakeAdb = new FakeAdbClient();
+    fakeAdbFactory = { create: () => fakeAdb as any };
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    testBasePath = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-traversal-test-"));
+    store = new DeviceSnapshotStore(testBasePath);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(testBasePath, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    fakeTimer.reset();
+  });
+
+  for (const badName of ["../traversal_x", "a/b", "/etc/passwd"]) {
+    it(`rejects '${badName}' before any adb snapshot-save command`, async () => {
+      const capture = new CaptureSnapshot(device, fakeAdbFactory, undefined, fakeTimer, store);
+      await expect(capture.execute({ snapshotName: badName, useVmSnapshot: true })).rejects.toThrow(
+        /invalid snapshot name/i,
+      );
+      // The VM path must never forward the raw name to the emulator console.
+      expect(
+        fakeAdb.getAllCommands().some((command) => command.startsWith("emu avd snapshot save")),
+      ).toBe(false);
+      // Nothing may have been written under the snapshots base directory.
+      const entries = await fs.readdir(testBasePath);
+      expect(entries).toEqual([]);
+    });
+  }
+});

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -478,6 +478,25 @@ describe("deviceSnapshotManager", () => {
     }
   });
 
+  test("captureDeviceSnapshot rejects a path-traversal name before capturing (#5705)", async () => {
+    for (const badName of ["../traversal_x", "a/b", "/etc/passwd"]) {
+      await expect(captureDeviceSnapshot(TEST_DEVICE, { snapshotName: badName })).rejects.toThrow(
+        /invalid snapshot name/i,
+      );
+    }
+    // The capture provider must never be invoked for an unsafe name.
+    expect(captureCalls).toEqual([]);
+  });
+
+  test("restoreDeviceSnapshot rejects a path-traversal name before lookup (#5705)", async () => {
+    for (const badName of ["../traversal_x", "a/b", "/etc/passwd"]) {
+      await expect(restoreDeviceSnapshot(TEST_DEVICE, { snapshotName: badName })).rejects.toThrow(
+        /invalid snapshot name/i,
+      );
+    }
+    expect(restoreCalls).toEqual([]);
+  });
+
   test("legacy flat-path cleanup never deletes a reserved scope root (#5707)", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-reserved-"));
     try {

--- a/test/utils/snapshotNameValidation.test.ts
+++ b/test/utils/snapshotNameValidation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test";
+import { assertSafeSnapshotName } from "../../src/utils/snapshotNameValidation";
+import { ActionableError } from "../../src/models";
+
+describe("assertSafeSnapshotName (#5705)", () => {
+  it("refuses a parent-directory traversal name '../x'", () => {
+    expect(() => assertSafeSnapshotName("../traversal_x")).toThrow(ActionableError);
+    expect(() => assertSafeSnapshotName("../x")).toThrow(/path separator/i);
+  });
+
+  it("refuses a nested path 'a/b'", () => {
+    expect(() => assertSafeSnapshotName("a/b")).toThrow(ActionableError);
+    expect(() => assertSafeSnapshotName("a/b")).toThrow(/path separator/i);
+  });
+
+  it("refuses an absolute POSIX path", () => {
+    expect(() => assertSafeSnapshotName("/etc/passwd")).toThrow(ActionableError);
+  });
+
+  it("refuses a Windows-style separator and drive-letter absolute path", () => {
+    expect(() => assertSafeSnapshotName("a\\b")).toThrow(/path separator/i);
+    expect(() => assertSafeSnapshotName("C:\\Windows\\x")).toThrow(ActionableError);
+  });
+
+  it("refuses the bare traversal segments '.' and '..'", () => {
+    expect(() => assertSafeSnapshotName("..")).toThrow(/traversal/i);
+    expect(() => assertSafeSnapshotName(".")).toThrow(/traversal/i);
+  });
+
+  it("refuses empty, whitespace-only, and NUL-containing names", () => {
+    expect(() => assertSafeSnapshotName("")).toThrow(ActionableError);
+    expect(() => assertSafeSnapshotName("   ")).toThrow(ActionableError);
+    expect(() => assertSafeSnapshotName("a\0b")).toThrow(/NUL/i);
+  });
+
+  it("accepts ordinary single-segment names, including dotted and spaced ones", () => {
+    expect(() => assertSafeSnapshotName("snapshot_2026-08-25_12-00-00")).not.toThrow();
+    expect(() => assertSafeSnapshotName("Pixel_5_baseline")).not.toThrow();
+    expect(() => assertSafeSnapshotName("v1.0")).not.toThrow();
+    expect(() => assertSafeSnapshotName("my snapshot")).not.toThrow();
+    expect(() => assertSafeSnapshotName("..foo")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`deviceSnapshot` used `snapshotName` directly in filesystem paths (`DeviceSnapshotStore` does `path.join(basePath, snapshotName, …)`) and forwarded the raw name to `adb emu avd snapshot save <name>`, so a name containing `..`, a path separator, or an absolute path could write — or save a VM snapshot — outside the snapshots directory. Confirmed on device: `snapshotName:"../traversal_x"` wrote `settings.json` to `~/.auto-mobile/traversal_x/…`, one level outside `snapshots/`, while reporting success.

This adds a small pure guard, `assertSafeSnapshotName()`, and enforces it at every entry before any filesystem or emulator/simulator call. It **rejects** rather than slugifies: a silent rename would hide the caller's mistake and could still collide with an existing snapshot.

## Linked Issue

Closes #5705

## Bug / Regression Context

- **Observed symptom:** a `snapshotName` with `..`/separators/an absolute path escaped `~/.auto-mobile/snapshots/`; the tool reported "captured successfully".
- **Repro steps / conditions:** `deviceSnapshot { action:"capture", platform:"android", snapshotName:"../traversal_x", includeSettings:true }`.

## Changes

- `src/utils/snapshotNameValidation.ts` — new `assertSafeSnapshotName()`; throws `ActionableError` for names that are empty/blank, contain a NUL byte, contain a `/` or `\` separator, are the bare `.`/`..` traversal segments, or are absolute (POSIX or Windows drive-letter).
- `src/server/deviceSnapshotManager.ts` — validate in `captureDeviceSnapshot` (before `ensureSnapshotAvailable`'s `fs.access`) and `restoreDeviceSnapshot` (before any snapshot lookup / legacy-manifest read).
- `src/features/action/CaptureSnapshot.ts` / `RestoreSnapshot.ts` — defense-in-depth guard at the top of `execute()`, before any `adb emu avd snapshot save|load` / `simctl` / filesystem call, so no future caller can bypass.

## Acceptance criteria

- [x] Reject any `snapshotName` containing path separators, `..`, or an absolute path — before any filesystem or `adb emu avd snapshot save`/`simctl` use.
- [x] Unit test asserting `../x`, `a/b`, and absolute paths are refused.
- [x] The VM path validates before forwarding the name to `adb emu avd snapshot save`.

## Validation

- [x] `bun test` for the touched suites green (`snapshotNameValidation`, `deviceSnapshotManager`, `CaptureSnapshot`, `RestoreSnapshot`).
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] `bun run lint` — no new ratchet violations; `bun run format:check` clean.
- [x] `bun run build` succeeds.
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms.

The `CaptureSnapshot` test additionally asserts a traversal name never reaches `emu avd snapshot save` and writes nothing under the snapshots base dir.

## Follow-ups

None. Store-level path methods remain a candidate for a defense-in-depth guard, but every current entry point is now validated upstream.
