### PR TITLE
fix(devices): order discovery observations monotonically

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -60,7 +60,6 @@ src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewH
 src/features/accessibility/WcagAudit.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"resource-id"' can't be used to index type 'ViewHierarchyNode'.
 src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, null | number | string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
-src/features/action/OpenURL.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
@@ -77,17 +76,12 @@ src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'merg
 src/features/action/swipeon/ScrollUntilVisible.ts: error TS2322: Type 'ViewHierarchyResult | undefined' is not assignable to type 'ViewHierarchyResult | null'.
 src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
-src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/NavigateTo.ts: error TS2459: Module '"./NavigationGraphManager"' declares 'ToolCallInteraction' locally, but it is not exported.
-src/features/navigation/NavigateTo.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 src/features/navigation/UIStateExtractor.ts: error TS2741: Property '$' is missing in type 'Record<string, any>' but required in type 'ViewHierarchyNode'.
@@ -103,8 +97,6 @@ src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'numb
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'string | undefined' is not assignable to type 'null | string'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/observe/android/CtrlProxyHierarchy.ts: error TS2554: Expected 0 arguments, but got 1.
 src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type 'null | undefined' is not assignable to type 'NormalizedHighlightBounds | undefined'.
 src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ type: "box"; style?: HighlightStyle | null | undefined; bounds: NormalizedHighlightBounds | undefined; } | { type: "circle"; style?: HighlightStyle | ... 1 more ... | undefined; bounds: NormalizedHighlightBounds | undefined; }' is not assignable to type 'HighlightShape'.
@@ -174,7 +166,6 @@ src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<
 src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
 src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
 src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
-# swap-fp: 10,13,19,25,66 :: src/db/migrator.ts: error TS7006: Parameter 'row' implicitly has an 'any' type.
 # swap-fp: 11 :: src/daemon/SocketServerRegistry.ts: error TS2345: Argument of type 'Promise<BaseSocketServer | void>' is not assignable to parameter of type 'Promise<void>'.
 # swap-fp: 11 :: src/db/failureAnalyticsRepository.ts: error TS2322: Type 'FailureType' is not assignable to type '"anr" | "crash" | "tool_failure"'.
 # swap-fp: 11 :: src/features/action/TapAnyElement.ts: error TS2416: Property 'hashViewHierarchy' in type 'TapAnyElement' is not assignable to the same property in base type 'BaseVisualChange'.
@@ -186,7 +177,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 11 :: src/features/record/android/DualTrackRecorder.ts: error TS2322: Type 'A11ySource | AndroidCtrlProxyClient' is not assignable to type 'A11ySource'.
 # swap-fp: 11,11 :: src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
 # swap-fp: 11,13,13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-# swap-fp: 11,53,57,65 :: src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 # swap-fp: 12,12 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 # swap-fp: 12,12 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 # swap-fp: 13 :: src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
@@ -203,12 +193,13 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 19 :: src/server/networkGraph.ts: error TS2345: Argument of type 'EventGroup | undefined' is not assignable to parameter of type 'EventGroup'.
 # swap-fp: 19,19,19,19 :: src/doctor/checks/ios.ts: error TS18048: 'elements' is possibly 'undefined'.
 # swap-fp: 20 :: src/features/accessibility/WcagAudit.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"resource-id"' can't be used to index type 'ViewHierarchyNode'.
-# swap-fp: 21,28 :: src/db/migrator.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
+# swap-fp: 20,26,39,69,83 :: src/db/migrator.ts: error TS7006: Parameter 'row' implicitly has an 'any' type.
+# swap-fp: 21,21 :: src/db/migrator.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 # swap-fp: 23 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'Map<string, number>' is not assignable to parameter of type 'Map<string, { timestamp: number; }>'.
-# swap-fp: 24 :: src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
 # swap-fp: 25 :: src/daemon/client.ts: error TS2345: Argument of type 'NonSharedBuffer | string' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
+# swap-fp: 25 :: src/features/observe/android/CtrlProxyHierarchy.ts: error TS2554: Expected 0 arguments, but got 1.
+# swap-fp: 26 :: src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
 # swap-fp: 27,45 :: src/db/database.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
-# swap-fp: 28 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
 # swap-fp: 3 :: src/daemon/failuresStreamSocketServer.ts: error TS2559: Type 'FailuresStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 # swap-fp: 3 :: src/daemon/performanceStreamSocketServer.ts: error TS2559: Type 'PerformanceStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 # swap-fp: 3 :: src/daemon/testRecordingSocketServer.ts: error TS2559: Type 'TestRecordingCommand' has no properties in common with type 'SocketRequest'.
@@ -216,16 +207,17 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 3 :: src/features/navigation/NavigateTo.ts: error TS2459: Module '"./NavigationGraphManager"' declares 'ToolCallInteraction' locally, but it is not exported.
 # swap-fp: 3 :: src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
 # swap-fp: 30 :: src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, null | number | string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+# swap-fp: 30 :: src/features/observe/DeviceServiceUtils.ts: error TS2694: Namespace '"src/features/observe/DeviceService"' has no exported member 'ImeActionResult'.
 # swap-fp: 30 :: src/server/observeTools.ts: error TS2322: Type 'TimingData' is not assignable to type 'TimingEntry'.
