### PR TITLE
fix(ios): assign inline semantic link occurrences case-insensitively

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
@@ -54,8 +54,9 @@ public enum SemanticLinkExtractor {
         attributed.enumerateAttribute(.link, in: fullRange) { value, range, _ in
             guard value != nil, range.length > 0 else { return }
             let text = nsText.substring(with: range)
-            let occurrence = occurrenceByText[text, default: 0]
-            occurrenceByText[text] = occurrence + 1
+            let occurrenceKey = text.lowercased()
+            let occurrence = occurrenceByText[occurrenceKey, default: 0]
+            occurrenceByText[occurrenceKey] = occurrence + 1
             links.append(
                 SdkSemanticLink(
                     text: text,
@@ -77,8 +78,9 @@ public enum SemanticLinkExtractor {
         for label in labels {
             let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            let occurrence = occurrenceByText[trimmed, default: 0]
-            occurrenceByText[trimmed] = occurrence + 1
+            let occurrenceKey = trimmed.lowercased()
+            let occurrence = occurrenceByText[occurrenceKey, default: 0]
+            occurrenceByText[occurrenceKey] = occurrence + 1
             links.append(SdkSemanticLink(text: trimmed, occurrence: occurrence))
         }
         return links

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
@@ -49,14 +49,12 @@ public enum SemanticLinkExtractor {
     public static func links(from attributed: NSAttributedString) -> [SdkSemanticLink] {
         let nsText = attributed.string as NSString
         var links: [SdkSemanticLink] = []
-        var occurrenceByText: [String: Int] = [:]
+        var occurrenceGroups: [(text: String, nextOccurrence: Int)] = []
         let fullRange = NSRange(location: 0, length: attributed.length)
         attributed.enumerateAttribute(.link, in: fullRange) { value, range, _ in
             guard value != nil, range.length > 0 else { return }
             let text = nsText.substring(with: range)
-            let occurrenceKey = text.lowercased()
-            let occurrence = occurrenceByText[occurrenceKey, default: 0]
-            occurrenceByText[occurrenceKey] = occurrence + 1
+            let occurrence = nextOccurrence(for: text, occurrenceGroups: &occurrenceGroups)
             links.append(
                 SdkSemanticLink(
                     text: text,
@@ -74,15 +72,31 @@ public enum SemanticLinkExtractor {
     /// character range — occurrence is still assigned in document order.
     public static func links(fromAccessibilityLinkLabels labels: [String]) -> [SdkSemanticLink] {
         var links: [SdkSemanticLink] = []
-        var occurrenceByText: [String: Int] = [:]
+        var occurrenceGroups: [(text: String, nextOccurrence: Int)] = []
         for label in labels {
             let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            let occurrenceKey = trimmed.lowercased()
-            let occurrence = occurrenceByText[occurrenceKey, default: 0]
-            occurrenceByText[occurrenceKey] = occurrence + 1
+            let occurrence = nextOccurrence(for: trimmed, occurrenceGroups: &occurrenceGroups)
             links.append(SdkSemanticLink(text: trimmed, occurrence: occurrence))
         }
         return links
+    }
+
+    private static func nextOccurrence(
+        for text: String,
+        occurrenceGroups: inout [(text: String, nextOccurrence: Int)]
+    )
+        -> Int
+    {
+        if let index = occurrenceGroups.firstIndex(where: {
+            $0.text.caseInsensitiveCompare(text) == .orderedSame
+        }) {
+            let occurrence = occurrenceGroups[index].nextOccurrence
+            occurrenceGroups[index].nextOccurrence += 1
+            return occurrence
+        }
+
+        occurrenceGroups.append((text: text, nextOccurrence: 1))
+        return 0
     }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
@@ -53,6 +53,20 @@ final class SemanticLinkExtractorTests: XCTestCase {
         XCTAssertNotEqual(links[0].start, links[2].start)
     }
 
+    func testMixedCaseDuplicateLinkTextGetsDistinctOccurrences() {
+        let text = "Read the Terms of Service, then the terms of service."
+        let ns = text as NSString
+        let first = ns.range(of: "Terms of Service")
+        let second = ns.range(of: "terms of service")
+        let links = SemanticLinkExtractor.links(from: linked(text, ranges: [
+            (first, "https://x/terms-first"),
+            (second, "https://x/terms-second"),
+        ]))
+
+        XCTAssertEqual(links.map(\.text), ["Terms of Service", "terms of service"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 1])
+    }
+
     func testStringValuedLinkAttributeIsAlsoDiscovered() {
         let text = "See Support here."
         let range = (text as NSString).range(of: "Support")
@@ -79,6 +93,15 @@ final class SemanticLinkExtractorTests: XCTestCase {
         XCTAssertEqual(links.map(\.occurrence), [0, 0, 1])
         XCTAssertNil(links[0].start)
         XCTAssertNil(links[0].end)
+    }
+
+    func testAccessibilityLinkLabelsAssignMixedCaseDuplicatesDistinctOccurrences() {
+        let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: [
+            "Terms of Service", "terms of service",
+        ])
+
+        XCTAssertEqual(links.map(\.text), ["Terms of Service", "terms of service"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 1])
     }
 
     func testAccessibilityLinkLabelsSkipBlankEntries() {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
@@ -67,6 +67,21 @@ final class SemanticLinkExtractorTests: XCTestCase {
         XCTAssertEqual(links.map(\.occurrence), [0, 1])
     }
 
+    func testUnicodeCaseInsensitiveDuplicateLinkTextGetsDistinctOccurrences() {
+        let text = "Read Σ, then ς."
+        let ns = text as NSString
+        let first = ns.range(of: "Σ")
+        let second = ns.range(of: "ς")
+        let links = SemanticLinkExtractor.links(from: linked(text, ranges: [
+            (first, "https://x/sigma-first"),
+            (second, "https://x/sigma-second"),
+        ]))
+
+        XCTAssertEqual("Σ".caseInsensitiveCompare("ς"), .orderedSame)
+        XCTAssertEqual(links.map(\.text), ["Σ", "ς"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 1])
+    }
+
     func testStringValuedLinkAttributeIsAlsoDiscovered() {
         let text = "See Support here."
         let range = (text as NSString).range(of: "Support")
@@ -101,6 +116,14 @@ final class SemanticLinkExtractorTests: XCTestCase {
         ])
 
         XCTAssertEqual(links.map(\.text), ["Terms of Service", "terms of service"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 1])
+    }
+
+    func testAccessibilityLinkLabelsAssignUnicodeCaseInsensitiveDuplicatesDistinctOccurrences() {
+        let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: ["Σ", "ς"])
+
+        XCTAssertEqual("Σ".caseInsensitiveCompare("ς"), .orderedSame)
+        XCTAssertEqual(links.map(\.text), ["Σ", "ς"])
         XCTAssertEqual(links.map(\.occurrence), [0, 1])
     }
 


### PR DESCRIPTION
## Summary

iOS now case-folds inline semantic-link occurrence keys while retaining each link's original text. Mixed-case duplicate labels therefore receive distinct occurrences, matching Android assignment and the runner's case-insensitive activation matching.

## Linked Issue

Closes [#5595](https://github.com/kaeawc/auto-mobile/issues/5595)

## Bug / Regression Context

- **Prior attempts:** UIKit semantic-link discovery in [#5560](https://github.com/kaeawc/auto-mobile/issues/5560), reused by the SwiftUI-link work in [#5578](https://github.com/kaeawc/auto-mobile/issues/5578).
- **Observed symptom:** `Terms of Service` and `terms of service` each received occurrence `0`, so a request for occurrence `1` could not resolve through the SDK hierarchy.
- **Repro steps / conditions:** Surface two inline links on one owner whose visible labels differ only by case; activate the second by its occurrence.

## Validation

- [x] Focused `SemanticLinkExtractorTests` fails before the fix and passes after it.
- [x] `scripts/ios/swift-test.sh` passes.
- [x] `swiftformat --lint` passes for both changed Swift files.
- [x] `scripts/all_fast_validate_checks.sh --skip ktfmt` passes (the full run's only unrelated failure was an unavailable pinned ktfmt version; this PR changes no Kotlin).
- [x] Typecheck gate reports no new errors using the installed pinned `tsgo`; `bunx tsgo` incorrectly attempted to fetch the nonexistent `tsgo` package despite the local executable.
- [x] No new dependencies or generic helpers.
- [x] Rebased onto latest `main` before implementation.

Made with [Cursor](https://cursor.com)