### PR TITLE
feat(devices): expose virtual device capability inventories

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -147,10 +147,10 @@ tools expose them. `catalogComplete` and per-platform `catalogObservations`
 show whether the catalog can safely be used for provisioning decisions.
 Each image also includes a versioned `capabilityInventory` that can be read
 before a session begins. Android reports recognized `android.hardware.*`
-identifiers from the AVD's configured image/profile settings; absent settings
-are not inferred. iOS Simulator reports its available `ios.simulator.biometric`
-control and marks `ios.simulator.nfc` as explicitly unsupported. Entries use
-`available`, `unavailable`, or `unsupported` states.
+identifiers from AVD configuration key/value pairs; absent, unrecognized, and
+malformed settings are not inferred. iOS-runtime Simulator reports its available
+`ios.simulator.biometric` control and marks `ios.simulator.nfc` as explicitly
+unsupported. Entries use `available`, `unavailable`, or `unsupported` states.
 
 **URI Template**: `automobile:devices/images/{platform}`
 

--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -145,6 +145,12 @@ Returns startable Android AVDs and iOS simulators plus a normalized
 Android system images, and Android device profiles where the installed platform
 tools expose them. `catalogComplete` and per-platform `catalogObservations`
 show whether the catalog can safely be used for provisioning decisions.
+Each image also includes a versioned `capabilityInventory` that can be read
+before a session begins. Android reports recognized `android.hardware.*`
+identifiers from the AVD's configured image/profile settings; absent settings
+are not inferred. iOS Simulator reports its available `ios.simulator.biometric`
+control and marks `ios.simulator.nfc` as explicitly unsupported. Entries use
+`available`, `unavailable`, or `unsupported` states.
 
 **URI Template**: `automobile:devices/images/{platform}`
 

--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -147,9 +147,10 @@ tools expose them. `catalogComplete` and per-platform `catalogObservations`
 show whether the catalog can safely be used for provisioning decisions.
 Each image also includes a versioned `capabilityInventory` that can be read
 before a session begins. Android reports recognized `android.hardware.*`
-identifiers from AVD configuration key/value pairs; absent, unrecognized, and
-malformed settings are not inferred. iOS-runtime Simulator reports its available
-`ios.simulator.biometric` control and marks `ios.simulator.nfc` as explicitly
+identifiers from emulator-provided AVD configuration key/value pairs; absent,
+unrecognized, malformed, and host-backed settings are not inferred. iOS-runtime
+Simulator reports its available `ios.simulator.biometric` control and marks
+`ios.simulator.nfc` as explicitly
 unsupported. Entries use `available`, `unavailable`, or `unsupported` states.
 
 **URI Template**: `automobile:devices/images/{platform}`

