### PR TITLE
fix(ci): serialize root package.json BATS mutators + verify GNU parallel

### DIFF
--- a/scripts/ci/run-bats.sh
+++ b/scripts/ci/run-bats.sh
@@ -10,8 +10,8 @@
 #
 # Two passes:
 #
-#   1. Parallel pass — everything EXCEPT files tagged `serial-boundary`. We
-#      parallelize ACROSS files but keep each file's tests SERIAL
+#   1. Parallel pass — everything EXCEPT files tagged `serial`. We parallelize
+#      ACROSS files but keep each file's tests SERIAL
 #      (`--no-parallelize-within-files`): tests inside one file share `setup()`
 #      / `teardown()`, so serializing within a file is the conservative default
 #      while still spreading the files across every core.
@@ -28,25 +28,40 @@
 #
 # `bats --jobs` requires GNU parallel; this script installs it when missing and
 # suppresses its first-run citation notice so it does not spam CI logs.
-set -euo pipefail
+#
+# The functions are defined unconditionally but main() only runs when the script
+# is executed, not sourced, so test/bats/run-bats.bats can source it and probe
+# individual functions (e.g. is_gnu_parallel) without triggering an install.
 
-BATS_DIR="${1:-test/bats}"
 SERIAL_TAG="serial"
 
 log() { printf '%s\n' "$*" >&2; }
 
+# `bats --jobs` requires *GNU* parallel specifically. A bare `command -v
+# parallel` is not enough: the unrelated moreutils `parallel` is also named
+# `parallel` and would satisfy it while breaking bats. Only GNU parallel prints
+# a "GNU parallel" banner from `--version`, so probe that capability.
+is_gnu_parallel() {
+  parallel --version 2> /dev/null | head -1 | grep -q "GNU parallel"
+}
+
 ensure_gnu_parallel() {
-  if command -v parallel > /dev/null 2>&1; then
+  if is_gnu_parallel; then
     return 0
   fi
-  log "GNU parallel not found; installing"
+  log "GNU parallel not found (or a non-GNU 'parallel' is on PATH); installing"
   if command -v brew > /dev/null 2>&1; then
     brew install parallel
   elif command -v apt-get > /dev/null 2>&1; then
     sudo apt-get update -qq
+    # The Debian/Ubuntu 'parallel' package IS GNU parallel.
     sudo apt-get install -y -qq parallel
   else
     log "ERROR: cannot install GNU parallel (no brew or apt-get)"
+    return 1
+  fi
+  if ! is_gnu_parallel; then
+    log "ERROR: GNU parallel still not available after install (a non-GNU 'parallel' may be shadowing it on PATH)"
     return 1
   fi
 }
@@ -59,18 +74,43 @@ silence_parallel_citation() {
   touch "$home_dir/will-cite"
 }
 
-ensure_gnu_parallel
-silence_parallel_citation
-
 # _NPROCESSORS_ONLN is portable across the Linux and macOS runners; fall back to
 # 2 if the host does not expose it.
-jobs="$(getconf _NPROCESSORS_ONLN 2> /dev/null || echo 2)"
-if ! [[ "$jobs" =~ ^[0-9]+$ ]] || [[ "$jobs" -lt 1 ]]; then
-  jobs=2
+job_count() {
+  local jobs
+  jobs="$(getconf _NPROCESSORS_ONLN 2> /dev/null || echo 2)"
+  if ! [[ "$jobs" =~ ^[0-9]+$ ]] || [[ "$jobs" -lt 1 ]]; then
+    jobs=2
+  fi
+  printf '%s\n' "$jobs"
+}
+
+main() {
+  # errexit is deliberately NOT set: this script branches on the exit status of
+  # helper functions (ensure_gnu_parallel, is_gnu_parallel) and of each bats
+  # pass, which under `set -e` both trips SC2310 (set -e is suppressed inside a
+  # function invoked in a condition) and would abort before the serial pass.
+  # Errors are handled explicitly instead, and rc aggregates both passes.
+  set -uo pipefail
+  local bats_dir="${1:-test/bats}"
+
+  ensure_gnu_parallel || exit 1
+  silence_parallel_citation
+
+  local jobs
+  jobs="$(job_count)"
+
+  local rc=0
+  log "Parallel pass: bats --jobs $jobs --no-parallelize-within-files (excluding $SERIAL_TAG) over $bats_dir"
+  bats --jobs "$jobs" --no-parallelize-within-files --filter-tags "!$SERIAL_TAG" "$bats_dir" || rc=1
+
+  log "Serial pass: bats (only $SERIAL_TAG) over $bats_dir"
+  bats --filter-tags "$SERIAL_TAG" "$bats_dir" || rc=1
+
+  return "$rc"
+}
+
+# Only run when executed directly; sourcing (from tests) just loads the functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
 fi