-# swap-fp: 30,32 :: src/db/performanceAuditRepository.ts: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "performance_audit_results", "timestamp">'.
 # swap-fp: 32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'class' does not exist on type 'ViewHierarchyNode'.
 # swap-fp: 32 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2459: Module '"./types"' declares 'GestureTimingResult' locally, but it is not exported.
 # swap-fp: 32 :: src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
-# swap-fp: 33 :: src/db/migrator.ts: error TS7006: Parameter 'table' implicitly has an 'any' type.
+# swap-fp: 32,40 :: src/db/performanceAuditRepository.ts: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "performance_audit_results", "timestamp">'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableElementsInContainer' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableParentsContainingText' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableSiblingsOfResourceId' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableSiblingsOfText' does not exist on type 'ElementFinder'.
+# swap-fp: 34 :: src/db/migrator.ts: error TS7006: Parameter 'table' implicitly has an 'any' type.
 # swap-fp: 34 :: src/features/accessibility/ContrastChecker.ts: error TS2532: Object is possibly 'undefined'.
 # swap-fp: 36 :: src/features/action/TapAnyElement.ts: error TS2339: Property 'doubleTap' does not exist on type 'IOSCtrlProxyClient'.
 # swap-fp: 36 :: src/features/action/TapAnyElement.ts: error TS2339: Property 'longPress' does not exist on type 'IOSCtrlProxyClient'.
@@ -233,30 +225,26 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 36 :: src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'mergeHierarchies' does not exist on type 'ViewHierarchy'.
 # swap-fp: 36 :: src/features/observe/ObserveScreen.ts: error TS2345: Argument of type 'ViewHierarchyResult | undefined' is not assignable to parameter of type 'ViewHierarchyResult'.
 # swap-fp: 36,61 :: src/server/observeTools.ts: error TS2339: Property 'sessionUuid' does not exist on type 'IdentifyInteractionsOptions'.
-# swap-fp: 39 :: src/features/observe/android/CtrlProxyHierarchy.ts: error TS2554: Expected 0 arguments, but got 1.
 # swap-fp: 39,45 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 # swap-fp: 40 :: src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?
-# swap-fp: 43 :: src/doctor/index.ts: error TS2367: This comparison appears to be unintentional because the types 'false | undefined' and 'true' have no overlap.
-# swap-fp: 43,45 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
+# swap-fp: 41 :: src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
+# swap-fp: 41 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
 # swap-fp: 44 :: src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type 'FailureType' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups", "type">'.
 # swap-fp: 44 :: src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type 'FailureType' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_notifications", "type">'.
 # swap-fp: 44 :: src/features/action/TapAnyElement.ts: error TS2339: Property 'selectClickable' does not exist on type 'ElementSelector'.
 # swap-fp: 44 :: src/features/utility/ElementParser.ts: error TS2345: Argument of type 'ViewHierarchyWindowInfo[]' is not assignable to parameter of type '{ windowLayer: number; }[]'.
+# swap-fp: 44,47 :: src/features/preferences/AppPreferences.ts: error TS2345: Argument of type 'PreferenceResultValue | null' is not assignable to parameter of type 'PreferenceValue | null'.
 # swap-fp: 45,46,46 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 46 :: src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"anr" | "crash" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups" | "failure_occurrences", "failure_groups.type">'.
 # swap-fp: 46 :: src/db/bunSqliteDialect.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 46 :: src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
-# swap-fp: 47 :: src/features/navigation/NavigateTo.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 # swap-fp: 47 :: src/features/observe/HierarchyPlatformValidator.ts: error TS2339: Property 'startsWith' does not exist on type '{}'.
-# swap-fp: 47,64 :: src/features/preferences/AppPreferences.ts: error TS2345: Argument of type 'PreferenceResultValue | null' is not assignable to parameter of type 'PreferenceValue | null'.
 # swap-fp: 49 :: src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
-# swap-fp: 5 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
 # swap-fp: 5 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ type: "box"; style?: HighlightStyle | null | undefined; bounds: NormalizedHighlightBounds | undefined; } | { type: "circle"; style?: HighlightStyle | ... 1 more ... | undefined; bounds: NormalizedHighlightBounds | undefined; }' is not assignable to type 'HighlightShape'.
 # swap-fp: 5 :: src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 # swap-fp: 5,7,7 :: src/server/networkGraph.ts: error TS18048: 'group' is possibly 'undefined'.
 # swap-fp: 51 :: src/server/navigationTools.ts: error TS2339: Property 'interactionsPerformed' does not exist on type 'ExploreExecutionResult'.
 # swap-fp: 52 :: src/features/observe/collectors/DeviceStateCollector.ts: error TS2554: Expected 0 arguments, but got 1.
-# swap-fp: 54 :: src/features/action/OpenURL.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 # swap-fp: 55 :: src/features/navigation/UIStateExtractor.ts: error TS2741: Property '$' is missing in type 'Record<string, any>' but required in type 'ViewHierarchyNode'.
 # swap-fp: 56 :: src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'getUiAutomatorHierarchy' does not exist on type 'ViewHierarchy'.
 # swap-fp: 56,58 :: src/features/utility/ElementFinder.ts: error TS2741: Property '$' is missing in type 'Record<string, unknown>' but required in type 'ViewHierarchyNode'.
