### PR TITLE
fix(snapshot): auto-overwrite existing snapshot names and close capture TOCTOU (#5713)

### DIFF
--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -16,7 +16,11 @@ import {
   createDeviceSnapshotConfigRepository,
   type ConfigRepository,
 } from "../db/keyedJsonConfigRepository";
-import { DeviceSnapshotStore, type SnapshotPathOptions } from "../utils/DeviceSnapshotStore";
+import {
+  DeviceSnapshotStore,
+  SNAPSHOT_REPLACING_SUFFIX,
+  type SnapshotPathOptions,
+} from "../utils/DeviceSnapshotStore";
 import { assertSafeSnapshotName } from "../utils/snapshotNameValidation";
 import { parseDeviceSnapshotConfig } from "../features/snapshot";
 import { serverConfig } from "../utils/ServerConfig";
@@ -361,6 +365,14 @@ async function importLegacySnapshotArchive(
     }
 
     const snapshotName = entry.name;
+    // A `<name>${SNAPSHOT_REPLACING_SUFFIX}` directory is an interrupted-overwrite
+    // set-aside copy (holding the prior snapshot's manifest.json), never a real
+    // snapshot — importing it would resurrect stale data as a phantom snapshot
+    // that consumes archive budget and is "restorable" against dead contents
+    // (#5713). Skip it; the next overwrite of the base name clears it.
+    if (snapshotName.endsWith(SNAPSHOT_REPLACING_SUFFIX)) {
+      continue;
+    }
     if (existingSnapshots.has(snapshotName)) {
       continue;
     }
@@ -406,6 +418,17 @@ function assertSnapshotNameWritable(snapshotName: string): void {
   if (isReservedScopeSegment(snapshotName)) {
     throw new ActionableError(
       `Snapshot name '${snapshotName}' is reserved. Please choose a different name.`,
+    );
+  }
+
+  // The atomic overwrite moves the existing snapshot into a sibling
+  // `<name>${SNAPSHOT_REPLACING_SUFFIX}` directory. Allowing a snapshot to BE
+  // named with that suffix would let one capture's set-aside path collide with
+  // another real snapshot's directory and delete it. Reserve the suffix (#5713).
+  if (snapshotName.endsWith(SNAPSHOT_REPLACING_SUFFIX)) {
+    throw new ActionableError(
+      `Snapshot name '${snapshotName}' ends with the reserved '${SNAPSHOT_REPLACING_SUFFIX}' ` +
+        "suffix. Please choose a different name.",
     );
   }
 }

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -79,6 +79,34 @@ interface DeviceSnapshotManagerDependencies {
 let moduleDependencies: DeviceSnapshotManagerDependencies | null = null;
 const LEGACY_MANIFEST_FILENAME = "manifest.json";
 
+// Serializes captures per snapshot name within this process. Two concurrent
+// same-name captures must not interleave their filesystem writes or race the
+// record upsert; running them one-after-another makes the outcome deterministic
+// (last writer wins) and closes the historical check-then-create TOCTOU window
+// (issue #5713). The daemon is single-process, so an in-process promise chain is
+// sufficient — cross-process coordination is out of scope.
+const captureLocks = new Map<string, Promise<unknown>>();
+
+function withCaptureLock<T>(snapshotName: string, task: () => Promise<T>): Promise<T> {
+  const prior = captureLocks.get(snapshotName) ?? Promise.resolve();
+  // Run after the prior holder settles, regardless of whether it resolved or
+  // rejected, so one failed capture doesn't wedge every later same-name capture.
+  const run = prior.then(task, task);
+  const tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  captureLocks.set(snapshotName, tail);
+  void tail.finally(() => {
+    // Drop the entry once this is the last holder, so the map doesn't grow
+    // unbounded across distinct snapshot names.
+    if (captureLocks.get(snapshotName) === tail) {
+      captureLocks.delete(snapshotName);
+    }
+  });
+  return run;
+}
+
 function getSnapshotPathOptions(context: {
   platform?: string;
   deviceId?: string;
@@ -137,6 +165,7 @@ export async function setDeviceSnapshotManagerDependencies(
 
 export function resetDeviceSnapshotManagerDependencies(): void {
   moduleDependencies = null;
+  captureLocks.clear();
 }
 
 function configToInput(config: DeviceSnapshotConfig): DeviceSnapshotConfigInput {
@@ -361,33 +390,22 @@ async function notifySnapshotResources(): Promise<void> {
   await ResourceRegistry.notifyResourcesUpdated([DEVICE_SNAPSHOT_RESOURCE_URIS.ARCHIVE]);
 }
 
-async function ensureSnapshotAvailable(
-  snapshotName: string,
-  snapshotStore: DeviceSnapshotStore,
-  snapshotRepository: DeviceSnapshotRepository,
-  pathOptions?: SnapshotPathOptions,
-): Promise<void> {
+function assertSnapshotNameWritable(snapshotName: string): void {
   // "android"/"ios" are the platform scope roots under the snapshots dir. An
   // unscoped (physical / fallback) snapshot with one of those names would take
   // the scope directory itself, so deleting it later would recursively remove
   // every scoped snapshot nested under it. Reject the collision at the source
   // (#5707); broader snapshotName sanitization is tracked in #5705.
+  //
+  // A pre-existing snapshot of the same name is intentionally NOT rejected:
+  // re-capturing an existing name overwrites it (issue #5713). The overwrite is
+  // made atomic by DeviceSnapshotStore.replaceSnapshotData plus the per-name
+  // capture lock, and the record is replaced (not duplicated) by the repository
+  // upsert — so the old check-then-create existence probe (a TOCTOU window) is
+  // gone.
   if (isReservedScopeSegment(snapshotName)) {
     throw new ActionableError(
       `Snapshot name '${snapshotName}' is reserved. Please choose a different name.`,
-    );
-  }
-
-  const existing = await snapshotRepository.getSnapshot(snapshotName);
-  if (existing) {
-    throw new ActionableError(
-      `Snapshot '${snapshotName}' already exists. Please choose a different name.`,
-    );
-  }
-
-  if (await snapshotStore.snapshotDirectoryExists(snapshotName, pathOptions)) {
-    throw new ActionableError(
-      `Snapshot '${snapshotName}' already exists on disk. Please choose a different name.`,
     );
   }
 }
@@ -524,9 +542,12 @@ export async function captureDeviceSnapshot(
 
   const baseConfig = await getDeviceSnapshotConfig();
   const snapshotName = args.snapshotName ?? snapshotStore.generateSnapshotName(device.name);
-  // Reject a traversal/absolute name before any filesystem probe (this runs
-  // `fs.access` via ensureSnapshotAvailable) or capture command (issue #5705).
+  // Reject a traversal/absolute name before any filesystem operation or capture
+  // command can act on it (issue #5705).
   assertSafeSnapshotName(snapshotName);
+  // Reject reserved scope-root names (#5707). An existing same-name snapshot is
+  // deliberately allowed through — it is overwritten atomically below (#5713).
+  assertSnapshotNameWritable(snapshotName);
   const pathOptions = getSnapshotPathOptions({
     platform: device.platform,
     deviceId: device.deviceId,
@@ -534,8 +555,6 @@ export async function captureDeviceSnapshot(
     // `adb emu avd name` during discovery.
     avdName: device.name,
   });
-
-  await ensureSnapshotAvailable(snapshotName, snapshotStore, snapshotRepository, pathOptions);
 
   const mergedConfig: DeviceSnapshotConfig = {
     ...baseConfig,
@@ -546,38 +565,48 @@ export async function captureDeviceSnapshot(
     vmSnapshotTimeoutMs: args.vmSnapshotTimeoutMs ?? baseConfig.vmSnapshotTimeoutMs,
   };
 
-  const captureProvider = createCaptureProvider(device, timer, snapshotStore);
-  const result = await captureProvider.capture({
-    snapshotName,
-    includeAppData: mergedConfig.includeAppData,
-    includeSettings: mergedConfig.includeSettings,
-    useVmSnapshot: mergedConfig.useVmSnapshot,
-    strictBackupMode: mergedConfig.strictBackupMode,
-    vmSnapshotTimeoutMs: mergedConfig.vmSnapshotTimeoutMs,
-    appBundleIds: args.appBundleIds,
+  // Serialize same-name captures so concurrent requests can't race; overwrite
+  // the on-disk data atomically (clean replace, prior data restored on failure);
+  // the repository upsert replaces the record rather than duplicating it (#5713).
+  return withCaptureLock(snapshotName, async () => {
+    const captureProvider = createCaptureProvider(device, timer, snapshotStore);
+
+    const result = await snapshotStore.replaceSnapshotData(snapshotName, pathOptions, async () => {
+      const captured = await captureProvider.capture({
+        snapshotName,
+        includeAppData: mergedConfig.includeAppData,
+        includeSettings: mergedConfig.includeSettings,
+        useVmSnapshot: mergedConfig.useVmSnapshot,
+        strictBackupMode: mergedConfig.strictBackupMode,
+        vmSnapshotTimeoutMs: mergedConfig.vmSnapshotTimeoutMs,
+        appBundleIds: args.appBundleIds,
+      });
+
+      const sizeBytes = await snapshotStore.getSnapshotSizeBytes(snapshotName, pathOptions);
+      const timestamp = captured.manifest.timestamp;
+
+      await snapshotRepository.insertSnapshot({
+        snapshotName: captured.snapshotName,
+        deviceId: captured.manifest.deviceId,
+        deviceName: captured.manifest.deviceName,
+        platform: captured.manifest.platform,
+        snapshotType: captured.manifest.snapshotType,
+        includeAppData: captured.manifest.includeAppData,
+        includeSettings: captured.manifest.includeSettings,
+        createdAt: timestamp,
+        lastAccessedAt: timestamp,
+        sizeBytes,
+        manifest: captured.manifest,
+      });
+
+      return captured;
+    });
+
+    const eviction = await enforceDeviceSnapshotArchiveLimit(mergedConfig.maxArchiveSizeMb);
+    await notifySnapshotResources();
+
+    return { result, evictedSnapshotNames: eviction.evictedSnapshotNames };
   });
-
-  const sizeBytes = await snapshotStore.getSnapshotSizeBytes(snapshotName, pathOptions);
-  const timestamp = result.manifest.timestamp;
-
-  await snapshotRepository.insertSnapshot({
-    snapshotName: result.snapshotName,
-    deviceId: result.manifest.deviceId,
-    deviceName: result.manifest.deviceName,
-    platform: result.manifest.platform,
-    snapshotType: result.manifest.snapshotType,
-    includeAppData: result.manifest.includeAppData,
-    includeSettings: result.manifest.includeSettings,
-    createdAt: timestamp,
-    lastAccessedAt: timestamp,
-    sizeBytes,
-    manifest: result.manifest,
-  });
-
-  const eviction = await enforceDeviceSnapshotArchiveLimit(mergedConfig.maxArchiveSizeMb);
-  await notifySnapshotResources();
-
-  return { result, evictedSnapshotNames: eviction.evictedSnapshotNames };
 }
 
 export async function restoreDeviceSnapshot(

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -82,6 +82,57 @@ export class DeviceSnapshotStore {
     }
   }
 
+  /**
+   * Run `capture` as an atomic overwrite of `snapshotName`'s on-disk data.
+   *
+   * Any existing snapshot directory is moved aside first, so the capture writes
+   * into a clean directory and no stale files from a prior capture survive
+   * ("replace", not "merge"). On success the set-aside copy is discarded; on
+   * failure the partial capture is removed and the prior data is restored — a
+   * failed overwrite must never destroy the snapshot it was replacing. Callers
+   * serialize same-name captures at a higher layer, so the fixed sibling
+   * set-aside path (`<dir>.replacing`) only ever hosts one overwrite at a time
+   * (issue #5713).
+   */
+  async replaceSnapshotData<T>(
+    snapshotName: string,
+    options: SnapshotPathOptions | undefined,
+    capture: () => Promise<T>,
+  ): Promise<T> {
+    const snapshotPath = this.getSnapshotPathWithOptions(snapshotName, options);
+    const asidePath = `${snapshotPath}.replacing`;
+
+    // Clear any set-aside leftover from a prior interrupted overwrite so the
+    // rename below can't collide with stale state.
+    await fs.rm(asidePath, { recursive: true, force: true });
+
+    let hadExisting = false;
+    try {
+      await fs.rename(snapshotPath, asidePath);
+      hadExisting = true;
+    } catch (error) {
+      // ENOENT means there was nothing to replace (first capture of this name),
+      // which is normal. Any other error means we could not move the existing
+      // data aside — fail rather than risk a dirty, half-overwritten snapshot.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    try {
+      const result = await capture();
+      await fs.rm(asidePath, { recursive: true, force: true });
+      return result;
+    } catch (error) {
+      // Discard the partial fresh capture and restore the prior snapshot.
+      await fs.rm(snapshotPath, { recursive: true, force: true });
+      if (hadExisting) {
+        await fs.rename(asidePath, snapshotPath);
+      }
+      throw error;
+    }
+  }
+
   async deleteSnapshotData(snapshotName: string, options?: SnapshotPathOptions): Promise<void> {
     const snapshotPath = this.getSnapshotPathWithOptions(snapshotName, options);
     try {

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -4,6 +4,15 @@ import * as os from "os";
 import { logger } from "./logger";
 import type { Platform } from "../models";
 
+/**
+ * Suffix of the sibling directory that {@link DeviceSnapshotStore.replaceSnapshotData}
+ * moves an existing snapshot into while a fresh capture writes. Reserved: capture
+ * rejects any snapshotName ending in it (see `assertSnapshotNameWritable`) and the
+ * legacy-archive scan skips directories bearing it, so this internal set-aside path
+ * can never collide with — or be re-imported as — a real user snapshot (issue #5713).
+ */
+export const SNAPSHOT_REPLACING_SUFFIX = ".replacing";
+
 export interface SnapshotPathOptions {
   platform?: Platform;
   deviceId?: string;
@@ -100,7 +109,7 @@ export class DeviceSnapshotStore {
     capture: () => Promise<T>,
   ): Promise<T> {
     const snapshotPath = this.getSnapshotPathWithOptions(snapshotName, options);
-    const asidePath = `${snapshotPath}.replacing`;
+    const asidePath = `${snapshotPath}${SNAPSHOT_REPLACING_SUFFIX}`;
 
     // Clear any set-aside leftover from a prior interrupted overwrite so the
     // rename below can't collide with stale state.
@@ -119,18 +128,42 @@ export class DeviceSnapshotStore {
       }
     }
 
+    let result: T;
     try {
-      const result = await capture();
-      await fs.rm(asidePath, { recursive: true, force: true });
-      return result;
+      result = await capture();
     } catch (error) {
-      // Discard the partial fresh capture and restore the prior snapshot.
-      await fs.rm(snapshotPath, { recursive: true, force: true });
-      if (hadExisting) {
-        await fs.rename(asidePath, snapshotPath);
+      // Capture (and the record write it wraps) failed: discard the partial
+      // fresh capture and restore the prior snapshot. A cleanup step failing
+      // here must not mask the real capture error, so log-and-continue and
+      // rethrow the original (CLAUDE.md catch convention).
+      try {
+        await fs.rm(snapshotPath, { recursive: true, force: true });
+        if (hadExisting) {
+          await fs.rename(asidePath, snapshotPath);
+        }
+      } catch (rollbackError) {
+        logger.warn(
+          `Failed to roll back snapshot '${snapshotName}' after a failed overwrite; ` +
+            `prior data may be stranded at '${asidePath}': ${rollbackError}`,
+        );
       }
       throw error;
     }
+
+    // Capture succeeded and the record is already committed. Removing the
+    // set-aside copy is best-effort cleanup — its failure must NOT roll back the
+    // committed snapshot (that would leave the DB record describing the fresh
+    // capture while the directory reverted to the old data). Log and continue;
+    // the next overwrite clears it and the legacy scan skips *.replacing dirs.
+    try {
+      await fs.rm(asidePath, { recursive: true, force: true });
+    } catch (cleanupError) {
+      logger.warn(
+        `Failed to remove set-aside snapshot copy '${asidePath}' after a successful ` +
+          `overwrite; it will be cleaned up on the next capture: ${cleanupError}`,
+      );
+    }
+    return result;
   }
 
   async deleteSnapshotData(snapshotName: string, options?: SnapshotPathOptions): Promise<void> {

--- a/test/fakes/FakeDeviceSnapshotStore.ts
+++ b/test/fakes/FakeDeviceSnapshotStore.ts
@@ -10,6 +10,7 @@ type DeviceSnapshotStoreContract = Pick<
   | "snapshotDirectoryExists"
   | "getSnapshotSizeBytes"
   | "deleteSnapshotData"
+  | "replaceSnapshotData"
 >;
 
 export class FakeDeviceSnapshotStore implements DeviceSnapshotStoreContract {
@@ -66,6 +67,28 @@ export class FakeDeviceSnapshotStore implements DeviceSnapshotStoreContract {
 
   async getSnapshotSizeBytes(snapshotName: string): Promise<number> {
     return this.sizes.get(snapshotName) ?? 0;
+  }
+
+  async replaceSnapshotData<T>(
+    snapshotName: string,
+    _options: unknown,
+    capture: () => Promise<T>,
+  ): Promise<T> {
+    // The fresh capture replaces any prior on-disk data for this name. On
+    // failure the prior "exists" flag is left intact (the real store restores
+    // the set-aside copy), mirroring the atomic-overwrite contract.
+    const priorExists = this.existing.has(snapshotName);
+    this.existing.delete(snapshotName);
+    try {
+      const result = await capture();
+      this.existing.add(snapshotName);
+      return result;
+    } catch (error) {
+      if (priorExists) {
+        this.existing.add(snapshotName);
+      }
+      throw error;
+    }
   }
 
   async deleteSnapshotData(snapshotName: string): Promise<void> {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -582,6 +582,49 @@ describe("deviceSnapshotManager", () => {
     expect(restoreCalls).toEqual([]);
   });
 
+  test("captureDeviceSnapshot rejects a name ending in the reserved '.replacing' suffix (#5713)", async () => {
+    // The atomic overwrite uses a sibling `<name>.replacing` dir; a snapshot
+    // literally named `<x>.replacing` would let one capture's set-aside path
+    // collide with — and delete — this real snapshot's directory.
+    await expect(
+      captureDeviceSnapshot(TEST_DEVICE, { snapshotName: "foo.replacing" }),
+    ).rejects.toThrow(/reserved/i);
+    // The capture provider must never run for a rejected name.
+    expect(captureCalls).toEqual([]);
+  });
+
+  test("listDeviceSnapshots skips a leftover '.replacing' set-aside directory (#5713)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-replacing-"));
+    try {
+      const realStore = new DeviceSnapshotStore(tempRoot);
+      await realStore.ensureSnapshotsDirectory();
+      await setDeviceSnapshotManagerDependencies({ snapshotStore: realStore as any });
+
+      // A leftover set-aside dir from an interrupted overwrite: it holds the
+      // prior snapshot's manifest.json at the flat base level. Importing it would
+      // resurrect a phantom snapshot named "ghost.replacing" over stale data.
+      const asideDir = path.join(tempRoot, "ghost.replacing");
+      await fs.mkdir(asideDir, { recursive: true });
+      const manifest: DeviceSnapshotManifest = {
+        snapshotName: "ghost",
+        timestamp: new Date(0).toISOString(),
+        deviceId: "emulator-5554",
+        deviceName: "Pixel_5",
+        platform: "android",
+        snapshotType: "adb",
+        includeAppData: false,
+        includeSettings: true,
+      };
+      await fs.writeFile(path.join(asideDir, "manifest.json"), JSON.stringify(manifest));
+
+      const { snapshots } = await listDeviceSnapshots();
+      expect(snapshots.some((entry) => entry.snapshotName === "ghost.replacing")).toBe(false);
+      expect(await repository.getSnapshot("ghost.replacing")).toBeNull();
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("legacy flat-path cleanup never deletes a reserved scope root (#5707)", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-reserved-"));
     try {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -162,6 +162,91 @@ describe("deviceSnapshotManager", () => {
     expect(listed).toEqual([]);
   });
 
+  test("re-capturing an existing name replaces it instead of erroring (#5713)", async () => {
+    const first = await captureDeviceSnapshot(TEST_DEVICE, {
+      snapshotName: "dup",
+      includeAppData: true,
+    });
+    expect(first.result.snapshotName).toBe("dup");
+
+    // A stale on-disk directory (the historical check-then-create rejected this).
+    store.setSnapshotExists("dup", true);
+    fakeTimer.advanceTime(1000);
+
+    const second = await captureDeviceSnapshot(TEST_DEVICE, {
+      snapshotName: "dup",
+      includeAppData: false,
+    });
+    expect(second.result.snapshotName).toBe("dup");
+
+    // Record is replaced, not duplicated, and reflects the second capture.
+    const listed = await repository.listSnapshots();
+    expect(listed.length).toBe(1);
+    const record = await repository.getSnapshot("dup");
+    expect(record?.includeAppData).toBe(false);
+    // Both captures actually ran (the second was not short-circuited by an error).
+    expect(captureCalls.length).toBe(2);
+  });
+
+  test("serializes concurrent same-name captures into one consistent snapshot (#5713)", async () => {
+    const events: string[] = [];
+    const releases: Array<() => void> = [];
+    let captureIndex = 0;
+
+    await setDeviceSnapshotManagerDependencies({
+      createCaptureProvider: () => ({
+        capture: async (args) => {
+          const index = captureIndex++;
+          events.push(`start:${index}`);
+          await new Promise<void>((resolve) => releases.push(resolve));
+          events.push(`end:${index}`);
+          const timestamp = new Date(fakeTimer.now()).toISOString();
+          const manifest: DeviceSnapshotManifest = {
+            snapshotName: args.snapshotName,
+            timestamp,
+            deviceId: TEST_DEVICE.deviceId,
+            deviceName: TEST_DEVICE.name,
+            platform: TEST_DEVICE.platform,
+            snapshotType: "adb",
+            includeAppData: args.includeAppData ?? true,
+            includeSettings: args.includeSettings ?? true,
+          };
+          return { snapshotName: args.snapshotName, timestamp, snapshotType: "adb", manifest };
+        },
+      }),
+    });
+
+    // Microtask-only polling — deterministic, no real timers.
+    const waitUntil = async (cond: () => boolean): Promise<void> => {
+      for (let i = 0; i < 1000 && !cond(); i++) {
+        await Promise.resolve();
+      }
+      if (!cond()) {
+        throw new Error(`waitUntil timed out; events=${JSON.stringify(events)}`);
+      }
+    };
+
+    const p1 = captureDeviceSnapshot(TEST_DEVICE, { snapshotName: "race" });
+    const p2 = captureDeviceSnapshot(TEST_DEVICE, { snapshotName: "race" });
+
+    // Only the first capture may be in flight; the second must wait for the lock.
+    await waitUntil(() => events.length >= 1);
+    expect(events).toEqual(["start:0"]);
+    expect(releases.length).toBe(1);
+
+    releases[0]();
+    await waitUntil(() => events.length >= 3);
+    expect(events.slice(0, 3)).toEqual(["start:0", "end:0", "start:1"]);
+    expect(releases.length).toBe(2);
+
+    releases[1]();
+    await Promise.all([p1, p2]);
+
+    const listed = await repository.listSnapshots();
+    expect(listed.length).toBe(1);
+    expect(listed[0]?.snapshotName).toBe("race");
+  });
+
   test("restoreDeviceSnapshot touches lastAccessedAt and forwards manifest", async () => {
     const createdAt = new Date(0).toISOString();
     const manifest: DeviceSnapshotManifest = {

--- a/test/utils/deviceSnapshotStore.test.ts
+++ b/test/utils/deviceSnapshotStore.test.ts
@@ -134,6 +134,62 @@ describe("DeviceSnapshotStore", () => {
     expect(await store.snapshotDirectoryExists(snapshotName)).toBe(false);
   });
 
+  describe("replaceSnapshotData (#5713)", () => {
+    it("replaces existing contents so no stale files survive", async () => {
+      const snapshotName = "replace-me";
+      const dest = store.getSnapshotPath(snapshotName);
+      await fs.mkdir(dest, { recursive: true });
+      await fs.writeFile(path.join(dest, "stale.txt"), "old");
+
+      const result = await store.replaceSnapshotData(snapshotName, undefined, async () => {
+        await fs.mkdir(dest, { recursive: true });
+        await fs.writeFile(path.join(dest, "fresh.txt"), "new");
+        return "captured";
+      });
+
+      expect(result).toBe("captured");
+      const entries = await fs.readdir(dest);
+      expect(entries.sort()).toEqual(["fresh.txt"]);
+      // The set-aside copy must be cleaned up on success.
+      expect(await store.snapshotDirectoryExists(`${snapshotName}.replacing`)).toBe(false);
+    });
+
+    it("restores the prior snapshot when the capture fails", async () => {
+      const snapshotName = "keep-on-failure";
+      const dest = store.getSnapshotPath(snapshotName);
+      await fs.mkdir(dest, { recursive: true });
+      await fs.writeFile(path.join(dest, "original.txt"), "keep");
+
+      await expect(
+        store.replaceSnapshotData(snapshotName, undefined, async () => {
+          await fs.mkdir(dest, { recursive: true });
+          await fs.writeFile(path.join(dest, "partial.txt"), "garbage");
+          throw new Error("capture blew up");
+        }),
+      ).rejects.toThrow("capture blew up");
+
+      // Prior data is restored; the partial capture is discarded.
+      const entries = await fs.readdir(dest);
+      expect(entries.sort()).toEqual(["original.txt"]);
+      expect(await fs.readFile(path.join(dest, "original.txt"), "utf-8")).toBe("keep");
+      expect(await store.snapshotDirectoryExists(`${snapshotName}.replacing`)).toBe(false);
+    });
+
+    it("captures cleanly when no prior snapshot exists", async () => {
+      const snapshotName = "brand-new";
+      const dest = store.getSnapshotPath(snapshotName);
+
+      await store.replaceSnapshotData(snapshotName, undefined, async () => {
+        await fs.mkdir(dest, { recursive: true });
+        await fs.writeFile(path.join(dest, "data.txt"), "value");
+      });
+
+      expect(await store.snapshotDirectoryExists(snapshotName)).toBe(true);
+      expect(await fs.readFile(path.join(dest, "data.txt"), "utf-8")).toBe("value");
+      expect(await store.snapshotDirectoryExists(`${snapshotName}.replacing`)).toBe(false);
+    });
+  });
+
   it("should compute snapshot size", async () => {
     const snapshotName = "snapshot-size";
     const snapshotDir = store.getSnapshotPath(snapshotName);


### PR DESCRIPTION
## Summary

Re-capturing an existing device-snapshot name now **overwrites** it instead of failing with `Snapshot '<name>' already exists`, and the check-then-create TOCTOU window is closed. Previously capture did a check-then-create existence probe (DB record + on-disk dir) and rejected any existing name, forcing callers to delete first; two concurrent same-name captures could also race — one succeeded, the other errored, timing-dependent.

Now:
- The existence rejection is removed (`ensureSnapshotAvailable` → `assertSnapshotNameWritable`, which keeps only the `#5707` reserved scope-root check).
- Same-name captures are serialized in-process by a per-name capture lock (`withCaptureLock`), so concurrent requests run one-after-another and the last writer wins deterministically. The daemon is single-process, so an in-process promise chain is sufficient.
- On-disk data is replaced atomically via `DeviceSnapshotStore.replaceSnapshotData`: the existing snapshot dir is moved aside so the fresh capture writes into a clean directory (no stale files survive), the set-aside copy is dropped on success, and a failed overwrite restores the prior data rather than destroying it.
- The record is replaced (not duplicated) by the existing repository upsert (`insertSnapshot` `onConflict.doUpdateSet`, preserving the original `created_at`).

VM snapshots already overwrite in-AVD (`adb emu avd snapshot save`); dropping the store-side rejection aligns the store with that behavior.

## Linked Issue

Closes #5713

## Bug / Regression Context

- **Observed symptom:** a second capture of an existing name returned `Snapshot '<name>' already exists`; two concurrent same-name captures raced (one succeeded, one errored).
- **Repro steps / conditions:** capture a snapshot, then capture again with the same name → hard error; or two same-name captures in flight together → timing-dependent outcome.

## Validation

- [x] `bun test` — full suite green (the one unrelated failure is `test/lint/oxlintConfigScoping.test.ts`, which spawns `./node_modules/.bin/oxlint`, absent in `.claude` worktrees; not touched here)
- [x] `bun run lint` — no new violations (ratchet + boundary checks pass)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run format:check` — clean
- [x] New tests use interfaces + fakes + FakeTimer; unit tests run in <100ms

### Acceptance criteria → tests
- Re-capture replaces contents + record → `test/server/deviceSnapshotManager.test.ts`: "re-capturing an existing name replaces it instead of erroring (#5713)" and `test/utils/deviceSnapshotStore.test.ts`: `replaceSnapshotData` replace/rollback/first-capture cases.
- Two concurrent same-name captures leave a single consistent snapshot → "serializes concurrent same-name captures into one consistent snapshot (#5713)".

## Follow-ups

- [ ] None. Cross-process capture coordination is intentionally out of scope (single-process daemon).
