### PR TITLE
feat(ios): videoRecording captures physical iOS devices via the CoreMediaIO helper (#2504)

### DIFF
--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -104,6 +104,11 @@ Platform-specific capture sources:
     `adb exec-out screenrecord -` → ffmpeg path. Raw frames carry no geometry, so ffmpeg is spawned
     on the first frame, which pins `-video_size`; frames that later change size (device rotation)
     are dropped rather than skewing the picture.
+  - Device capture is deliberately **not** fps-throttled by the helper, so the backend paces frames
+    against their capture timestamps to hold the requested rate, and repeats a frame across gap
+    slots (bounded at 2s) so a stalled or idle device does not compress the encoded timeline.
+  - A helper that exits nonzero mid-recording (device unplugged, lost capture session) fails the
+    `stop` with its stderr rather than archiving the truncated file as a complete recording.
   - The AutoMobile UDID is mapped onto the AVFoundation `uniqueID` via the helper's
     `--list-devices` JSON (exact match, then a separator-insensitive match, then the only attached
     device) because `--device-id` matches `uniqueID` exactly.

--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `videoRecording` MCP tool is fully implemented. Supports Android (via `automobile-video.dex` VirtualDisplay + MediaCodec H.264), iOS simulators (via `simctl io recordVideo`), and physical iOS devices (via the CoreMediaIO `screen-capture-helper` piped into FFmpeg). Highlights, archive management, and Unix socket config are all implemented. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `videoRecording` MCP tool is fully implemented. Supports Android (via `automobile-video.dex` VirtualDisplay + MediaCodec H.264), iOS simulators (via `simctl io recordVideo`), and physical iOS devices (via the CoreMediaIO `screen-capture-helper` piped into FFmpeg — implemented and unit-tested, pending on-hardware verification). Highlights, archive management, and Unix socket config are all implemented. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 Optional screen recording for debugging, performance analysis, and CI artifacts. Recording is off by default
 and optimized for low overhead with a low-quality default preset.
@@ -107,6 +107,10 @@ Platform-specific capture sources:
   - The AutoMobile UDID is mapped onto the AVFoundation `uniqueID` via the helper's
     `--list-devices` JSON (exact match, then a separator-insensitive match, then the only attached
     device) because `--device-id` matches `uniqueID` exactly.
+  - **Verification status:** the backend is covered by unit tests against fakes (helper frames,
+    FFmpeg process, `--list-devices` output); end-to-end capture has not yet been confirmed on
+    physical hardware, so treat physical-device support as implemented-but-unverified until a
+    recording succeeds on a real iPhone/iPad (issue #2504).
   - One-time prerequisite: the device must be connected over USB with "Trust This Computer"
     accepted, and macOS may prompt once for capture access. `stop` closes ffmpeg's stdin (rather
     than signalling it) so the MP4 `moov` atom is finalized.

--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -105,8 +105,14 @@ Platform-specific capture sources:
     on the first frame, which pins `-video_size`; frames that later change size (device rotation)
     are dropped rather than skewing the picture.
   - Device capture is deliberately **not** fps-throttled by the helper, so the backend paces frames
-    against their capture timestamps to hold the requested rate, and repeats a frame across gap
-    slots (bounded at 2s) so a stalled or idle device does not compress the encoded timeline.
+    against their capture timestamps to hold the requested rate, advancing the deadline by whole
+    elapsed slots (rebasing it on each arrival loses sub-slot lateness and drifts below the target
+    with integer-millisecond timestamps). Gap slots — mid-recording and between the last frame and
+    `stop` — are padded with the held picture, bounded at 2s, so a stalled or idle device does not
+    compress the encoded timeline.
+  - Encoder backpressure is bounded in whole frames (`writableLength` vs `frameBytes`), not the
+    stream's own `writableNeedDrain`: a pipe's 16KB high-water mark is exceeded by every
+    multi-megabyte BGRA frame, so the stream signal would read as permanent congestion.
   - A helper that exits nonzero mid-recording (device unplugged, lost capture session) fails the
     `stop` with its stderr rather than archiving the truncated file as a complete recording.
   - The AutoMobile UDID is mapped onto the AVFoundation `uniqueID` via the helper's

--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `videoRecording` MCP tool is fully implemented. Supports Android (via `automobile-video.dex` VirtualDisplay + MediaCodec H.264) and iOS simulator (via `simctl io recordVideo`). Highlights, archive management, and Unix socket config are all implemented. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `videoRecording` MCP tool is fully implemented. Supports Android (via `automobile-video.dex` VirtualDisplay + MediaCodec H.264), iOS simulators (via `simctl io recordVideo`), and physical iOS devices (via the CoreMediaIO `screen-capture-helper` piped into FFmpeg). Highlights, archive management, and Unix socket config are all implemented. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 Optional screen recording for debugging, performance analysis, and CI artifacts. Recording is off by default
 and optimized for low overhead with a low-quality default preset.
@@ -90,10 +90,26 @@ Platform-specific capture sources:
 - Android:
   - Physical devices: `adb exec-out screenrecord` (pipe to ffmpeg when transcoding or resizing).
   - Emulators: FFmpeg screen/window capture for higher throughput when ADB capture is slow.
-- iOS (simulator only, macOS):
+- iOS simulators (macOS):
   - Prefer `simctl io recordVideo` for simulator-native capture.
   - Unscaled simulator recordings are finalized with an FFmpeg stream-copy remux from `.mov` to `.mp4`; this avoids a lossy re-encode and still applies `maxDuration` when a caller provides one.
   - Fallback to FFmpeg capture when available and needed for cross-platform parity.
+- iOS physical devices (macOS):
+  - `xcrun devicectl` has no screen-recording verb and `simctl io recordVideo` only drives
+    Simulators, so a physical iPhone/iPad is captured through the Swift `screen-capture-helper`:
+    CoreMediaIO's `kCMIOHardwarePropertyAllowScreenCaptureDevices` exposes the USB-connected
+    device as a muxed `AVCaptureDevice`, and the helper streams its BGRA frames to stdout.
+  - `IosPhysicalVideoCaptureBackend` pipes those frames into `ffmpeg -f rawvideo -pixel_format bgra`
+    (`h264_videotoolbox`, falling back to `libx264`), structurally the same handoff as the Android
+    `adb exec-out screenrecord -` → ffmpeg path. Raw frames carry no geometry, so ffmpeg is spawned
+    on the first frame, which pins `-video_size`; frames that later change size (device rotation)
+    are dropped rather than skewing the picture.
+  - The AutoMobile UDID is mapped onto the AVFoundation `uniqueID` via the helper's
+    `--list-devices` JSON (exact match, then a separator-insensitive match, then the only attached
+    device) because `--device-id` matches `uniqueID` exactly.
+  - One-time prerequisite: the device must be connected over USB with "Trust This Computer"
+    accepted, and macOS may prompt once for capture access. `stop` closes ffmpeg's stdin (rather
+    than signalling it) so the MP4 `moov` atom is finalized.
 
 ## Storage and retention
 

--- a/src/features/screen-stream/screenCaptureHelperPath.ts
+++ b/src/features/screen-stream/screenCaptureHelperPath.ts
@@ -1,0 +1,50 @@
+import { existsSync } from "node:fs";
+import { ActionableError } from "../../models/ActionableError";
+
+/** Absolute path to a locally built `screen-capture-helper`, for development. */
+export const IOS_SCREEN_CAPTURE_HELPER_ENV = "AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER";
+/** Legacy spelling of {@link IOS_SCREEN_CAPTURE_HELPER_ENV}, still honored. */
+export const IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS = "AUTO_MOBILE_IOS_SCREEN_CAPTURE_HELPER";
+
+export interface IosScreenCaptureHelperPathResolverOptions {
+  env?: NodeJS.ProcessEnv;
+  exists?: (candidate: string) => boolean;
+}
+
+/**
+ * The developer's helper-binary override, under either env spelling. Daemon
+ * startup skips the release prefetch when this is set, so every consumer of the
+ * helper has to consult it before falling back to the pinned release asset.
+ */
+export function readScreenCaptureHelperEnvOverride(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return env[IOS_SCREEN_CAPTURE_HELPER_ENV] ?? env[IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS];
+}
+
+/**
+ * Resolve an explicitly configured helper path, falling back to the env
+ * override. Throws when no candidate exists on disk — callers that also accept
+ * the released helper should try {@link ScreenCaptureHelperProvider} instead of
+ * treating this as the only source.
+ */
+export function resolveIosScreenCaptureHelperPath(
+  explicitPath?: string,
+  options: IosScreenCaptureHelperPathResolverOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const exists = options.exists ?? existsSync;
+  const candidates = [explicitPath, readScreenCaptureHelperEnvOverride(env)].filter(
+    (candidate): candidate is string => Boolean(candidate),
+  );
+
+  for (const candidate of candidates) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new ActionableError(
+    `No executable screen-capture-helper was found at the configured path. Set ${IOS_SCREEN_CAPTURE_HELPER_ENV} to the absolute path of a local development build.`,
+  );
+}

--- a/src/features/video/HybridVideoCaptureBackend.ts
+++ b/src/features/video/HybridVideoCaptureBackend.ts
@@ -8,42 +8,36 @@ import type {
   VideoCaptureConfig,
 } from "./VideoRecorderService";
 import { FfmpegVideoProcessingBackend } from "./FfmpegVideoProcessingBackend";
+import { IosPhysicalVideoCaptureBackend } from "./IosPhysicalVideoCaptureBackend";
 import { PlatformVideoCaptureBackend } from "./PlatformVideoCaptureBackend";