@@ -264,13 +252,15 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 57 :: src/utils/filesystem/DefaultFileSystem.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 # swap-fp: 58,58 :: src/db/migrator.ts: error TS2339: Property 'execute' does not exist on type 'never'.
 # swap-fp: 59 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2345: Argument of type '{ idPrefix: string; responseType: string; messageType: string; params: { x1: number; y1: number; x2: number; y2: number; fingerCount: number; duration: number; offset: number | undefined; }; timeoutMs: number; perf: PerformanceTracker | undefined; notConnectedMessage: string; errorLabel: string; }' is not assignable to parameter of type 'SendCommandOptions<GestureTimingResult>'.
+# swap-fp: 6 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
+# swap-fp: 6 :: src/doctor/index.ts: error TS2367: This comparison appears to be unintentional because the types 'false | undefined' and 'true' have no overlap.
 # swap-fp: 6,6,6,6 :: src/db/migrator.ts: error TS2339: Property 'select' does not exist on type 'never'.
 # swap-fp: 61 :: src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
-# swap-fp: 66,66 :: src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
+# swap-fp: 63 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
+# swap-fp: 64,64 :: src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 # swap-fp: 67,73 :: src/features/utility/ElementFinder.ts: error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
-# swap-fp: 7 :: src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 7 :: src/features/observe/Idle.ts: error TS2741: Property 'updatedPrevTotalFrames' is missing in type '{ isStable: false; shouldUpdateLastNonIdleTime: true; updatedPrevMissedVsync: null; updatedPrevSlowUiThread: null; updatedPrevFrameDeadlineMissed: null; updatedFirstGfxInfoLog: false; }' but required in type 'UiStabilityResult'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug-perf", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -279,9 +269,8 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["predictive-ui", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
+# swap-fp: 7,7,11,13,13 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
-# swap-fp: 74 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
-# swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 8,9 :: src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
@@ -293,6 +282,5 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 9 :: src/server/networkGraph.ts: error TS2322: Type 'null | string | undefined' is not assignable to type 'null | string'.
 # swap-fp: 9,9,11,11 :: src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
 # swap-fp: 9,9,9 :: src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
-# swap-fp: 91 :: src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"appVersion" | "deviceId" | "deviceName" | "devicePlatform" | "deviceType" | "gitCommit" | "gradleVersion" | "isCi" | "jdkVersion" | "jvmTarget" | "limit" | "lookbackDays" | ... 6 more ... | "testMethod"'.
-# swap-fp: 95 :: src/features/observe/DeviceServiceUtils.ts: error TS2694: Namespace '"src/features/observe/DeviceService"' has no exported member 'ImeActionResult'.
+# swap-fp: 93 :: src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"appVersion" | "deviceId" | "deviceName" | "devicePlatform" | "deviceType" | "gitCommit" | "gradleVersion" | "isCi" | "jdkVersion" | "jvmTarget" | "limit" | "lookbackDays" | ... 6 more ... | "testMethod"'.
 # swap-fp: 97 :: src/server/navigationTools.ts: error TS2339: Property 'screensDiscovered' does not exist on type 'ExploreExecutionResult'.

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -136,8 +136,8 @@ export interface PooledDevice {
    */
   nameRefreshGeneration?: number;
   /**
-   * Discovery timestamp that last wrote the mutable display name. When both
-   * observations carry a stamp, the newer one wins regardless of its path.
+   * Discovery sequence value that last wrote the mutable display name. When
+   * both observations carry a stamp, the newer one wins regardless of its path.
    */
   nameObservedAt?: number;
   /** Authoritative AVD name captured when this pool starts an Android emulator. */

--- a/src/features/action/ExecuteGesture.ts
+++ b/src/features/action/ExecuteGesture.ts
@@ -1,4 +1,4 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BootedDevice, Point } from "../../models";
 import { FingerPath } from "../../models";
 import { GestureOptions } from "../../models";
