### PR TITLE
test(ios-sdk): cover hierarchy server lifecycle

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -1,6 +1,26 @@
-#if DEBUG && canImport(UIKit) && !os(watchOS)
+#if DEBUG && !os(watchOS)
 import Foundation
 import Network
+
+/// The hierarchy operations served by `SdkHierarchyServer`. Keeping this narrow
+/// lets the server's listener lifecycle compile and be tested on macOS, where
+/// `ViewHierarchyTracker` itself is unavailable because it needs UIKit.
+protocol SdkHierarchyServing: AnyObject {
+    func getLatestHierarchy() -> SdkViewHierarchy?
+    func walkNow() -> SdkViewHierarchy
+    var bundleId: String? { get }
+}
+
+/// The subset of `NWListener` operations `SdkHierarchyServer` drives. This
+/// seam keeps the server lifecycle testable without binding port 8766.
+protocol SdkHierarchyListener: AnyObject {
+    var stateUpdateHandler: (@Sendable (NWListener.State) -> Void)? { get set }
+    var newConnectionHandler: (@Sendable (NWConnection) -> Void)? { get set }
+    func start(queue: DispatchQueue)
+    func cancel()
+}
+
+extension NWListener: SdkHierarchyListener {}
 
 /// Minimal HTTP server running inside the target app on port 8766.
 /// Serves view hierarchy snapshots to control-proxy on demand.
@@ -16,14 +36,21 @@ final class SdkHierarchyServer: @unchecked Sendable {
     private static let httpHeaderDelimiter = Data("\r\n\r\n".utf8)
     private static let maxHttpBodyBytes = 1024 * 1024
 
-    private let lock = NSLock()
-    private var listener: NWListener?
+    private let lock: any NSLocking
+    private var listener: (any SdkHierarchyListener)?
+    private let listenerFactory: () throws -> any SdkHierarchyListener
     private let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.hierarchy-server")
-    private weak var tracker: ViewHierarchyTracker?
+    private weak var tracker: (any SdkHierarchyServing)?
     private let databaseRouteHandler = SdkDatabaseRouteHandler()
 
-    init(tracker: ViewHierarchyTracker) {
+    init(
+        tracker: any SdkHierarchyServing,
+        listenerFactory: @escaping () throws -> any SdkHierarchyListener = SdkHierarchyServer.makeListener,
+        lifecycleLock: any NSLocking = NSLock()
+    ) {
         self.tracker = tracker
+        self.listenerFactory = listenerFactory
+        lock = lifecycleLock
     }
 
     // MARK: - Lifecycle
@@ -39,11 +66,9 @@ final class SdkHierarchyServer: @unchecked Sendable {
         defer { lock.unlock() }
         guard listener == nil else { return }
 
-        let parameters = NWParameters.tcp
-        parameters.allowLocalEndpointReuse = true
-
         do {
-            let nwListener = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: Self.port))
+            let nwListener = try listenerFactory()
+            listener = nwListener
 
             nwListener.stateUpdateHandler = { state in
                 switch state {
@@ -61,7 +86,6 @@ final class SdkHierarchyServer: @unchecked Sendable {
             }
 
             nwListener.start(queue: queue)
-            listener = nwListener
         } catch {
             InternalLogger.debug("[SdkHierarchyServer] Failed to create listener: \(error)")
         }
@@ -73,6 +97,12 @@ final class SdkHierarchyServer: @unchecked Sendable {
         listener = nil
         lock.unlock()
         listenerToCancel?.cancel()
+    }
+
+    private static func makeListener() throws -> any SdkHierarchyListener {
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        return try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: port))
     }
 
     // MARK: - Connection Handling
@@ -236,6 +266,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
     }
 
     private func handleHighlight(_ connection: NWConnection, initialData: Data) {
+#if canImport(UIKit)
         readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
             guard let self = self else {
                 connection.cancel()
@@ -252,6 +283,9 @@ final class SdkHierarchyServer: @unchecked Sendable {
             }
             self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
         }
+#else
+        sendResponse(connection, statusCode: 503, body: Data("{\"error\":\"highlight_unavailable\"}".utf8))
+#endif
     }
 
     private func handleBodyRoute(

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
@@ -124,4 +124,8 @@ public final class ViewHierarchyTracker: @unchecked Sendable {
         return ViewHierarchyWalker.walk(bundleId: bundleId)
     }
 }
