### PR TITLE
fix(tap): preserve dialog window z-order

### DIFF
--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -336,6 +336,18 @@ export class DefaultElementFinder implements ElementFinder {
     return isClickableElementProperties(props);
   }
 
+  private selectAndRankTextMatches(matches: {
+    exactMatches: Element[];
+    partialMatches: Element[];
+  }): Element[] {
+    const selectedMatches =
+      matches.exactMatches.length > 0 ? matches.exactMatches : matches.partialMatches;
+    selectedMatches.sort(
+      (a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)),
+    );
+    return selectedMatches;
+  }
+
   private isCollectionNode(props: Record<string, unknown>): boolean {
     const className = typeof props.class === "string" ? props.class : "";
     const scrollable = props.scrollable === "true" || props.scrollable === true;
@@ -437,14 +449,9 @@ export class DefaultElementFinder implements ElementFinder {
       return [mainMatches, ...windowMatches].flatMap((matches) => matches.partialMatches);
     }
 
-    const rankedGroups = [...windowMatches, mainMatches];
-    const exactMatches = rankedGroups.flatMap((matches) => matches.exactMatches);
-    const matches =
-      exactMatches.length > 0
-        ? exactMatches
-        : rankedGroups.flatMap((matches) => matches.partialMatches);
-    matches.sort((a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)));
-    return matches;
+    return [...windowMatches, mainMatches].flatMap((matches) =>
+      this.selectAndRankTextMatches(matches),
+    );
   }
 
   /**

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -112,6 +112,63 @@ describe("DefaultElementSelector", () => {
     ).toBe("XCUIElementTypeStaticText");
   });
 
+  test("preserves window z-order before preferring actionable matches", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const viewHierarchy = {
+      hierarchy: { node: [] },
+      windows: [
+        {
+          windowLayer: 2,
+          hierarchy: {
+            node: {
+              $: {
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+                class: "XCUIElementTypeAlert",
+              },
+              node: [
+                {
+                  $: {
+                    bounds: { left: 10, top: 10, right: 90, bottom: 40 },
+                    class: "XCUIElementTypeStaticText",
+                    text: "Delete",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          windowLayer: 1,
+          hierarchy: {
+            node: {
+              $: {
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+                class: "XCUIElementTypeWindow",
+              },
+              node: [
+                {
+                  $: {
+                    bounds: { left: 10, top: 50, right: 90, bottom: 80 },
+                    class: "XCUIElementTypeButton",
+                    text: "Delete",
+                    actions: ["click"],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      screenWidth: 100,
+      screenHeight: 100,
+    } as unknown as ViewHierarchyResult;
+
+    const match = selector.selectByText(viewHierarchy, "Delete");
+
+    expect(match.element?.class).toBe("XCUIElementTypeStaticText");
+    expect(match.totalMatches).toBe(2);
+  });
+
   test("first strategy skips off-screen matches before selecting", () => {
     const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
     const viewHierarchy = createViewHierarchy([


### PR DESCRIPTION
## Summary

Preserve dialog/window z-order while applying the actionable-text preference introduced for #5638. Text matches are now ranked for actionability within each window group, while topmost windows remain ahead of lower and background windows.

## Linked Issue

Follow-up to #5638

## Bug / Regression Context

- **Observed symptom:** A clickable match in a covered lower window could outrank a static match in the topmost modal.
- **Cause:** Exact matches from all windows were flattened and globally sorted by actionability, discarding window layering.
- **Fix:** Rank each topmost-first window group independently, then concatenate groups in z-order.

## Validation

- [x] Added deterministic regression coverage for layered windows
- [x] Focused `DefaultElementSelector` and `ElementFinder` tests
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Formatting check

