### PR TITLE
feat(ios): add simulator biometric state controls

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -99,23 +99,35 @@ The `changeLocalization` MCP tool supports live locale changes on iOS simulators
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
 
-The `biometricAuth` MCP tool simulates Touch ID / Face ID on simulators by posting
-BiometricKit Darwin notifications inside the simulator via
+The `biometricAuth` MCP tool and `setDeviceState` control Touch ID / Face ID state
+on simulators through BiometricKit Darwin notifications via
 `xcrun simctl spawn <udid> notifyutil`. This reaches parity with the Android emulator
 `adb emu finger` path (see [Android biometrics](../android/biometrics.md)) for
 `match` / `fail`.
 
+Before provisioning, call `getIosSimulatorCapabilities` with a device type and runtime
+from `automobile:devices/images`. It reports the versioned capability identifiers
+`biometrics.enrollment`, `biometrics.match`, `biometrics.fail`, `biometrics.cancel`,
+and `biometrics.error`. Enrollment is supported; match/fail require an enrolled state;
+cancel/error are explicitly unsupported on iOS Simulator.
+
 ### How it works
 
-1. **Enroll** — a registered `notifyutil` set/read/post on
-   `com.apple.BiometricKit.enrollmentChanged` ensures a biometry is enrolled.
+1. **Set enrollment** — `setDeviceState` accepts
+   `biometrics: { enrollment: "enrolled" | "not_enrolled" }`; `biometricAuth`
+   also accepts `action: "enroll" | "unenroll"` for iOS Simulator. Each uses a
+   registered `notifyutil` set/read/post on
+   `com.apple.BiometricKit.enrollmentChanged`.
    Apple `notifyutil(1)` documents that state values require a current
    registration; the helper self-registers so enrollment does not depend on
    BiometricKit already owning the key. Empirical iOS 18.6 simulator checks
    showed this specific BiometricKit key also persisted without explicit `-1`,
    but the shared helper keeps the registration for keys without an external
    owner.
-2. **Match / non-match** — post the key the app's `LAContext` is waiting on:
+   When enrollment is changed in a daemon session, the original enrollment is
+   restored before that session releases the simulator.
+2. **Match / non-match** — `biometricAuth` first verifies that biometry is
+   enrolled, then posts the key the app's `LAContext` is waiting on:
    - Touch ID: `com.apple.BiometricKit_Sim.fingerTouch.match` / `…nomatch`
    - Face ID: `com.apple.BiometricKit_Sim.pearl.match` / `…nomatch`
 
@@ -126,14 +138,18 @@ BiometricKit Darwin notifications inside the simulator via
 
 | MCP `action`       | iOS result                                    |
 | ------------------ | --------------------------------------------- |
-| `match`            | post `*.match`                                |
-| `fail`             | post `*.nomatch`                              |
+| `enroll`           | set enrollment to `enrolled`                  |
+| `unenroll`         | set enrollment to `not_enrolled`              |
+| `match`            | verify enrolled state, then post `*.match`    |
+| `fail`             | verify enrolled state, then post `*.nomatch`  |
 | `cancel` / `error` | `supported: "partial"` — no simctl equivalent |
 
 ### Limitations
 
 - Simulator only. Physical iOS devices have no public biometric-injection API and return
   `supported: false`.
+- `match` and `fail` never force enrollment. Configure the state first so tests can
+  deterministically cover both enrolled and not-enrolled flows.
 - `cancel` / `error` cannot be injected — the notifications carry only match vs non-match.
   On Android these use the `AutoMobileBiometrics` SDK override, which has no iOS counterpart.
 

--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -111,6 +111,18 @@ from `automobile:devices/images`. It reports the versioned capability identifier
 and `biometrics.error`. Enrollment is supported; match/fail require an enrolled state;
 cancel/error are explicitly unsupported on iOS Simulator.
 
+The catalog lists every CoreSimulator device type and runtime, including watchOS
+and tvOS entries that have no BiometricKit at all, so the report first validates
+the selected pair and returns it as `selection: { valid, reason? }`. Only an
+iPhone or iPad device type on an iOS runtime is valid; anything else — a mismatched
+pair, a non-iOS runtime, or an unrecognized identifier — reports every biometric
+capability as `unsupported` with the reason, rather than advertising a contract the
+simulator cannot honor.
+
+Restoration on release is verified, and a failed restore is retried while the
+device stays quarantined, so a simulator never returns to the idle pool holding
+session-modified enrollment.
+
 ### How it works
 
 1. **Set enrollment** — `setDeviceState` accepts

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -651,10 +651,11 @@
               },
               "include": {
                 "type": "array",
+                "minItems": 1,
                 "description": "Optional device state fields to read",
                 "items": {
                   "type": "string",
-                  "enum": ["doNotDisturb"]
+                  "enum": ["doNotDisturb", "biometrics"]
                 }
               }
             }
@@ -676,11 +677,17 @@
               },
               "doNotDisturb": {
                 "$ref": "#/$defs/doNotDisturbStateInput"
+              },
+              "biometrics": {
+                "$ref": "#/$defs/biometricStateInput"
               }
             },
             "anyOf": [
               {
                 "required": ["doNotDisturb"]
+              },
+              {
+                "required": ["biometrics"]
               },
               {
                 "required": ["params"]
@@ -981,15 +988,29 @@
       ],
       "description": "Do Not Disturb state input"
     },
+    "biometricStateInput": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["enrollment"],
+      "properties": {
+        "enrollment": {
+          "type": "string",
+          "enum": ["enrolled", "not_enrolled"],
+          "description": "iOS Simulator biometric enrollment state"
+        }
+      },
+      "description": "iOS Simulator biometric state input"
+    },
     "getDeviceStateParams": {
       "type": "object",
       "additionalProperties": true,
       "properties": {
         "include": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
-            "enum": ["doNotDisturb"]
+            "enum": ["doNotDisturb", "biometrics"]
           },
           "description": "Optional device state fields to read"
         }
@@ -1002,11 +1023,17 @@
       "properties": {
         "doNotDisturb": {
           "$ref": "#/$defs/doNotDisturbStateInput"
+        },
+        "biometrics": {
+          "$ref": "#/$defs/biometricStateInput"
         }
       },
       "anyOf": [
         {
           "required": ["doNotDisturb"]
+        },
+        {
+          "required": ["biometrics"]
         }
       ],
       "description": "Parameters for setDeviceState"

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1581,6 +1581,7 @@
       "properties": {
         "include": {
           "description": "State fields to read; supports doNotDisturb and biometrics",
+          "minItems": 1,
           "type": "array",
           "items": {
             "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -397,9 +397,9 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "match/fail/cancel/error; cancel/error require Android SDK hook",
+          "description": "match/fail/enroll/unenroll on iOS Simulator; cancel/error require Android SDK hook",
           "type": "string",
-          "enum": ["match", "fail", "cancel", "error"]
+          "enum": ["match", "fail", "cancel", "error", "enroll", "unenroll"]
         },
         "modality": {
           "description": "Modality: any default, fingerprint, or face",
@@ -1574,17 +1574,17 @@
   },
   {
     "name": "getDeviceState",
-    "description": "Read device-level state such as Do Not Disturb",
+    "description": "Read device-level state such as Do Not Disturb and iOS Simulator biometric enrollment",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "include": {
-          "description": "State fields to read; supports doNotDisturb",
+          "description": "State fields to read; supports doNotDisturb and biometrics",
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["doNotDisturb"]
+            "enum": ["doNotDisturb", "biometrics"]
           }
         },
         "platform": {
@@ -1603,6 +1603,28 @@
           "type": "string"
         }
       },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "getIosSimulatorCapabilities",
+    "description": "Discover biometric capabilities for a selected iOS Simulator device type and runtime.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "deviceType": {
+          "description": "CoreSimulator device-type identifier selected from automobile:devices/images.",
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "description": "CoreSimulator runtime identifier selected from automobile:devices/images.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["deviceType", "runtime"],
       "additionalProperties": false
     }
   },
@@ -7506,7 +7528,7 @@
   },
   {
     "name": "setDeviceState",
-    "description": "Set device state such as Do Not Disturb.",
+    "description": "Set device state such as Do Not Disturb and iOS Simulator biometric enrollment.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -7525,6 +7547,19 @@
               "enum": ["off", "none", "priority", "alarms"]
             }
           },
