### PR TITLE
fix(android): make terminateApp idempotent

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -129,13 +129,15 @@ export class TerminateApp extends BaseVisualChange {
       // make this operation report that the selected profile was running.
       const isRunning = await perf.track("checkRunning", async () => {
         try {
+          // Filter stdout here: grep's exit status conflates an expected
+          // no-match (the app is already stopped) with a real ADB failure.
           const result = await this.adb.executeCommand(
-            `shell dumpsys activity processes | grep -E "${packageName}/u${targetUserId}a"`,
+            "shell dumpsys activity processes",
             undefined,
             undefined,
             true,
           );
-          return result.stdout.trim().length > 0;
+          return result.stdout.includes(`${packageName}/u${targetUserId}a`);
         } catch (error) {
           logger.warn(`[TerminateApp] Running-state check failed for user ${targetUserId}`, error);
           throw new ActionableError(

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -289,10 +289,7 @@ describe("TerminateApp (Android)", () => {
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
-    fakeAdb.setCommandResult(
-      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
-      "3220:com.example.app/u0a123",
-    );
+    fakeAdb.setCommandResult("shell dumpsys activity processes", "3220:com.example.app/u0a123");
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 
     const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
@@ -325,6 +322,35 @@ describe("TerminateApp (Android)", () => {
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
   });
 
+  test("returns already stopped when the process filter has no match", async () => {
+    fakeAdb.setForegroundApp(null);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "1",
+    );
+    // grep exits 1 when there are no matching processes. This is the expected
+    // signal that the installed app is already stopped, not an ADB failure.
+    fakeAdb.setCommandError(
+      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
+      new Error("Command failed with exit code 1"),
+    );
+    fakeAdb.setCommandResult("shell dumpsys activity processes", "3271:com.example.other/u0a123");
+
+    const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result).toEqual({
+      success: true,
+      packageName: "com.example.app",
+      wasInstalled: true,
+      wasRunning: false,
+      wasForeground: false,
+      userId: 0,
+    });
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
+  });
+
   test("fails instead of reporting a stopped app when the user-scoped process check fails", async () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
@@ -332,10 +358,7 @@ describe("TerminateApp (Android)", () => {
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
-    fakeAdb.setCommandError(
-      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
-      new Error("dumpsys unavailable"),
-    );
+    fakeAdb.setCommandError("shell dumpsys activity processes", new Error("dumpsys unavailable"));
 
     const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
 
@@ -559,10 +582,7 @@ describe("TerminateApp (observed interaction, perf-tree ownership)", () => {
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
-    fakeAdb.setCommandResult(
-      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
-      "3220:com.example.app/u0a123",
-    );
+    fakeAdb.setCommandResult("shell dumpsys activity processes", "3220:com.example.app/u0a123");
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 
     const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);


### PR DESCRIPTION
## Summary

- Detect Android running state by filtering successful `dumpsys` output in TypeScript, so a missing process is an already-stopped no-op rather than an MCP error.
- Preserve the actionable error for genuine `dumpsys` / ADB failures and add a deterministic regression test for the original `grep` exit-1 path.

## Linked Issue

Closes #5768

## Bug / Regression Context

- **Prior attempts:** None known.
- **Observed symptom:** A second `terminateApp` call on an installed Android app threw MCP `-32603`.
- **Repro steps / conditions:** Terminate an installed app with no active process; the shell `grep` filter exits 1 when it finds no process.

## Validation

- [x] `bun test test/features/action/TerminateApp.test.ts --bail`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] New behavior is covered through the existing `FakeAdbClient` and `FakeTimer` seams.
- [x] No dependency or reusable helper added; uses standard string matching.
- [x] Based on current `main@origin`.

## Device Verification

- [ ] Not run locally; this command-handling regression is deterministically covered by unit tests.
