### PR TITLE
test(utility): property-based tests for DefaultElementGeometry

### DIFF
--- a/test/features/utility/ElementGeometry.property.test.ts
+++ b/test/features/utility/ElementGeometry.property.test.ts
@@ -94,10 +94,7 @@ describe("DefaultElementGeometry.isPointInElement (property-based)", () => {
 });
 
 describe("DefaultElementGeometry.getVisibleBounds (property-based)", () => {
-  const screen = fc.tuple(
-    fc.integer({ min: 1, max: 4000 }),
-    fc.integer({ min: 1, max: 4000 }),
-  );
+  const screen = fc.tuple(fc.integer({ min: 1, max: 4000 }), fc.integer({ min: 1, max: 4000 }));
 
   test("returns null exactly when the element is not visible", () => {
     fc.assert(

--- a/test/features/utility/ElementGeometry.property.test.ts
+++ b/test/features/utility/ElementGeometry.property.test.ts
@@ -1,0 +1,221 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { DefaultElementGeometry } from "../../../src/features/utility/ElementGeometry";
+import type { Element } from "../../../src/models/Element";
+import type { ElementBounds } from "../../../src/models/ElementBounds";
+
+// Property-based tests for the pure gesture-geometry helpers. See
+// Backoff.property.test.ts for the pinned-seed rationale: the same generated
+// cases run every CI invocation, so a counterexample is reproducible.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const geometry = new DefaultElementGeometry();
+
+const elementWithBounds = (bounds: ElementBounds): Element => ({ bounds }) as unknown as Element;
+
+// Integer coordinates in the safe range; `left <= right` and `top <= bottom`
+// so every generated rectangle is non-inverted (the shape all callers pass).
+const validBounds: fc.Arbitrary<ElementBounds> = fc
+  .tuple(
+    fc.integer({ min: -5000, max: 5000 }),
+    fc.integer({ min: -5000, max: 5000 }),
+    fc.integer({ min: 0, max: 10_000 }),
+    fc.integer({ min: 0, max: 10_000 }),
+  )
+  .map(([x1, y1, w, h]) => ({ left: x1, top: y1, right: x1 + w, bottom: y1 + h }));
+
+// Strictly positive width AND height, so directional swipes make real progress.
+const nonDegenerateBounds: fc.Arbitrary<ElementBounds> = fc
+  .tuple(
+    fc.integer({ min: -5000, max: 5000 }),
+    fc.integer({ min: -5000, max: 5000 }),
+    fc.integer({ min: 1, max: 10_000 }),
+    fc.integer({ min: 1, max: 10_000 }),
+  )
+  .map(([x1, y1, w, h]) => ({ left: x1, top: y1, right: x1 + w, bottom: y1 + h }));
+
+const direction = fc.constantFrom<"up" | "down" | "left" | "right">("up", "down", "left", "right");
+
+const within = (v: number, lo: number, hi: number): boolean => v >= lo && v <= hi;
+
+describe("DefaultElementGeometry.getElementCenter (property-based)", () => {
+  test("center lies within the element's own bounds", () => {
+    fc.assert(
+      fc.property(validBounds, (b) => {
+        const c = geometry.getElementCenter(elementWithBounds(b));
+        return within(c.x, b.left, b.right) && within(c.y, b.top, b.bottom);
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("the center point is always classified as inside the element", () => {
+    fc.assert(
+      fc.property(validBounds, (b) => {
+        const el = elementWithBounds(b);
+        const c = geometry.getElementCenter(el);
+        return geometry.isPointInElement(el, c.x, c.y);
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("DefaultElementGeometry.isPointInElement (property-based)", () => {
+  test("all four corners are inclusive-inside", () => {
+    fc.assert(
+      fc.property(validBounds, (b) => {
+        const el = elementWithBounds(b);
+        return (
+          geometry.isPointInElement(el, b.left, b.top) &&
+          geometry.isPointInElement(el, b.right, b.bottom) &&
+          geometry.isPointInElement(el, b.left, b.bottom) &&
+          geometry.isPointInElement(el, b.right, b.top)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("a point strictly outside any edge is rejected", () => {
+    fc.assert(
+      fc.property(validBounds, (b) => {
+        const el = elementWithBounds(b);
+        return (
+          !geometry.isPointInElement(el, b.left - 1, b.top) &&
+          !geometry.isPointInElement(el, b.right + 1, b.top) &&
+          !geometry.isPointInElement(el, b.left, b.top - 1) &&
+          !geometry.isPointInElement(el, b.left, b.bottom + 1)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("DefaultElementGeometry.getVisibleBounds (property-based)", () => {
+  const screen = fc.tuple(
+    fc.integer({ min: 1, max: 4000 }),
+    fc.integer({ min: 1, max: 4000 }),
+  );
+
+  test("returns null exactly when the element is not visible", () => {
+    fc.assert(
+      fc.property(validBounds, screen, (b, [w, h]) => {
+        const el = elementWithBounds(b);
+        const visible = geometry.getVisibleBounds(el, w, h);
+        return (visible === null) === !geometry.isElementVisible(el, w, h);
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("a non-null visible region is clamped to the screen and is a sub-rect of the element", () => {
+    fc.assert(
+      fc.property(validBounds, screen, (b, [w, h]) => {
+        const visible = geometry.getVisibleBounds(elementWithBounds(b), w, h);
+        if (visible === null) {
+          return true;
+        }
+        const onScreen =
+          visible.left >= 0 && visible.top >= 0 && visible.right <= w && visible.bottom <= h;
+        const subRect =
+          visible.left >= b.left &&
+          visible.top >= b.top &&
+          visible.right <= b.right &&
+          visible.bottom <= b.bottom;
+        // Clamping a valid, visible rect can never invert it.
+        const nonInverted = visible.left <= visible.right && visible.top <= visible.bottom;
+        return onScreen && subRect && nonInverted;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("DefaultElementGeometry.getSwipeWithinBounds (property-based)", () => {
+  test("every swipe endpoint stays within the container bounds", () => {
+    fc.assert(
+      fc.property(validBounds, direction, (b, d) => {
+        const s = geometry.getSwipeWithinBounds(d, b);
+        return (
+          within(s.startX, b.left, b.right) &&
+          within(s.endX, b.left, b.right) &&
+          within(s.startY, b.top, b.bottom) &&
+          within(s.endY, b.top, b.bottom)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("vertical swipes hold X constant; horizontal swipes hold Y constant", () => {
+    fc.assert(
+      fc.property(validBounds, direction, (b, d) => {
+        const s = geometry.getSwipeWithinBounds(d, b);
+        const vertical = d === "up" || d === "down";
+        return vertical ? s.startX === s.endX : s.startY === s.endY;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("the finger moves in the requested direction (non-degenerate bounds)", () => {
+    fc.assert(
+      fc.property(nonDegenerateBounds, direction, (b, d) => {
+        const s = geometry.getSwipeWithinBounds(d, b);
+        switch (d) {
+          case "up":
+            // Finger travels toward the top => decreasing Y.
+            return s.endY < s.startY;
+          case "down":
+            return s.endY > s.startY;
+          case "left":
+            // Finger travels toward the left edge => decreasing X.
+            return s.endX < s.startX;
+          case "right":
+            return s.endX > s.startX;
+        }
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("DefaultElementGeometry.getSwipeDirectionForScroll (property-based)", () => {
+  test("is an involution with no fixed points", () => {
+    fc.assert(
+      fc.property(direction, (d) => {
+        const once = geometry.getSwipeDirectionForScroll(d);
+        return geometry.getSwipeDirectionForScroll(once) === d && once !== d;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("maps the four directions bijectively onto themselves", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const images = (["up", "down", "left", "right"] as const).map((d) =>
+          geometry.getSwipeDirectionForScroll(d),
+        );
+        return new Set(images).size === 4;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
+describe("DefaultElementGeometry.getSwipeDurationFromSpeed (property-based)", () => {
+  test("duration is strictly ordered fast < normal < slow", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        const fast = geometry.getSwipeDurationFromSpeed("fast");
+        const normal = geometry.getSwipeDurationFromSpeed("normal");
+        const slow = geometry.getSwipeDurationFromSpeed("slow");
+        return fast > 0 && fast < normal && normal < slow;
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`DefaultElementGeometry` (`src/features/utility/ElementGeometry.ts`) is a pure gesture-geometry module — center/point-containment, visible-bounds clamping, and swipe-coordinate math — but it was covered only by a handful of hard-coded example cases in `ElementGeometry.test.ts`. This adds a `fast-check` property-test suite that asserts the invariants the module actually promises, across 300 generated cases per property with a deterministic pinned seed (matching the existing convention in `bounds.property.test.ts` / `swipeOnUtils.property.test.ts`).

Properties added:

- **`getElementCenter`** — the center lies within the element's own bounds and is classified inside by `isPointInElement`.
- **`isPointInElement`** — inclusive at all four corners; rejects a point one pixel outside any edge.
- **`getVisibleBounds`** — returns `null` exactly when the element is not visible; a non-null region is clamped to the screen, is a sub-rectangle of the element, and is never inverted.
- **`getSwipeWithinBounds`** — every endpoint stays within the container; vertical swipes hold X constant and horizontal swipes hold Y constant; for non-degenerate bounds the finger moves in the requested direction (up ⇒ decreasing Y, etc.).
- **`getSwipeDirectionForScroll`** — involution with no fixed points; bijective over the four directions.
- **`getSwipeDurationFromSpeed`** — strictly ordered `fast < normal < slow`.

Test-only change: no source files touched. The module is pure, so no `getDatabase()`, fakes, or FakeTimer are needed; the suite runs well under the 100ms unit-test budget.

## Linked Issue

<!-- No tracking issue; proactive test-coverage expansion. -->

## Validation

- [x] `bun run lint` passes (oxlint ratchet: no new violations)
- [x] `bun run typecheck` reports no new errors (baseline gate: 174 known)
- [x] `bun run build` succeeds
- [x] New test file passes (12 properties) and runs in <100ms each
- [x] New code uses a pure module directly; no DB, no real `getDatabase()`

Note on the full `bun test` run in this cloud container: ~167 unrelated failures reproduce on a clean tree, all from host-port exhaustion (`No available ports … at or above 8765`) in the shared sandbox — e.g. `IOSCtrlProxyClient` / `PortManager` — not from this change. The added suite and its neighbor (`ElementGeometry.test.ts`) pass together (31 tests).

## Follow-ups

- [ ] None.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bVJbTPEVXtBbvMuxqtLYA)_