+          "additionalProperties": false
+        },
+        "biometrics": {
+          "description": "iOS Simulator biometric enrollment state to apply.",
+          "type": "object",
+          "properties": {
+            "enrollment": {
+              "description": "Set iOS Simulator biometric enrollment state.",
+              "type": "string",
+              "enum": ["enrolled", "not_enrolled"]
+            }
+          },
+          "required": ["enrollment"],
           "additionalProperties": false
         },
         "platform": {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -682,12 +682,25 @@ export class SessionManager {
   ): Promise<Session> {
     const replacement = this.createReboundSession(existing, assignedDevice, platform);
     await this.persistSession(replacement);
+    const activeSetups = Array.from(this.sessionSetupPromises, (setup) =>
+      setup.session === existing ? setup.promise : null,
+    ).filter((setup): setup is Promise<void> => setup !== null);
+    // A session-scoped biometric mutation targets the old simulator. Rebinding
+    // must wait for it before restoring that simulator and discarding its cache.
+    await Promise.allSettled(activeSetups);
 
     try {
       await this.restoreKeepScreenAwake(existing);
     } catch (error) {
       logger.warn(
         `Failed to restore keep-awake state for rebound session ${existing.sessionId}: ${error}`,
+      );
+    }
+    try {
+      await this.restoreBiometricEnrollment(existing);
+    } catch (error) {
+      logger.warn(
+        `Failed to restore biometric enrollment for rebound session ${existing.sessionId}: ${error}`,
       );
     }
 
@@ -962,8 +975,10 @@ export class SessionManager {
       const pendingSetups =
         setups.length > 0 ? (await this.waitForSessionSetup(sessionId, setups)).pending : null;
       const pendingRestoration = (await this.restoreKeepScreenAwakeBestEffort(session)).pending;
-      const pendingBiometricRestoration = (await this.restoreBiometricEnrollmentBestEffort(session))
-        .pending;
+      const pendingBiometricRestoration = await this.getPendingBiometricRestoration(
+        session,
+        pendingSetups,
+      );
       const pendingCleanup = [
         pendingSetups,
         pendingRestoration,
@@ -1138,24 +1153,29 @@ export class SessionManager {
     }
   }
 
-  private async restoreBiometricEnrollmentBestEffort(
-    session: Session,
-  ): Promise<{ pending: Promise<void> | null }> {
+  private async restoreBiometricEnrollment(session: Session): Promise<void> {
     const state = session.cacheData.biometricEnrollment;
     if (session.platform !== "ios" || !state) {
-      return { pending: null };
+      return;
     }
     const device: BootedDevice = {
       name: session.assignedDevice,
       platform: session.platform,
       deviceId: session.assignedDevice,
     };
-    const restoration = this.biometricEnrollmentRestorerFactory(device)
-      .restore(state.initialEnrollment)
-      .then(
-        () => ({ outcome: "restored" as const }),
-        (error) => ({ outcome: "failed" as const, error }),
-      );
+    await this.biometricEnrollmentRestorerFactory(device).restore(state.initialEnrollment);
+  }
+
+  private async restoreBiometricEnrollmentBestEffort(
+    session: Session,
+  ): Promise<{ pending: Promise<void> | null }> {
+    if (!session.cacheData.biometricEnrollment) {
+      return { pending: null };
+    }
+    const restoration = this.restoreBiometricEnrollment(session).then(
+      () => ({ outcome: "restored" as const }),
+      (error) => ({ outcome: "failed" as const, error }),
+    );
     let timeoutHandle: NodeJS.Timeout | undefined;
     const timeout = new Promise<{ outcome: "timed-out" }>((resolve) => {
       timeoutHandle = this.timer.setTimeout(
@@ -1181,6 +1201,30 @@ export class SessionManager {
         this.timer.clearTimeout(timeoutHandle);
       }
     }
+  }
+
+  /**
+   * A timed-out setup can still write simulator state. Defer its restoration
+   * until that write settles so an old command cannot overwrite the restore.
+   */
+  private restoreBiometricEnrollmentAfterSetups(
+    session: Session,
+    pendingSetups: Promise<void>,
+  ): Promise<void> {
+    return pendingSetups.then(async () => {
+      const pendingRestoration = (await this.restoreBiometricEnrollmentBestEffort(session)).pending;
+      await pendingRestoration;
+    });
+  }
+
+  private async getPendingBiometricRestoration(
+    session: Session,
+    pendingSetups: Promise<void> | null,
+  ): Promise<Promise<void> | null> {
+    if (pendingSetups && session.cacheData.biometricEnrollment) {
+      return this.restoreBiometricEnrollmentAfterSetups(session, pendingSetups);
+    }
+    return (await this.restoreBiometricEnrollmentBestEffort(session)).pending;
   }
 
   private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -175,6 +175,14 @@ export interface RebindSessionOptions {
 
 const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
 const BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS = 1_000;
+/**
+ * A failed restore leaves the simulator holding session-modified enrollment, so
+ * the device must not return to the idle pool on the strength of one attempt.
+ * Retries run inside the pending-cleanup promise, which keeps the device
+ * quarantined until they settle.
+ */
+const BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS = 2;
+const BIOMETRIC_ENROLLMENT_RESTORE_RETRY_DELAY_MS = 250;
 const SESSION_SETUP_DRAIN_TIMEOUT_MS = 1_000;
 const EXPIRY_RELEASE_REASONS = new Set([
   "lazy-expiry",
@@ -984,7 +992,7 @@ export class SessionManager {
         setups.length > 0 ? (await this.waitForSessionSetup(sessionId, setups)).pending : null;
       const pendingRestoration = (await this.restoreKeepScreenAwakeBestEffort(session)).pending;
       const pendingBiometricRestoration = session.cacheData.biometricEnrollment
-        ? await this.getPendingBiometricRestoration(session, pendingSetups)
+        ? (await this.getPendingBiometricRestoration(session, pendingSetups)).pending
         : null;
       const pendingCleanup = [
         pendingSetups,
@@ -1201,11 +1209,15 @@ export class SessionManager {
         logger.warn(
           `Failed to restore biometric enrollment for session ${session.sessionId}: ${result.error}`,
         );
-      } else if (result.outcome === "timed-out") {
+        // Quarantine the device until the retries below settle; a prompt
+        // rejection otherwise returns a dirty simulator straight to the pool.
+        return { pending: this.retryBiometricEnrollmentRestore(session, result.error) };
+      }
+      if (result.outcome === "timed-out") {
         logger.warn(
           `Timed out after ${BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS}ms restoring biometric enrollment for session ${session.sessionId}`,
         );
-        return { pending: restoration.then(() => undefined) };
+        return { pending: this.settleBiometricEnrollmentRestore(session, restoration) };
       }
       return { pending: null };
     } finally {
@@ -1213,6 +1225,49 @@ export class SessionManager {
         this.timer.clearTimeout(timeoutHandle);
       }
     }
+  }
+
+  /** A slow restore can still fail; retry before the device leaves quarantine. */
+  private async settleBiometricEnrollmentRestore(
+    session: Session,
+    restoration: Promise<{ outcome: "restored" } | { outcome: "failed"; error: unknown }>,
+  ): Promise<void> {
+    const result = await restoration;
+    if (result.outcome === "restored") {
+      return;
+    }
+    logger.warn(
+      `Failed to restore biometric enrollment for session ${session.sessionId}: ${result.error}`,
+    );
+    await this.retryBiometricEnrollmentRestore(session, result.error);
+  }
+
+  private async retryBiometricEnrollmentRestore(
+    session: Session,
+    initialError: unknown,
+  ): Promise<void> {
+    let lastError = initialError;
+    for (let attempt = 1; attempt <= BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS; attempt++) {
+      await this.timer.sleep(BIOMETRIC_ENROLLMENT_RESTORE_RETRY_DELAY_MS);
+      try {
+        await this.restoreBiometricEnrollment(session);
+        logger.info(
+          `Restored biometric enrollment for session ${session.sessionId} on retry ${attempt}`,
+        );
+        return;
+      } catch (error) {
+        // Teardown is best-effort: keep retrying, then report the last failure.
+        lastError = error;
+        logger.debug(
+          `Retry ${attempt} restoring biometric enrollment for session ${session.sessionId} failed: ${error}`,
+        );
+      }
+    }
+    logger.warn(
+      `Gave up restoring biometric enrollment for session ${session.sessionId} after ` +
+        `${BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS} retries; device ${session.assignedDevice} ` +
+        `may hold session-modified enrollment: ${lastError}`,
+    );
   }
 
   /**
@@ -1229,14 +1284,19 @@ export class SessionManager {
     });
   }
 
+  /**
+   * Returned wrapped, never bare: `return somePromise` inside an async function
+   * adopts that promise, which would make the caller await the very cleanup it
+   * is trying to hand off and stall the release.
+   */
   private async getPendingBiometricRestoration(
     session: Session,
     pendingSetups: Promise<void> | null,
-  ): Promise<Promise<void> | null> {
+  ): Promise<{ pending: Promise<void> | null }> {
     if (pendingSetups && session.cacheData.biometricEnrollment) {
-      return this.restoreBiometricEnrollmentAfterSetups(session, pendingSetups);
+      return { pending: this.restoreBiometricEnrollmentAfterSetups(session, pendingSetups) };
     }
-    return (await this.restoreBiometricEnrollmentBestEffort(session)).pending;
+    return { pending: (await this.restoreBiometricEnrollmentBestEffort(session)).pending };
   }
 
   private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -34,6 +34,13 @@ export interface BiometricEnrollmentSessionState {
   initialEnrollment: BiometricEnrollment;
 }
 
+/** What a pending restore must write, resolved before any await (see below). */
+interface BiometricRestoreTarget {
+  sessionId: string;
+  deviceId: string;
+  enrollment: BiometricEnrollment;
+}
+
 /** Narrow seam for restoring iOS Simulator biometric enrollment on release. */
 export interface BiometricEnrollmentRestorer {
   restore(enrollment: BiometricEnrollment): Promise<void>;
@@ -704,15 +711,16 @@ export class SessionManager {
         `Failed to restore keep-awake state for rebound session ${existing.sessionId}: ${error}`,
       );
     }
-    try {
-      await this.restoreBiometricEnrollment(existing);
-    } catch (error) {
-      logger.warn(
-        `Failed to restore biometric enrollment for rebound session ${existing.sessionId}: ${error}`,
-      );
-    }
+    // Same contract as release: a failed restore must not hand the old
+    // simulator back to the pool clean. Any outstanding retry is registered
+    // against that device below, so DevicePool.releaseDevice defers idling it.
+    const pendingBiometricRestoration = (await this.restoreBiometricEnrollmentBestEffort(existing))
+      .pending;
 
     const previousDevice = existing.assignedDevice;
+    if (pendingBiometricRestoration) {
+      this.trackPendingDeviceCleanup(previousDevice, [pendingBiometricRestoration]);
+    }
     // Preserve object identity so an already-started release observes the
     // rebinding and frees its live replacement rather than a stale snapshot.
     // Recreate the replacement after awaited work: activity and label-routing
@@ -1173,26 +1181,41 @@ export class SessionManager {
     }
   }
 
-  private async restoreBiometricEnrollment(session: Session): Promise<void> {
+  /**
+   * Snapshot of what a restore must write, taken before any await. A rebind
+   * reassigns `session.assignedDevice` while retries are still outstanding, so
+   * resolving the device lazily from the session would aim them at the new
+   * simulator and leave the old one dirty.
+   */
+  private biometricRestoreTarget(session: Session): BiometricRestoreTarget | null {
     const state = session.cacheData.biometricEnrollment;
     if (session.platform !== "ios" || !state) {
-      return;
+      return null;
     }
-    const device: BootedDevice = {
-      name: session.assignedDevice,
-      platform: session.platform,
+    return {
+      sessionId: session.sessionId,
       deviceId: session.assignedDevice,
+      enrollment: state.initialEnrollment,
     };
-    await this.biometricEnrollmentRestorerFactory(device).restore(state.initialEnrollment);
+  }
+
+  private async restoreBiometricEnrollment(target: BiometricRestoreTarget): Promise<void> {
+    const device: BootedDevice = {
+      name: target.deviceId,
+      platform: "ios",
+      deviceId: target.deviceId,
+    };
+    await this.biometricEnrollmentRestorerFactory(device).restore(target.enrollment);
   }
 
   private async restoreBiometricEnrollmentBestEffort(
     session: Session,
   ): Promise<{ pending: Promise<void> | null }> {
-    if (!session.cacheData.biometricEnrollment) {
+    const target = this.biometricRestoreTarget(session);
+    if (!target) {
       return { pending: null };
     }
-    const restoration = this.restoreBiometricEnrollment(session).then(
+    const restoration = this.restoreBiometricEnrollment(target).then(
       () => ({ outcome: "restored" as const }),
       (error) => ({ outcome: "failed" as const, error }),
     );
@@ -1211,13 +1234,13 @@ export class SessionManager {
         );
         // Quarantine the device until the retries below settle; a prompt
         // rejection otherwise returns a dirty simulator straight to the pool.
-        return { pending: this.retryBiometricEnrollmentRestore(session, result.error) };
+        return { pending: this.retryBiometricEnrollmentRestore(target, result.error) };
       }
       if (result.outcome === "timed-out") {
         logger.warn(
           `Timed out after ${BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS}ms restoring biometric enrollment for session ${session.sessionId}`,
         );
-        return { pending: this.settleBiometricEnrollmentRestore(session, restoration) };
+        return { pending: this.settleBiometricEnrollmentRestore(target, restoration) };
       }
       return { pending: null };
     } finally {
@@ -1229,7 +1252,7 @@ export class SessionManager {
 
   /** A slow restore can still fail; retry before the device leaves quarantine. */
   private async settleBiometricEnrollmentRestore(
-    session: Session,
+    target: BiometricRestoreTarget,
     restoration: Promise<{ outcome: "restored" } | { outcome: "failed"; error: unknown }>,
   ): Promise<void> {
     const result = await restoration;
@@ -1237,35 +1260,35 @@ export class SessionManager {
       return;
     }
     logger.warn(
-      `Failed to restore biometric enrollment for session ${session.sessionId}: ${result.error}`,
+      `Failed to restore biometric enrollment for session ${target.sessionId}: ${result.error}`,
     );
-    await this.retryBiometricEnrollmentRestore(session, result.error);
+    await this.retryBiometricEnrollmentRestore(target, result.error);
   }
 
   private async retryBiometricEnrollmentRestore(
-    session: Session,
+    target: BiometricRestoreTarget,
     initialError: unknown,
   ): Promise<void> {
     let lastError = initialError;
     for (let attempt = 1; attempt <= BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS; attempt++) {
       await this.timer.sleep(BIOMETRIC_ENROLLMENT_RESTORE_RETRY_DELAY_MS);
       try {
-        await this.restoreBiometricEnrollment(session);
+        await this.restoreBiometricEnrollment(target);
         logger.info(
-          `Restored biometric enrollment for session ${session.sessionId} on retry ${attempt}`,
+          `Restored biometric enrollment for session ${target.sessionId} on retry ${attempt}`,
         );
         return;
       } catch (error) {
         // Teardown is best-effort: keep retrying, then report the last failure.
         lastError = error;
         logger.debug(
-          `Retry ${attempt} restoring biometric enrollment for session ${session.sessionId} failed: ${error}`,
+          `Retry ${attempt} restoring biometric enrollment for session ${target.sessionId} failed: ${error}`,
         );
       }
     }
     logger.warn(
-      `Gave up restoring biometric enrollment for session ${session.sessionId} after ` +
-        `${BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS} retries; device ${session.assignedDevice} ` +
+      `Gave up restoring biometric enrollment for session ${target.sessionId} after ` +
+        `${BIOMETRIC_ENROLLMENT_RESTORE_RETRY_ATTEMPTS} retries; device ${target.deviceId} ` +
         `may hold session-modified enrollment: ${lastError}`,
     );
   }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -903,7 +903,7 @@ export class SessionManager {
    * Release waits for this work so restoration sees the final cached state.
    */
   trackSessionSetup(session: Session, createSetup: () => Promise<void>): Promise<void> {
-    if (this.releasingSessions.has(session) || this.sessions.get(session.sessionId) !== session) {
+    if (!this.canStartSessionSetup(session)) {
       return Promise.resolve();
     }
 
@@ -926,6 +926,14 @@ export class SessionManager {
       () => this.clearSessionSetup(tracked),
     );
     return setup;
+  }
+
+  private canStartSessionSetup(session: Session): boolean {
+    return (
+      !this.releasingSessions.has(session) &&
+      this.pendingSessionRebinds.get(session.sessionId)?.session !== session &&
+      this.sessions.get(session.sessionId) === session
+    );
   }
 
   /** Wait a bounded amount of time for releases already started by monitors. */
@@ -975,10 +983,9 @@ export class SessionManager {
       const pendingSetups =
         setups.length > 0 ? (await this.waitForSessionSetup(sessionId, setups)).pending : null;
       const pendingRestoration = (await this.restoreKeepScreenAwakeBestEffort(session)).pending;
-      const pendingBiometricRestoration = await this.getPendingBiometricRestoration(
-        session,
-        pendingSetups,
-      );
+      const pendingBiometricRestoration = session.cacheData.biometricEnrollment
+        ? await this.getPendingBiometricRestoration(session, pendingSetups)
+        : null;
       const pendingCleanup = [
         pendingSetups,
         pendingRestoration,
@@ -1010,13 +1017,7 @@ export class SessionManager {
         },
       };
 
-      if (releaseSnapshot.terminal) {
-        // Fence the UUID before durable persistence. If the write fails, callers
-        // must still stop routing tools to a device that is already confirmed
-        // lost; a later release retry can persist and complete removal.
-        this.terminalReleaseSnapshots.set(sessionId, releaseSnapshot);
-        await this.persistSessionRelease(releaseSnapshot);
-      }
+      await this.persistTerminalReleaseIfNeeded(releaseSnapshot);
       if (!this.removeSession(sessionId, session)) {
         if (pendingCleanup.length > 0) {
           this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
@@ -1077,6 +1078,17 @@ export class SessionManager {
         );
       }
     }
+  }
+
+  private async persistTerminalReleaseIfNeeded(snapshot: SessionReleaseSnapshot): Promise<void> {
+    if (!snapshot.terminal) {
+      return;
+    }
+    // Fence the UUID before durable persistence. If the write fails, callers
+    // must still stop routing tools to a device that is already confirmed
+    // lost; a later release retry can persist and complete removal.
+    this.terminalReleaseSnapshots.set(snapshot.sessionId, snapshot);
+    await this.persistSessionRelease(snapshot);
   }
 
   private clearSessionSetup(tracked: { session: Session; promise: Promise<void> }): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1189,7 +1189,12 @@ export class SessionManager {
    */
   private biometricRestoreTarget(session: Session): BiometricRestoreTarget | null {
     const state = session.cacheData.biometricEnrollment;
-    if (session.platform !== "ios" || !state) {
+    // Keyed on the cache alone, not session.platform. The slot is only ever
+    // written by the iOS Simulator biometric path, so its presence is the
+    // authoritative evidence that a simulator needs restoring — whereas
+    // session.platform carries whatever the caller declared to setActiveDevice
+    // and can disagree with the device actually bound.
+    if (!state) {
       return null;
     }
     return {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -10,6 +10,7 @@ import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { toActionableError } from "../models/ActionableError";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
+import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
 
 /**
  * Device-label → session-UUID map. `buildDeviceLabelMap` assigns each configured
@@ -26,6 +27,16 @@ export type DeviceLabelMap = Record<string, string>;
  */
 export interface KeepScreenAwakeRestorer {
   restore(state: KeepScreenAwakeState): Promise<void>;
+}
+
+/** Original simulator enrollment restored when a session releases its device. */
+export interface BiometricEnrollmentSessionState {
+  initialEnrollment: BiometricEnrollment;
+}
+
+/** Narrow seam for restoring iOS Simulator biometric enrollment on release. */
+export interface BiometricEnrollmentRestorer {
+  restore(enrollment: BiometricEnrollment): Promise<void>;
 }
 
 /**
@@ -50,6 +61,7 @@ export interface SessionCacheData {
   lastObserveTime?: number; // Timestamp of last hierarchy observation
   lastRenderedObservation?: ObserveResult; // Last observation emitted to the agent (sanitized), the #2761 diff baseline
   keepScreenAwake?: KeepScreenAwakeState; // Keep-awake state applied at session setup, restored on release
+  biometricEnrollment?: BiometricEnrollmentSessionState; // Original iOS Simulator biometric enrollment, restored on release
   deviceLabels?: DeviceLabelMap; // Device-label → session map for multi-device (`device:`-labelled) sessions
 }
 
@@ -162,6 +174,7 @@ export interface RebindSessionOptions {
 }
 
 const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
+const BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS = 1_000;
 const SESSION_SETUP_DRAIN_TIMEOUT_MS = 1_000;
 const EXPIRY_RELEASE_REASONS = new Set([
   "lazy-expiry",
@@ -249,6 +262,9 @@ export class SessionManager {
   private readonly keepScreenAwakeRestorerFactory: (
     device: BootedDevice,
   ) => KeepScreenAwakeRestorer;
+  private readonly biometricEnrollmentRestorerFactory: (
+    device: BootedDevice,
+  ) => BiometricEnrollmentRestorer;
   private activeSessionExecutionChecker: ActiveSessionExecutionChecker = () => false;
 
   // Session timeout: 30 minutes
@@ -275,11 +291,24 @@ export class SessionManager {
     // tests inject a fake to assert the typed slot's payload reaches `restore`.
     keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer = (device) =>
       new KeepScreenAwakeManager(device),
+    // Simulator enrollment is session-scoped state. Keep this seam parallel to
+    // keep-awake so lifecycle tests never invoke simctl.
+    biometricEnrollmentRestorerFactory: (device: BootedDevice) => BiometricEnrollmentRestorer = (
+      device,
+    ) => ({
+      restore: async (enrollment) => {
+        const result = await new DeviceState(device).setBiometricEnrollmentState(enrollment);
+        if (!result.supported || result.error || result.verified === false) {
+          throw new Error(result.error ?? "Failed to restore iOS Simulator biometric enrollment");
+        }
+      },
+    }),
   ) {
     this.timer = timer;
     this.deviceSessionRepository = deviceSessionRepository;
     this.getBarrier = getBarrier;
     this.keepScreenAwakeRestorerFactory = keepScreenAwakeRestorerFactory;
+    this.biometricEnrollmentRestorerFactory = biometricEnrollmentRestorerFactory;
     // Start periodic cleanup of expired sessions
     this.startCleanupTimer();
   }
@@ -933,9 +962,13 @@ export class SessionManager {
       const pendingSetups =
         setups.length > 0 ? (await this.waitForSessionSetup(sessionId, setups)).pending : null;
       const pendingRestoration = (await this.restoreKeepScreenAwakeBestEffort(session)).pending;
-      const pendingCleanup = [pendingSetups, pendingRestoration].filter(
-        (cleanup): cleanup is Promise<void> => cleanup !== null,
-      );
+      const pendingBiometricRestoration = (await this.restoreBiometricEnrollmentBestEffort(session))
+        .pending;
+      const pendingCleanup = [
+        pendingSetups,
+        pendingRestoration,
+        pendingBiometricRestoration,
+      ].filter((cleanup): cleanup is Promise<void> => cleanup !== null);
       const deviceId = session.assignedDevice;
       const releasedAtMs = this.timer.now();
       const releaseSnapshot: SessionReleaseSnapshot = {
@@ -1105,6 +1138,51 @@ export class SessionManager {
     }
   }
 
+  private async restoreBiometricEnrollmentBestEffort(
+    session: Session,
+  ): Promise<{ pending: Promise<void> | null }> {
+    const state = session.cacheData.biometricEnrollment;
+    if (session.platform !== "ios" || !state) {
+      return { pending: null };
+    }
+    const device: BootedDevice = {
+      name: session.assignedDevice,
+      platform: session.platform,
+      deviceId: session.assignedDevice,
+    };
+    const restoration = this.biometricEnrollmentRestorerFactory(device)
+      .restore(state.initialEnrollment)
+      .then(
+        () => ({ outcome: "restored" as const }),
+        (error) => ({ outcome: "failed" as const, error }),
+      );
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<{ outcome: "timed-out" }>((resolve) => {
+      timeoutHandle = this.timer.setTimeout(
+        () => resolve({ outcome: "timed-out" }),
+        BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS,
+      );
+    });
+    try {
+      const result = await Promise.race([restoration, timeout]);
+      if (result.outcome === "failed") {
+        logger.warn(
+          `Failed to restore biometric enrollment for session ${session.sessionId}: ${result.error}`,
+        );
+      } else if (result.outcome === "timed-out") {
+        logger.warn(
+          `Timed out after ${BIOMETRIC_ENROLLMENT_RESTORE_TIMEOUT_MS}ms restoring biometric enrollment for session ${session.sessionId}`,
+        );
+        return { pending: restoration.then(() => undefined) };
+      }
+      return { pending: null };
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
   private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {
     const previous = this.pendingDeviceCleanups.get(deviceId);
     const cleanup = Promise.allSettled(previous ? [previous, ...cleanups] : cleanups).then(
@@ -1232,6 +1310,23 @@ export class SessionManager {
    */
   getKeepScreenAwake(sessionId: string): KeepScreenAwakeState | undefined {
     return this.getSession(sessionId)?.cacheData.keepScreenAwake;
+  }
+
+  /**
+   * Preserve the pre-session iOS Simulator enrollment state. This setter is
+   * intentionally write-once per session: every later enrollment change must
+   * restore the same state the session first observed.
+   */
+  setBiometricEnrollment(sessionId: string, state: BiometricEnrollmentSessionState): void {
+    if (this.getBiometricEnrollment(sessionId)) {
+      return;
+    }
+    this.updateSessionCache(sessionId, { biometricEnrollment: state });
+  }
+
+  /** Read the original enrollment state without recording session activity. */
+  getBiometricEnrollment(sessionId: string): BiometricEnrollmentSessionState | undefined {
+    return this.getSession(sessionId)?.cacheData.biometricEnrollment;
   }
 
   /**

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -7,14 +7,10 @@ import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorDevice } from "./IosSimulatorPermissions";
-import {
-  IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
-  iosNotifyutilRegisteredSetReadPostCommand,
-  parseNotifyutilState,
-} from "../../utils/ios-cmdline-tools/notifyutil";
+import { DeviceState } from "../utility/DeviceState";
 
 export interface BiometricAuthOptions {
-  action: "match" | "fail" | "cancel" | "error";
+  action: "match" | "fail" | "cancel" | "error" | "enroll" | "unenroll";
   modality?: "any" | "fingerprint" | "face";
   fingerprintId?: number;
   errorCode?: number;
@@ -35,7 +31,6 @@ const DEFAULT_TTL_MS = 5000;
 export class BiometricAuth extends BaseVisualChange {
   /** Darwin notification keys the iOS Simulator's BiometricKit listens on. */
   private static readonly IOS_KEYS = {
-    enrollment: "com.apple.BiometricKit.enrollmentChanged",
     fingerTouch: {
       match: "com.apple.BiometricKit_Sim.fingerTouch.match",
       nomatch: "com.apple.BiometricKit_Sim.fingerTouch.nomatch",
@@ -75,6 +70,14 @@ export class BiometricAuth extends BaseVisualChange {
       return this.unsupported(
         options,
         "Biometric authentication is only supported on Android and iOS Simulator devices",
+      );
+    }
+
+    if (options.action === "enroll" || options.action === "unenroll") {
+      perf.end();
+      return this.unsupported(
+        options,
+        "Biometric enrollment control is currently available only on iOS Simulator.",
       );
     }
 
@@ -167,6 +170,8 @@ export class BiometricAuth extends BaseVisualChange {
    *
    * match -> *.match, fail -> *.nomatch. For modality "any" we post both fingerTouch and
    * pearl keys; a simulator only has one biometry enrolled so the other is a harmless no-op.
+   * Enrollment is preserved: callers configure it with `enroll`/`unenroll` or
+   * `setDeviceState`; match/fail never silently change it.
    * cancel/error have no simulator notification and return supported:"partial".
    * Physical iOS devices have no public injection API and return supported:false.
    */
@@ -195,6 +200,27 @@ export class BiometricAuth extends BaseVisualChange {
 
     const simctl = this.simctl ?? new SimCtlClient(this.device);
     const udid = this.device.deviceId;
+    const enrollment = new DeviceState(this.device, { simctl });
+
+    if (options.action === "enroll" || options.action === "unenroll") {
+      const enrollmentState = await enrollment.setBiometricEnrollmentState(
+        options.action === "enroll" ? "enrolled" : "not_enrolled",
+      );
+      return {
+        success:
+          enrollmentState.supported && !enrollmentState.error && enrollmentState.verified !== false,
+        action: options.action,
+        modality,
+        fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
+        supported: enrollmentState.supported,
+        ...(enrollmentState.error ? { error: enrollmentState.error } : {}),
+        ...(enrollmentState.error
+          ? {}
+          : { message: `Biometric enrollment set to ${enrollmentState.enrollment}.` }),
+      };
+    }
+
     const wantMatch = options.action === "match";
     const keys = BiometricAuth.IOS_KEYS;
 
@@ -209,12 +235,8 @@ export class BiometricAuth extends BaseVisualChange {
     }
 
     try {
-      // Ensure biometry is enrolled before attempting a match.
-      const enrollmentResult = await simctl.executeCommand(
-        iosNotifyutilRegisteredSetReadPostCommand(udid, keys.enrollment, "1"),
-        IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
-      );
-      if (enrollmentResult.stderr && enrollmentResult.stderr.trim().length > 0) {
+      const enrollmentState = await enrollment.getBiometricEnrollmentState();
+      if (enrollmentState.error) {
         return {
           success: false,
           action: options.action,
@@ -222,10 +244,10 @@ export class BiometricAuth extends BaseVisualChange {
           fingerprintId: options.fingerprintId,
           errorCode: options.errorCode,
           supported: true,
-          error: `notifyutil failed: ${enrollmentResult.stderr.trim()}`,
+          error: enrollmentState.error,
         };
       }
-      if (parseNotifyutilState(enrollmentResult.stdout ?? "") !== true) {
+      if (enrollmentState.enrollment !== "enrolled") {
         return {
           success: false,
           action: options.action,
@@ -234,7 +256,7 @@ export class BiometricAuth extends BaseVisualChange {
           errorCode: options.errorCode,
           supported: true,
           error:
-            "iOS biometric enrollment did not verify: notifyutil did not read back enrolled state.",
+            "iOS Simulator biometry is not enrolled. Call biometricAuth with action 'enroll' or setDeviceState biometrics.enrollment to 'enrolled' first.",
         };
       }
 
@@ -270,7 +292,7 @@ export class BiometricAuth extends BaseVisualChange {
         fingerprintId: options.fingerprintId,
         errorCode: options.errorCode,
         supported: true,
-        error: `Failed to post iOS biometric notification: ${errorMessage(error)}`,
+        error: `Failed to simulate iOS biometric authentication: ${errorMessage(error)}`,
       };
     }
   }
@@ -333,6 +355,9 @@ export class BiometricAuth extends BaseVisualChange {
         return "CANCEL";
       case "error":
         return "ERROR";
+      case "enroll":
+      case "unenroll":
+        return "";
     }
   }
 

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -253,6 +253,8 @@ function modeForInput(input: SetDeviceStateInput["doNotDisturb"]): DoNotDisturbM
   return input?.enabled === false ? "off" : "none";
 }
 
+export const EMPTY_STATE_SELECTION_ERROR = "At least one device state field must be included";
+
 function doNotDisturbInputError(input: SetDeviceStateInput["doNotDisturb"]): string | undefined {
   if (!input || input.enabled === undefined || input.mode === undefined) {
     return undefined;
@@ -282,6 +284,15 @@ export class DeviceState {
   async getState(
     include: ("doNotDisturb" | "biometrics")[] = ["doNotDisturb"],
   ): Promise<DeviceStateResult> {
+    // An empty selection would otherwise read nothing and report success.
+    if (include.length === 0) {
+      return {
+        success: false,
+        deviceId: this.device.deviceId,
+        platform: this.device.platform,
+        error: EMPTY_STATE_SELECTION_ERROR,
+      };
+    }
     const doNotDisturb = include.includes("doNotDisturb")
       ? this.device.platform === "android"
         ? await this.getAndroidDoNotDisturb()

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -55,11 +55,22 @@ export interface DoNotDisturbState {
   appliedMode?: DoNotDisturbMode;
 }
 
+export type BiometricEnrollment = "enrolled" | "not_enrolled";
+
+export interface BiometricEnrollmentState {
+  supported: boolean;
+  enrollment?: BiometricEnrollment;
+  method?: "ios_simulator_notifyutil";
+  verified?: boolean;
+  error?: string;
+}
+
 export interface DeviceStateResult {
   success: boolean;
   deviceId: string;
   platform: "android" | "ios";
   doNotDisturb?: DoNotDisturbState;
+  biometrics?: BiometricEnrollmentState;
   error?: string;
 }
 
@@ -67,6 +78,9 @@ export interface SetDeviceStateInput {
   doNotDisturb?: {
     enabled?: boolean;
     mode?: DoNotDisturbMode;
+  };
+  biometrics?: {
+    enrollment: BiometricEnrollment;
   };
 }
 
@@ -82,6 +96,9 @@ export interface DeviceStateDependencies {
 
 const IOS_DND_NOTIFICATION = "com.apple.donotdisturb.enabled";
 const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
+const IOS_BIOMETRIC_ENROLLMENT_NOTIFICATION = "com.apple.BiometricKit.enrollmentChanged";
+const IOS_BIOMETRICS_UNSUPPORTED_ERROR =
+  "Biometric enrollment state can only be read or set on an iOS Simulator.";
 
 /**
  * Physical iOS devices expose no public API to enable/disable Focus or Do Not
@@ -236,6 +253,16 @@ function modeForInput(input: SetDeviceStateInput["doNotDisturb"]): DoNotDisturbM
   return input?.enabled === false ? "off" : "none";
 }
 
+function doNotDisturbInputError(input: SetDeviceStateInput["doNotDisturb"]): string | undefined {
+  if (!input || input.enabled === undefined || input.mode === undefined) {
+    return undefined;
+  }
+  if ((input.enabled === false) !== (input.mode === "off")) {
+    return `doNotDisturb.enabled=${input.enabled} conflicts with doNotDisturb.mode="${input.mode}"`;
+  }
+  return undefined;
+}
+
 export class DeviceState {
   private device: BootedDevice;
 
@@ -252,23 +279,34 @@ export class DeviceState {
     this.timer = dependencies.timer ?? defaultTimer;
   }
 
-  async getState(): Promise<DeviceStateResult> {
-    const doNotDisturb =
-      this.device.platform === "android"
+  async getState(
+    include: ("doNotDisturb" | "biometrics")[] = ["doNotDisturb"],
+  ): Promise<DeviceStateResult> {
+    const doNotDisturb = include.includes("doNotDisturb")
+      ? this.device.platform === "android"
         ? await this.getAndroidDoNotDisturb()
-        : await this.getIosDoNotDisturb();
+        : await this.getIosDoNotDisturb()
+      : undefined;
+    const biometrics = include.includes("biometrics")
+      ? await this.getBiometricEnrollmentState()
+      : undefined;
+    const requestedStates = [doNotDisturb, biometrics].filter(
+      (state): state is DoNotDisturbState | BiometricEnrollmentState => state !== undefined,
+    );
+    const error = requestedStates.find((state) => state.error)?.error;
 
     return {
-      success: doNotDisturb.supported && !doNotDisturb.error,
+      success: requestedStates.every((state) => state.supported && !state.error),
       deviceId: this.device.deviceId,
       platform: this.device.platform,
-      doNotDisturb,
-      ...(doNotDisturb.error ? { error: doNotDisturb.error } : {}),
+      ...(doNotDisturb ? { doNotDisturb } : {}),
+      ...(biometrics ? { biometrics } : {}),
+      ...(error ? { error } : {}),
     };
   }
 
   async setState(input: SetDeviceStateInput): Promise<DeviceStateResult> {
-    if (!input.doNotDisturb) {
+    if (!input.doNotDisturb && !input.biometrics) {
       return {
         success: false,
         deviceId: this.device.deviceId,
@@ -277,32 +315,134 @@ export class DeviceState {
       };
     }
 
-    const { enabled, mode } = input.doNotDisturb;
-    if (enabled !== undefined && mode !== undefined) {
-      const impliesOff = enabled === false;
-      const modeIsOff = mode === "off";
-      if (impliesOff !== modeIsOff) {
-        return {
-          success: false,
-          deviceId: this.device.deviceId,
-          platform: this.device.platform,
-          error: `doNotDisturb.enabled=${enabled} conflicts with doNotDisturb.mode="${mode}"`,
-        };
-      }
+    const inputError = doNotDisturbInputError(input.doNotDisturb);
+    if (inputError) {
+      return {
+        success: false,
+        deviceId: this.device.deviceId,
+        platform: this.device.platform,
+        error: inputError,
+      };
     }
 
-    const doNotDisturb =
-      this.device.platform === "android"
+    const doNotDisturb = input.doNotDisturb
+      ? this.device.platform === "android"
         ? await this.setAndroidDoNotDisturb(input.doNotDisturb)
-        : await this.setIosDoNotDisturb(input.doNotDisturb);
+        : await this.setIosDoNotDisturb(input.doNotDisturb)
+      : undefined;
+    const biometrics = input.biometrics
+      ? await this.setBiometricEnrollmentState(input.biometrics.enrollment)
+      : undefined;
+    const requestedStates = [doNotDisturb, biometrics].filter(
+      (state): state is DoNotDisturbState | BiometricEnrollmentState => state !== undefined,
+    );
+    const error = requestedStates.find((state) => state.error)?.error;
 
     return {
-      success: doNotDisturb.supported && !doNotDisturb.error && doNotDisturb.verified !== false,
+      success: requestedStates.every(
+        (state) => state.supported && !state.error && state.verified !== false,
+      ),
       deviceId: this.device.deviceId,
       platform: this.device.platform,
-      doNotDisturb,
-      ...(doNotDisturb.error ? { error: doNotDisturb.error } : {}),
+      ...(doNotDisturb ? { doNotDisturb } : {}),
+      ...(biometrics ? { biometrics } : {}),
+      ...(error ? { error } : {}),
     };
+  }
+
+  async getBiometricEnrollmentState(): Promise<BiometricEnrollmentState> {
+    if (this.device.platform !== "ios" || !isIosSimulatorDevice(this.device)) {
+      return { supported: false, error: IOS_BIOMETRICS_UNSUPPORTED_ERROR };
+    }
+    const simctl = this.simctl ?? new SimCtlClient(this.device);
+    try {
+      const result = await simctl.executeCommand(
+        iosNotifyutilGetCommand(this.device.deviceId, IOS_BIOMETRIC_ENROLLMENT_NOTIFICATION),
+      );
+      const stderr = result.stderr?.trim();
+      if (stderr) {
+        return {
+          supported: true,
+          method: "ios_simulator_notifyutil",
+          error: `notifyutil failed: ${stderr}`,
+        };
+      }
+      const enrolled = parseNotifyutilState(result.stdout ?? "");
+      if (enrolled === null) {
+        return {
+          supported: true,
+          method: "ios_simulator_notifyutil",
+          error: "Could not parse iOS Simulator biometric enrollment state from notifyutil.",
+        };
+      }
+      return {
+        supported: true,
+        enrollment: enrolled ? "enrolled" : "not_enrolled",
+        method: "ios_simulator_notifyutil",
+        verified: true,
+      };
+    } catch (error) {
+      return {
+        supported: true,
+        method: "ios_simulator_notifyutil",
+        error: errorMessage(error),
+      };
+    }
+  }
+
+  async setBiometricEnrollmentState(
+    enrollment: BiometricEnrollment,
+  ): Promise<BiometricEnrollmentState> {
+    if (this.device.platform !== "ios" || !isIosSimulatorDevice(this.device)) {
+      return {
+        supported: false,
+        enrollment,
+        verified: false,
+        error: IOS_BIOMETRICS_UNSUPPORTED_ERROR,
+      };
+    }
+    const simctl = this.simctl ?? new SimCtlClient(this.device);
+    try {
+      const result = await simctl.executeCommand(
+        iosNotifyutilRegisteredSetReadPostCommand(
+          this.device.deviceId,
+          IOS_BIOMETRIC_ENROLLMENT_NOTIFICATION,
+          enrollment === "enrolled" ? "1" : "0",
+        ),
+        IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
+      );
+      const stderr = result.stderr?.trim();
+      if (stderr) {
+        return {
+          supported: true,
+          enrollment,
+          method: "ios_simulator_notifyutil",
+          verified: false,
+          error: `notifyutil failed: ${stderr}`,
+        };
+      }
+      const enrolled = parseNotifyutilState(result.stdout ?? "");
+      const verified = enrolled === (enrollment === "enrolled");
+      return {
+        supported: true,
+        ...(enrolled === null ? {} : { enrollment: enrolled ? "enrolled" : "not_enrolled" }),
+        method: "ios_simulator_notifyutil",
+        verified,
+        ...(verified
+          ? {}
+          : {
+              error: `iOS Simulator biometric enrollment did not verify: expected ${enrollment}.`,
+            }),
+      };
+    } catch (error) {
+      return {
+        supported: true,
+        enrollment,
+        method: "ios_simulator_notifyutil",
+        verified: false,
+        error: errorMessage(error),
+      };
+    }
   }
 
   private async getAndroidDoNotDisturb(): Promise<DoNotDisturbState> {

--- a/src/features/utility/iosSimulatorCapabilities.ts
+++ b/src/features/utility/iosSimulatorCapabilities.ts
@@ -29,16 +29,108 @@ export interface IosSimulatorCapabilitiesContext {
   runtime: string;
 }
 
+/**
+ * Whether the requested device-type/runtime pair can host BiometricKit at all.
+ * `automobile:devices/images` lists every CoreSimulator device type and runtime,
+ * including watchOS/tvOS entries, so the selection must be validated before any
+ * biometric capability is advertised.
+ */
+export interface IosSimulatorSelectionValidity {
+  valid: boolean;
+  reason?: string;
+}
+
 export interface IosSimulatorCapabilitiesReport {
   schemaVersion: typeof IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION;
   platform: "ios";
   deviceType: string;
   runtime: string;
+  selection: IosSimulatorSelectionValidity;
   capabilities: IosSimulatorCapability[];
 }
 
 const BIOMETRIC_ENROLLMENT_PREREQUISITE =
   "Set biometrics.enrollment to enrolled with setDeviceState before simulating a match or fail.";
+
+const DEVICE_TYPE_PREFIX = "com.apple.CoreSimulator.SimDeviceType.";
+const RUNTIME_PREFIX = "com.apple.CoreSimulator.SimRuntime.";
+
+/** CoreSimulator device families that expose BiometricKit (Touch ID / Face ID). */
+const BIOMETRIC_DEVICE_FAMILY_PATTERN = /^(iPhone|iPad)[-.]/i;
+const IOS_RUNTIME_PATTERN = /^iOS[-.]/i;
+
+function stripPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+/**
+ * Validate the selected pair. A trailing separator is appended before matching
+ * so a bare family name ("iPhone") and a versioned identifier ("iPhone-16") are
+ * treated alike, while "iPhoneish" is not.
+ */
+function validateSelection(
+  context: IosSimulatorCapabilitiesContext,
+): IosSimulatorSelectionValidity {
+  const deviceType = stripPrefix(context.deviceType.trim(), DEVICE_TYPE_PREFIX);
+  const runtime = stripPrefix(context.runtime.trim(), RUNTIME_PREFIX);
+  if (!BIOMETRIC_DEVICE_FAMILY_PATTERN.test(`${deviceType}-`)) {
+    return {
+      valid: false,
+      reason: `Device type "${context.deviceType}" has no BiometricKit support.`,
+    };
+  }
+  if (!IOS_RUNTIME_PATTERN.test(`${runtime}-`)) {
+    return {
+      valid: false,
+      reason: `Runtime "${context.runtime}" is not an iOS Simulator runtime.`,
+    };
+  }
+  return { valid: true };
+}
+
+function unsupportedCapabilities(reason: string): IosSimulatorCapability[] {
+  return (
+    [
+      "biometrics.enrollment",
+      "biometrics.match",
+      "biometrics.fail",
+      "biometrics.cancel",
+      "biometrics.error",
+    ] as const
+  ).map((id) => ({ id, state: "unsupported" as const, reason }));
+}
+
+function supportedCapabilities(): IosSimulatorCapability[] {
+  return [
+    {
+      id: "biometrics.enrollment",
+      state: "supported",
+      reason: "BiometricKit enrollment can be read and set through Simulator notifyutil.",
+    },
+    {
+      id: "biometrics.match",
+      state: "partial",
+      reason: "Simulator can inject a biometric match after enrollment is configured.",
+      prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
+    },
+    {
+      id: "biometrics.fail",
+      state: "partial",
+      reason: "Simulator can inject a biometric non-match after enrollment is configured.",
+      prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
+    },
+    {
+      id: "biometrics.cancel",
+      state: "unsupported",
+      reason: "iOS Simulator exposes no public biometric cancellation injection.",
+    },
+    {
+      id: "biometrics.error",
+      state: "unsupported",
+      reason: "iOS Simulator exposes no public biometric error injection.",
+    },
+  ];
+}
 
 /**
  * Report capabilities independent of a running simulator. This is intentionally
@@ -47,40 +139,16 @@ const BIOMETRIC_ENROLLMENT_PREREQUISITE =
 export function computeIosSimulatorCapabilities(
   context: IosSimulatorCapabilitiesContext,
 ): IosSimulatorCapabilitiesReport {
+  const selection = validateSelection(context);
   return {
     schemaVersion: IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION,
     platform: "ios",
     deviceType: context.deviceType,
     runtime: context.runtime,
-    capabilities: [
-      {
-        id: "biometrics.enrollment",
-        state: "supported",
-        reason: "BiometricKit enrollment can be read and set through Simulator notifyutil.",
-      },
-      {
-        id: "biometrics.match",
-        state: "partial",
-        reason: "Simulator can inject a biometric match after enrollment is configured.",
-        prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
-      },
-      {
-        id: "biometrics.fail",
-        state: "partial",
-        reason: "Simulator can inject a biometric non-match after enrollment is configured.",
-        prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
-      },
-      {
-        id: "biometrics.cancel",
-        state: "unsupported",
-        reason: "iOS Simulator exposes no public biometric cancellation injection.",
-      },
-      {
-        id: "biometrics.error",
-        state: "unsupported",
-        reason: "iOS Simulator exposes no public biometric error injection.",
-      },
-    ],
+    selection,
+    capabilities: selection.valid
+      ? supportedCapabilities()
+      : unsupportedCapabilities(selection.reason ?? "Unsupported iOS Simulator selection."),
   };
 }
 

--- a/src/features/utility/iosSimulatorCapabilities.ts
+++ b/src/features/utility/iosSimulatorCapabilities.ts
@@ -1,0 +1,92 @@
+/**
+ * Stable, pre-session capability contract for iOS Simulator features AutoMobile
+ * can control. Device type and runtime identify the caller's selected simulator;
+ * BiometricKit's notifyutil contract is shared by supported iOS Simulator types.
+ */
+
+export const IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION = 1 as const;
+
+export type IosSimulatorCapabilityId =
+  | "biometrics.enrollment"
+  | "biometrics.match"
+  | "biometrics.fail"
+  | "biometrics.cancel"
+  | "biometrics.error";
+
+export type IosSimulatorCapabilityState = "supported" | "partial" | "unsupported";
+
+export interface IosSimulatorCapability {
+  id: IosSimulatorCapabilityId;
+  state: IosSimulatorCapabilityState;
+  reason: string;
+  prerequisites?: string[];
+}
+
+export interface IosSimulatorCapabilitiesContext {
+  /** CoreSimulator device-type identifier selected from automobile:devices/images. */
+  deviceType: string;
+  /** CoreSimulator runtime identifier selected from automobile:devices/images. */
+  runtime: string;
+}
+
+export interface IosSimulatorCapabilitiesReport {
+  schemaVersion: typeof IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION;
+  platform: "ios";
+  deviceType: string;
+  runtime: string;
+  capabilities: IosSimulatorCapability[];
+}
+
+const BIOMETRIC_ENROLLMENT_PREREQUISITE =
+  "Set biometrics.enrollment to enrolled with setDeviceState before simulating a match or fail.";
+
+/**
+ * Report capabilities independent of a running simulator. This is intentionally
+ * pure so callers can negotiate the contract before creating a session.
+ */
+export function computeIosSimulatorCapabilities(
+  context: IosSimulatorCapabilitiesContext,
+): IosSimulatorCapabilitiesReport {
+  return {
+    schemaVersion: IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION,
+    platform: "ios",
+    deviceType: context.deviceType,
+    runtime: context.runtime,
+    capabilities: [
+      {
+        id: "biometrics.enrollment",
+        state: "supported",
+        reason: "BiometricKit enrollment can be read and set through Simulator notifyutil.",
+      },
+      {
+        id: "biometrics.match",
+        state: "partial",
+        reason: "Simulator can inject a biometric match after enrollment is configured.",
+        prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
+      },
+      {
+        id: "biometrics.fail",
+        state: "partial",
+        reason: "Simulator can inject a biometric non-match after enrollment is configured.",
+        prerequisites: [BIOMETRIC_ENROLLMENT_PREREQUISITE],
+      },
+      {
+        id: "biometrics.cancel",
+        state: "unsupported",
+        reason: "iOS Simulator exposes no public biometric cancellation injection.",
+      },
+      {
+        id: "biometrics.error",
+        state: "unsupported",
+        reason: "iOS Simulator exposes no public biometric error injection.",
+      },
+    ],
+  };
+}
+
+export function findIosSimulatorCapability(
+  report: IosSimulatorCapabilitiesReport,
+  id: IosSimulatorCapabilityId,
+): IosSimulatorCapability | undefined {
+  return report.capabilities.find((capability) => capability.id === id);
+}

--- a/src/models/BiometricAuthResult.ts
+++ b/src/models/BiometricAuthResult.ts
@@ -4,7 +4,7 @@ import { BaseActionResult } from "./BaseActionResult";
  * Result of a biometric authentication action
  */
 export interface BiometricAuthResult extends BaseActionResult {
-  action: "match" | "fail" | "cancel" | "error";
+  action: "match" | "fail" | "cancel" | "error" | "enroll" | "unenroll";
   modality: "any" | "fingerprint" | "face";
   fingerprintId?: number;
   errorCode?: number;

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -4,10 +4,15 @@ import { BiometricAuth, BiometricAuthOptions } from "../features/action/Biometri
 import { ActionableError, BootedDevice } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { computeIosSimulatorCapabilities } from "../features/utility/iosSimulatorCapabilities";
+import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
+import { DaemonState } from "../daemon/daemonState";
+import type { SessionManager } from "../daemon/sessionManager";
 
 // Type definitions for better TypeScript support
 export interface BiometricAuthArgs extends BiometricAuthOptions {
-  // Device targeting fields are added by addDeviceTargetingToSchema
+  // Device targeting fields are added by addDeviceTargetingToSchema.
+  sessionUuid?: string;
 }
 
 // Schema definition
@@ -15,8 +20,10 @@ export const biometricAuthSchema = addDeviceTargetingToSchema(
   z
     .object({
       action: z
-        .enum(["match", "fail", "cancel", "error"])
-        .describe("match/fail/cancel/error; cancel/error require Android SDK hook"),
+        .enum(["match", "fail", "cancel", "error", "enroll", "unenroll"])
+        .describe(
+          "match/fail/enroll/unenroll on iOS Simulator; cancel/error require Android SDK hook",
+        ),
       modality: z
         .enum(["any", "fingerprint", "face"])
         .optional()
@@ -34,6 +41,43 @@ export const biometricAuthSchema = addDeviceTargetingToSchema(
     }),
 );
 
+export const getIosSimulatorCapabilitiesSchema = z.object({
+  deviceType: z
+    .string()
+    .min(1)
+    .describe("CoreSimulator device-type identifier selected from automobile:devices/images."),
+  runtime: z
+    .string()
+    .min(1)
+    .describe("CoreSimulator runtime identifier selected from automobile:devices/images."),
+});
+
+interface BiometricEnrollmentCapture {
+  sessionManager?: SessionManager;
+  initialEnrollment?: BiometricEnrollment;
+}
+
+async function captureBiometricEnrollment(
+  device: BootedDevice,
+  args: BiometricAuthArgs,
+): Promise<BiometricEnrollmentCapture> {
+  const changesEnrollment = args.action === "enroll" || args.action === "unenroll";
+  if (!changesEnrollment || !args.sessionUuid || !DaemonState.getInstance().isInitialized()) {
+    return {};
+  }
+  const sessionManager = DaemonState.getInstance().getSessionManager();
+  if (sessionManager.getBiometricEnrollment(args.sessionUuid)) {
+    return { sessionManager };
+  }
+  const state = await new DeviceState(device).getBiometricEnrollmentState();
+  if (!state.supported || !state.enrollment || state.error) {
+    throw new ActionableError(
+      state.error ?? "Failed to read iOS Simulator biometric enrollment state",
+    );
+  }
+  return { sessionManager, initialEnrollment: state.enrollment };
+}
+
 /**
  * Register biometric authentication tools
  */
@@ -45,6 +89,7 @@ export function registerBiometricTools() {
     progress?: ProgressCallback,
   ) => {
     try {
+      const capture = await captureBiometricEnrollment(device, args);
       const biometricAuth = new BiometricAuth(device);
       const result = await biometricAuth.execute(
         {
@@ -57,6 +102,11 @@ export function registerBiometricTools() {
         progress,
       );
 
+      if (result.success && capture.sessionManager && capture.initialEnrollment) {
+        capture.sessionManager.setBiometricEnrollment(args.sessionUuid!, {
+          initialEnrollment: capture.initialEnrollment,
+        });
+      }
       if (!result.success) {
         throw new ActionableError(result.error || `Failed to execute biometric ${args.action}`);
       }
@@ -70,6 +120,24 @@ export function registerBiometricTools() {
       throw new ActionableError(`Failed to execute biometric authentication: ${error}`);
     }
   };
+
+  const getIosSimulatorCapabilitiesHandler = async (
+    args: z.infer<typeof getIosSimulatorCapabilitiesSchema>,
+  ) =>
+    createJSONToolResponse(
+      computeIosSimulatorCapabilities({
+        deviceType: args.deviceType,
+        runtime: args.runtime,
+      }),
+    );
+
+  ToolRegistry.register(
+    "getIosSimulatorCapabilities",
+    "Discover biometric capabilities for a selected iOS Simulator device type and runtime.",
+    getIosSimulatorCapabilitiesSchema,
+    getIosSimulatorCapabilitiesHandler,
+    { defaultEnabled: false },
+  );
 
   // Register the tool
   ToolRegistry.registerDeviceAware(

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -95,6 +95,7 @@ export function registerBiometricTools() {
       const result = await runSessionBiometricMutation(
         capture.sessionManager,
         args.sessionUuid,
+        device.deviceId,
         capture.initialEnrollment,
         () =>
           biometricAuth.execute(

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -8,6 +8,7 @@ import { computeIosSimulatorCapabilities } from "../features/utility/iosSimulato
 import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
 import { DaemonState } from "../daemon/daemonState";
 import type { SessionManager } from "../daemon/sessionManager";
+import { runSessionBiometricMutation } from "./sessionBiometricEnrollment";
 
 // Type definitions for better TypeScript support
 export interface BiometricAuthArgs extends BiometricAuthOptions {
@@ -91,22 +92,23 @@ export function registerBiometricTools() {
     try {
       const capture = await captureBiometricEnrollment(device, args);
       const biometricAuth = new BiometricAuth(device);
-      const result = await biometricAuth.execute(
-        {
-          action: args.action,
-          modality: args.modality,
-          fingerprintId: args.fingerprintId,
-          errorCode: args.errorCode,
-          ttlMs: args.ttlMs,
-        },
-        progress,
+      const result = await runSessionBiometricMutation(
+        capture.sessionManager,
+        args.sessionUuid,
+        capture.initialEnrollment,
+        () =>
+          biometricAuth.execute(
+            {
+              action: args.action,
+              modality: args.modality,
+              fingerprintId: args.fingerprintId,
+              errorCode: args.errorCode,
+              ttlMs: args.ttlMs,
+            },
+            progress,
+          ),
       );
 
-      if (result.success && capture.sessionManager && capture.initialEnrollment) {
-        capture.sessionManager.setBiometricEnrollment(args.sessionUuid!, {
-          initialEnrollment: capture.initialEnrollment,
-        });
-      }
       if (!result.success) {
         throw new ActionableError(result.error || `Failed to execute biometric ${args.action}`);
       }

--- a/src/server/sessionBiometricEnrollment.ts
+++ b/src/server/sessionBiometricEnrollment.ts
@@ -1,5 +1,41 @@
-import type { BiometricEnrollment } from "../features/utility/DeviceState";
+import type {
+  BiometricEnrollment,
+  DeviceStateResult,
+  SetDeviceStateInput,
+} from "../features/utility/DeviceState";
 import type { SessionManager } from "../daemon/sessionManager";
+
+/** Narrow seam over DeviceState so the merge below is testable without a device. */
+export interface DeviceStateSetter {
+  setState(input: SetDeviceStateInput): Promise<DeviceStateResult>;
+}
+
+/**
+ * A failed biometric pre-read must not swallow the other fields of a combined
+ * request. Session-scoped `setDeviceState` reads enrollment before mutating so
+ * release can restore it; when that read fails there is still nothing stopping
+ * the independent Do Not Disturb update, which the sessionless path applies.
+ * Apply it here too and report the biometric failure alongside it.
+ */
+export async function applyStateAfterBiometricCaptureFailure(
+  deviceState: DeviceStateSetter,
+  input: SetDeviceStateInput,
+  failure: DeviceStateResult,
+): Promise<DeviceStateResult> {
+  if (!input.doNotDisturb) {
+    return failure;
+  }
+  const applied = await deviceState.setState({ doNotDisturb: input.doNotDisturb });
+  const errors = [failure.error, applied.error].filter(
+    (error): error is string => error !== undefined,
+  );
+  return {
+    ...applied,
+    success: false,
+    ...(failure.biometrics ? { biometrics: failure.biometrics } : {}),
+    ...(errors.length > 0 ? { error: errors.join("; ") } : {}),
+  };
+}
 
 /**
  * Publish a newly captured enrollment state before mutating the simulator, then

--- a/src/server/sessionBiometricEnrollment.ts
+++ b/src/server/sessionBiometricEnrollment.ts
@@ -10,20 +10,26 @@ import type { SessionManager } from "../daemon/sessionManager";
 export async function runSessionBiometricMutation<T>(
   sessionManager: SessionManager | undefined,
   sessionUuid: string | undefined,
+  deviceId: string,
   initialEnrollment: BiometricEnrollment | undefined,
   mutation: () => Promise<T>,
 ): Promise<T> {
   if (!sessionManager || !sessionUuid) {
     return await mutation();
   }
-  if (initialEnrollment) {
-    sessionManager.setBiometricEnrollment(sessionUuid, { initialEnrollment });
-  }
   const session = sessionManager.getSession(sessionUuid);
   if (!session) {
     throw new Error(
       `Cannot mutate biometric enrollment: session ${sessionUuid} is no longer active.`,
     );
+  }
+  if (session.assignedDevice !== deviceId) {
+    throw new Error(
+      `Cannot mutate biometric enrollment: session ${sessionUuid} is bound to ${session.assignedDevice}, not ${deviceId}.`,
+    );
+  }
+  if (initialEnrollment) {
+    sessionManager.setBiometricEnrollment(sessionUuid, { initialEnrollment });
   }
 
   let completed = false;

--- a/src/server/sessionBiometricEnrollment.ts
+++ b/src/server/sessionBiometricEnrollment.ts
@@ -1,0 +1,41 @@
+import type { BiometricEnrollment } from "../features/utility/DeviceState";
+import type { SessionManager } from "../daemon/sessionManager";
+
+/**
+ * Publish a newly captured enrollment state before mutating the simulator, then
+ * bind the mutation to the session lifecycle. Release waits for this work before
+ * restoring the original state, so a late simctl write cannot leak into a reused
+ * simulator.
+ */
+export async function runSessionBiometricMutation<T>(
+  sessionManager: SessionManager | undefined,
+  sessionUuid: string | undefined,
+  initialEnrollment: BiometricEnrollment | undefined,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  if (!sessionManager || !sessionUuid) {
+    return await mutation();
+  }
+  if (initialEnrollment) {
+    sessionManager.setBiometricEnrollment(sessionUuid, { initialEnrollment });
+  }
+  const session = sessionManager.getSession(sessionUuid);
+  if (!session) {
+    throw new Error(
+      `Cannot mutate biometric enrollment: session ${sessionUuid} is no longer active.`,
+    );
+  }
+
+  let completed = false;
+  let result!: T;
+  await sessionManager.trackSessionSetup(session, async () => {
+    result = await mutation();
+    completed = true;
+  });
+  if (!completed) {
+    throw new Error(
+      `Cannot mutate biometric enrollment: session ${sessionUuid} began releasing before the mutation started.`,
+    );
+  }
+  return result;
+}

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -390,6 +390,7 @@ export function registerUtilityTools() {
     const result = await runSessionBiometricMutation(
       capture.sessionManager,
       args.sessionUuid,
+      device.deviceId,
       capture.initialEnrollment,
       () =>
         deviceState.setState({

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -21,7 +21,10 @@ import {
 } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 import type { SessionManager } from "../daemon/sessionManager";
-import { runSessionBiometricMutation } from "./sessionBiometricEnrollment";
+import {
+  applyStateAfterBiometricCaptureFailure,
+  runSessionBiometricMutation,
+} from "./sessionBiometricEnrollment";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(
@@ -121,6 +124,7 @@ export const getDeviceStateSchema = addDeviceTargetingToSchema(
   z.object({
     include: z
       .array(z.enum(["doNotDisturb", "biometrics"]))
+      .min(1)
       .optional()
       .describe("State fields to read; supports doNotDisturb and biometrics"),
   }),
@@ -382,9 +386,14 @@ export function registerUtilityTools() {
     const deviceState = new DeviceState(device);
     const capture = await captureBiometricEnrollment(device, args, deviceState);
     if (capture.failure) {
+      const result = await applyStateAfterBiometricCaptureFailure(
+        deviceState,
+        { doNotDisturb: args.doNotDisturb, biometrics: args.biometrics },
+        capture.failure,
+      );
       return createJSONToolResponse({
-        message: capture.failure.error ?? "Failed to read biometric enrollment state",
-        ...capture.failure,
+        message: result.error ?? "Failed to read biometric enrollment state",
+        ...result,
       });
     }
     const result = await runSessionBiometricMutation(

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -21,6 +21,7 @@ import {
 } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 import type { SessionManager } from "../daemon/sessionManager";
+import { runSessionBiometricMutation } from "./sessionBiometricEnrollment";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(
@@ -386,15 +387,16 @@ export function registerUtilityTools() {
         ...capture.failure,
       });
     }
-    const result = await deviceState.setState({
-      doNotDisturb: args.doNotDisturb,
-      biometrics: args.biometrics,
-    });
-    if (result.success && capture.sessionManager && capture.initialEnrollment) {
-      capture.sessionManager.setBiometricEnrollment(args.sessionUuid!, {
-        initialEnrollment: capture.initialEnrollment,
-      });
-    }
+    const result = await runSessionBiometricMutation(
+      capture.sessionManager,
+      args.sessionUuid,
+      capture.initialEnrollment,
+      () =>
+        deviceState.setState({
+          doNotDisturb: args.doNotDisturb,
+          biometrics: args.biometrics,
+        }),
+    );
 
     return createJSONToolResponse({
       message: result.success

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -2,7 +2,11 @@ import { z } from "zod/v4";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError } from "../models/ActionableError";
 import { SystemConfigurationManager } from "../features/utility/SystemConfigurationManager";
-import { DeviceState } from "../features/utility/DeviceState";
+import {
+  DeviceState,
+  type BiometricEnrollment,
+  type DeviceStateResult,
+} from "../features/utility/DeviceState";
 import { logger } from "../utils/logger";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
@@ -16,6 +20,7 @@ import {
   withJsonSchemaOverride,
 } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
+import type { SessionManager } from "../daemon/sessionManager";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(
@@ -105,12 +110,18 @@ const doNotDisturbStateInputSchema = z
     message: "Provide enabled or mode for doNotDisturb",
   });
 
+const biometricStateInputSchema = z.object({
+  enrollment: z
+    .enum(["enrolled", "not_enrolled"])
+    .describe("Set iOS Simulator biometric enrollment state."),
+});
+
 export const getDeviceStateSchema = addDeviceTargetingToSchema(
   z.object({
     include: z
-      .array(z.enum(["doNotDisturb"]))
+      .array(z.enum(["doNotDisturb", "biometrics"]))
       .optional()
-      .describe("State fields to read; supports doNotDisturb"),
+      .describe("State fields to read; supports doNotDisturb and biometrics"),
   }),
 );
 
@@ -119,8 +130,11 @@ export const setDeviceStateSchema = addDeviceTargetingToSchema(
     doNotDisturb: doNotDisturbStateInputSchema
       .optional()
       .describe("Do Not Disturb state to apply."),
+    biometrics: biometricStateInputSchema
+      .optional()
+      .describe("iOS Simulator biometric enrollment state to apply."),
   }),
-).refine((values) => values.doNotDisturb !== undefined, {
+).refine((values) => values.doNotDisturb !== undefined || values.biometrics !== undefined, {
   message: "At least one device state field must be provided",
 });
 
@@ -144,6 +158,40 @@ export interface ChangeLocalizationArgs {
 export type GetDeviceStateArgs = z.infer<typeof getDeviceStateSchema>;
 
 export type SetDeviceStateArgs = z.infer<typeof setDeviceStateSchema>;
+
+interface BiometricEnrollmentCapture {
+  sessionManager?: SessionManager;
+  initialEnrollment?: BiometricEnrollment;
+  failure?: DeviceStateResult;
+}
+
+async function captureBiometricEnrollment(
+  device: BootedDevice,
+  args: SetDeviceStateArgs,
+  deviceState: DeviceState,
+): Promise<BiometricEnrollmentCapture> {
+  if (!args.biometrics || !args.sessionUuid || !DaemonState.getInstance().isInitialized()) {
+    return {};
+  }
+  const sessionManager = DaemonState.getInstance().getSessionManager();
+  if (sessionManager.getBiometricEnrollment(args.sessionUuid)) {
+    return { sessionManager };
+  }
+  const state = await deviceState.getBiometricEnrollmentState();
+  if (!state.supported || !state.enrollment || state.error) {
+    return {
+      sessionManager,
+      failure: {
+        success: false,
+        deviceId: device.deviceId,
+        platform: device.platform,
+        biometrics: state,
+        ...(state.error ? { error: state.error } : {}),
+      },
+    };
+  }
+  return { sessionManager, initialEnrollment: state.enrollment };
+}
 
 // Register tools
 export function registerUtilityTools() {
@@ -317,9 +365,9 @@ export function registerUtilityTools() {
     });
   };
 
-  const getDeviceStateHandler = async (device: BootedDevice, _args: GetDeviceStateArgs) => {
+  const getDeviceStateHandler = async (device: BootedDevice, args: GetDeviceStateArgs) => {
     const deviceState = new DeviceState(device);
-    const result = await deviceState.getState();
+    const result = await deviceState.getState(args.include);
 
     return createJSONToolResponse({
       message: result.success
@@ -331,9 +379,22 @@ export function registerUtilityTools() {
 
   const setDeviceStateHandler = async (device: BootedDevice, args: SetDeviceStateArgs) => {
     const deviceState = new DeviceState(device);
+    const capture = await captureBiometricEnrollment(device, args, deviceState);
+    if (capture.failure) {
+      return createJSONToolResponse({
+        message: capture.failure.error ?? "Failed to read biometric enrollment state",
+        ...capture.failure,
+      });
+    }
     const result = await deviceState.setState({
       doNotDisturb: args.doNotDisturb,
+      biometrics: args.biometrics,
     });
+    if (result.success && capture.sessionManager && capture.initialEnrollment) {
+      capture.sessionManager.setBiometricEnrollment(args.sessionUuid!, {
+        initialEnrollment: capture.initialEnrollment,
+      });
+    }
 
     return createJSONToolResponse({
       message: result.success
@@ -362,7 +423,7 @@ export function registerUtilityTools() {
 
   ToolRegistry.registerDeviceAware(
     "getDeviceState",
-    "Read device-level state such as Do Not Disturb",
+    "Read device-level state such as Do Not Disturb and iOS Simulator biometric enrollment",
     getDeviceStateSchema,
     getDeviceStateHandler,
     { defaultEnabled: false },
@@ -370,7 +431,7 @@ export function registerUtilityTools() {
 
   ToolRegistry.registerDeviceAware(
     "setDeviceState",
-    "Set device state such as Do Not Disturb.",
+    "Set device state such as Do Not Disturb and iOS Simulator biometric enrollment.",
     setDeviceStateSchema,
     setDeviceStateHandler,
     { defaultEnabled: false },

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1513,6 +1513,36 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("biometric enrollment restoration platform independence", () => {
+    test("restores cached enrollment even when the session declares a non-iOS platform", async () => {
+      const restored: Array<{ deviceId: string; enrollment: string }> = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        (device) => ({
+          restore: async (enrollment) => {
+            restored.push({ deviceId: device.deviceId, enrollment });
+          },
+        }),
+      );
+      try {
+        // setActiveDevice stores the caller-declared platform, which can
+        // disagree with the simulator actually bound. The cached enrollment is
+        // iOS-only evidence and must still be restored.
+        await manager.createSession("mislabelled", "sim-1", "android");
+        manager.setBiometricEnrollment("mislabelled", { initialEnrollment: "not_enrolled" });
+
+        await manager.releaseSession("mislabelled");
+
+        expect(restored).toEqual([{ deviceId: "sim-1", enrollment: "not_enrolled" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+  });
+
   describe("biometric enrollment restoration on rebind", () => {
     test("quarantines the old simulator and retries when the rebind restore fails", async () => {
       const timer = new FakeTimer();

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -773,6 +773,29 @@ describe("SessionManager", () => {
       }
     });
 
+    test("does not admit device-state setup while a rebind is pending", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        const session = await manager.createSession("session-1", "emulator-old", "android");
+        repository.deferNextUpsert();
+
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+        let setupStarted = false;
+        await manager.trackSessionSetup(session, async () => {
+          setupStarted = true;
+        });
+
+        expect(setupStarted).toBe(false);
+        repository.finishUpsert();
+        await rebinding;
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("serializes expiry cleanup with a pending rebind", async () => {
       const repository = new DeferredDeviceSessionPersistence();
       const manager = new SessionManager(fakeTimer, repository, () => new FakeDbWriteBarrier());

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1513,6 +1513,47 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("biometric enrollment restoration on rebind", () => {
+    test("quarantines the old simulator and retries when the rebind restore fails", async () => {
+      const timer = new FakeTimer();
+      const attempts: string[] = [];
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        (device) => ({
+          restore: async () => {
+            attempts.push(device.deviceId);
+            if (attempts.length === 1) {
+              throw new Error("simctl rejected the restore");
+            }
+          },
+        }),
+      );
+      try {
+        await manager.createSession("ios-rebind-dirty", "sim-old", "ios");
+        manager.setBiometricEnrollment("ios-rebind-dirty", { initialEnrollment: "not_enrolled" });
+
+        await manager.rebindSession("ios-rebind-dirty", "sim-new", "ios");
+
+        // The rebind must not complete by silently abandoning the old simulator.
+        const cleanup = manager.getPendingDeviceCleanup("sim-old");
+        expect(cleanup).not.toBeNull();
+        expect(manager.getPendingDeviceCleanup("sim-new")).toBeNull();
+
+        await timer.advanceTimeAsync(250);
+        await cleanup;
+
+        // The retry targets the OLD simulator even though the session has
+        // already been reassigned to the new one.
+        expect(attempts).toEqual(["sim-old", "sim-old"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+  });
+
   describe("statistics", () => {
     test("should return correct session statistics", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1438,6 +1438,79 @@ describe("SessionManager", () => {
         manager.stopCleanupTimer();
       }
     });
+
+    test("keeps the device quarantined and retries when the restore fails", async () => {
+      const timer = new FakeTimer();
+      let attempts = 0;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        () => ({
+          restore: async () => {
+            attempts += 1;
+            if (attempts === 1) {
+              throw new Error("simctl rejected the restore");
+            }
+          },
+        }),
+      );
+      try {
+        await manager.createSession("ios-restore-retry", "sim-dirty", "ios");
+        manager.setBiometricEnrollment("ios-restore-retry", { initialEnrollment: "not_enrolled" });
+
+        await manager.releaseSession("ios-restore-retry");
+
+        // The failed first attempt must leave post-release work outstanding, so
+        // DevicePool defers the device instead of idling it dirty.
+        const cleanup = manager.getPendingDeviceCleanup("sim-dirty");
+        expect(cleanup).not.toBeNull();
+        expect(attempts).toBe(1);
+
+        await timer.advanceTimeAsync(250);
+        await cleanup;
+        expect(attempts).toBe(2);
+        expect(manager.getPendingDeviceCleanup("sim-dirty")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("stops retrying the restore after the bounded attempts are exhausted", async () => {
+      const timer = new FakeTimer();
+      let attempts = 0;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        () => ({
+          restore: async () => {
+            attempts += 1;
+            throw new Error("simctl rejected the restore");
+          },
+        }),
+      );
+      try {
+        await manager.createSession("ios-restore-exhausted", "sim-dirty-2", "ios");
+        manager.setBiometricEnrollment("ios-restore-exhausted", {
+          initialEnrollment: "not_enrolled",
+        });
+
+        await manager.releaseSession("ios-restore-exhausted");
+        const cleanup = manager.getPendingDeviceCleanup("sim-dirty-2");
+        await timer.advanceTimeAsync(250);
+        await timer.advanceTimeAsync(250);
+        await cleanup;
+
+        // One initial attempt plus the bounded retries, then the device is freed
+        // rather than quarantined forever.
+        expect(attempts).toBe(3);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
   });
 
   describe("statistics", () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1355,6 +1355,66 @@ describe("SessionManager", () => {
         manager.stopCleanupTimer();
       }
     });
+
+    test("restores the old simulator enrollment before a session rebinds", async () => {
+      const restored: Array<{ deviceId: string; enrollment: string }> = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        (device) => ({
+          restore: async (enrollment) => {
+            restored.push({ deviceId: device.deviceId, enrollment });
+          },
+        }),
+      );
+      try {
+        await manager.createSession("ios-rebind", "sim-a", "ios");
+        manager.setBiometricEnrollment("ios-rebind", { initialEnrollment: "enrolled" });
+
+        await manager.rebindSession("ios-rebind", "sim-b", "ios");
+
+        expect(restored).toEqual([{ deviceId: "sim-a", enrollment: "enrolled" }]);
+        expect(manager.getBiometricEnrollment("ios-rebind")).toBeUndefined();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("waits for an active biometric setup before restoring the old simulator", async () => {
+      const restored: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        () => ({ restore: async (enrollment) => restored.push(enrollment) }),
+      );
+      const started = Promise.withResolvers<void>();
+      const finished = Promise.withResolvers<void>();
+      try {
+        const session = await manager.createSession("ios-rebind-active", "sim-a", "ios");
+        manager.setBiometricEnrollment("ios-rebind-active", { initialEnrollment: "enrolled" });
+        const setup = manager.trackSessionSetup(session, async () => {
+          started.resolve();
+          await finished.promise;
+        });
+        await started.promise;
+
+        const rebind = manager.rebindSession("ios-rebind-active", "sim-b", "ios");
+        await Promise.resolve();
+        expect(restored).toEqual([]);
+
+        finished.resolve();
+        await setup;
+        await rebind;
+
+        expect(restored).toEqual(["enrolled"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
   });
 
   describe("statistics", () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import {
   SessionManager,
+  type BiometricEnrollmentRestorer,
   type KeepScreenAwakeRestorer,
   type SessionDeviceAssigner,
 } from "../../src/daemon/sessionManager";
@@ -1323,6 +1324,36 @@ describe("SessionManager", () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       await sessionManager.releaseSession("session-1");
       expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
+    });
+  });
+
+  describe("biometric enrollment restoration", () => {
+    test("restores the original iOS Simulator enrollment when a session releases", async () => {
+      const restored: string[] = [];
+      const restorer: BiometricEnrollmentRestorer = {
+        restore: async (enrollment) => {
+          restored.push(enrollment);
+        },
+      };
+      const manager = new SessionManager(
+        fakeTimer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        () => restorer,
+      );
+      try {
+        await manager.createSession("ios-biometric", "sim-1", "ios");
+        manager.setBiometricEnrollment("ios-biometric", { initialEnrollment: "not_enrolled" });
+        // The initial state is write-once; a later change must not replace it.
+        manager.setBiometricEnrollment("ios-biometric", { initialEnrollment: "enrolled" });
+
+        await manager.releaseSession("ios-biometric");
+
+        expect(restored).toEqual(["not_enrolled"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
     });
   });
 

--- a/test/features/action/BiometricAuthIos.test.ts
+++ b/test/features/action/BiometricAuthIos.test.ts
@@ -12,7 +12,9 @@ const TOUCH_MATCH = "com.apple.BiometricKit_Sim.fingerTouch.match";
 const TOUCH_NOMATCH = "com.apple.BiometricKit_Sim.fingerTouch.nomatch";
 const PEARL_MATCH = "com.apple.BiometricKit_Sim.pearl.match";
 const PEARL_NOMATCH = "com.apple.BiometricKit_Sim.pearl.nomatch";
+const ENROLL_GET_COMMAND = `spawn ${SIM_UDID} notifyutil -g ${ENROLL}`;
 const ENROLL_COMMAND = `spawn ${SIM_UDID} notifyutil -1 ${ENROLL} -s ${ENROLL} 1 -g ${ENROLL} -p ${ENROLL}`;
+const UNENROLL_COMMAND = `spawn ${SIM_UDID} notifyutil -1 ${ENROLL} -s ${ENROLL} 0 -g ${ENROLL} -p ${ENROLL}`;
 
 describe("BiometricAuth - iOS Simulator", () => {
   let simctl: FakeSimCtlClient;
@@ -26,19 +28,22 @@ describe("BiometricAuth - iOS Simulator", () => {
 
   beforeEach(() => {
     simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(ENROLL_COMMAND, `${ENROLL} 1\n${ENROLL}\n`);
+    simctl.setCommandResult(ENROLL_GET_COMMAND, `${ENROLL} 1\n`);
     timer = new FakeTimer();
     timer.enableAutoAdvance();
   });
 
-  test("match + fingerprint posts enrollment then fingerTouch.match", async () => {
+  test("match + fingerprint preserves enrollment then posts fingerTouch.match", async () => {
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
     const result = await auth.execute({ action: "match", modality: "fingerprint" });
 
     expect(result.success).toBe(true);
     expect(result.supported).toBe(true);
-    expect(commands()).toEqual([ENROLL_COMMAND, `spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`]);
-    expect(simctl.getMethodCalls("executeCommand")[0]?.timeoutMs).toBe(5000);
+    expect(commands()).toEqual([
+      ENROLL_GET_COMMAND,
+      `spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`,
+    ]);
+    expect(simctl.getMethodCalls("executeCommand")[0]?.timeoutMs).toBeUndefined();
   });
 
   test("match + face posts pearl.match", async () => {
@@ -72,6 +77,28 @@ describe("BiometricAuth - iOS Simulator", () => {
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
     await auth.execute({ action: "fail", modality: "face" });
     expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${PEARL_NOMATCH}`);
+  });
+
+  test("enroll explicitly sets and verifies iOS Simulator enrollment", async () => {
+    simctl.setCommandResult(ENROLL_COMMAND, `${ENROLL} 1\n${ENROLL}\n`);
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+
+    const result = await auth.execute({ action: "enroll" });
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("enroll");
+    expect(commands()).toEqual([ENROLL_COMMAND]);
+  });
+
+  test("unenroll explicitly clears and verifies iOS Simulator enrollment", async () => {
+    simctl.setCommandResult(UNENROLL_COMMAND, `${ENROLL} 0\n${ENROLL}\n`);
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+
+    const result = await auth.execute({ action: "unenroll" });
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("unenroll");
+    expect(commands()).toEqual([UNENROLL_COMMAND]);
   });
 
   test("physical iOS device is unsupported (no public injection API)", async () => {
@@ -115,34 +142,34 @@ describe("BiometricAuth - iOS Simulator", () => {
     expect(result.error).toContain("notifyutil failed");
   });
 
-  test("enrollment notifyutil stderr surfaces as failure", async () => {
-    simctl.setCommandResult(ENROLL_COMMAND, "", "notifyutil: enrollment unavailable");
+  test("enrollment read failure surfaces before posting biometric event", async () => {
+    simctl.setCommandResult(ENROLL_GET_COMMAND, "", "notifyutil: enrollment unavailable");
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
     const result = await auth.execute({ action: "match", modality: "fingerprint" });
 
     expect(result.success).toBe(false);
     expect(result.supported).toBe(true);
     expect(result.error).toContain("notifyutil failed");
-    expect(commands()).toEqual([ENROLL_COMMAND]);
+    expect(commands()).toEqual([ENROLL_GET_COMMAND]);
   });
 
-  test("enrollment readback must verify before posting biometric event", async () => {
-    simctl.setCommandResult(ENROLL_COMMAND, `${ENROLL} 0\n${ENROLL}\n`);
+  test("unenrolled state prevents match without silently enrolling", async () => {
+    simctl.setCommandResult(ENROLL_GET_COMMAND, `${ENROLL} 0\n`);
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
     const result = await auth.execute({ action: "match", modality: "fingerprint" });
 
     expect(result.success).toBe(false);
     expect(result.supported).toBe(true);
-    expect(result.error).toContain("enrollment did not verify");
-    expect(commands()).toEqual([ENROLL_COMMAND]);
+    expect(result.error).toContain("not enrolled");
+    expect(commands()).toEqual([ENROLL_GET_COMMAND]);
   });
 
   test("thrown simctl error is caught and reported", async () => {
-    simctl.setCommandError(ENROLL_COMMAND, new Error("simctl unavailable"));
+    simctl.setCommandError(ENROLL_GET_COMMAND, new Error("simctl unavailable"));
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
     const result = await auth.execute({ action: "match", modality: "fingerprint" });
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("Failed to post iOS biometric notification");
+    expect(result.error).toContain("simctl unavailable");
   });
 });

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -35,6 +35,11 @@ const IOS_SIMULATOR_DND_SET_ON_COMMAND =
 const IOS_SIMULATOR_DND_SET_OFF_COMMAND =
   "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled";
 const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
+const IOS_BIOMETRIC_ENROLLMENT = "com.apple.BiometricKit.enrollmentChanged";
+const IOS_BIOMETRIC_GET_COMMAND =
+  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.BiometricKit.enrollmentChanged";
+const IOS_BIOMETRIC_UNENROLL_COMMAND =
+  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.BiometricKit.enrollmentChanged -s com.apple.BiometricKit.enrollmentChanged 0 -g com.apple.BiometricKit.enrollmentChanged -p com.apple.BiometricKit.enrollmentChanged";
 
 function autoAdvanceTimer(): FakeTimer {
   const timer = new FakeTimer();
@@ -75,6 +80,43 @@ describe("DeviceState", () => {
       enabled: true,
       bestEffort: true,
     });
+  });
+
+  test("reads and sets iOS Simulator biometric enrollment", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(IOS_BIOMETRIC_GET_COMMAND, `${IOS_BIOMETRIC_ENROLLMENT} 1\n`);
+    simctl.setCommandResult(
+      IOS_BIOMETRIC_UNENROLL_COMMAND,
+      `${IOS_BIOMETRIC_ENROLLMENT} 0\n${IOS_BIOMETRIC_ENROLLMENT}\n`,
+    );
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+
+    const read = await deviceState.getState(["biometrics"]);
+    const write = await deviceState.setState({
+      biometrics: { enrollment: "not_enrolled" },
+    });
+
+    expect(read).toMatchObject({
+      success: true,
+      biometrics: { enrollment: "enrolled", verified: true },
+    });
+    expect(write).toMatchObject({
+      success: true,
+      biometrics: { enrollment: "not_enrolled", verified: true },
+    });
+    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+      { command: IOS_BIOMETRIC_GET_COMMAND, timeoutMs: undefined },
+      { command: IOS_BIOMETRIC_UNENROLL_COMMAND, timeoutMs: 5000 },
+    ]);
+  });
+
+  test("reports biometric enrollment unsupported outside iOS Simulator", async () => {
+    const deviceState = new DeviceState(androidDevice);
+    const result = await deviceState.setState({ biometrics: { enrollment: "enrolled" } });
+
+    expect(result.success).toBe(false);
+    expect(result.biometrics).toMatchObject({ supported: false, verified: false });
+    expect(result.error).toContain("iOS Simulator");
   });
 
   test("reports iOS 18+ simulator Do Not Disturb read as unsupported (dead legacy key)", async () => {

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -40,6 +40,8 @@ const IOS_BIOMETRIC_GET_COMMAND =
   "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.BiometricKit.enrollmentChanged";
 const IOS_BIOMETRIC_UNENROLL_COMMAND =
   "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.BiometricKit.enrollmentChanged -s com.apple.BiometricKit.enrollmentChanged 0 -g com.apple.BiometricKit.enrollmentChanged -p com.apple.BiometricKit.enrollmentChanged";
+const IOS18_BIOMETRIC_ENROLL_COMMAND =
+  "spawn 7B3A3792-DB53-4654-BA94-27A1D305C3B7 notifyutil -1 com.apple.BiometricKit.enrollmentChanged -s com.apple.BiometricKit.enrollmentChanged 1 -g com.apple.BiometricKit.enrollmentChanged -p com.apple.BiometricKit.enrollmentChanged";
 
 function autoAdvanceTimer(): FakeTimer {
   const timer = new FakeTimer();
@@ -117,6 +119,27 @@ describe("DeviceState", () => {
     expect(result.success).toBe(false);
     expect(result.biometrics).toMatchObject({ supported: false, verified: false });
     expect(result.error).toContain("iOS Simulator");
+  });
+
+  test("retains a verified biometric result when a sibling state request fails", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      IOS18_BIOMETRIC_ENROLL_COMMAND,
+      `${IOS_BIOMETRIC_ENROLLMENT} 1\n${IOS_BIOMETRIC_ENROLLMENT}\n`,
+    );
+    const deviceState = new DeviceState(ios18Simulator, { simctl });
+
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+      biometrics: { enrollment: "enrolled" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb?.supported).toBe(false);
+    expect(result.biometrics).toMatchObject({
+      enrollment: "enrolled",
+      verified: true,
+    });
   });
 
   test("reports iOS 18+ simulator Do Not Disturb read as unsupported (dead legacy key)", async () => {

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { BootedDevice } from "../../../src/models";
-import { DeviceState } from "../../../src/features/utility/DeviceState";
+import {
+  DeviceState,
+  EMPTY_STATE_SELECTION_ERROR,
+} from "../../../src/features/utility/DeviceState";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -632,5 +635,24 @@ describe("DeviceState", () => {
     expect(result.error).toContain("Focus Filter API");
     // Early return: no simctl/notifyutil command was ever issued.
     expect(simctl.getMethodCalls("executeCommand")).toEqual([]);
+  });
+
+  test("rejects an empty state selection instead of reporting a no-op success", async () => {
+    const simulator: BootedDevice = {
+      name: "iPhone 16 Pro",
+      platform: "ios",
+      deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
+      iosVersion: "18.6",
+    };
+    const simctl = new FakeSimCtlClient();
+    const deviceState = new DeviceState(simulator, { simctl });
+
+    const result = await deviceState.getState([]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(EMPTY_STATE_SELECTION_ERROR);
+    expect(result.doNotDisturb).toBeUndefined();
+    expect(result.biometrics).toBeUndefined();
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
   });
 });

--- a/test/features/utility/iosSimulatorCapabilities.test.ts
+++ b/test/features/utility/iosSimulatorCapabilities.test.ts
@@ -39,4 +39,65 @@ describe("iOS Simulator capabilities", () => {
       computeIosSimulatorCapabilities(context),
     );
   });
+
+  test("reports biometrics as unsupported for a non-iOS runtime", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-10-46mm",
+      runtime: "com.apple.CoreSimulator.SimRuntime.watchOS-11-0",
+    });
+
+    expect(report.selection).toEqual({
+      valid: false,
+      reason:
+        'Device type "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-10-46mm" has no BiometricKit support.',
+    });
+    for (const capability of report.capabilities) {
+      expect(capability.state).toBe("unsupported");
+    }
+  });
+
+  test("reports biometrics as unsupported when the device family and runtime disagree", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+      runtime: "com.apple.CoreSimulator.SimRuntime.tvOS-18-0",
+    });
+
+    expect(report.selection.valid).toBe(false);
+    expect(findIosSimulatorCapability(report, "biometrics.enrollment")).toMatchObject({
+      state: "unsupported",
+    });
+    expect(findIosSimulatorCapability(report, "biometrics.match")).toMatchObject({
+      state: "unsupported",
+    });
+  });
+
+  test("reports biometrics as unsupported for an unrecognized selection", () => {
+    const report = computeIosSimulatorCapabilities({ deviceType: "nonsense", runtime: "nonsense" });
+
+    expect(report.selection.valid).toBe(false);
+    expect(findIosSimulatorCapability(report, "biometrics.enrollment")).toMatchObject({
+      state: "unsupported",
+    });
+  });
+
+  test("accepts an iPad on an iOS runtime", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M4-8GB",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+    });
+
+    expect(report.selection.valid).toBe(true);
+    expect(findIosSimulatorCapability(report, "biometrics.enrollment")).toMatchObject({
+      state: "supported",
+    });
+  });
+
+  test("accepts bare device-type and runtime names without the CoreSimulator prefix", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "iPhone-16",
+      runtime: "iOS-18-6",
+    });
+
+    expect(report.selection.valid).toBe(true);
+  });
 });

--- a/test/features/utility/iosSimulatorCapabilities.test.ts
+++ b/test/features/utility/iosSimulatorCapabilities.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeIosSimulatorCapabilities,
+  findIosSimulatorCapability,
+  IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION,
+} from "../../../src/features/utility/iosSimulatorCapabilities";
+
+describe("iOS Simulator capabilities", () => {
+  test("reports a versioned pre-session biometric contract for the selected simulator", () => {
+    const report = computeIosSimulatorCapabilities({
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+    });
+
+    expect(report).toMatchObject({
+      schemaVersion: IOS_SIMULATOR_CAPABILITIES_SCHEMA_VERSION,
+      platform: "ios",
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+    });
+    expect(findIosSimulatorCapability(report, "biometrics.enrollment")).toMatchObject({
+      state: "supported",
+    });
+    expect(findIosSimulatorCapability(report, "biometrics.match")).toMatchObject({
+      state: "partial",
+    });
+    expect(findIosSimulatorCapability(report, "biometrics.cancel")).toMatchObject({
+      state: "unsupported",
+    });
+  });
+
+  test("produces identical reports for identical selections", () => {
+    const context = {
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+    };
+
+    expect(computeIosSimulatorCapabilities(context)).toEqual(
+      computeIosSimulatorCapabilities(context),
+    );
+  });
+});

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -159,6 +159,35 @@ steps:
       expect(result.valid).toBe(true);
     });
 
+    it("should validate biometric device state steps", () => {
+      const yaml = `
+name: biometric-state
+steps:
+  - tool: getDeviceState
+    include:
+      - biometrics
+  - tool: getDeviceState
+    include:
+      - doNotDisturb
+      - biometrics
+  - tool: setDeviceState
+    biometrics:
+      enrollment: enrolled
+  - tool: setDeviceState
+    params:
+      biometrics:
+        enrollment: not_enrolled
+  - tool: setDeviceState
+    params:
+      doNotDisturb:
+        enabled: true
+      biometrics:
+        enrollment: enrolled
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
     it("should validate iOS simulator permissions through cross-platform permission tools", () => {
       const yaml = `
 name: ios-permissions
@@ -497,6 +526,30 @@ steps:
       platform: android
       permissions:
         - camera
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject an unknown biometric enrollment value", () => {
+      const yaml = `
+name: bad-biometric-enrollment
+steps:
+  - tool: setDeviceState
+    biometrics:
+      enrollment: sometimes
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject an unknown getDeviceState include field", () => {
+      const yaml = `
+name: bad-include
+steps:
+  - tool: getDeviceState
+    include:
+      - notAThing
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(false);

--- a/test/server/sessionBiometricEnrollment.test.ts
+++ b/test/server/sessionBiometricEnrollment.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { runSessionBiometricMutation } from "../../src/server/sessionBiometricEnrollment";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+
+describe("runSessionBiometricMutation", () => {
+  test("publishes enrollment before a tracked mutation and restores after it settles", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = new SessionManager(
+      timer,
+      new FakeDeviceSessionPersistence(),
+      () => new FakeDbWriteBarrier(),
+      () => ({ restore: async () => {} }),
+      () => ({ restore: async (enrollment) => restored.push(enrollment) }),
+    );
+    const started = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+    try {
+      await manager.createSession("session-1", "sim-1", "ios");
+      const mutation = runSessionBiometricMutation(
+        manager,
+        "session-1",
+        "not_enrolled",
+        async () => {
+          started.resolve();
+          await finished.promise;
+          return "changed";
+        },
+      );
+      await started.promise;
+
+      const release = manager.releaseSession("session-1");
+      expect(restored).toEqual([]);
+
+      finished.resolve();
+      await expect(mutation).resolves.toBe("changed");
+      await release;
+
+      expect(restored).toEqual(["not_enrolled"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+});

--- a/test/server/sessionBiometricEnrollment.test.ts
+++ b/test/server/sessionBiometricEnrollment.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
-import { runSessionBiometricMutation } from "../../src/server/sessionBiometricEnrollment";
+import {
+  applyStateAfterBiometricCaptureFailure,
+  runSessionBiometricMutation,
+} from "../../src/server/sessionBiometricEnrollment";
+import type {
+  DeviceStateResult,
+  SetDeviceStateInput,
+} from "../../src/features/utility/DeviceState";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
@@ -68,5 +75,83 @@ describe("runSessionBiometricMutation", () => {
     } finally {
       manager.stopCleanupTimer();
     }
+  });
+});
+
+describe("applyStateAfterBiometricCaptureFailure", () => {
+  const failure: DeviceStateResult = {
+    success: false,
+    deviceId: "emulator-5554",
+    platform: "android",
+    biometrics: { supported: false, error: "iOS Simulator biometrics are unsupported" },
+    error: "iOS Simulator biometrics are unsupported",
+  };
+
+  const setterReturning = (result: DeviceStateResult) => {
+    const inputs: SetDeviceStateInput[] = [];
+    return {
+      inputs,
+      setState: async (input: SetDeviceStateInput) => {
+        inputs.push(input);
+        return result;
+      },
+    };
+  };
+
+  test("applies the independent Do Not Disturb field and keeps the biometric failure", async () => {
+    const setter = setterReturning({
+      success: true,
+      deviceId: "emulator-5554",
+      platform: "android",
+      doNotDisturb: { supported: true, enabled: true, mode: "priority" },
+    });
+
+    const result = await applyStateAfterBiometricCaptureFailure(
+      setter,
+      { doNotDisturb: { mode: "priority" }, biometrics: { enrollment: "enrolled" } },
+      failure,
+    );
+
+    expect(setter.inputs).toEqual([{ doNotDisturb: { mode: "priority" } }]);
+    expect(result.doNotDisturb).toEqual({ supported: true, enabled: true, mode: "priority" });
+    expect(result.biometrics).toEqual(failure.biometrics);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("iOS Simulator biometrics are unsupported");
+  });
+
+  test("reports both failures when the sibling field also fails", async () => {
+    const setter = setterReturning({
+      success: false,
+      deviceId: "emulator-5554",
+      platform: "android",
+      doNotDisturb: { supported: false },
+      error: "DND unsupported",
+    });
+
+    const result = await applyStateAfterBiometricCaptureFailure(
+      setter,
+      { doNotDisturb: { enabled: true }, biometrics: { enrollment: "enrolled" } },
+      failure,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("iOS Simulator biometrics are unsupported; DND unsupported");
+  });
+
+  test("returns the biometric failure untouched when nothing else was requested", async () => {
+    const setter = setterReturning({
+      success: true,
+      deviceId: "emulator-5554",
+      platform: "android",
+    });
+
+    const result = await applyStateAfterBiometricCaptureFailure(
+      setter,
+      { biometrics: { enrollment: "enrolled" } },
+      failure,
+    );
+
+    expect(setter.inputs).toEqual([]);
+    expect(result).toBe(failure);
   });
 });

--- a/test/server/sessionBiometricEnrollment.test.ts
+++ b/test/server/sessionBiometricEnrollment.test.ts
@@ -23,6 +23,7 @@ describe("runSessionBiometricMutation", () => {
       const mutation = runSessionBiometricMutation(
         manager,
         "session-1",
+        "sim-1",
         "not_enrolled",
         async () => {
           started.resolve();
@@ -40,6 +41,30 @@ describe("runSessionBiometricMutation", () => {
       await release;
 
       expect(restored).toEqual(["not_enrolled"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("does not mutate an old simulator after the session rebinds", async () => {
+    const manager = new SessionManager(
+      new FakeTimer(),
+      new FakeDeviceSessionPersistence(),
+      () => new FakeDbWriteBarrier(),
+    );
+    let mutationStarted = false;
+    try {
+      await manager.createSession("session-1", "sim-a", "ios");
+      await manager.rebindSession("session-1", "sim-b", "ios");
+
+      await expect(
+        runSessionBiometricMutation(manager, "session-1", "sim-a", "enrolled", async () => {
+          mutationStarted = true;
+        }),
+      ).rejects.toThrow("bound to sim-b, not sim-a");
+
+      expect(mutationStarted).toBe(false);
+      expect(manager.getBiometricEnrollment("session-1")).toBeUndefined();
     } finally {
       manager.stopCleanupTimer();
     }

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -39,6 +39,7 @@ describe("device state tools", () => {
     expect(getTool).toBeDefined();
     expect(getTool?.requiresDevice).toBe(true);
     expect(() => getTool!.schema.parse({ include: ["doNotDisturb"] })).not.toThrow();
+    expect(() => getTool!.schema.parse({ include: ["biometrics"] })).not.toThrow();
 
     expect(setTool).toBeDefined();
     expect(setTool?.requiresDevice).toBe(true);
@@ -50,6 +51,11 @@ describe("device state tools", () => {
     expect(() =>
       setTool!.schema.parse({
         doNotDisturb: { mode: "priority" },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      setTool!.schema.parse({
+        biometrics: { enrollment: "not_enrolled" },
       }),
     ).not.toThrow();
     expect(() => setTool!.schema.parse({})).toThrow();


### PR DESCRIPTION
## Summary
- Add a versioned, pre-session iOS Simulator biometric capability report.
- Make enrollment state explicit through `setDeviceState` and biometric enroll/unenroll actions; match and fail now preserve and verify the configured state.
- Restore a session's original enrollment during release, with injectable lifecycle seams and deterministic coverage.

## Review feedback addressed (71a99805f)
- **Validate the simulator selection before advertising biometrics.** `automobile:devices/images` lists every CoreSimulator device type and runtime, including watchOS/tvOS entries. `computeIosSimulatorCapabilities` now returns `selection: { valid, reason? }`; only an iPhone/iPad device type on an iOS runtime is valid, and anything else reports every biometric capability as `unsupported` with the reason.
- **Keep failed restorations out of the idle pool.** A failed enrollment restore on release now returns a pending cleanup promise that runs bounded retries (2 × 250 ms on the injected `Timer`), so `trackPendingDeviceCleanup` keeps the device quarantined instead of letting `DevicePool` idle a simulator holding session-modified enrollment. A slow restore that later fails takes the same path.
- **Do not stall the release on its own cleanup.** `getPendingBiometricRestoration` returned the pending promise bare from an `async` function, so the caller adopted it and `releaseSessionInternal` awaited the very cleanup it was handing off. It now returns `{ pending }`.
- **Apply valid sibling state when biometric capture fails.** A session-scoped `setDeviceState` whose biometric pre-read fails now still applies an independent `doNotDisturb` update — matching the sessionless path — and reports the biometric failure alongside it.
- **Reject empty device-state selection lists.** `getState([])` no longer reports a no-op success; it returns a typed error without issuing a command, and the schema gained `minItems: 1` on `include`.

## Linked Issue
Closes [#5781](https://github.com/kaeawc/auto-mobile/issues/5781)

## Validation
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test` (14,549 pass / 0 fail)
- [x] `bun run format:check`
- [x] Focused notification, lifecycle, capability, schema, and tool-registration tests use fakes and FakeTimer.

## Manual verification needed
Not run against a live Simulator; the `simctl spawn ... notifyutil` boundary is exercised through injected fakes. Worth confirming on hardware that a deliberately-failed restore (e.g. shutting the simulator mid-release) is retried and that the device is not reused until the retries settle.

## Risk
The feature depends on the existing BiometricKit Darwin-notification behavior. Failures are surfaced as verified state-control errors rather than silently enrolling or claiming an unsupported capability.
