### PR TITLE
fix(android): export CtrlProxy accessibility service

### DIFF
--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
         android:name=".CtrlProxy"
         android:label="@string/accessibility_service_name"
         android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
-        android:exported="false">
+        android:exported="true">
         <intent-filter>
           <action android:name="android.accessibilityservice.AccessibilityService" />
         </intent-filter>

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -62,6 +62,25 @@ class NetworkControlPermissionManifestTest {
   }
 
   @Test
+  fun `CtrlProxy accessibility service is exported for system discovery`() {
+    val service =
+      elements(readManifest("control-proxy"), "service").single {
+        it.androidAttribute("name") == ".CtrlProxy"
+      }
+
+    assertEquals(
+      "The Android framework discovers accessibility services through an intent query. The service " +
+        "must be exported so API 35 can bind it.",
+      "true",
+      service.androidAttribute("exported"),
+    )
+    assertEquals(
+      "android.permission.BIND_ACCESSIBILITY_SERVICE",
+      service.androidAttribute("permission"),
+    )
+  }
+
+  @Test
   fun `emulator contract receivers require the platform dump permission`() {
     assertEquals(
       PLATFORM_DUMP_PERMISSION,


### PR DESCRIPTION
## Summary

- export the CtrlProxy accessibility service so Android's framework service query can discover and bind it on API 35
- retain `BIND_ACCESSIBILITY_SERVICE`, limiting binding to the Android framework
- add a manifest-contract test that protects both requirements

## Root cause

CtrlProxy declared the accessibility service as non-exported. Android 15 omitted that component from its accessibility-service query, leaving the configured service unbound and causing runner-connect readiness to time out.

## Validation

- `./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.NetworkControlPermissionManifestTest`
- `./gradlew :control-proxy:assembleDebug`
- `bun run turbo:validate`
- `bun run typecheck`
- `scripts/ktfmt/validate_ktfmt.sh`

`./gradlew :control-proxy:lintDebug` remains red only on six existing API-level errors in untouched `CtrlProxy.kt` lines 1710–1721 and 2664–2667.

Closes #5767
