### PR TITLE
test: stabilize transient daemon liveness checks on Windows

### DIFF
--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -677,9 +677,6 @@ describe("Daemon manager process detection", () => {
   });
 
   test("excludes transient daemon-mode candidates that are gone by liveness re-check", () => {
-    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-transient-test-"));
-    const pidFilePath = join(dir, "daemon.pid");
-    writeDaemonPidFile(pidFilePath, 201);
     const manager = managerWithProcesses(
       [
         {
@@ -693,20 +690,13 @@ describe("Daemon manager process detection", () => {
           command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
         },
       ],
-      { livePids: new Set([201]), pidFilePath },
+      { livePids: new Set([201]) },
     );
 
-    try {
-      expect(manager.findOtherDaemonProcesses(201)).toEqual([]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    expect(manager.findOtherDaemonProcesses(201)).toEqual([]);
   });
 
   test("ignores daemon-mode candidates that are gone by liveness re-check", () => {
-    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-liveness-test-"));
-    const pidFilePath = join(dir, "daemon.pid");
-    writeDaemonPidFile(pidFilePath, 401);
     const manager = managerWithProcesses(
       [
         {
@@ -720,14 +710,10 @@ describe("Daemon manager process detection", () => {
           command: `bun /worktree-a/dist/src/index.js --daemon-mode`,
         },
       ],
-      { livePids: new Set([201]), pidFilePath },
+      { livePids: new Set([201]) },
     );
 
-    try {
-      expect(manager.findOtherDaemonProcesses(201)).toEqual([]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    expect(manager.findOtherDaemonProcesses(201)).toEqual([]);
   });
 
   test("fails closed when the process table cannot be inspected", () => {


### PR DESCRIPTION
## Summary

Removes unused synchronous PID-file setup and recursive temp-directory cleanup from the two transient daemon process liveness tests. Both tests already inject their process table and liveness state, and `findOtherDaemonProcesses()` only uses the explicit active PID, so this preserves the regression coverage while eliminating Windows filesystem cleanup from the timed test path.

## Linked Issue

Closes #5764

## Bug / Regression Context

- **Prior attempts:** The transient-process regression test was added in #2615.
- **Observed symptom:** The `windows-latest` Node TypeScript Build and Test job timed out this exact test at 5416.69 ms against Bun's 5000 ms per-test limit.
- **Repro steps / conditions:** CI-only Windows filesystem scheduling/cleanup delay; the same suite passed on Ubuntu at the same commit.

## Validation

- [x] `bun test test/daemon/manager.test.ts` (41 passing; both affected tests 0.02 ms)
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` (no new errors; baseline gate)
- [x] `bun run format:check`
- [x] Rebased onto latest `main`; no conflicts

## Follow-ups

- [x] No separate follow-up required.