-
-log "Parallel pass: bats --jobs $jobs --no-parallelize-within-files (excluding $SERIAL_TAG) over $BATS_DIR"
-bats --jobs "$jobs" --no-parallelize-within-files --filter-tags "!$SERIAL_TAG" "$BATS_DIR"
-
-log "Serial pass: bats (only $SERIAL_TAG) over $BATS_DIR"
-bats --filter-tags "$SERIAL_TAG" "$BATS_DIR"

--- a/test/bats/check-stdlib-first.bats
+++ b/test/bats/check-stdlib-first.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Rewrites the real root package.json (backup -> mutate -> restore) and writes
+# docs/decisions/ fixtures, operating in the repo root (no cd to a temp dir), so
+# it races any concurrent test that reads or rewrites package.json. Runs in the
+# serial pass; see scripts/ci/run-bats.sh and test/scripts/batsSerialTags.test.ts.
 
 SCRIPT="scripts/check-stdlib-first.sh"
 

--- a/test/bats/pin-runtime-deps.bats
+++ b/test/bats/pin-runtime-deps.bats
@@ -1,4 +1,9 @@
 #!/usr/bin/env bats
+# bats file_tags=serial
+# Rewrites the real root package.json (backup -> mutate -> restore) in the repo
+# root (no cd to a temp dir), so it races any concurrent test that reads or
+# rewrites package.json. Runs in the serial pass; see scripts/ci/run-bats.sh and
+# test/scripts/batsSerialTags.test.ts.
 #
 # Guards the hermetic drift-check of the pinned runtime dependency graph (#5421).
 # The pure pin/partition logic is covered by test/release/runtimePins.test.ts;

--- a/test/bats/run-bats.bats
+++ b/test/bats/run-bats.bats
@@ -22,8 +22,14 @@ printf '%s\n' "\$*" >> "$ARGS_FILE"
 EOF
   chmod +x "$STUB_BIN/bats"
 
+  # GNU parallel identifies itself via `--version`; the runner probes for that
+  # string, so the stub must emit it or the runner would try to install.
   cat > "$STUB_BIN/parallel" <<'EOF'
 #!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "GNU parallel 20230101"
+  exit 0
+fi
 exit 0
 EOF
   chmod +x "$STUB_BIN/parallel"
@@ -86,4 +92,27 @@ serial_pass_args() { grep -v -- '--jobs' "$ARGS_FILE"; }
   run env HOME="$FAKE_HOME" PATH="$STUB_BIN:$PATH" bash "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$(cat "$ARGS_FILE")" == *"test/bats"* ]]
+}
+
+# is_gnu_parallel must accept only GNU parallel, not the unrelated moreutils
+# `parallel` (which is also named `parallel` but breaks `bats --jobs`). Source
+# the script (main() is guarded) and probe the function directly.
+@test "is_gnu_parallel accepts GNU parallel" {
+  PATH="$STUB_BIN:$PATH" source "$SCRIPT"
+  PATH="$STUB_BIN:$PATH" run is_gnu_parallel
+  [ "$status" -eq 0 ]
+}
+
+@test "is_gnu_parallel rejects a non-GNU (moreutils-style) parallel" {
+  # moreutils parallel does not understand --version and errors instead.
+  cat > "$STUB_BIN/parallel" <<'EOF'
+#!/usr/bin/env bash
+echo "parallel: invalid option -- '-'" >&2
+exit 1
+EOF
+  chmod +x "$STUB_BIN/parallel"
+
+  source "$SCRIPT"
+  PATH="$STUB_BIN:/usr/bin:/bin" run is_gnu_parallel
+  [ "$status" -ne 0 ]
 }

