### PR TITLE
fix(ios): report Do Not Disturb unsupported on all iOS simulators (#2862)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -313,79 +313,67 @@ per-package resilience of iOS app-data restore.
 
 ## Do Not Disturb (setDeviceState)
 
-<kbd>✅ Implemented</kbd> <kbd>📱 Simulator (iOS ≤17) Only</kbd>
+<kbd>🚫 Unsupported on iOS</kbd>
 
-The `setDeviceState` / `getDeviceState` MCP tools control Do Not Disturb. On iOS,
-DND is **simulator-only and binary** (on/off) when the legacy notification path
-can prove it works — this is a hard platform limitation, not a missing wiring
-detail. Known **iOS 18+ simulators skip the legacy write probe and report
-`capability: "unsupported"`** (see below): DND moved to the private
-`donotdisturbd` Focus daemon. Unknown or older simulator runtimes attempt the
-legacy path, but write success is behavior-based and requires an independent
-fresh-process readback.
+The `setDeviceState` / `getDeviceState` MCP tools control Do Not Disturb. On iOS
+**both reads and writes report `capability: "unsupported"`** — on simulators and
+physical devices alike. This is a hard platform limitation, not missing wiring.
+Android keeps full four-tier `zen_mode` support; iOS has no equivalent, and that
+asymmetry is reported honestly rather than papered over with a best-effort no-op.
 
-### How it works (iOS ≤17 simulators)
+### Why (empirically verified — issue #2862)
 
-1. **Binary toggle** — the only lever the simulator exposes is the
-   `com.apple.donotdisturb.enabled` Darwin notification, driven via
-   `xcrun simctl spawn <udid> notifyutil`. All four flags are passed in a
-   **single combined invocation** — `notifyutil -1 <key> -s <key> <0|1> -g <key> -p <key>`
-   (`iosNotifyutilRegisteredSetReadPostCommand` in `src/utils/ios-cmdline-tools/notifyutil.ts`),
-   not four separate shell calls:
-   - `notifyutil -1 com.apple.donotdisturb.enabled ...` creates a temporary
-     registration so the state variable exists even if no other process already
-     owns the key.
-   - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value while
-     that registration is alive.
-   - `notifyutil -g com.apple.donotdisturb.enabled` reads the state in the same
-     invocation.
-   - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
-   - After a short settle, a separate fresh-process
-     `notifyutil -g com.apple.donotdisturb.enabled` verifies that the value
-     persisted. Only this independent readback can make the write
-     `verified: true`.
-2. **Honest capability reporting** — every result carries a machine-readable
-   `capability` field so callers can branch instead of string-matching warnings:
-   - `binary` — simulator legacy path verified: on/off only.
-   - `unsupported` — physical device, known **iOS 18+ simulator**, or a legacy
-     write whose independent readback reverted instead of persisting.
-   - (`full` is reserved for Android, where all four `zen_mode` tiers are
-     distinct, persisted, and verified.)
-3. **No silent downgrade** — a `priority` or `alarms` request applies plain DND
-   and reports it honestly: `requestedMode: "priority"|"alarms"`,
-   `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
-   `success` is `false`). The tool never claims a tier it cannot deliver.
-4. **Best effort with behavior verification** — results are `bestEffort: true`.
-   The same-invocation registered set/read/post proves only that the command
-   could set state while its registration existed; it is not authoritative by
-   itself. The setter only reports success when the independent readback
-   observes the requested binary state.
+Do Not Disturb is owned by the private **`donotdisturbd`** Focus daemon, which
+shipped with Focus in iOS 15. It owns the legacy
+`com.apple.donotdisturb.enabled` Darwin notification and resets it to its own
+authoritative value, so that notification neither reflects nor controls real
+Focus state: a write cannot be verified and a read is a confident falsehood
+(always `0`).
+
+Measured on booted simulators with `donotdisturbd` running in each, using the
+exact production command shape
+(`notifyutil -1 <key> -s <key> 1 -g <key> -p <key>`, then a **fresh-process**
+`notifyutil -g <key>`):
+
+| Runtime           | DND key fresh readback | Unmanaged control key\* |
+| ----------------- | ---------------------- | ----------------------- |
+| iOS 16.4 (20E247) | `0` — reverted         | `1` — persisted         |
+| iOS 17.5 (21F79)  | `0` — reverted         | `1` — persisted         |
+| iOS 18.x / 26.x   | `0` — reverted         | `1` — persisted         |
+
+\* `com.apple.BiometricKit.enrollmentChanged`, set the same way in the same
+session. It persisting proves the `notifyutil` mechanism itself works and that
+the DND key specifically is being reclaimed.
+
+The result is identical at every version, so there is no working boundary to
+draw. An earlier `IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17`
+fast-path assumed iOS ≤17 still worked; it did not. iOS 15 could not be measured
+because **Xcode 26.3 offers no iOS 15 simulator runtime for download** — which
+also means current tooling cannot create an iOS 15 simulator at all, so the
+legacy path was unreachable in practice as well as wrong.
+
+### Behavior
+
+- **No command is issued.** Neither the read nor the write spawns `notifyutil`.
+  A read would return a falsehood and a write would be an unverifiable no-op, so
+  both return early with a structured, actionable error.
+- **`priority`/`alarms` are not silently downgraded.** They report
+  `requestedMode` with `capability: "unsupported"` and no `appliedMode`, rather
+  than claiming plain DND was applied.
+- **Unknown runtime versions report unsupported too.** The answer no longer
+  depends on resolving the simulator's iOS version, so no `simctl list devices`
+  probe is made.
+- Biometric enrollment still uses `notifyutil` and is unaffected — that key has
+  no daemon owner, which is exactly what the control column above demonstrates.
 
 ### Limitations
 
-- **Known iOS 18+ simulators: unsupported fast-path.** iOS 18 moved Do Not Disturb / Focus to the
-  private **`donotdisturbd`** daemon (a Core Data store + Focus-assertion model).
-  That daemon owns the legacy `com.apple.donotdisturb.enabled` notification and
-  immediately resets it to its authoritative value — verified empirically, a
-  `notifyutil -s` write reads back `0` from a fresh process even sub-second later
-  (an unmanaged notify key set the same way persists). So the legacy key neither
-  reflects nor controls the real Focus state: writes cannot verify and reads are a
-  confident falsehood. When the simulator's iOS major version is known from device
-  metadata or `simctl list devices <udid> --json`, iOS 18+ is treated as an
-  unsupported fast-path to avoid a known-dead probe. When the version is unknown
-  or expected to support the legacy path, `setDeviceState` still probes behavior:
-  if the fresh-process readback reverts, the result is `capability:
-"unsupported"` instead of a false success. On unknown runtimes, an off request
-  reading back disabled is not enough to prove capability, because reclaimed
-  runtimes also settle to `0`; positive enable persistence is the useful proof.
-  Apple exposes no public API to read or set Focus/DND. Use an iOS 17 or earlier
-  simulator with verified legacy behavior, or set it manually / via a Shortcuts
-  automation.
-- **Simulator only.** Physical iOS devices return `supported: false`,
-  `capability: "unsupported"`, and a specific error: iOS exposes **no public
-  API** to enable/disable Focus or Do Not Disturb (only the read-only Focus
-  Filter API), and Apple's device tooling (`devicectl`, XCUITest) ships no
-  DND/Focus setter.
+- **Physical devices carry their own error.** They also return
+  `supported: false`, `capability: "unsupported"`, but with a distinct message:
+  iOS exposes **no public API** to enable/disable Focus or Do Not Disturb (only
+  the read-only Focus Filter API), and Apple's device tooling (`devicectl`,
+  XCUITest) ships no DND/Focus setter. Simulators get the `donotdisturbd`
+  explanation above instead.
 - **Binary, not per-mode.** Since iOS 15, DND lives inside the private **Focus**
   framework. There is no per-mode (priority vs. alarms-only) Darwin notification
   analogous to Android's `zen_mode` integer, so iOS cannot be mapped to the

--- a/scripts/oxlint-baseline.txt
+++ b/scripts/oxlint-baseline.txt
@@ -81,7 +81,6 @@
 1	src/features/talkback/FocusNavigationExecutor.ts	eslint(max-depth)
 1	src/features/talkback/TalkBackTapStrategy.ts	eslint(complexity)
 1	src/features/telemetry/TelemetryEventBuffer.ts	eslint(complexity)
-1	src/features/utility/DeviceState.ts	eslint(complexity)
 1	src/features/utility/SystemConfigurationManager.ts	auto-mobile(catch-convention)
 1	src/features/utility/ios/IosNotificationAuthorizationReader.ts	auto-mobile(catch-convention)
 1	src/features/video/FfmpegVideoProcessingBackend.ts	eslint(complexity)

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -17,10 +17,6 @@ import {
   iosNotifyutilRegisteredSetReadPostCommand,
   parseNotifyutilState,
 } from "../../utils/ios-cmdline-tools/notifyutil";
-import {
-  iosMajorVersionFromSimctlListDevices,
-  parseIosMajorVersion,
-} from "../../utils/ios-cmdline-tools/iosVersion";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
@@ -94,8 +90,6 @@ export interface DeviceStateDependencies {
   timer?: Timer;
 }
 
-const IOS_DND_NOTIFICATION = "com.apple.donotdisturb.enabled";
-const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
 const IOS_BIOMETRIC_ENROLLMENT_NOTIFICATION = "com.apple.BiometricKit.enrollmentChanged";
 const IOS_BIOMETRICS_UNSUPPORTED_ERROR =
   "Biometric enrollment state can only be read or set on an iOS Simulator.";
@@ -104,37 +98,41 @@ const IOS_BIOMETRICS_UNSUPPORTED_ERROR =
  * Physical iOS devices expose no public API to enable/disable Focus or Do Not
  * Disturb. The only sanctioned app-side hook is the read-only Focus Filter API
  * (apps react to an active Focus, they cannot set one), and Apple's device
- * tooling (devicectl, XCUITest) ships no DND/Focus setter. DND automation is
- * therefore simulator-only.
+ * tooling (devicectl, XCUITest) ships no DND/Focus setter. Simulators are no
+ * better off (see IOS_SIM_DND_UNSUPPORTED_ERROR) — DND automation is
+ * unavailable on iOS entirely — but the two carry distinct errors so callers
+ * can tell a device limitation from a daemon-owned key.
  */
 const IOS_PHYSICAL_DND_UNSUPPORTED_ERROR =
   "Do Not Disturb cannot be set on a physical iOS device: iOS exposes no public API to " +
-  "enable/disable Focus or Do Not Disturb (only the read-only Focus Filter API). " +
-  "Use an iOS Simulator for DND automation, or trigger DND manually / via a Shortcuts automation on device.";
-
-/** Last iOS major version where the legacy binary-DND notification is expected to work. */
-const IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17;
+  "enable/disable Focus or Do Not Disturb (only the read-only Focus Filter API), and Apple's " +
+  "device tooling (devicectl, XCUITest) ships no DND/Focus setter. Trigger DND manually or via a " +
+  "Shortcuts automation on device.";
 
 /**
- * iOS 18 moved Do Not Disturb / Focus to the `com.apple.donotdisturbd` daemon
- * (private Core Data store + a Focus-assertion model). That daemon now owns the
- * legacy `com.apple.donotdisturb.enabled` Darwin notification and immediately
- * resets it to its authoritative value: empirically, a value posted via
- * `notifyutil -s` is read back as `0` from a fresh process even sub-second later,
- * while an unmanaged notify key (e.g. BiometricKit's) set the same way persists.
- * So the legacy key neither reflects nor controls the real Focus state — a write
- * cannot verify and a read is a confident falsehood (always `0`). Apple ships no
- * public API to read or set Focus/DND. The version check is only a fast-path:
- * legacy writes that are attempted must still prove persistence with an
- * independent fresh-process readback before reporting success.
+ * Do Not Disturb is unsupported on **every** iOS simulator runtime, not just
+ * iOS 18+. DND/Focus is owned by the private `com.apple.donotdisturbd` daemon,
+ * which shipped with Focus in iOS 15 and reclaims the legacy
+ * `com.apple.donotdisturb.enabled` Darwin notification: a value posted with the
+ * `notifyutil -1 -s -g -p` shape reads back as `0` from a fresh process, while
+ * an unmanaged notify key (BiometricKit's) set the very same way persists as
+ * `1`. So the legacy key neither reflects nor controls real Focus state — a
+ * write is an unverifiable no-op and a read is a confident falsehood.
+ *
+ * Empirically verified (issue #2862) on booted simulators, `donotdisturbd`
+ * running in each: **iOS 16.4 (20E247)** and **iOS 17.5 (21F79)** both revert
+ * the key while the control key persists, matching the previously-recorded
+ * iOS 18.x and 26.x behavior. iOS 15 could not be tested because Xcode 26.3
+ * offers no iOS 15 simulator runtime for download — which also means no iOS 15
+ * simulator can be created with current tooling, so the old `<= 17` legacy
+ * fast-path was unreachable in practice as well as wrong.
  */
-const IOS18_SIM_DND_UNSUPPORTED_ERROR =
-  "Do Not Disturb cannot be reliably read or set on an iOS 18+ simulator: iOS 18 moved Do Not " +
-  "Disturb to the donotdisturbd Focus daemon, which owns the state in a private store and resets " +
-  "the legacy com.apple.donotdisturb.enabled notification — so that notification neither reflects " +
+const IOS_SIM_DND_UNSUPPORTED_ERROR =
+  "Do Not Disturb cannot be read or set on an iOS simulator: Do Not Disturb is owned by the " +
+  "private donotdisturbd Focus daemon, which holds the state in its own store and resets the " +
+  "legacy com.apple.donotdisturb.enabled notification — so that notification neither reflects " +
   "nor controls the real Focus state. iOS exposes no public API to read or set Focus / Do Not " +
-  "Disturb. Use an iOS 17 or earlier simulator for binary DND automation, or set it manually / via " +
-  "a Shortcuts automation.";
+  "Disturb. Set it manually in the simulator, or via a Shortcuts automation.";
 
 function parseAndroidZenMode(raw: string): DoNotDisturbState {
   const value = raw.trim();
@@ -184,66 +182,6 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
         warning: `Unknown Android zen_mode value: ${value}`,
       };
   }
-}
-
-function iosDndStateFromNotifyutilOutput(raw: string): DoNotDisturbState {
-  const enabled = parseNotifyutilState(raw);
-  if (enabled === null) {
-    return {
-      supported: true,
-      capability: "binary",
-      method: "ios_simulator_notifyutil",
-      bestEffort: true,
-      rawValue: raw,
-      warning: "Could not parse iOS simulator Do Not Disturb notifyutil state",
-    };
-  }
-
-  return {
-    supported: true,
-    capability: "binary",
-    enabled,
-    mode: enabled ? "none" : "off",
-    rawValue: enabled ? "1" : "0",
-    method: "ios_simulator_notifyutil",
-    bestEffort: true,
-  };
-}
-
-function iosDndUnsupportedReadbackResult(
-  state: DoNotDisturbState,
-  requestedMode: DoNotDisturbMode,
-  requestedEnabled: boolean,
-  reason: string,
-): DoNotDisturbState {
-  const observed = state.enabled === undefined ? "unknown" : state.enabled ? "enabled" : "disabled";
-  const requested = requestedEnabled ? "enabled" : "disabled";
-  return {
-    ...state,
-    supported: false,
-    capability: "unsupported",
-    requestedMode,
-    verified: false,
-    bestEffort: true,
-    error: `iOS simulator Do Not Disturb write did not persist: independent notifyutil readback observed ${observed} after requesting ${requested}. ${reason}`,
-  };
-}
-
-/**
- * Builds the honest warning for an iOS simulator DND write when the binary
- * state verified, but the requested priority/alarms tier cannot be represented.
- */
-function iosDndSetWarning(
-  requestedMode: DoNotDisturbMode,
-  downgraded: boolean,
-): string | undefined {
-  if (downgraded) {
-    const tier =
-      `iOS DND is binary on the simulator; requested "${requestedMode}" has no per-mode/priority/alarms ` +
-      "fidelity (no public Focus API)";
-    return `${tier}, so it was applied as plain DND.`;
-  }
-  return undefined;
 }
 
 function modeForInput(input: SetDeviceStateInput["doNotDisturb"]): DoNotDisturbMode {
@@ -532,71 +470,18 @@ export class DeviceState {
   }
 
   private async getIosDoNotDisturb(): Promise<DoNotDisturbState> {
-    if (!isIosSimulatorDevice(this.device)) {
-      return {
-        supported: false,
-        capability: "unsupported",
-        error: IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
-      };
-    }
-
-    const simctl = this.simctl ?? new SimCtlClient(this.device);
-
-    // iOS 18+ simulators: the legacy key is owned/reset by donotdisturbd, so
-    // `notifyutil -g` always reads `0` regardless of the real Focus state. Report
-    // unsupported rather than a confident falsehood — symmetric with the write
-    // path. iOS <18 (and unknown) keep the legacy best-effort read below.
-    const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
-    if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
-      return {
-        supported: false,
-        capability: "unsupported",
-        error: IOS18_SIM_DND_UNSUPPORTED_ERROR,
-      };
-    }
-
-    try {
-      const result = await simctl.executeCommand(
-        iosNotifyutilGetCommand(this.device.deviceId, IOS_DND_NOTIFICATION),
-      );
-      return iosDndStateFromNotifyutilOutput(result.stdout ?? "");
-    } catch (error) {
-      return {
-        supported: true,
-        capability: "binary",
-        method: "ios_simulator_notifyutil",
-        bestEffort: true,
-        error: errorMessage(error),
-      };
-    }
-  }
-
-  /**
-   * Resolve the simulator's major iOS version. Prefers the version already on the
-   * `BootedDevice` (populated by the daemon device pool); falls back to a live
-   * `simctl list devices <udid> --json` probe. Returns `null` when the version
-   * cannot be determined, so callers treat it as "unknown". Non-iOS runtimes
-   * (visionOS/tvOS/watchOS simulators) also resolve to `null` and fall through to
-   * the harmless legacy path — they are not real DND targets.
-   */
-  private async resolveSimulatorIosMajorVersion(
-    simctl: IosSimulatorClient,
-  ): Promise<number | null> {
-    const fromDevice = parseIosMajorVersion(this.device.iosVersion ?? this.device.osVersion);
-    if (fromDevice !== null) {
-      return fromDevice;
-    }
-    try {
-      const result = await simctl.executeCommand(`list devices ${this.device.deviceId} --json`);
-      return iosMajorVersionFromSimctlListDevices(result.stdout ?? "", this.device.deviceId);
-    } catch (error) {
-      logger.warn(
-        `[DeviceState] could not resolve iOS version for ${this.device.deviceId}: ` +
-          `${errorMessage(error)}`,
-        error,
-      );
-      return null;
-    }
+    // No iOS target — simulator or physical — can report DND. Simulators are
+    // covered by IOS_SIM_DND_UNSUPPORTED_ERROR (donotdisturbd owns the legacy
+    // key on every obtainable runtime); physical devices have no public API at
+    // all. Neither issues a notifyutil read, because a read would return a
+    // confident falsehood (always `0`) rather than the real Focus state.
+    return {
+      supported: false,
+      capability: "unsupported",
+      error: isIosSimulatorDevice(this.device)
+        ? IOS_SIM_DND_UNSUPPORTED_ERROR
+        : IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
+    };
   }
 
   private async setIosDoNotDisturb(
@@ -604,122 +489,20 @@ export class DeviceState {
   ): Promise<DoNotDisturbState> {
     const requestedMode = modeForInput(input);
 
-    // Physical iOS devices: precise, structured "not supported and why" — there
-    // is no public API to set Focus/DND, so this is an early return with no write.
-    if (!isIosSimulatorDevice(this.device)) {
-      return {
-        supported: false,
-        capability: "unsupported",
-        requestedMode,
-        error: IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
-      };
-    }
-
-    const simctl = this.simctl ?? new SimCtlClient(this.device);
-
-    // Known iOS 18+ simulators skip the legacy probe as a fast-path optimization:
-    // the key is owned/reset by donotdisturbd there. Unknown and older runtimes
-    // still attempt the legacy path, then prove behavior with a fresh readback.
-    const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
-    const versionKnown = iosMajor !== null;
-    if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
-      return {
-        supported: false,
-        capability: "unsupported",
-        requestedMode,
-        verified: false,
-        error: IOS18_SIM_DND_UNSUPPORTED_ERROR,
-      };
-    }
-
-    // Simulator legacy path: the only lever is the binary `com.apple.donotdisturb.enabled`
-    // Darwin notification. The set command self-registers so keys without some
-    // other live owner are still writable in-process, but that same-invocation
-    // set/read/post is not authoritative: donotdisturbd can reclaim the key
-    // immediately, so success depends on the independent fresh-process readback below.
-    // There is no per-mode (priority/alarms) Darwin notification analogous to
-    // Android's `zen_mode` integer, so `priority`/`alarms` requests are applied
-    // as plain DND ("none") and reported honestly rather than silently claiming
-    // the tier was honored.
-    const requestedEnabled = requestedMode !== "off";
-    const appliedMode: DoNotDisturbMode = requestedEnabled ? "none" : "off";
-    const downgraded = requestedMode === "priority" || requestedMode === "alarms";
-
-    try {
-      const value = requestedEnabled ? "1" : "0";
-      const writeResult = await simctl.executeCommand(
-        iosNotifyutilRegisteredSetReadPostCommand(
-          this.device.deviceId,
-          IOS_DND_NOTIFICATION,
-          value,
-        ),
-        IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
-      );
-      const writeStderr = writeResult.stderr?.trim();
-      if (writeStderr) {
-        return {
-          supported: true,
-          capability: "binary",
-          requestedMode,
-          method: "ios_simulator_notifyutil",
-          bestEffort: true,
-          error: `notifyutil failed: ${writeStderr}`,
-        };
-      }
-
-      await this.timer.sleep(IOS_DND_INDEPENDENT_READBACK_SETTLE_MS);
-      const readbackResult = await simctl.executeCommand(
-        iosNotifyutilGetCommand(this.device.deviceId, IOS_DND_NOTIFICATION),
-      );
-      const state = iosDndStateFromNotifyutilOutput(readbackResult.stdout ?? "");
-      const stateMatches = state.enabled === requestedEnabled;
-      if (!stateMatches) {
-        return iosDndUnsupportedReadbackResult(
-          state,
-          requestedMode,
-          requestedEnabled,
-          "The runtime may reset the legacy com.apple.donotdisturb.enabled notification via donotdisturbd.",
-        );
-      }
-      if (!requestedEnabled && !versionKnown) {
-        return iosDndUnsupportedReadbackResult(
-          state,
-          requestedMode,
-          requestedEnabled,
-          "The simulator iOS version is unknown, and an off request reading back disabled does not prove the legacy DND notification can enable DND.",
-        );
-      }
-      // For priority/alarms we applied *a* DND state but NOT the requested tier,
-      // so verified is intentionally false: setState() will then report
-      // success:false, surfacing the unfulfillable request instead of hiding it.
-      const verified = stateMatches && !downgraded;
-
-      const warning = iosDndSetWarning(requestedMode, downgraded);
-
-      // Only assert an applied mode when the binary readback confirmed the
-      // requested enabled state. If it did not, we cannot claim plain DND was
-      // applied — leave `appliedMode` unset and let `mode`/`enabled` reflect
-      // what the readback actually observed (via the `...state` spread).
-      const appliedFields = stateMatches ? { appliedMode, mode: appliedMode } : {};
-
-      return {
-        ...state,
-        capability: "binary",
-        requestedMode,
-        ...appliedFields,
-        verified,
-        bestEffort: true,
-        ...(warning ? { warning } : {}),
-      };
-    } catch (error) {
-      return {
-        supported: true,
-        capability: "binary",
-        requestedMode,
-        method: "ios_simulator_notifyutil",
-        bestEffort: true,
-        error: errorMessage(error),
-      };
-    }
+    // Neither iOS simulators nor physical devices can have DND set. The legacy
+    // com.apple.donotdisturb.enabled notification is owned and reset by the
+    // donotdisturbd Focus daemon on every runtime we can obtain, so writing it
+    // would post a notification that changes nothing and cannot be verified.
+    // Return without issuing any notifyutil write rather than reporting a
+    // best-effort success that is really a no-op.
+    return {
+      supported: false,
+      capability: "unsupported",
+      requestedMode,
+      verified: false,
+      error: isIosSimulatorDevice(this.device)
+        ? IOS_SIM_DND_UNSUPPORTED_ERROR
+        : IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
+    };
   }
 }

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../src/features/utility/DeviceState";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
-import { FakeTimer } from "../../fakes/FakeTimer";
 
 const androidDevice: BootedDevice = {
   name: "Pixel",
@@ -14,7 +13,8 @@ const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
 };
 
-// iOS < 18 simulator: the legacy notifyutil binary-DND path still applies.
+// iOS 17 simulator. DND is unsupported here too (issue #2862) — this fixture now
+// only exercises the still-working biometric-enrollment notifyutil path.
 const iosSimulator: BootedDevice = {
   name: "iPhone 16",
   platform: "ios",
@@ -22,7 +22,7 @@ const iosSimulator: BootedDevice = {
   iosVersion: "17.5",
 };
 
-// iOS 18+ simulator: DND moved to donotdisturbd, so the write path must honestly
+// iOS 18+ simulator: DND is owned by donotdisturbd, so the write path must honestly
 // report unsupported instead of posting a non-authoritative legacy notification.
 const ios18Simulator: BootedDevice = {
   name: "iPhone 16 Pro",
@@ -31,13 +31,6 @@ const ios18Simulator: BootedDevice = {
   iosVersion: "18.6",
 };
 
-const IOS_SIMULATOR_DND_GET_COMMAND =
-  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled";
-const IOS_SIMULATOR_DND_SET_ON_COMMAND =
-  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled";
-const IOS_SIMULATOR_DND_SET_OFF_COMMAND =
-  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled";
-const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
 const IOS_BIOMETRIC_ENROLLMENT = "com.apple.BiometricKit.enrollmentChanged";
 const IOS_BIOMETRIC_GET_COMMAND =
   "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.BiometricKit.enrollmentChanged";
@@ -45,12 +38,6 @@ const IOS_BIOMETRIC_UNENROLL_COMMAND =
   "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.BiometricKit.enrollmentChanged -s com.apple.BiometricKit.enrollmentChanged 0 -g com.apple.BiometricKit.enrollmentChanged -p com.apple.BiometricKit.enrollmentChanged";
 const IOS18_BIOMETRIC_ENROLL_COMMAND =
   "spawn 7B3A3792-DB53-4654-BA94-27A1D305C3B7 notifyutil -1 com.apple.BiometricKit.enrollmentChanged -s com.apple.BiometricKit.enrollmentChanged 1 -g com.apple.BiometricKit.enrollmentChanged -p com.apple.BiometricKit.enrollmentChanged";
-
-function autoAdvanceTimer(): FakeTimer {
-  const timer = new FakeTimer();
-  timer.enableAutoAdvance();
-  return timer;
-}
 
 describe("DeviceState", () => {
   test("reads Android Do Not Disturb from zen_mode", async () => {
@@ -68,22 +55,6 @@ describe("DeviceState", () => {
       enabled: true,
       mode: "none",
       rawValue: "2",
-    });
-  });
-
-  test("reads iOS <18 simulator Do Not Disturb from the legacy notifyutil key", async () => {
-    const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl });
-    const result = await deviceState.getState();
-
-    expect(result.success).toBe(true);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      enabled: true,
-      bestEffort: true,
     });
   });
 
@@ -183,231 +154,6 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("sets iOS <18 simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    simctl.setCommandResult(IOS_SIMULATOR_DND_SET_ON_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      enabled: true,
-      mode: "none",
-      requestedMode: "none",
-      appliedMode: "none",
-      bestEffort: true,
-      verified: true,
-    });
-    expect(result.doNotDisturb?.warning).toBeUndefined();
-    expect(timer.getSleepHistory()).toEqual([IOS_DND_INDEPENDENT_READBACK_SETTLE_MS]);
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
-      {
-        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
-        timeoutMs: 5000,
-      },
-      {
-        command: IOS_SIMULATOR_DND_GET_COMMAND,
-        timeoutMs: undefined,
-      },
-    ]);
-  });
-
-  test("reports unsupported when an independent iOS simulator DND readback reverts", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    simctl.setCommandResult(IOS_SIMULATOR_DND_SET_ON_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 0\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: false,
-      capability: "unsupported",
-      enabled: false,
-      mode: "off",
-      requestedMode: "none",
-      verified: false,
-      bestEffort: true,
-    });
-    expect(result.error).toContain("independent notifyutil readback");
-    expect(result.error).toContain("donotdisturbd");
-    expect(timer.getSleepHistory()).toEqual([IOS_DND_INDEPENDENT_READBACK_SETTLE_MS]);
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
-      {
-        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
-        timeoutMs: 5000,
-      },
-      {
-        command: IOS_SIMULATOR_DND_GET_COMMAND,
-        timeoutMs: undefined,
-      },
-    ]);
-  });
-
-  test("sets iOS <18 simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    simctl.setCommandResult(
-      IOS_SIMULATOR_DND_SET_OFF_COMMAND,
-      "com.apple.donotdisturb.enabled 0\n",
-    );
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 0\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: false },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      enabled: false,
-      mode: "off",
-      requestedMode: "off",
-      appliedMode: "off",
-      bestEffort: true,
-      verified: true,
-    });
-    expect(result.doNotDisturb?.warning).toBeUndefined();
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
-      {
-        command: IOS_SIMULATOR_DND_SET_OFF_COMMAND,
-        timeoutMs: 5000,
-      },
-      {
-        command: IOS_SIMULATOR_DND_GET_COMMAND,
-        timeoutMs: undefined,
-      },
-    ]);
-  });
-
-  test("sets iOS simulator Do Not Disturb with a registered notifyutil set/read/post", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    simctl.setCommandResult(
-      IOS_SIMULATOR_DND_SET_ON_COMMAND,
-      "com.apple.donotdisturb.enabled 1\ncom.apple.donotdisturb.enabled\n",
-    );
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      enabled: true,
-      requestedMode: "none",
-      appliedMode: "none",
-      verified: true,
-    });
-  });
-
-  test("reports honest downgrade for iOS simulator priority/alarms (no silent tier claim)", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    // notifyutil reads back enabled, but the requested *tier* cannot be applied.
-    simctl.setCommandResult(IOS_SIMULATOR_DND_SET_ON_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { mode: "priority" },
-    });
-
-    // Honest contract: the requested tier was NOT applied, so success is false.
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      enabled: true,
-      mode: "none",
-      requestedMode: "priority",
-      appliedMode: "none",
-      bestEffort: true,
-      verified: false,
-    });
-    expect(result.doNotDisturb?.warning).toContain("binary");
-    expect(result.doNotDisturb?.warning).toContain("priority");
-    // We still posted the binary toggle (a DND state was applied, just not the tier).
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
-      {
-        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
-        timeoutMs: 5000,
-      },
-      {
-        command: IOS_SIMULATOR_DND_GET_COMMAND,
-        timeoutMs: undefined,
-      },
-    ]);
-  });
-
-  test("reports unsupported when priority/alarms DND fails independent binary readback", async () => {
-    const simctl = new FakeSimCtlClient();
-    const timer = autoAdvanceTimer();
-    // Fresh notifyutil reads back DISABLED even though we requested an enabled tier:
-    // the binary toggle itself did not verify, on top of the tier downgrade.
-    simctl.setCommandResult(IOS_SIMULATOR_DND_SET_ON_COMMAND, "com.apple.donotdisturb.enabled 1\n");
-    simctl.setCommandResult(IOS_SIMULATOR_DND_GET_COMMAND, "com.apple.donotdisturb.enabled 0\n");
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
-    const result = await deviceState.setState({
-      doNotDisturb: { mode: "alarms" },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: false,
-      capability: "unsupported",
-      enabled: false,
-      mode: "off",
-      requestedMode: "alarms",
-      verified: false,
-      bestEffort: true,
-    });
-    // The readback did not confirm the write, so we must NOT claim an applied
-    // mode; the reported mode reflects what the readback observed (off).
-    expect(result.doNotDisturb?.appliedMode).toBeUndefined();
-    expect(result.doNotDisturb?.mode).toBe("off");
-    expect(result.doNotDisturb?.error).toContain("independent notifyutil readback");
-    expect(result.doNotDisturb?.warning).toBeUndefined();
-  });
-
-  test("surfaces simctl errors without throwing out of setState", async () => {
-    const simctl = new FakeSimCtlClient();
-    simctl.setCommandError(IOS_SIMULATOR_DND_SET_ON_COMMAND, new Error("simctl spawn failed"));
-
-    const deviceState = new DeviceState(iosSimulator, { simctl, timer: autoAdvanceTimer() });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      requestedMode: "none",
-      bestEffort: true,
-      method: "ios_simulator_notifyutil",
-    });
-    expect(result.doNotDisturb?.error).toContain("simctl spawn failed");
-    expect(result.error).toContain("simctl spawn failed");
-  });
-
   test("reports iOS 18+ simulator DND enable as unsupported without issuing a notifyutil write", async () => {
     const simctl = new FakeSimCtlClient();
 
@@ -425,7 +171,6 @@ describe("DeviceState", () => {
     });
     // Honest, actionable reason: DND moved to donotdisturbd; no public setter.
     expect(result.doNotDisturb?.error).toContain("donotdisturbd");
-    expect(result.doNotDisturb?.error).toContain("iOS 18");
     expect(result.doNotDisturb?.error).toContain("no public API");
     expect(result.error).toContain("donotdisturbd");
     // Critically: no misleading notifyutil command was ever posted.
@@ -489,127 +234,88 @@ describe("DeviceState", () => {
     expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
   });
 
-  test("resolves the iOS major version from `osVersion` when `iosVersion` is absent", async () => {
-    const osVersionOnlySimulator: BootedDevice = {
-      name: "iPhone 16 Pro",
-      platform: "ios",
-      deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
-      osVersion: "18.0",
-    };
+  test("reads iOS simulator Do Not Disturb as unsupported without issuing a notifyutil read", async () => {
     const simctl = new FakeSimCtlClient();
 
-    const deviceState = new DeviceState(osVersionOnlySimulator, { simctl });
-    const result = await deviceState.setState({ doNotDisturb: { enabled: true } });
-
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb?.capability).toBe("unsupported");
-    // Resolved from the device field → no live `simctl list devices` probe needed.
-    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
-    expect(commands.some((c) => c.includes("list devices"))).toBe(false);
-    expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
-  });
-
-  test("resolves iOS 18+ live via `simctl list devices` when the device omits iosVersion", async () => {
-    const bareSimulator: BootedDevice = {
-      name: "iPhone 16 Pro",
-      platform: "ios",
-      deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
-    };
-    const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(
-      "list devices 7B3A3792-DB53-4654-BA94-27A1D305C3B7 --json",
-      JSON.stringify({
-        devices: {
-          "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [
-            {
-              udid: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
-              name: "iPhone 16 Pro",
-              state: "Booted",
-            },
-          ],
-        },
-      }),
-    );
-
-    const deviceState = new DeviceState(bareSimulator, { simctl });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.doNotDisturb?.capability).toBe("unsupported");
-    // The version was resolved via the list query; still no notifyutil write.
-    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
-    expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
-    expect(commands).toContain("list devices 7B3A3792-DB53-4654-BA94-27A1D305C3B7 --json");
-  });
-
-  test("falls back to the legacy notifyutil path when the iOS version cannot be resolved", async () => {
-    const bareSimulator: BootedDevice = {
-      name: "iPhone",
-      platform: "ios",
-      deviceId: "AAAAAAAA-1111-2222-3333-444444444444",
-    };
-    const simctl = new FakeSimCtlClient();
-    // No iosVersion on the device and the list query returns nothing usable →
-    // unknown version → attempt the legacy path rather than over-refusing.
-    simctl.setCommandResult(
-      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
-      "com.apple.donotdisturb.enabled 1\n",
-    );
-    simctl.setCommandResult(
-      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -g com.apple.donotdisturb.enabled",
-      "com.apple.donotdisturb.enabled 1\n",
-    );
-
-    const deviceState = new DeviceState(bareSimulator, { simctl, timer: autoAdvanceTimer() });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: true },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
-      enabled: true,
-      verified: true,
-    });
-    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
-    expect(commands.some((c) => c.includes("notifyutil"))).toBe(true);
-  });
-
-  test("does not claim unknown-runtime iOS DND off is verified when readback is already disabled", async () => {
-    const bareSimulator: BootedDevice = {
-      name: "iPhone",
-      platform: "ios",
-      deviceId: "AAAAAAAA-1111-2222-3333-444444444444",
-    };
-    const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(
-      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
-      "com.apple.donotdisturb.enabled 0\n",
-    );
-    simctl.setCommandResult(
-      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -g com.apple.donotdisturb.enabled",
-      "com.apple.donotdisturb.enabled 0\n",
-    );
-
-    const deviceState = new DeviceState(bareSimulator, { simctl, timer: autoAdvanceTimer() });
-    const result = await deviceState.setState({
-      doNotDisturb: { enabled: false },
-    });
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.getState();
 
     expect(result.success).toBe(false);
     expect(result.doNotDisturb).toMatchObject({
       supported: false,
       capability: "unsupported",
-      enabled: false,
-      mode: "off",
-      requestedMode: "off",
-      verified: false,
-      bestEffort: true,
     });
-    expect(result.error).toContain("does not prove");
+    // A `notifyutil -g` read would report `0` regardless of the real Focus
+    // state, so it is not issued at all.
+    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
+    expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("reports iOS simulator DND priority/alarms as unsupported, not a silent downgrade", async () => {
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({ doNotDisturb: { mode: "priority" } });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "priority",
+      verified: false,
+    });
+    // No applied tier is claimed, and no write is posted.
+    expect(result.doNotDisturb?.appliedMode).toBeUndefined();
+    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
+    expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
+  });
+
+  // Previously an unresolvable iOS version fell through to the legacy
+  // best-effort write. donotdisturbd owns the key on every runtime Xcode can
+  // install, so an unknown version must report unsupported rather than post a
+  // notification that cannot take effect.
+  test("reports unsupported for an iOS simulator whose version cannot be resolved", async () => {
+    const unknownVersionSimulator: BootedDevice = {
+      name: "iPhone",
+      platform: "ios",
+      deviceId: "12345678-1234-1234-1234-123456789ABC",
+    };
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(unknownVersionSimulator, { simctl });
+    const result = await deviceState.setState({ doNotDisturb: { enabled: true } });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "none",
+      verified: false,
+    });
+    const commands = simctl.getMethodCalls("executeCommand").map((c) => c.command as string);
+    expect(commands.some((c) => c.includes("notifyutil"))).toBe(false);
+    // No version probe is needed either — the answer no longer depends on it.
+    expect(commands.some((c) => c.includes("list devices"))).toBe(false);
+  });
+
+  // Empirically verified on booted simulators for issue #2862, `donotdisturbd`
+  // running in each: on **iOS 16.4 (20E247)** and **iOS 17.5 (21F79)** a value
+  // posted with the production `notifyutil -1 -s -g -p` shape reads back as `0`
+  // from a fresh process, while an unmanaged control key set the same way
+  // persists as `1` — matching the already-recorded iOS 18.x/26.x behavior. The
+  // old `<= 17` legacy fast-path was therefore wrong at every testable version.
+  test("reports DND unsupported without a simctl call for every iOS simulator major", async () => {
+    for (const iosVersion of ["16.4", "17.5", "18.6", "26.2"]) {
+      const simctl = new FakeSimCtlClient();
+      const deviceState = new DeviceState({ ...iosSimulator, iosVersion }, { simctl });
+
+      const read = await deviceState.getState();
+      const write = await deviceState.setState({ doNotDisturb: { enabled: true } });
+
+      expect(read.doNotDisturb?.capability).toBe("unsupported");
+      expect(write.doNotDisturb?.capability).toBe("unsupported");
+      expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    }
   });
 
   test("reports physical iOS as unsupported with a precise no-public-API error", async () => {


### PR DESCRIPTION
Closes #2862

## What this verifies

#2862 asked whether the legacy `com.apple.donotdisturb.enabled` notifyutil path
actually works on iOS ≤17 simulators, since `donotdisturbd` has existed since
iOS 15 and the `> 17` unsupported boundary was never empirically checked.

**It does not work.** Measured on booted simulators, `donotdisturbd` confirmed
running in each (`launchctl list`), using the exact production command shape
from `iosNotifyutilRegisteredSetReadPostCommand` —
`notifyutil -1 <key> -s <key> 1 -g <key> -p <key>`, then a **fresh-process**
`notifyutil -g <key>`:

| Runtime | DND key fresh readback | Unmanaged control key\* |
| --- | --- | --- |
| iOS 16.4 (20E247) | `0` — reverted | `1` — persisted |
| iOS 17.5 (21F79) | `0` — reverted | `1` — persisted |
| iOS 18.x / 26.x | `0` — reverted (already recorded in #2856) | `1` — persisted |

\* `com.apple.BiometricKit.enrollmentChanged`, set the same way in the same
session. It persisting proves the notifyutil mechanism itself works on that
runtime and that the DND key **specifically** is being reclaimed — this rules
out "the command shape is wrong" as an explanation.

Reproduced twice on 17.5, and again with a 5-second settle instead of 1s, to
rule out a timing artifact.

### iOS 15

Not measurable: **Xcode 26.3 offers no iOS 15 simulator runtime for download**
(`xcodebuild -downloadPlatform iOS -buildVersion 15.0/15.2/15.4/15.5` → "not
available for download"). That also means current tooling cannot create an iOS
15 simulator at all — so the old `<= 17` legacy fast-path was unreachable in
practice as well as wrong. 16.4 is the oldest obtainable runtime, and it is
already dead.

## What changed

Per the issue's second acceptance option ("remove the legacy path entirely and
report unsupported for all iOS simulators"), since the result is identical at
every testable version and there is no working boundary left to draw:

- `IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR` and the version-gated
  fast-path are gone. `getIosDoNotDisturb` / `setIosDoNotDisturb` both return
  `capability: "unsupported"` **without spawning notifyutil** — a read would be
  a confident falsehood (always `0`), a write an unverifiable no-op.
- Simulator and physical devices keep **distinct** errors, so callers can tell a
  device limitation from a daemon-owned key.
- `priority`/`alarms` report `requestedMode` with no `appliedMode` instead of
  claiming plain DND was applied.
- An unresolvable iOS version no longer falls through to a legacy write, and no
  longer needs a `simctl list devices` probe — the answer doesn't depend on it.
- Dead helpers removed (`iosDndStateFromNotifyutilOutput`,
  `iosDndUnsupportedReadbackResult`, `iosDndSetWarning`,
  `resolveSimulatorIosMajorVersion`) — this drops DeviceState.ts off the oxlint
  complexity baseline (the only baseline line touched; the rest of that file is
  stale vs. main and deliberately left alone so it doesn't mask other work).
- **Biometric enrollment is untouched** and still uses notifyutil — that key has
  no daemon owner, which is exactly what the control column above demonstrates.
- `docs/design-docs/plat/ios/simctl.md` rewritten with the measurement table.

## Parity note

Android keeps full four-tier `zen_mode` support; iOS now honestly reports
`unsupported` on both platformsides rather than a best-effort no-op. The
asymmetry is real and is now reported rather than papered over.

## Validation

- `bun test` — 14625 pass, 0 fail
- `bun run lint` — ratchet gate clean, boundary-checks 13/13
- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- `turbo run build` — success

## Manual verification needed

The behavior change itself is fully unit-tested with fakes, and the empirical
claims above were measured on real simulators on a macOS host. Two residuals a
human may want to confirm:

1. **iOS 15** is asserted-unsupported by inference (donotdisturbd shipped with
   Focus in iOS 15; 16.4 and 17.5 both reclaim the key), not by measurement,
   because the runtime cannot be downloaded on Xcode 26. If anyone has an
   older Xcode with an iOS 15 runtime, that is the one gap.
2. This removes a previously-advertised capability. If any consumer depended on
   `capability: "binary"` for iOS, it now gets `"unsupported"` — intended, but
   worth a maintainer's eye.

Two runtimes (~20 GB) were downloaded onto the host Mac to run this. They are
left installed since they are useful for future simulator-parity work; remove
with `xcrun simctl runtime delete <build>` if unwanted.