@@ -13,7 +13,7 @@ import { logger } from "../../utils/logger";
  * Executes gestures using platform-specific commands
  */
 export class ExecuteGesture extends BaseVisualChange {
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
+  constructor(device: BootedDevice, adb: AdbExecutor | null = null) {
     super(device, adb);
     this.device = device;
   }

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1,4 +1,4 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BaseVisualChange } from "./BaseVisualChange";
 import {
@@ -91,13 +91,13 @@ export class LaunchApp extends BaseVisualChange {
   /**
    * Create an LaunchApp instance
    * @param device - Optional device
-   * @param adb - Optional AdbClient instance for testing
+   * @param adb - Optional ADB executor for testing
    * @param simctl - Optional SimCtlClient instance for testing
    * @param timer - Optional Timer instance for testing
    */
   constructor(
     device: BootedDevice,
-    adb: AdbClient | null = null,
+    adb: AdbExecutor | null = null,
     simctl: SimCtlClient | null = null,
     timer: Timer = defaultTimer,
     dependencies: LaunchAppDependencies = {},

--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -1,4 +1,4 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, OpenURLResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -37,13 +37,13 @@ export class OpenURL extends BaseVisualChange {
 
   /**
    * @param device - The target device
-   * @param adb - Optional AdbClient instance (for testing)
+   * @param adb - Optional ADB executor (for testing)
    * @param simctl - Optional SimCtlClient for the iOS simulator path (for testing)
    * @param devicectl - Optional DeviceUrlLauncher for the iOS physical-device path (for testing)
    */
   constructor(
     device: BootedDevice,
-    adb: AdbClient | null = null,
+    adb: AdbExecutor | null = null,
     simctl: SimCtlClient | null = null,
     devicectl: DeviceUrlLauncher | null = null,
   ) {

--- a/src/features/action/SwipeOnElement.ts
+++ b/src/features/action/SwipeOnElement.ts
@@ -1,4 +1,4 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, GestureOptions } from "../../models";
 import { Element } from "../../models";
@@ -18,7 +18,7 @@ export class SwipeOnElement extends BaseVisualChange {
 
   constructor(
     device: BootedDevice,
-    adb: AdbClient | null = null,
+    adb: AdbExecutor | null = null,
     geometry: ElementGeometry = new DefaultElementGeometry(),
   ) {
     super(device, adb);

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -10,7 +10,7 @@ import {
   TapOnSelectedElement,
   ViewHierarchyResult,
 } from "../../models";
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { TapOnElementOptions } from "../../models/TapOnElementOptions";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
@@ -195,7 +195,7 @@ export class TapOnElement extends BaseVisualChange {
 
   constructor(
     device: BootedDevice,
-    adb: AdbClient | null = null,
+    adb: AdbExecutor | null = null,
     options: TapOnElementDependencies = {},
   ) {
     super(device, adb, options.timer);

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -1,6 +1,6 @@
 import { BootedDevice } from "../../models";
 import { ObserveResult } from "../../models/ObserveResult";
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
 import { ToolRegistry } from "../../server/toolRegistry";
 import { throwIfInternalToolFailed } from "../../server/internalToolCall";
@@ -27,14 +27,14 @@ export interface ObserveScreenLike {
 
 export class DefaultUIStateSetup implements UIStateSetup {
   private device: BootedDevice;
-  private adb: AdbClient;
+  private adb: AdbExecutor;
   private observeScreenProvider: () => ObserveScreenLike;
   private timer: Timer;
   private sessionUuid?: string;
 
   constructor(
     device: BootedDevice,
-    adb: AdbClient,
+    adb: AdbExecutor,
     observeScreenProvider?: () => ObserveScreenLike,
     timer: Timer = defaultTimer,
     sessionUuid?: string,
@@ -43,7 +43,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
     this.adb = adb;
     this.timer = timer;
     this.sessionUuid = sessionUuid;
-    // The setup holds a resolved AdbClient (not a factory), so wrap it in a
+    // The setup holds a resolved ADB executor (not a factory), so wrap it in a
     // trivial factory to satisfy ObserveScreen's factory-only contract (matches
     // the AndroidCtrlProxyClient.getInstance call below).
     this.observeScreenProvider =

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -1,7 +1,7 @@
 import { errorMessage } from "../../utils/describeUnknownError";
 import { ActionableError, BootedDevice, Element, isTruthy, ObserveResult } from "../../models";
 import { BaseVisualChange, ProgressCallback } from "../action/BaseVisualChange";
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
 import { ToolRegistry } from "../../server/toolRegistry";
@@ -109,7 +109,7 @@ export class Explore extends BaseVisualChange {
 
   constructor(
     device: BootedDevice,
-    adb: AdbClient | null = null,
+    adb: AdbExecutor | null = null,
     timer: Timer = defaultTimer,
     navigationManager?: NavigationGraphService,
     sessionUuid?: string,

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -1,5 +1,5 @@
 import type { BootedDevice, Element, ObserveResult } from "../../models";
-import type { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { ProgressCallback } from "../action/BaseVisualChange";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { TapOnElement } from "../action/TapOnElement";
@@ -94,7 +94,7 @@ export function isRatingDialog(elements: Element[]): boolean {
 export async function handlePermissionDialog(
   elements: Element[],
   device: BootedDevice,
-  adb: AdbClient | null,
+  adb: AdbExecutor | null,
   progress?: ProgressCallback,
 ): Promise<boolean> {
   // Look for "Allow" or "While using" buttons
@@ -136,7 +136,7 @@ export async function handlePermissionDialog(
 async function dismissDialog(
   elements: Element[],
   device: BootedDevice,
-  adb: AdbClient | null,
+  adb: AdbExecutor | null,
   progress?: ProgressCallback,
 ): Promise<boolean> {
   const dismissKeywords = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
@@ -182,7 +182,7 @@ type DeadEndHandler = (progress?: ProgressCallback) => Promise<void>;
 export async function detectAndHandleBlockers(
   observation: ObserveResult,
   device: BootedDevice,
-  adb: AdbClient | null,
+  adb: AdbExecutor | null,
   elementParser: ElementParser,
   handleDeadEnd: DeadEndHandler,
   progress?: ProgressCallback,

--- a/src/features/navigation/NavigationScreenshotManager.ts
+++ b/src/features/navigation/NavigationScreenshotManager.ts
@@ -5,7 +5,7 @@ import { logger, type Logger } from "../../utils/logger";
 import { Image } from "../../utils/image-utils";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { BootedDevice } from "../../models";
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
 import {
@@ -177,7 +177,7 @@ export class NavigationScreenshotManager {
    */
   public async captureAndStore(
     device: BootedDevice,
-    adb: AdbClient,
+    adb: AdbExecutor,
     appId: string,
     screenName: string,
     screenshotCapture?: ScreenshotCapture,
@@ -244,7 +244,7 @@ export class NavigationScreenshotManager {
 
   private async doCaptureAndStore(
     device: BootedDevice,
-    adb: AdbClient,
+    adb: AdbExecutor,
     appId: string,
     screenName: string,
     screenshotCapture?: ScreenshotCapture,
@@ -255,7 +255,7 @@ export class NavigationScreenshotManager {
       // Ensure directory exists
       await this.fs.ensureDir(this.screenshotDir);
 
-      // 1. Capture screenshot. This manager holds a resolved AdbClient (not a factory),
+      // 1. Capture screenshot. This manager holds a resolved ADB executor (not a factory),
       // so wrap it in a trivial factory to satisfy TakeScreenshot's factory-only contract.
       const capture = screenshotCapture ?? new TakeScreenshot(device, { create: () => adb });
       const result = await capture.execute();

--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -28,8 +28,9 @@ export interface BootedDevice {
   platform: Platform;
   deviceId: string;
   /**
-   * Monotonic host-clock stamp for the discovery observation that produced this
-   * record. Cached and retained listings preserve their original stamp.
+   * Monotonic process-local sequence for the discovery observation that
+   * produced this record. Cached and retained listings preserve their original
+   * stamp.
    */
   observedAt?: number;
   /** ADB transport identity, which changes when a serial reconnects. */

--- a/src/utils/DiscoveryObservationSequence.ts
+++ b/src/utils/DiscoveryObservationSequence.ts
@@ -1,0 +1,24 @@
+/**
+ * Assigns a monotonic order to completed device-discovery observations.
+ *
+ * This intentionally does not use wall-clock time: NTP or manual clock changes
+ * can move `Date.now()` backward while a daemon is running.
+ */
+export interface DiscoveryObservationSequence {
+  next(): number;
+}
+
+export class MonotonicDiscoveryObservationSequence implements DiscoveryObservationSequence {
+  private value = 0;
+
+  next(): number {
+    this.value++;
+    return this.value;
+  }
+}
+
+/**
+ * Process-wide ordering source shared by Android and iOS discovery clients.
+ */
+export const defaultDiscoveryObservationSequence: DiscoveryObservationSequence =
+  new MonotonicDiscoveryObservationSequence();

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -35,6 +35,10 @@ import { TTLCache } from "../cache/Cache";
 import { Timer, defaultTimer } from "../SystemTimer";
 import { isAdbMissingDeviceError, notifyAdbMissingDevice } from "./AdbDeviceHealth";
 import { DefaultSystemDetection, type SystemDetection } from "../system/SystemDetection";
+import {
+  defaultDiscoveryObservationSequence,
+  type DiscoveryObservationSequence,
+} from "../DiscoveryObservationSequence";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
@@ -169,6 +173,7 @@ export class AdbClient implements AdbExecutor {
    * @param spawnFn - spawn function (for testing)
    * @param retryExecutor - retry executor for command retries (for testing)
    * @param timer - Timer for delays and time tracking
+   * @param observationSequence - Monotonic discovery ordering source
    */
   constructor(
     device: BootedDevice | null = null,
@@ -181,6 +186,7 @@ export class AdbClient implements AdbExecutor {
     timer: Timer = defaultTimer,
     private readonly systemDetectionFactory: () => SystemDetection = () =>
       new DefaultSystemDetection(),
+    private readonly observationSequence: DiscoveryObservationSequence = defaultDiscoveryObservationSequence,
   ) {
     this.device = device;
     // Test mode if: custom execAsync provided OR global test mode flag is set
@@ -1141,6 +1147,7 @@ export class AdbClient implements AdbExecutor {
     }
     const lines = result.stdout.split("\n").slice(1); // Skip the first line which is the header
 
+    const observedAt = this.observationSequence.next();
     const devices = lines
       .filter((line) => line.trim().length > 0)
       .flatMap((line) => {
@@ -1156,7 +1163,7 @@ export class AdbClient implements AdbExecutor {
             name: deviceId,
             platform: "android",
             deviceId,
-            observedAt: this.timer.now(),
+            observedAt,
             ...(transportId ? { transportId } : {}),
           } satisfies BootedDevice,
         ];

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -314,8 +314,13 @@ const defaultDependencies: DevicectlDeviceListerDependencies = {
  */
 export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
   private readonly deps: DevicectlDeviceListerDependencies;
-  private cache: { discovery: PhysicalIosDeviceDiscovery; expiresAt: number } | null = null;
-  private lastGood: { devices: BootedDevice[]; staleAfter: number } | null = null;
+  private cache: {
+    discovery: PhysicalIosDeviceDiscovery;
+    observedAt: number;
+    expiresAt: number;
+  } | null = null;
+  private lastGood: { devices: BootedDevice[]; observedAt: number; staleAfter: number } | null =
+    null;
   private inFlight: Promise<PhysicalIosDeviceDiscovery> | null = null;
 
   constructor(dependencies: Partial<DevicectlDeviceListerDependencies> = {}) {
@@ -326,7 +331,10 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
     if (this.deps.platform() !== "darwin") {
       return { devices: [], complete: true };
     }
-    if (this.cache && this.deps.timer.now() < this.cache.expiresAt) {
+    const now = this.deps.timer.now();
+    // A backward wall-clock adjustment makes cached freshness unknowable.
+    // Re-list immediately rather than retaining a stale physical-device name.
+    if (this.cache && now >= this.cache.observedAt && now < this.cache.expiresAt) {
       return this.cache.discovery;
     }
     // Concurrent sweeps share one devicectl process rather than racing two.
@@ -397,7 +405,11 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
           devices: mergeById(stamped.devices, this.retainedDevices(now)),
           complete: false,
         };
-    this.cache = { discovery: resolved, expiresAt: now + DEVICE_LIST_CACHE_TTL_MS };
+    this.cache = {
+      discovery: resolved,
+      observedAt: now,
+      expiresAt: now + DEVICE_LIST_CACHE_TTL_MS,
+    };
     return resolved;
   }
 
@@ -405,13 +417,17 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
     discovery: PhysicalIosDeviceDiscovery,
     now: number,
   ): PhysicalIosDeviceDiscovery {
-    this.lastGood = { devices: discovery.devices, staleAfter: now + LAST_GOOD_RETENTION_MS };
+    this.lastGood = {
+      devices: discovery.devices,
+      observedAt: now,
+      staleAfter: now + LAST_GOOD_RETENTION_MS,
+    };
     return discovery;
   }
 
   /** Devices the last good sweep found, while still inside the retention window. */
   private retainedDevices(now: number): BootedDevice[] {
-    if (!this.lastGood || now >= this.lastGood.staleAfter) {
+    if (!this.lastGood || now < this.lastGood.observedAt || now >= this.lastGood.staleAfter) {
       this.lastGood = null;
       return [];
     }

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -7,6 +7,10 @@ import { errorMessage } from "../describeUnknownError";
 import { DefaultHostCommandExecutor, type HostCommandOptions } from "../HostCommandExecutor";
 import { logger, type Logger } from "../logger";
 import { defaultTimer, type Timer } from "../SystemTimer";
+import {
+  defaultDiscoveryObservationSequence,
+  type DiscoveryObservationSequence,
+} from "../DiscoveryObservationSequence";
 import { inferIosFormFactor, isIosPhysicalUdid } from "./iosDeviceType";
 
 /**
@@ -277,6 +281,7 @@ const LAST_GOOD_RETENTION_MS = 60_000;
 interface DevicectlDeviceListerDependencies {
   platform: () => NodeJS.Platform;
   timer: Pick<Timer, "now">;
+  observationSequence: DiscoveryObservationSequence;
   execute: (file: string, args: string[], options: HostCommandOptions) => Promise<ExecResult>;
   readFile: (path: string) => Promise<string>;
   mkdtemp: (prefix: string) => Promise<string>;
@@ -295,6 +300,7 @@ const defaultDependencies: DevicectlDeviceListerDependencies = {
   tmpdir,
   logger,
   timer: defaultTimer,
+  observationSequence: defaultDiscoveryObservationSequence,
 };
 
 /**
@@ -371,13 +377,14 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
 
   private remember(discovery: PhysicalIosDeviceDiscovery): PhysicalIosDeviceDiscovery {
     const now = this.deps.timer.now();
+    const observedAt = this.deps.observationSequence.next();
     // A cache hit or retained result must retain when it was observed, rather
     // than appear newer merely because a later caller read it.
     const stamped = {
       ...discovery,
       devices: discovery.devices.map((device) => ({
         ...device,
-        observedAt: device.observedAt ?? now,
+        observedAt: device.observedAt ?? observedAt,
       })),
     };
     const resolved = stamped.complete

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -12,6 +12,10 @@ import {
 } from "../HostCommandExecutor";
 import { ExecResult, ActionableError, DeviceInfo, BootedDevice, ScreenSize } from "../../models";
 import { defaultTimer, Timer } from "../SystemTimer";
+import {
+  defaultDiscoveryObservationSequence,
+  type DiscoveryObservationSequence,
+} from "../DiscoveryObservationSequence";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
@@ -560,6 +564,7 @@ export class SimCtlClient implements SimCtl {
     fileSystem: SimCtlFileSystem = defaultSimCtlFileSystem,
     bootOptions: SimCtlBootOptions = DEFAULT_SIMCTL_BOOT_OPTIONS,
     private readonly plist: PlistReader = new PlistClient(),
+    private readonly observationSequence: DiscoveryObservationSequence = defaultDiscoveryObservationSequence,
   ) {
     this.device = device;
     this.usesInjectedExecAsync = execAsyncFn !== null;
@@ -1430,7 +1435,7 @@ export class SimCtlClient implements SimCtl {
       name: simulator.name,
       platform: simulator.platform,
       deviceId: simulator.deviceId,
-      observedAt: this.timer.now(),
+      observedAt: this.observationSequence.next(),
     } as BootedDevice;
   }
 
@@ -1522,6 +1527,7 @@ export class SimCtlClient implements SimCtl {
   async getBootedSimulatorsChecked(timeoutMs?: number): Promise<BootedDevice[]> {
     const simulatorList = await this.listSimulators(timeoutMs);
     logger.debug(`Found simulator list: ${simulatorList}`);
+    const observedAt = this.observationSequence.next();
     const bootedDevices: BootedDevice[] = [];
 
     // Extract booted devices from all runtime versions
@@ -1533,7 +1539,7 @@ export class SimCtlClient implements SimCtl {
             name: device.name,
             platform: "ios",
             deviceId: device.udid,
-            observedAt: this.timer.now(),
+            observedAt,
             iosVersion,
             osVersion: iosVersion,
             formFactor: inferIosFormFactor(device.deviceTypeIdentifier),

--- a/test/daemon/devicePoolPhysicalIosRename.test.ts
+++ b/test/daemon/devicePoolPhysicalIosRename.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDiscoveryObservationSequence } from "../fakes/FakeDiscoveryObservationSequence";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
@@ -22,6 +23,7 @@ describe("DevicePool physical iOS rename (#5690)", () => {
   let devicePool: DevicePool;
   let sessionManager: SessionManager;
   let fakeTimer: FakeTimer;
+  let observations: FakeDiscoveryObservationSequence;
   let fakeDeviceManager: FakeDeviceManager;
 
   const booted = (
@@ -48,6 +50,7 @@ describe("DevicePool physical iOS rename (#5690)", () => {
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
+    observations = new FakeDiscoveryObservationSequence();
     sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeDeviceManager = new FakeDeviceManager();
     devicePool = new DevicePool(
@@ -184,6 +187,15 @@ describe("DevicePool physical iOS rename (#5690)", () => {
       undefined,
       staleSnapshot,
     );
+
+    expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
+  });
+
+  test("a later observation wins after the wall clock rolls back", async () => {
+    fakeTimer.setCurrentTime(100);
+    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", observations.next()));
+    fakeTimer.setCurrentTime(1);
+    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone", observations.next()));
 
     expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
   });

--- a/test/daemon/devicePoolPhysicalIosRename.test.ts
+++ b/test/daemon/devicePoolPhysicalIosRename.test.ts
@@ -2,12 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { FakeDiscoveryObservationSequence } from "../fakes/FakeDiscoveryObservationSequence";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
-import type { BootedDevice, Platform } from "../../src/models";
+import type { BootedDevice, ExecResult, Platform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { DevicectlDeviceLister } from "../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
 
 /**
  * A physical iPhone can change its display name without the hardware or the
@@ -23,7 +23,6 @@ describe("DevicePool physical iOS rename (#5690)", () => {
   let devicePool: DevicePool;
   let sessionManager: SessionManager;
   let fakeTimer: FakeTimer;
-  let observations: FakeDiscoveryObservationSequence;
   let fakeDeviceManager: FakeDeviceManager;
 
   const booted = (
@@ -38,6 +37,25 @@ describe("DevicePool physical iOS rename (#5690)", () => {
     ...(observedAt !== undefined ? { observedAt } : {}),
   });
 
+  const physicalIosListing = (name: string): string =>
+    JSON.stringify({
+      info: { outcome: "success" },
+      result: {
+        devices: [
+          {
+            identifier: PHYSICAL_IPHONE_UDID,
+            deviceProperties: { name, osVersionNumber: "18.6" },
+            hardwareProperties: {
+              udid: PHYSICAL_IPHONE_UDID,
+              platform: "iOS",
+              productType: "iPhone16,1",
+            },
+            connectionProperties: { tunnelState: "connected" },
+          },
+        ],
+      },
+    });
+
   const initialize = async (device: BootedDevice): Promise<void> => {
     fakeDeviceManager.bootedDevices = [device];
     await devicePool.initializeWithDevices([device]);
@@ -50,7 +68,6 @@ describe("DevicePool physical iOS rename (#5690)", () => {
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
-    observations = new FakeDiscoveryObservationSequence();
     sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeDeviceManager = new FakeDeviceManager();
     devicePool = new DevicePool(
@@ -191,12 +208,33 @@ describe("DevicePool physical iOS rename (#5690)", () => {
     expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
   });
 
-  test("a later observation wins after the wall clock rolls back", async () => {
-    fakeTimer.setCurrentTime(100);
-    await initialize(booted(PHYSICAL_IPHONE_UDID, "ios", "Old iPhone", observations.next()));
-    fakeTimer.setCurrentTime(1);
-    await republishAs(booted(PHYSICAL_IPHONE_UDID, "ios", "New iPhone", observations.next()));
+  test("refreshes a physical iPhone rename after the lister clock rolls back", async () => {
+    let name = "Old iPhone";
+    let executions = 0;
+    const lister = new DevicectlDeviceLister({
+      platform: () => "darwin",
+      timer: fakeTimer,
+      tmpdir: () => "/tmp",
+      mkdtemp: async (prefix) => `${prefix}listing`,
+      rm: async () => {},
+      execute: async () => {
+        executions++;
+        return { stdout: "", stderr: "", toString: () => "" } as ExecResult;
+      },
+      readFile: async () => physicalIosListing(name),
+      logger: { debug: () => {}, warn: () => {} },
+    } as ConstructorParameters<typeof DevicectlDeviceLister>[0]);
 
+    fakeTimer.setCurrentTime(100);
+    const initial = await lister.listConnectedDevices();
+    await initialize(initial.devices[0]!);
+
+    name = "New iPhone";
+    fakeTimer.setCurrentTime(1);
+    const renamed = await lister.listConnectedDevices();
+    await republishAs(renamed.devices[0]!);
+
+    expect(executions).toBe(2);
     expect(devicePool.getDevice(PHYSICAL_IPHONE_UDID)?.name).toBe("New iPhone");
   });
 

--- a/test/fakes/FakeDiscoveryObservationSequence.ts
+++ b/test/fakes/FakeDiscoveryObservationSequence.ts
@@ -1,0 +1,14 @@
+import type { DiscoveryObservationSequence } from "../../src/utils/DiscoveryObservationSequence";
+
+export class FakeDiscoveryObservationSequence implements DiscoveryObservationSequence {
+  private value: number;
+
+  constructor(initialValue: number = 0) {
+    this.value = initialValue;
+  }
+
+  next(): number {
+    this.value++;
+    return this.value;
+  }
+}

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -9,6 +9,7 @@ import {
 import type { ExecResult } from "../../../src/models";
 import { isAdbMissingDeviceError } from "../../../src/utils/android-cmdline-tools/AdbDeviceHealth";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDiscoveryObservationSequence } from "../../fakes/FakeDiscoveryObservationSequence";
 
 function createExecResult(stdout: string, stderr: string = ""): ExecResult {
   return {
@@ -69,7 +70,8 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     };
     const timer = new FakeTimer();
     timer.advanceTime(42);
-    const adb = new AdbClient(null, execAsync, null, undefined, timer);
+    const observations = new FakeDiscoveryObservationSequence();
+    const adb = new AdbClient(null, execAsync, null, undefined, timer, undefined, observations);
 
     const devices = await adb.getBootedAndroidDevices();
 
@@ -78,10 +80,33 @@ describe("AdbClient.getBootedAndroidDevices", () => {
         name: "emulator-5554",
         platform: "android",
         deviceId: "emulator-5554",
-        observedAt: timer.now(),
+        observedAt: 1,
         transportId: "42",
       },
     ]);
+  });
+
+  test("keeps discovery ordering monotonic when the wall clock rolls back", async () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(100);
+    const observations = new FakeDiscoveryObservationSequence();
+    const adb = new AdbClient(
+      null,
+      async () =>
+        createExecResult(["List of devices attached", "emulator-5554\tdevice", ""].join("\n")),
+      null,
+      undefined,
+      timer,
+      undefined,
+      observations,
+    );
+
+    const initial = await adb.getBootedAndroidDevices();
+    timer.setCurrentTime(1);
+    const afterRollback = await adb.getBootedAndroidDevices({ bypassCache: true });
+
+    expect(initial[0]?.observedAt).toBe(1);
+    expect(afterRollback[0]?.observedAt).toBe(2);
   });
 
   test("bypasses the device-list cache when checking a connection incarnation", async () => {

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/utils/ios-cmdline-tools/DevicectlDeviceLister";
 import type { ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDiscoveryObservationSequence } from "../../fakes/FakeDiscoveryObservationSequence";
 import { runWithAbortSignal } from "../../../src/utils/AbortContext";
 import { join } from "path";
 
@@ -49,6 +50,7 @@ function makeLister(overrides: Record<string, unknown>): DevicectlDeviceLister {
     execute: async () => okExec,
     logger: { debug: () => {}, warn: () => {} },
     timer: new FakeTimer(),
+    observationSequence: new FakeDiscoveryObservationSequence(),
     ...overrides,
   } as ConstructorParameters<typeof DevicectlDeviceLister>[0]);
 }
@@ -461,14 +463,14 @@ describe("DevicectlDeviceLister", () => {
     });
 
     const initial = await lister.listConnectedDevices();
-    expect(initial.devices[0]?.observedAt).toBe(0);
+    expect(initial.devices[0]?.observedAt).toBe(1);
 
     timer.advanceTime(1_000);
-    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(0);
+    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(1);
 
     shouldFail = true;
     timer.advanceTime(DEVICE_LIST_CACHE_TTL_MS);
-    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(0);
+    expect((await lister.listConnectedDevices()).devices[0]?.observedAt).toBe(1);
   });
 
   test("caches an unavailable host so every sweep does not respawn devicectl", async () => {


### PR DESCRIPTION
## Summary

- Replace wall-clock `observedAt` values with one process-wide, injectable monotonic discovery sequence shared by Android and iOS discovery.
- Invalidate a physical-iOS discovery cache or retained listing after wall-clock rollback, forcing a fresh device-name observation.
- Remove eight concrete `AdbClient` assumptions in favor of the existing `AdbExecutor` interface and ratchet the typecheck baseline down.

## Root cause

The freshness comparison introduced by [PR #5757](https://github.com/kaeawc/auto-mobile/pull/5757) used `Date.now()` through `SystemTimer`. NTP or manual clock rollback could make a later discovery appear older. The physical-device cache also treated a rollback as permanently fresh until wall time caught up.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test`
