### PR TITLE
fix(ios): include all physical device apps

### DIFF
--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -878,7 +878,8 @@ export class DeviceAppManager implements DeviceUrlLauncher {
    * instead of returning an empty list (issue #2883).
    *
    * Unlike {@link queryInstalledAppEntry} this omits `--bundle-id`, which is
-   * what turns the lookup into a full listing. devicectl exec / JSON-read
+   * what turns the lookup into a full listing, and passes `--include-all-apps`
+   * to match simctl's unfiltered listing scope. devicectl exec / JSON-read
    * failures are wrapped and PROPAGATE: an empty list must mean "no apps", not
    * "devicectl is broken", because callers report that distinction as their
    * `successful` flag. macOS-only.
@@ -898,6 +899,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
         "device",
         "info",
         "apps",
+        "--include-all-apps",
         "--device",
         deviceUdid,
         "--json-output",

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -1594,7 +1594,7 @@ describe("DeviceAppManager.listInstalledApps", () => {
     };
   }
 
-  test("queries devicectl for the whole listing, without --bundle-id", async () => {
+  test("queries devicectl for the whole listing, including all app scopes and without --bundle-id", async () => {
     const commands: string[] = [];
     const manager = createManager({}, commands);
 
@@ -1604,6 +1604,7 @@ describe("DeviceAppManager.listInstalledApps", () => {
     expect(commands).toHaveLength(1);
     expect(commands[0]).toContain("devicectl device info apps");
     expect(commands[0]).toContain("--device 00008130-001C2D3E1234567A");
+    expect(commands[0]).toContain("--include-all-apps");
     expect(commands[0]).not.toContain("--bundle-id");
   });
 


### PR DESCRIPTION
## Summary
- Make physical-device app listings request every devicectl app scope, matching the unfiltered simulator listing.
- Lock the invocation shape in the existing DeviceAppManager unit test.

## Linked Issue
Closes [#5687](https://github.com/kaeawc/auto-mobile/issues/5687)

## Validation
- [x] `bun test test/utils/ios-cmdline-tools/DeviceAppManager.test.ts` (59 pass)
- [x] `bun test` (full suite pass; initial independent FFmpeg fixture flake passed on isolated retry)
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `scripts/all_fast_validate_checks.sh` (34 pass)
- [x] Verified installed Xcode's `devicectl device info apps --help`: `--include-all-apps` includes default, removable, and App Clip apps.

## Risk
The physical iOS path now returns system/default apps in addition to developer apps. This aligns its scope with `simctl listapps`; all existing callers continue to receive the same record format.

Made with [Cursor](https://cursor.com)