### PR TITLE
feat(observe): expose display cutout state

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -3146,6 +3146,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val allWindows = windows
     val rootNode = rootInActiveWindow
     val screenDimensions = getScreenDimensions()
+    val insets = getObservationInsets(screenDimensions)
 
     if (allWindows.isNullOrEmpty() && rootNode == null) {
       return null
@@ -3182,10 +3183,17 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         rotationAtCaptureStart,
         getRotationOrNull(),
       )
-    // The ADB EXTRACT_HIERARCHY route must carry the #4548 scale metadata too (this route does not
-    // add the other device metadata, but the daemon retains scale metadata off any route).
-    val hierarchyWithScaleMetadata =
-      withScaleMetadata(hierarchy?.copy(rotation = rotation), screenDimensions)
+    // The ADB EXTRACT_HIERARCHY route carries the same coordinate metadata as the direct path so
+    // fallback observations retain their typed insets and display-cutout state.
+    val enriched =
+      hierarchy?.copy(
+        screenWidth = screenDimensions?.width,
+        screenHeight = screenDimensions?.height,
+        rotation = rotation,
+        systemInsets = legacySystemInsets(insets),
+        insets = insets,
+      )
+    val hierarchyWithScaleMetadata = withScaleMetadata(enriched, screenDimensions)
     if (hierarchyWithScaleMetadata != null && contextAtExtractionStart == currentFrameContext()) {
       extractedHierarchyFrameContexts[hierarchyWithScaleMetadata] = contextAtExtractionStart
     }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -31,6 +31,9 @@ import android.view.View
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.DisplayCutoutBoundsInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.DisplayCutoutClassifier
+import dev.jasonpearson.automobile.ctrlproxy.models.DisplayCutoutInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.FrameMetricsSnapshot
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
@@ -2667,14 +2670,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       right = insets.right,
     )
 
+  private fun toDisplayCutoutBoundsInfo(bounds: Rect): DisplayCutoutBoundsInfo =
+    DisplayCutoutBoundsInfo(
+      left = bounds.left,
+      top = bounds.top,
+      right = bounds.right,
+      bottom = bounds.bottom,
+    )
+
   /** Get typed current-window inset metadata for coordinate and layout inspection. */
   @Suppress("DEPRECATION")
