### PR TITLE
fix(db): preserve newer migration rows on forward version-skew (#5684)

### DIFF
--- a/docs/design-docs/mcp/storage/migrations.md
+++ b/docs/design-docs/mcp/storage/migrations.md
@@ -83,7 +83,9 @@ drop a user's data.
 flowchart TD
     A["migrateToLatest() throws<br/>'corrupted migrations'"] --> B{"recovery enabled?<br/>(value not in {0,false,no,off})"};
     B -->|"no"| Z["Log guidance, rethrow<br/>(startup fails)"];
-    B -->|"yes"| C["Snapshot original migration history"];
+    B -->|"yes"| SKEW{"forward version-skew?<br/>(all shipped migrations applied &<br/>every unknown row is newer)"};
+    SKEW -->|"yes"| NOOP["✅ Leave ledger untouched<br/>(a newer build ran ahead)"];
+    SKEW -->|"no"| C["Snapshot original migration history"];
     C --> D["Rebuild kysely_migration table<br/>to match on-disk migrations<br/>(prune missing entries)"];
     D --> E["Re-run migrateToLatest()"];
     E -->|"success"| OK["✅ Migrations complete"];
@@ -100,13 +102,20 @@ flowchart TD
     classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
-    class A,Z,OK,REFUSE,REFUSE2 result;
-    class B,F,H,BK decision;
+    class A,Z,OK,NOOP,REFUSE,REFUSE2 result;
+    class B,SKEW,F,H,BK decision;
     class C,D,E,G,DROP,BACKUP,R logic;
 ```
 
 Key properties:
 
+- **Forward version-skew is a no-op (issue #5684).** Before any rebuild, if every
+  migration this build ships is already applied and the only unrecognized ledger
+  rows are lexically newer than the newest migration it knows, a _newer_ build
+  migrated this shared database ahead of this one. The ledger is left completely
+  untouched. Pruning those newer rows is what makes the newer daemon re-run them
+  on its next start, so two builds alternating on one `~/.auto-mobile` DB would
+  otherwise churn the history back and forth indefinitely.
 - **Safe first.** The rebuild only rewrites the `kysely_migration` bookkeeping
   table to match the migrations actually on disk; user data is not touched. Most
   corruption from a pruned/renamed migration is resolved here.

--- a/src/db/migrator.ts
+++ b/src/db/migrator.ts
@@ -174,8 +174,18 @@ async function rebuildMigrationTable(
  * sorts at or before the newest known migration (out-of-order / renamed /
  * middle-inserted) — is NOT forward skew and falls through to the existing
  * destructive rebuild/reset recovery. `availableNames` must be sorted (Kysely's
- * `Migrator.getMigrations()` guarantees this); comparison uses the same
- * lexicographic ordering Kysely applies to migration names.
+ * `Migrator.getMigrations()` guarantees this).
+ *
+ * Two conventions this repo already upholds keep the no-op safe; a future
+ * maintainer must not break either (issue #5684):
+ *   1. A shipped migration's body is immutable given its name. Like Kysely
+ *      itself (which never re-runs an applied name), this trusts name == applied;
+ *      re-bodying a released migration would let the no-op accept a divergent
+ *      schema silently.
+ *   2. Migration names are globally monotonic and append-only across releases,
+ *      so a newer mainline build's migrations always sort AFTER an older build's
+ *      newest. Branch divergence that interleaves names is deliberately treated
+ *      as corruption (condition 2 returns false), not forward skew.
  */
 export function isBenignForwardSkew(availableNames: string[], executedNames: string[]): boolean {
   // A build that ships no migrations cannot distinguish "newer build ran ahead"
@@ -195,10 +205,13 @@ export function isBenignForwardSkew(availableNames: string[], executedNames: str
   }
 
   // (2) Every executed row this build does not recognize must be strictly newer
-  //     than the newest migration it ships.
+  //     than the newest migration it ships. Compare with the same default
+  //     code-unit ordering that selected `newestKnown` (Kysely sorts the
+  //     available set with `Array#sort`); using `localeCompare` here could
+  //     disagree on case/diacritics against a code-unit-chosen `newestKnown`.
   const newestKnown = availableNames[availableNames.length - 1];
   for (const name of executedNames) {
-    if (!availableSet.has(name) && name.localeCompare(newestKnown) <= 0) {
+    if (!availableSet.has(name) && name <= newestKnown) {
       return false;
     }
   }

--- a/src/db/migrator.ts
+++ b/src/db/migrator.ts
@@ -157,6 +157,75 @@ async function rebuildMigrationTable(
   return { pruned, kept };
 }
 
+/**
+ * Classify a corrupted-migrations state as benign forward version-skew: every
+ * migration this build ships is already recorded as executed, and the only
+ * unrecognized ledger rows are lexically newer than the newest migration this
+ * build knows about — i.e. a NEWER build ran ahead against the same shared DB
+ * (issue #5684).
+ *
+ * In that case this build has nothing to do and MUST NOT rewrite the ledger.
+ * Pruning those newer rows (the pre-#5684 rebuild behavior) is what converts a
+ * harmless version skew into a churn loop: the newer daemon re-runs the pruned
+ * migration on its next start, and with two builds alternating on one DB the
+ * ledger is rewritten back and forth indefinitely.
+ *
+ * Anything else — a known migration not yet applied, or an unknown row that
+ * sorts at or before the newest known migration (out-of-order / renamed /
+ * middle-inserted) — is NOT forward skew and falls through to the existing
+ * destructive rebuild/reset recovery. `availableNames` must be sorted (Kysely's
+ * `Migrator.getMigrations()` guarantees this); comparison uses the same
+ * lexicographic ordering Kysely applies to migration names.
+ */
+export function isBenignForwardSkew(availableNames: string[], executedNames: string[]): boolean {
+  // A build that ships no migrations cannot distinguish "newer build ran ahead"
+  // from "everything is unknown"; stay conservative and let recovery decide.
+  if (availableNames.length === 0) {
+    return false;
+  }
+
+  const availableSet = new Set(availableNames);
+  const executedSet = new Set(executedNames);
+
+  // (1) Every migration this build knows about must already be applied.
+  for (const name of availableNames) {
+    if (!executedSet.has(name)) {
+      return false;
+    }
+  }
+
+  // (2) Every executed row this build does not recognize must be strictly newer
+  //     than the newest migration it ships.
+  const newestKnown = availableNames[availableNames.length - 1];
+  for (const name of executedNames) {
+    if (!availableSet.has(name) && name.localeCompare(newestKnown) <= 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Read the ledger and this build's migration set, and report whether the
+ * corrupted-migrations state is benign forward version-skew (see
+ * {@link isBenignForwardSkew}).
+ */
+async function isForwardVersionSkew(db: Kysely<unknown>, migrator: Migrator): Promise<boolean> {
+  if (!(await tableExists(db, DEFAULT_MIGRATION_TABLE))) {
+    return false;
+  }
+  const availableNames = (await migrator.getMigrations()).map((migration) => migration.name);
+  // Raw sql (like defaultCountTableRows) rather than selectFrom(... as any), which
+  // resolves to `never` under Kysely<unknown> and would add a fresh typecheck-
+  // baseline error.
+  const executedRows = await sql<{ name: string }>`select name from ${sql.table(
+    DEFAULT_MIGRATION_TABLE,
+  )}`.execute(db);
+  const executedNames = executedRows.rows.map((row) => row.name);
+  return isBenignForwardSkew(availableNames, executedNames);
+}
+
 const defaultCountTableRows: CountTableRows = async (db, tableName) => {
   const result = await sql<{ count: number }>`select count(*) as count from ${sql.table(
     tableName,
@@ -321,6 +390,54 @@ async function runMigrationsOnce(migrator: Migrator) {
   return result;
 }
 
+/**
+ * Handle a failed migration run: attempt recovery when the error is a corrupted
+ * migration history and recovery is enabled, otherwise rethrow. Extracted from
+ * {@link runMigrations} so the nested branching lives in its own depth budget.
+ * Returns normally when the database is healthy (recovered, or benign forward
+ * skew); throws otherwise.
+ */
+async function handleMigrationFailure(
+  db: Kysely<unknown>,
+  migrator: Migrator,
+  error: unknown,
+  options: RunMigrationsOptions,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (isCorruptedMigrationError(error) && isMigrationRecoveryEnabled(env)) {
+    // A newer build migrated this shared DB ahead of us; every migration we ship
+    // is already applied. Leave the ledger untouched instead of pruning the newer
+    // rows, which would make the newer daemon re-run them and churn the history
+    // back and forth (issue #5684).
+    if (await isForwardVersionSkew(db, migrator)) {
+      logger.info(
+        "Migration ledger records migrations newer than this build ships and all " +
+          "known migrations are already applied; a newer build migrated this database. " +
+          "Leaving migration history untouched (issue #5684).",
+      );
+      return;
+    }
+
+    const recoveryResult = await recoverCorruptedMigrations(db, migrator, error, options, env);
+    if (recoveryResult.error) {
+      logger.error("Failed to run migrations after recovery:", recoveryResult.error);
+      throw recoveryResult.error;
+    }
+    logger.info("All migrations completed successfully");
+    return;
+  }
+
+  if (isCorruptedMigrationError(error) && !isMigrationRecoveryEnabled(env)) {
+    logger.error(
+      "Corrupted migrations detected. Set AUTOMOBILE_MIGRATION_RECOVERY=1 to enable automatic " +
+        "recovery or reset the local database state.",
+    );
+  }
+
+  logger.error("Failed to run migrations:", error);
+  throw error;
+}
+
 async function recoverCorruptedMigrations(
   db: Kysely<unknown>,
   migrator: Migrator,
@@ -392,25 +509,8 @@ export async function runMigrations(
     const { error } = await runMigrationsOnce(migrator);
 
     if (error) {
-      if (isCorruptedMigrationError(error) && isMigrationRecoveryEnabled(env)) {
-        const recoveryResult = await recoverCorruptedMigrations(db, migrator, error, options, env);
-        if (recoveryResult.error) {
-          logger.error("Failed to run migrations after recovery:", recoveryResult.error);
-          throw recoveryResult.error;
-        }
-        logger.info("All migrations completed successfully");
-        return;
-      }
-
-      if (isCorruptedMigrationError(error) && !isMigrationRecoveryEnabled(env)) {
-        logger.error(
-          "Corrupted migrations detected. Set AUTOMOBILE_MIGRATION_RECOVERY=1 to enable automatic " +
-            "recovery or reset the local database state.",
-        );
-      }
-
-      logger.error("Failed to run migrations:", error);
-      throw error;
+      await handleMigrationFailure(db, migrator, error, options, env);
+      return;
     }
 
     logger.info("All migrations completed successfully");

--- a/test/db/migrator.test.ts
+++ b/test/db/migrator.test.ts
@@ -3,7 +3,7 @@ import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import type { Migration, MigrationProvider } from "kysely/migration";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
-import { runMigrations, isAnyTableNonEmpty } from "../../src/db/migrator";
+import { runMigrations, isAnyTableNonEmpty, isBenignForwardSkew } from "../../src/db/migrator";
 import { ActionableError } from "../../src/models/ActionableError";
 
 // --- Fake migration set (all in-memory, deterministic, <100ms) -------------
@@ -32,6 +32,7 @@ const WIDGETS = "2026_01_02_000_widgets";
 const GADGETS = "2026_01_05_000_gadgets";
 const BACKPORT = "2026_01_03_000_backport"; // sorts between WIDGETS and GADGETS
 const RENAMED_GADGETS = "2026_01_05_000_gizmos"; // rename of GADGETS, same table
+const FUTURE = "2026_01_09_000_future"; // sorts after GADGETS; only a newer build ships it
 
 function baseMigrations(): Record<string, Migration> {
   return {
@@ -78,24 +79,85 @@ describe("runMigrations recovery", () => {
     delete process.env.AUTOMOBILE_MIGRATION_RECOVERY;
   });
 
-  // Preserved: safe removed-migration prune path against the real migration folder.
-  test("prunes missing migrations from history", async () => {
-    await runMigrations(db);
+  // Forward version-skew (issue #5684): a NEWER build ran ahead against the same
+  // shared DB, recording a migration this (older) build does not ship, lexically
+  // newer than everything it knows. All of this build's migrations are already
+  // applied, so it must leave the ledger untouched rather than prune the newer
+  // row — pruning is what makes the newer daemon re-run the migration on its next
+  // start, and with two builds alternating that becomes a permanent churn loop.
+  test("preserves a newer build's migration row on forward skew (populated DB)", async () => {
+    const newerProvider = providerFor({
+      ...baseMigrations(),
+      [FUTURE]: createTableMigration("futures"),
+    });
+    await runMigrations(db, { provider: newerProvider, env: {} });
+    await insertSentinel(db);
+    const before = await migrationNames(db);
+    expect(before).toContain(FUTURE);
 
-    const missingName = "2099_01_01_000_missing_migration";
-    await sql`insert into kysely_migration (name, timestamp) values (${missingName}, ${new Date().toISOString()})`.execute(
-      db,
-    );
+    // The older build (no FUTURE) opens the same DB. It must NOT rewrite history.
+    await runMigrations(db, { provider: providerFor(baseMigrations()), env: {} });
 
-    await runMigrations(db);
+    expect(await migrationNames(db)).toEqual(before);
+    expect(await migrationNames(db)).toContain(FUTURE);
+    expect(await sentinelSurvives(db)).toBe(true);
+  });
 
-    const rows = await db
-      .selectFrom("kysely_migration" as any)
-      .select("name")
-      .execute();
-    const names = rows.map((row) => String(row.name));
+  // Forward skew must also no-op on an EMPTY DB: the pre-#5684 rebuild pruned the
+  // newer row even here, so guard that the empty-DB reset path is not taken.
+  test("does not reset or prune on forward skew when the DB has no user rows", async () => {
+    const newerProvider = providerFor({
+      ...baseMigrations(),
+      [FUTURE]: createTableMigration("futures"),
+    });
+    await runMigrations(db, { provider: newerProvider, env: {} });
+    // No sentinel: user tables are empty.
 
-    expect(names).not.toContain(missingName);
+    await runMigrations(db, { provider: providerFor(baseMigrations()), env: {} });
+
+    expect(await migrationNames(db)).toContain(FUTURE);
+  });
+
+  // The forward-skew short-circuit is gated behind recovery being enabled, like
+  // every other recovery branch: with recovery disabled the corrupted-migrations
+  // error is rethrown untouched.
+  test("forward skew still rethrows when recovery is disabled", async () => {
+    const newerProvider = providerFor({
+      ...baseMigrations(),
+      [FUTURE]: createTableMigration("futures"),
+    });
+    await runMigrations(db, { provider: newerProvider, env: {} });
+
+    let thrown: unknown;
+    try {
+      await runMigrations(db, {
+        provider: providerFor(baseMigrations()),
+        env: { AUTOMOBILE_MIGRATION_RECOVERY: "0" },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("corrupted migrations");
+    expect(await migrationNames(db)).toContain(FUTURE);
+  });
+
+  // Genuine corruption whose unknown row is NOT purely trailing-newer is still
+  // pruned/reset by the existing recovery path — the forward-skew guard must not
+  // swallow an out-of-order divergence. Backport sorts in the MIDDLE, so the
+  // empty-DB reset path replays cleanly (mirrors the auto-heal test).
+  test("still recovers a middle-inserted unknown migration (not forward skew)", async () => {
+    // A build that shipped a since-removed BACKPORT recorded it in history.
+    const withBackport = { ...baseMigrations(), [BACKPORT]: createTableMigration("sprockets") };
+    await runMigrations(db, { provider: providerFor(withBackport), env: {} });
+    expect(await migrationNames(db)).toContain(BACKPORT);
+
+    // This build does not ship BACKPORT and it sorts before GADGETS -> not
+    // forward skew -> the empty DB auto-heals by resetting and replaying.
+    await runMigrations(db, { provider: providerFor(baseMigrations()), env: {} });
+
+    expect(await migrationNames(db)).toEqual([WIDGETS, GADGETS].sort());
   });
 
   // (A) Populated + default: out-of-order backport refuses, rows intact.
@@ -319,9 +381,12 @@ describe("runMigrations recovery", () => {
     expect(await sentinelSurvives(db)).toBe(true);
   });
 
-  // (E) Safe removed-migration prune path heals and never invokes the backup guard,
-  //     even on a populated DB. Also confirms =true keeps the rebuild path enabled.
-  test("removed-migration prune path heals a populated DB without a backup", async () => {
+  // (E) A trailing migration this build no longer ships is name-indistinguishable
+  //     from a newer build's row, so it is now treated as forward skew (issue
+  //     #5684): the history is left untouched and the backup guard is never
+  //     invoked, on a populated DB, regardless of the recovery-destructiveness
+  //     level. (Pre-#5684 this pruned GADGETS from history.)
+  test("preserves a trailing removed migration on a populated DB without a backup", async () => {
     await runMigrations(db, { provider: providerFor(baseMigrations()), env: {} });
     await insertSentinel(db);
 
@@ -329,7 +394,8 @@ describe("runMigrations recovery", () => {
     const backup = async (): Promise<void> => {
       backupCalls++;
     };
-    // GADGETS removed from the available set -> history prune, re-run succeeds.
+    // GADGETS removed from the available set; it sorts after WIDGETS -> forward
+    // skew -> no rebuild, no reset, history intact.
     const reduced = { [WIDGETS]: createTableMigration("widgets") };
 
     await runMigrations(db, {
@@ -340,7 +406,7 @@ describe("runMigrations recovery", () => {
 
     expect(backupCalls).toBe(0);
     expect(await sentinelSurvives(db)).toBe(true);
-    expect(await migrationNames(db)).toEqual([WIDGETS]);
+    expect(await migrationNames(db)).toEqual([WIDGETS, GADGETS].sort());
   });
 
   // (F) The row-count excludes both bookkeeping tables so the seeded lock row does
@@ -450,5 +516,38 @@ describe("runMigrations recovery", () => {
     expect(fkStillEnforced).toBe(true);
 
     await fkDb.destroy();
+  });
+});
+
+describe("isBenignForwardSkew", () => {
+  const M1 = "2026_01_01_000_a";
+  const M2 = "2026_01_02_000_b";
+  const M3 = "2026_01_03_000_c";
+
+  test("true when the only unknown executed rows are newer than the newest known", () => {
+    expect(isBenignForwardSkew([M1, M2], [M1, M2, M3])).toBe(true);
+    expect(isBenignForwardSkew([M1, M2], [M1, M2, M3, "2026_01_04_000_d"])).toBe(true);
+  });
+
+  test("true when there are no unknown rows (nothing to reconcile)", () => {
+    expect(isBenignForwardSkew([M1, M2], [M1, M2])).toBe(true);
+  });
+
+  test("false when a known migration is not yet applied", () => {
+    // M2 is known but absent from the ledger -> genuine pending/out-of-order work.
+    expect(isBenignForwardSkew([M1, M2, M3], [M1, M3])).toBe(false);
+  });
+
+  test("false when an unknown row sorts before the newest known migration", () => {
+    const middle = "2026_01_015_000_x"; // between M1 and M2
+    expect(isBenignForwardSkew([M1, M2], [M1, middle, M2])).toBe(false);
+  });
+
+  test("false when an unknown row is older than every known migration", () => {
+    expect(isBenignForwardSkew([M2, M3], ["2026_01_01_000_older", M2, M3])).toBe(false);
+  });
+
+  test("false when this build ships no migrations (cannot classify)", () => {
+    expect(isBenignForwardSkew([], [M1])).toBe(false);
   });
 });

--- a/test/db/migrator.test.ts
+++ b/test/db/migrator.test.ts
@@ -79,6 +79,16 @@ describe("runMigrations recovery", () => {
     delete process.env.AUTOMOBILE_MIGRATION_RECOVERY;
   });
 
+  // Smoke test against the REAL on-disk migration folder (no injected provider):
+  // the whole shipped set applies cleanly on a fresh DB. Every other test in this
+  // file uses a fake provider, so this is the file's only guard that the real
+  // migration set is internally consistent.
+  test("applies the real migration folder on a fresh DB", async () => {
+    await runMigrations(db);
+    const names = await migrationNames(db);
+    expect(names.length).toBeGreaterThan(0);
+  });
+
   // Forward version-skew (issue #5684): a NEWER build ran ahead against the same
   // shared DB, recording a migration this (older) build does not ship, lexically
   // newer than everything it knows. All of this build's migrations are already
@@ -549,5 +559,16 @@ describe("isBenignForwardSkew", () => {
 
   test("false when this build ships no migrations (cannot classify)", () => {
     expect(isBenignForwardSkew([], [M1])).toBe(false);
+  });
+
+  // Guards the ordering-primitive choice: `newestKnown` is the max under the
+  // default code-unit sort Kysely uses for the available set, and condition (2)
+  // must compare with that same ordering. Uppercase letters sort BEFORE lowercase
+  // in code-unit order, so an unknown row starting with an uppercase letter is
+  // NOT newer than a lowercase newestKnown and must be rejected — localeCompare
+  // would wrongly rank it after and accept it.
+  test("uses code-unit ordering consistently for the newer-than check", () => {
+    // "Z..." (0x5A) sorts before "a..." (0x61) in code-unit order.
+    expect(isBenignForwardSkew(["a_known"], ["a_known", "Z_unknown"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

When two daemon builds share `~/.auto-mobile/auto-mobile.db` (multiple worktrees,
a published `bunx auto-mobile@latest` alongside a local build), the **older**
build opens a DB whose migration ledger holds rows a **newer** build wrote —
migration ids lexically newer than anything the older build ships. Kysely's
`#ensureNoMissingMigrations` raises `corrupted migrations`, and the recovery
path's safe rebuild (`rebuildMigrationTable`) then **pruned those newer rows**,
rewriting the ledger to the older build's migration set. The newer daemon
re-runs the pruned migration on its next start, and with two builds alternating
on one DB the ledger churns back and forth indefinitely.

This is the mechanism behind #5684. Before #5729's per-migration guard it was
*fatal* (`duplicate column name`); after #5729 the re-run no-ops, so the wedge is
gone but the ledger still churns. This PR removes the churn at its source.

`runMigrations` now detects **benign forward version-skew** before invoking
recovery: when every migration this build ships is already applied *and* the only
unrecognized ledger rows are lexically newer than the newest migration it knows,
it leaves the ledger completely untouched and no-ops. The older daemon serves
fine (all its migrations are applied) and never rewrites the newer build's rows —
so once both builds carry this fix the churn loop cannot form.

Genuine corruption is unchanged: a known migration not yet applied, or an unknown
row that sorts at/before the newest known migration (out-of-order / renamed /
middle-inserted), still falls through to the existing rebuild/reset recovery. The
destructive paths (`restoreMigrationHistory`, `resetDatabaseState`,
`dropAllTables`) are not touched.

## Linked Issue

Closes #5684

## Bug / Regression Context

- **Prior attempts:** #5729 guarded the `profile_type` migration (closed #5704), which
  removed the *fatal* outcome but not the ledger churn described here.
- **Observed symptom:** an older resident daemon rewrites `kysely_migration` to its own
  (older) set, dropping rows for migrations only a newer build ships; every pre-existing
  row's timestamp is rewritten to one instant.
- **Repro conditions:** a newer build migrates the shared DB, then an older build
  (`bunx auto-mobile@0.0.63`) opens it and prunes the newer row; the newer daemon re-adds
  it on restart; repeat.

## Changes

- `src/db/migrator.ts`
  - `isBenignForwardSkew(availableNames, executedNames)` — pure classifier (exported for
    unit testing) for "every known migration applied; all unknown rows strictly newer than
    the newest known".
  - `isForwardVersionSkew(db, migrator)` — reads the ledger and this build's set and applies
    the classifier. Uses a raw `sql` read (not `selectFrom(... as any)`) to avoid growing the
    typecheck baseline.
  - Short-circuit in the corrupted-migrations recovery branch: forward skew logs and returns
    without touching history.
  - Extracted the error-handling branch of `runMigrations` into `handleMigrationFailure` so
    the added check stays within the `max-depth` budget (no new lint-ratchet violation).
- `test/db/migrator.test.ts`
  - New forward-skew integration tests (populated DB, empty DB, recovery-disabled rethrow) and
    a "middle-inserted unknown migration still recovers" guard.
  - New `isBenignForwardSkew` pure-function tests.
  - Updated two pre-existing tests that pinned the old prune-the-newer-row behavior — a trailing
    removed migration is name-indistinguishable from a newer build's row, so it is now preserved
    (harmless: the orphan table lingers either way; only the ledger row differs).

## Validation

- [x] `bun test test/db/migrator.test.ts` (27) green; `bun test test/db/` (1025) green
- [x] Full `bun test` green except a pre-existing worktree `node_modules/.bin/oxlint` ENOENT
  artifact in `test/lint/oxlintConfigScoping.test.ts`, unrelated to this change
- [x] `bun run typecheck` — no new errors (174 baseline); `bun run lint` — no new ratchet
  violations; `bun run format:check` clean; `turbo run build` clean

## Acceptance criteria (inferred from the issue)

- [x] The safe rebuild no longer drops ledger rows for migrations absent from the running
  build but lexically newer than everything it knows (issue suggestion #2).
- [x] Genuine corruption still triggers the existing recovery.
- [x] Combined with #5729's guard, the wedge stays self-healing and the churn loop is
  eliminated for version pairs that both carry this fix.

## Follow-ups

- Issue suggestion #3 (record the writer's build version in the DB and refuse a destructive
  rebuild when the ledger was last written by a newer build) is intentionally **not** included:
  once forward skew is recognized, the destructive rebuild is no longer reached for that case,
  and writer-version recording is a schema/format change better decided on its own. Left tracked
  on #5684's history for a future deliberate pass if a non-forward-skew version-guard is still
  wanted.
- The already-published `0.0.63` daemon cannot be patched; its churn stops once a release
  carrying this fix is what `@latest` resolves to.
