### PR TITLE
test: bound WebRTC integration test I/O

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -271,9 +271,10 @@ export interface SimCtl {
   /**
    * Get the screen size of the simulator
    * @param deviceId - Optional device ID (defaults to current device or "booted")
+   * @param timeoutMs - Optional command timeout in milliseconds
    * @returns Promise with screen dimensions
    */
-  getScreenSize(deviceId?: string): Promise<ScreenSize>;
+  getScreenSize(deviceId?: string, timeoutMs?: number): Promise<ScreenSize>;
 
   /**
    * Set the simulator appearance
@@ -1891,13 +1892,13 @@ export class SimCtlClient implements SimCtl {
    * @param deviceId - Optional device ID (defaults to current device or "booted")
    * @returns Promise with screen dimensions
    */
-  async getScreenSize(deviceId?: string): Promise<ScreenSize> {
+  async getScreenSize(deviceId?: string, timeoutMs?: number): Promise<ScreenSize> {
     const targetDevice = deviceId || this.device?.deviceId || "booted";
 
     logger.info(`[iOS] Getting screen size for simulator ${targetDevice}`);
 
     // Use simctl io enumerate to get display information
-    const result = await this.executeCommandArgs(["io", targetDevice, "enumerate"]);
+    const result = await this.executeCommandArgs(["io", targetDevice, "enumerate"], timeoutMs);
 
     // Parse the text output to find LCD screen information
     const lines = result.stdout.split("\n");

--- a/test/helpers/abortableWaitFor.test.ts
+++ b/test/helpers/abortableWaitFor.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { waitFor } from "./abortableWaitFor";
+
+describe("abortableWaitFor", () => {
+  test("cancels and awaits an in-flight predicate when its deadline expires", async () => {
+    const timer = new FakeTimer();
+    let predicateSignal: AbortSignal | undefined;
+    let fakeSubprocessSettled = false;
+
+    const wait = waitFor(
+      (signal) =>
+        new Promise<boolean>((resolve) => {
+          predicateSignal = signal;
+          signal.addEventListener(
+            "abort",
+            () => {
+              fakeSubprocessSettled = true;
+              resolve(false);
+            },
+            { once: true },
+          );
+        }),
+      "fixture did not recover",
+      100,
+      timer,
+    );
+
+    expect(predicateSignal).toBeDefined();
+    expect(predicateSignal!.aborted).toBe(false);
+
+    let waitError: unknown;
+    const settled = wait.catch((error: unknown) => {
+      waitError = error;
+    });
+    await timer.advanceTimeAsync(100);
+
+    await settled;
+    expect(waitError).toEqual(
+      new Error(
+        "fixture did not recover did not complete within 100ms — bounded real-I/O deadline hit",
+      ),
+    );
+    expect(predicateSignal!.aborted).toBe(true);
+    expect(fakeSubprocessSettled).toBe(true);
+  });
+});

--- a/test/helpers/abortableWaitFor.ts
+++ b/test/helpers/abortableWaitFor.ts
@@ -1,0 +1,58 @@
+import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
+
+/** Bound an operation that can otherwise hold a CI isolate indefinitely. */
+export async function withDeadline<T>(
+  step: string,
+  timeoutMs: number,
+  run: () => Promise<T>,
+  timer: Timer = defaultTimer,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = timer.setTimeout(
+      () =>
+        reject(
+          new Error(
+            `${step} did not complete within ${timeoutMs}ms — bounded real-I/O deadline hit`,
+          ),
+        ),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([run(), deadline]);
+  } finally {
+    if (timeout !== undefined) {
+      timer.clearTimeout(timeout);
+    }
+  }
+}
+
+/**
+ * Poll a cancellable operation until it succeeds or its absolute deadline
+ * expires. The predicate must pass its signal to any cancellable real I/O.
+ */
+export async function waitFor(
+  predicate: (signal: AbortSignal) => Promise<boolean>,
+  message: string,
+  timeoutMs = 30_000,
+  timer: Timer = defaultTimer,
+): Promise<void> {
+  const deadline = timer.now() + timeoutMs;
+  while (timer.now() < deadline) {
+    const controller = new AbortController();
+    const result = predicate(controller.signal);
+    try {
+      if (await withDeadline(message, deadline - timer.now(), () => result, timer)) {
+        return;
+      }
+    } catch (error) {
+      controller.abort(error);
+      // Do not let a canceled subprocess race the caller's teardown.
+      await result.catch(() => undefined);
+      throw error;
+    }
+    await timer.sleep(100);
+  }
+  throw new Error(message);
+}

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
 import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
+import { waitFor, withDeadline } from "../helpers/abortableWaitFor";
 import {
   CaptureStageTimeline,
   captureRunIdentity,
@@ -75,29 +76,6 @@ interface ReaderDiagnostics {
 interface ChromeReader {
   chrome: ChildProcessWithoutNullStreams;
   cdp: CdpClient;
-}
-
-/** Bound an operation that can otherwise hold a CI isolate indefinitely. */
-async function withDeadline<T>(step: string, timeoutMs: number, run: () => Promise<T>): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  const deadline = new Promise<never>((_, reject) => {
-    timer = defaultTimer.setTimeout(
-      () =>
-        reject(
-          new Error(
-            `${step} did not complete within ${timeoutMs}ms — bounded real-I/O deadline hit`,
-          ),
-        ),
-      timeoutMs,
-    );
-  });
-  try {
-    return await Promise.race([run(), deadline]);
-  } finally {
-    if (timer !== undefined) {
-      defaultTimer.clearTimeout(timer);
-    }
-  }
 }
 
 class CdpClient {
@@ -195,21 +173,6 @@ function start(command: string, args: string[], logFile: string): ChildProcessWi
   child.stderr.pipe(log, { end: false });
   child.once("close", () => log.end());
   return child;
-}
-
-async function waitFor(
-  predicate: () => Promise<boolean>,
-  message: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await withDeadline(message, deadline - Date.now(), predicate)) {
-      return;
-    }
-    await Bun.sleep(100);
-  }
-  throw new Error(message);
 }
 
 async function waitForWebRtcStreamSocket(
@@ -713,17 +676,18 @@ async function captureProfile(): Promise<CaptureProfile> {
   }
 }
 
-async function launchFixture(): Promise<void> {
+async function launchFixture(signal?: AbortSignal): Promise<void> {
   if (platform === "android") {
     const id = androidDeviceId();
     await execFileAsync(
       "adb",
       ["-s", id, "shell", "am", "start", "-a", "android.settings.SETTINGS"],
-      { timeout: REAL_IO_TIMEOUT_MS, killSignal: "SIGKILL" },
+      { timeout: REAL_IO_TIMEOUT_MS, killSignal: "SIGKILL", signal },
     );
     await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"], {
       timeout: REAL_IO_TIMEOUT_MS,
       killSignal: "SIGKILL",
+      signal,
     });
     return;
   }
@@ -731,17 +695,19 @@ async function launchFixture(): Promise<void> {
     await execFileAsync("xcrun", ["simctl", "launch", "booted", "com.apple.Preferences"], {
       timeout: REAL_IO_TIMEOUT_MS,
       killSignal: "SIGKILL",
+      signal,
     });
     await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"], {
       timeout: REAL_IO_TIMEOUT_MS,
       killSignal: "SIGKILL",
+      signal,
     });
     return;
   }
   throw new Error("AUTOMOBILE_WEBRTC_DEVICE_PLATFORM must be android or ios");
 }
 
