### PR TITLE
fix(tap): prioritize exact cross-window text matches

### DIFF
--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -336,16 +336,9 @@ export class DefaultElementFinder implements ElementFinder {
     return isClickableElementProperties(props);
   }
 
-  private selectAndRankTextMatches(matches: {
-    exactMatches: Element[];
-    partialMatches: Element[];
-  }): Element[] {
-    const selectedMatches =
-      matches.exactMatches.length > 0 ? matches.exactMatches : matches.partialMatches;
-    selectedMatches.sort(
-      (a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)),
-    );
-    return selectedMatches;
+  private rankTextMatches(matches: Element[]): Element[] {
+    matches.sort((a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)));
+    return matches;
   }
 
   private isCollectionNode(props: Record<string, unknown>): boolean {
@@ -449,8 +442,10 @@ export class DefaultElementFinder implements ElementFinder {
       return [mainMatches, ...windowMatches].flatMap((matches) => matches.partialMatches);
     }
 
-    return [...windowMatches, mainMatches].flatMap((matches) =>
-      this.selectAndRankTextMatches(matches),
+    const matchesByWindowOrder = [...windowMatches, mainMatches];
+    const hasExactMatches = matchesByWindowOrder.some((matches) => matches.exactMatches.length > 0);
+    return matchesByWindowOrder.flatMap((matches) =>
+      this.rankTextMatches(hasExactMatches ? matches.exactMatches : matches.partialMatches),
     );
   }
 

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -169,6 +169,60 @@ describe("DefaultElementSelector", () => {
     expect(match.totalMatches).toBe(2);
   });
 
+  test("prefers an exact main-hierarchy match over a partial overlay match", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const viewHierarchy = {
+      hierarchy: {
+        node: {
+          $: {
+            bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+            class: "XCUIElementTypeWindow",
+          },
+          node: [
+            {
+              $: {
+                bounds: { left: 10, top: 10, right: 90, bottom: 40 },
+                class: "XCUIElementTypeButton",
+                text: "Delete",
+                actions: ["click"],
+              },
+            },
+          ],
+        },
+      },
+      windows: [
+        {
+          windowLayer: 1,
+          hierarchy: {
+            node: {
+              $: {
+                bounds: { left: 0, top: 80, right: 100, bottom: 100 },
+                class: "XCUIElementTypeOther",
+              },
+              node: [
+                {
+                  $: {
+                    bounds: { left: 10, top: 82, right: 90, bottom: 98 },
+                    class: "XCUIElementTypeStaticText",
+                    text: "Delete all files",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      screenWidth: 100,
+      screenHeight: 100,
+    } as unknown as ViewHierarchyResult;
+
+    const match = selector.selectByText(viewHierarchy, "Delete");
+
+    expect(match.element?.class).toBe("XCUIElementTypeButton");
+    expect(match.element?.text).toBe("Delete");
+    expect(match.totalMatches).toBe(1);
+  });
+
   test("first strategy skips off-screen matches before selecting", () => {
     const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
     const viewHierarchy = createViewHierarchy([


### PR DESCRIPTION
## Summary

Restore the default text-selection invariant that an exact match anywhere in the view hierarchy takes precedence over partial substring matches. Window z-order remains the tie-breaker within the selected match type, and clickable nodes remain preferred within each window.

## Linked Issue

Closes [#5773](https://github.com/kaeawc/auto-mobile/issues/5773)

## Bug / Regression Context

- **Prior attempts:** [#5759](https://github.com/kaeawc/auto-mobile/pull/5759) preserved window z-order but selected exact-or-partial matches independently per window.
- **Observed symptom:** A static overlay label such as `Delete all files` could be selected before an exact, clickable `Delete` control in the main hierarchy.
- **Repro steps / conditions:** Call default `selectByText("Delete")` with the partial match in an overlay window and the exact control in the main hierarchy.

## Validation

- [x] Focused `DefaultElementSelector` and `ElementFinder` tests (65 tests)
- [x] `bun test`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] `scripts/all_fast_validate_checks.sh`: 33/34 checks passed; the unrelated Kotlin formatter environment check failed because the installed `ktfmt` reports `unknown` instead of the required `0.64`. No Kotlin files changed.
- [x] Rebased onto current `main`
- [x] No new dependencies, interfaces, timers, or generic helpers