--- a/test/scripts/batsSerialTags.test.ts
+++ b/test/scripts/batsSerialTags.test.ts
@@ -3,15 +3,29 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // scripts/ci/run-bats.sh runs the BATS suite cross-file-parallel, except files
-// tagged `serial`, which it runs one at a time. A file that writes a fixture
-// into the REAL source tree (src/ | android/ | ios/) and then runs a scanner
-// over that tree races every other file under parallelism (that is exactly the
-// class of flake that motivated this: an unrelated file scans the tree while a
-// fixture is present). This guard fails if such a file lands without the tag,
-// so a new boundary/convention check cannot silently reintroduce the race.
+// tagged `serial`, which it runs one at a time. A file that writes into the REAL
+// working tree — a fixture under src/|android/|ios/, or a root-level committed
+// file such as package.json — and then runs a scanner over that tree races every
+// other file under parallelism (an unrelated file reads/scans the tree while the
+// mutation is live). This guard fails if such a file lands without the tag, so a
+// new boundary/convention check cannot silently reintroduce the race.
 
 const BATS_DIR = join(import.meta.dir, "..", "..", "test", "bats");
+
+// Real-tree path prefixes for variable-target detection (var assigned a path
+// under one of these, then used as a redirection target).
 const REAL_TREE = /^(src|android|ios)\//;
