### PR TITLE
test(ios): cover terminate handler failures

### DIFF
--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import { ToolRegistry } from "./toolRegistry";
-import { ActionableError, BootedDevice } from "../models";
+import { ActionableError, BootedDevice, type TerminateAppResult } from "../models";
 import { LaunchApp } from "../features/action/LaunchApp";
 import { TerminateApp } from "../features/action/TerminateApp";
 import { InstallApp } from "../features/action/InstallApp";
@@ -51,6 +51,41 @@ export function setListAppsToolDependencies(deps: Partial<ListAppsToolDependenci
 
 export function resetListAppsToolDependencies(): void {
   listAppsToolDependencies = null;
+}
+
+export interface TerminateAppExecutor {
+  execute(
+    appId: string,
+    options?: {
+      skipUiStability?: boolean;
+    },
+  ): Promise<TerminateAppResult>;
+}
+
+export interface TerminateAppToolDependencies {
+  createTerminateApp(device: BootedDevice): TerminateAppExecutor;
+}
+
+let terminateAppToolDependencies: TerminateAppToolDependencies | null = null;
+
+function getTerminateAppToolDependencies(): TerminateAppToolDependencies {
+  if (!terminateAppToolDependencies) {
+    terminateAppToolDependencies = {
+      createTerminateApp: (device) => new TerminateApp(device),
+    };
+  }
+  return terminateAppToolDependencies;
+}
+
+export function setTerminateAppToolDependencies(deps: Partial<TerminateAppToolDependencies>): void {
+  const currentDeps = getTerminateAppToolDependencies();
+  terminateAppToolDependencies = {
+    createTerminateApp: deps.createTerminateApp ?? currentDeps.createTerminateApp,
+  };
+}
+
+export function resetTerminateAppToolDependencies(): void {
+  terminateAppToolDependencies = null;
 }
 
 // Schema definitions
@@ -322,7 +357,7 @@ export function registerAppTools() {
   // Terminate app handler
   const terminateAppHandler = async (device: BootedDevice, args: AppActionArgs) => {
     try {
-      const terminateApp = new TerminateApp(device);
+      const terminateApp = getTerminateAppToolDependencies().createTerminateApp(device);
       const result = await terminateApp.execute(args.appId, {
         skipUiStability: true, // skip the 12+ second stability polling
       });

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   registerAppTools,
   resetListAppsToolDependencies,
+  resetTerminateAppToolDependencies,
   setListAppsToolDependencies,
+  setTerminateAppToolDependencies,
 } from "../../src/server/appTools";
 import {
   APP_RESOURCE_TEMPLATES,
@@ -15,6 +17,7 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeToolUtils } from "../fakes/FakeToolUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { getInstalledAppsCacheWriteCoordinator } from "../../src/db/installedAppsCacheWriteCoordinator";
+import type { BootedDevice } from "../../src/models";
 
 const resolveWithFakeTimer = async <T>(
   promise: Promise<T>,
@@ -61,12 +64,14 @@ describe("listApps tool", () => {
   beforeEach(() => {
     ToolRegistry.clearTools();
     resetListAppsToolDependencies();
+    resetTerminateAppToolDependencies();
     registerAppTools();
   });
 
   afterEach(() => {
     ToolRegistry.clearTools();
     resetListAppsToolDependencies();
+    resetTerminateAppToolDependencies();
   });
 
   test("registers listApps tool with a permissive schema", () => {
@@ -124,6 +129,46 @@ describe("listApps tool", () => {
 
     invalidateInstalledAppsCache(deviceId);
     expect(getInstalledAppsCacheWriteCoordinator().isDirty(deviceId)).toBe(true);
+  });
+});
+
+describe("terminateApp tool", () => {
+  const device: BootedDevice = {
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    resetListAppsToolDependencies();
+    resetTerminateAppToolDependencies();
+    registerAppTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    resetListAppsToolDependencies();
+    resetTerminateAppToolDependencies();
+  });
+
+  test("surfaces a typed TerminateApp failure instead of reporting success", async () => {
+    setTerminateAppToolDependencies({
+      createTerminateApp: () => ({
+        execute: async () => ({
+          success: false,
+          packageName: "com.example.app",
+          wasForeground: false,
+          error: "The installed-app listing failed",
+        }),
+      }),
+    });
+    const tool = ToolRegistry.getTool("terminateApp");
+
+    expect(tool?.deviceAwareHandler).toBeDefined();
+    await expect(tool!.deviceAwareHandler!(device, { appId: "com.example.app" })).rejects.toThrow(
+      "The installed-app listing failed",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

`terminateAppHandler` created `TerminateApp` directly, so its typed failure branch had no handler-level coverage. This adds a narrow injected action factory with the production constructor as its default, then proves a failed action raises its actionable error instead of returning a “Terminated app” response.

## Linked Issue

Closes [#5688](https://github.com/kaeawc/auto-mobile/issues/5688).

## Bug / Regression Context

- **Prior attempts:** [#5658](https://github.com/kaeawc/auto-mobile/pull/5658) added the guard but could only cover it at the action layer.
- **Observed symptom:** A future regression could make a typed `TerminateApp` failure appear to clients as a successful termination.
- **Repro steps / conditions:** Have `TerminateApp.execute()` return `{ success: false, error }` through the registered MCP handler.

## Validation

- [x] Focused `bun test test/server/appTools.listApps.test.ts test/features/action/TerminateApp.test.ts`
- [x] `bun test`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors
- [x] `bun run build`
- [ ] `scripts/all_fast_validate_checks.sh` — 33/34 checks passed; `ktfmt` could not verify its local version (`unknown`; repository requires `0.64`).
- [x] New code uses a narrow interface and a test-injected fake; no dependencies added
- [ ] Rebased onto latest `main` — `main` advanced by four commits after the branch was created.