+
+#if DEBUG
+extension ViewHierarchyTracker: SdkHierarchyServing {}
+#endif
 #endif

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkHierarchyServerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkHierarchyServerTests.swift
@@ -1,0 +1,127 @@
+@testable import AutoMobileSDK
+import Foundation
+import Network
+import XCTest
+
+final class SdkHierarchyServerTests: XCTestCase {
+    private final class FakeHierarchyTracker: SdkHierarchyServing {
+        var bundleId: String? {
+            "test.bundle"
+        }
+
+        func getLatestHierarchy() -> SdkViewHierarchy? {
+            nil
+        }
+
+        func walkNow() -> SdkViewHierarchy {
+            fatalError("The lifecycle test does not request a hierarchy")
+        }
+    }
+
+    private final class TrackingLock: NSLocking, @unchecked Sendable {
+        private let underlyingLock = NSLock()
+        private let stateLock = NSLock()
+        private var _isLocked = false
+
+        var isLocked: Bool {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isLocked
+        }
+
+        func lock() {
+            underlyingLock.lock()
+            stateLock.lock()
+            _isLocked = true
+            stateLock.unlock()
+        }
+
+        func unlock() {
+            stateLock.lock()
+            _isLocked = false
+            stateLock.unlock()
+            underlyingLock.unlock()
+        }
+    }
+
+    /// A listener whose `start(queue:)` cannot finish until the test permits it.
+    /// This lets the test inspect the lifecycle lock while `start()` is in its
+    /// critical section without binding a real network port.
+    private final class BlockingListener: SdkHierarchyListener, @unchecked Sendable {
+        var stateUpdateHandler: (@Sendable (NWListener.State) -> Void)?
+        var newConnectionHandler: (@Sendable (NWConnection) -> Void)?
+
+        private let stateLock = NSLock()
+        private var _isServing = false
+        private var _cancelCallCount = 0
+
+        let didEnterStart = DispatchSemaphore(value: 0)
+        let mayFinishStart = DispatchSemaphore(value: 0)
+
+        var isServing: Bool {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isServing
+        }
+
+        var cancelCallCount: Int {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _cancelCallCount
+        }
+
+        func start(queue _: DispatchQueue) {
+            didEnterStart.signal()
+            mayFinishStart.wait()
+
+            stateLock.lock()
+            _isServing = true
+            stateLock.unlock()
+        }
+
+        func cancel() {
+            stateLock.lock()
+            _cancelCallCount += 1
+            _isServing = false
+            stateLock.unlock()
+        }
+    }
+
+    func testStartKeepsLifecycleLockThroughListenerStartThenStopCancelsListener() {
+        let tracker = FakeHierarchyTracker()
+        let listener = BlockingListener()
+        let lifecycleLock = TrackingLock()
+        let server = SdkHierarchyServer(
+            tracker: tracker,
+            listenerFactory: { listener },
+            lifecycleLock: lifecycleLock
+        )
+        let startReturned = expectation(description: "start returns after the listener starts")
+        let stopReturned = expectation(description: "stop returns after cancelling the listener")
+
+        DispatchQueue.global().async {
+            server.start()
+            startReturned.fulfill()
+        }
+        XCTAssertEqual(
+            listener.didEnterStart.wait(timeout: .now() + 1),
+            .success,
+            "listener start should be entered"
+        )
+        XCTAssertTrue(
+            lifecycleLock.isLocked,
+            "start must retain the lifecycle lock while the listener starts"
+        )
+
+        DispatchQueue.global().async {
+            server.stop()
+            stopReturned.fulfill()
+        }
+
+        listener.mayFinishStart.signal()
+        wait(for: [startReturned, stopReturned], timeout: 1)
+
+        XCTAssertEqual(listener.cancelCallCount, 1)
+        XCTAssertFalse(listener.isServing, "teardown must not leave a listener serving")
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkHierarchyServerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkHierarchyServerTests.swift
@@ -23,6 +23,9 @@ final class SdkHierarchyServerTests: XCTestCase {
         private let stateLock = NSLock()
         private var _isLocked = false
 
+        /// Signals when another caller tries to acquire the lock while it is held.
+        let didAttemptLockWhileHeld = DispatchSemaphore(value: 0)
+
         var isLocked: Bool {
             stateLock.lock()
             defer { stateLock.unlock() }
@@ -30,6 +33,13 @@ final class SdkHierarchyServerTests: XCTestCase {
         }
 
         func lock() {
+            stateLock.lock()
+            let wasLocked = _isLocked
+            stateLock.unlock()
+            if wasLocked {
+                didAttemptLockWhileHeld.signal()
+            }
+
             underlyingLock.lock()
             stateLock.lock()
             _isLocked = true
@@ -118,6 +128,11 @@ final class SdkHierarchyServerTests: XCTestCase {
             stopReturned.fulfill()
         }
 
+        XCTAssertEqual(
+            lifecycleLock.didAttemptLockWhileHeld.wait(timeout: .now() + 1),
+            .success,
+            "stop must attempt to acquire the lifecycle lock before listener startup can finish"
+        )
         listener.mayFinishStart.signal()
         wait(for: [startReturned, stopReturned], timeout: 1)
 


### PR DESCRIPTION
## Summary
Adds a fakeable `NWListener` seam to `SdkHierarchyServer` and a deterministic lifecycle test. The test pauses listener startup while inspecting an injected lifecycle lock, proving `start()` retains that lock through listener setup without binding port 8766.

## Linked Issue
Closes [#5693](https://github.com/kaeawc/auto-mobile/issues/5693)

## Validation
- [x] `swift test -Xswiftc -warnings-as-errors` in `ios/auto-mobile-sdk`
- [x] Focused `SdkHierarchyServerTests` run without a real network listener
- [x] `scripts/ios/swift-build.sh && scripts/ios/swift-test.sh`
- [x] `bun run turbo:validate` — 14,631 tests passed
- [x] `bun run typecheck` — no new errors
- [ ] `scripts/all_fast_validate_checks.sh` — 33/34 checks passed; local `ktfmt` cannot verify its pinned version because the installed Java runtime exits with an environment-policy message
