### PR TITLE
feat(desktop): wire per-device Test facet to the test-runs resource (#5019)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -51,10 +51,10 @@ import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.PerformanceFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.TestFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
-import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceFacetPlaceholder
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
@@ -573,9 +573,9 @@ fun AutoMobileDesktopApp(
  * Real docked-facet content for a pane, wired to the per-device facets in desktop-core: Logs
  * (telemetry), Storage (auto-resolved app, Android + iOS), Network (per-device `getNetworkGraph`
  * tool call), Performance (per-device observation stream, filtered by deviceId), Failures
- * (cross-device aggregate), and Navigation (#4837 Phase C — app-scoped graph pulled by the pane
- * device's foreground app). Test (per-device daemon resource, #4715) falls back to the placeholder
- * for now.
+ * (cross-device aggregate), Navigation (#4837 Phase C — app-scoped graph pulled by the pane
+ * device's foreground app), and Test (per-device test-runs daemon resource, #4715 / #5017 — scoped
+ * to the pane device by deviceId).
  */
 @Composable
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
@@ -591,9 +591,10 @@ private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
     Tool.Failures -> FailuresFacet(column)
     // Navigation is app-scoped (#4837 Phase C): the facet resolves the pane device's foreground app
     // from the stream, then pulls that app's persisted graph by appId — so same-app panes share the
-    // graph and a foreign broadcast can't overwrite a pane (the #4838 contamination). Test
-    // (per-device daemon resource, #4715) still falls back to the placeholder.
+    // graph and a foreign broadcast can't overwrite a pane (the #4838 contamination).
     Tool.Navigation -> NavigationFacet(column)
-    else -> WorkspaceFacetPlaceholder(tool)
+    // Test reads the per-device test-runs daemon resource (automobile:test-runs?deviceId=<id>,
+    // #4715 / #5017), scoped to the pane device so panes don't cross-contaminate (#5019).
+    Tool.Test -> TestFacet(column)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRunResults.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRunResults.kt
@@ -42,6 +42,7 @@ data class TestRunQuery(
   val limit: Int? = null,
   val orderDirection: String? = null,
   val latestOnly: Boolean? = null,
+  val deviceId: String? = null,
 )
 
 @Serializable
@@ -62,6 +63,7 @@ fun TestRunQuery.toResourceUri(): String {
       add("limit", limit)
       add("orderDirection", orderDirection)
       add("latestOnly", latestOnly)
+      add("deviceId", deviceId)
     }
     .build()
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealTestDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealTestDataSource.kt
@@ -11,15 +11,22 @@ import dev.jasonpearson.automobile.desktop.core.test.TestStep
 /**
  * Real test data source that fetches from MCP resources. Uses the test-runs resource to get actual
  * test data with steps and screens.
+ *
+ * When [deviceId] is non-null the read is scoped to that device via
+ * `automobile:test-runs?deviceId=<id>` (see [TestRunQuery.deviceId]), so a per-device Test facet
+ * shows only its own pane's runs and never bleeds one device's runs into another. A null [deviceId]
+ * reads across all devices (the standalone dashboard's behavior).
  */
-class RealTestDataSource(private val clientProvider: (() -> AutoMobileClient)? = null) :
-  TestDataSource {
+class RealTestDataSource(
+  private val clientProvider: (() -> AutoMobileClient)? = null,
+  private val deviceId: String? = null,
+) : TestDataSource {
   override suspend fun getTestRuns(): Result<List<TestRun>> {
     val provider = clientProvider ?: return Result.Success(emptyList())
 
     return try {
       val client = provider()
-      val summary = client.getTestRuns(TestRunQuery(limit = 100))
+      val summary = client.getTestRuns(TestRunQuery(limit = 100, deviceId = deviceId))
 
       // Map TestRunEntry to TestRun
       val testRuns =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TestFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TestFacet.kt
@@ -1,0 +1,188 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.datasource.RealTestDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.datasource.TestDataSource
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.test.TestRun
+import dev.jasonpearson.automobile.desktop.core.test.TestStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private sealed interface TestFacetState {
+  data object Loading : TestFacetState
+
+  data object Empty : TestFacetState
+
+  data class Error(val message: String) : TestFacetState
+
+  data class Resolved(val runs: List<TestRun>) : TestFacetState
+}
+
+/**
+ * Docked-facet body for [Tool.Test]: the pane device's recent test runs (name · status · device ·
+ * duration), most recent first. Reads the daemon's `automobile:test-runs?deviceId=<id>` resource
+ * scoped to the pane's device (via [RealTestDataSource] / [TestDataSource.getTestRuns]) so each
+ * device column shows only its own runs — the per-device consumer of the resource shape landed
+ * in #4715 / #5017.
+ *
+ * The data source is injected via [dataSource] so the loading/empty/error states are testable
+ * without a live MCP daemon; the default reads through a [RealTestDataSource] built from the DI
+ * graph and scoped to [DeviceColumn.deviceId]. Everything is keyed on the device id so switching
+ * panes never bleeds one device's runs into another.
+ *
+ * This is a one-shot fetch of the latest runs; the full recording/detail flow remains the
+ * standalone Test dashboard.
+ */
+@Composable
+fun TestFacet(column: DeviceColumn, dataSource: TestDataSource? = null) {
+  val graph = LocalAutoMobileGraph.current
+  val source: TestDataSource =
+    remember(column.deviceId, dataSource) {
+      dataSource ?: RealTestDataSource({ graph.autoMobileClient }, column.deviceId)
+    }
+
+  var attempt by remember(column.deviceId) { mutableStateOf(0) }
+  var state by
+    remember(column.deviceId, attempt) { mutableStateOf<TestFacetState>(TestFacetState.Loading) }
+
+  LaunchedEffect(column.deviceId, attempt) {
+    // Read off the UI thread: the resource read hits the daemon and would otherwise block
+    // recomposition. Injected test data sources run inline (deterministic).
+    state =
+      when (val result = withContext(Dispatchers.IO) { source.getTestRuns() }) {
+        is Result.Success ->
+          if (result.data.isEmpty()) TestFacetState.Empty else TestFacetState.Resolved(result.data)
+        is Result.Error -> TestFacetState.Error(result.message ?: "Failed to load test runs")
+        // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
+        Result.Loading -> TestFacetState.Error("Test runs are still loading")
+      }
+  }
+
+  when (val current = state) {
+    TestFacetState.Loading -> TestFacetNote("Loading test runs…")
+    TestFacetState.Empty -> TestFacetNote("No test runs for this device")
+    is TestFacetState.Error -> TestFacetError(current.message) { attempt++ }
+    is TestFacetState.Resolved -> TestRunList(current.runs)
+  }
+}
+
+/** One row per test run, most recent first. */
+@Composable
+private fun TestRunList(runs: List<TestRun>) {
+  val sorted = remember(runs) { runs.sortedByDescending { it.startTime } }
+  LazyColumn(Modifier.fillMaxSize().padding(8.dp)) {
+    items(sorted, key = { it.id }) { run -> TestRunRowItem(run) }
+  }
+}
+
+@Composable
+private fun TestRunRowItem(run: TestRun) {
+  Row(
+    Modifier.fillMaxWidth()
+      .semantics { contentDescription = "Test run ${run.testName} ${statusLabel(run.status)}" }
+      .padding(vertical = 6.dp, horizontal = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Box(Modifier.size(8.dp).background(statusColor(run.status), CircleShape))
+    Column(Modifier.weight(1f).padding(horizontal = 8.dp)) {
+      Text(
+        run.testName,
+        style = MaterialTheme.typography.bodyMedium,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+      Text(
+        run.deviceName,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.outline,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+    Text(
+      statusLabel(run.status),
+      style = MaterialTheme.typography.labelMedium,
+      color = statusColor(run.status),
+      modifier = Modifier.width(64.dp),
+    )
+    Text(
+      "${run.durationMs / 1000.0}s",
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.outline,
+      modifier = Modifier.width(56.dp),
+    )
+  }
+}
+
+private fun statusLabel(status: TestStatus): String =
+  when (status) {
+    TestStatus.Passed -> "Passed"
+    TestStatus.Failed -> "Failed"
+    TestStatus.Running -> "Running"
+    TestStatus.Skipped -> "Skipped"
+  }
+
+@Composable
+private fun statusColor(status: TestStatus) =
+  when (status) {
+    TestStatus.Failed -> MaterialTheme.colorScheme.error
+    TestStatus.Passed -> MaterialTheme.colorScheme.primary
+    else -> MaterialTheme.colorScheme.onSurface
+  }
+
+/** Centered single-line note for the facet's transient (loading) or empty states. */
+@Composable
+private fun TestFacetNote(text: String) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}
+
+/** Error state with a Retry affordance that re-runs the test-runs load. */
+@Composable
+private fun TestFacetError(message: String, onRetry: () -> Unit) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.error)
+    Text(
+      "Retry",
+      color = MaterialTheme.colorScheme.primary,
+      modifier =
+        Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
+          contentDescription = "Retry loading test runs"
+        },
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ResourceUriBuilderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ResourceUriBuilderTest.kt
@@ -17,4 +17,12 @@ class ResourceUriBuilderTest {
       TestTimingQuery(testClass = "Example Test", isCi = true).toResourceUri(),
     )
   }
+
+  @Test
+  fun `scopes test runs to a device`() {
+    assertEquals(
+      "automobile:test-runs?limit=100&deviceId=emulator-5554",
+      TestRunQuery(limit = 100, deviceId = "emulator-5554").toResourceUri(),
+    )
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TestFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TestFacetTest.kt
@@ -1,0 +1,139 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.datasource.TestDataSource
+import dev.jasonpearson.automobile.desktop.core.test.TestPlatform
+import dev.jasonpearson.automobile.desktop.core.test.TestRun
+import dev.jasonpearson.automobile.desktop.core.test.TestStatus
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TestFacetTest {
+
+  private fun column() = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android)
+
+  private fun run(
+    id: String,
+    name: String,
+    status: TestStatus = TestStatus.Passed,
+    startTime: Long = 0,
+    durationMs: Int = 4000,
+    deviceName: String = "Pixel 8 API 35",
+  ) =
+    TestRun(
+      id = id,
+      testId = "test-$id",
+      testName = name,
+      status = status,
+      startTime = startTime,
+      durationMs = durationMs,
+      steps = emptyList(),
+      screensVisited = emptyList(),
+      deviceId = "d",
+      deviceName = deviceName,
+      platform = TestPlatform.Android,
+    )
+
+  private fun source(result: Result<List<TestRun>>) =
+    object : TestDataSource {
+      override suspend fun getTestRuns(): Result<List<TestRun>> = result
+    }
+
+  @Test
+  fun `shows the empty state when the device has no runs`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        TestFacet(column = column(), dataSource = source(Result.Success(emptyList())))
+      }
+    }
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("No test runs for this device", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
+    onNodeWithText("No test runs for this device", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `renders a row per test run, most recent first`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        TestFacet(
+          column = column(),
+          dataSource =
+            source(
+              Result.Success(
+                listOf(
+                  run("1", "testLoginFlow", startTime = 100),
+                  run("2", "testSignupValidation", status = TestStatus.Failed, startTime = 200),
+                )
+              )
+            ),
+        )
+      }
+    }
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("testLoginFlow", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("testLoginFlow", substring = true).assertIsDisplayed()
+    onNodeWithText("testSignupValidation", substring = true).assertIsDisplayed()
+    // The failed run carries a Failed status label.
+    onNodeWithContentDescription("Test run testSignupValidation Failed").assertIsDisplayed()
+  }
+
+  @Test
+  fun `surfaces a retryable error when the runs fail to load`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        TestFacet(
+          column = column(),
+          dataSource = source(Result.Error(RuntimeException("daemon down"))),
+        )
+      }
+    }
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("daemon down", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Retry loading test runs").assertIsDisplayed()
+  }
+
+  @Test
+  fun `retry re-invokes the loader and renders the recovered runs`() = runComposeUiTest {
+    val attempts = AtomicInteger(0)
+    setContent {
+      MaterialTheme {
+        val recovering =
+          object : TestDataSource {
+            override suspend fun getTestRuns(): Result<List<TestRun>> =
+              if (attempts.getAndIncrement() == 0) Result.Error(RuntimeException("daemon down"))
+              else Result.Success(listOf(run("1", "testNavigationSmoke")))
+          }
+        TestFacet(column = column(), dataSource = recovering)
+      }
+    }
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithContentDescription("Retry loading test runs").performClick()
+
+    waitUntil {
+      onAllNodesWithText("testNavigationSmoke", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("testNavigationSmoke", substring = true).assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
## Summary

Wires the desktop workspace **Test facet** to the per-device test-run resource so each device pane shows its own test runs instead of the daemon's single active device — the consumer-side follow-up to the per-device daemon-resource infrastructure landed in #5017 (closed #4715).

Mirrors how Navigation and Network were wired as their own consumer PRs.

## What changed

- **`TestFacet`** (new, `desktop-core/.../workspace/TestFacet.kt`): a stateless composable with loading / empty / error / resolved states and a retry affordance, following `NetworkFacet`'s IO-load shape. Its `TestDataSource` is injected (nullable param, `Real` default) and scoped to `column.deviceId`; everything is keyed on the device id so switching panes never bleeds one device's runs into another. Rows show name · status · device · duration, most recent first.
- **`RealTestDataSource` / `TestRunQuery`**: gain an optional `deviceId` so the read targets `automobile:test-runs?deviceId=<id>`. A `null` `deviceId` preserves the all-device behavior the standalone Test dashboard relies on (backward compatible).
- **Host** (`AutoMobileDesktopApp.WorkspaceFacet`): maps `Tool.Test -> TestFacet(column)`. The `when(tool)` is now exhaustive across all `Tool` entries, so the `else -> WorkspaceFacetPlaceholder` fallthrough (and its import) are dropped — a future `Tool` will now fail to compile until it's wired, instead of silently falling back.

## Acceptance criteria

- [x] A per-device Test facet renders in each device column, reading `automobile:test-runs?deviceId=<pane deviceId>` via `RealTestDataSource`.
- [x] Follows the workspace facet pattern: stateless composable + injected factory defaulting to real, fake for tests; unit-tested with a fake data source.
- [x] Empty/all-device behavior handled — a pane with no runs for its device shows a clean empty state.

## Testing

- `TestFacetTest` — empty state, one-row-per-run (most-recent-first, status label), retryable error, retry re-invokes loader and renders recovered runs.
- `ResourceUriBuilderTest` — pins the `deviceId` query round-trip (`automobile:test-runs?limit=100&deviceId=…`).
- Full `:desktop-core:test` and `:desktop-app:test` green locally; touched files pass ktfmt `--google-style`.

## Note

Adds runtime behavior in `android/` (a new facet + a `deviceId` query on the daemon read), so this is labeled `needs-human` and auto-merge is left off pending human review.

Closes #5019
