### PR TITLE
fix(ios): retry UserDefaults defaults commands

### DIFF
--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -103,7 +103,7 @@ export class AppPreferences {
       return this.getAndroidSharedPreference(input);
     }
 
-    return this.getIosUserDefault(input, this.iosDefaultsDeadline());
+    return this.getIosUserDefault(input);
   }
 
   async setPreference(input: SetPreferenceInput): Promise<PreferenceResult> {
@@ -223,7 +223,7 @@ export class AppPreferences {
 
   private async getIosUserDefault(
     input: GetPreferenceInput,
-    deadlineMs: number,
+    deadlineMs?: number,
   ): Promise<PreferenceResult> {
     if (!isIosSimulatorDevice(this.device)) {
       throw unsupportedPhysicalIosUserDefaultsError();
@@ -269,7 +269,7 @@ export class AppPreferences {
 
   private async readIosDefaultsType(
     input: GetPreferenceInput,
-    deadlineMs: number,
+    deadlineMs?: number,
   ): Promise<PreferenceValueType | undefined> {
     const domain = iosDefaultsDomain(input);
     try {
@@ -298,12 +298,13 @@ export class AppPreferences {
 
   private async executeIosDefaultsCommand(
     args: string[],
-    deadlineMs: number,
+    deadlineMs?: number,
   ): Promise<{ stdout: string; stderr: string }> {
     let finalError: unknown;
 
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      const remainingMs = deadlineMs - this.timer.now();
+      const remainingMs =
+        deadlineMs === undefined ? IOS_DEFAULTS_COMMAND_TIMEOUT_MS : deadlineMs - this.timer.now();
       if (remainingMs <= 0) {
         if (finalError) {
           throw finalError;

--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -11,6 +11,7 @@ import type { BootedDevice } from "../../models";
 import { ActionableError } from "../../models";
 import { isIosSimulatorDevice } from "../action/IosSimulatorPermissions";
 import { logger } from "../../utils/logger";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 
 export type PreferenceScope = "systemProperty" | "sharedPreferences" | "userDefaults";
 export type PreferenceValueType = "string" | "bool" | "int" | "float";
@@ -56,6 +57,7 @@ interface IosSimulatorPreferenceClient {
 export interface AppPreferencesDependencies {
   adbFactory?: AdbClientFactory;
   simctl?: IosSimulatorPreferenceClient | null;
+  timer?: Timer;
 }
 
 type AndroidPreferenceTag = "string" | "boolean" | "int" | "float";
@@ -65,7 +67,8 @@ interface AndroidPreferenceEntry {
   type: PreferenceResultType;
 }
 
-const IOS_DEFAULTS_TIMEOUT_MS = 5000;
+const IOS_DEFAULTS_COMMAND_TIMEOUT_MS = 10_000;
+const IOS_DEFAULTS_OPERATION_TIMEOUT_MS = 30_000;
 const ANDROID_INT_MIN = -2147483648;
 const ANDROID_INT_MAX = 2147483647;
 
@@ -79,6 +82,7 @@ const ANDROID_TYPE_TO_TAG: Record<PreferenceValueType, AndroidPreferenceTag> = {
 export class AppPreferences {
   private readonly adbFactory: AdbClientFactory;
   private readonly simctl: IosSimulatorPreferenceClient | null | undefined;
+  private readonly timer: Timer;
 
   constructor(
     private readonly device: BootedDevice,
@@ -86,6 +90,7 @@ export class AppPreferences {
   ) {
     this.adbFactory = dependencies.adbFactory ?? defaultAdbClientFactory;
     this.simctl = dependencies.simctl;
+    this.timer = dependencies.timer ?? defaultTimer;
   }
 
   async getPreference(input: GetPreferenceInput): Promise<PreferenceResult> {
@@ -98,7 +103,7 @@ export class AppPreferences {
       return this.getAndroidSharedPreference(input);
     }
 
-    return this.getIosUserDefault(input);
+    return this.getIosUserDefault(input, this.iosDefaultsDeadline());
   }
 
   async setPreference(input: SetPreferenceInput): Promise<PreferenceResult> {
@@ -114,10 +119,21 @@ export class AppPreferences {
         await this.setAndroidSharedPreference({ ...input, value: normalizedValue });
       }
     } else {
-      await this.setIosUserDefault({ ...input, value: normalizedValue });
+      const deadlineMs = this.iosDefaultsDeadline();
+      await this.setIosUserDefault({ ...input, value: normalizedValue }, deadlineMs);
+      const readBack = await this.getIosUserDefault(input, deadlineMs);
+      return this.verifiedWriteResult(input, normalizedValue, readBack);
     }
 
     const readBack = await this.getPreference(input);
+    return this.verifiedWriteResult(input, normalizedValue, readBack);
+  }
+
+  private verifiedWriteResult(
+    input: SetPreferenceInput,
+    normalizedValue: PreferenceValue,
+    readBack: PreferenceResult,
+  ): PreferenceResult {
     return {
       ...readBack,
       type: input.type,
@@ -205,18 +221,21 @@ export class AppPreferences {
     }
   }
 
-  private async getIosUserDefault(input: GetPreferenceInput): Promise<PreferenceResult> {
+  private async getIosUserDefault(
+    input: GetPreferenceInput,
+    deadlineMs: number,
+  ): Promise<PreferenceResult> {
     if (!isIosSimulatorDevice(this.device)) {
       throw unsupportedPhysicalIosUserDefaultsError();
     }
 
     const domain = iosDefaultsDomain(input);
     try {
-      const result = await this.getSimctl().executeCommandArgs(
+      const result = await this.executeIosDefaultsCommand(
         ["spawn", this.device.deviceId, "defaults", "read", domain, input.key],
-        IOS_DEFAULTS_TIMEOUT_MS,
+        deadlineMs,
       );
-      const type = await this.readIosDefaultsType(input);
+      const type = await this.readIosDefaultsType(input, deadlineMs);
       return this.result(input, true, parseIosDefaultsValue(result.stdout, type), type ?? "string");
     } catch (error) {
       if (looksLikeMissingIosDefault(error)) {
@@ -226,14 +245,14 @@ export class AppPreferences {
     }
   }
 
-  private async setIosUserDefault(input: SetPreferenceInput): Promise<void> {
+  private async setIosUserDefault(input: SetPreferenceInput, deadlineMs: number): Promise<void> {
     if (!isIosSimulatorDevice(this.device)) {
       throw unsupportedPhysicalIosUserDefaultsError();
     }
 
     const domain = iosDefaultsDomain(input);
     const typeFlag = iosDefaultsTypeFlag(input.type);
-    await this.getSimctl().executeCommandArgs(
+    await this.executeIosDefaultsCommand(
       [
         "spawn",
         this.device.deviceId,
@@ -244,29 +263,68 @@ export class AppPreferences {
         typeFlag,
         stringValue(input.value),
       ],
-      IOS_DEFAULTS_TIMEOUT_MS,
+      deadlineMs,
     );
   }
 
   private async readIosDefaultsType(
     input: GetPreferenceInput,
+    deadlineMs: number,
   ): Promise<PreferenceValueType | undefined> {
     const domain = iosDefaultsDomain(input);
     try {
-      const result = await this.getSimctl().executeCommandArgs(
+      const result = await this.executeIosDefaultsCommand(
         ["spawn", this.device.deviceId, "defaults", "read-type", domain, input.key],
-        IOS_DEFAULTS_TIMEOUT_MS,
+        deadlineMs,
       );
       return parseIosDefaultsType(result.stdout);
     } catch (error) {
       // `defaults read-type` fails when the key doesn't exist yet, which is a
       // normal "no preference set" state; undefined lets callers fall back.
-      logger.debug(
-        `src/features/preferences/AppPreferences.ts defaults type parse failed: ${error}`,
-        error,
-      );
-      return undefined;
+      if (looksLikeMissingIosDefault(error)) {
+        logger.debug(
+          `src/features/preferences/AppPreferences.ts defaults type read found no value: ${error}`,
+          error,
+        );
+        return undefined;
+      }
+      throw new ActionableError(`Failed to read iOS UserDefaults type with defaults: ${error}`);
     }
+  }
+
+  private iosDefaultsDeadline(): number {
+    return this.timer.now() + IOS_DEFAULTS_OPERATION_TIMEOUT_MS;
+  }
+
+  private async executeIosDefaultsCommand(
+    args: string[],
+    deadlineMs: number,
+  ): Promise<{ stdout: string; stderr: string }> {
+    let finalError: unknown;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const remainingMs = deadlineMs - this.timer.now();
+      if (remainingMs <= 0) {
+        if (finalError) {
+          throw finalError;
+        }
+        throw iosDefaultsOperationTimeoutError();
+      }
+
+      try {
+        return await this.getSimctl().executeCommandArgs(
+          args,
+          Math.min(IOS_DEFAULTS_COMMAND_TIMEOUT_MS, remainingMs),
+        );
+      } catch (error) {
+        finalError = error;
+        if (attempt === 1 || !isRetryableIosDefaultsError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw finalError;
   }
 
   private getSimctl(): IosSimulatorPreferenceClient {
@@ -645,6 +703,23 @@ function looksLikeMissingAndroidPrefsFile(error: unknown): boolean {
 function looksLikeMissingIosDefault(error: unknown): boolean {
   const message = errorMessage(error);
   return /does not exist|Domain .* does not exist|does not contain/i.test(message);
+}
+
+function isRetryableIosDefaultsError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    /timed out/i.test(message) ||
+    /(?:core ?simulator|simctl).*(?:connection|service)|(?:connection|service).*(?:core ?simulator|simctl)/i.test(
+      message,
+    ) ||
+    /connection (?:refused|reset|interrupted|invalidated)/i.test(message)
+  );
+}
+
+function iosDefaultsOperationTimeoutError(): ActionableError {
+  return new ActionableError(
+    `iOS UserDefaults preference operation timed out after ${IOS_DEFAULTS_OPERATION_TIMEOUT_MS}ms.`,
+  );
 }
 
 function preferenceWriteWarning(

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -773,30 +773,18 @@ export class SimCtlClient implements SimCtl {
     }
 
     if (!SimCtlClient.localSimctlAvailability) {
-      const availability = this.execAsync("xcrun", ["simctl", "--version"], undefined, signal)
-        .then(() => undefined)
-        .catch((err) => {
-          if (SimCtlClient.localSimctlAvailability === availability) {
-            SimCtlClient.localSimctlAvailability = null;
-          }
-          logger.debug(`[iOS] simctl unavailable: ${errorMessage(err)}`);
-          throw err;
-        });
-      SimCtlClient.localSimctlAvailability = availability;
+      try {
+        await this.execAsync("xcrun", ["simctl", "--version"], undefined, signal);
+        // Do not share an in-flight probe: each caller must own its cancellation
+        // signal. Cache only confirmation that simctl is available.
+        SimCtlClient.localSimctlAvailability = Promise.resolve();
+      } catch (error) {
+        logger.debug(`[iOS] simctl unavailable: ${errorMessage(error)}`);
+        throw error;
+      }
     }
 
-    const availability = SimCtlClient.localSimctlAvailability;
-    const clearAbortedAvailability = () => {
-      if (SimCtlClient.localSimctlAvailability === availability) {
-        SimCtlClient.localSimctlAvailability = null;
-      }
-    };
-    signal?.addEventListener("abort", clearAbortedAvailability, { once: true });
-    try {
-      await availability;
-    } finally {
-      signal?.removeEventListener("abort", clearAbortedAvailability);
-    }
+    await SimCtlClient.localSimctlAvailability;
   }
 
   private async isLocalSimctlAvailable(): Promise<boolean> {

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -648,8 +648,6 @@ export class SimCtlClient implements SimCtl {
 
     logger.debug(`[iOS] Executing command: ${fullCommand}`);
 
-    await this.ensureAvailableForCommand();
-
     const callerSignal = explicitSignal ?? getAbortSignal();
     const runCommand = (signal?: AbortSignal) =>
       this.execAsync("xcrun", localArgs, undefined, signal);
@@ -660,6 +658,7 @@ export class SimCtlClient implements SimCtl {
     if (timeoutMs) {
       let timeoutId: NodeJS.Timeout;
       let timeoutError: Error | undefined;
+      let runPromise: Promise<ExecResult> | undefined;
       const controller = new AbortController();
       const signal = callerSignal
         ? AbortSignal.any([callerSignal, controller.signal])
@@ -673,20 +672,28 @@ export class SimCtlClient implements SimCtl {
         }, timeoutMs);
       });
 
-      const runPromise = runCommand(signal);
-      // Once the timeout wins the race the aborted run promise rejects with an
-      // AbortError; keep it handled so it can't surface as an unhandledRejection.
-      runPromise.catch(() => {
-        /* settled after timeout; result consumed via race */
+      // Availability is an xcrun invocation too, so it must consume the same
+      // command budget instead of leaving a caller waiting before the actual
+      // simctl child process starts.
+      const availabilityPromise = this.ensureAvailableForCommand();
+      availabilityPromise.catch(() => {
+        /* consumed by the race below, including after a timeout */
       });
 
       try {
+        await Promise.race([availabilityPromise, timeoutPromise]);
+        runPromise = runCommand(signal);
+        // Once the timeout wins the race the aborted run promise rejects with an
+        // AbortError; keep it handled so it can't surface as an unhandledRejection.
+        runPromise.catch(() => {
+          /* settled after timeout; result consumed via race */
+        });
         const result = await Promise.race([runPromise, timeoutPromise]);
         const duration = this.timer.now() - startTime;
         logger.debug(`[iOS] Command completed in ${duration}ms: ${command}`);
         return result;
       } catch (error) {
-        if (waitForTimedOutCommandSettlement && error === timeoutError) {
+        if (waitForTimedOutCommandSettlement && runPromise && error === timeoutError) {
           await this.waitForCommandSettlement(runPromise, command);
         }
         const duration = this.timer.now() - startTime;
@@ -701,6 +708,7 @@ export class SimCtlClient implements SimCtl {
 
     // No timeout specified
     try {
+      await this.ensureAvailableForCommand();
       const result = await runCommand(callerSignal);
       const duration = this.timer.now() - startTime;
       logger.debug(`[iOS] Command completed in ${duration}ms: ${command}`);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -616,9 +616,9 @@ export class SimCtlClient implements SimCtl {
     return this.spawnProcess("xcrun", fullArgs, options);
   }
 
-  private async ensureAvailableForCommand(): Promise<void> {
+  private async ensureAvailableForCommand(signal?: AbortSignal): Promise<void> {
     try {
-      await this.ensureLocalSimctlAvailable();
+      await this.ensureLocalSimctlAvailable(signal);
     } catch (error) {
       const detail = errorMessage(error);
       const message =
@@ -675,7 +675,7 @@ export class SimCtlClient implements SimCtl {
       // Availability is an xcrun invocation too, so it must consume the same
       // command budget instead of leaving a caller waiting before the actual
       // simctl child process starts.
-      const availabilityPromise = this.ensureAvailableForCommand();
+      const availabilityPromise = this.ensureAvailableForCommand(signal);
       availabilityPromise.catch(() => {
         /* consumed by the race below, including after a timeout */
       });
@@ -762,9 +762,9 @@ export class SimCtlClient implements SimCtl {
     return this.isLocalSimctlAvailable();
   }
 
-  private async ensureLocalSimctlAvailable(): Promise<void> {
+  private async ensureLocalSimctlAvailable(signal?: AbortSignal): Promise<void> {
     if (this.usesInjectedExecAsync) {
-      await this.execAsync("xcrun", ["simctl", "--version"]);
+      await this.execAsync("xcrun", ["simctl", "--version"], undefined, signal);
       return;
     }
 
@@ -773,16 +773,30 @@ export class SimCtlClient implements SimCtl {
     }
 
     if (!SimCtlClient.localSimctlAvailability) {
-      SimCtlClient.localSimctlAvailability = this.execAsync("xcrun", ["simctl", "--version"])
+      const availability = this.execAsync("xcrun", ["simctl", "--version"], undefined, signal)
         .then(() => undefined)
         .catch((err) => {
-          SimCtlClient.localSimctlAvailability = null;
+          if (SimCtlClient.localSimctlAvailability === availability) {
+            SimCtlClient.localSimctlAvailability = null;
+          }
           logger.debug(`[iOS] simctl unavailable: ${errorMessage(err)}`);
           throw err;
         });
+      SimCtlClient.localSimctlAvailability = availability;
     }
 
-    await SimCtlClient.localSimctlAvailability;
+    const availability = SimCtlClient.localSimctlAvailability;
+    const clearAbortedAvailability = () => {
+      if (SimCtlClient.localSimctlAvailability === availability) {
+        SimCtlClient.localSimctlAvailability = null;
+      }
+    };
+    signal?.addEventListener("abort", clearAbortedAvailability, { once: true });
+    try {
+      await availability;
+    } finally {
+      signal?.removeEventListener("abort", clearAbortedAvailability);
+    }
   }
 
   private async isLocalSimctlAvailable(): Promise<boolean> {

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -837,12 +837,7 @@ describe("AppPreferences", () => {
       "read",
       "read-type",
     ]);
-    expect(simctl.calls.map((call) => call.timeoutMs)).toEqual([
-      10_000,
-      10_000,
-      10_000,
-      10_000,
-    ]);
+    expect(simctl.calls.map((call) => call.timeoutMs)).toEqual([10_000, 10_000, 10_000, 10_000]);
   });
 
   test("preserves the final iOS UserDefaults command error after one retry", async () => {

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -910,6 +910,36 @@ describe("AppPreferences", () => {
     ]);
   });
 
+  test("preserves the type-read retry for a direct iOS UserDefaults read", async () => {
+    const timer = new FakeTimer();
+    const simctl = new ScriptedSimCtlClient(
+      [
+        { elapsedMs: 10_000, error: new Error("Command timed out after 10000ms") },
+        { elapsedMs: 10_000, stdout: "enabled\n" },
+        { elapsedMs: 10_000, error: new Error("Command timed out after 10000ms") },
+        { elapsedMs: 10_000, stdout: "Type is string\n" },
+      ],
+      timer,
+    );
+    const preferences = new AppPreferences(iosSimulator, { simctl, timer });
+
+    const result = await preferences.getPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+    });
+
+    expect(result.value).toBe("enabled");
+    expect(timer.now()).toBe(40_000);
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "read",
+      "read",
+      "read-type",
+      "read-type",
+    ]);
+    expect(simctl.calls.map((call) => call.timeoutMs)).toEqual([10_000, 10_000, 10_000, 10_000]);
+  });
+
   test("bounds the full iOS UserDefaults write and verification operation to 30 seconds", async () => {
     const timer = new FakeTimer();
     const simctl = new ScriptedSimCtlClient(

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -6,6 +6,7 @@ import { createExecResult } from "../../../src/utils/execResult";
 import { AppPreferences } from "../../../src/features/preferences/AppPreferences";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 const androidDevice: BootedDevice = {
   name: "Pixel",
@@ -47,6 +48,43 @@ function decodeBase64WritePayload(command: string): string {
   const match = command.match(/([A-Za-z0-9+/=]{24,})/);
   expect(match).toBeTruthy();
   return Buffer.from(match![1], "base64").toString("utf8");
+}
+
+interface ScriptedSimCtlOutcome {
+  stdout?: string;
+  error?: Error;
+  elapsedMs?: number;
+}
+
+class ScriptedSimCtlClient {
+  readonly calls: Array<{ args: string[]; timeoutMs?: number }> = [];
+
+  constructor(
+    private readonly outcomes: ScriptedSimCtlOutcome[],
+    private readonly timer?: FakeTimer,
+  ) {}
+
+  async executeCommand(): Promise<{ stdout: string; stderr: string }> {
+    return { stdout: "", stderr: "" };
+  }
+
+  async executeCommandArgs(
+    args: string[],
+    timeoutMs?: number,
+  ): Promise<{ stdout: string; stderr: string }> {
+    this.calls.push({ args, timeoutMs });
+    const outcome = this.outcomes.shift();
+    if (!outcome) {
+      throw new Error("Unexpected simctl command");
+    }
+    if (outcome.elapsedMs) {
+      this.timer?.advanceTime(outcome.elapsedMs);
+    }
+    if (outcome.error) {
+      throw outcome.error;
+    }
+    return { stdout: outcome.stdout ?? "", stderr: "" };
+  }
 }
 
 describe("AppPreferences", () => {
@@ -456,7 +494,7 @@ describe("AppPreferences", () => {
           "-bool",
           "true",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
       {
         args: [
@@ -467,7 +505,7 @@ describe("AppPreferences", () => {
           "com.example.app",
           "onboardingComplete",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
       {
         args: [
@@ -478,7 +516,7 @@ describe("AppPreferences", () => {
           "com.example.app",
           "onboardingComplete",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
     ]);
   });
@@ -522,7 +560,7 @@ describe("AppPreferences", () => {
         "-string",
         "C:\\tmp",
       ],
-      timeoutMs: 5000,
+      timeoutMs: 10_000,
     });
     expect(argvCalls).toContainEqual({
       args: [
@@ -535,7 +573,7 @@ describe("AppPreferences", () => {
         "-string",
         "",
       ],
-      timeoutMs: 5000,
+      timeoutMs: 10_000,
     });
   });
 
@@ -597,7 +635,7 @@ describe("AppPreferences", () => {
           "group\\com.example",
           "path\\key",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
       {
         args: [
@@ -608,7 +646,7 @@ describe("AppPreferences", () => {
           "group\\com.example",
           "path\\key",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
     ]);
   });
@@ -711,7 +749,7 @@ describe("AppPreferences", () => {
           "com.example.app",
           "onboardingComplete",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
       {
         args: [
@@ -722,7 +760,7 @@ describe("AppPreferences", () => {
           "com.example.app",
           "onboardingComplete",
         ],
-        timeoutMs: 5000,
+        timeoutMs: 10_000,
       },
     ]);
   });
@@ -773,6 +811,134 @@ describe("AppPreferences", () => {
       value: null,
       key: "missingKey",
     });
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(1);
+  });
+
+  test("retries a timed-out iOS UserDefaults write once", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      { error: new Error("Command timed out after 10000ms") },
+      {},
+      { stdout: "enabled\n" },
+      { stdout: "Type is string\n" },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await preferences.setPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+      value: "enabled",
+      type: "string",
+    });
+
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "write",
+      "write",
+      "read",
+      "read-type",
+    ]);
+    expect(simctl.calls.map((call) => call.timeoutMs)).toEqual([
+      10_000,
+      10_000,
+      10_000,
+      10_000,
+    ]);
+  });
+
+  test("preserves the final iOS UserDefaults command error after one retry", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      { error: new Error("first defaults command timed out") },
+      { error: new Error("final defaults timeout") },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await expect(
+      preferences.setPreference({
+        scope: "userDefaults",
+        appId: "com.example.app",
+        key: "featureFlag",
+        value: "enabled",
+        type: "string",
+      }),
+    ).rejects.toThrow("final defaults timeout");
+    expect(simctl.calls.map((call) => call.args[3])).toEqual(["write", "write"]);
+  });
+
+  test("retries a transient CoreSimulator connection failure for UserDefaults reads once", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      {},
+      { error: new Error("Failed to connect to the CoreSimulator service") },
+      { stdout: "enabled\n" },
+      { stdout: "Type is string\n" },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    const result = await preferences.setPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+      value: "enabled",
+      type: "string",
+    });
+
+    expect(result.verified).toBeTrue();
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "write",
+      "read",
+      "read",
+      "read-type",
+    ]);
+  });
+
+  test("retries a timed-out iOS UserDefaults type-read once", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      {},
+      { stdout: "enabled\n" },
+      { error: new Error("Command timed out after 10000ms") },
+      { stdout: "Type is string\n" },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await preferences.setPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+      value: "enabled",
+      type: "string",
+    });
+
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "write",
+      "read",
+      "read-type",
+      "read-type",
+    ]);
+  });
+
+  test("bounds the full iOS UserDefaults write and verification operation to 30 seconds", async () => {
+    const timer = new FakeTimer();
+    const simctl = new ScriptedSimCtlClient(
+      [
+        { elapsedMs: 10_000 },
+        { elapsedMs: 10_000, error: new Error("Command timed out after 10000ms") },
+        { elapsedMs: 10_000, stdout: "enabled\n" },
+      ],
+      timer,
+    );
+    const preferences = new AppPreferences(iosSimulator, { simctl, timer });
+
+    await expect(
+      preferences.setPreference({
+        scope: "userDefaults",
+        appId: "com.example.app",
+        key: "featureFlag",
+        value: "enabled",
+        type: "string",
+      }),
+    ).rejects.toThrow("timed out after 30000ms");
+
+    expect(timer.now()).toBe(30_000);
+    expect(simctl.calls.map((call) => call.args[3])).toEqual(["write", "read", "read"]);
   });
 
   test("rejects physical iOS UserDefaults instead of reading the runner process defaults", async () => {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -309,14 +309,29 @@ describe("Simctl", function () {
     test("applies the command timeout while the simctl availability probe is pending", async function () {
       const timer = new FakeTimer();
       const commands: string[] = [];
-      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      let availabilityAttempts = 0;
+      let probeSignal: AbortSignal | undefined;
+      mockExecAsync = async (
+        _file: string,
+        args: string[],
+        _maxBuffer?: number,
+        signal?: AbortSignal,
+      ): Promise<ExecResult> => {
         commands.push(args.join(" "));
         if (args.join(" ") === "simctl --version") {
-          return new Promise<ExecResult>(() => {});
+          availabilityAttempts += 1;
+          if (availabilityAttempts === 1) {
+            probeSignal = signal;
+            return new Promise<ExecResult>((_resolve, reject) => {
+              signal?.addEventListener("abort", () => reject(new Error("probe aborted")));
+            });
+          }
+          return createExecResult("simctl version 1.0.0", "");
         }
         return createExecResult("", "");
       };
       simctl = new Simctl(mockDevice, mockExecAsync, timer);
+      forceStaticAvailabilityPath(simctl);
 
       const command = simctl.executeCommandArgs(["list", "devices"], 1234);
       await waitForCondition(
@@ -328,7 +343,21 @@ describe("Simctl", function () {
       await expect(command).rejects.toThrow(
         "Command timed out after 1234ms: xcrun simctl list devices",
       );
-      expect(commands).toEqual(["simctl --version"]);
+      expect(probeSignal?.aborted).toBe(true);
+      await waitForCondition(
+        () =>
+          (
+            Simctl as unknown as {
+              localSimctlAvailability: Promise<void> | null;
+            }
+          ).localSimctlAvailability === null,
+        "aborted availability probe cache reset",
+      );
+
+      await expect(simctl.executeCommandArgs(["list", "devices"], 1234)).resolves.toMatchObject({
+        stdout: "",
+      });
+      expect(commands).toEqual(["simctl --version", "simctl --version", "simctl list devices"]);
     });
 
     test("applies the default timeout to the bootstatus wait", async function () {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -306,7 +306,7 @@ describe("Simctl", function () {
       resolveCommand?.(createExecResult("late bootstatus", ""));
     });
 
-    test("applies the command timeout while the simctl availability probe is pending", async function () {
+    test("aborts an in-flight availability probe without poisoning future commands", async function () {
       const timer = new FakeTimer();
       const commands: string[] = [];
       let availabilityAttempts = 0;
@@ -330,7 +330,7 @@ describe("Simctl", function () {
         }
         return createExecResult("", "");
       };
-      simctl = new Simctl(mockDevice, mockExecAsync, timer);
+      simctl = new Simctl(mockDevice, mockExecAsync, timer, "darwin");
       forceStaticAvailabilityPath(simctl);
 
       const command = simctl.executeCommandArgs(["list", "devices"], 1234);
@@ -358,6 +358,48 @@ describe("Simctl", function () {
         stdout: "",
       });
       expect(commands).toEqual(["simctl --version", "simctl --version", "simctl list devices"]);
+    });
+
+    test("does not share cancellation between concurrent availability probes", async function () {
+      const timer = new FakeTimer();
+      let availabilityAttempts = 0;
+      let firstProbeSignal: AbortSignal | undefined;
+      mockExecAsync = async (
+        _file: string,
+        args: string[],
+        _maxBuffer?: number,
+        signal?: AbortSignal,
+      ): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          availabilityAttempts += 1;
+          if (availabilityAttempts === 1) {
+            firstProbeSignal = signal;
+            return new Promise<ExecResult>((_resolve, reject) => {
+              signal?.addEventListener("abort", () => reject(new Error("first probe aborted")));
+            });
+          }
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(mockDevice, mockExecAsync, timer, "darwin");
+      forceStaticAvailabilityPath(simctl);
+
+      const first = simctl.executeCommandArgs(["list", "devices"], 1234);
+      await waitForCondition(
+        () => firstProbeSignal !== undefined,
+        "first availability probe dispatch",
+      );
+
+      await expect(simctl.executeCommandArgs(["list", "devices"], 1234)).resolves.toMatchObject({
+        stdout: "",
+      });
+      timer.advanceTime(1234);
+
+      await expect(first).rejects.toThrow(
+        "Command timed out after 1234ms: xcrun simctl list devices",
+      );
+      expect(firstProbeSignal?.aborted).toBe(true);
     });
 
     test("applies the default timeout to the bootstatus wait", async function () {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -306,6 +306,31 @@ describe("Simctl", function () {
       resolveCommand?.(createExecResult("late bootstatus", ""));
     });
 
+    test("applies the command timeout while the simctl availability probe is pending", async function () {
+      const timer = new FakeTimer();
+      const commands: string[] = [];
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        commands.push(args.join(" "));
+        if (args.join(" ") === "simctl --version") {
+          return new Promise<ExecResult>(() => {});
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(mockDevice, mockExecAsync, timer);
+
+      const command = simctl.executeCommandArgs(["list", "devices"], 1234);
+      await waitForCondition(
+        () => commands.includes("simctl --version"),
+        "simctl availability probe dispatch",
+      );
+      timer.advanceTime(1234);
+
+      await expect(command).rejects.toThrow(
+        "Command timed out after 1234ms: xcrun simctl list devices",
+      );
+      expect(commands).toEqual(["simctl --version"]);
+    });
+
     test("applies the default timeout to the bootstatus wait", async function () {
       const timer = new FakeTimer();
       let resolveCommand: ((result: ExecResult) => void) | undefined;

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -334,10 +334,7 @@ describe("Simctl", function () {
       forceStaticAvailabilityPath(simctl);
 
       const command = simctl.executeCommandArgs(["list", "devices"], 1234);
-      await waitForCondition(
-        () => commands.includes("simctl --version"),
-        "simctl availability probe dispatch",
-      );
+      expect(commands).toEqual(["simctl --version"]);
       timer.advanceTime(1234);
 
       await expect(command).rejects.toThrow(
@@ -364,6 +361,7 @@ describe("Simctl", function () {
       const timer = new FakeTimer();
       let availabilityAttempts = 0;
       let firstProbeSignal: AbortSignal | undefined;
+      let firstProbeStarted = false;
       mockExecAsync = async (
         _file: string,
         args: string[],
@@ -374,6 +372,7 @@ describe("Simctl", function () {
           availabilityAttempts += 1;
           if (availabilityAttempts === 1) {
             firstProbeSignal = signal;
+            firstProbeStarted = true;
             return new Promise<ExecResult>((_resolve, reject) => {
               signal?.addEventListener("abort", () => reject(new Error("first probe aborted")));
             });
@@ -386,10 +385,7 @@ describe("Simctl", function () {
       forceStaticAvailabilityPath(simctl);
 
       const first = simctl.executeCommandArgs(["list", "devices"], 1234);
-      await waitForCondition(
-        () => firstProbeSignal !== undefined,
-        "first availability probe dispatch",
-      );
+      expect(firstProbeStarted).toBe(true);
 
       await expect(simctl.executeCommandArgs(["list", "devices"], 1234)).resolves.toMatchObject({
         stdout: "",


### PR DESCRIPTION
## Summary

Extends iOS UserDefaults `defaults` commands to a 10-second per-command deadline, retries one transient timeout or CoreSimulator connection failure, and shares a 30-second deadline across a write and its read-back verification.

## Linked Issue

Closes [#5754](https://github.com/kaeawc/auto-mobile/issues/5754)

## Bug / Regression Context

- **Observed symptom:** A temporarily busy booted simulator could make `setPreference` fail during a five-second `defaults` read-back despite a successful write.
- **Repro steps / conditions:** Set an iOS `userDefaults` preference while the simulator is under early-startup or installation load.

## Validation

- [x] `bun test test/features/preferences/AppPreferences.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Tests use an injected FakeTimer for the operation deadline.