+
+// Committed paths that, when they are the TARGET of a write op (redirect, cp,
+// mv, tee), mean the test rewrites the real working tree in place. Covers
+// root-level files (package.json and friends) and committed directories.
+const COMMITTED_TARGET =
+  "(?:package\\.json|package-lock\\.json|bun\\.lock|tsconfig[\\w.-]*\\.json|src/|android/|ios/|docs/|schemas/|scripts/|benchmark/)";
+const COMMITTED_WRITE = new RegExp(
+  // `> committed`, `>> committed`, `tee committed`, `cp SRC committed`, `mv SRC committed`.
+  String.raw`(?:>>?\s*|tee\s+|(?:cp|mv)\s+\S+\s+)"?` + COMMITTED_TARGET,
+  "m",
+);
 
 interface BatsFile {
   name: string;
@@ -24,11 +38,23 @@ function loadBatsFiles(): BatsFile[] {
     .map((name) => ({ name, text: readFileSync(join(BATS_DIR, name), "utf8") }));
 }
 
-// A file mutates the real tree when it assigns a variable to a real-tree path
-// and then uses that variable as a redirection target (printf/cat/echo > "$VAR").
-// Copies FROM a real path INTO a temp dir assign the real path but redirect to a
-// different (temp) target, so they are not flagged.
+// A file that `cd`s into a variable directory (`cd "$REPO"`, invariably a
+// mktemp-derived working dir in this suite) does its relative-path writes inside
+// that temp cwd, not the real checkout, so it is hermetic and exempt.
+function operatesInTempCwd(text: string): boolean {
+  return /^\s*cd\s+"?\$/m.test(text);
+}
+
+// A file mutates the real tree when it either (a) assigns a variable to a
+// real-tree path and uses that variable as a redirection target
+// (`printf ... > "$FIXTURE"`), or (b) writes directly to a committed path
+// (`> package.json`, `mv x package.json`, `cp x src/...`). Copies FROM a real
+// path INTO a temp dir assign/read the real path but write a temp target, so
+// they are not flagged.
 function mutatesRealTree(text: string): boolean {
+  if (operatesInTempCwd(text)) {
+    return false;
+  }
   const realVars = new Set<string>();
   for (const line of text.split("\n")) {
     const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)=["']?([^"'\s]+)/);
@@ -43,7 +69,7 @@ function mutatesRealTree(text: string): boolean {
       return true;
     }
   }
-  return false;
+  return COMMITTED_WRITE.test(text);
 }
 
 function hasSerialTag(text: string): boolean {
@@ -73,10 +99,25 @@ describe("bats serial-pass tagging (scripts/ci/run-bats.sh)", () => {
     expect(offenders).toEqual([]);
   });
 
-  test("the tag detector actually recognizes a known mutator (guards against a no-op regex)", () => {
+  test("the tag detector recognizes a src/-fixture mutator (guards against a no-op regex)", () => {
     const known = files.find((f) => f.name === "check-android-emulator-boundary.bats");
     expect(known).toBeDefined();
     expect(mutatesRealTree(known!.text)).toBe(true);
     expect(hasSerialTag(known!.text)).toBe(true);
+  });
+
+  test("the tag detector recognizes a root-level package.json mutator", () => {
+    const known = files.find((f) => f.name === "check-stdlib-first.bats");
+    expect(known).toBeDefined();
+    expect(mutatesRealTree(known!.text)).toBe(true);
+    expect(hasSerialTag(known!.text)).toBe(true);
+  });
+
+  test("a file that cds into a temp dir before writing is treated as hermetic", () => {
+    // docs-changed-since-last-deploy writes docs/*.md, but inside `cd "$REPO"`
+    // (a mktemp dir), so it must NOT be flagged as a real-tree mutator.
+    const hermetic = files.find((f) => f.name === "docs-changed-since-last-deploy.bats");
+    expect(hermetic).toBeDefined();
+    expect(mutatesRealTree(hermetic!.text)).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #5728 (merged) — addresses the Codex review on that PR. Two findings, both confirmed and reproduced.

## P1 — serialize tests that rewrite root-level `package.json`

`check-stdlib-first.bats` and `pin-runtime-deps.bats` back up → rewrite → restore the **real root `package.json`** (and `check-stdlib-first` writes `docs/decisions/` fixtures) while operating in the repo root (no `cd` into a temp dir). Under the new cross-file parallel pass they race each other and any concurrent test that reads `package.json` — a failed `mv`, nondeterministic assertions, or restoring the other test's fixture into the checkout.

- Tag both files `# bats file_tags=serial`.
- Extend `test/scripts/batsSerialTags.test.ts` so its guard also detects **root-level / committed-path writes** (`package.json`, `package-lock.json`, `bun.lock`, `tsconfig*`, and `src/|android/|ios/|docs/|schemas/|scripts/|benchmark/` via redirect / `cp` / `mv` / `tee`), and **exempts files that `cd` into a temp dir** (`docs-changed-since-last-deploy`, `validate-ktfmt` write relative paths inside a `mktemp` cwd, so they're hermetic). The extended detector flags exactly these two and nothing else.

## P2 — verify GNU parallel, not moreutils `parallel`

`command -v parallel` also matches the unrelated **moreutils `parallel`**, which does not drive `bats --jobs` — so on such a host the check passed and the suite would fail instead of installing GNU parallel. Now probe `parallel --version | grep -q 'GNU parallel'` before skipping install, and fail loudly if a non-GNU `parallel` still shadows it after install.

## Refactor

`run-bats.sh` is split into functions + a source-guarded `main()` so `test/bats/run-bats.bats` can source it and unit-test `is_gnu_parallel` (GNU accepted, moreutils-style rejected) without triggering an install. `errexit` is dropped in favor of explicit error handling — this avoids SC2310 (set -e suppressed inside a function invoked in a condition; the `shell-sete` gate flagged it) and lets both passes run with an aggregated exit code.

## Validation

shellcheck, shell-sete, shell-portability, yaml, oxfmt, typecheck (no new errors); `run-bats.bats` (7 pass incl. the two GNU-parallel cases), `batsSerialTags.test.ts` (5 pass), full suite via the runner — same single pre-existing env failure (`verify-runtime-deps`), no new failures; the two newly-tagged files pass in the serial pass.