### PR TITLE
fix(storage): guard decodeURIComponent in key-value storageResources handlers against malformed URIs

### DIFF
--- a/src/server/storageResources.ts
+++ b/src/server/storageResources.ts
@@ -1,4 +1,4 @@
-import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { ResourceRegistry, ResourceContent, getRequestedResourceUri } from "./resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -126,6 +126,35 @@ function getEntriesCacheKey(deviceId: string, packageName: string, fileName: str
   return `${deviceId}:${packageName}:${fileName}`;
 }
 
+// Decode a percent-encoded path segment, returning null when the encoding is
+// malformed. A host-defined package or file name may contain a literal `%`
+// that is not valid percent-encoding; letting decodeURIComponent's URIError
+// escape would bypass the JSON diagnostic envelope, exactly the failure mode
+// #5686 fixed for query params — here for path params (issue #5734).
+function safeDecodeSegment(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    logger.debug(`[StorageResources] Malformed URI segment '${value}': ${error}`);
+    return null;
+  }
+}
+
+// Structured diagnostic for a URI whose path segments are not valid
+// percent-encoding, served on the originally-requested URI so the client still
+// gets a typed JSON envelope rather than a raw MCP error.
+function malformedUriContent(params: Record<string, string>): ResourceContent {
+  return {
+    uri: getRequestedResourceUri(params) ?? "",
+    mimeType: "application/json",
+    text: JSON.stringify(
+      { error: "Malformed resource URI: a path segment is not valid percent-encoding." },
+      null,
+      2,
+    ),
+  };
+}
+
 /**
  * Build resource URI for storage files
  */
@@ -145,7 +174,10 @@ function buildEntriesUri(deviceId: string, packageName: string, fileName: string
  */
 async function getStorageFilesResource(params: Record<string, string>): Promise<ResourceContent> {
   const { deviceId, packageName } = params;
-  const decodedPackage = decodeURIComponent(packageName);
+  const decodedPackage = safeDecodeSegment(packageName);
+  if (decodedPackage === null) {
+    return malformedUriContent(params);
+  }
   const uri = buildFilesUri(deviceId, decodedPackage);
 
   logger.info(
@@ -213,8 +245,11 @@ async function getStorageFilesResource(params: Record<string, string>): Promise<
  */
 async function getStorageEntriesResource(params: Record<string, string>): Promise<ResourceContent> {
   const { deviceId, packageName, fileName } = params;
-  const decodedPackage = decodeURIComponent(packageName);
-  const decodedFileName = decodeURIComponent(fileName);
+  const decodedPackage = safeDecodeSegment(packageName);
+  const decodedFileName = safeDecodeSegment(fileName);
+  if (decodedPackage === null || decodedFileName === null) {
+    return malformedUriContent(params);
+  }
   const uri = buildEntriesUri(deviceId, decodedPackage, decodedFileName);
 
   try {

--- a/test/server/storageResources.test.ts
+++ b/test/server/storageResources.test.ts
@@ -62,4 +62,26 @@ describe("storageResources", () => {
     const content = await readResource(uri);
     expect(content.uri).toBe(uri);
   });
+
+  test("storage-files resource returns a JSON envelope for a malformed percent-encoded segment (not a raw throw)", async () => {
+    // A host-defined package segment with a literal `%` that is not valid
+    // percent-encoding must yield a typed JSON diagnostic served on the
+    // originally-requested URI, not a URIError that escapes the handler and
+    // ResourceRegistry (cf. #5686 for query params; issue #5734 for path params).
+    const uri = "automobile:devices/emulator-5554/storage/wei%rd/files";
+    const content = await readResource(uri);
+    expect(content.mimeType).toBe("application/json");
+    expect(content.uri).toBe(uri);
+    const body = JSON.parse(content.text ?? "{}");
+    expect(String(body.error)).toContain("percent-encoding");
+  });
+
+  test("storage-entries resource returns a JSON envelope for a malformed percent-encoded segment (not a raw throw)", async () => {
+    const uri = "automobile:devices/emulator-5554/storage/com.example.app/wei%rd/entries";
+    const content = await readResource(uri);
+    expect(content.mimeType).toBe("application/json");
+    expect(content.uri).toBe(uri);
+    const body = JSON.parse(content.text ?? "{}");
+    expect(String(body.error)).toContain("percent-encoding");
+  });
 });


### PR DESCRIPTION
## Summary

The key-value storage resource handlers in `src/server/storageResources.ts`
(`getStorageFilesResource`, `getStorageEntriesResource`) decoded their path
segments with `decodeURIComponent` **outside** the `try` block. A segment
containing a literal `%` that is not valid percent-encoding (e.g. a host-defined
name like `wei%rd`) matches the template's `[^/&]+` and reaches
`decodeURIComponent`, which throws `URIError`. That error escaped the handler and
`ResourceRegistry`'s ReadResource handler (no try/catch there), so the client
received a raw MCP error instead of the structured JSON diagnostic envelope — the
path-param analog of the query-param issue fixed in #5686.

This mirrors the fix already applied to the sibling `dataStoreResources.ts`
during review of #5727: decode each segment via a `safeDecodeSegment` helper that
catches `URIError`, logs at debug, and returns `null`; on `null` the handler
returns a structured JSON diagnostic built from the originally-requested URI via
`getRequestedResourceUri` rather than letting the throw escape.

## Linked Issue

Closes #5734

## Bug / Regression Context

- **Prior attempts:** #5686 fixed the same class for query params; #5727 fixed it
  for the new DataStore handlers via `safeDecodeSegment`. This applies the guard
  to the pre-existing key-value sibling handlers, which was out of scope for #5727.
- **Observed symptom:** a `URIError` escaped the resource handler and
  `ResourceRegistry`, so a malformed percent-encoded path segment surfaced as a
  raw MCP error instead of a JSON diagnostic.
- **Repro steps / conditions:** read a storage-files/entries resource whose
  package/file segment contains a literal `%` (e.g.
  `automobile:devices/emulator-5554/storage/wei%rd/files`).

## Changes

- `src/server/storageResources.ts`: added `safeDecodeSegment` (catches `URIError`,
  logs at debug, returns `null`) and `malformedUriContent` (structured JSON
  envelope on the originally-requested URI); both handlers now decode inside the
  guard and short-circuit to the diagnostic on malformed input.
- `test/server/storageResources.test.ts`: two regression tests reading a
  literal-`%` URI for each handler and asserting a JSON envelope (no `URIError`).

## Acceptance criteria

- [x] `getStorageFilesResource` / `getStorageEntriesResource` return a structured
  JSON envelope for a malformed percent-encoded path segment.
- [x] A unit test pins the behavior (no `URIError` escapes the handler).

## Validation

- [x] `bun test test/server/storageResources.test.ts` — 6 pass
- [x] `bun test` full suite — 14441 pass (1 unrelated env failure: worktree
  `node_modules/.bin/oxlint` ENOENT)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — no new ratchet violations; `format:check` clean
- [x] New code reuses the existing `getRequestedResourceUri` helper and mirrors
  the sibling `dataStoreResources.ts` pattern; unit tests run in <100ms

Relates to #5603, #5686.