-async function changeFixture(): Promise<void> {
+async function changeFixture(signal?: AbortSignal): Promise<void> {
   if (platform === "android") {
     const id = androidDeviceId();
     // A Home transition guarantees a visible surface change. The emulator may
@@ -750,6 +716,7 @@ async function changeFixture(): Promise<void> {
     await execFileAsync("adb", ["-s", id, "shell", "input", "keyevent", "HOME"], {
       timeout: REAL_IO_TIMEOUT_MS,
       killSignal: "SIGKILL",
+      signal,
     });
     return;
   }
@@ -757,6 +724,7 @@ async function changeFixture(): Promise<void> {
     await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "dark"], {
       timeout: REAL_IO_TIMEOUT_MS,
       killSignal: "SIGKILL",
+      signal,
     });
     return;
   }
@@ -1227,9 +1195,9 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
             let recovered: KeyframeRecoverySample | null = null;
             let toggle = false;
             await waitFor(
-              async () => {
+              async (signal) => {
                 toggle = !toggle;
-                await (toggle ? changeFixture() : launchFixture());
+                await (toggle ? changeFixture(signal) : launchFixture(signal));
                 const latest = await recoverySample(cdp!);
                 if (latest && keyframeRecovered(baseline, latest)) {
                   recovered = latest;

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -8,10 +8,6 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
-import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
-import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
-import { IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS } from "../../src/features/webrtc/IosH264Source";
-import { WEBRTC_STREAM_LEASE_TTL_MS } from "../../src/server/webrtcStreamManager";
 import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
 import {
   CaptureStageTimeline,
@@ -51,8 +47,15 @@ const ANDROID_VIDEO_SERVER_MEDIUM_FPS = 30;
 const FIXTURE_RESTORE_TIMEOUT_MS = 15_000;
 // bun caps a hook with no explicit deadline at 5000ms, which is what turned a
 // slow appearance restore into a failed run whose pipeline recorded `passed`.
-// Give the hook its own generous timeout, comfortably past the restore budget.
-const TEARDOWN_HOOK_TIMEOUT_MS = 30_000;
+// A worst-case cleanup takes 33s (heartbeat, Chrome and MediaMTX escalation,
+// and bounded daemon stop), so leave room for directory cleanup and artifact
+// writing instead of cancelling afterAll before it can reap every resource.
+const TEARDOWN_HOOK_TIMEOUT_MS = 45_000;
+// The outer test deadline is a last resort. Bound individual real-I/O calls so
+// a hung subprocess or socket names the failed operation rather than consuming
+// the entire device lane (#5715).
+const REAL_IO_TIMEOUT_MS = 30_000;
+const CDP_COMMAND_TIMEOUT_MS = REAL_IO_TIMEOUT_MS;
 
 interface ChromeTarget {
   type: string;
@@ -74,11 +77,38 @@ interface ChromeReader {
   cdp: CdpClient;
 }
 
+/** Bound an operation that can otherwise hold a CI isolate indefinitely. */
+async function withDeadline<T>(step: string, timeoutMs: number, run: () => Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = defaultTimer.setTimeout(
+      () =>
+        reject(
+          new Error(
+            `${step} did not complete within ${timeoutMs}ms — bounded real-I/O deadline hit`,
+          ),
+        ),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([run(), deadline]);
+  } finally {
+    if (timer !== undefined) {
+      defaultTimer.clearTimeout(timer);
+    }
+  }
+}
+
 class CdpClient {
   private nextId = 1;
   private readonly pending = new Map<
     number,
-    { resolve: (response: CdpResponse) => void; reject: (error: Error) => void }
+    {
+      resolve: (response: CdpResponse) => void;
+      reject: (error: Error) => void;
+      timeout: NodeJS.Timeout;
+    }
   >();
 
   private constructor(private readonly socket: WebSocket) {
@@ -92,29 +122,69 @@ class CdpClient {
         return;
       }
       this.pending.delete(response.id);
+      defaultTimer.clearTimeout(pending.timeout);
       response.error
         ? pending.reject(new Error(response.error.message))
         : pending.resolve(response);
     });
+    socket.on("error", (error) => this.rejectPending(error));
+    socket.on("close", () => this.rejectPending(new Error("Chrome DevTools connection closed")));
   }
 
   static async connect(url: string): Promise<CdpClient> {
-    const socket = new WebSocket(url);
-    await once(socket, "open");
-    return new CdpClient(socket);
+    const socket = new WebSocket(url, { handshakeTimeout: REAL_IO_TIMEOUT_MS });
+    try {
+      await withDeadline("Chrome DevTools connection", REAL_IO_TIMEOUT_MS, () =>
+        once(socket, "open"),
+      );
+      return new CdpClient(socket);
+    } catch (error) {
+      socket.terminate();
+      throw error;
+    }
   }
 
   command(method: string, params: Record<string, unknown> = {}): Promise<CdpResponse> {
     const id = this.nextId++;
-    const response = new Promise<CdpResponse>((resolve, reject) =>
-      this.pending.set(id, { resolve, reject }),
-    );
-    this.socket.send(JSON.stringify({ id, method, params }));
-    return response;
+    return new Promise<CdpResponse>((resolve, reject) => {
+      const timeout = defaultTimer.setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(
+            new Error(
+              `Chrome DevTools ${method} command timed out after ${CDP_COMMAND_TIMEOUT_MS}ms`,
+            ),
+          );
+        }
+      }, CDP_COMMAND_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timeout });
+      try {
+        this.socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        this.rejectPendingRequest(id, error);
+      }
+    });
   }
 
   close(): void {
     this.socket.close();
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      defaultTimer.clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private rejectPendingRequest(id: number, error: unknown): void {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(id);
+    defaultTimer.clearTimeout(pending.timeout);
+    pending.reject(error instanceof Error ? error : new Error(String(error)));
   }
 }
 
@@ -134,7 +204,7 @@ async function waitFor(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await predicate()) {
+    if (await withDeadline(message, deadline - Date.now(), predicate)) {
       return;
     }
     await Bun.sleep(100);
@@ -188,6 +258,7 @@ async function startWebRtcDaemon(
   // than surfacing only as a generic "socket did not become ready".
   const startError = await execFileAsync("bun", ["dist/src/index.js", "--daemon", "start"], {
     env: daemonEnvironment,
+    timeout: REAL_IO_TIMEOUT_MS,
   })
     .then(() => null)
     .catch((error: unknown) => (error instanceof Error ? error : new Error(String(error))));
@@ -232,10 +303,12 @@ async function stop(child: ChildProcessWithoutNullStreams | undefined): Promise<
   if (!child || child.exitCode !== null || child.signalCode !== null) {
     return;
   }
+  const exit = once(child, "exit");
   child.kill("SIGTERM");
-  await Promise.race([once(child, "exit"), Bun.sleep(3_000)]);
+  await Promise.race([exit, Bun.sleep(3_000)]);
   if (child.exitCode === null && child.signalCode === null) {
     child.kill("SIGKILL");
+    await withDeadline("process exit after SIGKILL", 3_000, () => exit);
   }
 }
 
@@ -328,7 +401,9 @@ async function connectReader(
       }
       try {
         const targets = (await (
-          await fetch(`http://127.0.0.1:${CHROME_DEBUG_PORT}/json/list`)
+          await fetch(`http://127.0.0.1:${CHROME_DEBUG_PORT}/json/list`, {
+            signal: AbortSignal.timeout(REAL_IO_TIMEOUT_MS),
+          })
         ).json()) as ChromeTarget[];
         target = targets.find(
           (candidate) => candidate.type === "page" && candidate.webSocketDebuggerUrl,
@@ -604,16 +679,15 @@ async function captureProfile(): Promise<CaptureProfile> {
       ? usesVideoServer
         ? ANDROID_VIDEO_SERVER_MEDIUM_FPS
         : null
-      : WEBRTC_IOS_SIMULATOR_FPS_DEFAULT;
+      : (await import("../../src/features/webrtc/webrtcStreamingConfig"))
+          .WEBRTC_IOS_SIMULATOR_FPS_DEFAULT;
   try {
     if (platform === "android") {
-      const { stdout } = await execFileAsync("adb", [
-        "-s",
-        androidDeviceId(),
-        "shell",
-        "wm",
-        "size",
-      ]);
+      const { stdout } = await execFileAsync(
+        "adb",
+        ["-s", androidDeviceId(), "shell", "wm", "size"],
+        { timeout: REAL_IO_TIMEOUT_MS },
+      );
       const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
       return {
         sourceSize: match ? { width: Number(match[1]), height: Number(match[2]) } : null,
@@ -623,7 +697,8 @@ async function captureProfile(): Promise<CaptureProfile> {
     // Not a hand-rolled `simctl io enumerate` regex: the first "Pixel Size:" in
     // that output belongs to the CarPlay screen, so a naive match reports
     // 720x480 for every simulator. SimCtlClient gates on the integrated display.
-    const screen = await new SimCtlClient().getScreenSize("booted");
+    const { SimCtlClient } = await import("../../src/utils/ios-cmdline-tools/SimCtlClient");
+    const screen = await new SimCtlClient().getScreenSize("booted", REAL_IO_TIMEOUT_MS);
     return { sourceSize: { width: screen.width, height: screen.height }, configuredFps };
   } catch (error) {
     // Diagnostic metadata only — a failed size query must not fail the lane.
@@ -635,21 +710,23 @@ async function captureProfile(): Promise<CaptureProfile> {
 async function launchFixture(): Promise<void> {
   if (platform === "android") {
     const id = androidDeviceId();
-    await execFileAsync("adb", [
-      "-s",
-      id,
-      "shell",
-      "am",
-      "start",
-      "-a",
-      "android.settings.SETTINGS",
-    ]);
-    await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"]);
+    await execFileAsync(
+      "adb",
+      ["-s", id, "shell", "am", "start", "-a", "android.settings.SETTINGS"],
+      { timeout: REAL_IO_TIMEOUT_MS },
+    );
+    await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"], {
+      timeout: REAL_IO_TIMEOUT_MS,
+    });
     return;
   }
   if (platform === "ios") {
-    await execFileAsync("xcrun", ["simctl", "launch", "booted", "com.apple.Preferences"]);
-    await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"]);
+    await execFileAsync("xcrun", ["simctl", "launch", "booted", "com.apple.Preferences"], {
+      timeout: REAL_IO_TIMEOUT_MS,
+    });
+    await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"], {
+      timeout: REAL_IO_TIMEOUT_MS,
+    });
     return;
   }
   throw new Error("AUTOMOBILE_WEBRTC_DEVICE_PLATFORM must be android or ios");
@@ -661,11 +738,15 @@ async function changeFixture(): Promise<void> {
     // A Home transition guarantees a visible surface change. The emulator may
     // accept a ui-mode setting without repainting the Settings window, which
     // made the old theme-only fixture indistinguishable from a frozen stream.
-    await execFileAsync("adb", ["-s", id, "shell", "input", "keyevent", "HOME"]);
+    await execFileAsync("adb", ["-s", id, "shell", "input", "keyevent", "HOME"], {
+      timeout: REAL_IO_TIMEOUT_MS,
+    });
     return;
   }
   if (platform === "ios") {
-    await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "dark"]);
+    await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "dark"], {
+      timeout: REAL_IO_TIMEOUT_MS,
+    });
     return;
   }
   throw new Error("AUTOMOBILE_WEBRTC_DEVICE_PLATFORM must be android or ios");
@@ -718,11 +799,14 @@ let decodedSize: CaptureDimensions | null = null;
 let egressKbps: number | null = null;
 let decodedFps: number | null = null;
 let outcome: "passed" | "failed" = "failed";
+// Bun still executes afterAll after a test deadline, unlike the test body's
+// finally. Retain this callback until it runs so a stalled operation cannot
+// orphan Chrome or MediaMTX on the macOS worker (#5715).
+let pendingPipelineTeardown: (() => Promise<void>) | undefined;
 // Window over which egress bitrate and decoded fps are averaged, and the
 // interval between the fixture toggles that keep the screen changing across it.
 const EGRESS_WINDOW_MS = 2_000;
 const EGRESS_TOGGLE_INTERVAL_MS = 400;
-const STREAM_LEASE_HEARTBEAT_INTERVAL_MS = WEBRTC_STREAM_LEASE_TTL_MS / 3;
 
 interface StreamLeaseHeartbeat {
   stop(): Promise<Error | null>;
@@ -737,6 +821,7 @@ function startStreamLeaseHeartbeat(
   streamId: string,
   leaseId: string,
   socketPath: string,
+  intervalMs: number,
   timer: Timer = defaultTimer,
 ): StreamLeaseHeartbeat {
   let stopped = false;
@@ -780,7 +865,7 @@ function startStreamLeaseHeartbeat(
       });
   };
 
-  const interval = timer.setInterval(renew, STREAM_LEASE_HEARTBEAT_INTERVAL_MS);
+  const interval = timer.setInterval(renew, intervalMs);
   (interval as { unref?: () => void }).unref?.();
   return {
     async stop(): Promise<Error | null> {
@@ -794,6 +879,14 @@ function startStreamLeaseHeartbeat(
 
 describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => {
   afterAll(async () => {
+    const cleanup = pendingPipelineTeardown;
+    pendingPipelineTeardown = undefined;
+    let cleanupError: unknown;
+    try {
+      await cleanup?.();
+    } catch (error) {
+      cleanupError = error;
+    }
     const record = timeline.toRecord({
       platform: platform ?? "unknown",
       streamId,
@@ -816,7 +909,10 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       `${JSON.stringify(record, null, 2)}\n`,
     );
     await writeFile(join(artifactDir, "result.txt"), `${summary}\n`);
-  });
+    if (cleanupError) {
+      throw cleanupError;
+    }
+  }, TEARDOWN_HOOK_TIMEOUT_MS);
 
   test(
     "the real device capture path renders changing video and stops cleanly",
@@ -870,6 +966,56 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       let observingStart = true;
       let startObserver: Promise<void> = Promise.resolve();
       let leaseHeartbeat: StreamLeaseHeartbeat | undefined;
+      pendingPipelineTeardown = async () => {
+        observingStart = false;
+        // Measured as its own phase (#4354) so a teardown that stalls stopping the
+        // daemon, MediaMTX or Chrome is attributable from the artifact rather than
+        // only from job logs. Attempt every cleanup step before surfacing failures
+        // so one stalled resource cannot orphan all of the later ones.
+        await timeline.runPhase("pipelineTeardown", async () => {
+          const cleanupErrors: unknown[] = [];
+          const cleanupStep = async (run: () => Promise<void> | void): Promise<void> => {
+            try {
+              await run();
+            } catch (error) {
+              cleanupErrors.push(error);
+            }
+          };
+
+          await cleanupStep(async () => {
+            const leaseHeartbeatError = await leaseHeartbeat?.stop();
+            if (leaseHeartbeatError) {
+              console.warn(
+                `WebRTC stream lease heartbeat failed during teardown: ${leaseHeartbeatError.message}`,
+              );
+            }
+          });
+          // Nothing in the observer rejects today; swallow anyway so a future edit
+          // cannot skip the teardown below and replace the real test failure.
+          await cleanupStep(() => startObserver.catch(() => undefined));
+          await cleanupStep(() => cdp?.close());
+          await cleanupStep(() => stop(chrome));
+          await cleanupStep(async () => {
+            if (started) {
+              await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], {
+                env: daemonEnvironment,
+                timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+              }).catch(() => undefined);
+            }
+          });
+          await cleanupStep(() => stop(mediamtx));
+          await cleanupStep(() => rm(webRtcSocketDir, { recursive: true, force: true }));
+          // The daemon dir lives under the artifact dir and holds its logs and DB.
+          // Now that artifacts upload on success too, keep it only for a failure to
+          // triage; a green run should ship the latency record, not a sqlite file.
+          if (outcome === "passed") {
+            await cleanupStep(() => rm(daemonDir, { recursive: true, force: true }));
+          }
+          if (cleanupErrors.length > 0) {
+            throw new AggregateError(cleanupErrors, "WebRTC device-capture teardown failed");
+          }
+        });
+      };
       try {
         await waitFor(async () => {
           if (mediamtx.exitCode !== null || mediamtx.signalCode !== null) {
@@ -877,7 +1023,9 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
               "MediaMTX exited before it became ready; inspect scratch/webrtc-device-integration/mediamtx.log",
             );
           }
-          const response = await fetch(`http://127.0.0.1:${webRtcPort}/`).catch(() => undefined);
+          const response = await fetch(`http://127.0.0.1:${webRtcPort}/`, {
+            signal: AbortSignal.timeout(REAL_IO_TIMEOUT_MS),
+          }).catch(() => undefined);
           if (!response) {
             return false;
           }
@@ -929,7 +1077,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
             // default so host-candidate negotiation cannot depend on runner DNS.
             iceServers: [],
           },
-          { socketPath: webRtcSocketPath },
+          { socketPath: webRtcSocketPath, timeoutMs: REAL_IO_TIMEOUT_MS },
         );
         if (!response.success) {
           throw new Error(
@@ -940,7 +1088,13 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         if (!leaseId) {
           throw new Error("started device WebRTC stream did not return an ownership lease");
         }
-        leaseHeartbeat = startStreamLeaseHeartbeat(streamId, leaseId, webRtcSocketPath);
+        const { WEBRTC_STREAM_LEASE_TTL_MS } = await import("../../src/server/webrtcStreamManager");
+        leaseHeartbeat = startStreamLeaseHeartbeat(
+          streamId,
+          leaseId,
+          webRtcSocketPath,
+          WEBRTC_STREAM_LEASE_TTL_MS / 3,
+        );
         await waitFor(async () => {
           const status = await sendWebRtcStreamRequest(
             { action: "status", id: `${streamId}-capture-status`, streamId, leaseId },
@@ -1023,6 +1177,8 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         // scope here. Fresh viewer subscribing relays a PLI upstream through
         // MediaMTX to the WHIP publisher, which calls source.requestKeyFrame().
         if (platform === "ios") {
+          const { IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS } =
+            await import("../../src/features/webrtc/IosH264Source");
           await timeline.runPhase("keyframeRecovery", async () => {
             // A brand-new WHEP subscription is the relayed PLI: it renegotiates
             // with MediaMTX, which requests a keyframe upstream. The recovery
@@ -1066,47 +1222,19 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         }
         const stopped = await sendWebRtcStreamRequest(
           { action: "stop", id: `${streamId}-stop`, streamId },
-          { socketPath: webRtcSocketPath },
+          { socketPath: webRtcSocketPath, timeoutMs: REAL_IO_TIMEOUT_MS },
         );
         expect(stopped.success).toBe(true);
         const listed = await sendWebRtcStreamRequest(
           { action: "list", id: `${streamId}-list` },
-          { socketPath: webRtcSocketPath },
+          { socketPath: webRtcSocketPath, timeoutMs: REAL_IO_TIMEOUT_MS },
         );
         expect(listed.streams?.some((stream) => stream.streamId === streamId)).toBe(false);
         outcome = "passed";
       } finally {
-        observingStart = false;
-        // Measured as its own phase (#4354) so a teardown that stalls stopping the
-        // daemon, MediaMTX or Chrome is attributable from the artifact rather than
-        // only from job logs. runPhase re-throws, preserving the prior semantics
-        // where a failed cleanup surfaces as a test failure.
-        await timeline.runPhase("pipelineTeardown", async () => {
-          const leaseHeartbeatError = await leaseHeartbeat?.stop();
-          if (leaseHeartbeatError) {
-            console.warn(
-              `WebRTC stream lease heartbeat failed during teardown: ${leaseHeartbeatError.message}`,
-            );
-          }
-          // Nothing in the observer rejects today; swallow anyway so a future edit
-          // cannot skip the teardown below and replace the real test failure.
-          await startObserver.catch(() => undefined);
-          cdp?.close();
-          await stop(chrome);
-          if (started) {
-            await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], {
-              env: daemonEnvironment,
-            }).catch(() => undefined);
-          }
-          await stop(mediamtx);
-          await rm(webRtcSocketDir, { recursive: true, force: true });
-          // The daemon dir lives under the artifact dir and holds its logs and DB.
-          // Now that artifacts upload on success too, keep it only for a failure to
-          // triage; a green run should ship the latency record, not a sqlite file.
-          if (outcome === "passed") {
-            await rm(daemonDir, { recursive: true, force: true });
-          }
-        });
+        const cleanup = pendingPipelineTeardown;
+        pendingPipelineTeardown = undefined;
+        await cleanup?.();
       }
     },
     deviceIntegrationTimeoutMs,

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -259,6 +259,7 @@ async function startWebRtcDaemon(
   const startError = await execFileAsync("bun", ["dist/src/index.js", "--daemon", "start"], {
     env: daemonEnvironment,
     timeout: REAL_IO_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   })
     .then(() => null)
     .catch((error: unknown) => (error instanceof Error ? error : new Error(String(error))));
@@ -356,7 +357,10 @@ function chromeDiagnostics(chrome: ChildProcessWithoutNullStreams, logFile: stri
  * stale user-data lock cannot wedge the relaunch. Returns the live process so
  * the caller can tear it down.
  */
-async function launchChromeReader(logFile: string): Promise<ChromeReader> {
+async function launchChromeReader(
+  logFile: string,
+  onStarted: (chrome: ChildProcessWithoutNullStreams) => void,
+): Promise<ChromeReader> {
   const maxAttempts = 2;
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -366,6 +370,7 @@ async function launchChromeReader(logFile: string): Promise<ChromeReader> {
       [...CHROME_LAUNCH_ARGS, `--user-data-dir=${userDataDir}`],
       logFile,
     );
+    onStarted(chrome);
     try {
       const cdp = await connectReader(chrome, logFile);
       return { chrome, cdp };
@@ -469,6 +474,7 @@ async function subscribeReader(cdp: CdpClient): Promise<void> {
 async function subscribeRecoveryReader(
   reader: ChromeReader,
   logFile: string,
+  onChromeStarted: (chrome: ChildProcessWithoutNullStreams) => void,
 ): Promise<ChromeReader> {
   try {
     await subscribeReader(reader.cdp);
@@ -477,7 +483,7 @@ async function subscribeRecoveryReader(
     reader.cdp.close();
     await stop(reader.chrome);
     await Bun.sleep(1_000);
-    const replacement = await launchChromeReader(logFile);
+    const replacement = await launchChromeReader(logFile, onChromeStarted);
     try {
       await subscribeReader(replacement.cdp);
       return replacement;
@@ -686,7 +692,7 @@ async function captureProfile(): Promise<CaptureProfile> {
       const { stdout } = await execFileAsync(
         "adb",
         ["-s", androidDeviceId(), "shell", "wm", "size"],
-        { timeout: REAL_IO_TIMEOUT_MS },
+        { timeout: REAL_IO_TIMEOUT_MS, killSignal: "SIGKILL" },
       );
       const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
       return {
@@ -713,19 +719,22 @@ async function launchFixture(): Promise<void> {
     await execFileAsync(
       "adb",
       ["-s", id, "shell", "am", "start", "-a", "android.settings.SETTINGS"],
-      { timeout: REAL_IO_TIMEOUT_MS },
+      { timeout: REAL_IO_TIMEOUT_MS, killSignal: "SIGKILL" },
     );
     await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"], {
       timeout: REAL_IO_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return;
   }
   if (platform === "ios") {
     await execFileAsync("xcrun", ["simctl", "launch", "booted", "com.apple.Preferences"], {
       timeout: REAL_IO_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"], {
       timeout: REAL_IO_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return;
   }
@@ -740,12 +749,14 @@ async function changeFixture(): Promise<void> {
     // made the old theme-only fixture indistinguishable from a frozen stream.
     await execFileAsync("adb", ["-s", id, "shell", "input", "keyevent", "HOME"], {
       timeout: REAL_IO_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return;
   }
   if (platform === "ios") {
     await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "dark"], {
       timeout: REAL_IO_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return;
   }
@@ -765,11 +776,13 @@ afterEach(async () => {
           const id = androidDeviceId();
           await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"], {
             timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+            killSignal: "SIGKILL",
           });
         }
         if (platform === "ios") {
           await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"], {
             timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+            killSignal: "SIGKILL",
           });
         }
       },
@@ -880,12 +893,15 @@ function startStreamLeaseHeartbeat(
 describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => {
   afterAll(async () => {
     const cleanup = pendingPipelineTeardown;
-    pendingPipelineTeardown = undefined;
     let cleanupError: unknown;
     try {
       await cleanup?.();
     } catch (error) {
       cleanupError = error;
+    } finally {
+      if (pendingPipelineTeardown === cleanup) {
+        pendingPipelineTeardown = undefined;
+      }
     }
     const record = timeline.toRecord({
       platform: platform ?? "unknown",
@@ -961,12 +977,16 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         join(artifactDir, "mediamtx.log"),
       );
       let chrome: ChildProcessWithoutNullStreams | undefined;
+      const rememberChrome = (nextChrome: ChildProcessWithoutNullStreams): void => {
+        chrome = nextChrome;
+      };
       let cdp: CdpClient | undefined;
       let started = false;
       let observingStart = true;
       let startObserver: Promise<void> = Promise.resolve();
       let leaseHeartbeat: StreamLeaseHeartbeat | undefined;
-      pendingPipelineTeardown = async () => {
+      let teardownPromise: Promise<void> | undefined;
+      const teardown = async (): Promise<void> => {
         observingStart = false;
         // Measured as its own phase (#4354) so a teardown that stalls stopping the
         // daemon, MediaMTX or Chrome is attributable from the artifact rather than
@@ -1000,6 +1020,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
               await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], {
                 env: daemonEnvironment,
                 timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+                killSignal: "SIGKILL",
               }).catch(() => undefined);
             }
           });
@@ -1015,6 +1036,10 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
             throw new AggregateError(cleanupErrors, "WebRTC device-capture teardown failed");
           }
         });
+      };
+      pendingPipelineTeardown = () => {
+        teardownPromise ??= teardown();
+        return teardownPromise;
       };
       try {
         await waitFor(async () => {
@@ -1038,7 +1063,10 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         profile = await captureProfile();
         // Chrome is launched before the measured window opens so its cold start —
         // seconds on a hosted runner — is not charged to the WHEP-connect stage.
-        ({ chrome, cdp } = await launchChromeReader(join(artifactDir, "chrome.log")));
+        ({ chrome, cdp } = await launchChromeReader(
+          join(artifactDir, "chrome.log"),
+          rememberChrome,
+        ));
         await ensureWebRtcDaemon(webRtcSocketPath, daemonEnvironment);
         timeline.mark("startRequest");
         // A video-only start returns as soon as the WHIP publish is accepted; the
@@ -1186,6 +1214,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
             ({ chrome, cdp } = await subscribeRecoveryReader(
               { chrome: chrome!, cdp: cdp! },
               join(artifactDir, "chrome.log"),
+              rememberChrome,
             ));
             const baseline: KeyframeRecoverySample = { keyFramesDecoded: 0, framesDecoded: 0 };
             // Under a static Simulator screen the restarted encoder's IDR only
@@ -1232,9 +1261,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         expect(listed.streams?.some((stream) => stream.streamId === streamId)).toBe(false);
         outcome = "passed";
       } finally {
-        const cleanup = pendingPipelineTeardown;
-        pendingPipelineTeardown = undefined;
-        await cleanup?.();
+        await pendingPipelineTeardown?.();
       }
     },
     deviceIntegrationTimeoutMs,

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -167,11 +167,14 @@ describe("#4343 device capture latency instrumentation", () => {
     expect(source).toContain("const REAL_IO_TIMEOUT_MS = 30_000;");
     expect(source).toContain("signal: AbortSignal.timeout(REAL_IO_TIMEOUT_MS)");
     expect(source).toContain("handshakeTimeout: REAL_IO_TIMEOUT_MS");
+    expect(source).toContain('killSignal: "SIGKILL"');
     expect(source).toContain("CDP_COMMAND_TIMEOUT_MS");
     expect(source).toContain("async function withDeadline<T>(");
     expect(source).toContain("await withDeadline(message, deadline - Date.now(), predicate)");
     expect(source).toContain("let pendingPipelineTeardown: (() => Promise<void>) | undefined;");
     expect(source).toContain("const cleanup = pendingPipelineTeardown;");
+    expect(source).toContain("teardownPromise ??= teardown()");
+    expect(source).toContain("onStarted(chrome);");
     expect(source).toContain("const cleanupErrors: unknown[] = [];");
     expect(source).toContain("await cleanupStep(() => stop(chrome));");
     expect(source).toContain(

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { CAPTURE_STAGES } from "../helpers/captureStageTimeline";
 
 const repoRoot = join(import.meta.dir, "../..");
+const execFileAsync = promisify(execFile);
 
 function read(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), "utf8");
@@ -154,6 +157,61 @@ describe("#4343 device capture latency instrumentation", () => {
 
     expect(source).toContain('runPhase("pipelineTeardown"');
   });
+
+  test("bounds real-I/O operations and leaves a teardown fallback for a timed-out body (#5715)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // The outer test deadline only reports a whole-suite hang. Every operation
+    // that can block on the hosted runner needs its own failure path, while the
+    // retained cleanup callback lets afterAll reap processes if Bun skips finally.
+    expect(source).toContain("const REAL_IO_TIMEOUT_MS = 30_000;");
+    expect(source).toContain("signal: AbortSignal.timeout(REAL_IO_TIMEOUT_MS)");
+    expect(source).toContain("handshakeTimeout: REAL_IO_TIMEOUT_MS");
+    expect(source).toContain("CDP_COMMAND_TIMEOUT_MS");
+    expect(source).toContain("async function withDeadline<T>(");
+    expect(source).toContain("await withDeadline(message, deadline - Date.now(), predicate)");
+    expect(source).toContain("let pendingPipelineTeardown: (() => Promise<void>) | undefined;");
+    expect(source).toContain("const cleanup = pendingPipelineTeardown;");
+    expect(source).toContain("const cleanupErrors: unknown[] = [];");
+    expect(source).toContain("await cleanupStep(() => stop(chrome));");
+    expect(source).toContain(
+      'new AggregateError(cleanupErrors, "WebRTC device-capture teardown failed")',
+    );
+    expect(source).toContain("const TEARDOWN_HOOK_TIMEOUT_MS = 45_000;");
+
+    const afterAllIndex = indexOfRequired(source, "afterAll(");
+    const cleanupIndex = indexOfRequired(source.slice(afterAllIndex), "await cleanup?.()");
+    const recordIndex = indexOfRequired(source.slice(afterAllIndex), "timeline.toRecord(");
+    expect(cleanupIndex).toBeLessThan(recordIndex);
+  });
+
+  test("keeps the default skipped-suite load path free of WebRTC and simulator runtime graphs (#5715)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // The macOS default test job does not enable device integration. Loading
+    // these runtime graphs before registering describe.skip can wedge the
+    // isolate before Bun prints the skipped test result.
+    expect(source).not.toContain('from "../../src/features/webrtc/IosH264Source"');
+    expect(source).not.toContain('from "../../src/server/webrtcStreamManager"');
+    expect(source).not.toContain('from "../../src/utils/ios-cmdline-tools/SimCtlClient"');
+    expect(source).not.toContain('from "../../src/features/webrtc/webrtcStreamingConfig"');
+    expect(source).toContain('await import("../../src/features/webrtc/IosH264Source")');
+    expect(source).toContain('await import("../../src/server/webrtcStreamManager")');
+    expect(source).toContain('await import("../../src/utils/ios-cmdline-tools/SimCtlClient")');
+    expect(source).toContain('await import("../../src/features/webrtc/webrtcStreamingConfig")');
+  });
+
+  test("loads the default skipped suite without initializing device capture", async () => {
+    const env = { ...process.env };
+    delete env.AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION;
+    const { stderr, stdout } = await execFileAsync("bun", ["test", INTEGRATION_TEST_PATH], {
+      cwd: repoRoot,
+      env,
+      timeout: 10_000,
+    });
+
+    expect(`${stdout}\n${stderr}`).toContain("(skip) device capture -> WHIP -> MediaMTX -> WHEP");
+  }, 15_000);
 
   test("collects phases on the shared timeline and keeps afterAll the sole record writer (#4354)", () => {
     const source = withoutComments(read(INTEGRATION_TEST_PATH));

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { parseSync } from "oxc-parser";
 import { CAPTURE_STAGES } from "../helpers/captureStageTimeline";
 
 const repoRoot = join(import.meta.dir, "../..");
@@ -28,6 +29,70 @@ function indexOfRequired(source: string, needle: string): number {
   const index = source.indexOf(needle);
   expect(`${needle} present: ${index >= 0}`).toBe(`${needle} present: true`);
   return index;
+}
+
+interface AstNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
+function visitAst(value: unknown, visit: (node: AstNode) => void): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitAst(item, visit);
+    }
+    return;
+  }
+  if (!isAstNode(value)) {
+    return;
+  }
+  visit(value);
+  for (const child of Object.values(value)) {
+    visitAst(child, visit);
+  }
+}
+
+function execFileOptionNames(source: string): string[][] {
+  const optionNames: string[][] = [];
+  visitAst(parseSync(INTEGRATION_TEST_PATH, source).program, (node) => {
+    if (
+      node.type !== "CallExpression" ||
+      !isAstNode(node.callee) ||
+      node.callee.type !== "Identifier" ||
+      node.callee.name !== "execFileAsync" ||
+      !Array.isArray(node.arguments)
+    ) {
+      return;
+    }
+    const options = node.arguments[2];
+    if (
+      !isAstNode(options) ||
+      options.type !== "ObjectExpression" ||
+      !Array.isArray(options.properties)
+    ) {
+      optionNames.push([]);
+      return;
+    }
+    optionNames.push(
+      options.properties.flatMap((property) => {
+        if (
+          !isAstNode(property) ||
+          property.type !== "Property" ||
+          !isAstNode(property.key) ||
+          property.key.type !== "Identifier" ||
+          typeof property.key.name !== "string"
+        ) {
+          return [];
+        }
+        return [property.key.name];
+      }),
+    );
+  });
+  return optionNames;
 }
 
 /**
@@ -167,10 +232,10 @@ describe("#4343 device capture latency instrumentation", () => {
     expect(source).toContain("const REAL_IO_TIMEOUT_MS = 30_000;");
     expect(source).toContain("signal: AbortSignal.timeout(REAL_IO_TIMEOUT_MS)");
     expect(source).toContain("handshakeTimeout: REAL_IO_TIMEOUT_MS");
-    expect(source).toContain('killSignal: "SIGKILL"');
     expect(source).toContain("CDP_COMMAND_TIMEOUT_MS");
-    expect(source).toContain("async function withDeadline<T>(");
-    expect(source).toContain("await withDeadline(message, deadline - Date.now(), predicate)");
+    expect(source).toContain('import { waitFor, withDeadline } from "../helpers/abortableWaitFor"');
+    expect(source).toContain("async (signal) => {");
+    expect(source).toContain("changeFixture(signal) : launchFixture(signal)");
     expect(source).toContain("let pendingPipelineTeardown: (() => Promise<void>) | undefined;");
     expect(source).toContain("const cleanup = pendingPipelineTeardown;");
     expect(source).toContain("teardownPromise ??= teardown()");
@@ -186,6 +251,18 @@ describe("#4343 device capture latency instrumentation", () => {
     const cleanupIndex = indexOfRequired(source.slice(afterAllIndex), "await cleanup?.()");
     const recordIndex = indexOfRequired(source.slice(afterAllIndex), "timeline.toRecord(");
     expect(cleanupIndex).toBeLessThan(recordIndex);
+  });
+
+  test("gives every subprocess its own forced-kill deadline (#5715)", () => {
+    // This uses the repository's installed Oxc TypeScript parser rather than
+    // matching nested call expressions with a line regex. Adding a subprocess,
+    // or deleting options from one existing call, must fail this guard.
+    const calls = execFileOptionNames(read(INTEGRATION_TEST_PATH));
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const optionNames of calls) {
+      expect(optionNames).toEqual(expect.arrayContaining(["timeout", "killSignal"]));
+    }
   });
 
   test("keeps the default skipped-suite load path free of WebRTC and simulator runtime graphs (#5715)", () => {


### PR DESCRIPTION
## Summary

The default macOS test run loaded the WebRTC device-capture runtime graph before registering its skipped suite, which could stall the Bun isolate with no per-file result. Defer that graph until the opt-in device test begins, and bound its real-I/O operations and teardown so an enabled lane fails with diagnostics and reaps its resources.

## Linked Issue

Closes [#5715](https://github.com/kaeawc/auto-mobile/issues/5715)

## Bug / Regression Context

- **Observed symptom:** `webrtcDeviceCapture.integration.test.ts` opened in the macOS full suite but never emitted a pass or skip result before the wall-clock watchdog.
- **Repro steps / conditions:** Run the default isolated suite without `AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION=1`.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `bun test test/integration/webrtcDeviceCaptureLatency.test.ts test/integration/webrtcDeviceCapture.integration.test.ts`
- [x] The no-flag skipped-suite regression check completes with the expected skipped result
- [x] New code uses existing `Timer` infrastructure and the test harness stays under the unit-time budget

## Follow-ups

- [ ] None