-  private fun getObservationInsets(): ObservationInsetsInfo {
+  private fun getObservationInsets(screenDimensions: ScreenDimensions?): ObservationInsetsInfo {
     return try {
       val windowManager = getSystemService(Context.WINDOW_SERVICE) as? WindowManager
       if (windowManager != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         val metrics = windowManager.currentWindowMetrics
         val windowInsets = metrics.windowInsets
+        val displayCutoutInsets =
+          toSystemInsetsInfo(
+            windowInsets.getInsetsIgnoringVisibility(android.view.WindowInsets.Type.displayCutout())
+          )
+        val displayCutoutBounds =
+          windowInsets.displayCutout?.boundingRects?.map(::toDisplayCutoutBoundsInfo).orEmpty()
         ObservationInsetsInfo(
           systemBars =
             SystemBarsInsetsInfo(
@@ -2689,11 +2706,18 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   )
                 ),
             ),
-          displayCutout =
-            toSystemInsetsInfo(
-              windowInsets.getInsetsIgnoringVisibility(
-                android.view.WindowInsets.Type.displayCutout()
-              )
+          displayCutout = displayCutoutInsets,
+          displayCutoutState =
+            DisplayCutoutInfo(
+              classification =
+                DisplayCutoutClassifier.classify(
+                  bounds = displayCutoutBounds,
+                  screen =
+                    screenDimensions
+                      ?: ScreenDimensions(metrics.bounds.width(), metrics.bounds.height()),
+                  cutoutInsets = displayCutoutInsets,
+                ),
+              bounds = displayCutoutBounds,
             ),
           systemGestures =
             toSystemInsetsInfo(
@@ -2903,7 +2927,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val capturedRootPackage = rootNode?.packageName?.toString()
     val capturedWindowClass = lastWindowClassName
     val screenDimensions = getScreenDimensions()
-    val insets = getObservationInsets()
+    val insets = getObservationInsets(screenDimensions)
 
     if (allWindows.isNullOrEmpty() && rootNode == null) {
       Log.w(TAG, "No windows or root node available for extraction")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/SystemInsetsInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/SystemInsetsInfo.kt
@@ -48,6 +48,96 @@ data class SystemChromeInfo(
   }
 }
 
+/** A non-functional display region in the observation's physical-pixel coordinate space. */
+@Serializable
+data class DisplayCutoutBoundsInfo(
+  val left: Int,
+  val top: Int,
+  val right: Int,
+  val bottom: Int,
+) {
+  val width: Int
+    get() = right - left
+
+  val height: Int
+    get() = bottom - top
+}
+
+/** Display-cutout classification and, when available, its observed non-functional regions. */
+@Serializable
+data class DisplayCutoutInfo(
+  val classification: String,
+  val bounds: List<DisplayCutoutBoundsInfo>? = null,
+) {
+  companion object {
+    val unknown = DisplayCutoutInfo(classification = "unknown")
+  }
+}
+
+/** Conservative, geometry-only classification for Android DisplayCutout regions. */
+object DisplayCutoutClassifier {
+  private const val EDGE_TOLERANCE_PX = 1
+  private const val MAX_COMPACT_SIZE_RATIO = 0.18
+  private const val MAX_COMPACT_ASPECT_RATIO = 1.6
+  private const val MIN_NOTCH_EDGE_RATIO = 0.22
+  private const val MAX_NOTCH_DEPTH_RATIO = 0.12
+  private const val MIN_NOTCH_ASPECT_RATIO = 2.0
+
+  fun classify(
+    bounds: List<DisplayCutoutBoundsInfo>,
+    screen: ScreenDimensions,
+    cutoutInsets: SystemInsetsInfo,
+  ): String {
+    if (bounds.isEmpty()) {
+      return if (cutoutInsets == SystemInsetsInfo()) "none" else "unknown"
+    }
+    if (!screen.isValid()) return "unknown"
+
+    val classifications = bounds.map { classifyRegion(it, screen) }
+    return when {
+      classifications.all { it == "hole_punch" } -> "hole_punch"
+      classifications.all { it == "notch" } -> "notch"
+      else -> "unknown"
+    }
+  }
+
+  private fun classifyRegion(
+    bounds: DisplayCutoutBoundsInfo,
+    screen: ScreenDimensions,
+  ): String {
+    val horizontalEdge =
+      when {
+        bounds.top <= EDGE_TOLERANCE_PX -> true
+        bounds.bottom >= screen.height - EDGE_TOLERANCE_PX -> true
+        else -> false
+      }
+    val verticalEdge =
+      when {
+        bounds.left <= EDGE_TOLERANCE_PX -> true
+        bounds.right >= screen.width - EDGE_TOLERANCE_PX -> true
+        else -> false
+      }
+    if (horizontalEdge == verticalEdge || bounds.width <= 0 || bounds.height <= 0) return "unknown"
+
+    val edgeLength = if (horizontalEdge) screen.width else screen.height
+    val perpendicularLength = if (horizontalEdge) screen.height else screen.width
+    val alongEdge = if (horizontalEdge) bounds.width else bounds.height
+    val depth = if (horizontalEdge) bounds.height else bounds.width
+    val aspectRatio = alongEdge.toDouble() / depth
+    val compactSize = maxOf(bounds.width, bounds.height).toDouble()
+    val shortestScreenEdge = minOf(screen.width, screen.height).toDouble()
+
+    return when {
+      compactSize <= shortestScreenEdge * MAX_COMPACT_SIZE_RATIO &&
+        aspectRatio <= MAX_COMPACT_ASPECT_RATIO -> "hole_punch"
+      alongEdge >= edgeLength * MIN_NOTCH_EDGE_RATIO &&
+        depth <= perpendicularLength * MAX_NOTCH_DEPTH_RATIO &&
+        aspectRatio >= MIN_NOTCH_ASPECT_RATIO -> "notch"
+      else -> "unknown"
+    }
+  }
+}
+
 /** Complete, typed inset snapshot captured with an accessibility hierarchy. */
 @Serializable
 data class ObservationInsetsInfo(
@@ -56,6 +146,7 @@ data class ObservationInsetsInfo(
   val units: String = "physical-pixels",
   val systemBars: SystemBarsInsetsInfo? = null,
   val displayCutout: SystemInsetsInfo? = null,
+  val displayCutoutState: DisplayCutoutInfo = DisplayCutoutInfo.unknown,
   val systemGestures: SystemInsetsInfo? = null,
   val mandatorySystemGestures: SystemInsetsInfo? = null,
   val tappableElement: SystemInsetsInfo? = null,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/DisplayCutoutClassifierTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/DisplayCutoutClassifierTest.kt
@@ -1,0 +1,80 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.DisplayCutoutBoundsInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.DisplayCutoutClassifier
+import dev.jasonpearson.automobile.ctrlproxy.models.ScreenDimensions
+import dev.jasonpearson.automobile.ctrlproxy.models.SystemInsetsInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DisplayCutoutClassifierTest {
+  @Test
+  fun `classifies an empty cutout with zero insets as none`() {
+    assertEquals(
+      "none",
+      DisplayCutoutClassifier.classify(
+        bounds = emptyList(),
+        screen = ScreenDimensions(width = 1080, height = 2400),
+        cutoutInsets = SystemInsetsInfo(),
+      ),
+    )
+  }
+
+  @Test
+  fun `classifies a wide top cutout as a notch`() {
+    assertEquals(
+      "notch",
+      DisplayCutoutClassifier.classify(
+        bounds = listOf(DisplayCutoutBoundsInfo(left = 380, top = 0, right = 700, bottom = 80)),
+        screen = ScreenDimensions(width = 1080, height = 2400),
+        cutoutInsets = SystemInsetsInfo(top = 80),
+      ),
+    )
+  }
+
+  @Test
+  fun `classifies a compact edge cutout as a hole punch`() {
+    assertEquals(
+      "hole_punch",
+      DisplayCutoutClassifier.classify(
+        bounds = listOf(DisplayCutoutBoundsInfo(left = 510, top = 0, right = 570, bottom = 60)),
+        screen = ScreenDimensions(width = 1080, height = 2400),
+        cutoutInsets = SystemInsetsInfo(top = 60),
+      ),
+    )
+  }
+
+  @Test
+  fun `classifies rotated notch geometry in current screen coordinates`() {
+    assertEquals(
+      "notch",
+      DisplayCutoutClassifier.classify(
+        bounds = listOf(DisplayCutoutBoundsInfo(left = 0, top = 380, right = 80, bottom = 700)),
+        screen = ScreenDimensions(width = 2400, height = 1080),
+        cutoutInsets = SystemInsetsInfo(left = 80),
+      ),
+    )
+  }
+
+  @Test
+  fun `keeps unsupported Dynamic Island-like and unavailable metadata unknown`() {
+    val screen = ScreenDimensions(width = 1170, height = 2532)
+
+    assertEquals(
+      "unknown",
+      DisplayCutoutClassifier.classify(
+        bounds = listOf(DisplayCutoutBoundsInfo(left = 410, top = 40, right = 760, bottom = 130)),
+        screen = screen,
+        cutoutInsets = SystemInsetsInfo(top = 130),
+      ),
+    )
+    assertEquals(
+      "unknown",
+      DisplayCutoutClassifier.classify(
+        bounds = emptyList(),
+        screen = screen,
+        cutoutInsets = SystemInsetsInfo(top = 80),
+      ),
+    )
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyScaleMetadataTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyScaleMetadataTest.kt
@@ -148,7 +148,19 @@ class ViewHierarchyScaleMetadataTest {
     )
     assertTrue(
       "ADB fallback must stamp only a stable rotation onto its hierarchy",
-      "hierarchy?.copy(rotation = rotation)" in body,
+      "rotation = rotation" in body,
+    )
+    assertTrue(
+      "ADB fallback must capture typed insets against the same screen dimensions",
+      "val insets = getObservationInsets(screenDimensions)" in body,
+    )
+    assertTrue(
+      "ADB fallback must preserve legacy system insets for compatibility",
+      "systemInsets = legacySystemInsets(insets)" in body,
+    )
+    assertTrue(
+      "ADB fallback must retain typed insets and display-cutout state",
+      "insets = insets" in body,
     )
   }
 

--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -45,6 +45,16 @@ an app request, not proof that the home indicator is currently hidden. Older And
 and iOS apps built with an older AutoMobile SDK omit `systemChrome`, so clients must treat its
 absence as unknown rather than inferring it from zero insets.
 
+`insets.displayCutoutState` is additive, platform-neutral metadata for the active display treatment.
+Its `classification` is one of `none`, `notch`, `dynamic_island`, `hole_punch`, or `unknown`.
+Android uses `DisplayCutout` regions to report `bounds` in the same physical-pixel coordinate space
+and current orientation as `screenSize` and hierarchy bounds; it returns `unknown` for ambiguous
+or unavailable cutout metadata. iOS has no public cutout-shape API, so it returns explicit `unknown`
+and omits `bounds`, even where safe-area values are present. `dynamic_island` is reserved for a
+future platform source that can determine it reliably. Older runners omit `displayCutoutState`
+entirely, which clients must likewise treat as unknown. The legacy `insets.displayCutout` edge
+insets remain available for safe-area layout auditing and do not classify the cutout shape.
+
 The observation gracefully handles various error conditions:
 
 - Screen off or device locked states

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -1111,12 +1111,27 @@ public struct EdgeInsetsInfo: Codable, Sendable {
     public let left: Double
 }
 
+public struct DisplayCutoutBoundsInfo: Codable, Sendable {
+    public let left: Double
+    public let top: Double
+    public let right: Double
+    public let bottom: Double
+}
+
+public struct DisplayCutoutInfo: Codable, Sendable {
+    public let classification: String
+    public let bounds: [DisplayCutoutBoundsInfo]?
+
+    public static let unknown = DisplayCutoutInfo(classification: "unknown", bounds: nil)
+}
+
 public struct ObservationInsetsInfo: Codable, Sendable {
     public let available: Bool
     public let source: String
     public let units: String
     public let safeArea: EdgeInsetsInfo?
     public let systemChrome: SystemChromeInfo?
+    public var displayCutoutState: DisplayCutoutInfo = .unknown
 
     public static let unavailable = ObservationInsetsInfo(
         available: false,

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -159,6 +159,26 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertEqual(result.insets.systemChrome?.statusBar, "hidden")
         XCTAssertEqual(result.insets.systemChrome?.homeIndicatorAutoHideRequested, true)
         XCTAssertEqual(result.insets.systemChrome?.source, "ios-status-bar-manager")
+        XCTAssertEqual(result.insets.displayCutoutState.classification, "unknown")
+        XCTAssertNil(result.insets.displayCutoutState.bounds)
+    }
+
+    func testIosSafeAreaDoesNotInferDynamicIslandCutout() {
+        let hierarchy = makeHierarchy(root: makeElement(text: "Hello"))
+        let sdkHierarchy = SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: "com.test.app",
+            screenScale: 3.0,
+            screenWidth: 393,
+            screenHeight: 852,
+            safeAreaInsets: SdkEdgeInsets(top: 59, right: 0, bottom: 34, left: 0),
+            root: nil
+        )
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+
+        XCTAssertEqual(result.insets.displayCutoutState.classification, "unknown")
+        XCTAssertNil(result.insets.displayCutoutState.bounds)
     }
 
     func testMergeChromeOnlySdkPayloadPreservesUnavailableInsetMetadata() {
@@ -191,6 +211,8 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertEqual(result.insets.source, "unavailable")
         XCTAssertEqual(result.insets.units, "unknown")
         XCTAssertNil(result.insets.safeArea)
+        XCTAssertEqual(result.insets.displayCutoutState.classification, "unknown")
+        XCTAssertNil(result.insets.displayCutoutState.bounds)
         XCTAssertEqual(result.insets.systemChrome?.visibility, "hidden")
     }
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3519,6 +3519,39 @@
                 }
               ]
             },
+            "displayCutoutState": {
+              "type": "object",
+              "properties": {
+                "classification": {
+                  "type": "string",
+                  "enum": ["none", "notch", "dynamic_island", "hole_punch", "unknown"]
+                },
+                "bounds": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "required": ["left", "top", "right", "bottom"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["classification"],
+              "additionalProperties": false
+            },
             "systemGestures": {
               "anyOf": [
                 {
@@ -4126,6 +4159,39 @@
                       "type": "null"
                     }
                   ]
+                },
+                "displayCutoutState": {
+                  "type": "object",
+                  "properties": {
+                    "classification": {
+                      "type": "string",
+                      "enum": ["none", "notch", "dynamic_island", "hole_punch", "unknown"]
+                    },
+                    "bounds": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "left": {
+                            "type": "number"
+                          },
+                          "top": {
+                            "type": "number"
+                          },
+                          "right": {
+                            "type": "number"
+                          },
+                          "bottom": {
+                            "type": "number"
+                          }
+                        },
+                        "required": ["left", "top", "right", "bottom"],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": ["classification"],
+                  "additionalProperties": false
                 },
                 "systemGestures": {
                   "anyOf": [

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -13,6 +13,28 @@ export interface ObservationSystemBarsInsets {
   stable: ObservationEdgeInsets;
 }
 
+export type DisplayCutoutClassification =
+  | "none"
+  | "notch"
+  | "dynamic_island"
+  | "hole_punch"
+  | "unknown";
+
+/** A non-functional display region in the observation's screen coordinate space. */
+export interface DisplayCutoutBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** Display-cutout classification and, when available, its observed non-functional regions. */
+export interface ObservationDisplayCutout {
+  classification: DisplayCutoutClassification;
+  /** Omitted when the platform cannot provide geometry. */
+  bounds?: DisplayCutoutBounds[];
+}
+
 /**
  * Current system-chrome visibility for the foreground app window. It describes
  * presentation state only; edge-to-edge layout remains an independent choice.
@@ -39,7 +61,10 @@ export interface ObservationInsets {
     | "unavailable";
   units: "physical-pixels" | "points" | "unknown";
   systemBars?: ObservationSystemBarsInsets;
+  /** Legacy edge insets for display cutouts, retained for safe-area auditing. */
   displayCutout?: ObservationEdgeInsets;
+  /** Additive platform-neutral cutout state; absence means an older runner. */
+  displayCutoutState?: ObservationDisplayCutout;
   systemGestures?: ObservationEdgeInsets;
   mandatorySystemGestures?: ObservationEdgeInsets;
   tappableElement?: ObservationEdgeInsets;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -261,6 +261,18 @@ const systemChromeSchema = z.object({
   source: z.enum(["android-window-insets", "ios-status-bar-manager"]),
 });
 
+const displayCutoutBoundsSchema = z.object({
+  left: z.number(),
+  top: z.number(),
+  right: z.number(),
+  bottom: z.number(),
+});
+
+const displayCutoutStateSchema = z.object({
+  classification: z.enum(["none", "notch", "dynamic_island", "hole_punch", "unknown"]),
+  bounds: z.array(displayCutoutBoundsSchema).optional(),
+});
+
 const observationInsetsSchema = z.object({
   available: z.boolean(),
   source: z.enum([
@@ -274,6 +286,7 @@ const observationInsetsSchema = z.object({
   // null (rather than omitting them), particularly on older API levels.
   systemBars: z.object({ visible: edgeInsetsSchema, stable: edgeInsetsSchema }).nullish(),
   displayCutout: edgeInsetsSchema.nullish(),
+  displayCutoutState: displayCutoutStateSchema.optional(),
   systemGestures: edgeInsetsSchema.nullish(),
   mandatorySystemGestures: edgeInsetsSchema.nullish(),
   tappableElement: edgeInsetsSchema.nullish(),

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -78,6 +78,7 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
         source: "ios-sdk-safe-area",
         units: "points",
         safeArea: { top: 59.5, right: 0, bottom: 34, left: 0 },
+        displayCutoutState: { classification: "unknown" },
         systemChrome: {
           visibility: "hidden",
           statusBar: "hidden",
@@ -115,6 +116,7 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
       homeIndicatorAutoHideRequested: true,
       source: "ios-status-bar-manager",
     });
+    expect(parsed.data?.insets?.displayCutoutState).toEqual({ classification: "unknown" });
   });
 
   test("accepts nullable Android inset categories", () => {
@@ -129,6 +131,10 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
             stable: { top: 24, right: 0, bottom: 48, left: 0 },
           },
           displayCutout: null,
+          displayCutoutState: {
+            classification: "hole_punch",
+            bounds: [{ left: 510, top: 0, right: 570, bottom: 60 }],
+          },
           systemGestures: null,
           mandatorySystemGestures: null,
           tappableElement: null,


### PR DESCRIPTION
## Summary
- Add additive `insets.displayCutoutState` metadata with a platform-neutral classification and optional geometry.
- Capture Android `DisplayCutout` regions in the observation coordinate space, classifying only clear notch and hole-punch shapes while preserving `unknown` for ambiguous cases.
- Return explicit iOS `unknown` state without shape inference, and document compatibility and geometry semantics.

## Test plan
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `bun test test/server/observeOutputSchema.test.ts`
- [x] `(cd android && ./gradlew -Dorg.gradle.jvmargs='-Xms512m -Xmx4g -Dfile.encoding=UTF-8' --no-daemon :control-proxy:test)`
- [x] `(cd ios/control-proxy && swift test --filter HierarchyMergerTests)`

Closes [#5779](https://github.com/kaeawc/auto-mobile/issues/5779)
