### PR TITLE
fix(db): guard installed_apps profile_type migration against existing column (#5704)

### DIFF
--- a/src/db/migrations/2026_08_24_000_installed_apps_profile_type.ts
+++ b/src/db/migrations/2026_08_24_000_installed_apps_profile_type.ts
@@ -1,7 +1,14 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
-  await db.schema.alterTable("installed_apps").addColumn("profile_type", "text").execute();
+  const existingColumn = await sql<{ name: string }>`
+    SELECT name FROM pragma_table_info('installed_apps')
+    WHERE name = 'profile_type'
+  `.execute(db);
+
+  if (existingColumn.rows.length === 0) {
+    await db.schema.alterTable("installed_apps").addColumn("profile_type", "text").execute();
+  }
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/test/db/installedAppsProfileTypeMigration.test.ts
+++ b/test/db/installedAppsProfileTypeMigration.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import type { MigrationProvider } from "kysely/migration";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up as installedAppsMigration } from "../../src/db/migrations/2026_01_11_000_installed_apps";
+import {
+  down as profileTypeMigrationDown,
+  up as profileTypeMigrationUp,
+} from "../../src/db/migrations/2026_08_24_000_installed_apps_profile_type";
+import { runMigrations } from "../../src/db/migrator";
+
+const MIGRATION_NAME = "2026_08_24_000_installed_apps_profile_type";
+
+function provider(): MigrationProvider {
+  return {
+    async getMigrations() {
+      return { [MIGRATION_NAME]: { up: profileTypeMigrationUp } };
+    },
+  };
+}
+
+async function profileTypeColumnExists(db: Kysely<unknown>): Promise<boolean> {
+  const columns = await sql<{ name: string }>`
+    SELECT name FROM pragma_table_info('installed_apps')
+    WHERE name = 'profile_type'
+  `.execute(db);
+  return columns.rows.length === 1;
+}
+
+describe("installed apps profile type migration", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(() => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("recovers when the column already exists without migration history", async () => {
+    await installedAppsMigration(db);
+    await profileTypeMigrationUp(db);
+    expect(await profileTypeColumnExists(db)).toBe(true);
+
+    // Ledger has no entry for this migration but the column is present:
+    // the runner must record the ledger entry and no-op the schema change.
+    await runMigrations(db, { provider: provider(), env: {} });
+
+    const migration = await db
+      .selectFrom("kysely_migration" as any)
+      .select("name")
+      .where("name", "=", MIGRATION_NAME)
+      .executeTakeFirst();
+    expect(migration?.name).toBe(MIGRATION_NAME);
+    expect(await profileTypeColumnExists(db)).toBe(true);
+  });
+
+  test("is re-runnable when the column already exists", async () => {
+    await installedAppsMigration(db);
+    await profileTypeMigrationUp(db);
+
+    // A second application must not throw duplicate column name.
+    await profileTypeMigrationUp(db);
+    expect(await profileTypeColumnExists(db)).toBe(true);
+  });
+
+  test("adds the profile type on a fresh schema and removes it on down", async () => {
+    await installedAppsMigration(db);
+    expect(await profileTypeColumnExists(db)).toBe(false);
+
+    await profileTypeMigrationUp(db);
+    expect(await profileTypeColumnExists(db)).toBe(true);
+
+    await profileTypeMigrationDown(db);
+    expect(await profileTypeColumnExists(db)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The `2026_08_24_000_installed_apps_profile_type` migration did an unguarded
`ALTER TABLE installed_apps ADD COLUMN profile_type`. When the column already
exists but the migration ledger lacks this exact id — a divergence that arises
whenever mixed daemon versions share `~/.auto-mobile/auto-mobile.db` (multiple
worktrees, a published `bunx auto-mobile@latest` alongside a local build) — the
runner re-executes the `ADD COLUMN`, SQLite rejects the duplicate, and the whole
startup migration transaction fails fatally. The daemon then hot-loops
(fail → back off → exit → relaunch) and never serves.

This adopts the `pragma_table_info` existence guard already used by the 08-23
sibling migration (`2026_08_23_000_device_teardown_operation_owner`), making the
`ADD COLUMN` a no-op when the column is present. The runner then records the
ledger entry and the divergence self-heals instead of wedging.

## Linked Issue

Closes #5704

## Bug / Regression Context

- **Prior attempts:** none; introduced with the `profile_type` work (#5604 / #5619 area).
- **Observed symptom:** daemon fatal-loops on startup with
  `SQLiteError: duplicate column name: profile_type`; socket never published, whole local fleet down.
- **Repro steps / conditions:** a `~/.auto-mobile/auto-mobile.db` where `installed_apps`
  already has `profile_type` but the ledger lacks `2026_08_24_000_installed_apps_profile_type`
  (e.g. after an older/newer daemon build ran against it). Start a current-HEAD daemon → fatal loop.
  A fresh `AUTOMOBILE_DB_PATH` starts fine.

## Validation

- [x] `bun run lint` + `bun test` — db suite (1017) green; full suite green except a
  pre-existing worktree `node_modules/.bin/oxlint` ENOENT artifact unrelated to this change
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New test runs in <100ms; uses in-memory SQLite via `BunSqliteDialect`

## Changes

- `src/db/migrations/2026_08_24_000_installed_apps_profile_type.ts` — guard `ADD COLUMN` with `pragma_table_info`.
- `test/db/installedAppsProfileTypeMigration.test.ts` — new regression test mirroring the 08-23 sibling test:
  self-heals when the column exists without a ledger row, is re-runnable, and still adds/drops on a fresh schema.

## Acceptance criteria (inferred from the issue)

- [x] Migration is idempotent — re-running with `profile_type` present does not throw `duplicate column name`.
- [x] When the column exists but the ledger lacks the entry, `runMigrations` records the ledger entry and no-ops the schema.
- [x] On a fresh schema it still adds the column; `down` removes it.

## Follow-ups

- The deeper migrator-level defect from #5684 (an older daemon's safe-rebuild dropping ledger rows for
  lexically-newer migrations it doesn't ship, and recording the writer's version to refuse a destructive
  rebuild) is intentionally out of scope here — this PR resolves the *fatal* half. Follow-up decision pending.