+
+type HybridBackendKind = "ffmpeg" | "platform" | "ios-physical";
 
 interface HybridBackendHandle {
   kind: "hybrid";
-  backend: "ffmpeg" | "platform";
+  backend: HybridBackendKind;
   handle: RecordingHandle;
 }
 
 export class HybridVideoCaptureBackend implements VideoCaptureBackend {
   private ffmpegBackend: VideoCaptureBackend;
   private platformBackend: VideoCaptureBackend;
+  private physicalIosBackend: VideoCaptureBackend;
 
   constructor(
     ffmpegBackend: VideoCaptureBackend = new FfmpegVideoProcessingBackend(),
     platformBackend: VideoCaptureBackend = new PlatformVideoCaptureBackend(),
+    physicalIosBackend: VideoCaptureBackend = new IosPhysicalVideoCaptureBackend(),
   ) {
     this.ffmpegBackend = ffmpegBackend;
     this.platformBackend = platformBackend;
+    this.physicalIosBackend = physicalIosBackend;
   }
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
     const device = config.device;
     if (!device) {
       throw new ActionableError("Device is required to start video recording.");
-    }
-
-    // Physical iOS devices are now discoverable and assignable through DevicePool, but the
-    // iOS video path routes every iOS device to FfmpegVideoProcessingBackend.startIos →
-    // `simctl io <deviceId> recordVideo`, which only drives Simulators. Reject a physical
-    // iPhone here (branching on the UDID type before backend selection) with an actionable
-    // error, rather than surfacing a confusing simctl transport failure.
-    if (device.platform === "ios" && isIosPhysicalUdid(device.deviceId)) {
-      throw new ActionableError(
-        `Video recording is not supported on physical iOS devices (${device.deviceId}); ` +
-          "it currently requires a Simulator (simctl io recordVideo).",
-      );
     }
 
     const backend = this.selectBackend(device);
@@ -53,7 +47,7 @@ export class HybridVideoCaptureBackend implements VideoCaptureBackend {
       ...handle,
       backendHandle: {
         kind: "hybrid",
-        backend: backend === this.ffmpegBackend ? "ffmpeg" : "platform",
+        backend: this.backendKind(backend),
         handle,
       },
     };
@@ -65,11 +59,7 @@ export class HybridVideoCaptureBackend implements VideoCaptureBackend {
       throw new Error("Missing backend handle for hybrid video recording.");
     }
 
-    if (hybridHandle.backend === "ffmpeg") {
-      return this.ffmpegBackend.stop(hybridHandle.handle);
-    }
-
-    return this.platformBackend.stop(hybridHandle.handle);
+    return this.backendFor(hybridHandle.backend).stop(hybridHandle.handle);
   }
 
   async forceStop(handle: RecordingHandle): Promise<void> {
@@ -77,16 +67,33 @@ export class HybridVideoCaptureBackend implements VideoCaptureBackend {
     if (!hybridHandle || hybridHandle.kind !== "hybrid") {
       throw new Error("Missing backend handle for hybrid video recording.");
     }
-    const backend = hybridHandle.backend === "ffmpeg" ? this.ffmpegBackend : this.platformBackend;
+    const backend = this.backendFor(hybridHandle.backend);
     if (!backend.forceStop) {
       throw new Error("Selected video capture backend does not support force stopping recordings.");
     }
     await backend.forceStop(hybridHandle.handle);
   }
 
+  private backendKind(backend: VideoCaptureBackend): HybridBackendKind {
+    if (backend === this.ffmpegBackend) {
+      return "ffmpeg";
+    }
+    return backend === this.physicalIosBackend ? "ios-physical" : "platform";
+  }
+
+  private backendFor(kind: HybridBackendKind): VideoCaptureBackend {
+    if (kind === "ffmpeg") {
+      return this.ffmpegBackend;
+    }
+    return kind === "ios-physical" ? this.physicalIosBackend : this.platformBackend;
+  }
+
   private selectBackend(device: BootedDevice): VideoCaptureBackend {
     if (device.platform === "ios") {
-      return this.ffmpegBackend;
+      // simctl io recordVideo only drives Simulators, and devicectl has no
+      // screen-recording verb, so a physical iPhone/iPad is captured through the
+      // CoreMediaIO screen-capture-helper instead (issue #2504).
+      return isIosPhysicalUdid(device.deviceId) ? this.physicalIosBackend : this.ffmpegBackend;
     }
 
     if (device.platform === "android") {

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -133,12 +133,16 @@ interface CaptureState {
   framesPacedOut: number;
   /** Repeated frames written to keep a capture gap at its real duration. */
   framesGapFilled: number;
+  /** Last payload written, repeated across gap slots that precede a new frame. */
+  lastPayload?: Buffer;
   /** Gap slots left unpadded, so the output is shorter than wall clock. */
   framesGapTruncated: number;
   framesWritten: number;
   framesDropped: number;
   helperStderr: string[];
   helperExit?: { code: number | null; signal: NodeJS.Signals | null };
+  /** First error emitted by the helper process (spawn ENOENT/EACCES, etc.). */
+  helperError?: Error;
 }
 
 /**
@@ -223,8 +227,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       state.helperExit = info;
     });
     helper.on("error", (error) => {
-      // The helper process failing is surfaced from stop() with the stderr tail;
-      // an unhandled 'error' listener would otherwise crash the daemon.
+      // A spawn failure (ENOENT/EACCES on the resolved binary) arrives here
+      // asynchronously, after start() has already returned, and may never be
+      // followed by an 'exit'. Keep the first one so stop() can report the real
+      // cause instead of a misleading "connect and trust the device" message. An
+      // unhandled 'error' listener would also crash the daemon.
+      state.helperError ??= error instanceof Error ? error : new Error(String(error));
       logger.warn(`[IosPhysicalVideo] capture helper error: ${errorMessage(error)}`);
     });
     helper.on("frame", (frame) => this.onFrame(frame, state, config));
@@ -336,17 +344,37 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       state.framesDropped += 1;
       return;
     }
+    this.writeFrameCopies(frame, state, encoder.stdin, copies);
+  }
+
+  /**
+   * Write the frame into its own slot, preceded by repeats of the previous
+   * picture for any slots the capture gap skipped. Padding with the NEW frame
+   * would move a visual transition earlier than it actually happened.
+   */
+  private writeFrameCopies(
+    frame: DecodedFrame,
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+    copies: number,
+  ): void {
     const payload = packFrame(frame);
+    const fillPayload = state.lastPayload ?? payload;
     for (let copy = 0; copy < copies; copy++) {
-      // Stop padding the moment the encoder falls behind: gap fill must never be
-      // the thing that congests it.
-      if (copy > 0 && encoder.stdin.writableNeedDrain) {
-        state.framesGapTruncated += copies - copy;
-        break;
+      const isCurrentFrameSlot = copy === copies - 1;
+      // Stop padding the moment the encoder falls behind — gap fill must never
+      // be the thing that congests it — but always emit the real frame.
+      if (copy > 0 && !isCurrentFrameSlot && stdin.writableNeedDrain) {
+        state.framesGapTruncated += copies - copy - 1;
+        stdin.write(payload);
+        state.framesWritten += 1;
+        state.lastPayload = payload;
+        return;
       }
-      encoder.stdin.write(payload);
+      stdin.write(isCurrentFrameSlot ? payload : fillPayload);
       state.framesWritten += 1;
     }
+    state.lastPayload = payload;
   }
 
   /**
@@ -552,6 +580,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
 
   private buildNoFramesMessage(state: CaptureState): string {
     const stderr = state.helperStderr.join("").trim();
+    if (state.helperError) {
+      return (
+        `The iOS capture helper could not be run, so no recording was produced: ${errorMessage(state.helperError)}.` +
+        (stderr ? `\nscreen-capture-helper: ${stderr}` : "")
+      );
+    }
     const exit = state.helperExit
       ? ` (helper exited code=${state.helperExit.code ?? "null"} signal=${state.helperExit.signal ?? "null"})`
       : "";
@@ -639,6 +673,12 @@ function throwIfCaptureStartAborted(abortSignal: AbortSignal | undefined): void 
   }
 }
 
+/** Largest even value <= `value`, floored at 2 so a scale filter stays valid. */
+function evenFloor(value: number): number {
+  const floored = Math.floor(value);
+  return Math.max(2, floored % 2 === 0 ? floored : floored - 1);
+}
+
 /** Lowercased, separator-free UDID for cross-vocabulary comparison. */
 function normalizeUdid(value: string): string {
   return value.replace(/-/g, "").toLowerCase();
@@ -685,8 +725,15 @@ export function buildRawVideoFfmpegArgs(
     "pipe:0",
   ];
 
-  if (config.resolution) {
-    args.push("-vf", `scale=${config.resolution.width}:${config.resolution.height}`);
+  // yuv420p subsamples chroma 2x2, so FFmpeg refuses an odd width or height —
+  // and iPhone panels really are odd (the 1179px-wide fixtures in this repo).
+  // The raw input keeps its true geometry (`-video_size` describes the actual
+  // byte layout and must not be rounded); evenness is imposed on the OUTPUT.
+  const requested = config.resolution;
+  if (requested) {
+    args.push("-vf", `scale=${evenFloor(requested.width)}:${evenFloor(requested.height)}`);
+  } else if (width % 2 !== 0 || height % 2 !== 0) {
+    args.push("-vf", `scale=${evenFloor(width)}:${evenFloor(height)}`);
   }
 
   args.push("-c:v", encoderName);

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -143,6 +143,10 @@ interface CaptureState {
   helperExit?: { code: number | null; signal: NodeJS.Signals | null };
   /** First error emitted by the helper process (spawn ENOENT/EACCES, etc.). */
   helperError?: Error;
+  /** True once we asked the helper to stop, so its exit is expected. */
+  stopRequested: boolean;
+  /** Whether the observed exit happened after we asked the helper to stop. */
+  helperExitWasRequested: boolean;
 }
 
 /**
@@ -210,6 +214,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       framesPacedOut: 0,
       framesGapFilled: 0,
       framesGapTruncated: 0,
+      stopRequested: false,
+      helperExitWasRequested: false,
       helperStderr: [],
     };
     const helper = this.createHelper({
@@ -225,6 +231,9 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
     helper.on("exit", (info) => {
       state.helperExit = info;
+      // Classify at the moment of exit: afterwards, `stopRequested` cannot tell
+      // an exit we caused from one that raced our stop.
+      state.helperExitWasRequested = state.stopRequested;
     });
     helper.on("error", (error) => {
       // A spawn failure (ENOENT/EACCES on the resolved binary) arrives here
@@ -237,7 +246,15 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
     helper.on("frame", (frame) => this.onFrame(frame, state, config));
 
-    await helper.start();
+    try {
+      await helper.start();
+    } catch (error) {
+      // The frame listener is already wired, so a helper that emitted a frame
+      // before rejecting may have spawned ffmpeg. No handle is returned here, so
+      // nothing else could ever stop it.
+      await this.abandonStartedCapture(helper, state);
+      throw error;
+    }
 
     if (abortSignal?.aborted) {
       // Shutdown landed while the helper was spawning: tear it down here, or the
@@ -266,6 +283,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
     const { helper, state, config } = backendHandle;
 
+    state.stopRequested = true;
     await helper.stop();
 
     const encoder = state.encoder;
@@ -326,24 +344,26 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       return;
     }
 
-    const copies = this.admitForPacing(frame, state, config.fps);
-    if (copies === 0) {
-      return;
-    }
-
     const encoder = state.encoder;
     if (!encoder?.stdin || encoder.stdin.writableEnded) {
       state.framesDropped += 1;
       return;
     }
+    // Congestion is checked BEFORE admission on purpose. Frames arrive from an
+    // event emitter, so there is no upstream backpressure to apply and buffering
+    // would grow without bound — but consuming the pacing slot for a frame that
+    // never reaches stdin would silently shorten the timeline. Dropping before
+    // admission leaves the slot owed, so the next frame pads it as a gap.
     if (encoder.stdin.writableNeedDrain) {
-      // Frames arrive from an event emitter, so there is no upstream backpressure
-      // to apply: buffering them while the encoder is behind would grow without
-      // bound over a long capture. Dropping the newest frame is what the helper's
-      // own bounded handoff does, and keeps latency from compounding.
       state.framesDropped += 1;
       return;
     }
+
+    const copies = this.admitForPacing(frame, state, config.fps);
+    if (copies === 0) {
+      return;
+    }
+
     this.writeFrameCopies(frame, state, encoder.stdin, copies);
   }
 
@@ -502,25 +522,37 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   }
 
   /**
-   * A helper that exited nonzero on its own (device unplugged, AVCaptureSession
-   * failure) truncates the capture. ffmpeg still finalizes the frames it did
-   * receive and exits 0, so without this check a partial recording would be
-   * archived as complete. Checked after the encoder is finalized, so the file on
-   * disk is at least playable for diagnosis.
+   * A helper that terminated on its own truncates the capture: the device was
+   * unplugged, the capture session died, or the process crashed. ffmpeg still
+   * finalizes the frames it did receive and exits 0, so without this check a
+   * partial recording would be archived as complete. Checked after the encoder
+   * is finalized, so the file on disk stays playable for diagnosis.
    *
-   * Our own `stop()` sends SIGTERM, which surfaces as `signal`, not a nonzero
-   * exit code — only a code the helper chose itself counts as a failure.
+   * The discriminator is whether we had asked the helper to stop yet — not the
+   * exit code. Our own `stop()` produces `{ code: null, signal: "SIGTERM" }`,
+   * which is indistinguishable by shape from an external `SIGABRT` crash.
    */
   private assertHelperSucceeded(state: CaptureState, outputPath: string): void {
+    const stderr = state.helperStderr.join("").trim();
+    const stderrSuffix = stderr ? `\nscreen-capture-helper: ${stderr}` : "";
+
+    if (state.helperError) {
+      throw new ActionableError(
+        `The iOS capture helper failed during the recording, so ${outputPath} is truncated: ` +
+          `${errorMessage(state.helperError)}.${stderrSuffix}`,
+      );
+    }
+
     const exit = state.helperExit;
-    if (!exit || exit.code === null || exit.code === 0) {
+    if (!exit || state.helperExitWasRequested) {
       return;
     }
-    const stderr = state.helperStderr.join("").trim();
+    const cause =
+      exit.signal !== null ? `signal ${exit.signal}` : `exit code ${exit.code ?? "null"}`;
     throw new ActionableError(
-      `The iOS capture helper exited with code ${exit.code} during the recording, so ${outputPath} ` +
-        "is truncated. The device was most likely unplugged or lost its capture session." +
-        (stderr ? `\nscreen-capture-helper: ${stderr}` : ""),
+      `The iOS capture helper terminated with ${cause} before the recording was stopped, so ` +
+        `${outputPath} is truncated. The device was most likely unplugged or lost its capture ` +
+        `session.${stderrSuffix}`,
     );
   }
 
@@ -529,6 +561,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     helper: PhysicalIosCaptureHelper,
     state: CaptureState,
   ): Promise<void> {
+    state.stopRequested = true;
     try {
       await helper.stop();
     } catch (error) {

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -47,6 +47,16 @@ export const IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS = 30000;
  */
 const MAX_GAP_FILL_SECONDS = 2;
 
+/**
+ * How many whole frames of encoder input may sit buffered before frames are
+ * dropped. The bound has to be expressed in FRAMES, not in the stream's own
+ * `writableNeedDrain`: a pipe's default high-water mark is 16KB, while one
+ * physical-device BGRA frame is megabytes (1179x2556x4 is ~12MB), so
+ * `writableNeedDrain` is true after every single write and would read as
+ * permanent congestion — dropping nearly every frame of a real recording.
+ */
+const MAX_BUFFERED_FRAMES = 2;
+
 /** Stderr lines retained from the helper for failure diagnostics. */
 const HELPER_STDERR_TAIL = 20;
 
@@ -135,6 +145,14 @@ interface CaptureState {
   framesGapFilled: number;
   /** Last payload written, repeated across gap slots that precede a new frame. */
   lastPayload?: Buffer;
+  /** Bytes in one packed frame; the unit for the encoder-buffer budget. */
+  frameBytes?: number;
+  /**
+   * Writes still owed to the encoder, in order. Repeats share one payload
+   * reference and carry a count, so a long gap costs a counter rather than N
+   * copies of a multi-megabyte buffer.
+   */
+  pendingWrites: { payload: Buffer; count: number }[];
   /** Gap slots left unpadded, so the output is shorter than wall clock. */
   framesGapTruncated: number;
   framesWritten: number;
@@ -214,6 +232,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       framesPacedOut: 0,
       framesGapFilled: 0,
       framesGapTruncated: 0,
+      pendingWrites: [],
       stopRequested: false,
       helperExitWasRequested: false,
       helperStderr: [],
@@ -291,6 +310,11 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       throw new ActionableError(this.buildNoFramesMessage(state));
     }
 
+    if (encoder.stdin) {
+      this.flushPendingWrites(state, encoder.stdin);
+    }
+    this.discardPendingWrites(state);
+
     // Closing stdin is what makes ffmpeg write the moov atom; a SIGKILL here
     // would leave an unplayable file, so wait for a clean exit instead.
     encoder.stdin?.end();
@@ -336,6 +360,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     const { width, height } = frame.header;
     if (!state.geometry) {
       state.geometry = { width, height };
+      state.frameBytes = width * height * BGRA_BYTES_PER_PIXEL;
       this.startEncoder(state, config, width, height);
     } else if (state.geometry.width !== width || state.geometry.height !== height) {
       // rawvideo has no per-frame geometry: a differently sized frame would be
@@ -354,7 +379,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     // would grow without bound — but consuming the pacing slot for a frame that
     // never reaches stdin would silently shorten the timeline. Dropping before
     // admission leaves the slot owed, so the next frame pads it as a gap.
-    if (encoder.stdin.writableNeedDrain) {
+    if (this.isEncoderCongested(state, encoder.stdin)) {
       state.framesDropped += 1;
       return;
     }
@@ -368,9 +393,13 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   }
 
   /**
-   * Write the frame into its own slot, preceded by repeats of the previous
-   * picture for any slots the capture gap skipped. Padding with the NEW frame
-   * would move a visual transition earlier than it actually happened.
+   * Queue the frame's own slot, preceded by repeats of the previous picture for
+   * any slots the capture gap skipped. Padding with the NEW frame would move a
+   * visual transition earlier than it actually happened.
+   *
+   * Writes go through a queue so bounded padding survives the encoder consuming
+   * stdin asynchronously: a synchronous truncate would collapse almost every gap
+   * once frames are big enough to fill the pipe buffer in one write.
    */
   private writeFrameCopies(
     frame: DecodedFrame,
@@ -379,22 +408,60 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     copies: number,
   ): void {
     const payload = packFrame(frame);
-    const fillPayload = state.lastPayload ?? payload;
-    for (let copy = 0; copy < copies; copy++) {
-      const isCurrentFrameSlot = copy === copies - 1;
-      // Stop padding the moment the encoder falls behind — gap fill must never
-      // be the thing that congests it — but always emit the real frame.
-      if (copy > 0 && !isCurrentFrameSlot && stdin.writableNeedDrain) {
-        state.framesGapTruncated += copies - copy - 1;
-        stdin.write(payload);
-        state.framesWritten += 1;
-        state.lastPayload = payload;
-        return;
-      }
-      stdin.write(isCurrentFrameSlot ? payload : fillPayload);
-      state.framesWritten += 1;
+    const pads = copies - 1;
+    if (pads > 0) {
+      state.pendingWrites.push({ payload: state.lastPayload ?? payload, count: pads });
     }
+    state.pendingWrites.push({ payload, count: 1 });
     state.lastPayload = payload;
+    this.flushPendingWrites(state, stdin);
+  }
+
+  /** Drain the write queue up to the buffered-frame budget. */
+  private flushPendingWrites(
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+  ): void {
+    if (stdin.writableEnded) {
+      state.pendingWrites = [];
+      return;
+    }
+    while (state.pendingWrites.length > 0 && !this.isEncoderCongested(state, stdin)) {
+      const next = state.pendingWrites[0];
+      stdin.write(next.payload);
+      state.framesWritten += 1;
+      next.count -= 1;
+      if (next.count === 0) {
+        state.pendingWrites.shift();
+      }
+    }
+  }
+
+  /**
+   * Give up on writes still queued when the recording ends: they would land
+   * after the encoder's input closed. Counted so the shortfall is reported.
+   */
+  private discardPendingWrites(state: CaptureState): void {
+    const owed = state.pendingWrites.reduce((total, entry) => total + entry.count, 0);
+    if (owed > 0) {
+      state.framesGapTruncated += owed;
+      state.pendingWrites = [];
+    }
+  }
+
+  /**
+   * True when the encoder already holds {@link MAX_BUFFERED_FRAMES} frames of
+   * input. Deliberately not `writableNeedDrain` — see {@link MAX_BUFFERED_FRAMES}.
+   */
+  private isEncoderCongested(
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+  ): boolean {
+    const frameBytes = state.frameBytes;
+    if (!frameBytes) {
+      return stdin.writableNeedDrain;
+    }
+    return stdin.writableLength >= frameBytes * MAX_BUFFERED_FRAMES;
   }
 
   /**
@@ -454,6 +521,11 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
     state.encoder = started.process;
     state.encoderTracker = started.tracker;
+    const stdin = started.process.stdin;
+    stdin?.on("drain", () => {
+      // The encoder consumed a frame: release whatever padding is still owed.
+      this.flushPendingWrites(state, stdin);
+    });
     started.process.stdin?.on("error", (error: Error) => {
       // ffmpeg exiting first closes stdin; the helper keeps writing until it is
       // stopped, so EPIPE here is expected rather than a fault to surface.

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -327,6 +327,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       recordingId: captureConfig.recordingId,
       outputPath: captureConfig.outputPath,
       startedAt: captureConfig.startedAt,
+      effectiveConfig: captureConfig,
       backendHandle: {
         kind: "ios-physical",
         helper,

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -17,6 +17,11 @@ import {
   type IosScreenCaptureHelperOptions,
 } from "../screen-stream/IOSScreenCaptureHelper";
 import { ScreenCaptureHelperProvider } from "../screen-stream/ScreenCaptureHelperProvider";
+import {
+  IOS_SCREEN_CAPTURE_HELPER_ENV,
+  readScreenCaptureHelperEnvOverride,
+  resolveIosScreenCaptureHelperPath,
+} from "../screen-stream/screenCaptureHelperPath";
 import type {
   RecordingHandle,
   RecordingResult,
@@ -94,6 +99,10 @@ export interface IosPhysicalVideoCaptureBackendOptions {
   /** Injectable so file-size reporting stays device- and disk-free in tests. */
   fileSize?: (filePath: string) => Promise<number | undefined>;
   encoderFinalizeTimeoutMs?: number;
+  /** Env seam so the developer override can be exercised without touching process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Existence seam for the overridden helper path. */
+  helperPathExists?: (candidate: string) => boolean;
 }
 
 interface IosPhysicalBackendHandle {
@@ -111,6 +120,10 @@ interface CaptureState {
   geometry?: { width: number; height: number };
   /** Encoder chosen up front so the first frame can spawn ffmpeg synchronously. */
   encoderName: string;
+  /** Capture timestamp the next admitted frame must reach, for fps pacing. */
+  nextFrameDueMs?: number;
+  /** Frames discarded purely to hold the declared cadence (not a fault). */
+  framesPacedOut: number;
   framesWritten: number;
   framesDropped: number;
   helperStderr: string[];
@@ -137,6 +150,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   private readonly platformProvider: () => NodeJS.Platform;
   private readonly fileSize: (filePath: string) => Promise<number | undefined>;
   private readonly encoderFinalizeTimeoutMs: number;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly helperPathExists?: (candidate: string) => boolean;
 
   constructor(options: IosPhysicalVideoCaptureBackendOptions = {}) {
     this.ffmpegClient = options.ffmpegClient ?? new DefaultFfmpegClient();
@@ -148,6 +163,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     this.fileSize = options.fileSize ?? getFileSize;
     this.encoderFinalizeTimeoutMs =
       options.encoderFinalizeTimeoutMs ?? IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS;
+    this.env = options.env ?? process.env;
+    this.helperPathExists = options.helperPathExists;
   }
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
@@ -175,6 +192,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       encoderName,
       framesWritten: 0,
       framesDropped: 0,
+      framesPacedOut: 0,
       helperStderr: [],
     };
     const helper = this.createHelper({
@@ -247,6 +265,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       });
     }
 
+    this.assertEncoderSucceeded(state, handle.outputPath);
+
     const sizeBytes = await this.fileSize(handle.outputPath);
     logger.info(
       `[IosPhysicalVideo] recording ${handle.recordingId} wrote ${state.framesWritten} frame(s) to ${handle.outputPath}.`,
@@ -254,7 +274,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     if (state.framesDropped > 0) {
       logger.warn(
         `[IosPhysicalVideo] dropped ${state.framesDropped} frame(s) whose geometry differed from the locked ` +
-          `${state.geometry?.width}x${state.geometry?.height} capture size (device rotation is not re-negotiated mid-recording).`,
+          `${state.geometry?.width}x${state.geometry?.height} capture size, or arrived while the encoder was congested.`,
+      );
+    }
+    if (state.framesPacedOut > 0) {
+      logger.debug(
+        `[IosPhysicalVideo] paced out ${state.framesPacedOut} frame(s) to hold the requested cadence.`,
       );
     }
 
@@ -292,6 +317,10 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       return;
     }
 
+    if (!this.admitForPacing(frame, state, config.fps)) {
+      return;
+    }
+
     const encoder = state.encoder;
     if (!encoder?.stdin || encoder.stdin.writableEnded) {
       state.framesDropped += 1;
@@ -307,6 +336,33 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
     encoder.stdin.write(packFrame(frame));
     state.framesWritten += 1;
+  }
+
+  /**
+   * Hold the declared cadence. AVFoundation device capture is deliberately not
+   * FPS-throttled by the helper (`DeviceCaptureSession.deviceFPS` documents
+   * this), so a device pushing 30 or 60 fps into a `-framerate 15` rawvideo
+   * stream would timestamp every frame at 15 fps — the recording would play back
+   * 2-4x slow and `-t` would cut it short. Admit a frame only once its capture
+   * timestamp reaches the next scheduled slot.
+   */
+  private admitForPacing(frame: DecodedFrame, state: CaptureState, fps: number): boolean {
+    const intervalMs = 1000 / fps;
+    const timestampMs = frame.header.timestampMs;
+    if (state.nextFrameDueMs === undefined) {
+      state.nextFrameDueMs = timestampMs + intervalMs;
+      return true;
+    }
+    if (timestampMs < state.nextFrameDueMs) {
+      state.framesPacedOut += 1;
+      return false;
+    }
+    // Advance by whole intervals so the cadence does not drift, but resync after
+    // a gap (helper stall, or a device that idles while the screen is static)
+    // rather than admitting a burst to "catch up".
+    const nextSlot = state.nextFrameDueMs + intervalMs;
+    state.nextFrameDueMs = nextSlot > timestampMs ? nextSlot : timestampMs + intervalMs;
+    return true;
   }
 
   private startEncoder(
@@ -331,6 +387,33 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       // stopped, so EPIPE here is expected rather than a fault to surface.
       logger.debug(`[IosPhysicalVideo] encoder stdin error (expected on encoder exit): ${error}`);
     });
+  }
+
+  /**
+   * A nonzero ffmpeg exit (full disk, rejected encoder settings) leaves a
+   * truncated file behind. Returning a successful RecordingResult would let the
+   * service archive it as complete, so surface the encoder's own stderr instead
+   * — the simulator path checks its tracker the same way.
+   */
+  private assertEncoderSucceeded(state: CaptureState, outputPath: string): void {
+    const exitState = state.encoderTracker?.exitState;
+    if (!exitState) {
+      return;
+    }
+    const failed =
+      (exitState.exitCode !== undefined &&
+        exitState.exitCode !== null &&
+        exitState.exitCode !== 0) ||
+      Boolean(exitState.signal);
+    if (!failed) {
+      return;
+    }
+    const stderr = state.encoderTracker?.stderr.join("").trim();
+    throw new ActionableError(
+      `FFmpeg failed to finalize the physical iOS recording at ${outputPath} ` +
+        `(exitCode: ${exitState.exitCode ?? "null"}, signal: ${exitState.signal ?? "null"}).` +
+        (stderr ? `\nffmpeg: ${stderr}` : ""),
+    );
   }
 
   /** Stop a capture that was cancelled between spawn and handle hand-off. */
@@ -400,12 +483,23 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   }
 
   private async resolveHelperBinary(): Promise<string> {
+    // Daemon startup skips the release prefetch when the developer override is
+    // set, so a local build must win over the pinned release asset — the same
+    // order IosH264Source.resolveHelperPath() uses.
+    const override = readScreenCaptureHelperEnvOverride(this.env);
+    if (override) {
+      return resolveIosScreenCaptureHelperPath(override, {
+        env: this.env,
+        exists: this.helperPathExists,
+      });
+    }
+
     const binaryPath = await this.helperProvider.ensure();
     if (!binaryPath) {
       throw new ActionableError(
         "Physical iOS video recording requires the signed screen-capture-helper from the matching GitHub Release, " +
           "which could not be resolved. For local development, build it with `bash scripts/ios/swift-build.sh` and " +
-          "set AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER to the resulting absolute path.",
+          `set ${IOS_SCREEN_CAPTURE_HELPER_ENV} to the resulting absolute path.`,
       );
     }
     return binaryPath;

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -429,7 +429,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     // would grow without bound — but consuming the pacing slot for a frame that
     // never reaches stdin would silently shorten the timeline. Dropping before
     // admission leaves the slot owed, so the next frame pads it as a gap.
-    if (this.isEncoderCongested(state, encoder.stdin)) {
+    if (this.isBackloggedForAdmission(state, encoder.stdin)) {
       state.framesDropped += 1;
       return;
     }
@@ -547,6 +547,22 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * True when the encoder already holds {@link MAX_BUFFERED_FRAMES} frames of
    * input. Deliberately not `writableNeedDrain` — see {@link MAX_BUFFERED_FRAMES}.
    */
+  /**
+   * Admission-side backlog check. Stricter than {@link isEncoderCongested}: the
+   * buffered-frame budget only measures the stream, so consuming one buffered
+   * write drops it back under the limit while older padding is still queued.
+   * Admitting there would append a new multi-megabyte payload — plus its gap
+   * fill — faster than the encoder drains, so a slow encoder could grow the
+   * queue without bound. A frame rejected here leaves its slot owed, and the
+   * next admitted frame pads it.
+   */
+  private isBackloggedForAdmission(
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+  ): boolean {
+    return state.pendingWrites.length > 0 || this.isEncoderCongested(state, stdin);
+  }
+
   private isEncoderCongested(
     state: CaptureState,
     stdin: NonNullable<FfmpegProcess["stdin"]>,

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -388,7 +388,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       recordingId: handle.recordingId,
       outputPath: handle.outputPath,
       startedAt: handle.startedAt,
-      endedAt: state.encoderTracker?.exitState.endedAt ?? new Date().toISOString(),
+      endedAt: new Date(stopRequestedAtMs).toISOString(),
       sizeBytes,
       codec: "h264",
     };
@@ -399,11 +399,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     if (!backendHandle || backendHandle.kind !== "ios-physical") {
       throw new Error("Missing backend handle for physical iOS video recording.");
     }
-    await backendHandle.helper.stop();
+    const helperStop = backendHandle.helper.stop();
     const encoder = backendHandle.state.encoder;
     if (encoder && encoder.exitCode === null && !encoder.killed) {
       encoder.kill("SIGKILL");
     }
+    await helperStop;
   }
 
   private onFrame(frame: DecodedFrame, state: CaptureState, config: VideoCaptureConfig): void {

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -424,7 +424,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       state.framesDropped += 1;
       return;
     }
-    // Congestion is checked BEFORE admission on purpose. Frames arrive from an
+    // Backlog is checked BEFORE admission on purpose. Frames arrive from an
     // event emitter, so there is no upstream backpressure to apply and buffering
     // would grow without bound — but consuming the pacing slot for a frame that
     // never reaches stdin would silently shorten the timeline. Dropping before
@@ -547,6 +547,17 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * True when the encoder already holds {@link MAX_BUFFERED_FRAMES} frames of
    * input. Deliberately not `writableNeedDrain` — see {@link MAX_BUFFERED_FRAMES}.
    */
+  private isEncoderCongested(
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+  ): boolean {
+    const frameBytes = state.frameBytes;
+    if (!frameBytes) {
+      return stdin.writableNeedDrain;
+    }
+    return stdin.writableLength >= frameBytes * MAX_BUFFERED_FRAMES;
+  }
+
   /**
    * Admission-side backlog check. Stricter than {@link isEncoderCongested}: the
    * buffered-frame budget only measures the stream, so consuming one buffered
@@ -561,17 +572,6 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     stdin: NonNullable<FfmpegProcess["stdin"]>,
   ): boolean {
     return state.pendingWrites.length > 0 || this.isEncoderCongested(state, stdin);
-  }
-
-  private isEncoderCongested(
-    state: CaptureState,
-    stdin: NonNullable<FfmpegProcess["stdin"]>,
-  ): boolean {
-    const frameBytes = state.frameBytes;
-    if (!frameBytes) {
-      return stdin.writableNeedDrain;
-    }
-    return stdin.writableLength >= frameBytes * MAX_BUFFERED_FRAMES;
   }
 
   /**

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -2,6 +2,7 @@ import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { errorMessage } from "../../utils/describeUnknownError";
 import { getFileSize, waitForExit, type ProcessTracker } from "../../utils/ChildProcessTracker";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import {
   DefaultHostCommandExecutor,
   type HostCommandExecutor,
@@ -56,6 +57,15 @@ const MAX_GAP_FILL_SECONDS = 2;
  * permanent congestion — dropping nearly every frame of a real recording.
  */
 const MAX_BUFFERED_FRAMES = 2;
+
+/**
+ * Absolute ceiling on repeat writes for one gap, independent of fps. The 2-second
+ * budget alone scales with the requested rate, and `parseVideoRecordingConfig()`
+ * puts no upper bound on fps — at an absurd rate two ordinary frames could enqueue
+ * tens of thousands of multi-megabyte duplicate encodes, starving live frames.
+ * 120 is 2 seconds at 60fps, past any rate a device recording sensibly uses.
+ */
+const MAX_GAP_FILL_FRAMES = 120;
 
 /** Stderr lines retained from the helper for failure diagnostics. */
 const HELPER_STDERR_TAIL = 20;
@@ -118,6 +128,8 @@ export interface IosPhysicalVideoCaptureBackendOptions {
   encoderFinalizeTimeoutMs?: number;
   /** Clock seam for trailing-stall padding; capture timestamps use another timebase. */
   now?: () => number;
+  /** Timer seam for the bounded drain wait at stop. */
+  timer?: Timer;
   /** Env seam so the developer override can be exercised without touching process.env. */
   env?: NodeJS.ProcessEnv;
   /** Existence seam for the overridden helper path. */
@@ -192,6 +204,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   private readonly fileSize: (filePath: string) => Promise<number | undefined>;
   private readonly encoderFinalizeTimeoutMs: number;
   private readonly now: () => number;
+  private readonly timer: Timer;
   private readonly env: NodeJS.ProcessEnv;
   private readonly helperPathExists?: (candidate: string) => boolean;
 
@@ -206,6 +219,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     this.encoderFinalizeTimeoutMs =
       options.encoderFinalizeTimeoutMs ?? IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS;
     this.now = options.now ?? Date.now;
+    this.timer = options.timer ?? defaultTimer;
     this.env = options.env ?? process.env;
     this.helperPathExists = options.helperPathExists;
   }
@@ -318,7 +332,10 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
 
     this.padTrailingStall(state, config.fps);
     if (encoder.stdin) {
-      this.flushPendingWrites(state, encoder.stdin);
+      // Only MAX_BUFFERED_FRAMES fit synchronously, so with real frame sizes most
+      // of the padding is still queued here. Let the encoder drain it before
+      // closing stdin, or the recording ends short by exactly that padding.
+      await this.drainPendingWrites(state, encoder.stdin);
     }
     this.discardPendingWrites(state);
 
@@ -446,6 +463,49 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   }
 
   /**
+   * Wait for the encoder to consume everything still queued, bounded by the
+   * finalization timeout so a wedged ffmpeg cannot hang the stop.
+   */
+  private async drainPendingWrites(
+    state: CaptureState,
+    stdin: NonNullable<FfmpegProcess["stdin"]>,
+  ): Promise<void> {
+    this.flushPendingWrites(state, stdin);
+    if (state.pendingWrites.length === 0 || stdin.writableEnded) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.timer.clearTimeout(timeout);
+        stdin.off("drain", onDrain);
+        stdin.off("close", finish);
+        resolve();
+      };
+      const onDrain = (): void => {
+        // The encoder-start listener flushes first; this only observes the result.
+        if (state.pendingWrites.length === 0) {
+          finish();
+        }
+      };
+      const timeout = this.timer.setTimeout(() => {
+        logger.warn(
+          "[IosPhysicalVideo] encoder did not consume the queued padding before the finalize timeout; " +
+            "the recording will be short by the remainder.",
+        );
+        finish();
+      }, this.encoderFinalizeTimeoutMs);
+      stdin.on("drain", onDrain);
+      stdin.once("close", finish);
+    });
+  }
+
+  /**
    * Give up on writes still queued when the recording ends: they would land
    * after the encoder's input closed. Counted so the shortfall is reported.
    */
@@ -501,7 +561,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     // recording plays ~1.5x fast and ends a third short.
     const elapsedSlots = Math.floor((timestampMs - state.nextFrameDueMs) / intervalMs) + 1;
     const missedSlots = elapsedSlots - 1;
-    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
+    const maxGapFill = gapFillLimit(fps);
 
     // Slots that elapsed with nothing to encode: a helper stall, or a device
     // that idles while the screen is static. `-framerate` gives every written
@@ -543,7 +603,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     if (elapsedSlots <= 0) {
       return;
     }
-    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
+    const maxGapFill = gapFillLimit(fps);
     const pads = Math.min(elapsedSlots, maxGapFill);
     if (elapsedSlots > pads) {
       state.framesGapTruncated += elapsedSlots - pads;
@@ -824,6 +884,11 @@ function throwIfCaptureStartAborted(abortSignal: AbortSignal | undefined): void 
   if (abortSignal?.aborted) {
     throw new ActionableError("Physical iOS recording start was cancelled during shutdown.");
   }
+}
+
+/** Repeat writes allowed for one gap: 2 seconds of frames, hard-capped. */
+function gapFillLimit(fps: number): number {
+  return Math.min(Math.ceil(fps * MAX_GAP_FILL_SECONDS), MAX_GAP_FILL_FRAMES);
 }
 
 /** Largest even value <= `value`, floored at 2 so a scale filter stays valid. */

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -60,12 +60,21 @@ const MAX_BUFFERED_FRAMES = 2;
 
 /**
  * Absolute ceiling on repeat writes for one gap, independent of fps. The 2-second
- * budget alone scales with the requested rate, and `parseVideoRecordingConfig()`
- * puts no upper bound on fps — at an absurd rate two ordinary frames could enqueue
- * tens of thousands of multi-megabyte duplicate encodes, starving live frames.
- * 120 is 2 seconds at 60fps, past any rate a device recording sensibly uses.
+ * budget alone scales with the requested rate, so it is a per-gap backstop behind
+ * {@link MAX_CAPTURE_FPS}: 120 is 2 seconds at the capture ceiling.
  */
 const MAX_GAP_FILL_FRAMES = 120;
+
+/**
+ * Highest cadence physical capture will honor. `parseVideoRecordingConfig()`
+ * accepts any positive fps, but no CoreMediaIO device streams past 60, and an
+ * absurd rate is not merely wasted: every incoming source frame owes gap-fill
+ * repeats for the slots it skipped, so the encoder stays saturated with
+ * duplicate multi-megabyte frames for the whole recording while the output
+ * timeline compresses. Clamping once at start keeps pacing and the ffmpeg
+ * `-framerate` label describing the same timeline.
+ */
+export const MAX_CAPTURE_FPS = 60;
 
 /** Stderr lines retained from the helper for failure diagnostics. */
 const HELPER_STDERR_TAIL = 20;
@@ -245,6 +254,18 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     const uniqueId = await this.resolveCaptureUniqueId(binaryPath, device);
     throwIfCaptureStartAborted(abortSignal);
 
+    const captureFps = clampCaptureFps(config.fps);
+    if (captureFps !== config.fps) {
+      logger.warn(
+        `[IosPhysicalVideo] requested ${config.fps} fps is not supported for physical capture; ` +
+          `recording at ${captureFps} fps instead.`,
+      );
+    }
+    // Everything downstream — pacing, gap fill, trailing padding and the ffmpeg
+    // `-framerate` label — must read the SAME rate, or the encoded timeline
+    // stops matching the timestamps it is labelled with.
+    const captureConfig: VideoCaptureConfig = { ...config, fps: captureFps };
+
     const state: CaptureState = {
       encoderName,
       framesWritten: 0,
@@ -283,7 +304,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       state.helperError ??= error instanceof Error ? error : new Error(String(error));
       logger.warn(`[IosPhysicalVideo] capture helper error: ${errorMessage(error)}`);
     });
-    helper.on("frame", (frame) => this.onFrame(frame, state, config));
+    helper.on("frame", (frame) => this.onFrame(frame, state, captureConfig));
 
     try {
       await helper.start();
@@ -303,14 +324,14 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     return {
-      recordingId: config.recordingId,
-      outputPath: config.outputPath,
-      startedAt: config.startedAt,
+      recordingId: captureConfig.recordingId,
+      outputPath: captureConfig.outputPath,
+      startedAt: captureConfig.startedAt,
       backendHandle: {
         kind: "ios-physical",
         helper,
         state,
-        config,
+        config: captureConfig,
       } satisfies IosPhysicalBackendHandle,
     };
   }
@@ -323,6 +344,10 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     const { helper, state, config } = backendHandle;
 
     state.stopRequested = true;
+    // Sample the clock BEFORE the helper shutdown: it SIGTERMs the capture
+    // process and waits out a grace period, and padding to a post-shutdown
+    // clock would encode that latency as trailing video the user never saw.
+    const stopRequestedAtMs = this.now();
     await helper.stop();
 
     const encoder = state.encoder;
@@ -330,7 +355,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       throw new ActionableError(this.buildNoFramesMessage(state));
     }
 
-    this.padTrailingStall(state, config.fps);
+    this.padTrailingStall(state, config.fps, stopRequestedAtMs);
     if (encoder.stdin) {
       // Only MAX_BUFFERED_FRAMES fit synchronously, so with real frame sizes most
       // of the padding is still queued here. Let the encoder drain it before
@@ -590,16 +615,17 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * whose screen is static (or a helper that stalled) delivers nothing during
    * that window, so without this the file ends at the last frame's slot — one
    * frame followed by a 500ms wait would encode ~0.1s of video. Wall clock is
-   * used rather than capture timestamps, which are in the helper's own timebase.
+   * used rather than capture timestamps, which are in the helper's own timebase,
+   * and the boundary is when stop was REQUESTED — see {@link stop}.
    */
-  private padTrailingStall(state: CaptureState, fps: number): void {
+  private padTrailingStall(state: CaptureState, fps: number, stopRequestedAtMs: number): void {
     const payload = state.lastPayload;
     const lastWriteAtMs = state.lastWriteAtMs;
     if (!payload || lastWriteAtMs === undefined) {
       return;
     }
     const intervalMs = 1000 / fps;
-    const elapsedSlots = Math.floor((this.now() - lastWriteAtMs) / intervalMs);
+    const elapsedSlots = Math.floor((stopRequestedAtMs - lastWriteAtMs) / intervalMs);
     if (elapsedSlots <= 0) {
       return;
     }
@@ -884,6 +910,18 @@ function throwIfCaptureStartAborted(abortSignal: AbortSignal | undefined): void 
   if (abortSignal?.aborted) {
     throw new ActionableError("Physical iOS recording start was cancelled during shutdown.");
   }
+}
+
+/**
+ * Cadence physical capture will actually run at. A non-finite or non-positive
+ * request cannot describe a timeline at all, so it falls back to the ceiling
+ * rather than poisoning every pacing computation with NaN.
+ */
+export function clampCaptureFps(fps: number): number {
+  if (!Number.isFinite(fps) || fps <= 0) {
+    return MAX_CAPTURE_FPS;
+  }
+  return Math.min(fps, MAX_CAPTURE_FPS);
 }
 
 /** Repeat writes allowed for one gap: 2 seconds of frames, hard-capped. */

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -264,7 +264,20 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     // Everything downstream — pacing, gap fill, trailing padding and the ffmpeg
     // `-framerate` label — must read the SAME rate, or the encoded timeline
     // stops matching the timestamps it is labelled with.
-    const captureConfig: VideoCaptureConfig = { ...config, fps: captureFps };
+    const captureConfig: VideoCaptureConfig = {
+      ...config,
+      fps: captureFps,
+      // yuv420p accepts only even dimensions. Keep the effective configuration
+      // aligned with the scale filter that the encoder will actually apply,
+      // while `buildRawVideoFfmpegArgs()` still uses the native frame geometry
+      // for rawvideo's input `-video_size`.
+      resolution: config.resolution
+        ? {
+            width: evenFloor(config.resolution.width),
+            height: evenFloor(config.resolution.height),
+          }
+        : undefined,
+    };
 
     const state: CaptureState = {
       encoderName,

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -1,0 +1,518 @@
+import { ActionableError, type BootedDevice } from "../../models";
+import { logger } from "../../utils/logger";
+import { errorMessage } from "../../utils/describeUnknownError";
+import { getFileSize, waitForExit, type ProcessTracker } from "../../utils/ChildProcessTracker";
+import {
+  DefaultHostCommandExecutor,
+  type HostCommandExecutor,
+} from "../../utils/HostCommandExecutor";
+import {
+  DefaultFfmpegClient,
+  type FfmpegClient,
+  type FfmpegProcess,
+} from "../../utils/media/FfmpegClient";
+import type { DecodedFrame } from "../screen-stream/frameProtocol";
+import {
+  IOSScreenCaptureHelper,
+  type IosScreenCaptureHelperOptions,
+} from "../screen-stream/IOSScreenCaptureHelper";
+import { ScreenCaptureHelperProvider } from "../screen-stream/ScreenCaptureHelperProvider";
+import type {
+  RecordingHandle,
+  RecordingResult,
+  VideoCaptureBackend,
+  VideoCaptureConfig,
+} from "./VideoRecorderService";
+
+/** Hardware H.264 encoder used whenever the host ffmpeg exposes it. */
+export const VIDEOTOOLBOX_H264_ENCODER = "h264_videotoolbox";
+/** Software fallback for an ffmpeg built without VideoToolbox. */
+export const SOFTWARE_H264_ENCODER = "libx264";
+
+/** Bytes per BGRA pixel — the helper's only raw pixel format. */
+const BGRA_BYTES_PER_PIXEL = 4;
+
+/** How long ffmpeg gets to finalize the MP4 (moov atom) after stdin closes. */
+export const IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS = 30000;
+
+/** Stderr lines retained from the helper for failure diagnostics. */
+const HELPER_STDERR_TAIL = 20;
+
+/**
+ * One entry of the helper's `--list-devices` JSON. Mirrors the Swift
+ * `DeviceInfo` (`ios/screen-capture/Sources/ScreenCaptureCore/DeviceInfo.swift`).
+ */
+export interface CaptureDeviceInfo {
+  uniqueID: string;
+  localizedName: string;
+  modelID: string;
+  manufacturer: string;
+}
+
+/**
+ * Enumerates the AVFoundation muxed capture devices the helper can see. The
+ * `uniqueID` AVFoundation reports is *not* guaranteed to be spelled like the
+ * AutoMobile UDID, and `--device-id` matches it exactly (see
+ * `ScreenCaptureHelper/main.swift`), so the mapping has to be resolved here.
+ */
+export interface CaptureDeviceLister {
+  list(binaryPath: string): Promise<CaptureDeviceInfo[]>;
+}
+
+/** Resolution seam for the signed `screen-capture-helper` binary. */
+export interface ScreenCaptureHelperEnsurer {
+  ensure(): Promise<string | null>;
+}
+
+/**
+ * The slice of {@link IOSScreenCaptureHelper} this backend drives. Narrow on
+ * purpose: a fake only has to emit frames and exit.
+ */
+export interface PhysicalIosCaptureHelper {
+  start(): void | Promise<void>;
+  stop(): Promise<unknown>;
+  on(event: "frame", listener: (frame: DecodedFrame) => void): unknown;
+  on(event: "stderr", listener: (line: string) => void): unknown;
+  on(
+    event: "exit",
+    listener: (info: { code: number | null; signal: NodeJS.Signals | null }) => void,
+  ): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export type PhysicalIosCaptureHelperFactory = (
+  options: IosScreenCaptureHelperOptions,
+) => PhysicalIosCaptureHelper;
+
+export interface IosPhysicalVideoCaptureBackendOptions {
+  ffmpegClient?: FfmpegClient;
+  helperProvider?: ScreenCaptureHelperEnsurer;
+  deviceLister?: CaptureDeviceLister;
+  createHelper?: PhysicalIosCaptureHelperFactory;
+  /** Injectable so the non-macOS rejection is testable on any CI host. */
+  platformProvider?: () => NodeJS.Platform;
+  /** Injectable so file-size reporting stays device- and disk-free in tests. */
+  fileSize?: (filePath: string) => Promise<number | undefined>;
+  encoderFinalizeTimeoutMs?: number;
+}
+
+interface IosPhysicalBackendHandle {
+  kind: "ios-physical";
+  helper: PhysicalIosCaptureHelper;
+  state: CaptureState;
+  config: VideoCaptureConfig;
+}
+
+/** Mutable capture bookkeeping shared between `start` and `stop`. */
+interface CaptureState {
+  encoder?: FfmpegProcess;
+  encoderTracker?: ProcessTracker;
+  /** Frame geometry locked from the first frame; later mismatches are dropped. */
+  geometry?: { width: number; height: number };
+  /** Encoder chosen up front so the first frame can spawn ffmpeg synchronously. */
+  encoderName: string;
+  framesWritten: number;
+  framesDropped: number;
+  helperStderr: string[];
+  helperExit?: { code: number | null; signal: NodeJS.Signals | null };
+}
+
+/**
+ * `xcrun devicectl` has no screen-recording verb and `simctl io recordVideo` is
+ * Simulator-only, so physical-iOS capture goes through the Swift
+ * `screen-capture-helper`: CoreMediaIO exposes the USB-connected device as a
+ * muxed `AVCaptureDevice`, the helper streams its BGRA frames to stdout, and
+ * this backend pipes them into `ffmpeg -f rawvideo` for H.264 encoding.
+ *
+ * Structurally this mirrors {@link FfmpegVideoProcessingBackend}'s Android path
+ * (`adb exec-out screenrecord -` → ffmpeg stdin); the difference is the input
+ * format, and that raw frames carry no geometry, so ffmpeg cannot be spawned
+ * until the first frame pins `-video_size` (issue #2504).
+ */
+export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
+  private readonly ffmpegClient: FfmpegClient;
+  private readonly helperProvider: ScreenCaptureHelperEnsurer;
+  private readonly deviceLister: CaptureDeviceLister;
+  private readonly createHelper: PhysicalIosCaptureHelperFactory;
+  private readonly platformProvider: () => NodeJS.Platform;
+  private readonly fileSize: (filePath: string) => Promise<number | undefined>;
+  private readonly encoderFinalizeTimeoutMs: number;
+
+  constructor(options: IosPhysicalVideoCaptureBackendOptions = {}) {
+    this.ffmpegClient = options.ffmpegClient ?? new DefaultFfmpegClient();
+    this.helperProvider = options.helperProvider ?? ScreenCaptureHelperProvider.getInstance();
+    this.deviceLister = options.deviceLister ?? new HelperCaptureDeviceLister();
+    this.createHelper =
+      options.createHelper ?? ((helperOptions) => new IOSScreenCaptureHelper(helperOptions));
+    this.platformProvider = options.platformProvider ?? (() => process.platform);
+    this.fileSize = options.fileSize ?? getFileSize;
+    this.encoderFinalizeTimeoutMs =
+      options.encoderFinalizeTimeoutMs ?? IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS;
+  }
+
+  async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
+    const device = config.device;
+    if (!device) {
+      throw new ActionableError("Device is required to start video recording.");
+    }
+    if (this.platformProvider() !== "darwin") {
+      throw new ActionableError(
+        "Physical iOS video recording requires macOS: the capture path uses CoreMediaIO/AVFoundation " +
+          "through the screen-capture-helper, which only exists on macOS.",
+      );
+    }
+
+    const encoderName = await this.resolveEncoder();
+    const binaryPath = await this.resolveHelperBinary();
+    const uniqueId = await this.resolveCaptureUniqueId(binaryPath, device);
+
+    const state: CaptureState = {
+      encoderName,
+      framesWritten: 0,
+      framesDropped: 0,
+      helperStderr: [],
+    };
+    const helper = this.createHelper({
+      binaryPath,
+      target: { kind: "device", deviceId: uniqueId },
+    });
+
+    helper.on("stderr", (line) => {
+      state.helperStderr.push(line);
+      if (state.helperStderr.length > HELPER_STDERR_TAIL) {
+        state.helperStderr.shift();
+      }
+    });
+    helper.on("exit", (info) => {
+      state.helperExit = info;
+    });
+    helper.on("error", (error) => {
+      // The helper process failing is surfaced from stop() with the stderr tail;
+      // an unhandled 'error' listener would otherwise crash the daemon.
+      logger.warn(`[IosPhysicalVideo] capture helper error: ${errorMessage(error)}`);
+    });
+    helper.on("frame", (frame) => this.onFrame(frame, state, config));
+
+    await helper.start();
+
+    return {
+      recordingId: config.recordingId,
+      outputPath: config.outputPath,
+      startedAt: config.startedAt,
+      backendHandle: {
+        kind: "ios-physical",
+        helper,
+        state,
+        config,
+      } satisfies IosPhysicalBackendHandle,
+    };
+  }
+
+  async stop(handle: RecordingHandle): Promise<RecordingResult> {
+    const backendHandle = handle.backendHandle as IosPhysicalBackendHandle | undefined;
+    if (!backendHandle || backendHandle.kind !== "ios-physical") {
+      throw new Error("Missing backend handle for physical iOS video recording.");
+    }
+    const { helper, state } = backendHandle;
+
+    await helper.stop();
+
+    const encoder = state.encoder;
+    if (!encoder) {
+      throw new ActionableError(this.buildNoFramesMessage(state));
+    }
+
+    // Closing stdin is what makes ffmpeg write the moov atom; a SIGKILL here
+    // would leave an unplayable file, so wait for a clean exit instead.
+    encoder.stdin?.end();
+    if (state.encoderTracker) {
+      // `signal: null`: closing stdin is the finalize mechanism, so a SIGINT here
+      // would race the moov write. The timeout still escalates to SIGKILL if the
+      // encoder wedges, matching the iOS simulator stop discipline.
+      await waitForExit(encoder, state.encoderTracker.exitPromise, {
+        timeoutMs: this.encoderFinalizeTimeoutMs,
+        signal: null,
+      });
+    }
+
+    const sizeBytes = await this.fileSize(handle.outputPath);
+    if (state.framesDropped > 0) {
+      logger.warn(
+        `[IosPhysicalVideo] dropped ${state.framesDropped} frame(s) whose geometry differed from the locked ` +
+          `${state.geometry?.width}x${state.geometry?.height} capture size (device rotation is not re-negotiated mid-recording).`,
+      );
+    }
+
+    return {
+      recordingId: handle.recordingId,
+      outputPath: handle.outputPath,
+      startedAt: handle.startedAt,
+      endedAt: state.encoderTracker?.exitState.endedAt ?? new Date().toISOString(),
+      sizeBytes,
+      codec: "h264",
+    };
+  }
+
+  async forceStop(handle: RecordingHandle): Promise<void> {
+    const backendHandle = handle.backendHandle as IosPhysicalBackendHandle | undefined;
+    if (!backendHandle || backendHandle.kind !== "ios-physical") {
+      throw new Error("Missing backend handle for physical iOS video recording.");
+    }
+    await backendHandle.helper.stop();
+    const encoder = backendHandle.state.encoder;
+    if (encoder && encoder.exitCode === null && !encoder.killed) {
+      encoder.kill("SIGKILL");
+    }
+  }
+
+  private onFrame(frame: DecodedFrame, state: CaptureState, config: VideoCaptureConfig): void {
+    const { width, height } = frame.header;
+    if (!state.geometry) {
+      state.geometry = { width, height };
+      this.startEncoder(state, config, width, height);
+    } else if (state.geometry.width !== width || state.geometry.height !== height) {
+      // rawvideo has no per-frame geometry: a differently sized frame would be
+      // read as a shifted picture for the rest of the file, so drop it.
+      state.framesDropped += 1;
+      return;
+    }
+
+    const encoder = state.encoder;
+    if (!encoder?.stdin || encoder.stdin.writableEnded) {
+      state.framesDropped += 1;
+      return;
+    }
+    encoder.stdin.write(packFrame(frame));
+    state.framesWritten += 1;
+  }
+
+  private startEncoder(
+    state: CaptureState,
+    config: VideoCaptureConfig,
+    width: number,
+    height: number,
+  ): void {
+    const args = buildRawVideoFfmpegArgs(config, width, height, state.encoderName);
+    logger.info(
+      `[IosPhysicalVideo] starting encoder: ${this.ffmpegClient.binaryPath} ${args.join(" ")}`,
+    );
+    const started = this.ffmpegClient.start({
+      args,
+      context: "physical iOS screen recording encoder",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    state.encoder = started.process;
+    state.encoderTracker = started.tracker;
+    started.process.stdin?.on("error", (error: Error) => {
+      // ffmpeg exiting first closes stdin; the helper keeps writing until it is
+      // stopped, so EPIPE here is expected rather than a fault to surface.
+      logger.debug(`[IosPhysicalVideo] encoder stdin error (expected on encoder exit): ${error}`);
+    });
+  }
+
+  /**
+   * Doubles as the ffmpeg availability check. VideoToolbox is present on every
+   * supported macOS host, but a self-built ffmpeg can lack it, so fall back to
+   * software encoding rather than failing the recording.
+   */
+  private async resolveEncoder(): Promise<string> {
+    let encoders: string[];
+    try {
+      encoders = (await this.ffmpegClient.probe()).encoders;
+    } catch (error) {
+      throw new ActionableError(
+        "FFmpeg is not available. Please install FFmpeg to use video recording.\n" +
+          "  macOS: brew install ffmpeg\n" +
+          `Error: ${errorMessage(error)}`,
+      );
+    }
+    if (encoders.includes(VIDEOTOOLBOX_H264_ENCODER)) {
+      return VIDEOTOOLBOX_H264_ENCODER;
+    }
+    logger.warn(
+      `[IosPhysicalVideo] ${VIDEOTOOLBOX_H264_ENCODER} unavailable; falling back to software ${SOFTWARE_H264_ENCODER}.`,
+    );
+    return SOFTWARE_H264_ENCODER;
+  }
+
+  private buildNoFramesMessage(state: CaptureState): string {
+    const stderr = state.helperStderr.join("").trim();
+    const exit = state.helperExit
+      ? ` (helper exited code=${state.helperExit.code ?? "null"} signal=${state.helperExit.signal ?? "null"})`
+      : "";
+    return (
+      `No frames were captured from the physical iOS device${exit}, so no recording was produced. ` +
+      "Connect the device over USB and accept the Trust This Computer prompt, then retry." +
+      (stderr ? `\nscreen-capture-helper: ${stderr}` : "")
+    );
+  }
+
+  private async resolveHelperBinary(): Promise<string> {
+    const binaryPath = await this.helperProvider.ensure();
+    if (!binaryPath) {
+      throw new ActionableError(
+        "Physical iOS video recording requires the signed screen-capture-helper from the matching GitHub Release, " +
+          "which could not be resolved. For local development, build it with `bash scripts/ios/swift-build.sh` and " +
+          "set AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER to the resulting absolute path.",
+      );
+    }
+    return binaryPath;
+  }
+
+  /**
+   * Map the AutoMobile UDID onto the AVFoundation `uniqueID` the helper matches
+   * on. The two agree on most hardware, but the reported id has been observed
+   * without the UDID's hyphen, so fall back to a normalized comparison and then
+   * — only when exactly one device is attached — to that device.
+   */
+  private async resolveCaptureUniqueId(binaryPath: string, device: BootedDevice): Promise<string> {
+    const devices = await this.deviceLister.list(binaryPath);
+    if (devices.length === 0) {
+      throw new ActionableError(
+        `No muxed external capture devices found for ${device.deviceId}. Connect the iPhone/iPad over USB, ` +
+          "accept the Trust This Computer prompt, and make sure it is not already being captured by QuickTime.",
+      );
+    }
+
+    const exact = devices.find((candidate) => candidate.uniqueID === device.deviceId);
+    if (exact) {
+      return exact.uniqueID;
+    }
+
+    const wanted = normalizeUdid(device.deviceId);
+    const normalized = devices.find((candidate) => normalizeUdid(candidate.uniqueID) === wanted);
+    if (normalized) {
+      return normalized.uniqueID;
+    }
+
+    if (devices.length === 1) {
+      logger.warn(
+        `[IosPhysicalVideo] capture device uniqueID ${devices[0].uniqueID} does not match ${device.deviceId}; ` +
+          "using the only attached device.",
+      );
+      return devices[0].uniqueID;
+    }
+
+    const candidates = devices
+      .map((candidate) => `${candidate.uniqueID} (${candidate.localizedName})`)
+      .join(", ");
+    throw new ActionableError(
+      `Could not match device ${device.deviceId} to an AVFoundation capture device. Attached: ${candidates}. ` +
+        "Disconnect the other devices, or record the matching UDID.",
+    );
+  }
+}
+
+/** Lowercased, separator-free UDID for cross-vocabulary comparison. */
+function normalizeUdid(value: string): string {
+  return value.replace(/-/g, "").toLowerCase();
+}
+
+/**
+ * Strip row padding so the buffer is exactly `width * height * 4` bytes. The
+ * helper reports `bytesPerRow` from the IOSurface, which AVFoundation aligns up;
+ * feeding the padded rows to `-f rawvideo` would skew every row of the picture.
+ */
+export function packFrame(frame: DecodedFrame): Buffer {
+  const { width, height, bytesPerRow } = frame.header;
+  const rowBytes = width * BGRA_BYTES_PER_PIXEL;
+  if (bytesPerRow === rowBytes) {
+    return frame.pixels;
+  }
+  const packed = Buffer.allocUnsafe(rowBytes * height);
+  for (let row = 0; row < height; row++) {
+    frame.pixels.copy(packed, row * rowBytes, row * bytesPerRow, row * bytesPerRow + rowBytes);
+  }
+  return packed;
+}
+
+/**
+ * ffmpeg argv for the raw-BGRA input. Kept as a free function so the encoder
+ * contract can be asserted without spawning anything.
+ */
+export function buildRawVideoFfmpegArgs(
+  config: VideoCaptureConfig,
+  width: number,
+  height: number,
+  encoderName: string,
+): string[] {
+  const args = [
+    "-f",
+    "rawvideo",
+    "-pixel_format",
+    "bgra",
+    "-video_size",
+    `${width}x${height}`,
+    "-framerate",
+    String(config.fps),
+    "-i",
+    "pipe:0",
+  ];
+
+  if (config.resolution) {
+    args.push("-vf", `scale=${config.resolution.width}:${config.resolution.height}`);
+  }
+
+  args.push("-c:v", encoderName);
+  if (encoderName === SOFTWARE_H264_ENCODER) {
+    args.push("-preset", "ultrafast");
+  }
+  args.push("-b:v", `${config.targetBitrateKbps}k`);
+  args.push("-pix_fmt", "yuv420p");
+  args.push("-movflags", "+faststart");
+
+  if (config.maxDurationSeconds && config.maxDurationSeconds > 0) {
+    args.push("-t", String(config.maxDurationSeconds));
+  }
+
+  args.push("-y", config.outputPath);
+  return args;
+}
+
+/**
+ * Production {@link CaptureDeviceLister}: runs the helper's `--list-devices`
+ * mode, which prints the JSON device list to stdout and exits.
+ */
+export class HelperCaptureDeviceLister implements CaptureDeviceLister {
+  constructor(
+    private readonly executor: HostCommandExecutor = new DefaultHostCommandExecutor(),
+    private readonly timeoutMs: number = 15000,
+  ) {}
+
+  async list(binaryPath: string): Promise<CaptureDeviceInfo[]> {
+    const result = await this.executor.executeCommand(binaryPath, ["--list-devices"], {
+      timeoutMs: this.timeoutMs,
+    });
+    return parseCaptureDeviceList(result.stdout);
+  }
+}
+
+/** Parse the `--list-devices` envelope, tolerating a helper that lists nothing. */
+export function parseCaptureDeviceList(stdout: string): CaptureDeviceInfo[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new ActionableError(
+      `screen-capture-helper --list-devices returned unparseable output: ${errorMessage(error)}`,
+    );
+  }
+  const devices = (parsed as { devices?: unknown } | null)?.devices;
+  if (!Array.isArray(devices)) {
+    throw new ActionableError(
+      "screen-capture-helper --list-devices returned no `devices` array; the helper may be out of date.",
+    );
+  }
+  return devices
+    .map((entry) => entry as Partial<CaptureDeviceInfo> | null)
+    .filter(
+      (entry): entry is Partial<CaptureDeviceInfo> & { uniqueID: string } =>
+        typeof entry?.uniqueID === "string" && entry.uniqueID.length > 0,
+    )
+    .map((entry) => ({
+      uniqueID: entry.uniqueID,
+      localizedName: entry.localizedName ?? entry.uniqueID,
+      modelID: entry.modelID ?? "",
+      manufacturer: entry.manufacturer ?? "",
+    }));
+}

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -162,9 +162,14 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       );
     }
 
+    const { abortSignal } = config;
+    throwIfCaptureStartAborted(abortSignal);
     const encoderName = await this.resolveEncoder();
+    throwIfCaptureStartAborted(abortSignal);
     const binaryPath = await this.resolveHelperBinary();
+    throwIfCaptureStartAborted(abortSignal);
     const uniqueId = await this.resolveCaptureUniqueId(binaryPath, device);
+    throwIfCaptureStartAborted(abortSignal);
 
     const state: CaptureState = {
       encoderName,
@@ -194,6 +199,13 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     helper.on("frame", (frame) => this.onFrame(frame, state, config));
 
     await helper.start();
+
+    if (abortSignal?.aborted) {
+      // Shutdown landed while the helper was spawning: tear it down here, or the
+      // capture process outlives the recording that was never handed back.
+      await this.abandonStartedCapture(helper, state);
+      throwIfCaptureStartAborted(abortSignal);
+    }
 
     return {
       recordingId: config.recordingId,
@@ -321,6 +333,26 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
   }
 
+  /** Stop a capture that was cancelled between spawn and handle hand-off. */
+  private async abandonStartedCapture(
+    helper: PhysicalIosCaptureHelper,
+    state: CaptureState,
+  ): Promise<void> {
+    try {
+      await helper.stop();
+    } catch (error) {
+      // Already-aborting path: report the leak risk but keep the abort as the
+      // error the caller sees.
+      logger.warn(
+        `[IosPhysicalVideo] failed to stop the capture helper after an aborted start: ${errorMessage(error)}`,
+      );
+    }
+    const encoder = state.encoder;
+    if (encoder && encoder.exitCode === null && !encoder.killed) {
+      encoder.kill("SIGKILL");
+    }
+  }
+
   /**
    * Doubles as the ffmpeg availability check. VideoToolbox is present on every
    * supported macOS host, but a self-built ffmpeg can lack it, so fall back to
@@ -339,6 +371,15 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
     if (encoders.includes(VIDEOTOOLBOX_H264_ENCODER)) {
       return VIDEOTOOLBOX_H264_ENCODER;
+    }
+    if (!encoders.includes(SOFTWARE_H264_ENCODER)) {
+      // Blindly naming an absent encoder would only fail once the first frame
+      // spawns ffmpeg, and stop() would then report "no frames captured" — the
+      // wrong cause entirely. Fail here, before the helper is started.
+      throw new ActionableError(
+        `This FFmpeg build exposes neither ${VIDEOTOOLBOX_H264_ENCODER} nor ${SOFTWARE_H264_ENCODER}, ` +
+          "so a physical iOS recording cannot be encoded. Install an FFmpeg with H.264 support (macOS: brew install ffmpeg).",
+      );
     }
     logger.warn(
       `[IosPhysicalVideo] ${VIDEOTOOLBOX_H264_ENCODER} unavailable; falling back to software ${SOFTWARE_H264_ENCODER}.`,
@@ -411,6 +452,16 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       `Could not match device ${device.deviceId} to an AVFoundation capture device. Attached: ${candidates}. ` +
         "Disconnect the other devices, or record the matching UDID.",
     );
+  }
+}
+
+/**
+ * Matches the Android/iOS ffmpeg start paths: a daemon shutdown mid-start must
+ * abort the recording rather than leave a capture process behind.
+ */
+function throwIfCaptureStartAborted(abortSignal: AbortSignal | undefined): void {
+  if (abortSignal?.aborted) {
+    throw new ActionableError("Physical iOS recording start was cancelled during shutdown.");
   }
 }
 

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -116,6 +116,8 @@ export interface IosPhysicalVideoCaptureBackendOptions {
   /** Injectable so file-size reporting stays device- and disk-free in tests. */
   fileSize?: (filePath: string) => Promise<number | undefined>;
   encoderFinalizeTimeoutMs?: number;
+  /** Clock seam for trailing-stall padding; capture timestamps use another timebase. */
+  now?: () => number;
   /** Env seam so the developer override can be exercised without touching process.env. */
   env?: NodeJS.ProcessEnv;
   /** Existence seam for the overridden helper path. */
@@ -145,6 +147,8 @@ interface CaptureState {
   framesGapFilled: number;
   /** Last payload written, repeated across gap slots that precede a new frame. */
   lastPayload?: Buffer;
+  /** Wall-clock time of the last write, for trailing-stall padding. */
+  lastWriteAtMs?: number;
   /** Bytes in one packed frame; the unit for the encoder-buffer budget. */
   frameBytes?: number;
   /**
@@ -187,6 +191,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
   private readonly platformProvider: () => NodeJS.Platform;
   private readonly fileSize: (filePath: string) => Promise<number | undefined>;
   private readonly encoderFinalizeTimeoutMs: number;
+  private readonly now: () => number;
   private readonly env: NodeJS.ProcessEnv;
   private readonly helperPathExists?: (candidate: string) => boolean;
 
@@ -200,6 +205,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     this.fileSize = options.fileSize ?? getFileSize;
     this.encoderFinalizeTimeoutMs =
       options.encoderFinalizeTimeoutMs ?? IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS;
+    this.now = options.now ?? Date.now;
     this.env = options.env ?? process.env;
     this.helperPathExists = options.helperPathExists;
   }
@@ -310,6 +316,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       throw new ActionableError(this.buildNoFramesMessage(state));
     }
 
+    this.padTrailingStall(state, config.fps);
     if (encoder.stdin) {
       this.flushPendingWrites(state, encoder.stdin);
     }
@@ -414,6 +421,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
     state.pendingWrites.push({ payload, count: 1 });
     state.lastPayload = payload;
+    state.lastWriteAtMs = this.now();
     this.flushPendingWrites(state, stdin);
   }
 
@@ -484,24 +492,64 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       return 0;
     }
 
+    // Advance the EXISTING deadline by the slots that elapsed, rather than
+    // rebasing it on this frame's timestamp. Rebasing loses the fraction of a
+    // slot the frame arrived late, and with integer-millisecond capture
+    // timestamps that compounds: a 30fps source (0, 33, 66, 100, ...) paced to
+    // 15fps (66.67ms) would miss 66 by 0.67ms, admit 100, and rebase from there
+    // — settling at 10fps while ffmpeg still labels the result 15fps, so the
+    // recording plays ~1.5x fast and ends a third short.
+    const elapsedSlots = Math.floor((timestampMs - state.nextFrameDueMs) / intervalMs) + 1;
+    const missedSlots = elapsedSlots - 1;
+    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
+
     // Slots that elapsed with nothing to encode: a helper stall, or a device
     // that idles while the screen is static. `-framerate` gives every written
     // frame a contiguous fixed-rate timestamp, so skipping those slots would
     // compress real time — a 5s freeze would play back in a fraction of a
     // second, and a duration-capped recording would end early. Repeat the frame
     // to keep the encoded timeline on wall clock.
-    const missedSlots = Math.floor((timestampMs - state.nextFrameDueMs) / intervalMs);
-    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
-    const gapFill = Math.min(missedSlots, maxGapFill);
-    if (missedSlots > gapFill) {
+    if (missedSlots > maxGapFill) {
       // Padding an arbitrarily long stall would write unbounded duplicate frames,
       // so very long gaps stay compressed; the recording is shorter than wall
-      // clock by the excess, which the warning names.
-      state.framesGapTruncated += missedSlots - gapFill;
+      // clock by the excess, which the warning names. Time was deliberately
+      // dropped here, so the schedule restarts from this frame.
+      state.framesGapTruncated += missedSlots - maxGapFill;
+      state.framesGapFilled += maxGapFill;
+      state.nextFrameDueMs = timestampMs + intervalMs;
+      return maxGapFill + 1;
     }
-    state.framesGapFilled += gapFill;
-    state.nextFrameDueMs = timestampMs + intervalMs;
-    return gapFill + 1;
+
+    state.framesGapFilled += missedSlots;
+    state.nextFrameDueMs += elapsedSlots * intervalMs;
+    return elapsedSlots;
+  }
+
+  /**
+   * Pad the interval between the last delivered frame and `stop()`. A device
+   * whose screen is static (or a helper that stalled) delivers nothing during
+   * that window, so without this the file ends at the last frame's slot — one
+   * frame followed by a 500ms wait would encode ~0.1s of video. Wall clock is
+   * used rather than capture timestamps, which are in the helper's own timebase.
+   */
+  private padTrailingStall(state: CaptureState, fps: number): void {
+    const payload = state.lastPayload;
+    const lastWriteAtMs = state.lastWriteAtMs;
+    if (!payload || lastWriteAtMs === undefined) {
+      return;
+    }
+    const intervalMs = 1000 / fps;
+    const elapsedSlots = Math.floor((this.now() - lastWriteAtMs) / intervalMs);
+    if (elapsedSlots <= 0) {
+      return;
+    }
+    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
+    const pads = Math.min(elapsedSlots, maxGapFill);
+    if (elapsedSlots > pads) {
+      state.framesGapTruncated += elapsedSlots - pads;
+    }
+    state.framesGapFilled += pads;
+    state.pendingWrites.push({ payload, count: pads });
   }
 
   private startEncoder(

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -236,6 +236,9 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     const sizeBytes = await this.fileSize(handle.outputPath);
+    logger.info(
+      `[IosPhysicalVideo] recording ${handle.recordingId} wrote ${state.framesWritten} frame(s) to ${handle.outputPath}.`,
+    );
     if (state.framesDropped > 0) {
       logger.warn(
         `[IosPhysicalVideo] dropped ${state.framesDropped} frame(s) whose geometry differed from the locked ` +
@@ -279,6 +282,14 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
 
     const encoder = state.encoder;
     if (!encoder?.stdin || encoder.stdin.writableEnded) {
+      state.framesDropped += 1;
+      return;
+    }
+    if (encoder.stdin.writableNeedDrain) {
+      // Frames arrive from an event emitter, so there is no upstream backpressure
+      // to apply: buffering them while the encoder is behind would grow without
+      // bound over a long capture. Dropping the newest frame is what the helper's
+      // own bounded handoff does, and keeps latency from compounding.
       state.framesDropped += 1;
       return;
     }

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -40,6 +40,13 @@ const BGRA_BYTES_PER_PIXEL = 4;
 /** How long ffmpeg gets to finalize the MP4 (moov atom) after stdin closes. */
 export const IOS_PHYSICAL_ENCODER_FINALIZE_TIMEOUT_MS = 30000;
 
+/**
+ * Ceiling on repeated frames used to hold a capture gap at its real duration.
+ * Beyond this the recording is allowed to compress rather than write unbounded
+ * duplicates of a multi-megabyte frame.
+ */
+const MAX_GAP_FILL_SECONDS = 2;
+
 /** Stderr lines retained from the helper for failure diagnostics. */
 const HELPER_STDERR_TAIL = 20;
 
@@ -124,6 +131,10 @@ interface CaptureState {
   nextFrameDueMs?: number;
   /** Frames discarded purely to hold the declared cadence (not a fault). */
   framesPacedOut: number;
+  /** Repeated frames written to keep a capture gap at its real duration. */
+  framesGapFilled: number;
+  /** Gap slots left unpadded, so the output is shorter than wall clock. */
+  framesGapTruncated: number;
   framesWritten: number;
   framesDropped: number;
   helperStderr: string[];
@@ -193,6 +204,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       framesWritten: 0,
       framesDropped: 0,
       framesPacedOut: 0,
+      framesGapFilled: 0,
+      framesGapTruncated: 0,
       helperStderr: [],
     };
     const helper = this.createHelper({
@@ -243,7 +256,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     if (!backendHandle || backendHandle.kind !== "ios-physical") {
       throw new Error("Missing backend handle for physical iOS video recording.");
     }
-    const { helper, state } = backendHandle;
+    const { helper, state, config } = backendHandle;
 
     await helper.stop();
 
@@ -266,22 +279,10 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     this.assertEncoderSucceeded(state, handle.outputPath);
+    this.assertHelperSucceeded(state, handle.outputPath);
 
     const sizeBytes = await this.fileSize(handle.outputPath);
-    logger.info(
-      `[IosPhysicalVideo] recording ${handle.recordingId} wrote ${state.framesWritten} frame(s) to ${handle.outputPath}.`,
-    );
-    if (state.framesDropped > 0) {
-      logger.warn(
-        `[IosPhysicalVideo] dropped ${state.framesDropped} frame(s) whose geometry differed from the locked ` +
-          `${state.geometry?.width}x${state.geometry?.height} capture size, or arrived while the encoder was congested.`,
-      );
-    }
-    if (state.framesPacedOut > 0) {
-      logger.debug(
-        `[IosPhysicalVideo] paced out ${state.framesPacedOut} frame(s) to hold the requested cadence.`,
-      );
-    }
+    this.logCaptureAccounting(state, config, handle);
 
     return {
       recordingId: handle.recordingId,
@@ -317,7 +318,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       return;
     }
 
-    if (!this.admitForPacing(frame, state, config.fps)) {
+    const copies = this.admitForPacing(frame, state, config.fps);
+    if (copies === 0) {
       return;
     }
 
@@ -334,8 +336,17 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       state.framesDropped += 1;
       return;
     }
-    encoder.stdin.write(packFrame(frame));
-    state.framesWritten += 1;
+    const payload = packFrame(frame);
+    for (let copy = 0; copy < copies; copy++) {
+      // Stop padding the moment the encoder falls behind: gap fill must never be
+      // the thing that congests it.
+      if (copy > 0 && encoder.stdin.writableNeedDrain) {
+        state.framesGapTruncated += copies - copy;
+        break;
+      }
+      encoder.stdin.write(payload);
+      state.framesWritten += 1;
+    }
   }
 
   /**
@@ -346,23 +357,36 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * 2-4x slow and `-t` would cut it short. Admit a frame only once its capture
    * timestamp reaches the next scheduled slot.
    */
-  private admitForPacing(frame: DecodedFrame, state: CaptureState, fps: number): boolean {
+  private admitForPacing(frame: DecodedFrame, state: CaptureState, fps: number): number {
     const intervalMs = 1000 / fps;
     const timestampMs = frame.header.timestampMs;
     if (state.nextFrameDueMs === undefined) {
       state.nextFrameDueMs = timestampMs + intervalMs;
-      return true;
+      return 1;
     }
     if (timestampMs < state.nextFrameDueMs) {
       state.framesPacedOut += 1;
-      return false;
+      return 0;
     }
-    // Advance by whole intervals so the cadence does not drift, but resync after
-    // a gap (helper stall, or a device that idles while the screen is static)
-    // rather than admitting a burst to "catch up".
-    const nextSlot = state.nextFrameDueMs + intervalMs;
-    state.nextFrameDueMs = nextSlot > timestampMs ? nextSlot : timestampMs + intervalMs;
-    return true;
+
+    // Slots that elapsed with nothing to encode: a helper stall, or a device
+    // that idles while the screen is static. `-framerate` gives every written
+    // frame a contiguous fixed-rate timestamp, so skipping those slots would
+    // compress real time — a 5s freeze would play back in a fraction of a
+    // second, and a duration-capped recording would end early. Repeat the frame
+    // to keep the encoded timeline on wall clock.
+    const missedSlots = Math.floor((timestampMs - state.nextFrameDueMs) / intervalMs);
+    const maxGapFill = Math.ceil(fps * MAX_GAP_FILL_SECONDS);
+    const gapFill = Math.min(missedSlots, maxGapFill);
+    if (missedSlots > gapFill) {
+      // Padding an arbitrarily long stall would write unbounded duplicate frames,
+      // so very long gaps stay compressed; the recording is shorter than wall
+      // clock by the excess, which the warning names.
+      state.framesGapTruncated += missedSlots - gapFill;
+    }
+    state.framesGapFilled += gapFill;
+    state.nextFrameDueMs = timestampMs + intervalMs;
+    return gapFill + 1;
   }
 
   private startEncoder(
@@ -389,6 +413,39 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
   }
 
+  /** One place for the per-recording frame accounting, all of it diagnostic. */
+  private logCaptureAccounting(
+    state: CaptureState,
+    config: VideoCaptureConfig,
+    handle: RecordingHandle,
+  ): void {
+    logger.info(
+      `[IosPhysicalVideo] recording ${handle.recordingId} wrote ${state.framesWritten} frame(s) to ${handle.outputPath}.`,
+    );
+    if (state.framesDropped > 0) {
+      logger.warn(
+        `[IosPhysicalVideo] dropped ${state.framesDropped} frame(s) whose geometry differed from the locked ` +
+          `${state.geometry?.width}x${state.geometry?.height} capture size, or arrived while the encoder was congested.`,
+      );
+    }
+    if (state.framesPacedOut > 0) {
+      logger.debug(
+        `[IosPhysicalVideo] paced out ${state.framesPacedOut} frame(s) to hold the requested cadence.`,
+      );
+    }
+    if (state.framesGapFilled > 0) {
+      logger.debug(
+        `[IosPhysicalVideo] repeated ${state.framesGapFilled} frame(s) to keep capture gaps at their real duration.`,
+      );
+    }
+    if (state.framesGapTruncated > 0) {
+      logger.warn(
+        `[IosPhysicalVideo] ${state.framesGapTruncated} gap slot(s) were left unpadded, so the recording is ` +
+          `about ${(state.framesGapTruncated / config.fps).toFixed(1)}s shorter than the wall-clock capture.`,
+      );
+    }
+  }
+
   /**
    * A nonzero ffmpeg exit (full disk, rejected encoder settings) leaves a
    * truncated file behind. Returning a successful RecordingResult would let the
@@ -413,6 +470,29 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       `FFmpeg failed to finalize the physical iOS recording at ${outputPath} ` +
         `(exitCode: ${exitState.exitCode ?? "null"}, signal: ${exitState.signal ?? "null"}).` +
         (stderr ? `\nffmpeg: ${stderr}` : ""),
+    );
+  }
+
+  /**
+   * A helper that exited nonzero on its own (device unplugged, AVCaptureSession
+   * failure) truncates the capture. ffmpeg still finalizes the frames it did
+   * receive and exits 0, so without this check a partial recording would be
+   * archived as complete. Checked after the encoder is finalized, so the file on
+   * disk is at least playable for diagnosis.
+   *
+   * Our own `stop()` sends SIGTERM, which surfaces as `signal`, not a nonzero
+   * exit code — only a code the helper chose itself counts as a failure.
+   */
+  private assertHelperSucceeded(state: CaptureState, outputPath: string): void {
+    const exit = state.helperExit;
+    if (!exit || exit.code === null || exit.code === 0) {
+      return;
+    }
+    const stderr = state.helperStderr.join("").trim();
+    throw new ActionableError(
+      `The iOS capture helper exited with code ${exit.code} during the recording, so ${outputPath} ` +
+        "is truncated. The device was most likely unplugged or lost its capture session." +
+        (stderr ? `\nscreen-capture-helper: ${stderr}` : ""),
     );
   }
 

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -33,6 +33,8 @@ export interface RecordingHandle {
   recordingId: string;
   outputPath: string;
   startedAt: string;
+  /** Configuration actually used by a backend that adjusted the request. */
+  effectiveConfig?: VideoRecordingConfig;
   backendHandle?: unknown;
 }
 
@@ -186,13 +188,14 @@ export class VideoRecorderService {
 
     const resolvedOutputPath = handle.outputPath || outputPath;
     const resolvedFileName = path.basename(resolvedOutputPath);
+    const effectiveConfig = handle.effectiveConfig ?? config;
 
     const active: ActiveRecordingState = {
       recordingId,
       outputPath: resolvedOutputPath,
       fileName: resolvedFileName,
       startedAt: handle.startedAt || startedAt,
-      config,
+      config: effectiveConfig,
       outputName: options.outputName,
       handle,
       forceStopRequested: false,

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -17,6 +17,28 @@ import {
   type SecurePermissions,
 } from "../../utils/filesystem/securePermissions";
 
+/**
+ * Keep only the declared {@link VideoRecordingConfig} fields. A backend that
+ * derives its `effectiveConfig` from the internal {@link VideoCaptureConfig} it
+ * was handed carries runtime-only members — recording id, absolute paths, the
+ * device descriptor, an `AbortSignal` — and this value is both returned to the
+ * caller and persisted as the recording's public configuration.
+ */
+function toPublicRecordingConfig(config: VideoRecordingConfig): VideoRecordingConfig {
+  const narrowed: VideoRecordingConfig = {
+    qualityPreset: config.qualityPreset,
+    targetBitrateKbps: config.targetBitrateKbps,
+    maxThroughputMbps: config.maxThroughputMbps,
+    fps: config.fps,
+    maxArchiveSizeMb: config.maxArchiveSizeMb,
+    format: config.format,
+  };
+  if (config.resolution) {
+    narrowed.resolution = config.resolution;
+  }
+  return narrowed;
+}
+
 export interface VideoCaptureConfig extends VideoRecordingConfig {
   recordingId: string;
   outputDirectory: string;
@@ -188,7 +210,7 @@ export class VideoRecorderService {
 
     const resolvedOutputPath = handle.outputPath || outputPath;
     const resolvedFileName = path.basename(resolvedOutputPath);
-    const effectiveConfig = handle.effectiveConfig ?? config;
+    const effectiveConfig = toPublicRecordingConfig(handle.effectiveConfig ?? config);
 
     const active: ActiveRecordingState = {
       recordingId,

--- a/src/features/video/index.ts
+++ b/src/features/video/index.ts
@@ -16,3 +16,4 @@ export { DEFAULT_VIDEO_RECORDING_CONFIG, parseVideoRecordingConfig } from "./Vid
 export { PlatformVideoCaptureBackend } from "./PlatformVideoCaptureBackend";
 export { FfmpegVideoProcessingBackend } from "./FfmpegVideoProcessingBackend";
 export { HybridVideoCaptureBackend } from "./HybridVideoCaptureBackend";
+export { IosPhysicalVideoCaptureBackend } from "./IosPhysicalVideoCaptureBackend";

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -1,5 +1,4 @@
 import { errorMessage } from "../../utils/describeUnknownError";
-import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { ActionableError, toActionableError, type BootedDevice } from "../../models";
@@ -57,9 +56,20 @@ import type {
 import { H264AnnexBParser, isKeyFrameNal, NAL_TYPE_IDR } from "./h264";
 import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "./webrtcStreamingConfig";
+import {
+  IOS_SCREEN_CAPTURE_HELPER_ENV,
+  IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS,
+  readScreenCaptureHelperEnvOverride,
+  resolveIosScreenCaptureHelperPath,
+} from "../screen-stream/screenCaptureHelperPath";
 
-export const IOS_SCREEN_CAPTURE_HELPER_ENV = "AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER";
-export const IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS = "AUTO_MOBILE_IOS_SCREEN_CAPTURE_HELPER";
+export {
+  IOS_SCREEN_CAPTURE_HELPER_ENV,
+  IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS,
+  resolveIosScreenCaptureHelperPath,
+};
+export type { IosScreenCaptureHelperPathResolverOptions } from "../screen-stream/screenCaptureHelperPath";
+
 export const IOS_WEBRTC_FFMPEG_ENV = "AUTOMOBILE_IOS_WEBRTC_FFMPEG";
 export const IOS_WEBRTC_FFMPEG_ENV_ALIAS = "AUTO_MOBILE_IOS_WEBRTC_FFMPEG";
 /**
@@ -808,13 +818,7 @@ export class IosH264Source implements H264CaptureSource {
   }
 
   private async resolveHelperPath(): Promise<string> {
-    const configuredPath =
-      this.helperPath ??
-      readEnvWithLegacy(
-        process.env,
-        IOS_SCREEN_CAPTURE_HELPER_ENV,
-        IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS,
-      );
+    const configuredPath = this.helperPath ?? readScreenCaptureHelperEnvOverride(process.env);
     if (configuredPath) {
       return resolveIosScreenCaptureHelperPath(configuredPath, {
         exists: this.helperPathExists,
@@ -1921,41 +1925,6 @@ function tightlyPackBgraFrame(frame: DecodedFrame): Buffer {
     frame.pixels.copy(packed, row * tightBytesPerRow, sourceStart, sourceStart + tightBytesPerRow);
   }
   return packed;
-}
-
-export interface IosScreenCaptureHelperPathResolverOptions {
-  env?: NodeJS.ProcessEnv;
-  exists?: (candidate: string) => boolean;
-}
-
-export function resolveIosScreenCaptureHelperPath(
-  explicitPath?: string,
-  options: IosScreenCaptureHelperPathResolverOptions = {},
-): string {
-  const env = options.env ?? process.env;
-  const exists = options.exists ?? existsSync;
-  const candidates = [
-    explicitPath,
-    readEnvWithLegacy(env, IOS_SCREEN_CAPTURE_HELPER_ENV, IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS),
-  ].filter((candidate): candidate is string => Boolean(candidate));
-
-  for (const candidate of candidates) {
-    if (exists(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new ActionableError(
-    `No executable screen-capture-helper was found at the configured path. Set ${IOS_SCREEN_CAPTURE_HELPER_ENV} to the absolute path of a local development build.`,
-  );
-}
-
-function readEnvWithLegacy(
-  env: NodeJS.ProcessEnv,
-  primaryName: string,
-  legacyName: string,
-): string | undefined {
-  return env[primaryName] ?? env[legacyName];
 }
 
 /** True when the force-raw escape hatch is set on either the primary or alias env var. */

--- a/test/features/video/HybridVideoCaptureBackend.test.ts
+++ b/test/features/video/HybridVideoCaptureBackend.test.ts
@@ -42,6 +42,7 @@ class FakeBackend implements VideoCaptureBackend {
 describe("HybridVideoCaptureBackend - Unit Tests", function () {
   let ffmpegBackend: FakeBackend;
   let platformBackend: FakeBackend;
+  let physicalIosBackend: FakeBackend;
   let backend: HybridVideoCaptureBackend;
   let baseConfig: VideoCaptureConfig;
 
@@ -53,7 +54,8 @@ describe("HybridVideoCaptureBackend - Unit Tests", function () {
     delete process.env.AUTOMOBILE_ANDROID_VIDEO_USE_FFMPEG_PIPE;
     ffmpegBackend = new FakeBackend("ffmpeg");
     platformBackend = new FakeBackend("platform");
-    backend = new HybridVideoCaptureBackend(ffmpegBackend, platformBackend);
+    physicalIosBackend = new FakeBackend("ios-physical");
+    backend = new HybridVideoCaptureBackend(ffmpegBackend, platformBackend, physicalIosBackend);
 
     baseConfig = {
       recordingId: "test-recording",
@@ -130,8 +132,9 @@ describe("HybridVideoCaptureBackend - Unit Tests", function () {
     await expect(backend.start(configWithoutDevice)).rejects.toThrow("Device is required");
   });
 
-  // Physical iOS devices are discoverable now, but the iOS video path is simctl-only.
-  test("start rejects a physical iOS device (simctl recordVideo is simulator-only)", async function () {
+  // simctl recordVideo is Simulator-only, so a physical iPhone is captured through
+  // the CoreMediaIO screen-capture-helper backend instead (#2504).
+  test("routes a physical iOS device to the CoreMediaIO helper backend", async function () {
     const physicalConfig: VideoCaptureConfig = {
       ...baseConfig,
       device: {
@@ -139,11 +142,31 @@ describe("HybridVideoCaptureBackend - Unit Tests", function () {
         deviceId: "00008030-001C2D3E1234567A", // physical UDID (8-hex + 16-hex)
       } as BootedDevice,
     };
-    await expect(backend.start(physicalConfig)).rejects.toThrow(
-      "not supported on physical iOS devices",
-    );
+    const handle = await backend.start(physicalConfig);
+
+    expect(physicalIosBackend.startCalls.length).toBe(1);
     expect(ffmpegBackend.startCalls.length).toBe(0);
     expect(platformBackend.startCalls.length).toBe(0);
+
+    await backend.stop(handle);
+
+    expect(physicalIosBackend.stopCalls.length).toBe(1);
+    expect(ffmpegBackend.stopCalls.length).toBe(0);
+    expect(platformBackend.stopCalls.length).toBe(0);
+  });
+
+  test("routes a legacy 40-hex physical iOS UDID to the helper backend too", async function () {
+    const legacyConfig: VideoCaptureConfig = {
+      ...baseConfig,
+      device: {
+        platform: "ios",
+        deviceId: "a".repeat(40),
+      } as BootedDevice,
+    };
+    await backend.start(legacyConfig);
+
+    expect(physicalIosBackend.startCalls.length).toBe(1);
+    expect(ffmpegBackend.startCalls.length).toBe(0);
   });
 
   test("start routes a Simulator iOS device to the ffmpeg backend", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -108,9 +108,21 @@ class FakeCaptureHelper extends EventEmitter implements PhysicalIosCaptureHelper
     this.emit("started");
   }
 
+  exited = false;
+
+  /** The real helper SIGTERMs the process and awaits its exit. */
   async stop(): Promise<unknown> {
     this.stopped += 1;
-    return { code: 0, signal: null };
+    if (!this.exited) {
+      this.exitWith({ code: null, signal: "SIGTERM" });
+    }
+    return { code: null, signal: "SIGTERM" };
+  }
+
+  /** Terminate the helper process, as the OS or a crash would. */
+  exitWith(info: { code: number | null; signal: NodeJS.Signals | null }): void {
+    this.exited = true;
+    this.emit("exit", info);
   }
 
   /**
@@ -396,6 +408,40 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  // A frame dropped for congestion must not consume its pacing slot, or the
+  // timeline silently compresses by exactly the congested interval.
+  test("owes a skipped slot when a frame is dropped under backpressure", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.stdin.pause();
+    encoder.stdin.cork();
+    while (!encoder.stdin.writableNeedDrain) {
+      encoder.stdin.write(Buffer.alloc(64 * 1024));
+    }
+    const congestedBytes = encoder.stdin.writableLength;
+
+    // Two due frames arrive while ffmpeg is behind and are dropped.
+    harness.helper.emitFrame(2, 2, 8, 0x22, 100);
+    harness.helper.emitFrame(2, 2, 8, 0x33, 200);
+    expect(encoder.stdin.writableLength).toBe(congestedBytes);
+
+    encoder.stdin.uncork();
+    encoder.stdin.resume();
+    // Draining is asynchronous; let the stream flush before measuring.
+    await new Promise((resolve) => setImmediate(resolve));
+    const drainedBytes = encoder.written.reduce((n, c) => n + c.length, 0);
+
+    // The next frame pads the two slots the congestion owed, then its own.
+    harness.helper.emitFrame(2, 2, 8, 0x44, 300);
+    const frameBytes = 2 * 2 * 4;
+    const writtenAfter = encoder.written.reduce((n, c) => n + c.length, 0) - drainedBytes;
+    expect(writtenAfter / frameBytes).toBe(3);
+    await harness.backend.stop(handle);
+  });
+
   test("honors resolution and maxDuration like the simulator path", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(
@@ -479,6 +525,30 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
       harness.backend.start(makeConfig({ abortSignal: controller.signal })),
     ).rejects.toThrow("cancelled during shutdown");
     expect(harness.helper.started).toBe(0);
+  });
+
+  test("start cleans up an encoder spawned before helper.start() rejected", async function () {
+    const ffmpeg = new FakeFfmpegClient();
+    const helper = new FakeCaptureHelper();
+    // A helper that emits a frame (spawning ffmpeg) and then fails to start.
+    helper.start = () => {
+      helper.started += 1;
+      helper.emitFrame(4, 2);
+      throw new Error("helper refused to start");
+    };
+    const backend = new IosPhysicalVideoCaptureBackend({
+      ffmpegClient: ffmpeg,
+      helperProvider: { ensure: async () => "/helpers/screen-capture-helper" },
+      deviceLister: new FakeDeviceLister([captureDevice(PHYSICAL_UDID)]),
+      createHelper: () => helper,
+      platformProvider: () => "darwin",
+      fileSize: async () => 1,
+    });
+
+    await expect(backend.start(makeConfig())).rejects.toThrow("helper refused to start");
+
+    expect(helper.stopped).toBe(1);
+    expect(ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
   });
 
   test("start stops the helper when shutdown lands while it is spawning", async function () {
@@ -593,21 +663,49 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     harness.helper.emitFrame(4, 2);
     // Device unplugged: the helper exits on its own while ffmpeg finalizes fine.
     harness.helper.emit("stderr", "error: iOS device capture failed");
-    harness.helper.emit("exit", { code: 3, signal: null });
+    harness.helper.exitWith({ code: 3, signal: null });
 
-    await expect(harness.backend.stop(handle)).rejects.toThrow("capture helper exited with code 3");
+    await expect(harness.backend.stop(handle)).rejects.toThrow(
+      "terminated with exit code 3 before the recording was stopped",
+    );
     // The partial file is still finalized so it can be inspected.
     expect(harness.ffmpeg.processes[0].stdin.writableEnded).toBe(true);
   });
 
-  test("a SIGTERM exit from our own stop is not treated as a helper failure", async function () {
+  // Our own stop() SIGTERMs the helper, so a signal exit is only a failure when
+  // it happened before we asked — the exit code alone cannot tell them apart.
+  test("a SIGTERM exit caused by our own stop is not treated as a helper failure", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig());
     harness.helper.emitFrame(4, 2);
-    harness.helper.emit("exit", { code: null, signal: "SIGTERM" });
 
     const result = await harness.backend.stop(handle);
+
+    expect(harness.helper.exited).toBe(true);
     expect(result.codec).toBe("h264");
+  });
+
+  test("stop rejects when the helper was killed by a signal before shutdown", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+    // An external kill / crash looks identical in shape to our own SIGTERM.
+    harness.helper.exitWith({ code: null, signal: "SIGABRT" });
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow(
+      "terminated with signal SIGABRT before the recording was stopped",
+    );
+  });
+
+  test("stop rejects when the helper errored after frames had already arrived", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+    harness.helper.emit("error", new Error("capture session lost"));
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow(
+      "failed during the recording, so /tmp/archive/rec-1/video.mp4 is truncated: capture session lost",
+    );
   });
 
   test("stop rejects a recording whose encoder exited nonzero", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -608,6 +608,39 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  // The buffered-frame budget only measures what the stream itself holds. When
+  // the encoder consumes one buffered write, `writableLength` drops back under
+  // the budget while older padding is STILL queued — admitting the next live
+  // frame there lets a slow encoder grow the queue faster than it drains.
+  test("drops live frames while earlier padding is still queued", async function () {
+    const harness = makeHarness({ now: () => 1_000 });
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x11, 0);
+    const encoder = harness.ffmpeg.processes[0];
+    const frameBytes = 128 * 128 * 4;
+    encoder.stdin.pause();
+
+    // 500ms at 10fps owes 4 pads plus the frame; the 2-frame budget leaves the
+    // remainder queued.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x22, 500);
+
+    // The encoder consumes one buffered write. `drain` has not fired yet, so the
+    // queue is still non-empty while the buffered-frame budget looks free again.
+    expect(encoder.stdin.read(frameBytes)?.length).toBe(frameBytes);
+    expect(encoder.stdin.writableLength).toBeLessThan(frameBytes * 2);
+
+    // A live frame arriving in that window must be dropped, not appended.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x33, 600);
+
+    encoder.stdin.resume();
+    await harness.backend.stop(handle);
+
+    // 1 + 4 pads + 1: the dropped frame adds nothing, and its slot stays owed.
+    expect(encoder.bytesWritten / frameBytes).toBe(6);
+    expect(encoder.written.some((chunk) => chunk[0] === 0x33)).toBe(false);
+  });
+
   test("releases gap padding on drain instead of truncating it synchronously", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig({ fps: 10 }));

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -288,9 +288,11 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig());
 
-    harness.helper.emitFrame(4, 2);
-    harness.helper.emitFrame(2, 4); // rotation mid-recording
-    harness.helper.emitFrame(4, 2);
+    // Timestamps stay inside one 15fps slot of each other so the pacing gate
+    // neither drops nor pads anything, isolating the geometry behavior.
+    harness.helper.emitFrame(4, 2, 16, 0xaa, 0);
+    harness.helper.emitFrame(2, 4, 8, 0xaa, 35); // rotation mid-recording
+    harness.helper.emitFrame(4, 2, 16, 0xaa, 70);
 
     expect(harness.ffmpeg.startRequests.length).toBe(1);
     expect(harness.ffmpeg.processes[0].bytesWritten).toBe(2 * 4 * 2 * 4);
@@ -336,7 +338,11 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
-  test("resyncs pacing after a capture gap instead of admitting a catch-up burst", async function () {
+  // `-framerate` gives every written frame a contiguous fixed-rate timestamp, so
+  // skipping the idle slots would compress real time and end a duration-capped
+  // recording early. The gap is padded with repeats, bounded at 2s so a long
+  // stall cannot write unbounded copies of a multi-megabyte frame.
+  test("pads a capture gap so the encoded timeline keeps wall-clock duration", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig({ fps: 10 }));
 
@@ -347,7 +353,23 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     }
 
     const framePayloadBytes = 4 * 2 * 4;
-    expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(2);
+    const written = harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes;
+    // 1 initial + 20 gap-fill repeats (the 2s cap at 10fps) + 1 resumed frame;
+    // the 60fps tail after it is paced out.
+    expect(written).toBe(22);
+    await harness.backend.stop(handle);
+  });
+
+  test("pads a short gap in full without hitting the cap", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(4, 2, 16, 0xaa, 0);
+    harness.helper.emitFrame(4, 2, 16, 0xaa, 500); // 400ms of missed slots
+
+    const framePayloadBytes = 4 * 2 * 4;
+    // 1 initial + 4 repeats for the missed 100ms slots + the frame itself.
+    expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(6);
     await harness.backend.stop(handle);
   });
 
@@ -492,6 +514,29 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     expect(harness.helper.stopped).toBe(1);
     expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
+  test("stop rejects a recording the capture helper aborted mid-stream", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+    // Device unplugged: the helper exits on its own while ffmpeg finalizes fine.
+    harness.helper.emit("stderr", "error: iOS device capture failed");
+    harness.helper.emit("exit", { code: 3, signal: null });
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow("capture helper exited with code 3");
+    // The partial file is still finalized so it can be inspected.
+    expect(harness.ffmpeg.processes[0].stdin.writableEnded).toBe(true);
+  });
+
+  test("a SIGTERM exit from our own stop is not treated as a helper failure", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+    harness.helper.emit("exit", { code: null, signal: "SIGTERM" });
+
+    const result = await harness.backend.stop(handle);
+    expect(result.codec).toBe("h264");
   });
 
   test("stop rejects a recording whose encoder exited nonzero", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -113,9 +113,23 @@ class FakeCaptureHelper extends EventEmitter implements PhysicalIosCaptureHelper
     return { code: 0, signal: null };
   }
 
-  emitFrame(width: number, height: number, bytesPerRow = width * 4, fill = 0xaa): void {
+  /**
+   * Capture timestamps advance by more than one 15fps interval by default, so a
+   * plain `emitFrame()` is admitted by the pacing gate. Pass `timestampMs`
+   * explicitly to exercise a device pushing frames faster than the request.
+   */
+  private clockMs = 0;
+
+  emitFrame(
+    width: number,
+    height: number,
+    bytesPerRow = width * 4,
+    fill = 0xaa,
+    timestampMs?: number,
+  ): void {
+    this.clockMs += 100;
     this.emit("frame", {
-      header: { width, height, bytesPerRow, timestampMs: 1 },
+      header: { width, height, bytesPerRow, timestampMs: timestampMs ?? this.clockMs },
       pixels: Buffer.alloc(bytesPerRow * height, fill),
     } satisfies DecodedFrame);
   }
@@ -305,6 +319,38 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  // AVFoundation device capture is not fps-throttled by the helper, so a 60fps
+  // device feeding a `-framerate 15` rawvideo stream would play back 4x slow.
+  test("paces an unthrottled device down to the requested fps", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    // 20 frames at 60fps spans ~317ms of capture; at 10fps (100ms slots) that
+    // admits the frames at t≈0, 100, 200 and 300 — four, not twenty.
+    for (let i = 0; i < 20; i++) {
+      harness.helper.emitFrame(4, 2, 16, 0xaa, i * 16.67);
+    }
+
+    const framePayloadBytes = 4 * 2 * 4;
+    expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(4);
+    await harness.backend.stop(handle);
+  });
+
+  test("resyncs pacing after a capture gap instead of admitting a catch-up burst", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(4, 2, 16, 0xaa, 0);
+    // Device idled for 5s (static screen), then resumed at 60fps.
+    for (let i = 0; i < 5; i++) {
+      harness.helper.emitFrame(4, 2, 16, 0xaa, 5000 + i * 16.67);
+    }
+
+    const framePayloadBytes = 4 * 2 * 4;
+    expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(2);
+    await harness.backend.stop(handle);
+  });
+
   test("honors resolution and maxDuration like the simulator path", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(
@@ -446,6 +492,50 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     expect(harness.helper.stopped).toBe(1);
     expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
+  test("stop rejects a recording whose encoder exited nonzero", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.stderr.write("No space left on device");
+    encoder.exit(1);
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow(
+      "FFmpeg failed to finalize the physical iOS recording",
+    );
+  });
+
+  test("prefers a locally built helper named by the env override", async function () {
+    const ffmpeg = new FakeFfmpegClient();
+    const helper = new FakeCaptureHelper();
+    const helperOptions: { binaryPath: string }[] = [];
+    let providerCalls = 0;
+    const backend = new IosPhysicalVideoCaptureBackend({
+      ffmpegClient: ffmpeg,
+      helperProvider: {
+        ensure: async () => {
+          providerCalls += 1;
+          return "/released/screen-capture-helper";
+        },
+      },
+      deviceLister: new FakeDeviceLister([captureDevice(PHYSICAL_UDID)]),
+      createHelper: (created) => {
+        helperOptions.push({ binaryPath: created.binaryPath });
+        return helper;
+      },
+      platformProvider: () => "darwin",
+      fileSize: async () => 1,
+      env: { AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER: "/local/build/screen-capture-helper" },
+      helperPathExists: (candidate) => candidate === "/local/build/screen-capture-helper",
+    });
+
+    await backend.start(makeConfig());
+
+    expect(helperOptions[0].binaryPath).toBe("/local/build/screen-capture-helper");
+    expect(providerCalls).toBe(0);
   });
 
   test("stop rejects a handle that did not come from this backend", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -194,6 +194,7 @@ function makeHarness(
     helperPath?: string | null;
     platform?: NodeJS.Platform;
     sizeBytes?: number;
+    now?: () => number;
   } = {},
 ): Harness {
   const ffmpeg = new FakeFfmpegClient();
@@ -216,6 +217,7 @@ function makeHarness(
     },
     platformProvider: () => options.platform ?? "darwin",
     fileSize: async () => options.sizeBytes ?? 4096,
+    now: options.now,
   });
 
   return { backend, ffmpeg, helper, lister, helperOptions };
@@ -270,6 +272,40 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
       sizeBytes: 4096,
       codec: "h264",
     });
+  });
+
+  // A static screen delivers no frames, so without trailing padding the file
+  // ends at the last frame's slot however long the recording actually ran.
+  test("pads the stall between the last frame and stop", async function () {
+    let clockMs = 10_000;
+    const harness = makeHarness({ now: () => clockMs });
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+    clockMs += 500; // screen static for half a second before stop
+
+    await harness.backend.stop(handle);
+
+    const frameBytes = 2 * 2 * 4;
+    const written = harness.ffmpeg.processes[0].written.reduce((n, c) => n + c.length, 0);
+    // The frame itself plus five 100ms slots of held picture.
+    expect(written / frameBytes).toBe(6);
+  });
+
+  test("caps trailing padding for a very long final stall", async function () {
+    let clockMs = 10_000;
+    const harness = makeHarness({ now: () => clockMs });
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+    clockMs += 60_000; // a minute of stillness must not write 600 duplicates
+
+    await harness.backend.stop(handle);
+
+    const frameBytes = 2 * 2 * 4;
+    const written = harness.ffmpeg.processes[0].written.reduce((n, c) => n + c.length, 0);
+    // 1 frame + the 2s cap at 10fps.
+    expect(written / frameBytes).toBe(21);
   });
 
   test("stop closes ffmpeg stdin so the moov atom is finalized instead of killing the encoder", async function () {
@@ -347,6 +383,26 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     const framePayloadBytes = 4 * 2 * 4;
     expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(4);
+    await harness.backend.stop(handle);
+  });
+
+  // Capture timestamps are integer milliseconds, so a 30fps source reports
+  // 0, 33, 66, 100... Rebasing the deadline on each admitted frame discards the
+  // sub-slot lateness and compounds it, settling well below the requested rate
+  // while ffmpeg still labels the output 15fps — the file plays fast and short.
+  test("holds the requested rate against integer-millisecond capture timestamps", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 15 }));
+
+    // 10 frames of a 30fps source spanning 300ms.
+    for (let i = 0; i < 10; i++) {
+      harness.helper.emitFrame(4, 2, 16, 0xaa, Math.round(i * (1000 / 30)));
+    }
+
+    const framePayloadBytes = 4 * 2 * 4;
+    // 300ms at 15fps is ~5 frames. Deadline rebasing yielded 4 and drifted
+    // further the longer the recording ran.
+    expect(harness.ffmpeg.processes[0].bytesWritten / framePayloadBytes).toBe(5);
     await harness.backend.stop(handle);
   });
 

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -3,7 +3,9 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import {
   buildRawVideoFfmpegArgs,
+  clampCaptureFps,
   IosPhysicalVideoCaptureBackend,
+  MAX_CAPTURE_FPS,
   packFrame,
   parseCaptureDeviceList,
   SOFTWARE_H264_ENCODER,
@@ -66,6 +68,27 @@ class FakeFfmpegProcess extends EventEmitter {
   get bytesWritten(): number {
     return this.written.reduce((total, chunk) => total + chunk.length, 0);
   }
+
+  /**
+   * Resolve once the encoder has actually received `bytes` of input. An explicit
+   * condition rather than a scheduler turn: `PassThrough` drain handlers and the
+   * backend's queued writes settle over an unspecified number of turns, so a
+   * single `setImmediate` can observe a partial `written` list.
+   */
+  waitForBytes(bytes: number): Promise<void> {
+    if (this.bytesWritten >= bytes) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      const onData = (): void => {
+        if (this.bytesWritten >= bytes) {
+          this.stdin.off("data", onData);
+          resolve();
+        }
+      };
+      this.stdin.on("data", onData);
+    });
+  }
 }
 
 class FakeFfmpegClient implements FfmpegClient {
@@ -110,9 +133,13 @@ class FakeCaptureHelper extends EventEmitter implements PhysicalIosCaptureHelper
 
   exited = false;
 
+  /** Runs inside stop(), modelling the real helper's SIGTERM grace period. */
+  onStop?: () => void;
+
   /** The real helper SIGTERMs the process and awaits its exit. */
   async stop(): Promise<unknown> {
     this.stopped += 1;
+    this.onStop?.();
     if (!this.exited) {
       this.exitWith({ code: null, signal: "SIGTERM" });
     }
@@ -338,6 +365,30 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(written / frameBytes).toBe(21);
   });
 
+  // The helper SIGTERMs its capture process and waits out a grace period, so
+  // sampling the clock after that await would encode the shutdown latency as
+  // trailing video — up to 30 extra frames at the default 15fps.
+  test("pads to the stop request, not to the end of the helper's shutdown", async function () {
+    let clockMs = 10_000;
+    const harness = makeHarness({ now: () => clockMs });
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+    // A slow helper: two seconds of shutdown grace after stop is requested.
+    harness.helper.onStop = () => {
+      clockMs += 2000;
+    };
+
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+    clockMs += 500; // real stall the user saw, before stop was requested
+
+    await harness.backend.stop(handle);
+
+    const frameBytes = 2 * 2 * 4;
+    const written = harness.ffmpeg.processes[0].written.reduce((n, c) => n + c.length, 0);
+    // The frame plus the five 100ms slots of real stall — the shutdown grace
+    // period contributes nothing.
+    expect(written / frameBytes).toBe(6);
+  });
+
   test("stop closes ffmpeg stdin so the moov atom is finalized instead of killing the encoder", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig());
@@ -516,8 +567,10 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     encoder.stdin.uncork();
     encoder.stdin.resume();
-    // Draining is asynchronous; let the stream flush before measuring.
-    await new Promise((resolve) => setImmediate(resolve));
+    // Draining is asynchronous: wait for the filler plus the one real frame to
+    // actually reach the encoder rather than for a scheduler turn.
+    const realFrameBytes = 2 * 2 * 4;
+    await encoder.waitForBytes(congestedBytes + realFrameBytes);
     const drainedBytes = encoder.written.reduce((n, c) => n + c.length, 0);
 
     // The next frame pads the two slots the congestion owed, then its own.
@@ -573,29 +626,44 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     encoder.stdin.uncork();
     encoder.stdin.resume();
-    await new Promise((resolve) => setImmediate(resolve));
+    // 1 + 4 pads + 1: wait for the queue to actually land, not for one turn.
+    await encoder.waitForBytes(6 * frameBytes);
 
-    // Everything owed reaches the encoder once it drains: 1 + 4 pads + 1.
+    // Everything owed reaches the encoder once it drains, and nothing extra.
     const written = encoder.written.reduce((n, c) => n + c.length, 0);
     expect(written / frameBytes).toBe(6);
     await harness.backend.stop(handle);
   });
 
-  // fps has no upper bound in the recording config, and a 2-second fill budget
-  // scales with it: at an absurd rate two ordinary frames would enqueue tens of
-  // thousands of multi-megabyte duplicate encodes.
-  test("caps gap-fill work in absolute frames, not just seconds of fps", async function () {
+  // fps has no upper bound in the recording config, and gap fill is owed on
+  // EVERY source frame: at an absurd rate each ordinary frame would enqueue
+  // another batch of multi-megabyte duplicates for the whole recording, so the
+  // rate is clamped once at start rather than bounded per gap.
+  test("clamps an unsupported capture fps to the device ceiling", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig({ fps: 1_000_000 }));
 
     harness.helper.emitFrame(2, 2, 8, 0x11, 0);
     harness.helper.emitFrame(2, 2, 8, 0x22, 100);
 
+    // The encoder is labelled with the rate the pacing actually used, or the
+    // encoded timeline would not match its own timestamps.
+    const args = harness.ffmpeg.startRequests[0].args;
+    expect(args[args.indexOf("-framerate") + 1]).toBe(String(MAX_CAPTURE_FPS));
+
     const frameBytes = 2 * 2 * 4;
     const written = harness.ffmpeg.processes[0].written.reduce((n, c) => n + c.length, 0);
-    // 1 initial + the 120-frame absolute cap + the frame itself.
-    expect(written / frameBytes).toBe(122);
+    // 1 initial + the four 16.67ms slots the 100ms gap skipped + the frame.
+    expect(written / frameBytes).toBe(6);
     await harness.backend.stop(handle);
+  });
+
+  test("clamps a non-finite fps request rather than pacing on NaN", function () {
+    expect(clampCaptureFps(Number.NaN)).toBe(MAX_CAPTURE_FPS);
+    expect(clampCaptureFps(0)).toBe(MAX_CAPTURE_FPS);
+    expect(clampCaptureFps(-30)).toBe(MAX_CAPTURE_FPS);
+    expect(clampCaptureFps(15)).toBe(15);
+    expect(clampCaptureFps(MAX_CAPTURE_FPS + 1)).toBe(MAX_CAPTURE_FPS);
   });
 
   test("honors resolution and maxDuration like the simulator path", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -282,6 +282,28 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  test("drops frames instead of buffering without bound while the encoder is behind", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.stdin.pause();
+    encoder.stdin.cork();
+    // Overfill the encoder's stdin so it reports needing a drain.
+    while (!encoder.stdin.writableNeedDrain) {
+      encoder.stdin.write(Buffer.alloc(64 * 1024));
+    }
+    const bufferedBefore = encoder.stdin.writableLength;
+
+    harness.helper.emitFrame(4, 2);
+
+    expect(encoder.stdin.writableLength).toBe(bufferedBefore);
+    encoder.stdin.uncork();
+    encoder.stdin.resume();
+    await harness.backend.stop(handle);
+  });
+
   test("honors resolution and maxDuration like the simulator path", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -105,6 +105,7 @@ class FakeCaptureHelper extends EventEmitter implements PhysicalIosCaptureHelper
 
   start(): void {
     this.started += 1;
+    this.emit("started");
   }
 
   async stop(): Promise<unknown> {
@@ -329,6 +330,40 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(args[args.indexOf("-c:v") + 1]).toBe(SOFTWARE_H264_ENCODER);
     expect(args).toContain("-preset");
     await harness.backend.stop(handle);
+  });
+
+  test("start rejects when ffmpeg exposes no usable H.264 encoder", async function () {
+    const harness = makeHarness();
+    harness.ffmpeg.encoders = ["mpeg4"];
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow(
+      "neither h264_videotoolbox nor libx264",
+    );
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("start rejects an already-aborted recording without spawning the helper", async function () {
+    const harness = makeHarness();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      harness.backend.start(makeConfig({ abortSignal: controller.signal })),
+    ).rejects.toThrow("cancelled during shutdown");
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("start stops the helper when shutdown lands while it is spawning", async function () {
+    const controller = new AbortController();
+    const harness = makeHarness();
+    // Abort once the helper has spawned but before the handle is handed back.
+    harness.helper.on("started", () => controller.abort());
+
+    await expect(
+      harness.backend.start(makeConfig({ abortSignal: controller.signal })),
+    ).rejects.toThrow("cancelled during shutdown");
+    expect(harness.helper.started).toBe(1);
+    expect(harness.helper.stopped).toBe(1);
   });
 
   test("start rejects on a non-macOS host before spawning anything", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -373,6 +373,29 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  // Slots before the new frame arrived showed the OLD picture; filling them with
+  // the new one would move a visual transition earlier than it happened.
+  test("pads gap slots with the previous frame, not the newly arrived one", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+    harness.helper.emitFrame(2, 2, 8, 0x22, 500);
+
+    const encoder = harness.ffmpeg.processes[0];
+    const frames = Buffer.concat(encoder.written);
+    const frameBytes = 2 * 2 * 4;
+    expect(frames.length / frameBytes).toBe(6);
+    // Slots 0..4 carry the old picture; only the final slot is the new frame.
+    for (let slot = 0; slot < 5; slot++) {
+      const start = slot * frameBytes;
+      expect(frames.subarray(start, start + frameBytes).every((b) => b === 0x11)).toBe(true);
+    }
+    const last = frames.subarray(5 * frameBytes);
+    expect(last.every((b) => b === 0x22)).toBe(true);
+    await harness.backend.stop(handle);
+  });
+
   test("honors resolution and maxDuration like the simulator path", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(
@@ -384,6 +407,43 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(args).toContain("-vf");
     expect(args[args.indexOf("-vf") + 1]).toBe("scale=640:480");
     expect(args[args.indexOf("-t") + 1]).toBe("12");
+    await harness.backend.stop(handle);
+  });
+
+  // yuv420p subsamples chroma 2x2, so an odd edge makes ffmpeg refuse the encode.
+  // Real iPhone panels are odd (1179x2556), which would fail every recording.
+  test("scales an odd native capture size to even dimensions for yuv420p", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+
+    harness.helper.emitFrame(1179, 2555, 1179 * 4);
+
+    const args = harness.ffmpeg.startRequests[0].args;
+    // The raw input keeps the true byte geometry; only the output is evened.
+    expect(args[args.indexOf("-video_size") + 1]).toBe("1179x2555");
+    expect(args[args.indexOf("-vf") + 1]).toBe("scale=1178:2554");
+    await harness.backend.stop(handle);
+  });
+
+  test("leaves an already-even capture size unscaled", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+
+    harness.helper.emitFrame(4, 2);
+
+    expect(harness.ffmpeg.startRequests[0].args).not.toContain("-vf");
+    await harness.backend.stop(handle);
+  });
+
+  test("rounds an odd requested resolution down to even", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(
+      makeConfig({ resolution: { width: 641, height: 481 } }),
+    );
+    harness.helper.emitFrame(4, 2);
+
+    const args = harness.ffmpeg.startRequests[0].args;
+    expect(args[args.indexOf("-vf") + 1]).toBe("scale=640:480");
     await harness.backend.stop(handle);
   });
 
@@ -492,6 +552,17 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     await expect(harness.backend.start(makeConfig())).rejects.toThrow(
       "Could not match device 00008030-001C2D3E1234567A",
+    );
+  });
+
+  test("stop reports the helper spawn failure rather than a trust hint", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    // A spawn failure arrives after start() returned and may never emit "exit".
+    harness.helper.emit("error", new Error("spawn /helpers/screen-capture-helper EACCES"));
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow(
+      "could not be run, so no recording was produced: spawn /helpers/screen-capture-helper EACCES",
     );
   });
 

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -292,6 +292,36 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(written / frameBytes).toBe(6);
   });
 
+  // Only the 2-frame budget fits synchronously, so with real frame sizes most of
+  // the trailing padding is still queued when stop() runs. Discarding it there
+  // would shorten the recording by exactly that padding.
+  test("drains queued trailing padding before closing the encoder", async function () {
+    let clockMs = 10_000;
+    const harness = makeHarness({ now: () => clockMs });
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    // 64KB frames: the 2-frame budget cannot absorb the padding in one flush.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x11, 0);
+    const encoder = harness.ffmpeg.processes[0];
+    // Stop consuming so queued writes genuinely accumulate, as a busy encoder does.
+    encoder.stdin.pause();
+    clockMs += 500;
+
+    const stopPromise = harness.backend.stop(handle);
+    await new Promise((resolve) => setImmediate(resolve));
+    const frameBytes = 128 * 128 * 4;
+    // Only the budget made it in synchronously; the rest is still owed.
+    expect(encoder.written.reduce((n, c) => n + c.length, 0) / frameBytes).toBeLessThan(6);
+
+    encoder.stdin.resume();
+    const result = await stopPromise;
+
+    const written = encoder.written.reduce((n, c) => n + c.length, 0);
+    // 1 frame + five 100ms slots, none lost to the buffer budget.
+    expect(written / frameBytes).toBe(6);
+    expect(result.codec).toBe("h264");
+  });
+
   test("caps trailing padding for a very long final stall", async function () {
     let clockMs = 10_000;
     const harness = makeHarness({ now: () => clockMs });
@@ -548,6 +578,23 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     // Everything owed reaches the encoder once it drains: 1 + 4 pads + 1.
     const written = encoder.written.reduce((n, c) => n + c.length, 0);
     expect(written / frameBytes).toBe(6);
+    await harness.backend.stop(handle);
+  });
+
+  // fps has no upper bound in the recording config, and a 2-second fill budget
+  // scales with it: at an absurd rate two ordinary frames would enqueue tens of
+  // thousands of multi-megabyte duplicate encodes.
+  test("caps gap-fill work in absolute frames, not just seconds of fps", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 1_000_000 }));
+
+    harness.helper.emitFrame(2, 2, 8, 0x11, 0);
+    harness.helper.emitFrame(2, 2, 8, 0x22, 100);
+
+    const frameBytes = 2 * 2 * 4;
+    const written = harness.ffmpeg.processes[0].written.reduce((n, c) => n + c.length, 0);
+    // 1 initial + the 120-frame absolute cap + the frame itself.
+    expect(written / frameBytes).toBe(122);
     await harness.backend.stop(handle);
   });
 

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -442,6 +442,59 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.stop(handle);
   });
 
+  // A pipe's default high-water mark is 16KB while one real BGRA frame is
+  // megabytes, so `writableNeedDrain` is true after EVERY write. Treating that
+  // as congestion would drop nearly every frame of a real recording — and the
+  // small payloads used elsewhere in this file would never reveal it.
+  test("keeps recording when a single frame exceeds the stream high-water mark", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    // 128x128 BGRA = 64KB per frame, four times the default 16KB watermark.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x11, 0);
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.stdin.pause();
+
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x22, 100);
+    // One buffered frame already trips the stream's own backpressure signal...
+    expect(encoder.stdin.writableNeedDrain).toBe(true);
+
+    // ...but it is not congestion by the frame-based budget, so the next frame
+    // is still encoded rather than dropped.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x33, 200);
+
+    const frameBytes = 128 * 128 * 4;
+    expect(encoder.stdin.writableLength / frameBytes).toBe(2);
+    encoder.stdin.resume();
+    await harness.backend.stop(handle);
+  });
+
+  test("releases gap padding on drain instead of truncating it synchronously", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig({ fps: 10 }));
+
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x11, 0);
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.stdin.pause();
+    encoder.stdin.cork();
+
+    // 500ms gap at 10fps owes 4 pads plus the frame; the 2-frame budget cannot
+    // take them all at once, so the remainder must survive as queued work.
+    harness.helper.emitFrame(128, 128, 128 * 4, 0x22, 500);
+    const frameBytes = 128 * 128 * 4;
+    const bufferedNow = encoder.stdin.writableLength / frameBytes;
+    expect(bufferedNow).toBeLessThan(6);
+
+    encoder.stdin.uncork();
+    encoder.stdin.resume();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Everything owed reaches the encoder once it drains: 1 + 4 pads + 1.
+    const written = encoder.written.reduce((n, c) => n + c.length, 0);
+    expect(written / frameBytes).toBe(6);
+    await harness.backend.stop(handle);
+  });
+
   test("honors resolution and maxDuration like the simulator path", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -761,6 +761,7 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
 
     const args = harness.ffmpeg.startRequests[0].args;
     expect(args[args.indexOf("-vf") + 1]).toBe("scale=640:480");
+    expect(handle.effectiveConfig?.resolution).toEqual({ width: 640, height: 480 });
     await harness.backend.stop(handle);
   });
 

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import {
+  buildRawVideoFfmpegArgs,
+  IosPhysicalVideoCaptureBackend,
+  packFrame,
+  parseCaptureDeviceList,
+  SOFTWARE_H264_ENCODER,
+  VIDEOTOOLBOX_H264_ENCODER,
+  type CaptureDeviceInfo,
+  type CaptureDeviceLister,
+  type PhysicalIosCaptureHelper,
+} from "../../../src/features/video/IosPhysicalVideoCaptureBackend";
+import type { VideoCaptureConfig } from "../../../src/features/video/VideoRecorderService";
+import type { DecodedFrame } from "../../../src/features/screen-stream/frameProtocol";
+import type {
+  FfmpegClient,
+  FfmpegProbeResult,
+  FfmpegProcess,
+  FfmpegStartRequest,
+  FfmpegStartedProcess,
+} from "../../../src/utils/media/FfmpegClient";
+import { trackProcess } from "../../../src/utils/ChildProcessTracker";
+import type { BootedDevice } from "../../../src/models";
+
+const PHYSICAL_UDID = "00008030-001C2D3E1234567A";
+
+class FakeFfmpegProcess extends EventEmitter {
+  readonly binaryPath = "ffmpeg";
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly written: Buffer[] = [];
+  killSignals: (NodeJS.Signals | number | undefined)[] = [];
+
+  constructor() {
+    super();
+    this.stdin.on("data", (chunk: Buffer) => {
+      this.written.push(Buffer.from(chunk));
+    });
+    // ffmpeg finalizes and exits once its stdin closes; the real binary's moov
+    // write is what stop() waits for.
+    this.stdin.on("end", () => this.exit(0));
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killSignals.push(signal);
+    this.killed = true;
+    this.exit(null, typeof signal === "string" ? signal : "SIGKILL");
+    return true;
+  }
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    if (this.exitCode !== null || this.signalCode !== null) {
+      return;
+    }
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit("exit", code, signal);
+  }
+
+  get bytesWritten(): number {
+    return this.written.reduce((total, chunk) => total + chunk.length, 0);
+  }
+}
+
+class FakeFfmpegClient implements FfmpegClient {
+  readonly binaryPath = "ffmpeg";
+  readonly startRequests: FfmpegStartRequest[] = [];
+  readonly processes: FakeFfmpegProcess[] = [];
+  probeError: Error | null = null;
+  encoders: string[] = [VIDEOTOOLBOX_H264_ENCODER, SOFTWARE_H264_ENCODER];
+
+  start(request: FfmpegStartRequest): FfmpegStartedProcess {
+    this.startRequests.push(request);
+    const process = new FakeFfmpegProcess();
+    this.processes.push(process);
+    const tracked = process as unknown as FfmpegProcess;
+    return { process: tracked, tracker: trackProcess(tracked) };
+  }
+
+  async run(): Promise<never> {
+    throw new Error("run() is not used by the physical iOS backend");
+  }
+
+  async probe(): Promise<FfmpegProbeResult> {
+    if (this.probeError) {
+      throw this.probeError;
+    }
+    return { version: "7.1", encoders: this.encoders };
+  }
+
+  pipe(): void {
+    throw new Error("pipe() is not used by the physical iOS backend");
+  }
+}
+
+class FakeCaptureHelper extends EventEmitter implements PhysicalIosCaptureHelper {
+  started = 0;
+  stopped = 0;
+
+  start(): void {
+    this.started += 1;
+  }
+
+  async stop(): Promise<unknown> {
+    this.stopped += 1;
+    return { code: 0, signal: null };
+  }
+
+  emitFrame(width: number, height: number, bytesPerRow = width * 4, fill = 0xaa): void {
+    this.emit("frame", {
+      header: { width, height, bytesPerRow, timestampMs: 1 },
+      pixels: Buffer.alloc(bytesPerRow * height, fill),
+    } satisfies DecodedFrame);
+  }
+}
+
+class FakeDeviceLister implements CaptureDeviceLister {
+  readonly listedBinaries: string[] = [];
+
+  constructor(private readonly devices: CaptureDeviceInfo[]) {}
+
+  async list(binaryPath: string): Promise<CaptureDeviceInfo[]> {
+    this.listedBinaries.push(binaryPath);
+    return this.devices;
+  }
+}
+
+function captureDevice(uniqueID: string, localizedName = "iPhone"): CaptureDeviceInfo {
+  return { uniqueID, localizedName, modelID: "iPhone16,1", manufacturer: "Apple Inc." };
+}
+
+function makeConfig(overrides: Partial<VideoCaptureConfig> = {}): VideoCaptureConfig {
+  return {
+    recordingId: "rec-1",
+    outputDirectory: "/tmp/archive/rec-1",
+    outputPath: "/tmp/archive/rec-1/video.mp4",
+    fileName: "video.mp4",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    qualityPreset: "low",
+    targetBitrateKbps: 1000,
+    maxThroughputMbps: 5,
+    fps: 15,
+    maxArchiveSizeMb: 100,
+    format: "mp4",
+    device: { platform: "ios", deviceId: PHYSICAL_UDID } as BootedDevice,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  backend: IosPhysicalVideoCaptureBackend;
+  ffmpeg: FakeFfmpegClient;
+  helper: FakeCaptureHelper;
+  lister: FakeDeviceLister;
+  helperOptions: { binaryPath: string; deviceId?: string }[];
+}
+
+function makeHarness(
+  options: {
+    devices?: CaptureDeviceInfo[];
+    helperPath?: string | null;
+    platform?: NodeJS.Platform;
+    sizeBytes?: number;
+  } = {},
+): Harness {
+  const ffmpeg = new FakeFfmpegClient();
+  const helper = new FakeCaptureHelper();
+  const lister = new FakeDeviceLister(options.devices ?? [captureDevice(PHYSICAL_UDID)]);
+  const helperOptions: { binaryPath: string; deviceId?: string }[] = [];
+  const helperPath =
+    options.helperPath === undefined ? "/helpers/screen-capture-helper" : options.helperPath;
+
+  const backend = new IosPhysicalVideoCaptureBackend({
+    ffmpegClient: ffmpeg,
+    helperProvider: { ensure: async () => helperPath },
+    deviceLister: lister,
+    createHelper: (created) => {
+      helperOptions.push({
+        binaryPath: created.binaryPath,
+        deviceId: created.target.kind === "device" ? created.target.deviceId : undefined,
+      });
+      return helper;
+    },
+    platformProvider: () => options.platform ?? "darwin",
+    fileSize: async () => options.sizeBytes ?? 4096,
+  });
+
+  return { backend, ffmpeg, helper, lister, helperOptions };
+}
+
+describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
+  test("records a physical iOS device by piping helper BGRA frames into ffmpeg rawvideo", async function () {
+    const harness = makeHarness();
+
+    const handle = await harness.backend.start(makeConfig());
+    expect(harness.helper.started).toBe(1);
+    expect(harness.helperOptions[0]).toEqual({
+      binaryPath: "/helpers/screen-capture-helper",
+      deviceId: PHYSICAL_UDID,
+    });
+    // ffmpeg cannot be spawned before a frame pins the raw geometry.
+    expect(harness.ffmpeg.startRequests.length).toBe(0);
+
+    harness.helper.emitFrame(4, 2);
+    harness.helper.emitFrame(4, 2);
+    expect(harness.ffmpeg.startRequests.length).toBe(1);
+    expect(harness.ffmpeg.startRequests[0].args).toEqual([
+      "-f",
+      "rawvideo",
+      "-pixel_format",
+      "bgra",
+      "-video_size",
+      "4x2",
+      "-framerate",
+      "15",
+      "-i",
+      "pipe:0",
+      "-c:v",
+      VIDEOTOOLBOX_H264_ENCODER,
+      "-b:v",
+      "1000k",
+      "-pix_fmt",
+      "yuv420p",
+      "-movflags",
+      "+faststart",
+      "-y",
+      "/tmp/archive/rec-1/video.mp4",
+    ]);
+
+    const result = await harness.backend.stop(handle);
+
+    expect(harness.helper.stopped).toBe(1);
+    expect(harness.ffmpeg.processes[0].bytesWritten).toBe(2 * 4 * 2 * 4);
+    expect(result).toMatchObject({
+      recordingId: "rec-1",
+      outputPath: "/tmp/archive/rec-1/video.mp4",
+      sizeBytes: 4096,
+      codec: "h264",
+    });
+  });
+
+  test("stop closes ffmpeg stdin so the moov atom is finalized instead of killing the encoder", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(2, 2);
+
+    await harness.backend.stop(handle);
+
+    const encoder = harness.ffmpeg.processes[0];
+    expect(encoder.stdin.writableEnded).toBe(true);
+    expect(encoder.killSignals).toEqual([]);
+    expect(encoder.exitCode).toBe(0);
+  });
+
+  test("strips row padding so each written frame is exactly width*height*4 bytes", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+
+    // AVFoundation aligns bytesPerRow up; the padded tail must not reach ffmpeg.
+    harness.helper.emitFrame(3, 2, 32);
+
+    expect(harness.ffmpeg.processes[0].bytesWritten).toBe(3 * 2 * 4);
+    await harness.backend.stop(handle);
+  });
+
+  test("drops frames whose geometry differs from the locked capture size", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+
+    harness.helper.emitFrame(4, 2);
+    harness.helper.emitFrame(2, 4); // rotation mid-recording
+    harness.helper.emitFrame(4, 2);
+
+    expect(harness.ffmpeg.startRequests.length).toBe(1);
+    expect(harness.ffmpeg.processes[0].bytesWritten).toBe(2 * 4 * 2 * 4);
+    await harness.backend.stop(handle);
+  });
+
+  test("honors resolution and maxDuration like the simulator path", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(
+      makeConfig({ resolution: { width: 640, height: 480 }, maxDurationSeconds: 12 }),
+    );
+    harness.helper.emitFrame(4, 2);
+
+    const args = harness.ffmpeg.startRequests[0].args;
+    expect(args).toContain("-vf");
+    expect(args[args.indexOf("-vf") + 1]).toBe("scale=640:480");
+    expect(args[args.indexOf("-t") + 1]).toBe("12");
+    await harness.backend.stop(handle);
+  });
+
+  test("falls back to software H.264 when ffmpeg lacks VideoToolbox", async function () {
+    const harness = makeHarness();
+    harness.ffmpeg.encoders = ["libx264"];
+
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(4, 2);
+
+    const args = harness.ffmpeg.startRequests[0].args;
+    expect(args[args.indexOf("-c:v") + 1]).toBe(SOFTWARE_H264_ENCODER);
+    expect(args).toContain("-preset");
+    await harness.backend.stop(handle);
+  });
+
+  test("start rejects on a non-macOS host before spawning anything", async function () {
+    const harness = makeHarness({ platform: "linux" });
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow(
+      "Physical iOS video recording requires macOS",
+    );
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("start rejects with install guidance when ffmpeg is missing", async function () {
+    const harness = makeHarness();
+    harness.ffmpeg.probeError = new Error("spawn ffmpeg ENOENT");
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow("FFmpeg is not available");
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("start rejects with build guidance when the capture helper cannot be resolved", async function () {
+    const harness = makeHarness({ helperPath: null });
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow("screen-capture-helper");
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("start rejects when no muxed capture device is attached", async function () {
+    const harness = makeHarness({ devices: [] });
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow(
+      "No muxed external capture devices found",
+    );
+    expect(harness.helper.started).toBe(0);
+  });
+
+  test("maps the UDID onto an AVFoundation uniqueID spelled without the hyphen", async function () {
+    const harness = makeHarness({
+      devices: [captureDevice("0000803000" + "1C2D3E1234567A"), captureDevice("other-device")],
+    });
+
+    await harness.backend.start(makeConfig());
+
+    expect(harness.helperOptions[0].deviceId).toBe("00008030001C2D3E1234567A");
+  });
+
+  test("falls back to the only attached device when no id matches", async function () {
+    const harness = makeHarness({ devices: [captureDevice("avf-unique-id")] });
+
+    await harness.backend.start(makeConfig());
+
+    expect(harness.helperOptions[0].deviceId).toBe("avf-unique-id");
+  });
+
+  test("refuses to guess between several unmatched capture devices", async function () {
+    const harness = makeHarness({
+      devices: [captureDevice("avf-a", "iPhone A"), captureDevice("avf-b", "iPhone B")],
+    });
+
+    await expect(harness.backend.start(makeConfig())).rejects.toThrow(
+      "Could not match device 00008030-001C2D3E1234567A",
+    );
+  });
+
+  test("stop reports an actionable trust/connection error when no frame ever arrived", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emit("stderr", "error: no muxed external capture devices found");
+    harness.helper.emit("exit", { code: 1, signal: null });
+
+    await expect(harness.backend.stop(handle)).rejects.toThrow("No frames were captured");
+    expect(harness.helper.stopped).toBe(1);
+  });
+
+  test("forceStop kills the encoder without waiting for finalization", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(2, 2);
+
+    await harness.backend.forceStop(handle);
+
+    expect(harness.helper.stopped).toBe(1);
+    expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
+  test("stop rejects a handle that did not come from this backend", async function () {
+    const harness = makeHarness();
+
+    await expect(
+      harness.backend.stop({
+        recordingId: "x",
+        outputPath: "/tmp/x.mp4",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        backendHandle: { kind: "hybrid" },
+      }),
+    ).rejects.toThrow("Missing backend handle for physical iOS");
+  });
+});
+
+describe("packFrame", function () {
+  test("returns the original buffer when there is no row padding", function () {
+    const frame: DecodedFrame = {
+      header: { width: 2, height: 2, bytesPerRow: 8, timestampMs: 0 },
+      pixels: Buffer.alloc(16, 1),
+    };
+    expect(packFrame(frame)).toBe(frame.pixels);
+  });
+
+  test("copies only the visible bytes of each padded row", function () {
+    const pixels = Buffer.alloc(2 * 12);
+    pixels.fill(0x11, 0, 8); // row 0 visible
+    pixels.fill(0xff, 8, 12); // row 0 padding
+    pixels.fill(0x22, 12, 20); // row 1 visible
+    pixels.fill(0xff, 20, 24); // row 1 padding
+
+    const packed = packFrame({
+      header: { width: 2, height: 2, bytesPerRow: 12, timestampMs: 0 },
+      pixels,
+    });
+
+    expect(packed.length).toBe(16);
+    expect(packed.subarray(0, 8).every((byte) => byte === 0x11)).toBe(true);
+    expect(packed.subarray(8, 16).every((byte) => byte === 0x22)).toBe(true);
+  });
+});
+
+describe("buildRawVideoFfmpegArgs", function () {
+  test("pins the raw input format ahead of the input so ffmpeg can parse the pipe", function () {
+    const args = buildRawVideoFfmpegArgs(makeConfig(), 828, 1792, VIDEOTOOLBOX_H264_ENCODER);
+    expect(args.indexOf("-f")).toBeLessThan(args.indexOf("-i"));
+    expect(args[args.indexOf("-video_size") + 1]).toBe("828x1792");
+  });
+});
+
+describe("parseCaptureDeviceList", function () {
+  test("parses the helper --list-devices envelope", function () {
+    const devices = parseCaptureDeviceList(
+      JSON.stringify({
+        devices: [
+          {
+            uniqueID: "avf-1",
+            localizedName: "iPhone 15",
+            modelID: "iPhone16,1",
+            manufacturer: "Apple Inc.",
+          },
+        ],
+      }),
+    );
+    expect(devices).toEqual([
+      {
+        uniqueID: "avf-1",
+        localizedName: "iPhone 15",
+        modelID: "iPhone16,1",
+        manufacturer: "Apple Inc.",
+      },
+    ]);
+  });
+
+  test("returns an empty list when the helper sees no devices", function () {
+    expect(parseCaptureDeviceList('{"devices":[]}')).toEqual([]);
+  });
+
+  test("rejects unparseable or shape-drifted helper output", function () {
+    expect(() => parseCaptureDeviceList("not json")).toThrow("unparseable output");
+    expect(() => parseCaptureDeviceList('{"items":[]}')).toThrow("no `devices` array");
+  });
+});

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -389,6 +389,20 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(written / frameBytes).toBe(6);
   });
 
+  test("reports the stop boundary rather than the encoder's delayed exit", async function () {
+    let clockMs = 10_000;
+    const harness = makeHarness({ now: () => clockMs });
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(2, 2);
+    harness.helper.onStop = () => {
+      clockMs += 2_000;
+    };
+
+    const result = await harness.backend.stop(handle);
+
+    expect(result.endedAt).toBe(new Date(10_000).toISOString());
+  });
+
   test("stop closes ffmpeg stdin so the moov atom is finalized instead of killing the encoder", async function () {
     const harness = makeHarness();
     const handle = await harness.backend.start(makeConfig());
@@ -911,6 +925,19 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await harness.backend.forceStop(handle);
 
     expect(harness.helper.stopped).toBe(1);
+    expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
+  test("forceStop kills the encoder even when helper shutdown rejects", async function () {
+    const harness = makeHarness();
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(2, 2);
+    harness.helper.onStop = () => {
+      throw new Error("helper shutdown failed");
+    };
+
+    await expect(harness.backend.forceStop(handle)).rejects.toThrow("helper shutdown failed");
+
     expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
   });
 

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -240,6 +240,40 @@ describe("VideoRecorderService", () => {
       expect(metadata.config.fps).toBe(60);
     });
 
+    // A backend's `effectiveConfig` is reported to the caller and persisted as
+    // the recording's public configuration, so a backend that spreads its whole
+    // internal capture config must not leak runtime-only fields (abort signals,
+    // absolute paths, the device descriptor) into it.
+    test("narrows a backend's effective configuration to the public fields", async () => {
+      backend.start = async (config) => {
+        const handle = {
+          recordingId: config.recordingId,
+          outputPath: config.outputPath,
+          startedAt: config.startedAt,
+          effectiveConfig: { ...config, fps: 60 },
+        };
+        backend.startResults.push(handle);
+        return handle;
+      };
+
+      const recording = await service.startRecording({ config: { fps: 120 } });
+      const metadata = await service.stopRecording(recording.recordingId);
+
+      const publicKeys = [
+        "qualityPreset",
+        "targetBitrateKbps",
+        "maxThroughputMbps",
+        "fps",
+        "maxArchiveSizeMb",
+        "format",
+        "resolution",
+      ];
+      for (const config of [recording.config, metadata.config]) {
+        expect(Object.keys(config).every((key) => publicKeys.includes(key))).toBe(true);
+        expect(config.fps).toBe(60);
+      }
+    });
+
     test("creates output directory", async () => {
       await service.startRecording();
       const dir = path.join(archiveRoot, "rec-1");

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -221,6 +221,25 @@ describe("VideoRecorderService", () => {
       expect(backend.startCalls[0].fps).toBe(30);
     });
 
+    test("reports and persists a backend's effective configuration", async () => {
+      backend.start = async (config) => {
+        const handle = {
+          recordingId: config.recordingId,
+          outputPath: config.outputPath,
+          startedAt: config.startedAt,
+          effectiveConfig: { ...config, fps: 60 },
+        };
+        backend.startResults.push(handle);
+        return handle;
+      };
+
+      const recording = await service.startRecording({ config: { fps: 120 } });
+      const metadata = await service.stopRecording(recording.recordingId);
+
+      expect(recording.config.fps).toBe(60);
+      expect(metadata.config.fps).toBe(60);
+    });
+
     test("creates output directory", async () => {
       await service.startRecording();
       const dir = path.join(archiveRoot, "rec-1");


### PR DESCRIPTION
Closes [#2504](https://github.com/kaeawc/auto-mobile/issues/2504).

## Problem

`videoRecording` worked on iOS **Simulators only**. Both iOS backends routed every iOS device to `simctl io recordVideo` (Simulator-only), and `HybridVideoCaptureBackend.start` rejected a physical UDID outright with "Video recording is not supported on physical iOS devices". Android already records physical devices through `adb exec-out screenrecord`, so real iPhones/iPads were the one mainstream target with no recording path — the parity gap this milestone tracks.

## Mechanism

`xcrun devicectl` has no screen-recording verb, so the simulator pattern of swapping `simctl` → `devicectl` does not apply. This wires in the mechanism the repo already ships:

1. CoreMediaIO's `kCMIOHardwarePropertyAllowScreenCaptureDevices` exposes the USB-connected device as a muxed `AVCaptureDevice` (`ios/screen-capture/Sources/ScreenCaptureHelper/CMIOSystem.swift`).
2. The Swift `screen-capture-helper` streams that device's BGRA frames to stdout, decoded by the existing `IOSScreenCaptureHelper` / `FrameDecoder`.
3. The new `IosPhysicalVideoCaptureBackend` pipes those frames into `ffmpeg -f rawvideo -pixel_format bgra` — structurally the same handoff as `FfmpegVideoProcessingBackend.startAndroid`'s `screenrecord` → ffmpeg pipe, with a raw input instead of an mp4 one.

`HybridVideoCaptureBackend.selectBackend` now splits iOS on `isIosPhysicalUdid`: Simulator → the existing ffmpeg/simctl path (unchanged), physical → the new backend.

### Details worth reviewing

- **ffmpeg starts on the first frame.** Raw frames carry no geometry, so `-video_size` cannot be known before one arrives. Frames that later report a different size (rotation) are dropped rather than skewing every subsequent row of the file.
- **Row padding is stripped** (`packFrame`): AVFoundation aligns `bytesPerRow` up from `width * 4`, and feeding the padded rows to `rawvideo` would shear the picture.
- **UDID → AVFoundation `uniqueID` mapping.** `--device-id` matches `uniqueID` exactly (`ScreenCaptureHelper/main.swift` exits 1 otherwise), and the reported id is not guaranteed to be spelled like the AutoMobile UDID. Resolution is exact match → separator-insensitive match → the only attached device; with several unmatched devices it errors rather than guessing.
- **`stop()` closes ffmpeg stdin instead of signalling it** (`waitForExit(..., { signal: null })`), so the MP4 moov atom is finalized; the bounded timeout still escalates to SIGKILL on a wedge. A capture that never produced a frame fails with the USB-trust cause and the helper's stderr tail instead of returning an empty file.
- Encoder selection probes once through `FfmpegClient` — `h264_videotoolbox`, falling back to `libx264 -preset ultrafast` — which doubles as the "ffmpeg missing" check.

## Tests

22 new unit tests (`bun test test/features/video/` → 146 pass, 377 ms), all device-free via fakes: a fake capture helper emitting synthetic BGRA frames, a fake `FfmpegClient` whose process records what was written, and a fake `--list-devices` lister. They cover the rawvideo argv, padded-row packing, geometry-mismatch drops, resolution/`maxDuration` handling, VideoToolbox fallback, each `ActionableError` (non-macOS, missing ffmpeg, unresolvable helper, no attached device, ambiguous devices, no frames captured), stdin-close finalization vs. `forceStop`, and both physical-UDID shapes routing through `HybridVideoCaptureBackend`.

`turbo run lint build test` and `bun run typecheck` are green (full suite: 14547 pass / 0 fail); `bun run format:check` clean.

## Manual verification needed

No iOS hardware was attached while writing this (`xcrun devicectl list devices` → "No devices found"), so the on-device half of the issue's evaluation criteria is unproven: that `videoRecording` start/stop against a physical UDID yields a playable H.264 MP4 of the real device screen, that the AVFoundation `uniqueID` matches the UDID as assumed by the mapping's fast path, and the one-time USB-trust prompt flow. The manual test plan in [#2504](https://github.com/kaeawc/auto-mobile/issues/2504) is unchanged and still applies.

Deliberately deferred: the helper also supports in-helper VideoToolbox H.264 (`--encode h264`) for device targets, which would let ffmpeg do a stream copy instead of a re-encode. The TS `CaptureTarget` models `encode` for simulator targets only, and the issue specifies the rawvideo pipe, so that stays a follow-up.

_Generated by [Claude Code](https://claude.ai/code)_

---

## Review follow-ups (post-review commits)

- **fps pacing (Codex P1).** AVFoundation device capture is deliberately not fps-throttled by the helper (`DeviceCaptureSession.deviceFPS` documents this), so a 60fps device feeding a `-framerate 15` rawvideo stream would have timestamped every frame at 15fps — 4x slow playback, with `-t` cutting the recording short. Frames are now admitted against a capture-timestamp schedule, resyncing after a gap instead of admitting a catch-up burst.
- **Encoder failures are no longer reported as success.** A nonzero ffmpeg exit (full disk, rejected encoder settings) now throws with the retained ffmpeg stderr rather than letting the service archive a truncated file as complete.
- **`AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER` is honored.** Resolution went straight to the pinned release asset even though daemon startup skips the release prefetch when that override is set. The path resolver moved out of `IosH264Source` into `src/features/screen-stream/screenCaptureHelperPath.ts`, so both consumers share one override-first implementation (`IosH264Source` re-exports the names, so existing importers are unaffected).
- **Startup cancellation.** `start()` honors `config.abortSignal` between each async setup step and tears the helper down if shutdown lands while it is spawning, matching the Android and iOS ffmpeg start paths.
- **No usable H.264 encoder now fails in `start()`** instead of surfacing later as the misleading "no frames captured".
- Backpressure was already handled before the review (drop while `stdin.writableNeedDrain`), and the docs now record that physical-device support is unit-tested but unverified on hardware.

Three suggestions were declined with reasons on their threads: clickable-link rewriting of bare `#NNNN` in source comments (CLAUDE.md explicitly settles this the other way), making one log call path-free (both sibling backends log output paths at info), and removing the single-attached-device fallback (that fallback is the behavior #2504 specifies).

Test count is now 33 in the backend suite; full suite 14555 pass / 0 fail.
