### PR TITLE
feat(desktop): scope performance audit-history per device (#5086)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -43,6 +43,7 @@ interface AutoMobileClient {
     endTime: String? = null,
     limit: Int? = null,
     offset: Int? = null,
+    deviceId: String? = null,
   ): PerformanceAuditHistoryResult
 
   fun getTestTimings(query: TestTimingQuery = TestTimingQuery()): TestTimingSummary

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -168,8 +168,9 @@ class McpDaemonClient(
     endTime: String?,
     limit: Int?,
     offset: Int?,
+    deviceId: String?,
   ): PerformanceAuditHistoryResult {
-    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset)
+    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset, deviceId)
     val contents = readResource(uri)
     return decodePerformanceAuditResource(json, contents)
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -120,8 +120,9 @@ class McpHttpClient(
     endTime: String?,
     limit: Int?,
     offset: Int?,
+    deviceId: String?,
   ): PerformanceAuditHistoryResult {
-    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset)
+    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset, deviceId)
     val contents = readResource(uri)
     return decodePerformanceAuditResource(json, contents)
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -124,8 +124,9 @@ class McpStdioClient(
     endTime: String?,
     limit: Int?,
     offset: Int?,
+    deviceId: String?,
   ): PerformanceAuditHistoryResult {
-    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset)
+    val uri = buildPerformanceResultsUri(startTime, endTime, limit, offset, deviceId)
     val contents = readResource(uri)
     return decodePerformanceAuditResource(json, contents)
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResults.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResults.kt
@@ -56,6 +56,7 @@ internal fun buildPerformanceResultsUri(
   endTime: String?,
   limit: Int?,
   offset: Int?,
+  deviceId: String?,
 ): String {
   return ResourceUriBuilder(PERFORMANCE_RESULTS_RESOURCE_URI)
     .apply {
@@ -63,6 +64,7 @@ internal fun buildPerformanceResultsUri(
       add("endTime", endTime)
       add("limit", limit)
       add("offset", offset)
+      add("deviceId", deviceId)
     }
     .build()
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/DataSourceFactory.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/DataSourceFactory.kt
@@ -51,10 +51,12 @@ interface DataSourceFactory {
    *
    * @param mode The data source mode (Fake or Real)
    * @param clientProvider Optional override client provider (e.g. for process-specific connections)
+   * @param deviceId The device to scope audit-history reads to (null = all devices)
    */
   fun createPerformanceDataSource(
     mode: DataSourceMode,
     clientProvider: (() -> AutoMobileClient)? = null,
+    deviceId: String? = null,
   ): PerformanceDataSource
 
   /**
@@ -162,10 +164,11 @@ class DefaultDataSourceFactory(private val client: AutoMobileClient) : DataSourc
   override fun createPerformanceDataSource(
     mode: DataSourceMode,
     clientProvider: (() -> AutoMobileClient)?,
+    deviceId: String?,
   ): PerformanceDataSource {
     return when (mode) {
       DataSourceMode.Fake -> FakePerformanceDataSource()
-      DataSourceMode.Real -> RealPerformanceDataSource(resolveProvider(clientProvider))
+      DataSourceMode.Real -> RealPerformanceDataSource(resolveProvider(clientProvider), deviceId)
     }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealPerformanceDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealPerformanceDataSource.kt
@@ -13,15 +13,21 @@ import dev.jasonpearson.automobile.desktop.core.performance.PerformanceRun
 /**
  * Real performance data source that fetches from MCP resources. Uses the performance-results
  * resource to get actual performance audit data.
+ *
+ * When [deviceId] is set, the audit-history read is scoped to that device so a pane in a
+ * multi-device workspace only surfaces its own device's audit history (the performance-results
+ * resource filters server-side by `deviceId`). Null = unscoped (all devices).
  */
-class RealPerformanceDataSource(private val clientProvider: (() -> AutoMobileClient)? = null) :
-  PerformanceDataSource {
+class RealPerformanceDataSource(
+  private val clientProvider: (() -> AutoMobileClient)? = null,
+  private val deviceId: String? = null,
+) : PerformanceDataSource {
   override suspend fun getPerformanceRun(): Result<PerformanceRun> {
     val provider = clientProvider ?: return Result.Success(createEmptyRun())
 
     return try {
       val client = provider()
-      val auditResult = client.listPerformanceAuditResults(limit = 50)
+      val auditResult = client.listPerformanceAuditResults(limit = 50, deviceId = deviceId)
 
       if (auditResult.results.isEmpty()) {
         return Result.Success(createEmptyRun())

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/performance/PerformanceDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/performance/PerformanceDashboard.kt
@@ -57,7 +57,8 @@ fun PerformanceDashboard(
   clientProvider: (() -> AutoMobileClient)? = null, // MCP client for real data
   observationStreamClient: ObservationStream? = null, // Per-device stream for real-time updates
   // Device this dashboard is scoped to; when set, cross-device stream updates are dropped so panes
-  // in a multi-device workspace can't contaminate each other's live metrics. Null = no filtering.
+  // in a multi-device workspace can't contaminate each other's live metrics, and the audit-history
+  // fetch is scoped to this device. Null = no filtering.
   deviceId: String? = null,
   // Initial metrics from parent to avoid empty state flicker when opening
   initialFps: Float? = null,
@@ -555,7 +556,7 @@ fun PerformanceDashboard(
   }
 
   // Initial fetch as fallback (only if we don't already have data from initial metrics)
-  LaunchedEffect(dataSourceMode, clientProvider) {
+  LaunchedEffect(dataSourceMode, clientProvider, deviceId) {
     // Skip fetch if we already have data from initial metrics
     if (currentRun != null) {
       isLoading = false
@@ -566,7 +567,11 @@ fun PerformanceDashboard(
     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
       try {
         val dataSource =
-          graph.dataSourceFactory.createPerformanceDataSource(dataSourceMode, clientProvider)
+          graph.dataSourceFactory.createPerformanceDataSource(
+            dataSourceMode,
+            clientProvider,
+            deviceId,
+          )
         when (val result = dataSource.getPerformanceRun()) {
           is dev.jasonpearson.automobile.desktop.core.datasource.Result.Success -> {
             // Only update if we still don't have data (stream might have pushed by now)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -283,14 +283,25 @@ class FakeAutoMobileClient : AutoMobileClient {
     return setFeatureFlagResult
   }
 
+  /** deviceId passed to the most recent [listPerformanceAuditResults] call (null if unscoped). */
+  var lastListPerformanceAuditResultsDeviceId: String? = null
+
   override fun listPerformanceAuditResults(
     startTime: String?,
     endTime: String?,
     limit: Int?,
     offset: Int?,
+    deviceId: String?,
   ): PerformanceAuditHistoryResult {
     calls.add("listPerformanceAuditResults")
-    return listPerformanceAuditResultsResult
+    lastListPerformanceAuditResultsDeviceId = deviceId
+    // Mirror the performance-results resource's server-side deviceId filter so device-scoped
+    // reads only surface their own device's entries.
+    if (deviceId == null) {
+      return listPerformanceAuditResultsResult
+    }
+    val scoped = listPerformanceAuditResultsResult.results.filter { it.deviceId == deviceId }
+    return listPerformanceAuditResultsResult.copy(results = scoped)
   }
 
   override fun getTestTimings(query: TestTimingQuery): TestTimingSummary {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
@@ -23,10 +23,9 @@ import kotlinx.coroutines.delay
  * [socketAvailable] are the injected timer/daemon-availability seams that let that recovery be
  * tested with virtual time.
  *
- * Note: only the LIVE metrics here are per-device (the stream carries a deviceId). The dashboard's
- * audit-history fallback still reads via the DI graph's active-device client — device-scoping that
- * path is a separate follow-up (thread deviceId through listPerformanceAuditResults), not fixed
- * here.
+ * Both the LIVE metrics (the stream carries a deviceId) and the audit-history fallback are scoped
+ * to [column]'s device: [PerformanceDashboard] threads [DeviceColumn.deviceId] through
+ * `listPerformanceAuditResults` so a pane only surfaces its own device's audit history.
  */
 @Composable
 fun PerformanceFacet(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResultsUriTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResultsUriTest.kt
@@ -1,0 +1,35 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PerformanceAuditResultsUriTest {
+
+  @Test
+  fun `omits absent parameters`() {
+    assertEquals(
+      "automobile:performance-results",
+      buildPerformanceResultsUri(
+        startTime = null,
+        endTime = null,
+        limit = null,
+        offset = null,
+        deviceId = null,
+      ),
+    )
+  }
+
+  @Test
+  fun `scopes audit-history read to a device`() {
+    assertEquals(
+      "automobile:performance-results?limit=50&deviceId=emulator-5554",
+      buildPerformanceResultsUri(
+        startTime = null,
+        endTime = null,
+        limit = 50,
+        offset = null,
+        deviceId = "emulator-5554",
+      ),
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealPerformanceDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealPerformanceDataSourceTest.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceAuditHistoryEntry
+import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceAuditHistoryResult
+import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceAuditMetrics
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies that [RealPerformanceDataSource] scopes the audit-history read to its device so a pane
+ * in a multi-device workspace only surfaces its own device's audit history (issue #5086).
+ */
+class RealPerformanceDataSourceTest {
+
+  private fun entry(id: Long, deviceId: String, touchLatencyMs: Double) =
+    PerformanceAuditHistoryEntry(
+      id = id,
+      deviceId = deviceId,
+      sessionId = "session-$id",
+      packageName = "com.example.app",
+      timestamp = "2026-01-01T00:00:0${id}Z",
+      passed = true,
+      metrics = PerformanceAuditMetrics(touchLatencyMs = touchLatencyMs),
+    )
+
+  private fun clientWithTwoDevices(): FakeAutoMobileClient {
+    return FakeAutoMobileClient().apply {
+      listPerformanceAuditResultsResult =
+        PerformanceAuditHistoryResult(
+          results =
+            listOf(
+              entry(id = 1, deviceId = "device-A", touchLatencyMs = 50.0),
+              entry(id = 2, deviceId = "device-B", touchLatencyMs = 999.0),
+            )
+        )
+    }
+  }
+
+  @Test
+  fun `scoped data source threads its deviceId to the client`() = runBlocking {
+    val client = clientWithTwoDevices()
+    val dataSource = RealPerformanceDataSource(clientProvider = { client }, deviceId = "device-A")
+
+    dataSource.getPerformanceRun()
+
+    assertEquals("device-A", client.lastListPerformanceAuditResultsDeviceId)
+  }
+
+  @Test
+  fun `pane scoped to device A does not surface device B audit results`() = runBlocking {
+    val client = clientWithTwoDevices()
+    val dataSource = RealPerformanceDataSource(clientProvider = { client }, deviceId = "device-A")
+
+    val result = dataSource.getPerformanceRun()
+
+    assertTrue(result is Result.Success)
+    val run = (result as Result.Success).data
+    assertEquals("device-A", run.deviceName)
+    val touchLatency = run.metrics.firstOrNull { it.id == "touch_latency" }
+    assertTrue("expected a touch_latency metric for device A", touchLatency != null)
+    val values = touchLatency!!.history.map { it.value }
+    // Device B's distinctive 999ms sample must never leak into device A's pane.
+    assertFalse("device B's audit sample leaked into device A", values.contains(999f))
+    assertTrue(values.contains(50f))
+  }
+
+  @Test
+  fun `unscoped data source aggregates all devices`() = runBlocking {
+    val client = clientWithTwoDevices()
+    val dataSource = RealPerformanceDataSource(clientProvider = { client }, deviceId = null)
+
+    val result = dataSource.getPerformanceRun()
+
+    assertTrue(result is Result.Success)
+    val run = (result as Result.Success).data
+    val touchLatency = run.metrics.first { it.id == "touch_latency" }
+    val values = touchLatency.history.map { it.value }
+    assertTrue(values.contains(50f))
+    assertTrue(values.contains(999f))
+    assertEquals(null, client.lastListPerformanceAuditResultsDeviceId)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
@@ -399,6 +399,7 @@ class FakeAutoMobileClient : AutoMobileClient {
     endTime: String?,
     limit: Int?,
     offset: Int?,
+    deviceId: String?,
   ) = notImplemented()
 
   override fun getTestTimings(


### PR DESCRIPTION
## Summary

Scopes the Performance facet's **audit-history** read per-device so a pane in a multi-device workspace only surfaces its own device's audit history. This is [#4832](https://github.com/kaeawc/auto-mobile/issues/4832) part 3, previously flagged in-code in `PerformanceFacet`'s KDoc.

Previously only the *live* metrics were per-device (the `ObservationStream` carries a deviceId); the audit-history fallback resolved via the DI graph's **active-device** client, so a pane could show another device's audit history.

## Changes

- `AutoMobileClient.listPerformanceAuditResults` gains a `deviceId` param, passed to the `performance-results` MCP resource's already-supported server-side `deviceId` query filter (`buildPerformanceResultsUri`), across all three clients (daemon/http/stdio).
- `RealPerformanceDataSource` and `DataSourceFactory.createPerformanceDataSource` accept `deviceId`, mirroring the existing `createStorageDataSource` / `createAppListDataSource` pattern.
- `PerformanceDashboard` threads its scoped `deviceId` into the audit-history fetch and re-fetches when the device changes.
- `FakeAutoMobileClient` mirrors the server-side `deviceId` filter and records the last `deviceId` for assertions.

## Acceptance criteria

- [x] `deviceId` threaded through the audit-history read (`listPerformanceAuditResults` and its data source).
- [x] Test with a fake client that a pane scoped to device A does not surface device B's audit results (`RealPerformanceDataSourceTest`).
- [x] URI-builder test locks the server-side `deviceId` filter (`PerformanceAuditResultsUriTest`).

## Testing

- `./gradlew :desktop-core:test --tests RealPerformanceDataSourceTest --tests PerformanceAuditResultsUriTest --tests NavigationScreenshotLoaderTest` — green.
- Full `:desktop-core:test` — green apart from the known `DeviceControlSessionTest` Compose-snapshot flake, which passes on isolated rerun and is unrelated to this diff.
- ktfmt validation — clean.

Labeled `needs-human` and auto-merge left off because the diff threads real data-fetch scoping through `android/` runtime code.

Closes #5086