--- a/src/features/device-control/virtualDeviceCapabilities.ts
+++ b/src/features/device-control/virtualDeviceCapabilities.ts
@@ -68,11 +68,21 @@ export function buildAndroidAvdCapabilityInventory(
  * no simulator implementation and is explicit so clients do not infer support
  * from the device type.
  */
-export function iosSimulatorCapabilityInventory(): VirtualDeviceCapabilityInventory {
+export function iosSimulatorCapabilityInventory(
+  isAvailable: boolean = true,
+  availabilityError?: string,
+): VirtualDeviceCapabilityInventory {
   return {
     schemaVersion: VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION,
     capabilities: [
-      { id: "ios.simulator.biometric", state: "available", source: "platform" },
+      {
+        id: "ios.simulator.biometric",
+        state: isAvailable ? "available" : "unavailable",
+        source: "platform",
+        ...(isAvailable
+          ? {}
+          : { reason: availabilityError ?? "The iOS Simulator runtime is unavailable." }),
+      },
       {
         id: "ios.simulator.nfc",
         state: "unsupported",

--- a/src/features/device-control/virtualDeviceCapabilities.ts
+++ b/src/features/device-control/virtualDeviceCapabilities.ts
@@ -49,10 +49,7 @@ function avdCapabilityState(
   if (kind === "boolean" && ENABLED_BOOLEAN_AVD_VALUES.has(normalized)) {
     return "available";
   }
-  if (
-    kind === "camera" &&
-    (ENABLED_CAMERA_AVD_VALUES.has(normalized) || /^webcam\d+$/.test(normalized))
-  ) {
+  if (kind === "camera" && ENABLED_CAMERA_AVD_VALUES.has(normalized)) {
     return "available";
   }
   return undefined;

--- a/src/features/device-control/virtualDeviceCapabilities.ts
+++ b/src/features/device-control/virtualDeviceCapabilities.ts
@@ -1,0 +1,84 @@
+/**
+ * Versioned inventory contract for virtual-device hardware capabilities.
+ *
+ * Android identifiers preserve the corresponding Android feature names. iOS
+ * Simulator identifiers are namespaced because they describe simulator control
+ * surfaces rather than physical hardware.
+ */
+export const VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION = 1 as const;
+
+export type VirtualDeviceCapabilityState = "available" | "unavailable" | "unsupported";
+
+export interface VirtualDeviceCapability {
+  /** Stable identifier suitable for automated matching. */
+  id: string;
+  /** Whether the capability is usable, configured off, or impossible on this platform. */
+  state: VirtualDeviceCapabilityState;
+  /** Where AutoMobile obtained the capability state. */
+  source: "avd_config" | "platform";
+  /** Explanation for a capability that cannot be enabled by device configuration. */
+  reason?: string;
+}
+
+export interface VirtualDeviceCapabilityInventory {
+  schemaVersion: typeof VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION;
+  /** Deduplicated, lexically ordered capability entries. */
+  capabilities: VirtualDeviceCapability[];
+}
+
+const ANDROID_AVD_CAPABILITIES = [
+  ["hw.camera.back", "android.hardware.camera"],
+  ["hw.camera.front", "android.hardware.camera.front"],
+  ["hw.fingerprint", "android.hardware.fingerprint"],
+  ["hw.gps", "android.hardware.location.gps"],
+  ["hw.nfc", "android.hardware.nfc"],
+] as const;
+
+const DISABLED_AVD_VALUES = new Set(["0", "false", "no", "none", "off"]);
+
+function avdCapabilityState(value: string): Exclude<VirtualDeviceCapabilityState, "unsupported"> {
+  return DISABLED_AVD_VALUES.has(value.trim().toLowerCase()) ? "unavailable" : "available";
+}
+
+/**
+ * Derive normalized Android feature identifiers from the AVD config values
+ * selected by its image and hardware profile. Unknown config keys stay out of
+ * the report so the inventory never over-claims an unverified feature.
+ */
+export function buildAndroidAvdCapabilityInventory(
+  config: Readonly<Record<string, string | undefined>>,
+): VirtualDeviceCapabilityInventory {
+  const capabilities = new Map<string, VirtualDeviceCapability>();
+  for (const [configKey, id] of ANDROID_AVD_CAPABILITIES) {
+    const value = config[configKey];
+    if (value?.trim()) {
+      capabilities.set(id, { id, state: avdCapabilityState(value), source: "avd_config" });
+    }
+  }
+
+  return {
+    schemaVersion: VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION,
+    capabilities: [...capabilities.values()].sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+/**
+ * Capabilities exposed by iOS Simulator independently of a running session.
+ * `ios.simulator.biometric` corresponds to simctl biometric controls; NFC has
+ * no simulator implementation and is explicit so clients do not infer support
+ * from the device type.
+ */
+export function iosSimulatorCapabilityInventory(): VirtualDeviceCapabilityInventory {
+  return {
+    schemaVersion: VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION,
+    capabilities: [
+      { id: "ios.simulator.biometric", state: "available", source: "platform" },
+      {
+        id: "ios.simulator.nfc",
+        state: "unsupported",
+        source: "platform",
+        reason: "iOS Simulator cannot emulate NFC hardware.",
+      },
+    ],
+  };
+}

--- a/src/features/device-control/virtualDeviceCapabilities.ts
+++ b/src/features/device-control/virtualDeviceCapabilities.ts
@@ -27,17 +27,35 @@ export interface VirtualDeviceCapabilityInventory {
 }
 
 const ANDROID_AVD_CAPABILITIES = [
-  ["hw.camera.back", "android.hardware.camera"],
-  ["hw.camera.front", "android.hardware.camera.front"],
-  ["hw.fingerprint", "android.hardware.fingerprint"],
-  ["hw.gps", "android.hardware.location.gps"],
-  ["hw.nfc", "android.hardware.nfc"],
+  { configKey: "hw.camera.back", id: "android.hardware.camera", kind: "camera" },
+  { configKey: "hw.camera.front", id: "android.hardware.camera.front", kind: "camera" },
+  { configKey: "hw.fingerprint", id: "android.hardware.fingerprint", kind: "boolean" },
+  { configKey: "hw.gps", id: "android.hardware.location.gps", kind: "boolean" },
+  { configKey: "hw.nfc", id: "android.hardware.nfc", kind: "boolean" },
 ] as const;
 
 const DISABLED_AVD_VALUES = new Set(["0", "false", "no", "none", "off"]);
+const ENABLED_BOOLEAN_AVD_VALUES = new Set(["1", "true", "yes"]);
+const ENABLED_CAMERA_AVD_VALUES = new Set(["emulated", "virtualscene"]);
 
-function avdCapabilityState(value: string): Exclude<VirtualDeviceCapabilityState, "unsupported"> {
-  return DISABLED_AVD_VALUES.has(value.trim().toLowerCase()) ? "unavailable" : "available";
+function avdCapabilityState(
+  value: string,
+  kind: (typeof ANDROID_AVD_CAPABILITIES)[number]["kind"],
+): Exclude<VirtualDeviceCapabilityState, "unsupported"> | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (DISABLED_AVD_VALUES.has(normalized)) {
+    return "unavailable";
+  }
+  if (kind === "boolean" && ENABLED_BOOLEAN_AVD_VALUES.has(normalized)) {
+    return "available";
+  }
+  if (
+    kind === "camera" &&
+    (ENABLED_CAMERA_AVD_VALUES.has(normalized) || /^webcam\d+$/.test(normalized))
+  ) {
+    return "available";
+  }
+  return undefined;
 }
 
 /**
@@ -49,10 +67,11 @@ export function buildAndroidAvdCapabilityInventory(
   config: Readonly<Record<string, string | undefined>>,
 ): VirtualDeviceCapabilityInventory {
   const capabilities = new Map<string, VirtualDeviceCapability>();
-  for (const [configKey, id] of ANDROID_AVD_CAPABILITIES) {
-    const value = config[configKey];
-    if (value?.trim()) {
-      capabilities.set(id, { id, state: avdCapabilityState(value), source: "avd_config" });
+  for (const definition of ANDROID_AVD_CAPABILITIES) {
+    const value = config[definition.configKey];
+    const state = value && avdCapabilityState(value, definition.kind);
+    if (state) {
+      capabilities.set(definition.id, { id: definition.id, state, source: "avd_config" });
     }
   }
 
@@ -69,20 +88,35 @@ export function buildAndroidAvdCapabilityInventory(
  * from the device type.
  */
 export function iosSimulatorCapabilityInventory(
-  isAvailable: boolean = true,
-  availabilityError?: string,
+  options: {
+    isAvailable?: boolean;
+    availabilityError?: string;
+    runtime?: string;
+  } = {},
 ): VirtualDeviceCapabilityInventory {
+  const supportsBiometricControls =
+    options.runtime === undefined ||
+    options.runtime.startsWith("com.apple.CoreSimulator.SimRuntime.iOS-");
+  const biometricCapability: VirtualDeviceCapability = !supportsBiometricControls
+    ? {
+        id: "ios.simulator.biometric",
+        state: "unsupported",
+        source: "platform",
+        reason: "Biometric controls are only supported for iOS Simulator runtimes.",
+      }
+    : options.isAvailable === false
+      ? {
+          id: "ios.simulator.biometric",
+          state: "unavailable",
+          source: "platform",
+          reason: options.availabilityError ?? "The iOS Simulator runtime is unavailable.",
+        }
+      : { id: "ios.simulator.biometric", state: "available", source: "platform" };
+
   return {
     schemaVersion: VIRTUAL_DEVICE_CAPABILITY_INVENTORY_SCHEMA_VERSION,
     capabilities: [
-      {
-        id: "ios.simulator.biometric",
-        state: isAvailable ? "available" : "unavailable",
-        source: "platform",
-        ...(isAvailable
-          ? {}
-          : { reason: availabilityError ?? "The iOS Simulator runtime is unavailable." }),
-      },
+      biometricCapability,
       {
         id: "ios.simulator.nfc",
         state: "unsupported",

--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -1,5 +1,6 @@
 import { Platform } from "./Platform";
 import { FormFactor } from "./DeviceMatchCriteria";
+import type { VirtualDeviceCapabilityInventory } from "../features/device-control/virtualDeviceCapabilities";
 
 export interface DeviceInfo {
   name: string;
@@ -21,6 +22,8 @@ export interface DeviceInfo {
   runtime?: string;
   model?: string;
   architecture?: string;
+  /** Pre-session virtual hardware inventory when the platform can inspect it. */
+  capabilityInventory?: VirtualDeviceCapabilityInventory;
 }
 
 export interface BootedDevice {

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -423,7 +423,11 @@ function toDeviceImageInfo(device: DeviceInfo, avdInfo?: AvdInfo): DeviceImageIn
     capabilityInventory:
       device.capabilityInventory ??
       (device.platform === "ios"
-        ? iosSimulatorCapabilityInventory(device.isAvailable !== false, device.availabilityError)
+        ? iosSimulatorCapabilityInventory({
+            isAvailable: device.isAvailable,
+            availabilityError: device.availabilityError,
+            runtime: device.runtime,
+          })
         : buildAndroidAvdCapabilityInventory({})),
   };
 }

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -423,7 +423,7 @@ function toDeviceImageInfo(device: DeviceInfo, avdInfo?: AvdInfo): DeviceImageIn
     capabilityInventory:
       device.capabilityInventory ??
       (device.platform === "ios"
-        ? iosSimulatorCapabilityInventory()
+        ? iosSimulatorCapabilityInventory(device.isAvailable !== false, device.availabilityError)
         : buildAndroidAvdCapabilityInventory({})),
   };
 }

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -15,6 +15,11 @@ import {
   type AppleDeviceRuntime,
   type AppleDeviceType,
 } from "../utils/ios-cmdline-tools/SimCtlClient";
+import {
+  buildAndroidAvdCapabilityInventory,
+  iosSimulatorCapabilityInventory,
+  type VirtualDeviceCapabilityInventory,
+} from "../features/device-control/virtualDeviceCapabilities";
 
 // Resource URIs
 export const DEVICE_IMAGE_RESOURCE_URIS = {
@@ -42,6 +47,12 @@ interface DeviceImageInfo {
   runtime?: string;
   model?: string;
   architecture?: string;
+  /**
+   * Versioned hardware feature inventory for this startable virtual device.
+   * Android entries are derived from its AVD config; iOS entries model the
+   * simulator platform independently of a started session.
+   */
+  capabilityInventory: VirtualDeviceCapabilityInventory;
 }
 
 interface ProvisioningRuntime {
@@ -409,6 +420,11 @@ function toDeviceImageInfo(device: DeviceInfo, avdInfo?: AvdInfo): DeviceImageIn
     runtime: device.runtime,
     model: device.model,
     architecture: device.architecture,
+    capabilityInventory:
+      device.capabilityInventory ??
+      (device.platform === "ios"
+        ? iosSimulatorCapabilityInventory()
+        : buildAndroidAvdCapabilityInventory({})),
   };
 }
 

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -721,6 +721,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             screenHeight: config.screenHeight ?? device.screenHeight,
             screenDensity: config.screenDensity ?? device.screenDensity,
             formFactor: inferAndroidFormFactor(config.deviceName) ?? device.formFactor,
+            capabilityInventory: config.capabilityInventory ?? device.capabilityInventory,
           };
         } catch (error) {
           logger.debug(`Failed to enrich AVD ${device.name}: ${error}`);

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -1,5 +1,9 @@
 import { logger } from "../logger";
 import { dirname, join } from "node:path";
+import {
+  buildAndroidAvdCapabilityInventory,
+  type VirtualDeviceCapabilityInventory,
+} from "../../features/device-control/virtualDeviceCapabilities";
 
 /** Minimum guest memory required by modern Play Store system images. */
 export const MIN_AVD_RAM_MB = 2048;
@@ -21,6 +25,8 @@ export interface AvdConfig {
   ramSizeInvalid?: boolean;
   deviceName?: string;
   tag?: string;
+  /** Stable hardware features derived from the AVD's local profile settings. */
+  capabilityInventory?: VirtualDeviceCapabilityInventory;
 }
 
 /**
@@ -163,6 +169,7 @@ export function parseAvdConfig(content: string): AvdConfig {
     ...parseDeviceMetadata(props),
     ...parseApiMetadata(props),
     ...parseArchitecture(props),
+    capabilityInventory: buildAndroidAvdCapabilityInventory(Object.fromEntries(props)),
   };
 }
 

--- a/test/features/device-control/virtualDeviceCapabilities.test.ts
+++ b/test/features/device-control/virtualDeviceCapabilities.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAndroidAvdCapabilityInventory,
+  iosSimulatorCapabilityInventory,
+} from "../../../src/features/device-control/virtualDeviceCapabilities";
+
+describe("virtual device capability inventories", () => {
+  test("normalizes configured Android hardware features into stable, deduplicated identifiers", () => {
+    expect(
+      buildAndroidAvdCapabilityInventory({
+        "hw.camera.back": "virtualscene",
+        "hw.camera.front": "emulated",
+        "hw.fingerprint": "yes",
+        "hw.gps": "yes",
+        "hw.nfc": "no",
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        { id: "android.hardware.camera", state: "available", source: "avd_config" },
+        { id: "android.hardware.camera.front", state: "available", source: "avd_config" },
+        { id: "android.hardware.fingerprint", state: "available", source: "avd_config" },
+        { id: "android.hardware.location.gps", state: "available", source: "avd_config" },
+        { id: "android.hardware.nfc", state: "unavailable", source: "avd_config" },
+      ],
+    });
+  });
+
+  test("returns an empty inventory when an AVD exposes no mapped hardware features", () => {
+    expect(buildAndroidAvdCapabilityInventory({ "hw.ramSize": "2048" })).toEqual({
+      schemaVersion: 1,
+      capabilities: [],
+    });
+  });
+
+  test("reports supported and unsupported iOS Simulator capabilities with stable identifiers", () => {
+    expect(iosSimulatorCapabilityInventory()).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        { id: "ios.simulator.biometric", state: "available", source: "platform" },
+        {
+          id: "ios.simulator.nfc",
+          state: "unsupported",
+          source: "platform",
+          reason: "iOS Simulator cannot emulate NFC hardware.",
+        },
+      ],
+    });
+  });
+});

--- a/test/features/device-control/virtualDeviceCapabilities.test.ts
+++ b/test/features/device-control/virtualDeviceCapabilities.test.ts
@@ -26,11 +26,14 @@ describe("virtual device capability inventories", () => {
     });
   });
 
-  test("returns an empty inventory when an AVD exposes no mapped hardware features", () => {
-    expect(buildAndroidAvdCapabilityInventory({ "hw.ramSize": "2048" })).toEqual({
-      schemaVersion: 1,
-      capabilities: [],
-    });
+  test("returns an empty inventory when an AVD exposes no mapped or recognized hardware features", () => {
+    expect(
+      buildAndroidAvdCapabilityInventory({
+        "hw.fingerprint": "disabled",
+        "hw.gps": "corrupted",
+        "hw.ramSize": "2048",
+      }),
+    ).toEqual({ schemaVersion: 1, capabilities: [] });
   });
 
   test("reports supported and unsupported iOS Simulator capabilities with stable identifiers", () => {
@@ -38,6 +41,30 @@ describe("virtual device capability inventories", () => {
       schemaVersion: 1,
       capabilities: [
         { id: "ios.simulator.biometric", state: "available", source: "platform" },
+        {
+          id: "ios.simulator.nfc",
+          state: "unsupported",
+          source: "platform",
+          reason: "iOS Simulator cannot emulate NFC hardware.",
+        },
+      ],
+    });
+  });
+
+  test("marks biometric controls unsupported outside an iOS Simulator runtime", () => {
+    expect(
+      iosSimulatorCapabilityInventory({
+        runtime: "com.apple.CoreSimulator.SimRuntime.tvOS-18-0",
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        {
+          id: "ios.simulator.biometric",
+          state: "unsupported",
+          source: "platform",
+          reason: "Biometric controls are only supported for iOS Simulator runtimes.",
+        },
         {
           id: "ios.simulator.nfc",
           state: "unsupported",

--- a/test/features/device-control/virtualDeviceCapabilities.test.ts
+++ b/test/features/device-control/virtualDeviceCapabilities.test.ts
@@ -29,6 +29,7 @@ describe("virtual device capability inventories", () => {
   test("returns an empty inventory when an AVD exposes no mapped or recognized hardware features", () => {
     expect(
       buildAndroidAvdCapabilityInventory({
+        "hw.camera.back": "webcam999",
         "hw.fingerprint": "disabled",
         "hw.gps": "corrupted",
         "hw.ramSize": "2048",

--- a/test/server/resources/deviceImages.test.ts
+++ b/test/server/resources/deviceImages.test.ts
@@ -126,6 +126,56 @@ describe("Device Image Resources with Fakes", () => {
       });
     });
 
+    test("returns a pre-session capability inventory for each virtual device", async () => {
+      fakeDeviceUtils.setDeviceImages("android", [
+        {
+          name: "Pixel 9",
+          platform: "android",
+          isRunning: false,
+          capabilityInventory: {
+            schemaVersion: 1,
+            capabilities: [
+              { id: "android.hardware.nfc", state: "unavailable", source: "avd_config" },
+            ],
+          },
+        },
+      ]);
+      fakeDeviceUtils.setDeviceImages("ios", [
+        {
+          name: "iPhone 16",
+          platform: "ios",
+          isRunning: false,
+        },
+      ]);
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager,
+        simctl: fakeSimCtl,
+      });
+
+      const result = await handler.getDeviceImagesForPlatforms(["android", "ios"]);
+
+      expect(
+        result.images.find((image) => image.platform === "android")?.capabilityInventory,
+      ).toEqual({
+        schemaVersion: 1,
+        capabilities: [{ id: "android.hardware.nfc", state: "unavailable", source: "avd_config" }],
+      });
+      expect(result.images.find((image) => image.platform === "ios")?.capabilityInventory).toEqual({
+        schemaVersion: 1,
+        capabilities: expect.arrayContaining([
+          { id: "ios.simulator.biometric", state: "available", source: "platform" },
+          {
+            id: "ios.simulator.nfc",
+            state: "unsupported",
+            source: "platform",
+            reason: "iOS Simulator cannot emulate NFC hardware.",
+          },
+        ]),
+      });
+    });
+
     test("merges installed-only Android system images into the complete catalog", async () => {
       fakeDeviceUtils.setDeviceImages("android", []);
       const availableImage = {

--- a/test/server/resources/deviceImages.test.ts
+++ b/test/server/resources/deviceImages.test.ts
@@ -176,6 +176,43 @@ describe("Device Image Resources with Fakes", () => {
       });
     });
 
+    test("marks iOS Simulator capabilities unavailable when its runtime is unavailable", async () => {
+      fakeDeviceUtils.setDeviceImages("ios", [
+        {
+          name: "Unavailable iPhone",
+          platform: "ios",
+          isRunning: false,
+          isAvailable: false,
+          availabilityError: "iOS 18.0 runtime is not installed",
+        },
+      ]);
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager,
+        simctl: fakeSimCtl,
+      });
+      const result = await handler.getDeviceImagesForPlatforms(["ios"]);
+
+      expect(result.images[0]?.capabilityInventory).toEqual({
+        schemaVersion: 1,
+        capabilities: [
+          {
+            id: "ios.simulator.biometric",
+            state: "unavailable",
+            source: "platform",
+            reason: "iOS 18.0 runtime is not installed",
+          },
+          {
+            id: "ios.simulator.nfc",
+            state: "unsupported",
+            source: "platform",
+            reason: "iOS Simulator cannot emulate NFC hardware.",
+          },
+        ],
+      });
+    });
+
     test("merges installed-only Android system images into the complete catalog", async () => {
       fakeDeviceUtils.setDeviceImages("android", []);
       const availableImage = {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
@@ -227,4 +227,44 @@ describe("AndroidEmulatorClient listAvds", () => {
       { name: "Pixel_Tablet", platform: "android", isRunning: false, source: "local" },
     ]);
   });
+
+  test("includes configured Android hardware capabilities in the AVD listing", async () => {
+    const configReader: AvdConfigReader = {
+      async readConfig() {
+        return {
+          capabilityInventory: {
+            schemaVersion: 1,
+            capabilities: [
+              { id: "android.hardware.camera", state: "available", source: "avd_config" },
+            ],
+          },
+        };
+      },
+    };
+    const execAsync = async (_command: string): Promise<ExecResult> =>
+      createExecResult("Pixel_9\n");
+    const client = new AndroidEmulatorClient(
+      execAsync,
+      null,
+      new FakeTimer(),
+      undefined,
+      configReader,
+    );
+    (client as any).ensureEmulatorPath = async () => "emulator";
+
+    await expect(client.listAvds()).resolves.toEqual([
+      {
+        name: "Pixel_9",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+        capabilityInventory: {
+          schemaVersion: 1,
+          capabilities: [
+            { id: "android.hardware.camera", state: "available", source: "avd_config" },
+          ],
+        },
+      },
+    ]);
+  });
 });

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -65,6 +65,21 @@ describe("parseAvdConfig", () => {
     expect(config.tag).toBe("google_apis");
   });
 
+  it("derives a normalized hardware capability inventory", () => {
+    const config = parseAvdConfig(
+      ["hw.camera.back=virtualscene", "hw.fingerprint=yes", "hw.nfc=no"].join("\n"),
+    );
+
+    expect(config.capabilityInventory).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        { id: "android.hardware.camera", state: "available", source: "avd_config" },
+        { id: "android.hardware.fingerprint", state: "available", source: "avd_config" },
+        { id: "android.hardware.nfc", state: "unavailable", source: "avd_config" },
+      ],
+    });
+  });
+
   it("parses the configured RAM size in megabytes", () => {
     const config = parseAvdConfig("hw.ramSize=1536\n");
     expect(config.ramSizeMb).toBe(1536);
@@ -127,12 +142,14 @@ describe("parseAvdConfig", () => {
       "AvdId=Pixel_7_API_34",
       "PlayStore.enabled=true",
       "abi.type=arm64-v8a",
+      "hw.camera.back=virtualscene",
       "hw.cpu.arch=arm64",
       "hw.device.manufacturer=Google",
       "hw.device.name=pixel_7",
       "hw.lcd.density=420",
       "hw.lcd.height=2400",
       "hw.lcd.width=1080",
+      "hw.nfc=no",
       "image.sysdir.1=system-images/android-34/google_apis_playstore/arm64-v8a/",
       "tag.id=google_apis_playstore",
     ].join("\n");
@@ -146,6 +163,13 @@ describe("parseAvdConfig", () => {
     expect(config.screenDensity).toBe(420);
     expect(config.deviceName).toBe("pixel_7");
     expect(config.tag).toBe("google_apis_playstore");
+    expect(config.capabilityInventory).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        { id: "android.hardware.camera", state: "available", source: "avd_config" },
+        { id: "android.hardware.nfc", state: "unavailable", source: "avd_config" },
+      ],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Adds a versioned `capabilityInventory` to every device-image resource response, so callers can inspect virtual-device hardware before opening a test session. Android inventory entries derive from configured AVD hardware settings; iOS Simulator publishes biometric control availability and its explicit NFC limitation.

## Linked Issue
Closes [#5780](https://github.com/kaeawc/auto-mobile/issues/5780)

## Validation
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Focused capability tests (78 passing)
- [x] New code uses injected AVD configuration and deterministic fakes

## Risk
Additive resource fields only. Unknown Android configuration keys are omitted rather than inferred.
