### PR TITLE
fix(devices): honor newer physical iOS rename observations

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -135,6 +135,11 @@ export interface PooledDevice {
    * snapshot that would otherwise revert it (#5690).
    */
   nameRefreshGeneration?: number;
+  /**
+   * Discovery timestamp that last wrote the mutable display name. When both
+   * observations carry a stamp, the newer one wins regardless of its path.
+   */
+  nameObservedAt?: number;
   /** Authoritative AVD name captured when this pool starts an Android emulator. */
   avdName?: string;
   /** Source image metadata used to evaluate allocation criteria during recovery. */
@@ -557,6 +562,7 @@ export class DevicePool {
         errorCount: 0,
         iosVersion: device.iosVersion,
         simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+        ...(device.observedAt !== undefined ? { nameObservedAt: device.observedAt } : {}),
         incarnation: this.nextDeviceIncarnation(),
       });
       this.deviceSessionStarts.set(device.deviceId, now);
@@ -657,6 +663,7 @@ export class DevicePool {
             errorCount: 0,
             iosVersion: device.iosVersion,
             simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+            ...(device.observedAt !== undefined ? { nameObservedAt: device.observedAt } : {}),
             incarnation: this.nextDeviceIncarnation(),
           });
           this.deviceSessionStarts.set(device.deviceId, now);
@@ -762,6 +769,7 @@ export class DevicePool {
         errorCount: 0,
         iosVersion: device.iosVersion,
         simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+        ...(device.observedAt !== undefined ? { nameObservedAt: device.observedAt } : {}),
         incarnation: this.nextDeviceIncarnation(),
       });
       this.recordSourceAndroidAvd(device.deviceId, sourceImage);
