### PR TITLE
fix(ios): harden preference timeout handling

### DIFF
--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -65,6 +65,19 @@ export const MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS = 90_000;
 export const MIN_UNINSTALL_APP_MCP_TIMEOUT_MS = 60_000;
 
 /**
+ * Floor for preference tools — iOS `setPreference` has a 30s write/read-back
+ * deadline and direct `getPreference` permits independently retried value and
+ * type reads for up to 40s. The transport budget starts before queueing, so it
+ * needs headroom to return the feature's own terminal result.
+ */
+export const MIN_PREFERENCE_MCP_TIMEOUT_MS = 60_000;
+
+const PREFERENCE_TOOL_TIMEOUT_FLOORS: Readonly<Record<string, number>> = {
+  getPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+  setPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+};
+
+/**
  * Floor for `openLink` — deep links can trigger sign-in, onboarding, data sync,
  * or other post-open navigation before the final observation settles. A sign-in
  * deeplink that launches the app and performs a backend token exchange was
@@ -105,6 +118,10 @@ function resolveEnvTimeoutFloorMs(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
 }
 
+function resolvePreferenceToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
+  return PREFERENCE_TOOL_TIMEOUT_FLOORS[toolName ?? ""];
+}
+
 function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
   switch (toolName) {
     case "executePlan":
@@ -136,7 +153,7 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
         DEFAULT_OBSERVE_MCP_TIMEOUT_MS,
       );
     default:
-      return undefined;
+      return resolvePreferenceToolTimeoutFloorMs(toolName);
   }
 }
 

--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -703,17 +703,21 @@ function looksLikeMissingAndroidPrefsFile(error: unknown): boolean {
 
 function looksLikeMissingIosDefault(error: unknown): boolean {
   const message = errorMessage(error);
-  return /does not exist|Domain .* does not exist|does not contain/i.test(message);
+  return [
+    /The domain\/default pair of \([^)]+\) does not exist\.?$/i,
+    /Domain [^\n]+ does not exist\.?$/i,
+    /Domain [^\n]+ does not contain (?:a value for )?[^\n]+\.?$/i,
+  ].some((pattern) => pattern.test(message));
 }
 
 function isRetryableIosDefaultsError(error: unknown): boolean {
   const message = errorMessage(error);
   return (
     /timed out/i.test(message) ||
-    /(?:core ?simulator|simctl).*(?:connection|service)|(?:connection|service).*(?:core ?simulator|simctl)/i.test(
-      message,
-    ) ||
-    /connection (?:refused|reset|interrupted|invalidated)/i.test(message)
+    /Failed to connect to (?:the )?CoreSimulator service/i.test(message) ||
+    /CoreSimulatorService connection (?:refused|reset|interrupted|invalidated)/i.test(message) ||
+    /connection (?:refused|reset|interrupted|invalidated)/i.test(message) ||
+    /Unable to lookup in current state: Booting/i.test(message)
   );
 }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -753,7 +753,13 @@ export class SimCtlClient implements SimCtl {
     });
 
     try {
-      return await Promise.race([probe.then(() => true, () => false), timeout]);
+      return await Promise.race([
+        probe.then(
+          () => true,
+          () => false,
+        ),
+        timeout,
+      ]);
     } catch (error) {
       logger.debug(`src/utils/ios-cmdline-tools/SimCtlClient.ts fallback failed: ${error}`, error);
       return false;

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -20,6 +20,7 @@ import { getAbortSignal } from "../AbortContext";
 import { Mutex } from "async-mutex";
 
 const COMMAND_SETTLEMENT_GRACE_MS = 1_000;
+const SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS = 10_000;
 
 export interface AppleDevice {
   udid: string;
@@ -517,7 +518,6 @@ export class SimCtlClient implements SimCtl {
   ) => Promise<ExecResult>;
   private timer: Timer;
   private platform: NodeJS.Platform;
-  private readonly usesInjectedExecAsync: boolean;
   private readonly spawnProcess: (
     command: string,
     args: string[],
@@ -531,7 +531,6 @@ export class SimCtlClient implements SimCtl {
   // Static cache for device list
   private static deviceListCache: { devices: DeviceInfo[]; timestamp: number } | null = null;
   private static readonly DEVICE_LIST_CACHE_TTL = 5000; // 5 seconds
-  private static localSimctlAvailability: Promise<void> | null = null;
   private static readonly simulatorBoots = new Map<string, SimulatorBootState>();
 
   /**
@@ -562,7 +561,6 @@ export class SimCtlClient implements SimCtl {
     private readonly plist: PlistReader = new PlistClient(),
   ) {
     this.device = device;
-    this.usesInjectedExecAsync = execAsyncFn !== null;
     this.execAsync = execAsyncFn || execAsync;
     this.timer = timer;
     this.platform = platform;
@@ -610,23 +608,9 @@ export class SimCtlClient implements SimCtl {
       throw new Error("Command cannot be empty");
     }
 
-    await this.ensureAvailableForCommand();
     const fullArgs = ["simctl", ...args];
     logger.debug(`[iOS] Starting command: xcrun ${fullArgs.join(" ")}`);
     return this.spawnProcess("xcrun", fullArgs, options);
-  }
-
-  private async ensureAvailableForCommand(signal?: AbortSignal): Promise<void> {
-    try {
-      await this.ensureLocalSimctlAvailable(signal);
-    } catch (error) {
-      const detail = errorMessage(error);
-      const message =
-        this.platform === "darwin"
-          ? `simctl is not available. Please install Xcode command line tools to continue. ${detail}`
-          : "iOS simulator tooling is only available on macOS.";
-      throw new ActionableError(message);
-    }
   }
 
   private async executeCommandArgv(
@@ -672,16 +656,7 @@ export class SimCtlClient implements SimCtl {
         }, timeoutMs);
       });
 
-      // Availability is an xcrun invocation too, so it must consume the same
-      // command budget instead of leaving a caller waiting before the actual
-      // simctl child process starts.
-      const availabilityPromise = this.ensureAvailableForCommand(signal);
-      availabilityPromise.catch(() => {
-        /* consumed by the race below, including after a timeout */
-      });
-
       try {
-        await Promise.race([availabilityPromise, timeoutPromise]);
         runPromise = runCommand(signal);
         // Once the timeout wins the race the aborted run promise rejects with an
         // AbortError; keep it handled so it can't surface as an unhandledRejection.
@@ -696,11 +671,12 @@ export class SimCtlClient implements SimCtl {
         if (waitForTimedOutCommandSettlement && runPromise && error === timeoutError) {
           await this.waitForCommandSettlement(runPromise, command);
         }
+        const commandError = this.toActionableSimctlUnavailableError(error);
         const duration = this.timer.now() - startTime;
         logger.warn(
-          `[iOS] Command failed after ${duration}ms: ${command} - ${(error as Error).message}`,
+          `[iOS] Command failed after ${duration}ms: ${command} - ${errorMessage(commandError)}`,
         );
-        throw error;
+        throw commandError;
       } finally {
         this.timer.clearTimeout(timeoutId!);
       }
@@ -708,17 +684,17 @@ export class SimCtlClient implements SimCtl {
 
     // No timeout specified
     try {
-      await this.ensureAvailableForCommand();
       const result = await runCommand(callerSignal);
       const duration = this.timer.now() - startTime;
       logger.debug(`[iOS] Command completed in ${duration}ms: ${command}`);
       return result;
     } catch (error) {
+      const commandError = this.toActionableSimctlUnavailableError(error);
       const duration = this.timer.now() - startTime;
       logger.warn(
-        `[iOS] Command failed after ${duration}ms: ${command} - ${(error as Error).message}`,
+        `[iOS] Command failed after ${duration}ms: ${command} - ${errorMessage(commandError)}`,
       );
-      throw error;
+      throw commandError;
     }
   }
 
@@ -762,40 +738,46 @@ export class SimCtlClient implements SimCtl {
     return this.isLocalSimctlAvailable();
   }
 
-  private async ensureLocalSimctlAvailable(signal?: AbortSignal): Promise<void> {
-    if (this.usesInjectedExecAsync) {
-      await this.execAsync("xcrun", ["simctl", "--version"], undefined, signal);
-      return;
-    }
-
-    if (this.platform !== "darwin") {
-      throw new ActionableError("iOS simulator tooling is only available on macOS.");
-    }
-
-    if (!SimCtlClient.localSimctlAvailability) {
-      try {
-        await this.execAsync("xcrun", ["simctl", "--version"], undefined, signal);
-        // Do not share an in-flight probe: each caller must own its cancellation
-        // signal. Cache only confirmation that simctl is available.
-        SimCtlClient.localSimctlAvailability = Promise.resolve();
-      } catch (error) {
-        logger.debug(`[iOS] simctl unavailable: ${errorMessage(error)}`);
-        throw error;
-      }
-    }
-
-    await SimCtlClient.localSimctlAvailability;
-  }
-
   private async isLocalSimctlAvailable(): Promise<boolean> {
+    const controller = new AbortController();
+    let timeoutId: NodeJS.Timeout | undefined;
+    const probe = this.execAsync("xcrun", ["--find", "simctl"], undefined, controller.signal);
+    probe.catch(() => {
+      // The race below owns the result; this also handles an abort after it wins.
+    });
+    const timeout = new Promise<false>((resolve) => {
+      timeoutId = this.timer.setTimeout(() => {
+        controller.abort();
+        resolve(false);
+      }, SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS);
+    });
+
     try {
-      await this.ensureLocalSimctlAvailable();
-      return true;
+      return await Promise.race([probe.then(() => true, () => false), timeout]);
     } catch (error) {
-      // ensureLocalSimctlAvailable already logged the underlying reason; here we only need the boolean result.
       logger.debug(`src/utils/ios-cmdline-tools/SimCtlClient.ts fallback failed: ${error}`, error);
       return false;
+    } finally {
+      if (timeoutId) {
+        this.timer.clearTimeout(timeoutId);
+      }
     }
+  }
+
+  private toActionableSimctlUnavailableError(error: unknown): unknown {
+    const detail = errorMessage(error);
+    if (
+      !/(?:unable to find utility ["']?simctl|active developer path .* does not exist|xcode-select: error|command not found: xcrun|spawn xcrun ENOENT)/i.test(
+        detail,
+      )
+    ) {
+      return error;
+    }
+    const message =
+      this.platform === "darwin"
+        ? `simctl is not available. Please install Xcode command line tools to continue. ${detail}`
+        : "iOS simulator tooling is only available on macOS.";
+    return new ActionableError(message);
   }
 
   /**

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -7,6 +7,7 @@ import {
   LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+  MIN_PREFERENCE_MCP_TIMEOUT_MS,
   MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
   MIN_TEARDOWN_DEVICE_MCP_TIMEOUT_MS,
@@ -110,6 +111,16 @@ describe("resolveMcpRequestTimeoutMs", () => {
       expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
     },
     {
+      name: "getPreference floor when timeoutMs omitted",
+      tool: "getPreference",
+      expected: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+    },
+    {
+      name: "setPreference floor when timeoutMs omitted",
+      tool: "setPreference",
+      expected: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+    },
+    {
       name: "observe default floor when timeoutMs omitted",
       tool: "observe",
       expected: DEFAULT_OBSERVE_MCP_TIMEOUT_MS,
@@ -162,6 +173,18 @@ describe("resolveMcpRequestTimeoutMs", () => {
       tool: "uninstallApp",
       timeoutMs: 30_000,
       expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
+    },
+    {
+      name: "raises short getPreference to floor",
+      tool: "getPreference",
+      timeoutMs: 30_000,
+      expected: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+    },
+    {
+      name: "raises short setPreference to floor",
+      tool: "setPreference",
+      timeoutMs: 30_000,
+      expected: MIN_PREFERENCE_MCP_TIMEOUT_MS,
     },
     {
       name: "raises short observe to floor",

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -814,6 +814,22 @@ describe("AppPreferences", () => {
     expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(1);
   });
 
+  test("surfaces an invalid simulator instead of reporting a missing iOS default", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      { error: new Error("Invalid device: simulator 12345678 does not exist") },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await expect(
+      preferences.getPreference({
+        scope: "userDefaults",
+        appId: "com.example.app",
+        key: "featureFlag",
+      }),
+    ).rejects.toThrow("Invalid device");
+    expect(simctl.calls).toHaveLength(1);
+  });
+
   test("retries a timed-out iOS UserDefaults write once", async () => {
     const simctl = new ScriptedSimCtlClient([
       { error: new Error("Command timed out after 10000ms") },
@@ -863,6 +879,50 @@ describe("AppPreferences", () => {
     const simctl = new ScriptedSimCtlClient([
       {},
       { error: new Error("Failed to connect to the CoreSimulator service") },
+      { stdout: "enabled\n" },
+      { stdout: "Type is string\n" },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    const result = await preferences.setPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+      value: "enabled",
+      type: "string",
+    });
+
+    expect(result.verified).toBeTrue();
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "write",
+      "read",
+      "read",
+      "read-type",
+    ]);
+  });
+
+  test("does not retry a permanent CoreSimulator configuration error", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      { error: new Error("CoreSimulatorService is unavailable because Xcode is not configured") },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await expect(
+      preferences.setPreference({
+        scope: "userDefaults",
+        appId: "com.example.app",
+        key: "featureFlag",
+        value: "enabled",
+        type: "string",
+      }),
+    ).rejects.toThrow("Xcode is not configured");
+    expect(simctl.calls.map((call) => call.args[3])).toEqual(["write"]);
+  });
+
+  test("retries a UserDefaults read while the simulator is booting", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      {},
+      { error: new Error("Unable to lookup in current state: Booting") },
       { stdout: "enabled\n" },
       { stdout: "Type is string\n" },
     ]);

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -9,16 +9,10 @@ import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../../src/utils/deviceTimeou
 function resetSimctlCaches(): void {
   const simctlClass = Simctl as unknown as {
     deviceListCache: { devices: unknown[]; timestamp: number } | null;
-    localSimctlAvailability: Promise<void> | null;
     simulatorBoots: Map<string, unknown>;
   };
   simctlClass.deviceListCache = null;
-  simctlClass.localSimctlAvailability = null;
   simctlClass.simulatorBoots.clear();
-}
-
-function forceStaticAvailabilityPath(instance: Simctl): void {
-  (instance as unknown as { usesInjectedExecAsync: boolean }).usesInjectedExecAsync = false;
 }
 
 async function waitForCondition(condition: () => boolean, description: string): Promise<void> {
@@ -82,22 +76,10 @@ describe("Simctl", function () {
   describe("isAvailable", function () {
     test("should return true when simctl is available", async function () {
       mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
-        if (file === "xcrun" && args.join(" ") === "simctl --version") {
-          return {
-            stdout: "simctl version 1.0.0",
-            stderr: "",
-            toString: () => "simctl version 1.0.0",
-            trim: () => "simctl version 1.0.0",
-            includes: () => false,
-          };
+        if (file === "xcrun" && args.join(" ") === "--find simctl") {
+          return createExecResult("/Applications/Xcode.app/usr/bin/simctl\n", "");
         }
-        return {
-          stdout: "",
-          stderr: "",
-          toString: () => "",
-          trim: () => "",
-          includes: () => false,
-        };
+        throw new Error(`Unexpected command: ${file} ${args.join(" ")}`);
       };
 
       simctl = new Simctl(null, mockExecAsync);
@@ -116,38 +98,73 @@ describe("Simctl", function () {
       const available = await simctl.isAvailable();
       expect(available).toBe(false);
     });
+
+    test("checks tool resolution without masking a device-health command error", async function () {
+      const commands: string[] = [];
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        commands.push(args.join(" "));
+        if (args.join(" ") === "--find simctl") {
+          return createExecResult("/Applications/Xcode.app/usr/bin/simctl\n", "");
+        }
+        throw new Error("Unable to boot device in current state: Shutdown");
+      };
+      simctl = new Simctl(null, mockExecAsync);
+
+      await expect(simctl.isAvailable()).resolves.toBe(true);
+      await expect(simctl.executeCommandArgs(["boot", "test-ios-device-id"])).rejects.toThrow(
+        "Unable to boot device in current state: Shutdown",
+      );
+      expect(commands).toEqual(["--find simctl", "simctl boot test-ios-device-id"]);
+    });
+
+    test("bounds and aborts a stalled tool-resolution check", async function () {
+      const timer = new FakeTimer();
+      let probeSignal: AbortSignal | undefined;
+      mockExecAsync = async (
+        _file: string,
+        _args: string[],
+        _maxBuffer?: number,
+        signal?: AbortSignal,
+      ): Promise<ExecResult> => {
+        probeSignal = signal;
+        return new Promise<ExecResult>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("probe aborted")));
+        });
+      };
+      simctl = new Simctl(null, mockExecAsync, timer);
+
+      const availability = simctl.isAvailable();
+      expect(probeSignal?.aborted).toBe(false);
+      timer.advanceTime(10_000);
+
+      await expect(availability).resolves.toBe(false);
+      expect(probeSignal?.aborted).toBe(true);
+    });
   });
 
   describe("executeCommand", function () {
-    test("should execute simctl commands with xcrun prefix", async function () {
-      let executedFile = "";
-      let executedArgs: string[] = [];
+    test("dispatches a simctl command once without a version preflight", async function () {
+      const commands: Array<{ file: string; args: string[] }> = [];
       mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
-        executedFile = file;
-        executedArgs = args;
-        if (file === "xcrun" && args.join(" ") === "simctl --version") {
-          return {
-            stdout: "simctl version 1.0.0",
-            stderr: "",
-            toString: () => "simctl version 1.0.0",
-            trim: () => "simctl version 1.0.0",
-            includes: () => false,
-          };
-        }
-        return {
-          stdout: "command executed",
-          stderr: "",
-          toString: () => "command executed",
-          trim: () => "command executed",
-          includes: () => false,
-        };
+        commands.push({ file, args });
+        return createExecResult("command executed", "");
       };
 
       simctl = new Simctl(mockDevice, mockExecAsync);
       await simctl.executeCommand("list devices");
 
-      expect(executedFile).toBe("xcrun");
-      expect(executedArgs).toEqual(["simctl", "list", "devices"]);
+      expect(commands).toEqual([{ file: "xcrun", args: ["simctl", "list", "devices"] }]);
+    });
+
+    test("maps a missing simctl utility to actionable Xcode guidance", async function () {
+      mockExecAsync = async (): Promise<ExecResult> => {
+        throw new Error('xcrun: error: unable to find utility "simctl", not a developer tool');
+      };
+      simctl = new Simctl(mockDevice, mockExecAsync, undefined, "darwin");
+
+      await expect(simctl.executeCommandArgs(["list", "devices"])).rejects.toThrow(
+        "Please install Xcode command line tools",
+      );
     });
 
     test("should execute pre-split simctl arguments without dropping empty strings or backslashes", async function () {
@@ -195,10 +212,9 @@ describe("Simctl", function () {
     test("starts a supervised simctl command with literal argv", async function () {
       const started: { command?: string; args?: readonly string[]; options?: SpawnOptions } = {};
       const child = {} as ChildProcess;
-      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
-        if (args.join(" ") === "simctl --version") {
-          return createExecResult("simctl version 1.0.0", "");
-        }
+      let execCalls = 0;
+      mockExecAsync = async (): Promise<ExecResult> => {
+        execCalls += 1;
         return createExecResult("", "");
       };
       simctl = new Simctl(
@@ -229,6 +245,7 @@ describe("Simctl", function () {
         "/tmp/a path;$(safe).mov",
       ]);
       expect(started.options).toEqual({ stdio: ["ignore", "ignore", "pipe"] });
+      expect(execCalls).toBe(0);
     });
   });
 
@@ -304,98 +321,6 @@ describe("Simctl", function () {
         "Command timed out after 1234ms: xcrun simctl bootstatus test-ios-device-id -b",
       );
       resolveCommand?.(createExecResult("late bootstatus", ""));
-    });
-
-    test("aborts an in-flight availability probe without poisoning future commands", async function () {
-      const timer = new FakeTimer();
-      const commands: string[] = [];
-      let availabilityAttempts = 0;
-      let probeSignal: AbortSignal | undefined;
-      mockExecAsync = async (
-        _file: string,
-        args: string[],
-        _maxBuffer?: number,
-        signal?: AbortSignal,
-      ): Promise<ExecResult> => {
-        commands.push(args.join(" "));
-        if (args.join(" ") === "simctl --version") {
-          availabilityAttempts += 1;
-          if (availabilityAttempts === 1) {
-            probeSignal = signal;
-            return new Promise<ExecResult>((_resolve, reject) => {
-              signal?.addEventListener("abort", () => reject(new Error("probe aborted")));
-            });
-          }
-          return createExecResult("simctl version 1.0.0", "");
-        }
-        return createExecResult("", "");
-      };
-      simctl = new Simctl(mockDevice, mockExecAsync, timer, "darwin");
-      forceStaticAvailabilityPath(simctl);
-
-      const command = simctl.executeCommandArgs(["list", "devices"], 1234);
-      expect(commands).toEqual(["simctl --version"]);
-      timer.advanceTime(1234);
-
-      await expect(command).rejects.toThrow(
-        "Command timed out after 1234ms: xcrun simctl list devices",
-      );
-      expect(probeSignal?.aborted).toBe(true);
-      await waitForCondition(
-        () =>
-          (
-            Simctl as unknown as {
-              localSimctlAvailability: Promise<void> | null;
-            }
-          ).localSimctlAvailability === null,
-        "aborted availability probe cache reset",
-      );
-
-      await expect(simctl.executeCommandArgs(["list", "devices"], 1234)).resolves.toMatchObject({
-        stdout: "",
-      });
-      expect(commands).toEqual(["simctl --version", "simctl --version", "simctl list devices"]);
-    });
-
-    test("does not share cancellation between concurrent availability probes", async function () {
-      const timer = new FakeTimer();
-      let availabilityAttempts = 0;
-      let firstProbeSignal: AbortSignal | undefined;
-      let firstProbeStarted = false;
-      mockExecAsync = async (
-        _file: string,
-        args: string[],
-        _maxBuffer?: number,
-        signal?: AbortSignal,
-      ): Promise<ExecResult> => {
-        if (args.join(" ") === "simctl --version") {
-          availabilityAttempts += 1;
-          if (availabilityAttempts === 1) {
-            firstProbeSignal = signal;
-            firstProbeStarted = true;
-            return new Promise<ExecResult>((_resolve, reject) => {
-              signal?.addEventListener("abort", () => reject(new Error("first probe aborted")));
-            });
-          }
-          return createExecResult("simctl version 1.0.0", "");
-        }
-        return createExecResult("", "");
-      };
-      simctl = new Simctl(mockDevice, mockExecAsync, timer, "darwin");
-      forceStaticAvailabilityPath(simctl);
-
-      const first = simctl.executeCommandArgs(["list", "devices"], 1234);
-      expect(firstProbeStarted).toBe(true);
-
-      await expect(simctl.executeCommandArgs(["list", "devices"], 1234)).resolves.toMatchObject({
-        stdout: "",
-      });
-      timer.advanceTime(1234);
-
-      await expect(first).rejects.toThrow(
-        "Command timed out after 1234ms: xcrun simctl list devices",
-      );
-      expect(firstProbeSignal?.aborted).toBe(true);
     });
 
     test("applies the default timeout to the bootstatus wait", async function () {
@@ -567,8 +492,8 @@ describe("Simctl", function () {
   });
 
   describe("listSimulatorImages", function () {
-    test("should retry local simctl availability after a transient failed probe", async function () {
-      let versionProbeCalls = 0;
+    test("runs discovery directly without a tool-resolution preflight", async function () {
+      const commands: string[] = [];
       const payload = simulatorListPayload([
         {
           udid: "iphone-17-pro-udid",
@@ -581,27 +506,19 @@ describe("Simctl", function () {
       ]);
 
       mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
-        if (file === "xcrun" && args.join(" ") === "simctl --version") {
-          versionProbeCalls++;
-          if (versionProbeCalls === 1) {
-            throw new Error("transient xcrun failure");
-          }
-          return createExecResult("simctl version 1051.50", "");
-        }
+        commands.push(`${file} ${args.join(" ")}`);
         if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
           return createExecResult(payload, "");
         }
-        return createExecResult("", "");
+        throw new Error(`Unexpected command: ${file} ${args.join(" ")}`);
       };
 
       simctl = new Simctl(null, mockExecAsync, undefined, "darwin");
-      forceStaticAvailabilityPath(simctl);
 
-      await expect(simctl.listSimulatorImages()).rejects.toThrow(/transient xcrun failure/);
       const devices = await simctl.listSimulatorImages();
 
-      expect(versionProbeCalls).toBe(2);
       expect(devices.map((device) => device.name)).toEqual(["iPhone 17 Pro"]);
+      expect(commands).toEqual(["xcrun simctl list devices --json"]);
     });
 
     test("should not cache an empty simulator discovery result", async function () {
@@ -989,11 +906,7 @@ describe("Simctl", function () {
       expect(runtimes[0].isAvailable).toBe(true);
     });
 
-    // REWRITE (#4177 item 2): a bare `rejects.toThrow()` here passed on the
-    // availability-probe error, not the `list runtimes` command error, because
-    // `ensureLocalSimctlAvailable` fires first. Let the probe succeed so only the
-    // real command fails, and assert the *command's* message surfaces.
-    test("surfaces the runtimes command error, not the availability-probe error", async function () {
+    test("surfaces the runtimes command error", async function () {
       mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
         if (args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 0.0", "");
@@ -1062,9 +975,7 @@ describe("Simctl", function () {
       expect(types[0].name).toBe("iPhone 17 Pro");
     });
 
-    // REWRITE (#4177 item 2): as with getRuntimes, assert the command error and
-    // not the availability probe.
-    test("surfaces the devicetypes command error, not the availability-probe error", async function () {
+    test("surfaces the devicetypes command error", async function () {
       mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
         if (args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 0.0", "");


### PR DESCRIPTION
## Summary
- Add 60-second daemon timeout headroom for preference tool requests.
- Restrict UserDefaults missing-key and retry detection to known signatures.
- Dispatch SimCtl commands directly while retaining bounded tool-resolution diagnostics.

Closes [#5754](https://github.com/kaeawc/auto-mobile/issues/5754)

## Test plan
- [x] `bun test test/daemon/mcpRequestTimeout.test.ts`
- [x] `bun test test/features/preferences/AppPreferences.test.ts`
- [x] `bun test test/utils/ios-cmdline-tools/simctl.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`

Made with [Cursor](https://cursor.com)