### PR TITLE
fix(snapshot): unwind orphan iOS snapshot dir on failed capture (#5723)

### DIFF
--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -469,6 +469,27 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     const appDataPath = this.store.getAppDataPath(snapshotName, pathOptions);
     await fs.mkdir(appDataPath, { recursive: true });
 
+    // The mkdir above creates the snapshot directory (recursive parent). If the
+    // backup then fails — strict-mode all-or-nothing, the 0-backed-up guard, or
+    // an installation-listing error — that directory is left behind and blocks a
+    // later capture reusing the same explicit `snapshotName` at
+    // ensureSnapshotAvailable's "already exists on disk" guard. Unwind it before
+    // re-throwing so an explicit-name retry can succeed (issue #5723). Safe
+    // because ensureSnapshotAvailable already verified the directory did not
+    // exist before this capture, so we only remove what this capture created.
+    try {
+      return await this.backupIosAppContainers(sanitized, strictBackupMode, appDataPath);
+    } catch (error) {
+      await this.store.deleteSnapshotData(snapshotName, pathOptions);
+      throw error;
+    }
+  }
+
+  private async backupIosAppContainers(
+    sanitized: string[],
+    strictBackupMode: boolean,
+    appDataPath: string,
+  ): Promise<DeviceSnapshotManifest["appDataBackup"]> {
     // Validate installation up front so an unknown bundle is reported as
     // not-installed rather than silently "succeeding".
     const installedBundleIds = await this.getInstalledIosBundleIds();

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -825,6 +825,46 @@ describe("CaptureSnapshot (iOS)", () => {
     await expect(promise).rejects.toThrow(/backed up 0 of 1/i);
   });
 
+  it("removes the orphan snapshot directory when strictBackupMode fails (#5723)", async () => {
+    // strictBackupMode rejects a not-installed bundle, but captureIosAppData has
+    // already run fs.mkdir on the app-data path (creating the parent snapshot
+    // dir). It must unwind that directory so an explicit-name retry isn't blocked
+    // by ensureSnapshotAvailable's "already exists on disk" guard.
+    const pathOptions = { platform: "ios", deviceId: device.deviceId } as const;
+    const snapshotName = "strict-orphan";
+    const captureSnapshot = makeCapture();
+
+    await expect(
+      captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        strictBackupMode: true,
+        appBundleIds: ["com.example.missing"],
+      }),
+    ).rejects.toThrow("Failed to backup app data");
+
+    expect(await store.snapshotDirectoryExists(snapshotName, pathOptions)).toBe(false);
+  });
+
+  it("removes the orphan snapshot directory when 0 packages back up (#5723)", async () => {
+    // The 0-backed-up guard fires after the app-data mkdir; the created snapshot
+    // dir must be unwound before re-throwing.
+    const pathOptions = { platform: "ios", deviceId: device.deviceId } as const;
+    const snapshotName = "empty-orphan";
+    simctl.setInstalledApps([{ CFBundleIdentifier: "com.example.other" }]);
+    const captureSnapshot = makeCapture();
+
+    await expect(
+      captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        appBundleIds: ["com.fake.doesnotexist"],
+      }),
+    ).rejects.toThrow(/backed up 0 of 1/i);
+
+    expect(await store.snapshotDirectoryExists(snapshotName, pathOptions)).toBe(false);
+  });
+
   it("succeeds when at least one bundle is captured in a mixed set", async () => {
     // Mixed/partial policy (non-strict): one captured, one skipped-no-container,
     // one not-installed. backedUpPackages is non-empty, so the capture succeeds.


### PR DESCRIPTION
## Summary

When an iOS `deviceSnapshot capture` fails, `captureIosAppData`
(`src/features/action/CaptureSnapshot.ts`) has already run
`fs.mkdir(appDataPath, { recursive: true })`, which creates the parent
snapshot directory, before it can throw. The failure paths are: strict-mode
all-or-nothing (#5711), the 0-backed-up guard (#5710), and an
installation-listing error. The leftover directory then blocks a later capture
reusing the same explicit `snapshotName` at `ensureSnapshotAvailable`'s
"already exists on disk" guard (`src/server/deviceSnapshotManager.ts`), even
though the failed capture persisted no DB record and no usable backup.

The post-mkdir backup work is now wrapped so any throw removes the created
snapshot directory (`deleteSnapshotData`) before re-throwing. This is safe
because `ensureSnapshotAvailable` already verified the directory did not exist
before this capture, so only what this capture created is removed.

## Linked Issue

Closes #5723

## Bug / Regression Context

- **Prior attempts:** Surfaced by the code review on PR #5722 (closes #5710) and
  deferred to keep that PR scoped. The partial-dir behavior is pre-existing
  (landed with the strict-mode throw in f20157cdfc); #5710 only broadened *when*
  the throw fires.
- **Observed symptom:** A capture pinning an explicit `snapshotName` fails, then
  a retry with the same name fails with "already exists on disk".
- **Repro steps / conditions:** Capture with an explicit `snapshotName` and
  `includeAppData:true` where 0 apps back up (or strict-mode rejects), then
  retry with the same `snapshotName`.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — full suite 14447 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses existing helper (`DeviceSnapshotStore.deleteSnapshotData`)

## Acceptance Criteria

Per the issue's Fix section: on any capture failure that already created the
snapshot directory, unwind it before re-throwing so an explicit-name retry can
succeed. Applies to both the strict-mode throw and the 0-backed-up guard.

Pinned by two new tests in `test/features/action/CaptureSnapshot.test.ts`:
- "removes the orphan snapshot directory when strictBackupMode fails (#5723)"
- "removes the orphan snapshot directory when 0 packages back up (#5723)"

The retry-unblocking follows directly: `ensureSnapshotAvailable` keys its
"already exists on disk" guard on `snapshotDirectoryExists`, so removing the
directory is exactly what lets the retry through.

## Device Verification

N/A — filesystem cleanup on a failure path; fully covered by unit tests with a
real `DeviceSnapshotStore` (temp dir) and a fake simctl client.
