### PR TITLE
fix(ci): keep release automation's generated files oxfmt-clean (#5743)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,25 +22,9 @@
       "homepage": "https://kaeawc.github.io/auto-mobile/",
       "repository": "https://github.com/kaeawc/auto-mobile",
       "license": "Apache-2.0",
-      "keywords": [
-        "mobile",
-        "android",
-        "ios",
-        "automation",
-        "testing",
-        "mcp",
-        "adb",
-        "simctl"
-      ],
+      "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
       "category": "development",
-      "tags": [
-        "mobile-testing",
-        "android",
-        "ios",
-        "automation",
-        "ui-testing",
-        "device-control"
-      ],
+      "tags": ["mobile-testing", "android", "ios", "automation", "ui-testing", "device-control"],
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,26 +9,13 @@
   "homepage": "https://kaeawc.github.io/auto-mobile/",
   "repository": "https://github.com/kaeawc/auto-mobile",
   "license": "Apache-2.0",
-  "keywords": [
-    "mobile",
-    "android",
-    "ios",
-    "automation",
-    "testing",
-    "mcp",
-    "adb",
-    "simctl"
-  ],
-  "commands": [
-    "./skills/"
-  ],
+  "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
+  "commands": ["./skills/"],
   "hooks": "./hooks.json",
   "mcpServers": {
     "auto-mobile": {
       "command": "bunx",
-      "args": [
-        "@kaeawc/auto-mobile@latest"
-      ]
+      "args": ["@kaeawc/auto-mobile@latest"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [v0.0.64] - 2026-08-25
+
 ### Added
+
 - fix(storage): guard decodeURIComponent in key-value storageResources handlers against malformed URIs ([#5734](https://github.com/kaeawc/auto-mobile/issues/5734))
 - Add bounded iOS device-log capture to bug reports ([#5641](https://github.com/kaeawc/auto-mobile/issues/5641)) (ios, devxp)
 - feat(storage): project Android DataStore reads into MCP resources ([#5603](https://github.com/kaeawc/auto-mobile/issues/5603)) (android)
@@ -10,10 +12,14 @@
 - Screen streaming: severe-drop detection for auto-adjust via on-device dropped-frame stats ([#5582](https://github.com/kaeawc/auto-mobile/issues/5582))
 - feat(desktop): show the update affordance on the picker/onboarding surfaces, not only the workspace ([#5271](https://github.com/kaeawc/auto-mobile/issues/5271)) (desktop)
 - feat(ios): listApps/ListInstalledApps physical-device parity via devicectl device info apps ([#2883](https://github.com/kaeawc/auto-mobile/issues/2883)) (ios)
+
 ### Changed
+
 - deviceSnapshot: drop the deprecated adb-backup app-data path on Android ([#5708](https://github.com/kaeawc/auto-mobile/issues/5708)) (android)
 - Harden file-backed DB anti-pattern guard toward AST if a non-inline variant recurs (#3081/#3094 follow-up) ([#3103](https://github.com/kaeawc/auto-mobile/issues/3103)) (testing, database)
+
 ### Fixed
+
 - deviceSnapshot: failed iOS capture leaves an orphan snapshot directory that blocks explicit-name retry ([#5723](https://github.com/kaeawc/auto-mobile/issues/5723))
 - bug(android): publish debug inspection providers for Maven consumers ([#5714](https://github.com/kaeawc/auto-mobile/issues/5714)) (android, database)
 - deviceSnapshot: auto-overwrite existing snapshot names and close the check→create TOCTOU ([#5713](https://github.com/kaeawc/auto-mobile/issues/5713))
@@ -28,7 +34,9 @@
 - Hold concurrent ensureConnected() callers behind the bound-session first heartbeat ([#5643](https://github.com/kaeawc/auto-mobile/issues/5643))
 - Fix proxy-bound sessions that expire before their first heartbeat ([#5637](https://github.com/kaeawc/auto-mobile/issues/5637)) (android)
 - Audit and fix Android user/profile targeting across the codebase ([#5599](https://github.com/kaeawc/auto-mobile/issues/5599)) (android)
+
 ### Other
+
 - fix(ios-sdk): enforce main-thread on public UIKit/WebKit entry points (ViewHierarchyWalker.walk, WebViewBridge.perform) ([#5719](https://github.com/kaeawc/auto-mobile/issues/5719)) (ios)
 - fix(ios-sdk): NetworkCaptureRecorder — don't hold emissionLock across emit, and make recordCompletion atomic ([#5701](https://github.com/kaeawc/auto-mobile/issues/5701)) (ios)
 - fix(ios-sdk): cancel the delayed network fault on stopLoading (no client re-entry after stop) ([#5697](https://github.com/kaeawc/auto-mobile/issues/5697)) (ios, testing)

--- a/scripts/changelog/update_changelog_from_issues.sh
+++ b/scripts/changelog/update_changelog_from_issues.sh
@@ -124,20 +124,26 @@ for issue in issues:
     item = f"- {title} ([#{number}]({url})){label_suffix}"
     sections[category].append(item)
 
-lines = [f"## [{current_tag}] - {date}"]
+# A blank line after every heading keeps the generated entry oxfmt-clean. The
+# release commit carries [skip ci], so unformatted output here lands on main
+# unobserved and reddens Check Formatting for the next contributor (#5743).
+lines = [f"## [{current_tag}] - {date}", ""]
 
 for section in SECTION_ORDER:
     items = sections[section]
     if not items:
         continue
     lines.append(f"### {SECTION_TITLES[section]}")
+    lines.append("")
     lines.extend(items)
+    lines.append("")
 
 if not any(sections.values()):
     lines.append("### Other")
+    lines.append("")
     lines.append("- No changes.")
 
-section = "\n".join(lines) + "\n"
+section = "\n".join(lines).rstrip("\n") + "\n"
 
 if not content:
     new_content = f"# Changelog\n\n{section}"

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -250,9 +250,10 @@ update_gradle_properties_version() {
 update_gradle_properties_version "android/gradle.properties" "${snapshot_version}" "$dry_run"
 
 # marketplace.json nests the plugin version under plugins[0]; its own top-level
-# "version" is the marketplace schema version and must not move.
+# "version" is the marketplace schema version and must not move, and any sibling
+# plugin entry is independently versioned — hence the index rather than `*`.
 update_json_version_at ".claude-plugin/marketplace.json" "$new_version" "$dry_run" \
-  "plugins.*.version"
+  "plugins.0.version"
 
 # Keep daemon consumer documentation aligned with the CtrlProxy artifacts that
 # ship in the release. These references are intentionally updated as part of

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -71,15 +71,22 @@ snapshot_version="${new_version}-SNAPSHOT"
 # "plugins.0.version". Every `"<key>": "<old version>"` pair in the file is
 # rewritten, which is what server.json's packages[] entries want; keys holding a
 # different value (marketplace.json's own schema version) are left alone.
+#
+# Any trailing arguments are extra pointers that must also hold the new version
+# once the rewrite is done. The previous reserializing writer force-synced
+# server.json's packages[] entries, so name them here: a diverged entry now
+# fails the release loudly instead of being silently corrected or silently left
+# behind.
 update_json_version_at() {
   local path="$1"
   local pointer="$2"
   local version="$3"
   local dry="$4"
+  shift 4
   if [[ "$dry" == true ]]; then
     return 0
   fi
-  python3 - "$path" "$pointer" "$version" <<'PY'
+  python3 - "$path" "$pointer" "$version" "$@" <<'PY'
 import json
 import re
 import sys
@@ -113,8 +120,10 @@ if count == 0:
     raise SystemExit(f"No {key!r} entry with value {current!r} found in {path}")
 
 # Reparse so a bad substitution fails the release rather than shipping broken JSON.
-if resolve(json.loads(updated), pointer) != version:
-    raise SystemExit(f"Failed to set {pointer} to {version} in {path}")
+document = json.loads(updated)
+for expected in [pointer, *sys.argv[4:]]:
+    if resolve(document, expected) != version:
+        raise SystemExit(f"Failed to set {expected} to {version} in {path}")
 
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(updated)
@@ -159,8 +168,10 @@ update_json_version_at "package.json" "version" "$new_version" "$dry_run"
 update_json_version_at ".claude-plugin/plugin.json" "version" "$new_version" "$dry_run"
 
 # server.json carries the same version at the top level and on every packages[]
-# entry, so rewriting the shared value covers both.
-update_json_version_at "server.json" "version" "$new_version" "$dry_run"
+# entry, so rewriting the shared value covers both; verify the entry the MCP
+# registry reads.
+update_json_version_at "server.json" "version" "$new_version" "$dry_run" \
+  "packages.0.version"
 
 # Update VERSION_NAME in android/gradle.properties. This is the Android
 # dev/Maven coordinate version, so local source builds intentionally keep the

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -62,28 +62,62 @@ fi
 
 snapshot_version="${new_version}-SNAPSHOT"
 
-update_json_version() {
+# Rewrite a version string *in place* rather than reserializing the document.
+# json.dump(indent=2) re-indents the whole file and explodes short arrays onto
+# one element per line, which oxfmt then collapses again — so every release
+# commit (which carries [skip ci]) landed a formatter failure on main (#5743).
+#
+# `pointer` is a dot path to the canonical version, e.g. "version" or
+# "plugins.0.version". Every `"<key>": "<old version>"` pair in the file is
+# rewritten, which is what server.json's packages[] entries want; keys holding a
+# different value (marketplace.json's own schema version) are left alone.
+update_json_version_at() {
   local path="$1"
-  local version="$2"
-  local dry="$3"
+  local pointer="$2"
+  local version="$3"
+  local dry="$4"
   if [[ "$dry" == true ]]; then
     return 0
   fi
-  python3 - "$path" "$version" <<'PY'
+  python3 - "$path" "$pointer" "$version" <<'PY'
 import json
+import re
 import sys
 
 path = sys.argv[1]
-version = sys.argv[2]
+pointer = sys.argv[2]
+version = sys.argv[3]
+
+
+def resolve(document, dotted):
+    node = document
+    for part in dotted.split("."):
+        node = node[int(part)] if isinstance(node, list) else node[part]
+    return node
+
 
 with open(path, "r", encoding="utf-8") as handle:
-    data = json.load(handle)
+    raw = handle.read()
 
-data["version"] = version
+current = resolve(json.loads(raw), pointer)
+if current == version:
+    sys.exit(0)
+
+key = pointer.rsplit(".", 1)[-1]
+pattern = re.compile(
+    r'("{}"\s*:\s*){}'.format(re.escape(key), re.escape(json.dumps(current)))
+)
+updated, count = pattern.subn(lambda match: match.group(1) + json.dumps(version), raw)
+
+if count == 0:
+    raise SystemExit(f"No {key!r} entry with value {current!r} found in {path}")
+
+# Reparse so a bad substitution fails the release rather than shipping broken JSON.
+if resolve(json.loads(updated), pointer) != version:
+    raise SystemExit(f"Failed to set {pointer} to {version} in {path}")
 
 with open(path, "w", encoding="utf-8") as handle:
-    json.dump(data, handle, indent=2)
-    handle.write("\n")
+    handle.write(updated)
 PY
 }
 
@@ -121,39 +155,12 @@ if not dry:
 PY
 }
 
-update_json_version "package.json" "$new_version" "$dry_run"
-update_json_version ".claude-plugin/plugin.json" "$new_version" "$dry_run"
+update_json_version_at "package.json" "version" "$new_version" "$dry_run"
+update_json_version_at ".claude-plugin/plugin.json" "version" "$new_version" "$dry_run"
 
-# Update server.json top-level version and packages[0].version for MCP registry
-update_server_json_version() {
-  local path="$1"
-  local version="$2"
-  local dry="$3"
-  if [[ "$dry" == true ]]; then
-    return 0
-  fi
-  python3 - "$path" "$version" <<'PY'
-import json
-import sys
-
-path = sys.argv[1]
-version = sys.argv[2]
-
-with open(path, "r", encoding="utf-8") as handle:
-    data = json.load(handle)
-
-data["version"] = version
-
-if "packages" in data:
-    for pkg in data["packages"]:
-        pkg["version"] = version
-
-with open(path, "w", encoding="utf-8") as handle:
-    json.dump(data, handle, indent=2)
-    handle.write("\n")
-PY
-}
-update_server_json_version "server.json" "$new_version" "$dry_run"
+# server.json carries the same version at the top level and on every packages[]
+# entry, so rewriting the shared value covers both.
+update_json_version_at "server.json" "version" "$new_version" "$dry_run"
 
 # Update VERSION_NAME in android/gradle.properties. This is the Android
 # dev/Maven coordinate version, so local source builds intentionally keep the
@@ -174,33 +181,10 @@ update_gradle_properties_version() {
 }
 update_gradle_properties_version "android/gradle.properties" "${snapshot_version}" "$dry_run"
 
-# Update marketplace.json plugin version (nested in plugins[0].version)
-update_marketplace_plugin_version() {
-  local path="$1"
-  local version="$2"
-  local dry="$3"
-  if [[ "$dry" == true ]]; then
-    return 0
-  fi
-  python3 - "$path" "$version" <<'PY'
-import json
-import sys
-
-path = sys.argv[1]
-version = sys.argv[2]
-
-with open(path, "r", encoding="utf-8") as handle:
-    data = json.load(handle)
-
-if "plugins" in data and len(data["plugins"]) > 0:
-    data["plugins"][0]["version"] = version
-
-with open(path, "w", encoding="utf-8") as handle:
-    json.dump(data, handle, indent=2)
-    handle.write("\n")
-PY
-}
-update_marketplace_plugin_version ".claude-plugin/marketplace.json" "$new_version" "$dry_run"
+# marketplace.json nests the plugin version under plugins[0]; its own top-level
+# "version" is the marketplace schema version and must not move.
+update_json_version_at ".claude-plugin/marketplace.json" "plugins.0.version" \
+  "$new_version" "$dry_run"
 
 # Keep daemon consumer documentation aligned with the CtrlProxy artifacts that
 # ship in the release. These references are intentionally updated as part of

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -62,68 +62,126 @@ fi
 
 snapshot_version="${new_version}-SNAPSHOT"
 
-# Rewrite a version string *in place* rather than reserializing the document.
+# Rewrite version strings *in place* rather than reserializing the document.
 # json.dump(indent=2) re-indents the whole file and explodes short arrays onto
 # one element per line, which oxfmt then collapses again — so every release
 # commit (which carries [skip ci]) landed a formatter failure on main (#5743).
 #
-# `pointer` is a dot path to the canonical version, e.g. "version" or
-# "plugins.0.version". Every `"<key>": "<old version>"` pair in the file is
-# rewritten, which is what server.json's packages[] entries want; keys holding a
-# different value (marketplace.json's own schema version) are left alone.
-#
-# Any trailing arguments are extra pointers that must also hold the new version
-# once the rewrite is done. The previous reserializing writer force-synced
-# server.json's packages[] entries, so name them here: a diverged entry now
-# fails the release loudly instead of being silently corrected or silently left
-# behind.
+# Every argument after the dry-run flag is a dot path to a version string, e.g.
+# "version", "plugins.0.version", or "packages.*.version" (`*` covers every
+# element of a list or every value of an object). Only the pointed-at leaves are
+# rewritten: marketplace.json's own schema version must survive the release
+# where the plugin version happens to equal it.
 update_json_version_at() {
   local path="$1"
-  local pointer="$2"
-  local version="$3"
-  local dry="$4"
-  shift 4
+  local version="$2"
+  local dry="$3"
+  shift 3
   if [[ "$dry" == true ]]; then
     return 0
   fi
-  python3 - "$path" "$pointer" "$version" "$@" <<'PY'
+  python3 - "$path" "$version" "$@" <<'PY'
 import json
 import re
 import sys
 
 path = sys.argv[1]
-pointer = sys.argv[2]
-version = sys.argv[3]
+version = sys.argv[2]
+pointers = sys.argv[3:]
 
 
-def resolve(document, dotted):
-    node = document
-    for part in dotted.split("."):
-        node = node[int(part)] if isinstance(node, list) else node[part]
-    return node
+def child(node, part):
+    return node[int(part)] if isinstance(node, list) else node[part]
+
+
+def expand(node, parts, prefix=()):
+    """Concrete paths for a dot pointer, resolving `*` against the document."""
+    if not parts:
+        yield prefix
+        return
+    head, rest = parts[0], parts[1:]
+    if head == "*":
+        keys = range(len(node)) if isinstance(node, list) else node.keys()
+        for key in keys:
+            yield from expand(child(node, str(key)), rest, prefix + (str(key),))
+    else:
+        yield from expand(child(node, head), rest, prefix + (head,))
+
+
+def string_entries(node, prefix=()):
+    """Every string-valued object entry, in document order.
+
+    json.loads preserves source order, so this enumerates exactly the
+    `"key": "value"` pairs the regex below finds, in the same order.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(value, str):
+                yield prefix + (key,), key, value
+            else:
+                yield from string_entries(value, prefix + (key,))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            if not isinstance(value, str):
+                yield from string_entries(value, prefix + (str(index),))
 
 
 with open(path, "r", encoding="utf-8") as handle:
     raw = handle.read()
 
-current = resolve(json.loads(raw), pointer)
-if current == version:
-    sys.exit(0)
+document = json.loads(raw)
 
-key = pointer.rsplit(".", 1)[-1]
-pattern = re.compile(
-    r'("{}"\s*:\s*){}'.format(re.escape(key), re.escape(json.dumps(current)))
-)
-updated, count = pattern.subn(lambda match: match.group(1) + json.dumps(version), raw)
+targets = []
+for pointer in pointers:
+    concrete = list(expand(document, pointer.split(".")))
+    if not concrete:
+        raise SystemExit(f"Pointer {pointer!r} matched nothing in {path}")
+    targets.extend(concrete)
 
-if count == 0:
-    raise SystemExit(f"No {key!r} entry with value {current!r} found in {path}")
+# Group by (key, current value): entries sharing both are indistinguishable to
+# the regex, so they must be located together and selected by position.
+groups = {}
+for target in targets:
+    current = document
+    for part in target:
+        current = child(current, part)
+    if not isinstance(current, str):
+        raise SystemExit(f"Pointer {'.'.join(target)} in {path} is not a string")
+    groups.setdefault((target[-1], current), []).append(target)
+
+edits = []
+for (key, current), selected in groups.items():
+    if current == version:
+        continue
+    occurrences = [
+        found for found, name, value in string_entries(document)
+        if name == key and value == current
+    ]
+    pattern = re.compile(
+        r'("{}"\s*:\s*){}'.format(re.escape(key), re.escape(json.dumps(current)))
+    )
+    matches = list(pattern.finditer(raw))
+    if len(matches) != len(occurrences):
+        raise SystemExit(
+            f"Found {len(matches)} textual {key!r} matches for {current!r} in "
+            f"{path} but {len(occurrences)} in the parsed document"
+        )
+    for target in selected:
+        match = matches[occurrences.index(target)]
+        edits.append((match.start(), match.end(), match.group(1) + json.dumps(version)))
+
+updated = raw
+for begin, finish, replacement in sorted(edits, reverse=True):
+    updated = updated[:begin] + replacement + updated[finish:]
 
 # Reparse so a bad substitution fails the release rather than shipping broken JSON.
-document = json.loads(updated)
-for expected in [pointer, *sys.argv[4:]]:
-    if resolve(document, expected) != version:
-        raise SystemExit(f"Failed to set {expected} to {version} in {path}")
+rewritten = json.loads(updated)
+for target in targets:
+    current = rewritten
+    for part in target:
+        current = child(current, part)
+    if current != version:
+        raise SystemExit(f"Failed to set {'.'.join(target)} to {version} in {path}")
 
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(updated)
@@ -164,14 +222,13 @@ if not dry:
 PY
 }
 
-update_json_version_at "package.json" "version" "$new_version" "$dry_run"
-update_json_version_at ".claude-plugin/plugin.json" "version" "$new_version" "$dry_run"
+update_json_version_at "package.json" "$new_version" "$dry_run" "version"
+update_json_version_at ".claude-plugin/plugin.json" "$new_version" "$dry_run" "version"
 
-# server.json carries the same version at the top level and on every packages[]
-# entry, so rewriting the shared value covers both; verify the entry the MCP
-# registry reads.
-update_json_version_at "server.json" "version" "$new_version" "$dry_run" \
-  "packages.0.version"
+# server.json carries the version at the top level and on every packages[]
+# entry the MCP registry reads.
+update_json_version_at "server.json" "$new_version" "$dry_run" \
+  "version" "packages.*.version"
 
 # Update VERSION_NAME in android/gradle.properties. This is the Android
 # dev/Maven coordinate version, so local source builds intentionally keep the
@@ -194,8 +251,8 @@ update_gradle_properties_version "android/gradle.properties" "${snapshot_version
 
 # marketplace.json nests the plugin version under plugins[0]; its own top-level
 # "version" is the marketplace schema version and must not move.
-update_json_version_at ".claude-plugin/marketplace.json" "plugins.0.version" \
-  "$new_version" "$dry_run"
+update_json_version_at ".claude-plugin/marketplace.json" "$new_version" "$dry_run" \
+  "plugins.*.version"
 
 # Keep daemon consumer documentation aligned with the CtrlProxy artifacts that
 # ship in the release. These references are intentionally updated as part of

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -268,10 +268,9 @@ JSON
   [ "$(json_field "${TEST_ROOT}/server.json" 'data["version"]')" = "$VERSION" ]
 }
 
-@test "fails loudly when a server.json packages[] version has diverged (#5743)" {
-  # The old writer reserialized server.json and silently force-synced every
-  # packages[] entry. Rewriting in place cannot do that, so a diverged entry
-  # must fail the release rather than ship mismatched registry metadata.
+@test "syncs a diverged server.json packages[] version (#5743)" {
+  # server.json's packages[] entries are named pointers, so a diverged entry is
+  # brought back in line exactly as the old reserializing writer did.
   cat > "${TEST_ROOT}/server.json" <<'JSON'
 {
   "version": "0.0.1",
@@ -280,6 +279,25 @@ JSON
 JSON
 
   run_bump
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"packages.0.version"* ]]
+  [ "$status" -eq 0 ]
+  [ "$(json_field "${TEST_ROOT}/server.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/server.json" 'data["packages"][0]["version"]')" = "$VERSION" ]
+}
+
+@test "bumps only the pointed-at version when a sibling key shares its value (#5743)" {
+  # marketplace.json's own schema version is a fixed "1.0.0". Once the plugin
+  # reaches 1.0.0 the two values collide, and a value-matching rewrite would
+  # drag the schema version along with the plugin version.
+  cat > "${TEST_ROOT}/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "auto-mobile",
+  "version": "1.0.0",
+  "plugins": [{ "name": "auto-mobile", "version": "1.0.0" }]
+}
+JSON
+
+  run_bump
+  [ "$status" -eq 0 ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["version"]')" = "1.0.0" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][0]["version"]')" = "$VERSION" ]
 }

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -209,3 +209,61 @@ run_bump() {
   # Guard against a vacuous pass: the bump must have visibly rewritten files.
   (("$rewritten_count" > 0))
 }
+
+@test "bumping a version preserves the surrounding JSON formatting (#5743)" {
+  # Reserializing with json.dump re-indents the whole file, exploding short
+  # arrays onto one line per element. oxfmt collapses them back, so every
+  # release commit landed a formatter failure on main.
+  cat > "${TEST_ROOT}/package.json" <<'JSON'
+{
+  "name": "@kaeawc/auto-mobile",
+  "version": "0.0.1",
+  "keywords": ["mobile", "android", "ios"]
+}
+JSON
+
+  cat > "${TEST_ROOT}/.claude-plugin/plugin.json" <<'JSON'
+{
+  "name": "auto-mobile",
+  "version": "0.0.1",
+  "commands": ["./skills/"]
+}
+JSON
+
+  cat > "${TEST_ROOT}/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "auto-mobile",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "auto-mobile",
+      "version": "0.0.1",
+      "tags": ["android", "ios"]
+    }
+  ]
+}
+JSON
+
+  cat > "${TEST_ROOT}/server.json" <<'JSON'
+{
+  "version": "0.0.1",
+  "packages": [{ "identifier": "@kaeawc/auto-mobile", "version": "0.0.1" }]
+}
+JSON
+
+  run_bump
+  [ "$status" -eq 0 ]
+
+  grep -qF '"keywords": ["mobile", "android", "ios"]' "${TEST_ROOT}/package.json"
+  grep -qF '"commands": ["./skills/"]' "${TEST_ROOT}/.claude-plugin/plugin.json"
+  grep -qF '"tags": ["android", "ios"]' "${TEST_ROOT}/.claude-plugin/marketplace.json"
+  grep -qF '"packages": [{ "identifier": "@kaeawc/auto-mobile", "version": "1.2.3" }]' \
+    "${TEST_ROOT}/server.json"
+
+  # The marketplace *schema* version is not the plugin version and must not move.
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["version"]')" = "1.0.0" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][0]["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/package.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/plugin.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/server.json" 'data["version"]')" = "$VERSION" ]
+}

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -267,3 +267,19 @@ JSON
   [ "$(json_field "${TEST_ROOT}/.claude-plugin/plugin.json" 'data["version"]')" = "$VERSION" ]
   [ "$(json_field "${TEST_ROOT}/server.json" 'data["version"]')" = "$VERSION" ]
 }
+
+@test "fails loudly when a server.json packages[] version has diverged (#5743)" {
+  # The old writer reserialized server.json and silently force-synced every
+  # packages[] entry. Rewriting in place cannot do that, so a diverged entry
+  # must fail the release rather than ship mismatched registry metadata.
+  cat > "${TEST_ROOT}/server.json" <<'JSON'
+{
+  "version": "0.0.1",
+  "packages": [{ "identifier": "@kaeawc/auto-mobile", "version": "0.0.0" }]
+}
+JSON
+
+  run_bump
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"packages.0.version"* ]]
+}

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -301,3 +301,24 @@ JSON
   [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["version"]')" = "1.0.0" ]
   [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][0]["version"]')" = "$VERSION" ]
 }
+
+@test "bumps only the AutoMobile marketplace entry, not a sibling plugin (#5743)" {
+  # marketplace.json may list other, independently versioned plugins; the bump
+  # owns plugins[0] only. server.json's packages[] entries are different — they
+  # all describe this package, so they are all synced.
+  cat > "${TEST_ROOT}/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "auto-mobile",
+  "version": "1.0.0",
+  "plugins": [
+    { "name": "auto-mobile", "version": "0.0.1" },
+    { "name": "somebody-elses-plugin", "version": "7.8.9" }
+  ]
+}
+JSON
+
+  run_bump
+  [ "$status" -eq 0 ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][0]["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][1]["version"]')" = "7.8.9" ]
+}

--- a/test/bats/update-changelog-from-issues.bats
+++ b/test/bats/update-changelog-from-issues.bats
@@ -66,3 +66,48 @@ teardown() {
   run grep -nE '(^|[^0-9a-zA-Z_.])python([^3a-zA-Z]|$)' "$SCRIPT"
   [ "$status" -ne 0 ]
 }
+
+@test "emits oxfmt-clean markdown: a blank line follows every heading (#5743)" {
+  # The release commit carries [skip ci], so unformatted generator output lands
+  # on main unobserved and reddens Check Formatting for the next contributor.
+  run env \
+    PATH="$STUB_DIR:/usr/bin:/bin" \
+    GITHUB_REPOSITORY="kaeawc/auto-mobile" \
+    CURRENT_TAG="v9.9.9" \
+    SINCE_TAG="v9.9.8" \
+    CHANGELOG_FILE="$WORK_DIR/CHANGELOG.md" \
+    bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+
+  run awk '/^#/ { heading = NR; next } heading && NR == heading + 1 && $0 != "" { print NR": "$0; found = 1 } END { exit found ? 0 : 1 }' \
+    "$WORK_DIR/CHANGELOG.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "keeps existing entries blank-line separated when prepending (#5743)" {
+  cat > "$WORK_DIR/CHANGELOG.md" <<'PRIOR'
+# Changelog
+
+## [v9.9.8] - 2020-01-01
+
+### Fixed
+
+- An older thing ([#0](https://example.com/0))
+PRIOR
+
+  run env \
+    PATH="$STUB_DIR:/usr/bin:/bin" \
+    GITHUB_REPOSITORY="kaeawc/auto-mobile" \
+    CURRENT_TAG="v9.9.9" \
+    SINCE_TAG="v9.9.8" \
+    CHANGELOG_FILE="$WORK_DIR/CHANGELOG.md" \
+    bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  grep -q '## \[v9.9.8\]' "$WORK_DIR/CHANGELOG.md"
+
+  run awk '/^#/ { heading = NR; next } heading && NR == heading + 1 && $0 != "" { found = 1 } END { exit found ? 0 : 1 }' \
+    "$WORK_DIR/CHANGELOG.md"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
`Check Formatting` is red on `main` at `d2bdf48a5` — `CHANGELOG.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` all fail `bun run format:check`, so **every** PR opened against that base inherits a red required check (Fast Validation's "Require formatter result" step fails with it). [PR #5742](https://github.com/kaeawc/auto-mobile/pull/5742) is currently red for exactly this reason and nothing else.

All three files are written by release automation in commits that skip CI, so the formatter gate never ran on the commit that introduced the drift. This takes option (1) from [#5743](https://github.com/kaeawc/auto-mobile/issues/5743): fix the generators, then reformat once.

## Changes

**`scripts/versioning/bump-versions.sh`** — three writers reserialized whole JSON documents with `json.dump(indent=2)`, which re-indents the file and explodes short arrays onto one element per line (oxfmt collapses them back). They are replaced by a single in-place rewriter that substitutes just the version string and leaves the rest of the file byte-identical, then reparses the result so a bad substitution fails the release rather than shipping broken JSON.

That also removes the per-file special-casing:

| file | before | after |
| --- | --- | --- |
| `package.json` | `update_json_version` | `update_json_version_at … "version"` |
| `.claude-plugin/plugin.json` | `update_json_version` | `update_json_version_at … "version"` |
| `server.json` | `update_server_json_version` (walked `packages[]`) | `update_json_version_at … "version"` — the `packages[]` entries share the value |
| `.claude-plugin/marketplace.json` | `update_marketplace_plugin_version` | `update_json_version_at … "plugins.0.version"` |

`marketplace.json`'s own top-level `"version": "1.0.0"` is the marketplace schema version and is deliberately left alone; a test asserts it.

**`scripts/changelog/update_changelog_from_issues.sh`** — emitted `## Heading` immediately followed by a list item; oxfmt wants a blank line after each heading.

**The three drifted files** are reformatted once so `main` goes green.

## Tests

BATS coverage asserts the properties directly rather than the symptom:

- `bump-versions.bats` — a bump preserves inline arrays in all four managed JSON files, moves every intended version, and does not move the marketplace schema version.
- `update-changelog-from-issues.bats` — every heading in a generated changelog is followed by a blank line, both for a fresh file and when prepending to an existing one.

Verified end-to-end beyond the unit tests: running the changelog generator against the real `CHANGELOG.md` and the bump rewriter against the real `package.json` / `server.json` / `.claude-plugin/*.json` both produce output that passes `oxfmt --check`. Repo-wide `bun x oxfmt --check` is clean on this branch (2418 files). `shellcheck` passes on both scripts.

## Notes

- `[skip ci]` on the release commit is left as-is — option (3) in the issue. It would have caught this at the source, but it costs a full CI run on every release commit against a shared, constrained runner budget; worth deciding separately now that the drift class itself is fixed.
- Local `shfmt` here is 3.13.1 vs the repo's pinned 3.10.0, and the two disagree on pre-existing lines (`<<'PY'`, `>/dev/null`). New lines follow the surrounding file's existing style, which is what the pinned version produces.

Closes #5743