### PR TITLE
fix(ios): retain verified defaults values after type timeout

### DIFF
--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -279,8 +279,8 @@ export class AppPreferences {
       );
       return parseIosDefaultsType(result.stdout);
     } catch (error) {
-      // `defaults read-type` fails when the key doesn't exist yet, which is a
-      // normal "no preference set" state; undefined lets callers fall back.
+      // This auxiliary type probe must not discard a successfully-read value.
+      // Returning undefined lets callers fall back to the string representation.
       if (looksLikeMissingIosDefault(error)) {
         logger.debug(
           `src/features/preferences/AppPreferences.ts defaults type read found no value: ${error}`,
@@ -288,7 +288,17 @@ export class AppPreferences {
         );
         return undefined;
       }
-      throw new ActionableError(`Failed to read iOS UserDefaults type with defaults: ${error}`);
+      if (deadlineMs !== undefined && this.timer.now() >= deadlineMs) {
+        throw error;
+      }
+      if (!isRetryableIosDefaultsError(error)) {
+        throw new ActionableError(`Failed to read iOS UserDefaults type with defaults: ${error}`);
+      }
+      logger.warn(
+        `src/features/preferences/AppPreferences.ts defaults type read failed; falling back to string: ${error}`,
+        error,
+      );
+      return undefined;
     }
   }
 

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -970,6 +970,62 @@ describe("AppPreferences", () => {
     ]);
   });
 
+  test("returns a verified write when the iOS UserDefaults type-read times out", async () => {
+    const timer = new FakeTimer();
+    const simctl = new ScriptedSimCtlClient(
+      [
+        {},
+        { stdout: "enabled\n" },
+        { elapsedMs: 10_000, error: new Error("Command timed out after 10000ms") },
+        { elapsedMs: 10_000, error: new Error("Command timed out after 10000ms") },
+      ],
+      timer,
+    );
+    const preferences = new AppPreferences(iosSimulator, { simctl, timer });
+
+    const result = await preferences.setPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "featureFlag",
+      value: "enabled",
+      type: "string",
+    });
+
+    expect(result).toMatchObject({
+      found: true,
+      value: "enabled",
+      verified: true,
+    });
+    expect(timer.now()).toBe(20_000);
+    expect(simctl.calls.map((call) => call.args[3])).toEqual([
+      "write",
+      "read",
+      "read-type",
+      "read-type",
+    ]);
+  });
+
+  test("surfaces a permanent iOS UserDefaults type-read failure", async () => {
+    const simctl = new ScriptedSimCtlClient([
+      {},
+      { stdout: "enabled\n" },
+      { error: new Error("Xcode is not configured") },
+    ]);
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+
+    await expect(
+      preferences.setPreference({
+        scope: "userDefaults",
+        appId: "com.example.app",
+        key: "featureFlag",
+        value: "enabled",
+        type: "string",
+      }),
+    ).rejects.toThrow("Xcode is not configured");
+
+    expect(simctl.calls.map((call) => call.args[3])).toEqual(["write", "read", "read-type"]);
+  });
+
   test("preserves the type-read retry for a direct iOS UserDefaults read", async () => {
     const timer = new FakeTimer();
     const simctl = new ScriptedSimCtlClient(


### PR DESCRIPTION
## Summary

Keep a successful iOS UserDefaults value read available when its best-effort `defaults read-type` probe exhausts retryable failures before the operation deadline. Permanent type-probe failures and an exhausted operation deadline still surface errors.

## Linked Issue

Closes [#5772](https://github.com/kaeawc/auto-mobile/issues/5772)

## Bug / Regression Context

- **Prior attempts:** [#5755](https://github.com/kaeawc/auto-mobile/pull/5755) added retry handling but made terminal `read-type` errors fatal to an already-successful value read.
- **Observed symptom:** `setPreference` threw after the value was written and verified when both auxiliary type-read attempts timed out.
- **Repro steps / conditions:** An iOS UserDefaults write and `defaults read` succeed; both retryable `defaults read-type` attempts time out within the shared 30-second deadline.

## Validation

- [x] `bun test test/features/preferences/AppPreferences.test.ts`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `scripts/all_fast_validate_checks.sh`
- [x] New code uses injected `FakeTimer` and a scripted SimCtl fake; relevant unit tests remain deterministic.

## Follow-ups

- [x] No follow-up issue needed.