@@ -4803,7 +4811,10 @@ export class DevicePool {
    */
   async reserveDeviceForReadiness(
     deviceId: string,
-    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
+    expectedIdentity: Pick<
+      BootedDevice,
+      "deviceId" | "name" | "platform" | "transportId" | "observedAt"
+    >,
     stableRuntimeName = expectedIdentity.name,
     verifiedAndroidAvdName?: string,
   ): Promise<DeviceReadinessReservation> {
@@ -5002,7 +5013,7 @@ export class DevicePool {
     platform: Platform,
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
-    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     allowSessionRebind = false,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
@@ -5146,7 +5157,9 @@ export class DevicePool {
 
   private async validateOrReloadIdlePooledDevice(
     device: PooledDevice,
-    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform"> | undefined,
+    expectedIdentity:
+      | Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">
+      | undefined,
     unavailableMessage: string,
     readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<PooledDevice> {
@@ -5211,7 +5224,9 @@ export class DevicePool {
 
   private assertRuntimeIdentity(
     pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId"> | undefined,
+    expected:
+      | Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId" | "observedAt">
+      | undefined,
   ): void {
     if (!expected || this.matchesRuntimeIdentity(pooled, expected)) {
       // A tolerated match is still an opportunity to reconcile: every caller
@@ -5259,25 +5274,42 @@ export class DevicePool {
    */
   private applyMutableRuntimeMetadata(
     pooled: PooledDevice,
-    discovered: Pick<BootedDevice, "name">,
+    discovered: Pick<BootedDevice, "name" | "observedAt">,
     source: MutableMetadataSource,
   ): void {
-    if (pooled.name === discovered.name || !this.hasMutableDisplayName(pooled)) {
+    if (!this.hasMutableDisplayName(pooled)) {
       return;
     }
-    // A start-path snapshot can predate a refresh that already folded in a
-    // newer name: the assignment mutex serializes the writes but establishes no
-    // ordering between the two observations. Such a snapshot may therefore only
-    // fill in a name no refresh has ever spoken for, never overwrite one (#5690).
-    if (source === "snapshot" && pooled.nameRefreshGeneration !== undefined) {
+    if (
+      discovered.observedAt !== undefined &&
+      pooled.nameObservedAt !== undefined &&
+      discovered.observedAt <= pooled.nameObservedAt
+    ) {
       logger.debug(
-        `Ignoring '${discovered.name}' for ${pooled.id}: a refresh already observed '${pooled.name}'`,
+        `Ignoring '${discovered.name}' for ${pooled.id}: observation ${discovered.observedAt} ` +
+          `is not newer than ${pooled.nameObservedAt}`,
       );
       return;
     }
-    logger.info(`Device ${pooled.id} renamed from '${pooled.name}' to '${discovered.name}'`);
-    pooled.name = discovered.name;
-    if (source === "refresh") {
+    // A refresh that predates observation stamps still establishes a name-order
+    // boundary. Do not let an otherwise-orderable snapshot cross it: its age
+    // cannot be compared to that refresh, so retaining the #5742 latch is the
+    // conservative fallback for legacy callers and test fakes.
+    if (source === "snapshot" && pooled.nameRefreshGeneration !== undefined) {
+      logger.debug(
+        `Ignoring '${discovered.name}' for ${pooled.id}: an unstamped refresh already observed '${pooled.name}'`,
+      );
+      return;
+    }
+    if (pooled.name !== discovered.name) {
+      logger.info(`Device ${pooled.id} renamed from '${pooled.name}' to '${discovered.name}'`);
+      pooled.name = discovered.name;
+    }
+    if (discovered.observedAt !== undefined) {
+      pooled.nameObservedAt = discovered.observedAt;
+      delete pooled.nameRefreshGeneration;
+    } else if (source === "refresh") {
+      delete pooled.nameObservedAt;
       pooled.nameRefreshGeneration = this.refreshGeneration;
     }
   }
@@ -5329,7 +5361,7 @@ export class DevicePool {
     mcpSessionId?: string,
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
-    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string | undefined> {
@@ -5356,7 +5388,7 @@ export class DevicePool {
     mcpSessionId?: string,
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
-    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string> {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5291,13 +5291,17 @@ export class DevicePool {
       );
       return;
     }
-    // A refresh that predates observation stamps still establishes a name-order
-    // boundary. Do not let an otherwise-orderable snapshot cross it: its age
-    // cannot be compared to that refresh, so retaining the #5742 latch is the
-    // conservative fallback for legacy callers and test fakes.
-    if (source === "snapshot" && pooled.nameRefreshGeneration !== undefined) {
+    // An unstamped start-path snapshot cannot be ordered against either a
+    // legacy refresh latch or a timestamped write. Keep both as a conservative
+    // boundary for legacy callers and test fakes; a stamped snapshot still uses
+    // the newer-wins comparison above.
+    if (
+      source === "snapshot" &&
+      (pooled.nameRefreshGeneration !== undefined ||
+        (discovered.observedAt === undefined && pooled.nameObservedAt !== undefined))
+    ) {
       logger.debug(
-        `Ignoring '${discovered.name}' for ${pooled.id}: an unstamped refresh already observed '${pooled.name}'`,
+        `Ignoring '${discovered.name}' for ${pooled.id}: an unorderable snapshot cannot replace '${pooled.name}'`,
       );
       return;
     }

--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -27,6 +27,11 @@ export interface BootedDevice {
   name: string;
   platform: Platform;
   deviceId: string;
+  /**
+   * Monotonic host-clock stamp for the discovery observation that produced this
+   * record. Cached and retained listings preserve their original stamp.
+   */
+  observedAt?: number;
   /** ADB transport identity, which changes when a serial reconnects. */
   transportId?: string;
   source?: "local";

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1156,6 +1156,7 @@ export class AdbClient implements AdbExecutor {
             name: deviceId,
             platform: "android",
             deviceId,
+            observedAt: this.timer.now(),
             ...(transportId ? { transportId } : {}),
           } satisfies BootedDevice,
         ];

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -371,14 +371,23 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
 
   private remember(discovery: PhysicalIosDeviceDiscovery): PhysicalIosDeviceDiscovery {
     const now = this.deps.timer.now();
-    const resolved = discovery.complete
-      ? this.recordLastGood(discovery, now)
+    // A cache hit or retained result must retain when it was observed, rather
+    // than appear newer merely because a later caller read it.
+    const stamped = {
+      ...discovery,
+      devices: discovery.devices.map((device) => ({
+        ...device,
+        observedAt: device.observedAt ?? now,
+      })),
+    };
+    const resolved = stamped.complete
+      ? this.recordLastGood(stamped, now)
       : {
           // A partial sweep and the retained listing are both incomplete views of
           // the same hardware, so neither may evict the other's device: union
           // them. When the sweep failed outright its half is empty and this
           // degrades to pure retention.
-          devices: mergeById(discovery.devices, this.retainedDevices(now)),
+          devices: mergeById(stamped.devices, this.retainedDevices(now)),
           complete: false,
         };
     this.cache = { discovery: resolved, expiresAt: now + DEVICE_LIST_CACHE_TTL_MS };

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1420,6 +1420,7 @@ export class SimCtlClient implements SimCtl {
       name: simulator.name,
       platform: simulator.platform,
       deviceId: simulator.deviceId,
+      observedAt: this.timer.now(),
     } as BootedDevice;
   }
 
@@ -1522,6 +1523,7 @@ export class SimCtlClient implements SimCtl {
             name: device.name,
             platform: "ios",
             deviceId: device.udid,
+            observedAt: this.timer.now(),
             iosVersion,
             osVersion: iosVersion,
             formFactor: inferIosFormFactor(device.deviceTypeIdentifier),

--- a/test/daemon/devicePoolPhysicalIosRename.test.ts
+++ b/test/daemon/devicePoolPhysicalIosRename.test.ts
@@ -205,6 +205,24 @@ describe("DevicePool physical iOS rename (#5690)", () => {
     expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
   });
 
+  test("an unstamped start snapshot cannot revert a stamped refresh", async () => {
+    fakeTimer.advanceTime(1);
+    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", fakeTimer.now()));
+    fakeTimer.advanceTime(1);
+    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone", fakeTimer.now()));
+
+    await devicePool.bindOrReuseDeviceSession(
+      "owner-session",
+      PHYSICAL_IPHONE_UDID,
+      "ios",
+      undefined,
+      undefined,
+      booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone"),
+    );
+
+    expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
+  });
+
   test("still replaces a physical iOS UDID whose platform changes", async () => {
     await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Jason's iPhone"));
     const incarnation = devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.incarnation;

--- a/test/daemon/devicePoolPhysicalIosRename.test.ts
+++ b/test/daemon/devicePoolPhysicalIosRename.test.ts
@@ -24,10 +24,16 @@ describe("DevicePool physical iOS rename (#5690)", () => {
   let fakeTimer: FakeTimer;
   let fakeDeviceManager: FakeDeviceManager;
 
-  const booted = (deviceId: string, platform: Platform, name: string): BootedDevice => ({
+  const booted = (
+    deviceId: string,
+    platform: Platform,
+    name: string,
+    observedAt?: number,
+  ): BootedDevice => ({
     name,
     platform,
     deviceId,
+    ...(observedAt !== undefined ? { observedAt } : {}),
   });
 
   const initialize = async (device: BootedDevice): Promise<void> => {
@@ -138,17 +144,55 @@ describe("DevicePool physical iOS rename (#5690)", () => {
     expect(devicePool.getDevice(SIMULATOR_UDID)?.name).toBe("iPhone 15");
   });
 
-  test("a stale start snapshot never reverts a name a refresh already folded in", async () => {
-    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone"));
+  test("a newer start-path observation updates a name a refresh already folded in", async () => {
+    fakeTimer.advanceTime(1);
+    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", fakeTimer.now()));
+    fakeTimer.advanceTime(1);
+    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "Refresh iPhone", fakeTimer.now()));
+    fakeTimer.advanceTime(1);
+
+    await devicePool.bindOrReuseDeviceSession(
+      "owner-session",
+      PHYSICAL_IPHONE_UDID,
+      "ios",
+      undefined,
+      undefined,
+      booted(PHYSICAL_IPHONE_UDID, "ios", "Start-path iPhone", fakeTimer.now()),
+    );
+
+    expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("Start-path iPhone");
+  });
+
+  test("an older start snapshot never reverts a name a refresh already folded in", async () => {
+    fakeTimer.advanceTime(1);
+    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", fakeTimer.now()));
     // Capture the snapshot the start path will carry, then let a refresh land
     // the newer observation first.
-    const staleSnapshot = booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone");
-    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone"));
+    const staleSnapshot = booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", fakeTimer.now());
+    fakeTimer.advanceTime(1);
+    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone", fakeTimer.now()));
     expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
 
     // The start path now acquires the assignment mutex with its older snapshot.
     // The mutex serializes the writes but says nothing about which observation
     // is newer, so reconciliation must not write the obsolete label back.
+    await devicePool.bindOrReuseDeviceSession(
+      "owner-session",
+      PHYSICAL_IPHONE_UDID,
+      "ios",
+      undefined,
+      undefined,
+      staleSnapshot,
+    );
+
+    expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
+  });
+
+  test("an unstamped start snapshot cannot revert an unstamped refresh", async () => {
+    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone"));
+    const staleSnapshot = booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone");
+    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone"));
+
     await devicePool.bindOrReuseDeviceSession(
       "owner-session",
       PHYSICAL_IPHONE_UDID,

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import type { ExecResult } from "../../../src/models";
 import { isAdbMissingDeviceError } from "../../../src/utils/android-cmdline-tools/AdbDeviceHealth";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 function createExecResult(stdout: string, stderr: string = ""): ExecResult {
   return {
@@ -66,7 +67,9 @@ describe("AdbClient.getBootedAndroidDevices", () => {
       }
       return createExecResult("");
     };
-    const adb = new AdbClient(null, execAsync);
+    const timer = new FakeTimer();
+    timer.advanceTime(42);
+    const adb = new AdbClient(null, execAsync, null, undefined, timer);
 
     const devices = await adb.getBootedAndroidDevices();
 
@@ -75,6 +78,7 @@ describe("AdbClient.getBootedAndroidDevices", () => {
         name: "emulator-5554",
         platform: "android",
         deviceId: "emulator-5554",
+        observedAt: timer.now(),
         transportId: "42",
       },
     ]);

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -446,6 +446,31 @@ describe("DevicectlDeviceLister", () => {
     expect(executions).toBe(2);
   });
 
+  test("preserves an observation stamp for cached and retained physical devices", async () => {
+    const timer = new FakeTimer();
+    let shouldFail = false;
+    const lister = makeLister({
+      timer,
+      execute: async () => {
+        if (shouldFail) {
+          throw new Error("devicectl blipped");
+        }
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    const initial = await lister.listConnectedDevices();
+    expect(initial.devices[0]?.observedAt).toBe(0);
+
+    timer.advanceTime(1_000);
+    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(0);
+
+    shouldFail = true;
+    timer.advanceTime(DEVICE_LIST_CACHE_TTL_MS);
+    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(0);
+  });
+
   test("caches an unavailable host so every sweep does not respawn devicectl", async () => {
     let executions = 0;
     const lister = makeLister({


### PR DESCRIPTION
## Summary

Carry an optional discovery observation timestamp on `BootedDevice` and retain it through Android, simulator, and physical-iOS discovery caches.

`DevicePool` now accepts a newer start-path observation for a physical iPhone's mutable display name while rejecting an older one. Unstamped callers retain the conservative refresh latch from [PR #5742](https://github.com/kaeawc/auto-mobile/pull/5742).

This is a stacked PR based on [PR #5742](https://github.com/kaeawc/auto-mobile/pull/5742).

## Linked Issue

Closes [#5753](https://github.com/kaeawc/auto-mobile/issues/5753)

## Bug / Regression Context

- **Prior attempts:** [PR #5742](https://github.com/kaeawc/auto-mobile/pull/5742) correctly prevented stale start snapshots from reverting refresh data, but its permanent latch also rejected genuinely newer start-path observations.
- **Observed symptom:** A physical iPhone renamed from `A` to `B` by refresh, then to `C` before the next refresh, retained the stale pooled label `B`.
- **Repro steps / conditions:** Refresh a physical iPhone rename, then resolve a later start-path snapshot with a newer display name.

## Validation

- [x] `bun test test/daemon/devicePoolPhysicalIosRename.test.ts test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors
- [x] `scripts/all_fast_validate_checks.sh`
- [x] Unit tests use the existing fakes and `FakeTimer`; no device required

## Follow-ups

- [x] No out-of-scope follow-up needed
