### PR TITLE
fix(ios): handle trailing newlines in missing defaults errors

### DIFF
--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -712,7 +712,7 @@ function looksLikeMissingAndroidPrefsFile(error: unknown): boolean {
 }
 
 function looksLikeMissingIosDefault(error: unknown): boolean {
-  const message = errorMessage(error);
+  const message = errorMessage(error).trim();
   return [
     /The domain\/default pair of \([^)]+\) does not exist\.?$/i,
     /Domain [^\n]+ does not exist\.?$/i,

--- a/test/features/preferences/AppPreferences.test.ts
+++ b/test/features/preferences/AppPreferences.test.ts
@@ -791,11 +791,13 @@ describe("AppPreferences", () => {
     });
   });
 
-  test("returns a not-found result when iOS defaults reports a missing key", async () => {
+  test("returns a not-found result for multiline defaults missing-key stderr", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandError(
       "spawn 12345678-1234-1234-1234-123456789ABC defaults read com.example.app missingKey",
-      new Error("The domain/default pair of (com.example.app, missingKey) does not exist"),
+      new Error(
+        "Command failed:\nxcrun simctl spawn 12345678-1234-1234-1234-123456789ABC defaults read com.example.app missingKey\n2026-08-26 20:58:25.401 defaults[57675:53795649]\nThe domain/default pair of (com.example.app, missingKey) does not exist\n",
+      ),
     );
 
     const preferences = new AppPreferences(iosSimulator, { simctl });
@@ -812,6 +814,35 @@ describe("AppPreferences", () => {
       key: "missingKey",
     });
     expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(1);
+  });
+
+  test("falls back to a string when multiline defaults read-type stderr reports a missing key", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC defaults read com.example.app missingType",
+      "fallback value\n",
+    );
+    simctl.setCommandError(
+      "spawn 12345678-1234-1234-1234-123456789ABC defaults read-type com.example.app missingType",
+      new Error(
+        "Command failed:\nxcrun simctl spawn 12345678-1234-1234-1234-123456789ABC defaults read-type com.example.app missingType\n2026-08-26 20:58:25.401 defaults[57675:53795649]\nThe domain/default pair of (com.example.app, missingType) does not exist\n",
+      ),
+    );
+
+    const preferences = new AppPreferences(iosSimulator, { simctl });
+    const result = await preferences.getPreference({
+      scope: "userDefaults",
+      appId: "com.example.app",
+      key: "missingType",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      found: true,
+      value: "fallback value",
+      type: "string",
+    });
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(2);
   });
 
   test("surfaces an invalid simulator instead of reporting a missing iOS default", async () => {


### PR DESCRIPTION
## Summary
- Normalize iOS `defaults` error text before matching missing-key diagnostics.
- Return the documented not-found result when `simctl` stderr has its trailing newline; preserve string fallback for a missing type probe.

## Root cause
Anchored missing-default patterns did not match `defaults` stderr when it ended with a newline, so ordinary missing keys were surfaced as MCP errors.

## Validation
- `bun test test/features/preferences/AppPreferences.test.ts`
- `bun run format:check -- src/features/preferences/AppPreferences.ts test/features/preferences/AppPreferences.test.ts`
- `bun run lint`
- `bun run build`
- `bun run typecheck`

Repository-wide `bun test --isolate` was started through `bun run turbo:validate`, but was stopped after 13 minutes without new output while unrelated concurrent worktrees were also CPU-saturating full test processes.

Closes [#5763](https://github.com/kaeawc/auto-mobile/issues/5763).
