### PR TITLE
refactor(devices): per-source iOS discovery liveness so a failed simctl sweep keeps a confirmed iPhone assignable

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1600,6 +1600,7 @@ export class Daemon {
             bootedDeviceIds,
             candidateDeviceIds,
             succeededPlatforms,
+            succeededSources: discovery.succeededSources,
             candidatePlatforms,
             candidateIncarnations,
             deviceDisconnectMissIncarnations: this.deviceDisconnectMissIncarnations,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -4139,18 +4139,25 @@ export class DevicePool {
     const discovery = await this.deviceManager.getBootedDevicesDetailed("ios");
     const sources = discovery.succeededSources;
     const platformSucceeded = discovery.succeededPlatforms.has("ios");
-    // Presence only proves liveness when the source that listed the device
-    // completed. A failed devicectl sweep still returns its retained last-good
-    // iPhones (`DevicectlDeviceLister.retainedDevices`), and treating those as
-    // fresh would hand an unplugged device to a session instead of raising the
-    // intended unable-to-verify error.
+    // Presence alone does not prove liveness: a failed devicectl sweep replays
+    // its retained last-good iPhones, and treating those as fresh would hand an
+    // unplugged device to a session instead of raising the intended
+    // unable-to-verify error. Freshness is decided per device rather than per
+    // source, because devicectl also reports source-wide incompleteness for a
+    // sweep in which a device WAS freshly parsed beside one unreadable record —
+    // dropping that device would reject a connected iPhone.
+    const fresh = discovery.freshDeviceIds;
     return {
       discoverySucceeded: sources ? sources.has("ios-simulator") : platformSucceeded,
       physicalDiscoverySucceeded: sources ? sources.has("ios-physical") : platformSucceeded,
       bootedDeviceIds: new Set(
         discovery.devices
-          .filter((booted) => didSourceSucceedForDevice(discovery, "ios", booted.deviceId))
-          .map((booted) => booted.deviceId),
+          .map((booted) => booted.deviceId)
+          .filter((deviceId) =>
+            // Producers that do not report freshness fall back to the source
+            // aggregate, which is what they meant before #5683.
+            fresh ? fresh.has(deviceId) : didSourceSucceedForDevice(discovery, "ios", deviceId),
+          ),
       ),
     };
   }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -177,9 +177,13 @@ type SessionAssignmentSnapshot = Pick<
  * One iOS liveness sweep, carrying completeness per source (#5683).
  *
  * `discoverySucceeded` is the simulator (`simctl`) half and keeps its original
- * meaning; `physicalDiscoverySucceeded` is the devicectl half. `bootedDeviceIds`
- * holds every device either source positively observed, so a device present
- * there is proven live no matter which source failed.
+ * meaning; `physicalDiscoverySucceeded` is the devicectl half.
+ *
+ * `bootedDeviceIds` holds only devices a source **freshly** observed this
+ * sweep. That distinction is load-bearing: `DevicectlDeviceLister` replays its
+ * last-good listing for up to 60s behind `complete: false`, so a returned
+ * device is not by itself proof of liveness — only a returned device whose own
+ * source completed is.
  */
 interface IosLivenessSnapshot {
   discoverySucceeded: boolean;
@@ -4135,13 +4139,19 @@ export class DevicePool {
     const discovery = await this.deviceManager.getBootedDevicesDetailed("ios");
     const sources = discovery.succeededSources;
     const platformSucceeded = discovery.succeededPlatforms.has("ios");
-    // Every returned device was positively observed by whichever source ran, so
-    // the id set is kept even for a partial sweep. The per-source flags below
-    // decide only what an *absence* from that set means.
+    // Presence only proves liveness when the source that listed the device
+    // completed. A failed devicectl sweep still returns its retained last-good
+    // iPhones (`DevicectlDeviceLister.retainedDevices`), and treating those as
+    // fresh would hand an unplugged device to a session instead of raising the
+    // intended unable-to-verify error.
     return {
       discoverySucceeded: sources ? sources.has("ios-simulator") : platformSucceeded,
       physicalDiscoverySucceeded: sources ? sources.has("ios-physical") : platformSucceeded,
-      bootedDeviceIds: new Set(discovery.devices.map((booted) => booted.deviceId)),
+      bootedDeviceIds: new Set(
+        discovery.devices
+          .filter((booted) => didSourceSucceedForDevice(discovery, "ios", booted.deviceId))
+          .map((booted) => booted.deviceId),
+      ),
     };
   }
 
@@ -4162,9 +4172,10 @@ export class DevicePool {
       return "unknown";
     }
 
-    // Direct observation outranks both flags: a confirmed physical iPhone stays
-    // assignable through a failed simctl sweep, and an idle simulator stays
-    // assignable through a failed devicectl sweep (#5683).
+    // A fresh observation by either source outranks the other's failure: a
+    // devicectl-confirmed iPhone stays assignable through a failed simctl
+    // sweep, and an idle simulator through a failed devicectl sweep (#5683).
+    // The snapshot has already dropped retained-but-unverified ids.
     if (iosLiveness.bootedDeviceIds.has(device.id)) {
       return "assignable";
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -28,7 +28,8 @@ import {
   DeviceAllocationRequest,
 } from "./DeviceCriteriaMatcher";
 import { resetAdbDeviceListCache } from "../utils/android-cmdline-tools/AdbClient";
-import { hasMutableDisplayName } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { hasMutableDisplayName, isIosPhysicalUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { didSourceSucceedForDevice, type DiscoverySource } from "../utils/discoverySource";
 import { consolePortFromSerial } from "../utils/android-cmdline-tools/EmulatorConsoleClient";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
@@ -172,8 +173,17 @@ type SessionAssignmentSnapshot = Pick<
   "sessionId" | "status" | "lastUsedAt" | "assignmentCount" | "errorCount" | "autolockSessionId"
 >;
 
+/**
+ * One iOS liveness sweep, carrying completeness per source (#5683).
+ *
+ * `discoverySucceeded` is the simulator (`simctl`) half and keeps its original
+ * meaning; `physicalDiscoverySucceeded` is the devicectl half. `bootedDeviceIds`
+ * holds every device either source positively observed, so a device present
+ * there is proven live no matter which source failed.
+ */
 interface IosLivenessSnapshot {
   discoverySucceeded: boolean;
+  physicalDiscoverySucceeded: boolean;
   bootedDeviceIds: Set<string>;
 }
 
@@ -624,6 +634,7 @@ export class DevicePool {
         bootedDeviceIds,
         bootedPlatforms,
         discovery.succeededPlatforms,
+        discovery.succeededSources,
       );
       if (removed === undefined) {
         logger.info("Discarding an out-of-date device discovery snapshot");
@@ -1297,6 +1308,7 @@ export class DevicePool {
     bootedDeviceIds: Set<string>,
     bootedPlatforms: Set<Platform>,
     succeededPlatforms: Set<Platform>,
+    succeededSources?: Set<DiscoverySource>,
   ): Promise<number> {
     let removedCount = 0;
 
@@ -1311,11 +1323,19 @@ export class DevicePool {
         );
         continue;
       }
-      // Discovery for this platform failed or was unavailable this refresh, so
-      // we cannot confirm the device is gone. Retain it rather than pruning a
-      // device that may still be running (e.g. iOS simctl failed while Android
-      // discovery succeeded, or all tooling was transiently unreachable).
-      if (!succeededPlatforms.has(device.platform)) {
+      // The source that would have listed this device failed or was unavailable
+      // this refresh, so we cannot confirm the device is gone. Retain it rather
+      // than pruning a device that may still be running (e.g. simctl failed
+      // while devicectl and Android discovery succeeded). Asking per source
+      // rather than per platform keeps one failing iOS half from either
+      // freezing the other half's pruning or pruning its own devices (#5683).
+      if (
+        !didSourceSucceedForDevice(
+          { succeededPlatforms, succeededSources },
+          device.platform,
+          device.id,
+        )
+      ) {
         this.refreshMissingDeviceMisses.delete(device.id);
         logger.warn(
           `Device ${device.id} retained: ${device.platform} discovery did not succeed this refresh`,
@@ -1350,6 +1370,7 @@ export class DevicePool {
     bootedDeviceIds: Set<string>,
     bootedPlatforms: Set<Platform>,
     succeededPlatforms: Set<Platform>,
+    succeededSources?: Set<DiscoverySource>,
   ): Promise<number | undefined> {
     const removeMissingDevices = async () => {
       if (refreshGeneration !== this.refreshGeneration) {
@@ -1359,6 +1380,7 @@ export class DevicePool {
         bootedDeviceIds,
         bootedPlatforms,
         succeededPlatforms,
+        succeededSources,
       );
     };
     return assignmentLockHeld
@@ -4003,13 +4025,15 @@ export class DevicePool {
 
       if (status === "stale") {
         logger.warn(
-          `[DevicePool] Removing idle iOS simulator ${device.id}: simctl no longer reports it as booted`,
+          `[DevicePool] Removing idle iOS ${this.iosDeviceNoun(device.id)} ${device.id}: ` +
+            "iOS discovery no longer reports it as booted",
         );
         await this.removeDevice(device.id);
       } else {
         livenessUnknown = true;
         logger.warn(
-          `[DevicePool] Cannot assign idle iOS simulator ${device.id}: iOS liveness discovery failed`,
+          `[DevicePool] Cannot assign idle iOS ${this.iosDeviceNoun(device.id)} ${device.id}: ` +
+            "its iOS liveness discovery source failed",
         );
       }
       candidates = candidates.filter((candidate) => candidate.id !== skippedDeviceId);
@@ -4082,9 +4106,9 @@ export class DevicePool {
     }
 
     const iosLiveness = await this.getIosLivenessSnapshot();
-    if (!iosLiveness.discoverySucceeded) {
+    if (!iosLiveness.discoverySucceeded && !iosLiveness.physicalDiscoverySucceeded) {
       logger.warn(
-        "[DevicePool] Retaining idle iOS simulators: iOS liveness discovery failed before allocation planning",
+        "[DevicePool] Retaining idle iOS devices: no iOS liveness source completed before allocation planning",
       );
       return 0;
     }
@@ -4097,7 +4121,8 @@ export class DevicePool {
       }
       if (this.getIdleDeviceLivenessStatus(device, iosLiveness) === "stale") {
         logger.warn(
-          `[DevicePool] Removing idle iOS simulator ${device.id}: simctl no longer reports it as booted`,
+          `[DevicePool] Removing idle iOS ${this.iosDeviceNoun(device.id)} ${device.id}: ` +
+            "iOS discovery no longer reports it as booted",
         );
         await this.removeDevice(device.id);
         removedCount++;
@@ -4108,17 +4133,21 @@ export class DevicePool {
 
   private async getIosLivenessSnapshot(): Promise<IosLivenessSnapshot> {
     const discovery = await this.deviceManager.getBootedDevicesDetailed("ios");
-    if (!discovery.succeededPlatforms.has("ios")) {
-      return {
-        discoverySucceeded: false,
-        bootedDeviceIds: new Set(),
-      };
-    }
-
+    const sources = discovery.succeededSources;
+    const platformSucceeded = discovery.succeededPlatforms.has("ios");
+    // Every returned device was positively observed by whichever source ran, so
+    // the id set is kept even for a partial sweep. The per-source flags below
+    // decide only what an *absence* from that set means.
     return {
-      discoverySucceeded: true,
+      discoverySucceeded: sources ? sources.has("ios-simulator") : platformSucceeded,
+      physicalDiscoverySucceeded: sources ? sources.has("ios-physical") : platformSucceeded,
       bootedDeviceIds: new Set(discovery.devices.map((booted) => booted.deviceId)),
     };
+  }
+
+  /** "simulator" or "device", so a log about a physical iPhone reads truthfully. */
+  private iosDeviceNoun(deviceId: string): string {
+    return isIosPhysicalUdid(deviceId) ? "device" : "simulator";
   }
 
   private getIdleDeviceLivenessStatus(
@@ -4129,15 +4158,22 @@ export class DevicePool {
       return "assignable";
     }
 
-    if (!iosLiveness?.discoverySucceeded) {
+    if (!iosLiveness) {
       return "unknown";
     }
 
+    // Direct observation outranks both flags: a confirmed physical iPhone stays
+    // assignable through a failed simctl sweep, and an idle simulator stays
+    // assignable through a failed devicectl sweep (#5683).
     if (iosLiveness.bootedDeviceIds.has(device.id)) {
       return "assignable";
     }
 
-    return "stale";
+    // Only the source that would have listed this device can call it gone.
+    const observingSourceSucceeded = isIosPhysicalUdid(device.id)
+      ? iosLiveness.physicalDiscoverySucceeded
+      : iosLiveness.discoverySucceeded;
+    return observingSourceSucceeded ? "stale" : "unknown";
   }
 
   private async assertIdleDeviceAssignable(
@@ -4163,15 +4199,17 @@ export class DevicePool {
 
     if (status === "stale") {
       logger.warn(
-        `[DevicePool] Removing idle iOS simulator ${device.id}: simctl no longer reports it as booted`,
+        `[DevicePool] Removing idle iOS ${this.iosDeviceNoun(device.id)} ${device.id}: ` +
+          "iOS discovery no longer reports it as booted",
       );
       await this.removeDevice(device.id);
       throw new ActionableError(unavailableMessage);
     }
 
+    const noun = this.iosDeviceNoun(device.id);
     throw new ActionableError(
-      `Unable to verify iOS simulator '${device.id}' is still booted before assignment.\n` +
-        `iOS simulator discovery failed, so AutoMobile did not assign this pooled UDID.`,
+      `Unable to verify iOS ${noun} '${device.id}' is still booted before assignment.\n` +
+        `iOS ${noun} discovery failed, so AutoMobile did not assign this pooled UDID.`,
     );
   }
 

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -130,8 +130,14 @@ export function evaluateDeviceDisconnects(
     // Only the source that would have listed this device can call it missing:
     // a failed simctl sweep must not age out a devicectl-confirmed iPhone, and
     // a failed devicectl sweep must not age out a booted simulator (#5683).
+    //
+    // A candidate with no known platform is maximally unverifiable: a device
+    // still assigned to a session but detached from the pool (ADB-reset
+    // recovery) is added by id alone, so no source can be asked about it.
+    // Ageing it out would disconnect a live session on the strength of a sweep
+    // that never covered it.
     const platform = input.candidatePlatforms.get(deviceId);
-    if (platform && !didSourceSucceedForDevice(input, platform, deviceId)) {
+    if (!platform || !didSourceSucceedForDevice(input, platform, deviceId)) {
       clearMiss(deviceId);
       continue;
     }

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -1,4 +1,5 @@
 import type { Platform } from "../models";
+import { didSourceSucceedForDevice, type DiscoverySource } from "../utils/discoverySource";
 
 export type DisconnectCandidateIncarnation = number | string;
 
@@ -42,6 +43,12 @@ export interface DisconnectMonitorEvaluationInput {
   bootedDeviceIds: Set<string>;
   candidateDeviceIds: Set<string>;
   succeededPlatforms: Set<Platform>;
+  /**
+   * Per-source completeness (#5683). Optional: absent, every check falls back
+   * to the platform aggregate, which is what callers did before iOS grew a
+   * second discovery source.
+   */
+  succeededSources?: Set<DiscoverySource>;
   candidatePlatforms: Map<string, Platform>;
   candidateIncarnations?: Map<string, DisconnectCandidateIncarnation>;
   deviceDisconnectMissIncarnations?: Map<string, DisconnectCandidateIncarnation>;
@@ -98,7 +105,8 @@ export function evaluateDeviceDisconnects(
   if (
     input.bootedDeviceIds.size === 0 &&
     input.candidateDeviceIds.size > 0 &&
-    input.succeededPlatforms.size === 0
+    input.succeededPlatforms.size === 0 &&
+    (input.succeededSources?.size ?? 0) === 0
   ) {
     return { disconnected, missed, skippedAllDiscoveryFailed: true };
   }
@@ -119,8 +127,11 @@ export function evaluateDeviceDisconnects(
       continue;
     }
 
+    // Only the source that would have listed this device can call it missing:
+    // a failed simctl sweep must not age out a devicectl-confirmed iPhone, and
+    // a failed devicectl sweep must not age out a booted simulator (#5683).
     const platform = input.candidatePlatforms.get(deviceId);
-    if (platform && !input.succeededPlatforms.has(platform)) {
+    if (platform && !didSourceSucceedForDevice(input, platform, deviceId)) {
       clearMiss(deviceId);
       continue;
     }

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -10,6 +10,7 @@ import {
   type PhysicalIosDeviceDiscovery,
 } from "./ios-cmdline-tools/DevicectlDeviceLister";
 import { isIosPhysicalUdid } from "./ios-cmdline-tools/iosDeviceType";
+import type { DiscoverySource } from "./discoverySource";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import { deleteAvd } from "./android-cmdline-tools/avdmanager";
 import { logger } from "./logger";
@@ -44,6 +45,15 @@ export interface DeviceDiscoveryError {
 export interface BootedDeviceDiscovery {
   devices: BootedDevice[];
   succeededPlatforms: Set<Platform>;
+  /**
+   * Per-source completeness, one level finer than `succeededPlatforms` (#5683).
+   *
+   * iOS is discovered by two independent sources, so the platform flag alone
+   * cannot say which half of a mixed outcome is authoritative. Consumers that
+   * decide assignability or pruning for an individual device must ask
+   * `didSourceSucceedForDevice` rather than reading the platform aggregate.
+   */
+  succeededSources?: Set<DiscoverySource>;
   /** Platform-specific typed failures for incomplete observations. */
   discoveryErrors?: Partial<Record<Platform, DeviceDiscoveryError>>;
 }
@@ -446,6 +456,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   ): Promise<BootedDeviceDiscovery> {
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const succeededSources = new Set<DiscoverySource>();
     const discoveryErrors: Partial<Record<Platform, DeviceDiscoveryError>> = {};
 
     if (platform === "android" || platform === "either") {
@@ -459,6 +470,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         );
         devices.push(...emulators);
         succeededPlatforms.add("android");
+        succeededSources.add("android");
       } catch (error) {
         logger.warn(
           `[DeviceManager] Android booted-device discovery failed; retaining tracked Android devices: ${error}`,
@@ -473,17 +485,24 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     if (platform === "ios" || platform === "either") {
       const ios = await this.discoverBootedIosDevices();
       // Physical devices that devicectl confirmed are reported even when
-      // simulator discovery failed; `succeeded` still gates pruning, because a
-      // failed simctl sweep cannot prove a tracked simulator is gone.
+      // simulator discovery failed, and vice versa. `succeededPlatforms.ios`
+      // still means "simctl completed" for the platform-level consumers that
+      // predate #5683; the per-source set below is what lets a consumer decide
+      // an individual device without over-reading either failure.
       devices.push(...ios.devices);
-      if (ios.succeeded) {
+      if (ios.simulatorsSucceeded) {
         succeededPlatforms.add("ios");
-      } else if (ios.error) {
+        succeededSources.add("ios-simulator");
+      }
+      if (ios.physicalSucceeded) {
+        succeededSources.add("ios-physical");
+      }
+      if (!ios.simulatorsSucceeded && ios.error) {
         discoveryErrors.ios = ios.error;
       }
     }
 
-    return { devices, succeededPlatforms, discoveryErrors };
+    return { devices, succeededPlatforms, succeededSources, discoveryErrors };
   }
 
   async getDeviceImagesDetailed(
@@ -536,15 +555,18 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
 
   private async discoverBootedIosDevices(): Promise<{
     devices: BootedDevice[];
-    succeeded: boolean;
+    simulatorsSucceeded: boolean;
+    physicalSucceeded: boolean;
     error?: DeviceDiscoveryError;
   }> {
     // iOS tooling that is genuinely unavailable on this host cannot confirm a
-    // device is gone, so report it as un-discovered rather than empty.
+    // device is gone, so report it as un-discovered rather than empty. Neither
+    // source ran, so neither is authoritative.
     if (!(await this.canDiscoverIosLocally())) {
       return {
         devices: [],
-        succeeded: false,
+        simulatorsSucceeded: false,
+        physicalSucceeded: false,
         error: {
           code: "unavailable",
           message: "iOS booted-device discovery is unavailable.",
@@ -554,27 +576,29 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     // Physical-device discovery runs regardless of the simulator outcome and
     // cannot fail the sweep: it is best-effort by contract.
     const physical = await this.listPhysicalIosDevices();
+    if (!physical.complete) {
+      logger.warn(
+        "[DeviceManager] iOS physical-device discovery was incomplete; " +
+          "reporting last-known physical devices, which cannot prove one disconnected.",
+      );
+    }
     try {
       const simulators = await this.simctl.getBootedSimulatorsChecked();
-      // `succeeded` stays tied to simctl alone. It is a per-platform flag with
-      // no room for "simulators are authoritative but physical devices are
-      // not", and clearing it on a devicectl blip would make every idle
-      // simulator unassignable. The lister keeps a failing sweep from dropping a
-      // connected device by retaining its last-known devices instead.
-      if (!physical.complete) {
-        logger.warn(
-          "[DeviceManager] iOS physical-device discovery was incomplete; " +
-            "reporting last-known physical devices alongside authoritative simulators.",
-        );
-      }
-      return { devices: mergeIosDevices(simulators, physical.devices), succeeded: true };
+      return {
+        devices: mergeIosDevices(simulators, physical.devices),
+        simulatorsSucceeded: true,
+        physicalSucceeded: physical.complete,
+      };
     } catch (error) {
+      // A failed simctl sweep says nothing about the devicectl half: a physical
+      // device it positively observed stays authoritative (#5683).
       logger.warn(
-        `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`,
+        `[DeviceManager] iOS simulator discovery failed; retaining tracked simulators: ${error}`,
       );
       return {
         devices: physical.devices,
-        succeeded: false,
+        simulatorsSucceeded: false,
+        physicalSucceeded: physical.complete,
         error: {
           code: "failed",
           message: `iOS booted-device discovery failed: ${errorMessage(error)}`,

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -54,8 +54,30 @@ export interface BootedDeviceDiscovery {
    * `didSourceSucceedForDevice` rather than reading the platform aggregate.
    */
   succeededSources?: Set<DiscoverySource>;
+  /**
+   * Devices this sweep **freshly** observed, as opposed to replayed from a
+   * retained listing (#5683).
+   *
+   * Source-level completeness cannot stand in for this. `devicectl` reports
+   * `complete: false` both when every listed device is a stale replay and when
+   * a device was freshly parsed beside one unreadable record — opposite
+   * liveness answers from the same flag. Only membership here proves a device
+   * was seen just now.
+   */
+  freshDeviceIds?: Set<string>;
   /** Platform-specific typed failures for incomplete observations. */
   discoveryErrors?: Partial<Record<Platform, DeviceDiscoveryError>>;
+}
+
+/** The iOS sources that completed, from one sweep's per-source outcome. */
+function iosSucceededSources(outcome: {
+  simulatorsSucceeded: boolean;
+  physicalSucceeded: boolean;
+}): DiscoverySource[] {
+  return [
+    ...(outcome.simulatorsSucceeded ? (["ios-simulator"] as const) : []),
+    ...(outcome.physicalSucceeded ? (["ios-physical"] as const) : []),
+  ];
 }
 
 export interface BootedDeviceDiscoveryOptions {
@@ -457,28 +479,21 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
     const succeededSources = new Set<DiscoverySource>();
+    const freshDeviceIds = new Set<string>();
     const discoveryErrors: Partial<Record<Platform, DeviceDiscoveryError>> = {};
 
     if (platform === "android" || platform === "either") {
-      try {
-        const emulators = await this.emulator.getBootedDevicesChecked(
-          false,
-          {
-            bypassDeviceListCache: options.bypassAndroidDeviceListCache,
-          },
-          getAbortSignal(),
-        );
-        devices.push(...emulators);
+      const android = await this.discoverBootedAndroidDevices(options);
+      devices.push(...android.devices);
+      if (android.error) {
+        discoveryErrors.android = android.error;
+      } else {
         succeededPlatforms.add("android");
         succeededSources.add("android");
-      } catch (error) {
-        logger.warn(
-          `[DeviceManager] Android booted-device discovery failed; retaining tracked Android devices: ${error}`,
-        );
-        discoveryErrors.android = {
-          code: "failed",
-          message: `Android booted-device discovery failed: ${errorMessage(error)}`,
-        };
+        // adb has no retention replay: a listed device was listed just now.
+        for (const emulator of android.devices) {
+          freshDeviceIds.add(emulator.deviceId);
+        }
       }
     }
 
@@ -487,22 +502,23 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       // Physical devices that devicectl confirmed are reported even when
       // simulator discovery failed, and vice versa. `succeededPlatforms.ios`
       // still means "simctl completed" for the platform-level consumers that
-      // predate #5683; the per-source set below is what lets a consumer decide
-      // an individual device without over-reading either failure.
+      // predate #5683; the per-source set is what lets a consumer decide an
+      // individual device without over-reading either failure.
       devices.push(...ios.devices);
+      for (const source of iosSucceededSources(ios)) {
+        succeededSources.add(source);
+      }
       if (ios.simulatorsSucceeded) {
         succeededPlatforms.add("ios");
-        succeededSources.add("ios-simulator");
-      }
-      if (ios.physicalSucceeded) {
-        succeededSources.add("ios-physical");
-      }
-      if (!ios.simulatorsSucceeded && ios.error) {
+      } else if (ios.error) {
         discoveryErrors.ios = ios.error;
+      }
+      for (const deviceId of ios.freshDeviceIds) {
+        freshDeviceIds.add(deviceId);
       }
     }
 
-    return { devices, succeededPlatforms, succeededSources, discoveryErrors };
+    return { devices, succeededPlatforms, succeededSources, freshDeviceIds, discoveryErrors };
   }
 
   async getDeviceImagesDetailed(
@@ -553,10 +569,37 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     return { devices, succeededPlatforms, discoveryErrors };
   }
 
+  private async discoverBootedAndroidDevices(
+    options: BootedDeviceDiscoveryOptions,
+  ): Promise<{ devices: BootedDevice[]; error?: DeviceDiscoveryError }> {
+    try {
+      return {
+        devices: await this.emulator.getBootedDevicesChecked(
+          false,
+          { bypassDeviceListCache: options.bypassAndroidDeviceListCache },
+          getAbortSignal(),
+        ),
+      };
+    } catch (error) {
+      logger.warn(
+        `[DeviceManager] Android booted-device discovery failed; retaining tracked Android devices: ${error}`,
+      );
+      return {
+        devices: [],
+        error: {
+          code: "failed",
+          message: `Android booted-device discovery failed: ${errorMessage(error)}`,
+        },
+      };
+    }
+  }
+
   private async discoverBootedIosDevices(): Promise<{
     devices: BootedDevice[];
     simulatorsSucceeded: boolean;
     physicalSucceeded: boolean;
+    /** Ids observed by this sweep, excluding devicectl's retained replay. */
+    freshDeviceIds: Set<string>;
     error?: DeviceDiscoveryError;
   }> {
     // iOS tooling that is genuinely unavailable on this host cannot confirm a
@@ -567,6 +610,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         devices: [],
         simulatorsSucceeded: false,
         physicalSucceeded: false,
+        freshDeviceIds: new Set(),
         error: {
           code: "unavailable",
           message: "iOS booted-device discovery is unavailable.",
@@ -582,12 +626,22 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
           "reporting last-known physical devices, which cannot prove one disconnected.",
       );
     }
+    // A device devicectl parsed this sweep is fresh even when a sibling record
+    // was unreadable; only the replayed half is stale.
+    const retainedPhysicalIds = physical.retainedDeviceIds ?? new Set<string>();
+    const freshPhysicalIds = physical.devices
+      .map((device) => device.deviceId)
+      .filter((deviceId) => !retainedPhysicalIds.has(deviceId));
     try {
       const simulators = await this.simctl.getBootedSimulatorsChecked();
       return {
         devices: mergeIosDevices(simulators, physical.devices),
         simulatorsSucceeded: true,
         physicalSucceeded: physical.complete,
+        freshDeviceIds: new Set([
+          ...simulators.map((device) => device.deviceId),
+          ...freshPhysicalIds,
+        ]),
       };
     } catch (error) {
       // A failed simctl sweep says nothing about the devicectl half: a physical
@@ -599,6 +653,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         devices: physical.devices,
         simulatorsSucceeded: false,
         physicalSucceeded: physical.complete,
+        freshDeviceIds: new Set(freshPhysicalIds),
         error: {
           code: "failed",
           message: `iOS booted-device discovery failed: ${errorMessage(error)}`,

--- a/src/utils/discoverySource.ts
+++ b/src/utils/discoverySource.ts
@@ -1,0 +1,66 @@
+import type { Platform } from "../models/Platform";
+import { isIosPhysicalUdid } from "./ios-cmdline-tools/iosDeviceType";
+
+/**
+ * A single discovery mechanism, one level below `Platform`.
+ *
+ * iOS has two independent sources — `simctl` for booted simulators and
+ * `devicectl` for connected physical devices (#5620) — and either can fail
+ * while the other reports a device it directly observed. A per-platform
+ * "succeeded" flag cannot express that: tying it to devicectl made a blip
+ * strip every idle simulator of its liveness proof, and tying it to simctl
+ * alone (what #5682 shipped) left a confirmed iPhone unassignable whenever
+ * simctl failed. Carrying completeness per source removes the tension (#5683).
+ *
+ * Android has exactly one source today; it is named here so callers can treat
+ * every platform uniformly rather than special-casing iOS.
+ */
+export type DiscoverySource = "android" | "ios-simulator" | "ios-physical";
+
+/**
+ * The source that would have observed this device.
+ *
+ * The UDID shape is the same runtime signal the iOS tooling already uses to
+ * route between `simctl` and `devicectl`, so classification here cannot drift
+ * from the command that actually ran. An iOS device with no id at all is
+ * attributed to the simulator source, which is the conservative default: it is
+ * the source whose failure already suppresses pruning.
+ */
+export function discoverySourceFor(
+  platform: Platform,
+  deviceId: string | undefined,
+): DiscoverySource {
+  if (platform === "android") {
+    return "android";
+  }
+  return deviceId !== undefined && isIosPhysicalUdid(deviceId) ? "ios-physical" : "ios-simulator";
+}
+
+/** The completeness half of a discovery result, per platform and per source. */
+export interface DiscoveryCompleteness {
+  succeededPlatforms: ReadonlySet<Platform>;
+  /**
+   * Sources whose sweep completed. Optional so a producer that predates
+   * per-source reporting (or a fake that does not model it) still resolves
+   * through the platform aggregate below.
+   */
+  succeededSources?: ReadonlySet<DiscoverySource>;
+}
+
+/**
+ * True when the source that would have observed this device completed its
+ * sweep, so its silence about the device is evidence the device is gone.
+ *
+ * False means "we could not find out" — never "it disconnected".
+ */
+export function didSourceSucceedForDevice(
+  completeness: DiscoveryCompleteness,
+  platform: Platform,
+  deviceId: string | undefined,
+): boolean {
+  const sources = completeness.succeededSources;
+  if (sources) {
+    return sources.has(discoverySourceFor(platform, deviceId));
+  }
+  return completeness.succeededPlatforms.has(platform);
+}

--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -44,6 +44,17 @@ export interface IosPhysicalDeviceLister {
 export interface PhysicalIosDeviceDiscovery {
   devices: BootedDevice[];
   complete: boolean;
+  /**
+   * Devices in `devices` that came from the retention replay rather than this
+   * sweep, so a caller can tell "still plugged in" from "last seen recently".
+   *
+   * `complete` alone cannot make that call in either direction: a sweep with
+   * one malformed record reports `complete: false` while every listed device
+   * was freshly parsed, and a failed sweep reports `complete: false` while
+   * every listed device is a replay. Liveness decisions need this set; pruning
+   * decisions still want `complete` (#5683).
+   */
+  retainedDeviceIds?: ReadonlySet<string>;
 }
 
 /**
@@ -395,16 +406,28 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
         observedAt: device.observedAt ?? observedAt,
       })),
     };
-    const resolved = stamped.complete
-      ? this.recordLastGood(stamped, now)
-      : {
-          // A partial sweep and the retained listing are both incomplete views of
-          // the same hardware, so neither may evict the other's device: union
-          // them. When the sweep failed outright its half is empty and this
-          // degrades to pure retention.
-          devices: mergeById(stamped.devices, this.retainedDevices(now)),
-          complete: false,
-        };
+    let resolved: PhysicalIosDeviceDiscovery;
+    if (stamped.complete) {
+      resolved = this.recordLastGood(stamped, now);
+    } else {
+      // A partial sweep and the retained listing are both incomplete views of
+      // the same hardware, so neither may evict the other's device: union
+      // them. When the sweep failed outright its half is empty and this
+      // degrades to pure retention.
+      const fresh = new Set(stamped.devices.map((device) => device.deviceId));
+      const retained = this.retainedDevices(now);
+      // Only the replayed half is stale. A device this sweep parsed stays fresh
+      // even though a sibling record was unreadable.
+      const retainedDeviceIds = retained
+        .map((device) => device.deviceId)
+        .filter((id) => !fresh.has(id));
+      resolved = {
+        devices: mergeById(stamped.devices, retained),
+        complete: false,
+        // Omitted when empty so a pure-failure sweep keeps its original shape.
+        ...(retainedDeviceIds.length > 0 ? { retainedDeviceIds: new Set(retainedDeviceIds) } : {}),
+      };
+    }
     this.cache = {
       discovery: resolved,
       observedAt: now,

--- a/test/daemon/perSourceIosLiveness.test.ts
+++ b/test/daemon/perSourceIosLiveness.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { evaluateDeviceDisconnects } from "../../src/daemon/disconnectMonitor";
+import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
+import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type { BootedDevice, Platform } from "../../src/models";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Issue #5683: iOS has two independent discovery sources behind one platform
+ * flag. `simctl` lists booted simulators; `devicectl` lists connected physical
+ * devices. Either can fail alone, and #5682 had to tie the single per-platform
+ * flag to simctl — which left a devicectl-confirmed iPhone unassignable
+ * whenever simctl blipped.
+ *
+ * These pin all four combinations of (simctl ok/failed) x (devicectl ok/failed)
+ * with fakes only, so they hold on a host with no iOS tooling at all.
+ */
+const PHYSICAL_UDID = "00008130-000A1B2C3D4E5F60";
+const SIMULATOR_UDID = "1E2A3B4C-5D6E-4F70-8192-A3B4C5D6E7F8";
+
+const iosDevice = (deviceId: string, name: string): BootedDevice => ({
+  name,
+  platform: "ios",
+  deviceId,
+});
+
+const PHYSICAL = iosDevice(PHYSICAL_UDID, "Jason's iPhone");
+const SIMULATOR = iosDevice(SIMULATOR_UDID, "iPhone 16 Pro");
+
+describe("MultiPlatformDeviceManager reports iOS completeness per source (#5683)", () => {
+  const manager = (options: {
+    simctlOk: boolean;
+    devicectlOk: boolean;
+  }): MultiPlatformDeviceManager =>
+    new MultiPlatformDeviceManager(
+      null,
+      {
+        isAvailable: async () => true,
+        getBootedSimulatorsChecked: async () => {
+          if (!options.simctlOk) {
+            throw new Error("simctl list devices failed");
+          }
+          return [SIMULATOR];
+        },
+      } as unknown as SimCtlClient,
+      { getBootedDevicesChecked: async () => [] } as unknown as AndroidEmulatorClient,
+      undefined,
+      undefined,
+      {
+        listConnectedDevices: async () =>
+          options.devicectlOk
+            ? { devices: [PHYSICAL], complete: true }
+            : { devices: [], complete: false },
+      },
+    );
+
+  test("both sources succeed: every source is complete and both devices are reported", async () => {
+    const discovery = await manager({ simctlOk: true, devicectlOk: true }).getBootedDevicesDetailed(
+      "ios",
+    );
+
+    expect([...discovery.succeededSources!].sort()).toEqual(["ios-physical", "ios-simulator"]);
+    expect(discovery.devices.map((device) => device.deviceId).sort()).toEqual(
+      [PHYSICAL_UDID, SIMULATOR_UDID].sort(),
+    );
+  });
+
+  test("simctl fails, devicectl succeeds: the physical source stays complete", async () => {
+    const discovery = await manager({
+      simctlOk: false,
+      devicectlOk: true,
+    }).getBootedDevicesDetailed("ios");
+
+    expect(discovery.succeededSources!.has("ios-physical")).toBe(true);
+    expect(discovery.succeededSources!.has("ios-simulator")).toBe(false);
+    // The platform aggregate keeps its pre-#5683 simctl-only meaning.
+    expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+  });
+
+  test("devicectl fails, simctl succeeds: the simulator source stays complete", async () => {
+    const discovery = await manager({
+      simctlOk: true,
+      devicectlOk: false,
+    }).getBootedDevicesDetailed("ios");
+
+    expect(discovery.succeededSources!.has("ios-simulator")).toBe(true);
+    expect(discovery.succeededSources!.has("ios-physical")).toBe(false);
+    expect(discovery.succeededPlatforms.has("ios")).toBe(true);
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([SIMULATOR_UDID]);
+  });
+
+  test("both sources fail: no source is complete", async () => {
+    const discovery = await manager({
+      simctlOk: false,
+      devicectlOk: false,
+    }).getBootedDevicesDetailed("ios");
+
+    expect(discovery.succeededSources!.size).toBe(0);
+    expect(discovery.succeededPlatforms.has("ios")).toBe(false);
+    expect(discovery.devices).toEqual([]);
+    expect(discovery.discoveryErrors?.ios?.code).toBe("failed");
+  });
+});
+
+describe("DevicePool idle assignability is decided per source (#5683)", () => {
+  let devicePool: DevicePool;
+  let sessionManager: SessionManager;
+  let deviceManager: FakeDeviceManager;
+
+  beforeEach(() => {
+    const timer = new FakeTimer();
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    deviceManager = new FakeDeviceManager();
+    devicePool = new DevicePool(
+      sessionManager,
+      "test-daemon-session-id",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceManager,
+      new DefaultRetryExecutor(timer),
+    );
+  });
+
+  afterEach(() => {
+    sessionManager.stopCleanupTimer();
+  });
+
+  const pool = async (devices: BootedDevice[]): Promise<void> => {
+    deviceManager.bootedDevices = devices;
+    await devicePool.initializeWithDevices(devices);
+  };
+
+  test("a confirmed physical iPhone stays assignable when simctl fails", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    deviceManager.failedSources.add("ios-simulator");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-a", PHYSICAL_UDID, "ios"),
+    ).resolves.toBeDefined();
+    expect(devicePool.getDevice(PHYSICAL_UDID)?.sessionId).toBe("session-a");
+  });
+
+  test("an idle simulator stays assignable when devicectl fails", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    deviceManager.failedSources.add("ios-physical");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-b", SIMULATOR_UDID, "ios"),
+    ).resolves.toBeDefined();
+    expect(devicePool.getDevice(SIMULATOR_UDID)?.sessionId).toBe("session-b");
+  });
+
+  test("a failing simctl sweep does not prune the simulator it could not list", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    deviceManager.failedSources.add("ios-simulator");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-c", SIMULATOR_UDID, "ios"),
+    ).rejects.toThrow(/Unable to verify iOS simulator/);
+    // Unverifiable, never proven gone: the pooled entry survives.
+    expect(devicePool.getDevice(SIMULATOR_UDID)).toBeDefined();
+  });
+
+  test("a failing devicectl sweep does not prune the iPhone it could not list", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    deviceManager.failedSources.add("ios-physical");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-d", PHYSICAL_UDID, "ios"),
+    ).rejects.toThrow(/Unable to verify iOS device/);
+    expect(devicePool.getDevice(PHYSICAL_UDID)).toBeDefined();
+  });
+
+  test("a complete sweep that no longer lists an iPhone still prunes it", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    deviceManager.bootedDevices = [SIMULATOR];
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-e", PHYSICAL_UDID, "ios"),
+    ).rejects.toThrow();
+    expect(devicePool.getDevice(PHYSICAL_UDID)).toBeNull();
+  });
+});
+
+describe("disconnect monitor ages out only devices whose own source succeeded (#5683)", () => {
+  const evaluate = (succeededSources: Array<"ios-simulator" | "ios-physical">) => {
+    const misses = new Map<string, number>();
+    const result = evaluateDeviceDisconnects({
+      deviceDisconnectMisses: misses,
+      confirmedDisconnectedDeviceIds: new Set<string>(),
+      bootedDeviceIds: new Set<string>(),
+      candidateDeviceIds: new Set([PHYSICAL_UDID, SIMULATOR_UDID]),
+      succeededPlatforms: new Set<Platform>(
+        succeededSources.includes("ios-simulator") ? ["ios"] : [],
+      ),
+      succeededSources: new Set(succeededSources),
+      candidatePlatforms: new Map<string, Platform>([
+        [PHYSICAL_UDID, "ios"],
+        [SIMULATOR_UDID, "ios"],
+      ]),
+      missThreshold: 2,
+    });
+    return result.missed.map((entry) => entry.deviceId).sort();
+  };
+
+  test("a failed simctl sweep counts a miss for the iPhone only", () => {
+    expect(evaluate(["ios-physical"])).toEqual([PHYSICAL_UDID]);
+  });
+
+  test("a failed devicectl sweep counts a miss for the simulator only", () => {
+    expect(evaluate(["ios-simulator"])).toEqual([SIMULATOR_UDID]);
+  });
+
+  test("both sources complete counts a miss for both", () => {
+    expect(evaluate(["ios-simulator", "ios-physical"])).toEqual(
+      [PHYSICAL_UDID, SIMULATOR_UDID].sort(),
+    );
+  });
+
+  test("both sources failed counts no misses at all", () => {
+    expect(evaluate([])).toEqual([]);
+  });
+});

--- a/test/daemon/perSourceIosLiveness.test.ts
+++ b/test/daemon/perSourceIosLiveness.test.ts
@@ -34,30 +34,63 @@ const iosDevice = (deviceId: string, name: string): BootedDevice => ({
 const PHYSICAL = iosDevice(PHYSICAL_UDID, "Jason's iPhone");
 const SIMULATOR = iosDevice(SIMULATOR_UDID, "iPhone 16 Pro");
 
+/**
+ * The surface `MultiPlatformDeviceManager.getBootedDevicesDetailed` actually
+ * calls on each injected client. Naming them keeps the fakes checked against a
+ * real signature: the constructor takes the concrete classes, so the cast at
+ * the boundary is unavoidable, but it now covers a declared shape rather than
+ * an anonymous literal, and any drift in these two methods fails to compile.
+ */
+interface SimctlBootedDeviceSurface {
+  isAvailable(): Promise<boolean>;
+  getBootedSimulatorsChecked(): Promise<BootedDevice[]>;
+}
+
+interface EmulatorBootedDeviceSurface {
+  getBootedDevicesChecked(): Promise<BootedDevice[]>;
+}
+
+class FakeBootedSimctl implements SimctlBootedDeviceSurface {
+  constructor(private readonly simulators: BootedDevice[] | Error) {}
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async getBootedSimulatorsChecked(): Promise<BootedDevice[]> {
+    if (this.simulators instanceof Error) {
+      throw this.simulators;
+    }
+    return this.simulators;
+  }
+}
+
+class FakeBootedEmulator implements EmulatorBootedDeviceSurface {
+  async getBootedDevicesChecked(): Promise<BootedDevice[]> {
+    return [];
+  }
+}
+
 describe("MultiPlatformDeviceManager reports iOS completeness per source (#5683)", () => {
   const manager = (options: {
     simctlOk: boolean;
     devicectlOk: boolean;
+    /** Mirrors `DevicectlDeviceLister` replaying its last-good listing. */
+    retainedPhysical?: boolean;
   }): MultiPlatformDeviceManager =>
     new MultiPlatformDeviceManager(
       null,
-      {
-        isAvailable: async () => true,
-        getBootedSimulatorsChecked: async () => {
-          if (!options.simctlOk) {
-            throw new Error("simctl list devices failed");
-          }
-          return [SIMULATOR];
-        },
-      } as unknown as SimCtlClient,
-      { getBootedDevicesChecked: async () => [] } as unknown as AndroidEmulatorClient,
+      new FakeBootedSimctl(
+        options.simctlOk ? [SIMULATOR] : new Error("simctl list devices failed"),
+      ) as unknown as SimCtlClient,
+      new FakeBootedEmulator() as unknown as AndroidEmulatorClient,
       undefined,
       undefined,
       {
         listConnectedDevices: async () =>
           options.devicectlOk
             ? { devices: [PHYSICAL], complete: true }
-            : { devices: [], complete: false },
+            : { devices: options.retainedPhysical ? [PHYSICAL] : [], complete: false },
       },
     );
 
@@ -95,6 +128,21 @@ describe("MultiPlatformDeviceManager reports iOS completeness per source (#5683)
     expect(discovery.succeededSources!.has("ios-physical")).toBe(false);
     expect(discovery.succeededPlatforms.has("ios")).toBe(true);
     expect(discovery.devices.map((device) => device.deviceId)).toEqual([SIMULATOR_UDID]);
+  });
+
+  test("a retained physical listing is reported without marking its source complete", async () => {
+    const discovery = await manager({
+      simctlOk: true,
+      devicectlOk: false,
+      retainedPhysical: true,
+    }).getBootedDevicesDetailed("ios");
+
+    // Retention exists so a devicectl blip cannot prune a connected iPhone, so
+    // the device is still reported -- but its source did not complete.
+    expect(discovery.devices.map((device) => device.deviceId).sort()).toEqual(
+      [PHYSICAL_UDID, SIMULATOR_UDID].sort(),
+    );
+    expect(discovery.succeededSources!.has("ios-physical")).toBe(false);
   });
 
   test("both sources fail: no source is complete", async () => {
@@ -176,6 +224,22 @@ describe("DevicePool idle assignability is decided per source (#5683)", () => {
     await expect(
       devicePool.bindOrReuseDeviceSession("session-d", PHYSICAL_UDID, "ios"),
     ).rejects.toThrow(/Unable to verify iOS device/);
+    expect(devicePool.getDevice(PHYSICAL_UDID)).toBeDefined();
+  });
+
+  test("a retained-but-unverified iPhone is not assignable when both sources fail", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    // devicectl failed but replays its last-good listing, and simctl failed
+    // too. Nothing observed the iPhone this sweep, so presence in the returned
+    // list must not be read as proof it is still plugged in.
+    deviceManager.failedSources.add("ios-physical");
+    deviceManager.retainedSources.add("ios-physical");
+    deviceManager.failedSources.add("ios-simulator");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-f", PHYSICAL_UDID, "ios"),
+    ).rejects.toThrow(/Unable to verify iOS device/);
+    // Unverifiable, never proven gone: retained, not pruned.
     expect(devicePool.getDevice(PHYSICAL_UDID)).toBeDefined();
   });
 

--- a/test/daemon/perSourceIosLiveness.test.ts
+++ b/test/daemon/perSourceIosLiveness.test.ts
@@ -145,6 +145,47 @@ describe("MultiPlatformDeviceManager reports iOS completeness per source (#5683)
     expect(discovery.succeededSources!.has("ios-physical")).toBe(false);
   });
 
+  test("a freshly parsed iPhone is fresh even when a sibling record is unreadable", async () => {
+    // `parseDevicectlDeviceList` reports source-wide `complete: false` when any
+    // entry is malformed, while still returning the devices it did parse.
+    const manager = new MultiPlatformDeviceManager(
+      null,
+      new FakeBootedSimctl([SIMULATOR]) as unknown as SimCtlClient,
+      new FakeBootedEmulator() as unknown as AndroidEmulatorClient,
+      undefined,
+      undefined,
+      { listConnectedDevices: async () => ({ devices: [PHYSICAL], complete: false }) },
+    );
+
+    const discovery = await manager.getBootedDevicesDetailed("ios");
+
+    // The source is incomplete, but this device was observed just now.
+    expect(discovery.succeededSources!.has("ios-physical")).toBe(false);
+    expect(discovery.freshDeviceIds!.has(PHYSICAL_UDID)).toBe(true);
+  });
+
+  test("a replayed iPhone is reported but not fresh", async () => {
+    const manager = new MultiPlatformDeviceManager(
+      null,
+      new FakeBootedSimctl([SIMULATOR]) as unknown as SimCtlClient,
+      new FakeBootedEmulator() as unknown as AndroidEmulatorClient,
+      undefined,
+      undefined,
+      {
+        listConnectedDevices: async () => ({
+          devices: [PHYSICAL],
+          complete: false,
+          retainedDeviceIds: new Set([PHYSICAL_UDID]),
+        }),
+      },
+    );
+
+    const discovery = await manager.getBootedDevicesDetailed("ios");
+
+    expect(discovery.devices.map((device) => device.deviceId)).toContain(PHYSICAL_UDID);
+    expect(discovery.freshDeviceIds!.has(PHYSICAL_UDID)).toBe(false);
+  });
+
   test("both sources fail: no source is complete", async () => {
     const discovery = await manager({
       simctlOk: false,
@@ -241,6 +282,18 @@ describe("DevicePool idle assignability is decided per source (#5683)", () => {
     ).rejects.toThrow(/Unable to verify iOS device/);
     // Unverifiable, never proven gone: retained, not pruned.
     expect(devicePool.getDevice(PHYSICAL_UDID)).toBeDefined();
+  });
+
+  test("a freshly parsed iPhone stays assignable when its source is incomplete", async () => {
+    await pool([PHYSICAL, SIMULATOR]);
+    // devicectl parsed this iPhone but choked on a sibling record, so the
+    // source is incomplete while the device itself was seen just now.
+    deviceManager.incompleteSources.add("ios-physical");
+
+    await expect(
+      devicePool.bindOrReuseDeviceSession("session-g", PHYSICAL_UDID, "ios"),
+    ).resolves.toBeDefined();
+    expect(devicePool.getDevice(PHYSICAL_UDID)?.sessionId).toBe("session-g");
   });
 
   test("a complete sweep that no longer lists an iPhone still prunes it", async () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -157,6 +157,13 @@ describe("disconnect monitor miss counting", () => {
     expect(misses.has("device-1")).toBe(false);
   });
 
+  // These three exercise the miss-counting mechanism itself. They simulate an
+  // Android device ("ADB returning some devices but not ours"), so they name
+  // its platform: a candidate with no platform at all is unverifiable by
+  // construction and is deliberately never aged out (see below).
+  const ANDROID_CANDIDATE = new Map([["device-1", "android"]]);
+  const ANDROID_SUCCEEDED = new Set(["android"]);
+
   test("increments miss count when device is absent", () => {
     const misses = new Map<string, number>();
 
@@ -165,10 +172,22 @@ describe("disconnect monitor miss counting", () => {
     expect(misses.has("device-1")).toBe(false);
 
     // Simulate ADB returning some devices but not ours
-    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    runDisconnectPoll(
+      misses,
+      new Set(["other"]),
+      new Set(["device-1"]),
+      ANDROID_SUCCEEDED,
+      ANDROID_CANDIDATE,
+    );
     expect(misses.get("device-1")).toBe(1);
 
-    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    runDisconnectPoll(
+      misses,
+      new Set(["other"]),
+      new Set(["device-1"]),
+      ANDROID_SUCCEEDED,
+      ANDROID_CANDIDATE,
+    );
     expect(misses.get("device-1")).toBe(2);
   });
 
@@ -176,12 +195,51 @@ describe("disconnect monitor miss counting", () => {
     const misses = new Map<string, number>();
 
     for (let i = 1; i < DEVICE_DISCONNECT_MISS_THRESHOLD; i++) {
-      const result = runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+      const result = runDisconnectPoll(
+        misses,
+        new Set(["other"]),
+        new Set(["device-1"]),
+        ANDROID_SUCCEEDED,
+        ANDROID_CANDIDATE,
+      );
       expect(result.disconnected).toEqual([]);
     }
 
-    const result = runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    const result = runDisconnectPoll(
+      misses,
+      new Set(["other"]),
+      new Set(["device-1"]),
+      ANDROID_SUCCEEDED,
+      ANDROID_CANDIDATE,
+    );
     expect(result.disconnected).toEqual(["device-1"]);
+  });
+
+  /**
+   * A device still assigned to a session but detached from the pool (ADB-reset
+   * recovery) is added to the candidate set by id alone, with no
+   * `candidatePlatforms` entry — `daemon.ts` cannot name a platform it no
+   * longer tracks. No discovery source can be asked about such a candidate, so
+   * ageing it out would disconnect a live session on the strength of a sweep
+   * that never covered it (#5683 review).
+   */
+  test("never ages out a candidate whose platform is unknown", () => {
+    const misses = new Map<string, number>();
+
+    for (let i = 0; i <= DEVICE_DISCONNECT_MISS_THRESHOLD; i++) {
+      const result = runDisconnectPoll(
+        misses,
+        new Set(["other"]),
+        new Set(["orphaned-session-device"]),
+        // Only devicectl completed: enough to clear the all-failed early
+        // return, and still no way to verify a platformless candidate.
+        new Set(),
+        new Map(),
+      );
+      expect(result.disconnected).toEqual([]);
+    }
+
+    expect(misses.has("orphaned-session-device")).toBe(false);
   });
 
   test("miss-counts an Android candidate when Android discovery succeeds empty", () => {
@@ -324,15 +382,23 @@ describe("disconnect monitor miss counting", () => {
 
   test("miss count resets after device reappears then starts over", () => {
     const misses = new Map<string, number>();
+    const poll = (booted: Set<string>) =>
+      runDisconnectPoll(
+        misses,
+        booted,
+        new Set(["device-1"]),
+        ANDROID_SUCCEEDED,
+        ANDROID_CANDIDATE,
+      );
 
-    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
-    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    poll(new Set(["other"]));
+    poll(new Set(["other"]));
     expect(misses.get("device-1")).toBe(2);
 
-    runDisconnectPoll(misses, new Set(["device-1"]), new Set(["device-1"]));
+    poll(new Set(["device-1"]));
     expect(misses.has("device-1")).toBe(false);
 
-    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    poll(new Set(["other"]));
     expect(misses.get("device-1")).toBe(1);
   });
 

--- a/test/fakes/FakeDeviceManager.ts
+++ b/test/fakes/FakeDeviceManager.ts
@@ -22,6 +22,11 @@ export class FakeDeviceManager implements PlatformDeviceManager {
   // `succeededSources`, so a consumer that mistakes presence for a fresh
   // observation is caught.
   retainedSources: Set<DiscoverySource> = new Set();
+  // Sources that did not complete but whose reported devices were still
+  // observed this sweep — devicectl's partial-parse state, where one malformed
+  // record makes the whole listing incomplete while the devices it did parse
+  // are fresh. Contributes devices AND freshness, but not `succeededSources`.
+  incompleteSources: Set<DiscoverySource> = new Set();
 
   constructor(images: DeviceInfo[] = [], booted: BootedDevice[] = []) {
     this.deviceImages = images;
@@ -55,7 +60,8 @@ export class FakeDeviceManager implements PlatformDeviceManager {
       const source = discoverySourceFor(device.platform, device.deviceId);
       return (
         (!this.failedPlatforms.has(device.platform) && !this.failedSources.has(source)) ||
-        this.retainedSources.has(source)
+        this.retainedSources.has(source) ||
+        this.incompleteSources.has(source)
       );
     });
   }
@@ -65,25 +71,37 @@ export class FakeDeviceManager implements PlatformDeviceManager {
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
     const succeededSources = new Set<DiscoverySource>();
+    const freshDeviceIds = new Set<string>();
     const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
     const sourceFailed = (source: DiscoverySource, p: Platform): boolean =>
-      this.failedPlatforms.has(p) || this.failedSources.has(source);
+      this.failedPlatforms.has(p) ||
+      this.failedSources.has(source) ||
+      this.incompleteSources.has(source);
     for (const p of requested) {
       const platformSources: DiscoverySource[] =
         p === "android" ? ["android"] : ["ios-simulator", "ios-physical"];
       for (const source of platformSources) {
         const failed = sourceFailed(source, p);
-        if (failed && !this.retainedSources.has(source)) {
+        const reportsDevices =
+          !failed || this.retainedSources.has(source) || this.incompleteSources.has(source);
+        if (!reportsDevices) {
           continue;
         }
         if (!failed) {
           succeededSources.add(source);
         }
-        devices.push(
-          ...this.bootedDevices.filter(
-            (device) => device.platform === p && discoverySourceFor(p, device.deviceId) === source,
-          ),
+        const fromSource = this.bootedDevices.filter(
+          (device) => device.platform === p && discoverySourceFor(p, device.deviceId) === source,
         );
+        devices.push(...fromSource);
+        // A retained source replays devices it saw earlier; they are reported
+        // but were not observed this sweep. An incomplete source's devices WERE
+        // observed this sweep, even though the source did not complete.
+        if (!failed || this.incompleteSources.has(source)) {
+          for (const device of fromSource) {
+            freshDeviceIds.add(device.deviceId);
+          }
+        }
       }
       // Mirrors production: the platform aggregate tracks the simulator source
       // for iOS, so platform-level consumers keep their pre-#5683 meaning.
@@ -97,7 +115,7 @@ export class FakeDeviceManager implements PlatformDeviceManager {
         };
       }
     }
-    return { devices, succeededPlatforms, succeededSources, discoveryErrors };
+    return { devices, succeededPlatforms, succeededSources, freshDeviceIds, discoveryErrors };
   }
 
   async startDevice(

--- a/test/fakes/FakeDeviceManager.ts
+++ b/test/fakes/FakeDeviceManager.ts
@@ -1,6 +1,7 @@
 import { ChildProcess } from "child_process";
 import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { BootedDeviceDiscovery, PlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { discoverySourceFor, type DiscoverySource } from "../../src/utils/discoverySource";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceTimeouts";
 
 export class FakeDeviceManager implements PlatformDeviceManager {
@@ -11,6 +12,10 @@ export class FakeDeviceManager implements PlatformDeviceManager {
   // Platforms whose discovery should report as failed/unavailable (used to
   // exercise partial-discovery handling). Defaults to all platforms succeeding.
   failedPlatforms: Set<Platform> = new Set();
+  // Individual discovery sources that should report as failed. iOS has two
+  // (simctl and devicectl) and either can fail alone (#5683); a source listed
+  // here contributes no devices and is absent from `succeededSources`.
+  failedSources: Set<DiscoverySource> = new Set();
 
   constructor(images: DeviceInfo[] = [], booted: BootedDevice[] = []) {
     this.deviceImages = images;
@@ -45,19 +50,37 @@ export class FakeDeviceManager implements PlatformDeviceManager {
     const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const succeededSources = new Set<DiscoverySource>();
     const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
+    const sourceFailed = (source: DiscoverySource, p: Platform): boolean =>
+      this.failedPlatforms.has(p) || this.failedSources.has(source);
     for (const p of requested) {
-      if (this.failedPlatforms.has(p)) {
+      const platformSources: DiscoverySource[] =
+        p === "android" ? ["android"] : ["ios-simulator", "ios-physical"];
+      for (const source of platformSources) {
+        if (sourceFailed(source, p)) {
+          continue;
+        }
+        succeededSources.add(source);
+        devices.push(
+          ...this.bootedDevices.filter(
+            (device) => device.platform === p && discoverySourceFor(p, device.deviceId) === source,
+          ),
+        );
+      }
+      // Mirrors production: the platform aggregate tracks the simulator source
+      // for iOS, so platform-level consumers keep their pre-#5683 meaning.
+      const platformSucceeded = !sourceFailed(p === "android" ? "android" : "ios-simulator", p);
+      if (platformSucceeded) {
+        succeededPlatforms.add(p);
+      } else {
         discoveryErrors[p] = {
           code: "unavailable",
           message: `${p === "ios" ? "iOS" : "Android"} booted-device discovery is unavailable.`,
         };
-        continue;
       }
-      succeededPlatforms.add(p);
-      devices.push(...this.bootedDevices.filter((device) => device.platform === p));
     }
-    return { devices, succeededPlatforms, discoveryErrors };
+    return { devices, succeededPlatforms, succeededSources, discoveryErrors };
   }
 
   async startDevice(

--- a/test/fakes/FakeDeviceManager.ts
+++ b/test/fakes/FakeDeviceManager.ts
@@ -14,8 +14,14 @@ export class FakeDeviceManager implements PlatformDeviceManager {
   failedPlatforms: Set<Platform> = new Set();
   // Individual discovery sources that should report as failed. iOS has two
   // (simctl and devicectl) and either can fail alone (#5683); a source listed
-  // here contributes no devices and is absent from `succeededSources`.
+  // here is absent from `succeededSources`.
   failedSources: Set<DiscoverySource> = new Set();
+  // Failed sources that still replay their last-good listing, which is what
+  // `DevicectlDeviceLister` does for up to 60s behind `complete: false`. A
+  // source listed here contributes its devices while staying absent from
+  // `succeededSources`, so a consumer that mistakes presence for a fresh
+  // observation is caught.
+  retainedSources: Set<DiscoverySource> = new Set();
 
   constructor(images: DeviceInfo[] = [], booted: BootedDevice[] = []) {
     this.deviceImages = images;
@@ -40,10 +46,18 @@ export class FakeDeviceManager implements PlatformDeviceManager {
   }
 
   async getBootedDevices(platform: SomePlatform): Promise<BootedDevice[]> {
-    if (platform === "either") {
-      return this.bootedDevices;
-    }
-    return this.bootedDevices.filter((device) => device.platform === platform);
+    // Honour the same failure configuration as `getBootedDevicesDetailed`, so a
+    // test cannot bypass a configured source failure through this path.
+    return this.bootedDevices.filter((device) => {
+      if (platform !== "either" && device.platform !== platform) {
+        return false;
+      }
+      const source = discoverySourceFor(device.platform, device.deviceId);
+      return (
+        (!this.failedPlatforms.has(device.platform) && !this.failedSources.has(source)) ||
+        this.retainedSources.has(source)
+      );
+    });
   }
 
   async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
@@ -58,10 +72,13 @@ export class FakeDeviceManager implements PlatformDeviceManager {
       const platformSources: DiscoverySource[] =
         p === "android" ? ["android"] : ["ios-simulator", "ios-physical"];
       for (const source of platformSources) {
-        if (sourceFailed(source, p)) {
+        const failed = sourceFailed(source, p);
+        if (failed && !this.retainedSources.has(source)) {
           continue;
         }
-        succeededSources.add(source);
+        if (!failed) {
+          succeededSources.add(source);
+        }
         devices.push(
           ...this.bootedDevices.filter(
             (device) => device.platform === p && discoverySourceFor(p, device.deviceId) === source,

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -365,6 +365,22 @@ describe("DevicectlDeviceLister", () => {
     expect(partial.complete).toBe(false);
   });
 
+  test("a device parsed beside a malformed record is fresh, not retained", async () => {
+    const lister = makeLister({
+      readFile: async () =>
+        JSON.stringify(devicectlPayload([connectedIphone(), { notADevice: true }])),
+    });
+
+    const discovery = await lister.listConnectedDevices();
+
+    // One unreadable record makes the whole sweep non-authoritative, but the
+    // iPhone beside it was still observed just now (#5683). Marking it retained
+    // would make a connected phone unassignable.
+    expect(discovery.complete).toBe(false);
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.retainedDeviceIds ?? new Set()).not.toContain(PHYSICAL_UDID);
+  });
+
   test("retains the last good listing across a failing sweep, then lets it go stale", async () => {
     const timer = new FakeTimer();
     let shouldFail = false;
@@ -389,6 +405,9 @@ describe("DevicectlDeviceLister", () => {
     // sweep is still flagged non-authoritative.
     expect(blipped.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
     expect(blipped.complete).toBe(false);
+    // It is a replay, not an observation: liveness decisions must not read it
+    // as proof the phone is still plugged in (#5683).
+    expect([...(blipped.retainedDeviceIds ?? [])]).toEqual([PHYSICAL_UDID]);
 
     timer.advanceTime(60_000);
     const stale = await lister.listConnectedDevices();


### PR DESCRIPTION
Closes [#5683](https://github.com/kaeawc/auto-mobile/issues/5683).

## The gap

iOS has two independent discovery sources behind one `succeededPlatforms` flag: `simctl` for booted simulators and `devicectl` for connected physical devices (`DevicectlDeviceLister`). Either can fail while the other positively observes a device, and one flag per platform cannot express that.

[#5682](https://github.com/kaeawc/auto-mobile/pull/5682) resolved the resulting tension by tying `succeeded` to simctl alone — clearing it on a devicectl blip made `DevicePool.selectAssignableIdleDevice()` skip every valid idle simulator, a strictly worse failure. That left the mirror case unhandled: when simctl failed but devicectl positively reported a connected iPhone, `getIosLivenessSnapshot()` discarded every returned ID and `assertIdleDeviceAssignable()` rejected the iPhone as unverifiable — a device it had just directly observed.

## What changed

**Completeness is carried per source, and liveness is decided by per-device freshness.**

- New `src/utils/discoverySource.ts`: `DiscoverySource` (`android` | `ios-simulator` | `ios-physical`), `discoverySourceFor()` (routes on the same UDID shape the iOS tooling already uses to choose between simctl and devicectl, so classification cannot drift from the command that ran), and `didSourceSucceedForDevice()`.
- `BootedDeviceDiscovery` gains optional `succeededSources` and `freshDeviceIds`. `discoverBootedIosDevices()` reports the simulator and physical halves separately instead of collapsing them.
- `PhysicalIosDeviceDiscovery` gains `retainedDeviceIds`, marking the replayed half of a sweep.
- `DevicePool`: `IosLivenessSnapshot` carries both source flags, and `bootedDeviceIds` holds only devices observed *this* sweep. An absence is read as `stale` only when the *observing* source completed, and as `unknown` otherwise. `removeDevicesMissingFrom()` gates retention the same way.
- `disconnectMonitor.evaluateDeviceDisconnects()` ages out a candidate only when its own source succeeded, and never ages out a candidate whose platform is unknown.
- Liveness log and error text is now source-aware: a physical iPhone no longer reports as "iOS simulator".

`succeededPlatforms` keeps its pre-#5683 simctl-only meaning, and both new fields are optional, so every platform-level consumer and any fake that does not model them resolves through the aggregate with unchanged behavior.

### Why freshness, not source completeness

`devicectl` reports `complete: false` in two situations that demand **opposite** liveness answers:

| situation | listed devices | correct reading |
|---|---|---|
| failed sweep replaying `lastGood` (60 s window) | stale replay | cannot verify — not assignable |
| partial parse (one malformed record) | freshly parsed | observed just now — assignable |

A source-level boolean cannot separate these, so provenance is tracked per device at the point of discovery — the alternative the issue itself proposed. This is the substance of three review findings on this PR, two of which were real bugs in earlier revisions of the change (one in each direction).

## Acceptance criteria

All four combinations of (simctl ok/failed) x (devicectl ok/failed) are pinned in `test/daemon/perSourceIosLiveness.test.ts` at three levels — the discovery producer, `DevicePool` assignability, and the disconnect monitor — with fakes only, so they hold on a host with no iOS tooling at all. `FakeDeviceManager` gained `failedSources`, `retainedSources`, and `incompleteSources` seams to express each half-failed iOS sweep faithfully.

- ✅ A failed simctl sweep with a successful devicectl sweep leaves a confirmed physical UDID assignable.
- ✅ A failed devicectl sweep with a successful simctl sweep leaves idle simulators assignable (already true; pinned so it stays true).
- ✅ Neither failure mode prunes a device the other source did not observe.
- ✅ A complete sweep that no longer lists a device still prunes it — the fix does not make devices unprunable.
- ✅ A retained (replayed) iPhone is **not** assignable when neither source succeeded.
- ✅ A freshly parsed iPhone **is** assignable even when its source reports incomplete.
- ✅ A candidate with no known platform is never aged out by the disconnect monitor.

## Validation

`bun test` 14524 pass / 0 fail · `bun run build` · `bun run typecheck` (no new errors) · `bun run lint` (no new ratchet violations; the Android branch of `getBootedDevicesDetailed` was extracted to a helper to stay under the complexity threshold) · `bun run format:check` clean.

## Manual verification needed

Everything above is proven with fakes, which is the correct level for this logic — but no part of it has run against real hardware. Worth confirming on a Mac with a physical iPhone attached:

1. With the device connected, induce a simctl failure and check the UDID still binds a session.
2. With the device connected, induce a devicectl failure and check idle simulators still bind, and that the iPhone is retained rather than pruned.

Note for the reviewer: three review rounds each surfaced a genuine correctness bug in this change, and the second was introduced by the fix for the first. The final model (per-device freshness) is the one that survives both directions, but this logic proved subtler than it looks and deserves a real read rather than a rubber stamp.