### PR TITLE
fix(android): acknowledge completed text input promptly

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -4098,31 +4098,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
 
-      // Trigger a hierarchy refresh after successful text input
-      // This ensures the next observe will get the updated text
-      if (success) {
-        // Wait for UI to settle (no accessibility events for 50ms), then extract hierarchy
-        // This dynamically adapts to how long validation/animations take, instead of using a fixed
-        // delay
-        // Flow emissions are suppressed during this to prevent race conditions with debounced
-        // broadcasts
-        val freshHierarchy =
-          hierarchyDebouncer.extractAfterQuiescence(
-            quiescenceMs = 50L, // Wait for 50ms of no events
-            maxWaitMs = 500L, // But don't wait more than 500ms total
-            pollIntervalMs = 10L, // Check every 10ms
-          )
-        if (freshHierarchy != null) {
-          // Broadcast hierarchy synchronously (sync=true) to ensure it arrives before
-          // set_text_result
-          kotlinx.coroutines.runBlocking { broadcastHierarchyUpdate(freshHierarchy, sync = true) }
-        }
-      }
-
       val totalTime = System.currentTimeMillis() - startTime
-      Log.d(TAG, "Set text total time: ${totalTime}ms")
-
-      // Broadcast set_text_result synchronously to ensure ordering after hierarchy
+      Log.d(TAG, "Set text completed in ${totalTime}ms")
+      // ACTION_SET_TEXT and the requested keyboard state are complete, so acknowledge before
+      // optional hierarchy work. Waiting for quiescence/extraction first can turn a completed
+      // write into a host-side timeout.
       kotlinx.coroutines.runBlocking {
         broadcastSetTextResult(
           requestId,
@@ -4130,6 +4110,30 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           if (success) null else "performAction returned false",
           totalTime,
         )
+      }
+
+      // Trigger a hierarchy refresh after successful text input
+      // This ensures the next observe will get the updated text
+      if (success) {
+        serviceScope.launch {
+          try {
+            // Wait for UI to settle (no accessibility events for 50ms), then extract hierarchy.
+            // This best-effort follow-up must not delay the set_text_result acknowledgement.
+            val freshHierarchy =
+              hierarchyDebouncer.extractAfterQuiescence(
+                quiescenceMs = 50L,
+                maxWaitMs = 500L,
+                pollIntervalMs = 10L,
+              )
+            if (freshHierarchy != null) {
+              broadcastHierarchyUpdate(freshHierarchy, sync = true)
+            }
+          } catch (e: CancellationException) {
+            throw e
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to refresh hierarchy after text input", e)
+          }
+        }
       }
     } catch (e: Exception) {
       perfProvider.end()
@@ -5726,7 +5730,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     resultBroadcaster.guard(requestId, "set_text_result") {
-      webSocketServer.broadcastWithPerf { perfTiming ->
+      webSocketServer.broadcastWithPerfSync { perfTiming ->
         webSocketFrameJson("set_text_result", requestId = requestId, perfTiming = perfTiming) {
           put("success", success)
           put("totalTimeMs", totalTimeMs)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SetTextAcknowledgementOrderTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SetTextAcknowledgementOrderTest.kt
@@ -1,0 +1,81 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Regression guard for #5685.
+ *
+ * A successful ACTION_SET_TEXT changes the device immediately. Its correlated result must be
+ * broadcast before optional hierarchy settling and extraction, whose latency otherwise turns a
+ * completed write into a host-side timeout.
+ *
+ * CtrlProxy is an AccessibilityService and cannot be constructed in a fast unit test. This
+ * Android-free source test verifies the ordering at the production call site.
+ */
+class SetTextAcknowledgementOrderTest {
+
+  @Test
+  fun `performSetText acknowledges a successful action before hierarchy postprocessing`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    val body = functionBody(source, "private fun performSetText(")
+    val action = body.indexOf("targetNode.performAction(")
+    val acknowledgement = body.indexOf("broadcastSetTextResult(", startIndex = action)
+    val hierarchy = body.indexOf("hierarchyDebouncer.extractAfterQuiescence(", startIndex = action)
+
+    assertTrue("performSetText must call ACTION_SET_TEXT", action >= 0)
+    assertTrue(
+      "performSetText must broadcast set_text_result after ACTION_SET_TEXT",
+      acknowledgement > action,
+    )
+    assertTrue(
+      "performSetText must post-process the hierarchy after ACTION_SET_TEXT",
+      hierarchy > action,
+    )
+    assertTrue(
+      "set_text_result must acknowledge a successful ACTION_SET_TEXT before hierarchy postprocessing",
+      acknowledgement < hierarchy,
+    )
+
+    val broadcaster = functionBody(source, "private suspend fun broadcastSetTextResult(")
+    assertTrue(
+      "set_text_result must use synchronous delivery instead of the backpressured event flow",
+      "webSocketServer.broadcastWithPerfSync" in broadcaster,
+    )
+  }
+
+  private fun functionBody(source: String, signature: String): String {
+    val start = source.indexOf(signature)
+    if (start < 0) fail("$signature not found in CtrlProxy.kt")
+    val open = source.indexOf('{', start)
+    if (open < 0) fail("$signature body not found in CtrlProxy.kt")
+    return source.substring(open, KotlinSourceScan.matchBrace(source, open))
+  }
+
+  private fun readCtrlProxySource(): String = locateCtrlProxySource().readText()
+
+  private fun locateCtrlProxySource(): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt"
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull { it.isFile }
+    if (direct != null) return direct
+
+    var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+    while (dir != null) {
+      for (candidate in
+        listOf(
+          File(dir, rel),
+          File(dir, "control-proxy/$rel"),
+          File(dir, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      dir = dir.parentFile
+    }
+    fail("Could not locate CtrlProxy.kt from user.dir=${System.getProperty("user.dir")}")
+    error("unreachable")
+  }
+}


### PR DESCRIPTION
## Summary

- Acknowledge a completed Android `ACTION_SET_TEXT` before optional hierarchy settling and extraction can consume the host's request deadline.
- Deliver `set_text_result` synchronously, while retaining the hierarchy refresh as a logged best-effort background task.
- Add a Kotlin regression guard for acknowledgement ordering and delivery mode.

## Linked Issue

Closes [#5685](https://github.com/kaeawc/auto-mobile/issues/5685)

## Bug / Regression Context

- **Prior attempts:** [#4429](https://github.com/kaeawc/auto-mobile/issues/4429) added explicit `eventOnly` input but deliberately did not retry timed-out accessibility writes.
- **Observed symptom:** `inputText` returned `success: false` after five seconds even though the device had accepted the text.
- **Repro steps / conditions:** Android accessibility text input against a busy Settings search field.

## Validation

- [x] `scripts/ktfmt/validate_ktfmt.sh`
- [x] `:control-proxy:testDebugUnitTest`
- [x] `bun run typecheck`
- [x] All 33 non-ktfmt checks from `scripts/all_fast_validate_checks.sh`; ktfmt was re-run successfully after formatting.
- [ ] Device repro: no Android device was attached in this environment.

## Kotlin Reuse Check

- [x] Reused existing `serviceScope`, `ResultBroadcaster`, and synchronous WebSocket broadcast primitives; no helper or dependency added.

## Follow-ups

- [x] No follow-up issues needed.
