### PR TITLE
feat(device-control): support display cutout preferences

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -174,7 +174,7 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 
 - 📋 Device inventory and pool status are exposed via the `automobile:devices/booted` resource.
 - 🚀 `startDevice` starts a device with the specified device image.
-- 🧱 `provisionDevice` creates or adopts an exact virtual-device identity. It requires the `device-control` capability.
+- 🧱 `provisionDevice` creates or adopts an exact virtual-device identity. Its optional `device.spec.displayCutout` preference (`none`, `notch`, `dynamic_island`, `hole_punch`, or `any`) verifies the supplied exact device type; it never substitutes a different type. Successful responses report the resolved classification. It requires the `device-control` capability.
 - ❌ `killDevice` terminates a running device.
 - 🧹 `deleteDevice` stops and permanently deletes a device identified by its `platform` and stable identity from `automobile:devices/booted`, then verifies its absence from that platform inventory.
 - 🔧 `setActiveDevice` sets the active device for subsequent operations. It is a

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7004,6 +7004,11 @@
                       "type": "string",
                       "minLength": 1
                     },
+                    "displayCutout": {
+                      "description": "Required display cutout class for the exact device type; 'any' accepts every class",
+                      "type": "string",
+                      "enum": ["none", "notch", "dynamic_island", "hole_punch", "any"]
+                    },
                     "configuration": {
                       "type": "object",
                       "properties": {
@@ -7047,6 +7052,11 @@
                       "description": "CoreSimulator device-type identifier",
                       "type": "string",
                       "minLength": 1
+                    },
+                    "displayCutout": {
+                      "description": "Required display cutout class for the exact device type; 'any' accepts every class",
+                      "type": "string",
+                      "enum": ["none", "notch", "dynamic_island", "hole_punch", "any"]
                     }
                   },
                   "required": ["runtime", "deviceType"],

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3759,12 +3759,17 @@ export function registerDeviceTools() {
     const store = deps.provisionDeviceOperationStoreFactory();
     const operation = await store.begin(args.operationId, fingerprint);
     try {
-      if (!operation.started) {
-        if (
-          await canReplayCompletedProvisionDeviceOperation(args, deps, operation.result, signal)
-        ) {
-          return operation.result;
+      if (
+        !operation.started &&
+        (await canReplayCompletedProvisionDeviceOperation(args, deps, operation.result, signal))
+      ) {
+        const replayResult = backfillProvisionDeviceCutout(args, operation.result);
+        if (replayResult !== operation.result) {
+          await completeProvisionDeviceOperation(store, args.operationId, replayResult);
         }
+        return replayResult;
+      }
+      if (!operation.started) {
         await releaseErroredProvisionDeviceSession(operation.result);
 
         // Sessions are daemon-local and are expired during daemon startup. A
@@ -3822,6 +3827,32 @@ export function registerDeviceTools() {
       name: deviceRecord.name,
       platform: deviceRecord.platform,
       deviceId: typeof deviceRecord.deviceId === "string" ? deviceRecord.deviceId : undefined,
+    };
+  }
+
+  function backfillProvisionDeviceCutout(
+    args: ProvisionDeviceArgs,
+    result: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const displayCutout = classifyDisplayCutout(args.device.platform, args.device.spec.deviceType);
+    const resolvedSpec = result.resolvedSpec;
+    const resolvedSpecRecord =
+      typeof resolvedSpec === "object" && resolvedSpec !== null && !Array.isArray(resolvedSpec)
+        ? (resolvedSpec as Record<string, unknown>)
+        : undefined;
+    const resolvedDisplayCutout = resolvedSpecRecord?.displayCutout;
+    const hasTopLevelCutout = typeof result.displayCutout === "string";
+    const hasResolvedCutout = typeof resolvedDisplayCutout === "string";
+    if (hasTopLevelCutout && hasResolvedCutout) {
+      return result;
+    }
+    return {
+      ...result,
+      displayCutout: hasTopLevelCutout ? result.displayCutout : displayCutout,
+      resolvedSpec: {
+        ...(resolvedSpecRecord ?? args.device.spec),
+        displayCutout: hasResolvedCutout ? resolvedDisplayCutout : displayCutout,
+      },
     };
   }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -110,6 +110,7 @@ import {
 import { DeviceTeardownService, type DeviceTeardownPhase } from "../utils/deviceTeardownService";
 import { DeviceShutdownService } from "../utils/deviceShutdownService";
 import { hasMutableDisplayName } from "../utils/ios-cmdline-tools/iosDeviceType";
+import { classifyDisplayCutout, DISPLAY_CUTOUT_PREFERENCES } from "../utils/displayCutout";
 
 // Schema definitions
 export const listDeviceImagesSchema = z.object({
@@ -242,6 +243,12 @@ const androidProvisionDeviceSpecSchema = z
   .object({
     runtime: z.string().min(1).describe("Installed Android system-image package identifier"),
     deviceType: z.string().min(1).describe("Android avdmanager device profile identifier"),
+    displayCutout: z
+      .enum(DISPLAY_CUTOUT_PREFERENCES)
+      .optional()
+      .describe(
+        "Required display cutout class for the exact device type; 'any' accepts every class",
+      ),
     configuration: z
       .object({
         memoryMb: z.number().int().positive().optional(),
@@ -271,6 +278,12 @@ const iosProvisionDeviceSpecSchema = z
   .object({
     runtime: z.string().min(1).describe("CoreSimulator runtime identifier"),
     deviceType: z.string().min(1).describe("CoreSimulator device-type identifier"),
+    displayCutout: z
+      .enum(DISPLAY_CUTOUT_PREFERENCES)
+      .optional()
+      .describe(
+        "Required display cutout class for the exact device type; 'any' accepts every class",
+      ),
   })
   .strict();
 
@@ -4398,6 +4411,9 @@ export function registerDeviceTools() {
       device: booted?.device ?? provisioned.device,
       requestedSpec: args.device.spec,
       resolvedSpec: provisioned.resolvedSpec,
+      displayCutout:
+        provisioned.resolvedSpec.displayCutout ??
+        classifyDisplayCutout(args.device.platform, provisioned.resolvedSpec.deviceType),
       created: createdByOperation,
       adopted: !createdByOperation,
       lifecycleState: booted ? "ready" : createdByOperation ? "created" : "adopted",

--- a/src/utils/displayCutout.ts
+++ b/src/utils/displayCutout.ts
@@ -59,9 +59,10 @@ const IOS_DYNAMIC_ISLAND_IDENTIFIERS = new Set([
   "iphone-16-pro",
   "iphone-16-pro-max",
   "iphone-17",
-  "iphone-17-air",
   "iphone-17-pro",
   "iphone-17-pro-max",
+  "iphone-air",
+  "iphone-17e",
 ]);
 
 const ANDROID_NO_CUTOUT_IDS = new Set([
@@ -97,12 +98,17 @@ const ANDROID_HOLE_PUNCH_IDS = new Set([
   "pixel_9_pro",
   "pixel_9_pro_xl",
   "pixel_9_pro_fold",
-  "pixel_fold",
 ]);
 
 function simulatorDeviceTypeName(deviceType: string): string {
   const prefix = "com.apple.CoreSimulator.SimDeviceType.";
-  return deviceType.startsWith(prefix) ? deviceType.slice(prefix.length).toLowerCase() : "";
+  return deviceType.startsWith(prefix)
+    ? deviceType
+        .slice(prefix.length)
+        .toLowerCase()
+        .replaceAll(/-+/g, "-")
+        .replaceAll(/(^-|-$)/g, "")
+    : "";
 }
 
 /**

--- a/src/utils/displayCutout.ts
+++ b/src/utils/displayCutout.ts
@@ -1,0 +1,143 @@
+import type { Platform } from "../models/Platform";
+
+export const DISPLAY_CUTOUT_PREFERENCES = [
+  "none",
+  "notch",
+  "dynamic_island",
+  "hole_punch",
+  "any",
+] as const;
+
+export type DisplayCutoutPreference = (typeof DISPLAY_CUTOUT_PREFERENCES)[number];
+export type DisplayCutoutClassification = Exclude<DisplayCutoutPreference, "any"> | "unknown";
+
+const IOS_NO_CUTOUT_IDENTIFIERS = new Set([
+  "iphone-se",
+  "iphone-se-2nd-generation",
+  "iphone-se-3rd-generation",
+  "iphone-6",
+  "iphone-6-plus",
+  "iphone-6s",
+  "iphone-6s-plus",
+  "iphone-7",
+  "iphone-7-plus",
+  "iphone-8",
+  "iphone-8-plus",
+  "ipod-touch-7th-generation",
+]);
+
+const IOS_NOTCH_IDENTIFIERS = new Set([
+  "iphone-x",
+  "iphone-xr",
+  "iphone-xs",
+  "iphone-xs-max",
+  "iphone-11",
+  "iphone-11-pro",
+  "iphone-11-pro-max",
+  "iphone-12",
+  "iphone-12-mini",
+  "iphone-12-pro",
+  "iphone-12-pro-max",
+  "iphone-13",
+  "iphone-13-mini",
+  "iphone-13-pro",
+  "iphone-13-pro-max",
+  "iphone-14",
+  "iphone-14-plus",
+  "iphone-16e",
+]);
+
+const IOS_DYNAMIC_ISLAND_IDENTIFIERS = new Set([
+  "iphone-14-pro",
+  "iphone-14-pro-max",
+  "iphone-15",
+  "iphone-15-plus",
+  "iphone-15-pro",
+  "iphone-15-pro-max",
+  "iphone-16",
+  "iphone-16-plus",
+  "iphone-16-pro",
+  "iphone-16-pro-max",
+  "iphone-17",
+  "iphone-17-air",
+  "iphone-17-pro",
+  "iphone-17-pro-max",
+]);
+
+const ANDROID_NO_CUTOUT_IDS = new Set([
+  "pixel",
+  "pixel_2",
+  "pixel_2_xl",
+  "pixel_3",
+  "pixel_3a",
+  "pixel_3a_xl",
+  "pixel_4",
+  "pixel_4_xl",
+  "pixel_c",
+  "pixel_tablet",
+]);
+
+const ANDROID_NOTCH_IDS = new Set(["pixel_3_xl"]);
+
+const ANDROID_HOLE_PUNCH_IDS = new Set([
+  "pixel_4a",
+  "pixel_4a_5g",
+  "pixel_5",
+  "pixel_5a",
+  "pixel_6",
+  "pixel_6_pro",
+  "pixel_6a",
+  "pixel_7",
+  "pixel_7_pro",
+  "pixel_7a",
+  "pixel_8",
+  "pixel_8_pro",
+  "pixel_8a",
+  "pixel_9",
+  "pixel_9_pro",
+  "pixel_9_pro_xl",
+  "pixel_9_pro_fold",
+  "pixel_fold",
+]);
+
+function simulatorDeviceTypeName(deviceType: string): string {
+  const prefix = "com.apple.CoreSimulator.SimDeviceType.";
+  return deviceType.startsWith(prefix) ? deviceType.slice(prefix.length).toLowerCase() : "";
+}
+
+/**
+ * Classifies device profiles from their public platform identifiers. This
+ * intentionally never uses camera metadata: a device may have cameras without
+ * a display obstruction, and the simulator/AVD catalog does not publish a
+ * portable cutout capability.
+ */
+export function classifyDisplayCutout(
+  platform: Platform,
+  deviceType: string,
+): DisplayCutoutClassification {
+  if (platform === "ios") {
+    const identifier = simulatorDeviceTypeName(deviceType);
+    if (IOS_NO_CUTOUT_IDENTIFIERS.has(identifier) || identifier.startsWith("ipad-")) {
+      return "none";
+    }
+    if (IOS_NOTCH_IDENTIFIERS.has(identifier)) {
+      return "notch";
+    }
+    if (IOS_DYNAMIC_ISLAND_IDENTIFIERS.has(identifier)) {
+      return "dynamic_island";
+    }
+    return "unknown";
+  }
+
+  const identifier = deviceType.toLowerCase();
+  if (ANDROID_NO_CUTOUT_IDS.has(identifier)) {
+    return "none";
+  }
+  if (ANDROID_NOTCH_IDS.has(identifier)) {
+    return "notch";
+  }
+  if (ANDROID_HOLE_PUNCH_IDS.has(identifier)) {
+    return "hole_punch";
+  }
+  return "unknown";
+}

--- a/src/utils/displayCutout.ts
+++ b/src/utils/displayCutout.ts
@@ -76,6 +76,9 @@ const ANDROID_NO_CUTOUT_IDS = new Set([
   "pixel_4_xl",
   "pixel_c",
   "pixel_tablet",
+  "nexus 5x",
+  "medium phone",
+  "small phone",
 ]);
 
 const ANDROID_NOTCH_IDS = new Set(["pixel_3_xl"]);

--- a/src/utils/exactDeviceProvisioning.ts
+++ b/src/utils/exactDeviceProvisioning.ts
@@ -17,6 +17,11 @@ import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { throwIfAborted } from "./toolUtils";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import {
+  classifyDisplayCutout,
+  type DisplayCutoutClassification,
+  type DisplayCutoutPreference,
+} from "./displayCutout";
+import {
   getVirtualDeviceLifecycleCoordinator,
   type VirtualDeviceLifecycleCoordinator,
   type VirtualDeviceLifecycleIdentity,
@@ -26,6 +31,7 @@ import {
 export interface AndroidDeviceSpecification {
   runtime: string;
   deviceType: string;
+  displayCutout?: DisplayCutoutPreference;
   configuration?: {
     memoryMb?: number;
   };
@@ -34,9 +40,17 @@ export interface AndroidDeviceSpecification {
 export interface IosDeviceSpecification {
   runtime: string;
   deviceType: string;
+  displayCutout?: DisplayCutoutPreference;
 }
 
 export type ExactDeviceSpecification = AndroidDeviceSpecification | IosDeviceSpecification;
+export type ResolvedExactDeviceSpecification =
+  | (Omit<AndroidDeviceSpecification, "displayCutout"> & {
+      displayCutout: DisplayCutoutClassification;
+    })
+  | (Omit<IosDeviceSpecification, "displayCutout"> & {
+      displayCutout: DisplayCutoutClassification;
+    });
 
 export interface ExactDeviceProvisionRequest {
   platform: "android" | "ios";
@@ -57,13 +71,14 @@ export interface ExactDeviceProvisionRequest {
 export interface ExactProvisionedDevice {
   device: DeviceInfo;
   created: boolean;
-  resolvedSpec: ExactDeviceSpecification;
+  resolvedSpec: ResolvedExactDeviceSpecification;
 }
 
 export type ProvisionDeviceFailureCode =
   | "creation_not_allowed"
   | "identity_conflict"
   | "timeout"
+  | "unsupported"
   | "platform_command_failed";
 
 export class ProvisionDeviceError extends ActionableError {
@@ -236,6 +251,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
   }
 
   async provision(request: ExactDeviceProvisionRequest): Promise<ExactProvisionedDevice> {
+    const displayCutout = this.resolveDisplayCutout(request);
     const ownLease = request.lifecycleLease === undefined;
     const lease =
       request.lifecycleLease ??
@@ -253,7 +269,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
     };
     try {
       throwIfAborted(coordinatedRequest.signal);
-      const result = await this.provisionLocked(coordinatedRequest);
+      const result = await this.provisionLocked(coordinatedRequest, displayCutout);
       const stableId =
         result.device.platform === "android" ? result.device.name : result.device.deviceId;
       if (!stableId) {
@@ -289,6 +305,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
 
   private async provisionLocked(
     request: ExactDeviceProvisionRequest,
+    displayCutout: DisplayCutoutClassification,
   ): Promise<ExactProvisionedDevice> {
     const images = await this.dependencies.listDeviceImages(request.platform);
     const existing = this.findExisting(images, request);
@@ -297,7 +314,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
       return {
         device: existing,
         created: false,
-        resolvedSpec: request.spec,
+        resolvedSpec: this.withResolvedDisplayCutout(request.spec, displayCutout),
       };
     }
 
@@ -310,9 +327,41 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
 
     await request.onBeforeCreate?.();
     if (request.platform === "android") {
-      return await this.createAndroid(request, request.spec as AndroidDeviceSpecification);
+      return await this.createAndroid(
+        request,
+        request.spec as AndroidDeviceSpecification,
+        displayCutout,
+      );
     }
-    return await this.createIos(request, request.spec as IosDeviceSpecification);
+    return await this.createIos(request, request.spec as IosDeviceSpecification, displayCutout);
+  }
+
+  private resolveDisplayCutout(request: ExactDeviceProvisionRequest): DisplayCutoutClassification {
+    const resolved = classifyDisplayCutout(request.platform, request.spec.deviceType);
+    const preference = request.spec.displayCutout;
+    if (preference === undefined || preference === "any") {
+      return resolved;
+    }
+    if (resolved === "unknown") {
+      throw new ProvisionDeviceError(
+        "unsupported",
+        `Display cutout preference '${preference}' is unsupported for ${request.platform} device type '${request.spec.deviceType}' because its cutout class is unknown.`,
+      );
+    }
+    if (resolved !== preference) {
+      throw new ProvisionDeviceError(
+        "identity_conflict",
+        `Exact ${request.platform} device type '${request.spec.deviceType}' has display cutout '${resolved}', not requested '${preference}'.`,
+      );
+    }
+    return resolved;
+  }
+
+  private withResolvedDisplayCutout(
+    spec: ExactDeviceSpecification,
+    displayCutout: DisplayCutoutClassification,
+  ): ResolvedExactDeviceSpecification {
+    return { ...spec, displayCutout } as ResolvedExactDeviceSpecification;
   }
 
   private findExisting(
@@ -423,6 +472,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
   private async createAndroid(
     request: ExactDeviceProvisionRequest,
     spec: AndroidDeviceSpecification,
+    displayCutout: DisplayCutoutClassification,
   ): Promise<ExactProvisionedDevice> {
     const created = await this.dependencies.avdManager.createAvd(
       {
@@ -451,13 +501,14 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
         platform: "android",
         isRunning: false,
       },
-      resolvedSpec: spec,
+      resolvedSpec: this.withResolvedDisplayCutout(spec, displayCutout),
     };
   }
 
   private async createIos(
     request: ExactDeviceProvisionRequest,
     spec: IosDeviceSpecification,
+    displayCutout: DisplayCutoutClassification,
   ): Promise<ExactProvisionedDevice> {
     const deviceId = await this.dependencies.iosSimulator.createSimulator(
       request.name,
@@ -475,7 +526,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
         runtime: spec.runtime,
         deviceType: spec.deviceType,
       },
-      resolvedSpec: spec,
+      resolvedSpec: this.withResolvedDisplayCutout(spec, displayCutout),
     };
   }
 }

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -5,6 +5,7 @@ import {
   resetDeviceToolsDependencies,
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
+import { classifyDisplayCutout } from "../../src/utils/displayCutout";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import type {
   ExactDeviceProvisionRequest,
@@ -34,7 +35,10 @@ class FakeExactDeviceProvisioner implements ExactDeviceProvisioner {
         platform: request.platform,
         isRunning: false,
       },
-      resolvedSpec: request.spec,
+      resolvedSpec: {
+        ...request.spec,
+        displayCutout: classifyDisplayCutout(request.platform, request.spec.deviceType),
+      },
     };
   }
 }
@@ -140,6 +144,34 @@ describe("provisionDevice handler", () => {
     });
   });
 
+  test("accepts only documented display-cutout preferences", () => {
+    const input = {
+      operationId: "operation-display-cutout-schema",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+          displayCutout: "hole_punch",
+        },
+      },
+    };
+
+    expect(provisionDeviceSchema.parse(input).device.spec).toMatchObject({
+      displayCutout: "hole_punch",
+    });
+    expect(() =>
+      provisionDeviceSchema.parse({
+        ...input,
+        device: {
+          ...input.device,
+          spec: { ...input.device.spec, displayCutout: "camera" },
+        },
+      }),
+    ).toThrow();
+  });
+
   test("advertises the platform-discriminated device schema with deterministic oneOf", () => {
     const definition = ToolRegistry.getToolDefinitions().find(
       (candidate) => candidate.name === "provisionDevice",
@@ -182,6 +214,7 @@ describe("provisionDevice handler", () => {
         spec: {
           runtime: "system-images;android-36;google_apis;x86_64",
           deviceType: "pixel_9",
+          displayCutout: "hole_punch",
           configuration: { memoryMb: 4096 },
         },
       },
@@ -208,6 +241,7 @@ describe("provisionDevice handler", () => {
       spec: {
         runtime: "system-images;android-36;google_apis;x86_64",
         deviceType: "pixel_9",
+        displayCutout: "hole_punch",
         configuration: { memoryMb: 4096 },
       },
     });
@@ -222,6 +256,7 @@ describe("provisionDevice handler", () => {
         name: "phone-api-36-a",
         platform: "android",
       },
+      displayCutout: "hole_punch",
     });
     expect(second).toEqual(first);
   });
@@ -484,6 +519,7 @@ describe("provisionDevice handler", () => {
       resolvedSpec: {
         runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
         deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        displayCutout: "dynamic_island",
       },
     };
     let releaseReadiness!: () => void;
@@ -911,7 +947,10 @@ describe("provisionDevice handler", () => {
             platform: "android",
             isRunning: false,
           },
-          resolvedSpec: request.spec,
+          resolvedSpec: {
+            ...request.spec,
+            displayCutout: classifyDisplayCutout(request.platform, request.spec.deviceType),
+          },
         };
       },
     };
@@ -967,7 +1006,10 @@ describe("provisionDevice handler", () => {
             platform: "android",
             isRunning: false,
           },
-          resolvedSpec: request.spec,
+          resolvedSpec: {
+            ...request.spec,
+            displayCutout: classifyDisplayCutout(request.platform, request.spec.deviceType),
+          },
         };
       },
     };
@@ -1064,7 +1106,10 @@ describe("provisionDevice handler", () => {
         platform: "android",
         isRunning: false,
       },
-      resolvedSpec: args.device.spec,
+      resolvedSpec: {
+        ...args.device.spec,
+        displayCutout: classifyDisplayCutout(args.device.platform, args.device.spec.deviceType),
+      },
     });
 
     expect(JSON.parse(((await second) as any).content[0].text)).toMatchObject({
@@ -1086,6 +1131,7 @@ describe("provisionDevice handler", () => {
         spec: {
           runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
           deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+          displayCutout: "any",
         },
       },
       boot: false,
@@ -1101,7 +1147,7 @@ describe("provisionDevice handler", () => {
             ...base.device,
             spec: {
               ...base.device.spec,
-              deviceType: "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M4",
+              displayCutout: "dynamic_island",
             },
           },
         })) as any

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -94,6 +94,18 @@ class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore
     operation.result = result;
   }
 
+  setStoredResult(operationId: string, result: Record<string, unknown>): void {
+    const operation = this.results.get(operationId);
+    if (!operation) {
+      throw new Error(`missing operation ${operationId}`);
+    }
+    operation.result = result;
+  }
+
+  getStoredResult(operationId: string): Record<string, unknown> | undefined {
+    return this.results.get(operationId)?.result;
+  }
+
   async fail(): Promise<void> {
     this.failCalls++;
   }
@@ -259,6 +271,41 @@ describe("provisionDevice handler", () => {
       displayCutout: "hole_punch",
     });
     expect(second).toEqual(first);
+  });
+
+  test("backfills cutout fields when replaying a legacy persisted result", async () => {
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-legacy-cutout-replay",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: false,
+      readiness: "none" as const,
+    };
+
+    const first = JSON.parse(((await tool.handler(args)) as any).content[0].text);
+    const legacyResult = { ...first };
+    delete legacyResult.displayCutout;
+    legacyResult.resolvedSpec = { ...legacyResult.resolvedSpec };
+    delete legacyResult.resolvedSpec.displayCutout;
+    operationStore.setStoredResult(args.operationId, legacyResult);
+
+    const replay = JSON.parse(((await tool.handler(args)) as any).content[0].text);
+
+    expect(replay).toMatchObject({
+      displayCutout: "hole_punch",
+      resolvedSpec: { displayCutout: "hole_punch" },
+    });
+    expect(replay).toEqual(operationStore.getStoredResult(args.operationId));
   });
 
   test("coordinates completed provisioning replays with teardown", async () => {

--- a/test/utils/displayCutout.test.ts
+++ b/test/utils/displayCutout.test.ts
@@ -12,18 +12,28 @@ describe("classifyDisplayCutout", () => {
     expect(
       classifyDisplayCutout(
         "ios",
-        "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation",
+        "com.apple.CoreSimulator.SimDeviceType.iPhone-SE--2nd-generation-",
+      ),
+    ).toBe("none");
+    expect(
+      classifyDisplayCutout(
+        "ios",
+        "com.apple.CoreSimulator.SimDeviceType.iPod-touch--7th-generation-",
       ),
     ).toBe("none");
     expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-14")).toBe(
       "notch",
     );
-    expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-17")).toBe(
+    expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-Air")).toBe(
+      "dynamic_island",
+    );
+    expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-17e")).toBe(
       "dynamic_island",
     );
   });
 
   test("keeps an unknown model unclassified instead of guessing from camera hardware", () => {
     expect(classifyDisplayCutout("android", "future_phone_with_three_cameras")).toBe("unknown");
+    expect(classifyDisplayCutout("android", "pixel_fold")).toBe("unknown");
   });
 });

--- a/test/utils/displayCutout.test.ts
+++ b/test/utils/displayCutout.test.ts
@@ -4,6 +4,9 @@ import { classifyDisplayCutout } from "../../src/utils/displayCutout";
 describe("classifyDisplayCutout", () => {
   test("classifies known Android profile identifiers without inspecting camera metadata", () => {
     expect(classifyDisplayCutout("android", "pixel_2")).toBe("none");
+    expect(classifyDisplayCutout("android", "Nexus 5X")).toBe("none");
+    expect(classifyDisplayCutout("android", "Medium Phone")).toBe("none");
+    expect(classifyDisplayCutout("android", "Small Phone")).toBe("none");
     expect(classifyDisplayCutout("android", "pixel_3_xl")).toBe("notch");
     expect(classifyDisplayCutout("android", "pixel_9")).toBe("hole_punch");
   });

--- a/test/utils/displayCutout.test.ts
+++ b/test/utils/displayCutout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { classifyDisplayCutout } from "../../src/utils/displayCutout";
+
+describe("classifyDisplayCutout", () => {
+  test("classifies known Android profile identifiers without inspecting camera metadata", () => {
+    expect(classifyDisplayCutout("android", "pixel_2")).toBe("none");
+    expect(classifyDisplayCutout("android", "pixel_3_xl")).toBe("notch");
+    expect(classifyDisplayCutout("android", "pixel_9")).toBe("hole_punch");
+  });
+
+  test("classifies known iOS simulator device types including no-cutout devices", () => {
+    expect(
+      classifyDisplayCutout(
+        "ios",
+        "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation",
+      ),
+    ).toBe("none");
+    expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-14")).toBe(
+      "notch",
+    );
+    expect(classifyDisplayCutout("ios", "com.apple.CoreSimulator.SimDeviceType.iPhone-17")).toBe(
+      "dynamic_island",
+    );
+  });
+
+  test("keeps an unknown model unclassified instead of guessing from camera hardware", () => {
+    expect(classifyDisplayCutout("android", "future_phone_with_three_cameras")).toBe("unknown");
+  });
+});

--- a/test/utils/exactDeviceProvisioning.test.ts
+++ b/test/utils/exactDeviceProvisioning.test.ts
@@ -108,7 +108,7 @@ describe("DefaultExactDeviceProvisioner", () => {
     expect(result).toEqual({
       created: true,
       device: androidImage("phone-api-36-a"),
-      resolvedSpec: ANDROID_SPEC,
+      resolvedSpec: { ...ANDROID_SPEC, displayCutout: "hole_punch" },
     });
     expect(calls).toEqual([
       {
@@ -152,6 +152,7 @@ describe("DefaultExactDeviceProvisioner", () => {
       spec: {
         runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
         deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        displayCutout: "dynamic_island",
       },
     });
 
@@ -169,6 +170,7 @@ describe("DefaultExactDeviceProvisioner", () => {
       resolvedSpec: {
         runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
         deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        displayCutout: "dynamic_island",
       },
     });
   });
@@ -476,7 +478,7 @@ describe("DefaultExactDeviceProvisioner", () => {
     expect(result).toEqual({
       created: false,
       device: androidImage("phone-api-36-a"),
-      resolvedSpec: ANDROID_SPEC,
+      resolvedSpec: { ...ANDROID_SPEC, displayCutout: "hole_punch" },
     });
   });
 
@@ -515,5 +517,61 @@ describe("DefaultExactDeviceProvisioner", () => {
     });
 
     expect(writes).toEqual([]);
+  });
+
+  test("rejects an existing Android AVD whose exact type conflicts with the requested cutout", async () => {
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [androidImage("phone-api-36-a")],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb: 4096,
+        }),
+      },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    await expect(
+      provisioner.provision({
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: { ...ANDROID_SPEC, displayCutout: "none" },
+      }),
+    ).rejects.toMatchObject({
+      code: "identity_conflict",
+      message: expect.stringContaining("hole_punch"),
+    });
+  });
+
+  test("rejects a cutout preference when the exact device type cannot be classified", async () => {
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: { readConfig: async () => null },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    await expect(
+      provisioner.provision({
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: ANDROID_SPEC.runtime,
+          deviceType: "unclassified_profile",
+          displayCutout: "notch",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "unsupported",
+      message: expect.stringContaining("unknown"),
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add documented `displayCutout` preferences to exact `provisionDevice` requests and generated tool definitions.
- Classify supported Android AVD and iOS CoreSimulator profiles without using camera metadata; reject incompatible or unknown requested classifications.
- Return the resolved class with the exact resolved spec, preserving idempotency and existing-device compatibility.

## Linked Issue

Closes [#5778](https://github.com/kaeawc/auto-mobile/issues/5778)

## Validation

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test` (14,530 passed, 0 failed)
- [x] `scripts/all_fast_validate_checks.sh` (34 checks passed)

## Risk

The profile map deliberately returns `unknown` for unrecognized or display-state-dependent models, requiring callers to use `any` or a supported exact profile instead of silently guessing.
