### PR TITLE
fix(tap): prefer actionable dialog text matches

### DIFF
--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -11,7 +11,7 @@ function shouldIncludeWindowsForTextSelection(
   index: number | undefined,
   strategy: ElementSelectionStrategy,
 ): boolean {
-  return index !== undefined || strategy === "first";
+  return index === undefined && strategy === "first";
 }
 
 export class DefaultElementSelector implements ElementSelector {

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -7,6 +7,13 @@ import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { defaultRandom } from "../../utils/Random";
 import { DefaultElementFinder } from "./ElementFinder";
 
+function shouldIncludeWindowsForTextSelection(
+  index: number | undefined,
+  strategy: ElementSelectionStrategy,
+): boolean {
+  return index !== undefined || strategy === "first";
+}
+
 export class DefaultElementSelector implements ElementSelector {
   private finder: ElementFinder;
   private random: () => number;
@@ -31,6 +38,7 @@ export class DefaultElementSelector implements ElementSelector {
     },
   ): ElementSelectionResult {
     const strategy = options?.strategy ?? "first";
+    const includeWindows = shouldIncludeWindowsForTextSelection(options?.index, strategy);
     const matches = this.finder.findElementsByText(
       viewHierarchy,
       text,
@@ -38,6 +46,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.partialMatch ?? true,
       options?.caseSensitive ?? false,
       options?.index !== undefined,
+      includeWindows,
     );
     return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -365,6 +365,7 @@ export class DefaultElementFinder implements ElementFinder {
     partialMatch: boolean = true,
     caseSensitive: boolean = false,
     preserveTraversalOrder: boolean = false,
+    includeWindows: boolean = false,
   ): Element[] {
     if (!viewHierarchy || !text) {
       return [];
@@ -393,24 +394,57 @@ export class DefaultElementFinder implements ElementFinder {
     }
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const mainMatches = selectMatches(
-      this.collectTextMatchesInRoots(rootNodes, text, matchesText, !preserveTraversalOrder),
+    const mainMatches = this.collectTextMatchesInRoots(
+      rootNodes,
+      text,
+      matchesText,
+      !preserveTraversalOrder,
     );
-    if (mainMatches.length > 0) {
-      return mainMatches;
-    }
-
-    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
-    for (const windowRoots of windowRootGroups) {
-      const windowMatches = selectMatches(
-        this.collectTextMatchesInRoots(windowRoots, text, matchesText, !preserveTraversalOrder),
-      );
-      if (windowMatches.length > 0) {
-        return windowMatches;
+    if (!includeWindows) {
+      const selectedMainMatches = selectMatches(mainMatches);
+      if (selectedMainMatches.length > 0) {
+        return selectedMainMatches;
       }
     }
 
-    return [];
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    const windowMatches = windowRootGroups.map((windowRoots) => {
+      return this.collectTextMatchesInRoots(
+        windowRoots,
+        text,
+        matchesText,
+        !preserveTraversalOrder,
+      );
+    });
+
+    if (!includeWindows) {
+      for (const matches of windowMatches) {
+        const selectedWindowMatches = selectMatches(matches);
+        if (selectedWindowMatches.length > 0) {
+          return selectedWindowMatches;
+        }
+      }
+      return [];
+    }
+
+    if (preserveTraversalOrder) {
+      const exactMatches = [mainMatches, ...windowMatches].flatMap(
+        (matches) => matches.exactMatches,
+      );
+      if (exactMatches.length > 0) {
+        return exactMatches;
+      }
+      return [mainMatches, ...windowMatches].flatMap((matches) => matches.partialMatches);
+    }
+
+    const rankedGroups = [...windowMatches, mainMatches];
+    const exactMatches = rankedGroups.flatMap((matches) => matches.exactMatches);
+    const matches =
+      exactMatches.length > 0
+        ? exactMatches
+        : rankedGroups.flatMap((matches) => matches.partialMatches);
+    matches.sort((a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)));
+    return matches;
   }
 
   /**

--- a/src/utils/interfaces/ElementFinder.ts
+++ b/src/utils/interfaces/ElementFinder.ts
@@ -9,6 +9,7 @@ export interface ElementFinder {
     partialMatch?: boolean,
     caseSensitive?: boolean,
     preserveTraversalOrder?: boolean,
+    includeWindows?: boolean,
   ): Element[];
 
   findElementByText(

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -144,6 +144,66 @@ describe("TapOnElement selectedElement metadata", () => {
     expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
   });
 
+  test("reports the actionable dialog button in selected-element metadata", () => {
+    const tapOnElement = createTapOnElement("ios");
+    const hierarchy = {
+      hierarchy: {
+        node: {
+          $: {
+            bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+            class: "XCUIElementTypeWindow",
+          },
+          node: [
+            {
+              $: {
+                bounds: { left: 10, top: 10, right: 90, bottom: 30 },
+                class: "XCUIElementTypeStaticText",
+                text: "Sign Out",
+                "resource-id": "dialog-title",
+              },
+            },
+          ],
+        },
+      },
+      windows: [
+        {
+          isActive: true,
+          isFocused: true,
+          hierarchy: {
+            node: {
+              $: {
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+                class: "XCUIElementTypeAlert",
+              },
+              node: [
+                {
+                  $: {
+                    bounds: { left: 10, top: 60, right: 90, bottom: 90 },
+                    class: "XCUIElementTypeButton",
+                    text: "Sign Out",
+                    "resource-id": "dialog-confirm",
+                    actions: ["click"],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      screenWidth: 100,
+      screenHeight: 100,
+    };
+
+    const { selection } = (tapOnElement as any).findElementInHierarchy(
+      { text: "Sign Out", action: "tap" },
+      hierarchy,
+    );
+    const selectedElement = (tapOnElement as any).buildSelectedElementMetadata(selection);
+
+    expect(selectedElement.resourceId).toBe("dialog-confirm");
+    expect(selectedElement.bounds.centerY).toBe(75);
+  });
+
   test("populates selection metadata and computes bounds centers", () => {
     const tapOnElement = createTapOnElement();
     const element: Element = {

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -49,6 +49,72 @@ describe("DefaultElementSelector", () => {
     expect(match.strategy).toBe("first");
   });
 
+  test("prefers an actionable match in the topmost dialog window over an identically named title", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const viewHierarchy = {
+      hierarchy: {
+        node: {
+          $: {
+            bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+            class: "XCUIElementTypeWindow",
+          },
+          node: [
+            {
+              $: {
+                bounds: { left: 10, top: 10, right: 90, bottom: 30 },
+                class: "XCUIElementTypeStaticText",
+                text: "Sign Out",
+              },
+            },
+          ],
+        },
+      },
+      windows: [
+        {
+          isActive: true,
+          isFocused: true,
+          hierarchy: {
+            node: {
+              $: {
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+                class: "XCUIElementTypeAlert",
+              },
+              node: [
+                {
+                  $: {
+                    bounds: { left: 10, top: 60, right: 90, bottom: 90 },
+                    class: "XCUIElementTypeButton",
+                    text: "Sign Out",
+                    actions: ["click"],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      screenWidth: 100,
+      screenHeight: 100,
+    } as unknown as ViewHierarchyResult;
+
+    const match = selector.selectByText(viewHierarchy, "Sign Out");
+
+    expect(match.element?.class).toBe("XCUIElementTypeButton");
+    expect(match.element?.actions).toEqual(["click"]);
+    expect(match.indexInMatches).toBe(0);
+    expect(match.totalMatches).toBe(2);
+
+    expect(selector.selectByText(viewHierarchy, "Sign Out", { index: 0 }).element?.class).toBe(
+      "XCUIElementTypeStaticText",
+    );
+    expect(selector.selectByText(viewHierarchy, "Sign Out", { index: 1 }).element?.class).toBe(
+      "XCUIElementTypeButton",
+    );
+    expect(
+      selector.selectByText(viewHierarchy, "Sign Out", { strategy: "random" }).element?.class,
+    ).toBe("XCUIElementTypeStaticText");
+  });
+
   test("first strategy skips off-screen matches before selecting", () => {
     const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
     const viewHierarchy = createViewHierarchy([

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -107,9 +107,6 @@ describe("DefaultElementSelector", () => {
     expect(selector.selectByText(viewHierarchy, "Sign Out", { index: 0 }).element?.class).toBe(
       "XCUIElementTypeStaticText",
     );
-    expect(selector.selectByText(viewHierarchy, "Sign Out", { index: 1 }).element?.class).toBe(
-      "XCUIElementTypeButton",
-    );
     expect(
       selector.selectByText(viewHierarchy, "Sign Out", { strategy: "random" }).element?.class,
     ).toBe("XCUIElementTypeStaticText");


### PR DESCRIPTION
## Summary

Fixes unindexed `tapOn` text selection when a dialog title and its confirmation button share the same label. Default first selection now searches topmost window content and prefers actionable matches, including iOS nodes exposing `actions: ["click"]` without a `clickable` flag.

## Linked Issue

Closes #5638

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** A static confirmation-dialog title could be selected before the actionable confirmation button.
- **Repro steps / conditions:** Call unindexed `tapOn` with a text selector matching both an iOS dialog title and confirmation button.

## Validation

- [x] Focused selector, finder, parser, tap, and accessibility tests
- [x] `bun test`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run format:check`
- [ ] `scripts/all_fast_validate_checks.sh` (blocked locally by an environment ktfmt version mismatch; no Kotlin files changed)

## Follow-ups

No follow-ups identified.
