### PR TITLE
feat(mcp): add target-discriminated putAppFile contract

### DIFF
--- a/docs/design-docs/mcp/app-file-service.md
+++ b/docs/design-docs/mcp/app-file-service.md
@@ -4,16 +4,22 @@
 
 `putAppFile` and the app-file resources share one internal service so tools and
 resources do not call `adb`, `run-as`, `simctl`, or the host filesystem directly.
+The public write contract is a non-empty `files` batch plus a discriminated
+`target`: `app_containers`, `user_files`, or `media_library`. The legacy
+single-file app-container arguments are accepted only as a compatibility input
+path; generated tool definitions advertise the canonical target-based shape.
 
 ## Service Boundary
 
 - Public MCP handlers call `AppFileService` in `src/server/appFileService.ts`.
-- `DefaultAppFileService` owns shared validation, source preparation, device
-  resolution for resources, provider selection, and typed result metadata.
-- Platform-specific behavior lives behind `AppFileProvider` implementations:
-  `AndroidAppFileProvider` and `IosSimulatorAppFileProvider`.
-- Providers receive normalized app IDs, logical containers, safe relative paths,
-  and prepared source file paths. They should not accept raw MCP arguments.
+- `DefaultAppFileService` owns target/path normalization, whole-batch conflict
+  preflight, source preparation and cleanup, device resolution for resources,
+  provider selection, and typed result metadata.
+- The provider registry keys write providers by platform plus logical storage
+  domain. List and read provider seams are separate, so a write-only target
+  never promises resource operations it cannot implement.
+- Providers receive normalized targets, safe relative paths, and prepared local
+  source file paths. They should not accept raw MCP arguments.
 
 ## Shared Validation
 
@@ -23,22 +29,19 @@ Keep validation that is common to all platforms in the service or contract layer
   parsing.
 - `normalizeAppFileRelativePath` rejects absolute paths, empty paths, repeated
   separators, `.`, and `..` traversal.
-- `AppFileService` validates app IDs before provider selection so unsafe app IDs
-  cannot reach platform path construction.
+- `AppFileService` validates app IDs, user-file namespaces, paths, duplicate
+  destinations, and directory-prefix conflicts before provider mutation begins.
 
 Provider-specific checks should only cover platform capability differences. For
 example, Android rejects `library`, and iOS rejects `externalFiles`.
 
 ## Adding Containers
 
-1. Add the logical name to `APP_FILE_CONTAINERS` in
-   `src/server/appFileContract.ts`.
-2. Map the container in each provider in `src/server/appFileService.ts`.
-3. If a platform cannot support the container, throw an explicit
-   `ActionableError` through the unsupported-operation helper. Include the
-   operation, app ID, container, and platform in the message.
-4. Add tests in `test/server/appFileService.test.ts` for shared validation,
-   provider routing, and the platform-specific capability behavior.
+1. Add the logical domain or app container to `src/server/appFileContract.ts`.
+2. Register a write provider for every supported platform/domain pair.
+3. Add list/read providers only where those operations are actually supported.
+4. Add fake-backed tests in `test/server/appFileService.test.ts` for shared
+   validation, provider routing, cleanup, result mapping, and platform limits.
 
 ## Adding Providers
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7233,36 +7233,104 @@
   },
   {
     "name": "putAppFile",
-    "description": "Write file/text/base64 content into an app container.",
+    "description": "Write files into a bounded logical storage target.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "appId": {
-          "type": "string",
-          "minLength": 1
+        "target": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "domain": {
+                  "type": "string",
+                  "const": "app_containers"
+                },
+                "appId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "container": {
+                  "description": "App container",
+                  "type": "string",
+                  "enum": ["documents", "library", "cache", "tmp", "externalFiles"]
+                }
+              },
+              "required": ["domain", "appId", "container"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "domain": {
+                  "type": "string",
+                  "const": "user_files"
+                },
+                "namespace": {
+                  "description": "One caller-named fixture namespace",
+                  "type": "string"
+                },
+                "reset": {
+                  "description": "Remove only this fixture namespace before writing",
+                  "type": "boolean"
+                }
+              },
+              "required": ["domain", "namespace"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "domain": {
+                  "type": "string",
+                  "const": "media_library"
+                }
+              },
+              "required": ["domain"],
+              "additionalProperties": false
+            }
+          ]
         },
-        "container": {
-          "description": "App container",
-          "type": "string",
-          "enum": ["documents", "library", "cache", "tmp", "externalFiles"]
-        },
-        "sourcePath": {
-          "description": "Host file path",
-          "type": "string",
-          "minLength": 1
-        },
-        "contentText": {
-          "description": "UTF-8 content",
-          "type": "string"
-        },
-        "contentBase64": {
-          "description": "Base64 content",
-          "type": "string"
-        },
-        "destinationPath": {
-          "description": "Container-relative destination path",
-          "type": "string"
+        "files": {
+          "description": "Files to write",
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sourcePath": {
+                "description": "Host file path",
+                "type": "string",
+                "minLength": 1
+              },
+              "contentText": {
+                "description": "UTF-8 content",
+                "type": "string"
+              },
+              "contentBase64": {
+                "description": "Base64 content",
+                "type": "string"
+              },
+              "destinationPath": {
+                "description": "Safe path relative to the declared storage target",
+                "type": "string"
+              }
+            },
+            "required": ["destinationPath"],
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "required": ["sourcePath"]
+              },
+              {
+                "required": ["contentText"]
+              },
+              {
+                "required": ["contentBase64"]
+              }
+            ]
+          }
         },
         "platform": {
           "type": "string",
@@ -7280,7 +7348,7 @@
           "type": "string"
         }
       },
-      "required": ["appId", "container", "destinationPath"],
+      "required": ["target", "files"],
       "additionalProperties": false
     }
   },

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -243,10 +243,10 @@ const mediaLibraryTargetSchema = z.object({ domain: z.literal("media_library") }
 
 const putAppFileInputSchema = z
   .object({
-  sourcePath: z.string().min(1).optional().describe("Host file path"),
-  contentText: z.string().optional().describe("UTF-8 content"),
-  contentBase64: z.string().optional().describe("Base64 content"),
-  destinationPath: z.string().describe("Safe path relative to the declared storage target"),
+    sourcePath: z.string().min(1).optional().describe("Host file path"),
+    contentText: z.string().optional().describe("UTF-8 content"),
+    contentBase64: z.string().optional().describe("Base64 content"),
+    destinationPath: z.string().describe("Safe path relative to the declared storage target"),
   })
   .strict()
   .superRefine((file, ctx) => {
@@ -317,11 +317,13 @@ function preprocessLegacyPutAppFileArgs(input: unknown): unknown {
     return args.legacySingleFile === undefined ? input : { ...args, legacySingleFile: false };
   }
   const appId =
-    args.appId ?? appIdFieldAliases.map((alias) => args[alias]).find((value) => value !== undefined);
+    args.appId ??
+    appIdFieldAliases.map((alias) => args[alias]).find((value) => value !== undefined);
   if (appId === undefined || args.container === undefined) {
     return input;
   }
-  const { container, destinationPath, sourcePath, contentText, contentBase64, ...deviceArgs } = args;
+  const { container, destinationPath, sourcePath, contentText, contentBase64, ...deviceArgs } =
+    args;
   delete deviceArgs.appId;
   for (const alias of appIdFieldAliases) {
     delete deviceArgs[alias];

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -1,5 +1,10 @@
 import { z } from "zod/v4";
-import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import {
+  addDeviceTargetingToSchema,
+  appIdFieldAliases,
+  withAppIdAliases,
+  withJsonSchemaOverride,
+} from "./toolSchemaHelpers";
 import type { Platform } from "../models";
 
 export const APP_FILE_CONTAINERS = [
@@ -24,7 +29,47 @@ export interface AppFileResourceParts {
   path?: string;
 }
 
+export type StorageDomain = "app_containers" | "user_files" | "media_library";
+
+export interface AppContainersTarget {
+  domain: "app_containers";
+  appId: string;
+  container: AppFileContainer;
+}
+
+export interface UserFilesTarget {
+  domain: "user_files";
+  namespace: string;
+  reset?: boolean;
+}
+
+export interface MediaLibraryTarget {
+  domain: "media_library";
+}
+
+export type PutAppFileTarget = AppContainersTarget | UserFilesTarget | MediaLibraryTarget;
+
+export interface PutAppFileInput {
+  destinationPath: string;
+  sourcePath?: string;
+  contentText?: string;
+  contentBase64?: string;
+}
+
 export interface PutAppFileArgs {
+  target: PutAppFileTarget;
+  files: PutAppFileInput[];
+  /** Internal compatibility marker populated by the legacy-shape preprocessor. */
+  legacySingleFile?: boolean;
+  platform?: Platform;
+  deviceId?: string;
+  device?: string;
+  sessionUuid?: string;
+  keepScreenAwake?: boolean;
+}
+
+/** The single-file app-container request accepted while callers migrate to {@link PutAppFileArgs}. */
+export interface LegacyPutAppFileArgs {
   appId: string;
   container: AppFileContainer;
   destinationPath: string;
@@ -47,6 +92,27 @@ export interface PutAppFileResult {
   destinationPath: string;
   byteCount: number;
   resourceUri: string;
+}
+
+export interface PutAppFileWriteEffect {
+  type: string;
+  status: "completed" | "notRequested" | "unavailable";
+  reason?: string;
+}
+
+export interface PutAppFileWriteResult {
+  destinationPath: string;
+  byteCount: number;
+  resourceUri?: string;
+  effects: PutAppFileWriteEffect[];
+}
+
+export interface PutAppFileBatchResult {
+  success: true;
+  deviceId: string;
+  platform: Platform;
+  target: PutAppFileTarget;
+  files: PutAppFileWriteResult[];
 }
 
 export interface AppFileListRequest {
@@ -109,18 +175,82 @@ export function normalizeAppFileRelativePath(path: string): string {
   return normalized;
 }
 
-const putAppFileBaseSchema = z.object({
-  appId: z.string().min(1),
-  container: appFileContainerSchema.describe("App container"),
+/** A namespace is exactly one caller-named child directory, keeping reset scope bounded. */
+export function normalizeUserFilesNamespace(namespace: string): string {
+  const normalized = namespace.trim();
+  if (
+    normalized.length === 0 ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    normalized.includes("\0")
+  ) {
+    throw new Error(
+      "namespace must be a non-empty single directory name without path separators or traversal segments",
+    );
+  }
+  return normalized;
+}
+
+export function normalizePutAppFileTarget(target: PutAppFileTarget): PutAppFileTarget {
+  switch (target.domain) {
+    case "app_containers":
+      return {
+        domain: target.domain,
+        appId: target.appId.trim(),
+        container: target.container,
+      };
+    case "user_files":
+      return {
+        domain: target.domain,
+        namespace: normalizeUserFilesNamespace(target.namespace),
+        ...(target.reset === undefined ? {} : { reset: target.reset }),
+      };
+    case "media_library":
+      return { domain: target.domain };
+  }
+}
+
+const appContainersTargetSchema = z
+  .object({
+    domain: z.literal("app_containers"),
+    appId: z.string().min(1),
+    container: appFileContainerSchema.describe("App container"),
+  })
+  .strict();
+
+const userFilesTargetSchema = z
+  .object({
+    domain: z.literal("user_files"),
+    namespace: z.string().describe("One caller-named fixture namespace"),
+    reset: z.boolean().optional().describe("Remove only this fixture namespace before writing"),
+  })
+  .strict()
+  .superRefine((target, ctx) => {
+    try {
+      normalizeUserFilesNamespace(target.namespace);
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message: error instanceof Error ? error.message : "namespace must be safe",
+        path: ["namespace"],
+      });
+    }
+  });
+
+const mediaLibraryTargetSchema = z.object({ domain: z.literal("media_library") }).strict();
+
+const putAppFileInputSchema = z
+  .object({
   sourcePath: z.string().min(1).optional().describe("Host file path"),
   contentText: z.string().optional().describe("UTF-8 content"),
   contentBase64: z.string().optional().describe("Base64 content"),
-  destinationPath: z.string().describe("Container-relative destination path"),
-});
-
-export const putAppFileSchema = withAppIdAliases(
-  addDeviceTargetingToSchema(putAppFileBaseSchema).superRefine((args, ctx) => {
-    if (countDefined([args.sourcePath, args.contentText, args.contentBase64]) !== 1) {
+  destinationPath: z.string().describe("Safe path relative to the declared storage target"),
+  })
+  .strict()
+  .superRefine((file, ctx) => {
+    if (countDefined([file.sourcePath, file.contentText, file.contentBase64]) !== 1) {
       ctx.addIssue({
         code: "custom",
         message: "Provide exactly one content source: sourcePath, contentText, or contentBase64.",
@@ -129,7 +259,7 @@ export const putAppFileSchema = withAppIdAliases(
     }
 
     try {
-      normalizeAppFileRelativePath(args.destinationPath);
+      normalizeAppFileRelativePath(file.destinationPath);
     } catch (error) {
       ctx.addIssue({
         code: "custom",
@@ -139,17 +269,14 @@ export const putAppFileSchema = withAppIdAliases(
       });
     }
 
-    if (args.contentBase64 !== undefined) {
+    if (file.contentBase64 !== undefined) {
       try {
-        const decoded = Buffer.from(args.contentBase64, "base64");
+        const decoded = Buffer.from(file.contentBase64, "base64");
         const canonical = decoded.toString("base64");
         const unpadded = canonical.replace(/=+$/, "");
-        if (args.contentBase64 !== canonical && args.contentBase64 !== unpadded) {
+        if (file.contentBase64 !== canonical && file.contentBase64 !== unpadded) {
           throw new Error("round-trip mismatch");
         }
-        // An empty ("") or all-padding ("====") payload round-trips cleanly but
-        // decodes to zero bytes, silently writing an empty file to the device.
-        // Reject it so the caller must send real content (#4183 A4).
         if (decoded.length === 0) {
           throw new Error("empty payload");
         }
@@ -161,7 +288,77 @@ export const putAppFileSchema = withAppIdAliases(
         });
       }
     }
-  }),
+  });
+
+const canonicalPutAppFileSchema = addDeviceTargetingToSchema(
+  z
+    .object({
+      target: z.discriminatedUnion("domain", [
+        appContainersTargetSchema,
+        userFilesTargetSchema,
+        mediaLibraryTargetSchema,
+      ]),
+      files: z.array(putAppFileInputSchema).min(1).describe("Files to write"),
+      // This marker is populated only by the compatibility preprocessor and is
+      // removed from the advertised schema below.
+      legacySingleFile: z.literal(true).optional(),
+    })
+    .strict(),
+);
+
+function preprocessLegacyPutAppFileArgs(input: unknown): unknown {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+  const args = input as Record<string, unknown>;
+  if (args.target !== undefined) {
+    // The marker is reserved for a legacy object that this preprocessor itself
+    // converts. A canonical caller cannot select legacy response semantics.
+    return args.legacySingleFile === undefined ? input : { ...args, legacySingleFile: false };
+  }
+  const appId =
+    args.appId ?? appIdFieldAliases.map((alias) => args[alias]).find((value) => value !== undefined);
+  if (appId === undefined || args.container === undefined) {
+    return input;
+  }
+  const { container, destinationPath, sourcePath, contentText, contentBase64, ...deviceArgs } = args;
+  delete deviceArgs.appId;
+  for (const alias of appIdFieldAliases) {
+    delete deviceArgs[alias];
+  }
+  return {
+    ...deviceArgs,
+    target: { domain: "app_containers", appId, container },
+    files: [{ destinationPath, sourcePath, contentText, contentBase64 }],
+    legacySingleFile: true,
+  };
+}
+
+export const putAppFileSchema = withJsonSchemaOverride(
+  withAppIdAliases(z.preprocess(preprocessLegacyPutAppFileArgs, canonicalPutAppFileSchema)),
+  (jsonSchema) => {
+    const properties = jsonSchema.properties as Record<string, unknown> | undefined;
+    if (properties) {
+      delete properties.legacySingleFile;
+      const target = properties.target as Record<string, unknown> | undefined;
+      if (target && Array.isArray(target.anyOf)) {
+        target.oneOf = target.anyOf;
+        delete target.anyOf;
+      }
+      const files = properties.files as Record<string, unknown> | undefined;
+      const file = files?.items as Record<string, unknown> | undefined;
+      if (file) {
+        file.oneOf = [
+          { required: ["sourcePath"] },
+          { required: ["contentText"] },
+          { required: ["contentBase64"] },
+        ];
+      }
+    }
+    if (Array.isArray(jsonSchema.required)) {
+      jsonSchema.required = jsonSchema.required.filter((field) => field !== "legacySingleFile");
+    }
+  },
 );
 
 function encodePathSegments(path: string): string {

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -9,10 +9,18 @@ import {
   AppFileListResult,
   AppFileReadRequest,
   AppFileReadResult,
+  AppContainersTarget,
+  LegacyPutAppFileArgs,
   PutAppFileArgs,
+  PutAppFileBatchResult,
+  PutAppFileInput,
   PutAppFileResult,
+  PutAppFileTarget,
+  PutAppFileWriteResult,
+  StorageDomain,
   buildAppFileResourceUri,
   normalizeAppFileRelativePath,
+  normalizePutAppFileTarget,
 } from "./appFileContract";
 import { ActionableError, BootedDevice, Platform, type ExecResult } from "../models";
 import {
@@ -28,15 +36,19 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { logger } from "../utils/logger";
 import { prepareFileSource } from "./fileSourcePreparation";
 
-export interface PutAppFileRequest extends PutAppFileArgs {
+export type PutAppFileRequest = Omit<PutAppFileArgs, "device"> & {
   device: BootedDevice;
   signal?: AbortSignal;
-}
+};
+
+export type LegacyPutAppFileRequest = Omit<LegacyPutAppFileArgs, "device"> & {
+  device: BootedDevice;
+  signal?: AbortSignal;
+};
 
 export interface PutAppFileProviderRequest {
   device: BootedDevice;
-  appId: string;
-  container: AppFileContainer;
+  target: PutAppFileTarget;
   destinationPath: string;
   sourcePath: string;
   byteCount: number;
@@ -52,15 +64,29 @@ export interface AppFileProviderReadRequest extends AppFileReadRequest {
   path: string;
 }
 
-export interface AppFileProvider {
+export interface AppFileWriteProvider {
   readonly platform: Platform;
-  putFile(request: PutAppFileProviderRequest): Promise<void>;
+  readonly domain: StorageDomain;
+  putFile(request: PutAppFileProviderRequest): Promise<void | { effects?: PutAppFileWriteResult["effects"] }>;
+}
+
+export interface AppFileListProvider {
+  readonly platform: Platform;
+  readonly domain: "app_containers";
   listFiles(request: AppFileProviderListRequest): Promise<AppFileListResult>;
+}
+
+export interface AppFileReadProvider {
+  readonly platform: Platform;
+  readonly domain: "app_containers";
   readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult>;
 }
 
+export type AppFileProvider = AppFileWriteProvider | AppFileListProvider | AppFileReadProvider;
+
 export interface AppFileService {
-  putFile(request: PutAppFileRequest): Promise<PutAppFileResult>;
+  putFile(request: PutAppFileRequest): Promise<PutAppFileBatchResult>;
+  putFile(request: LegacyPutAppFileRequest): Promise<PutAppFileResult>;
   listFiles(request: AppFileListRequest): Promise<AppFileListResult>;
   readFile(request: AppFileReadRequest): Promise<AppFileReadResult>;
 }
@@ -175,8 +201,78 @@ function createDefaultProviders(
   ];
 }
 
+function providerKey(platform: Platform, domain: StorageDomain): string {
+  return `${platform}:${domain}`;
+}
+
+function isCanonicalPutRequest(
+  request: PutAppFileRequest | LegacyPutAppFileRequest,
+): request is PutAppFileRequest {
+  return "target" in request && "files" in request;
+}
+
+function legacyRequestToCanonical(request: LegacyPutAppFileRequest): PutAppFileRequest {
+  const { appId, container, destinationPath, sourcePath, contentText, contentBase64, ...deviceArgs } =
+    request;
+  return {
+    ...deviceArgs,
+    target: { domain: "app_containers", appId, container },
+    files: [{ destinationPath, sourcePath, contentText, contentBase64 }],
+  };
+}
+
+function normalizeTarget(target: PutAppFileTarget): PutAppFileTarget {
+  const normalized = normalizePutAppFileTarget(target);
+  if (normalized.domain === "app_containers") {
+    return { ...normalized, appId: normalizeAppId(normalized.appId) };
+  }
+  return normalized;
+}
+
+function requireAppContainersTarget(target: PutAppFileTarget): AppContainersTarget {
+  if (target.domain !== "app_containers") {
+    throw new ActionableError(`app-container provider received unsupported target domain: ${target.domain}`);
+  }
+  return target;
+}
+
+function validateDestinationConflicts(files: PutAppFileInput[]): void {
+  for (const file of files) {
+    if (
+      files.some(
+        (other) =>
+          other !== file &&
+          (other.destinationPath === file.destinationPath ||
+            other.destinationPath.startsWith(`${file.destinationPath}/`)),
+      )
+    ) {
+      throw new ActionableError(
+        `destinationPath conflicts with another file in this request: ${file.destinationPath}`,
+      );
+    }
+  }
+}
+
+async function prepareSources(
+  files: PutAppFileInput[],
+  fileSystem: AppFileFileSystem,
+): Promise<Awaited<ReturnType<typeof prepareFileSource>>[]> {
+  const prepared: Awaited<ReturnType<typeof prepareFileSource>>[] = [];
+  try {
+    for (const file of files) {
+      prepared.push(await prepareFileSource(file, fileSystem));
+    }
+    return prepared;
+  } catch (error) {
+    await Promise.all(prepared.map((source) => source.cleanup?.()));
+    throw error;
+  }
+}
+
 class DefaultAppFileService implements AppFileService {
-  private readonly providersByPlatform = new Map<Platform, AppFileProvider>();
+  private readonly writeProviders = new Map<string, AppFileWriteProvider>();
+  private readonly listProviders = new Map<string, AppFileListProvider>();
+  private readonly readProviders = new Map<string, AppFileReadProvider>();
 
   constructor(
     providers: AppFileProvider[],
@@ -184,50 +280,98 @@ class DefaultAppFileService implements AppFileService {
     private readonly fileSystem: AppFileFileSystem,
   ) {
     for (const provider of providers) {
-      this.providersByPlatform.set(provider.platform, provider);
+      if ("putFile" in provider) {
+        this.writeProviders.set(providerKey(provider.platform, provider.domain), provider);
+      }
+      if ("listFiles" in provider) {
+        this.listProviders.set(providerKey(provider.platform, provider.domain), provider);
+      }
+      if ("readFile" in provider) {
+        this.readProviders.set(providerKey(provider.platform, provider.domain), provider);
+      }
     }
   }
 
-  async putFile(request: PutAppFileRequest): Promise<PutAppFileResult> {
-    const appId = normalizeAppId(request.appId);
-    const destinationPath = normalizeAppFileRelativePath(request.destinationPath);
-    const provider = this.getProvider(request.device.platform, "putFile", appId, request.container);
-    const source = await prepareFileSource(request, this.fileSystem);
+  async putFile(request: PutAppFileRequest): Promise<PutAppFileBatchResult>;
+  async putFile(request: LegacyPutAppFileRequest): Promise<PutAppFileResult>;
+  async putFile(
+    request: PutAppFileRequest | LegacyPutAppFileRequest,
+  ): Promise<PutAppFileBatchResult | PutAppFileResult> {
+    const canonicalInput = isCanonicalPutRequest(request);
+    const legacy = !canonicalInput || request.legacySingleFile === true;
+    const canonical = canonicalInput ? request : legacyRequestToCanonical(request);
+    const target = normalizeTarget(canonical.target);
+    const files = canonical.files.map((file) => ({
+      ...file,
+      destinationPath: normalizeAppFileRelativePath(file.destinationPath),
+    }));
+    validateDestinationConflicts(files);
+    const prepared = await prepareSources(files, this.fileSystem);
     try {
-      await provider.putFile({
-        device: request.device,
-        appId,
-        container: request.container,
-        destinationPath,
-        sourcePath: source.path,
-        byteCount: source.byteCount,
-        signal: request.signal,
-      });
-
-      return {
+      const provider = this.getWriteProvider(request.device.platform, target.domain);
+      const results: PutAppFileWriteResult[] = [];
+      for (let index = 0; index < files.length; index += 1) {
+        const file = files[index]!;
+        const source = prepared[index]!;
+        const providerTarget =
+          target.domain === "user_files" && target.reset === true && index > 0
+            ? { ...target, reset: false }
+            : target;
+        const providerResult = await provider.putFile({
+          device: request.device,
+          target: providerTarget,
+          destinationPath: file.destinationPath,
+          sourcePath: source.path,
+          byteCount: source.byteCount,
+          signal: request.signal,
+        });
+        results.push({
+          destinationPath: file.destinationPath,
+          byteCount: source.byteCount,
+          ...(target.domain === "app_containers"
+            ? {
+                resourceUri: buildAppFileResourceUri({
+                  deviceId: request.device.deviceId,
+                  appId: target.appId,
+                  container: target.container,
+                  path: file.destinationPath,
+                }),
+              }
+            : {}),
+          effects: providerResult?.effects ?? [],
+        });
+      }
+      const result: PutAppFileBatchResult = {
         success: true,
         deviceId: request.device.deviceId,
         platform: request.device.platform,
-        appId,
-        container: request.container,
-        destinationPath,
-        byteCount: source.byteCount,
-        resourceUri: buildAppFileResourceUri({
-          deviceId: request.device.deviceId,
-          appId,
-          container: request.container,
-          path: destinationPath,
-        }),
+        target,
+        files: results,
+      };
+      if (!legacy) {
+        return result;
+      }
+      const file = results[0]!;
+      const appTarget = target as AppContainersTarget;
+      return {
+        success: true,
+        deviceId: result.deviceId,
+        platform: result.platform,
+        appId: appTarget.appId,
+        container: appTarget.container,
+        destinationPath: file.destinationPath,
+        byteCount: file.byteCount,
+        resourceUri: file.resourceUri!,
       };
     } finally {
-      await source.cleanup?.();
+      await Promise.all(prepared.map((source) => source.cleanup?.()));
     }
   }
 
   async listFiles(request: AppFileListRequest): Promise<AppFileListResult> {
     const appId = normalizeAppId(request.appId);
     const device = await this.deviceResolver(request.deviceId);
-    const provider = this.getProvider(device.platform, "listFiles", appId, request.container);
+    const provider = this.getListProvider(device.platform, "app_containers", "listFiles", appId, request.container);
     return provider.listFiles({
       device,
       deviceId: device.deviceId,
@@ -240,7 +384,7 @@ class DefaultAppFileService implements AppFileService {
     const appId = normalizeAppId(request.appId);
     const path = normalizeAppFileRelativePath(request.path);
     const device = await this.deviceResolver(request.deviceId);
-    const provider = this.getProvider(device.platform, "readFile", appId, request.container);
+    const provider = this.getReadProvider(device.platform, "app_containers", "readFile", appId, request.container);
     return provider.readFile({
       device,
       deviceId: device.deviceId,
@@ -250,13 +394,22 @@ class DefaultAppFileService implements AppFileService {
     });
   }
 
-  private getProvider(
+  private getWriteProvider(platform: Platform, domain: StorageDomain): AppFileWriteProvider {
+    const provider = this.writeProviders.get(providerKey(platform, domain));
+    if (!provider) {
+      throw new ActionableError(`putFile is not supported for ${domain} on ${platform}: no write provider is registered`);
+    }
+    return provider;
+  }
+
+  private getListProvider(
     platform: Platform,
+    domain: "app_containers",
     operation: string,
     appId: string,
     container: AppFileContainer,
-  ): AppFileProvider {
-    const provider = this.providersByPlatform.get(platform);
+  ): AppFileListProvider {
+    const provider = this.listProviders.get(providerKey(platform, domain));
     if (!provider) {
       throw unsupportedAppFileOperation(
         operation,
@@ -268,10 +421,27 @@ class DefaultAppFileService implements AppFileService {
     }
     return provider;
   }
+
+  private getReadProvider(
+    platform: Platform,
+    domain: "app_containers",
+    operation: string,
+    appId: string,
+    container: AppFileContainer,
+  ): AppFileReadProvider {
+    const provider = this.readProviders.get(providerKey(platform, domain));
+    if (!provider) {
+      throw unsupportedAppFileOperation(operation, platform, appId, container, "no app file provider is registered");
+    }
+    return provider;
+  }
 }
 
-class AndroidAppFileProvider implements AppFileProvider {
+class AndroidAppFileProvider
+  implements AppFileWriteProvider, AppFileListProvider, AppFileReadProvider
+{
   readonly platform = "android" as const;
+  readonly domain = "app_containers" as const;
 
   constructor(
     private readonly adbFactory: AdbClientFactory,
@@ -279,14 +449,15 @@ class AndroidAppFileProvider implements AppFileProvider {
   ) {}
 
   async putFile(request: PutAppFileProviderRequest): Promise<void> {
+    const appTarget = requireAppContainersTarget(request.target);
     const adb = this.adbFactory.create(request.device);
-    const target = resolveAndroidTarget(request.appId, request.container, request.destinationPath);
+    const target = resolveAndroidTarget(appTarget.appId, appTarget.container, request.destinationPath);
     if (target.kind === "unsupported") {
       throw unsupportedAppFileOperation(
         "putFile",
         request.device.platform,
-        request.appId,
-        request.container,
+        appTarget.appId,
+        appTarget.container,
         target.message,
       );
     }
@@ -297,8 +468,8 @@ class AndroidAppFileProvider implements AppFileProvider {
         `shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`,
         {
           device: request.device,
-          appId: request.appId,
-          container: request.container,
+          appId: appTarget.appId,
+          container: appTarget.container,
           operation: "write",
           access: "externalFiles",
         },
@@ -309,8 +480,8 @@ class AndroidAppFileProvider implements AppFileProvider {
         `push ${shellQuote(request.sourcePath)} ${shellQuote(target.absolutePath)}`,
         {
           device: request.device,
-          appId: request.appId,
-          container: request.container,
+          appId: appTarget.appId,
+          container: appTarget.container,
           operation: "write",
           access: "externalFiles",
         },
@@ -325,8 +496,8 @@ class AndroidAppFileProvider implements AppFileProvider {
       `push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`,
       {
         device: request.device,
-        appId: request.appId,
-        container: request.container,
+        appId: appTarget.appId,
+        container: appTarget.container,
         operation: "write",
         access: "run-as",
       },
@@ -339,11 +510,11 @@ class AndroidAppFileProvider implements AppFileProvider {
         `chmod 600 ${shellQuote(target.relativePath)}`;
       await executeAndroidAppFileCommand(
         adb,
-        `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(command)}`,
+        `shell run-as ${shellQuote(appTarget.appId)} sh -c ${shellQuote(command)}`,
         {
           device: request.device,
-          appId: request.appId,
-          container: request.container,
+          appId: appTarget.appId,
+          container: appTarget.container,
           operation: "write",
           access: "run-as",
         },
@@ -488,8 +659,11 @@ class AndroidAppFileProvider implements AppFileProvider {
   }
 }
 
-class IosSimulatorAppFileProvider implements AppFileProvider {
+class IosSimulatorAppFileProvider
+  implements AppFileWriteProvider, AppFileListProvider, AppFileReadProvider
+{
   readonly platform = "ios" as const;
+  readonly domain = "app_containers" as const;
 
   constructor(
     private readonly simctlFactory: (device: BootedDevice) => SimCtlClient,
@@ -497,10 +671,11 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
   ) {}
 
   async putFile(request: PutAppFileProviderRequest): Promise<void> {
+    const appTarget = requireAppContainersTarget(request.target);
     const target = await this.resolvePath(
       request.device,
-      request.appId,
-      request.container,
+      appTarget.appId,
+      appTarget.container,
       request.destinationPath,
       "putFile",
     );

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -67,7 +67,9 @@ export interface AppFileProviderReadRequest extends AppFileReadRequest {
 export interface AppFileWriteProvider {
   readonly platform: Platform;
   readonly domain: StorageDomain;
-  putFile(request: PutAppFileProviderRequest): Promise<void | { effects?: PutAppFileWriteResult["effects"] }>;
+  putFile(
+    request: PutAppFileProviderRequest,
+  ): Promise<void | { effects?: PutAppFileWriteResult["effects"] }>;
 }
 
 export interface AppFileListProvider {
@@ -212,8 +214,15 @@ function isCanonicalPutRequest(
 }
 
 function legacyRequestToCanonical(request: LegacyPutAppFileRequest): PutAppFileRequest {
-  const { appId, container, destinationPath, sourcePath, contentText, contentBase64, ...deviceArgs } =
-    request;
+  const {
+    appId,
+    container,
+    destinationPath,
+    sourcePath,
+    contentText,
+    contentBase64,
+    ...deviceArgs
+  } = request;
   return {
     ...deviceArgs,
     target: { domain: "app_containers", appId, container },
@@ -231,7 +240,9 @@ function normalizeTarget(target: PutAppFileTarget): PutAppFileTarget {
 
 function requireAppContainersTarget(target: PutAppFileTarget): AppContainersTarget {
   if (target.domain !== "app_containers") {
-    throw new ActionableError(`app-container provider received unsupported target domain: ${target.domain}`);
+    throw new ActionableError(
+      `app-container provider received unsupported target domain: ${target.domain}`,
+    );
   }
   return target;
 }
@@ -371,7 +382,13 @@ class DefaultAppFileService implements AppFileService {
   async listFiles(request: AppFileListRequest): Promise<AppFileListResult> {
     const appId = normalizeAppId(request.appId);
     const device = await this.deviceResolver(request.deviceId);
-    const provider = this.getListProvider(device.platform, "app_containers", "listFiles", appId, request.container);
+    const provider = this.getListProvider(
+      device.platform,
+      "app_containers",
+      "listFiles",
+      appId,
+      request.container,
+    );
     return provider.listFiles({
       device,
       deviceId: device.deviceId,
@@ -384,7 +401,13 @@ class DefaultAppFileService implements AppFileService {
     const appId = normalizeAppId(request.appId);
     const path = normalizeAppFileRelativePath(request.path);
     const device = await this.deviceResolver(request.deviceId);
-    const provider = this.getReadProvider(device.platform, "app_containers", "readFile", appId, request.container);
+    const provider = this.getReadProvider(
+      device.platform,
+      "app_containers",
+      "readFile",
+      appId,
+      request.container,
+    );
     return provider.readFile({
       device,
       deviceId: device.deviceId,
@@ -397,7 +420,9 @@ class DefaultAppFileService implements AppFileService {
   private getWriteProvider(platform: Platform, domain: StorageDomain): AppFileWriteProvider {
     const provider = this.writeProviders.get(providerKey(platform, domain));
     if (!provider) {
-      throw new ActionableError(`putFile is not supported for ${domain} on ${platform}: no write provider is registered`);
+      throw new ActionableError(
+        `putFile is not supported for ${domain} on ${platform}: no write provider is registered`,
+      );
     }
     return provider;
   }
@@ -431,7 +456,13 @@ class DefaultAppFileService implements AppFileService {
   ): AppFileReadProvider {
     const provider = this.readProviders.get(providerKey(platform, domain));
     if (!provider) {
-      throw unsupportedAppFileOperation(operation, platform, appId, container, "no app file provider is registered");
+      throw unsupportedAppFileOperation(
+        operation,
+        platform,
+        appId,
+        container,
+        "no app file provider is registered",
+      );
     }
     return provider;
   }
@@ -451,7 +482,11 @@ class AndroidAppFileProvider
   async putFile(request: PutAppFileProviderRequest): Promise<void> {
     const appTarget = requireAppContainersTarget(request.target);
     const adb = this.adbFactory.create(request.device);
-    const target = resolveAndroidTarget(appTarget.appId, appTarget.container, request.destinationPath);
+    const target = resolveAndroidTarget(
+      appTarget.appId,
+      appTarget.container,
+      request.destinationPath,
+    );
     if (target.kind === "unsupported") {
       throw unsupportedAppFileOperation(
         "putFile",

--- a/src/server/appFileTools.ts
+++ b/src/server/appFileTools.ts
@@ -7,7 +7,7 @@ import type { BootedDevice } from "../models";
 export function registerAppFileTools(): void {
   ToolRegistry.registerDeviceAware(
     "putAppFile",
-    "Write file/text/base64 content into an app container.",
+    "Write files into a bounded logical storage target.",
     putAppFileSchema,
     async (device: BootedDevice, args: PutAppFileArgs, _progress, signal) => {
       const result = await getAppFileService().putFile({ ...args, device, signal });

--- a/test/server/appFileContract.test.ts
+++ b/test/server/appFileContract.test.ts
@@ -3,6 +3,7 @@ import {
   APP_FILE_RESOURCE_TEMPLATES,
   buildAppFileResourceUri,
   normalizeAppFileRelativePath,
+  normalizePutAppFileTarget,
   parseAppFileResourceParams,
   putAppFileSchema,
 } from "../../src/server/appFileContract";
@@ -71,12 +72,11 @@ describe("App file resource contract", () => {
 
 describe("putAppFileSchema contentBase64 guard (#4183 A4)", () => {
   const base = {
-    appId: "com.example.app",
-    container: "documents" as const,
-    destinationPath: "notes/hello.txt",
+    target: { domain: "app_containers" as const, appId: "com.example.app", container: "documents" as const },
+    files: [{ destinationPath: "notes/hello.txt" }],
   };
   const parseWithBase64 = (contentBase64: string) =>
-    putAppFileSchema.safeParse({ ...base, contentBase64 });
+    putAppFileSchema.safeParse({ ...base, files: [{ ...base.files[0], contentBase64 }] });
 
   // Table is the spec. Rows 6 ("====") and 7 ("") are the live bug: they
   // round-trip as "valid" base64 but decode to zero bytes, writing an empty
@@ -95,6 +95,84 @@ describe("putAppFileSchema contentBase64 guard (#4183 A4)", () => {
     ["", false],
   ])("contentBase64 %p accepted=%p", (payload, accepted) => {
     expect(parseWithBase64(payload).success).toBe(accepted);
+  });
+});
+
+describe("putAppFile canonical target contract (#5803)", () => {
+  const textFile = { destinationPath: "fixtures/welcome.txt", contentText: "hello" };
+
+  test.each([
+    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [textFile] },
+    { target: { domain: "user_files", namespace: "run-42", reset: true }, files: [textFile] },
+    { target: { domain: "media_library" }, files: [textFile] },
+  ])("accepts target branch %#", (args) => {
+    expect(putAppFileSchema.safeParse(args).success).toBe(true);
+  });
+
+  test("normalizes the legacy single-file app-container shape into the canonical batch", () => {
+    expect(
+      putAppFileSchema.parse({
+        appId: "com.example.app",
+        container: "documents",
+        destinationPath: "./fixtures/welcome.txt",
+        contentText: "hello",
+      }),
+    ).toMatchObject({
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [{ destinationPath: "./fixtures/welcome.txt", contentText: "hello" }],
+    });
+  });
+
+  test("keeps established app ID aliases on the legacy compatibility path", () => {
+    expect(
+      putAppFileSchema.parse({
+        bundleId: "com.example.app",
+        container: "documents",
+        destinationPath: "fixture.txt",
+        contentText: "hello",
+      }),
+    ).toMatchObject({
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [{ destinationPath: "fixture.txt", contentText: "hello" }],
+    });
+  });
+
+  test("keeps established app ID aliases in canonical app-container targets", () => {
+    expect(
+      putAppFileSchema.parse({
+        target: { domain: "app_containers", bundleId: "com.example.app", container: "documents" },
+        files: [textFile],
+      }),
+    ).toMatchObject({
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+    });
+  });
+
+  test("does not let canonical callers select legacy response semantics", () => {
+    expect(
+      putAppFileSchema.safeParse({
+        target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+        files: [textFile],
+        legacySingleFile: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  test.each([
+    { target: { domain: "app_containers", appId: "com.example.app", container: "documents", namespace: "nope" }, files: [textFile] },
+    { target: { domain: "user_files", namespace: "../escape", appId: "com.example.app" }, files: [textFile] },
+    { target: { domain: "media_library", namespace: "nope" }, files: [textFile] },
+    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [] },
+    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [{ ...textFile, sourcePath: "/tmp/file" }] },
+    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [{ ...textFile, destinationPath: "../escape" }] },
+  ])("rejects invalid target or file input %#", (args) => {
+    expect(putAppFileSchema.safeParse(args).success).toBe(false);
+  });
+
+  test("normalizes each target before provider selection", () => {
+    expect(
+      normalizePutAppFileTarget({ domain: "user_files", namespace: " run-42 ", reset: true }),
+    ).toEqual({ domain: "user_files", namespace: "run-42", reset: true });
   });
 });
 

--- a/test/server/appFileContract.test.ts
+++ b/test/server/appFileContract.test.ts
@@ -72,7 +72,11 @@ describe("App file resource contract", () => {
 
 describe("putAppFileSchema contentBase64 guard (#4183 A4)", () => {
   const base = {
-    target: { domain: "app_containers" as const, appId: "com.example.app", container: "documents" as const },
+    target: {
+      domain: "app_containers" as const,
+      appId: "com.example.app",
+      container: "documents" as const,
+    },
     files: [{ destinationPath: "notes/hello.txt" }],
   };
   const parseWithBase64 = (contentBase64: string) =>
@@ -102,7 +106,10 @@ describe("putAppFile canonical target contract (#5803)", () => {
   const textFile = { destinationPath: "fixtures/welcome.txt", contentText: "hello" };
 
   test.each([
-    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [textFile] },
+    {
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [textFile],
+    },
     { target: { domain: "user_files", namespace: "run-42", reset: true }, files: [textFile] },
     { target: { domain: "media_library" }, files: [textFile] },
   ])("accepts target branch %#", (args) => {
@@ -159,12 +166,32 @@ describe("putAppFile canonical target contract (#5803)", () => {
   });
 
   test.each([
-    { target: { domain: "app_containers", appId: "com.example.app", container: "documents", namespace: "nope" }, files: [textFile] },
-    { target: { domain: "user_files", namespace: "../escape", appId: "com.example.app" }, files: [textFile] },
+    {
+      target: {
+        domain: "app_containers",
+        appId: "com.example.app",
+        container: "documents",
+        namespace: "nope",
+      },
+      files: [textFile],
+    },
+    {
+      target: { domain: "user_files", namespace: "../escape", appId: "com.example.app" },
+      files: [textFile],
+    },
     { target: { domain: "media_library", namespace: "nope" }, files: [textFile] },
-    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [] },
-    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [{ ...textFile, sourcePath: "/tmp/file" }] },
-    { target: { domain: "app_containers", appId: "com.example.app", container: "documents" }, files: [{ ...textFile, destinationPath: "../escape" }] },
+    {
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [],
+    },
+    {
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [{ ...textFile, sourcePath: "/tmp/file" }],
+    },
+    {
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [{ ...textFile, destinationPath: "../escape" }],
+    },
   ])("rejects invalid target or file input %#", (args) => {
     expect(putAppFileSchema.safeParse(args).success).toBe(false);
   });

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -5,6 +5,7 @@ import {
   type AppFileStats,
   createAppFileServiceForTesting,
   type AppFileProvider,
+  type AppFileWriteProvider,
   type PutAppFileProviderRequest,
 } from "../../src/server/appFileService";
 import type { BootedDevice } from "../../src/models";
@@ -99,6 +100,83 @@ describe("AppFileService", () => {
       }),
     ).rejects.toThrow("contentBase64 must be valid, non-empty base64.");
     expect(provider.putRequests).toEqual([]);
+  });
+
+  test("routes a normalized canonical batch by platform and logical domain", async () => {
+    const provider = new RecordingStorageWriteProvider("android", "user_files", {
+      effects: [{ type: "media_index", status: "notRequested", reason: "not media" }],
+    });
+    const service = createAppFileServiceForTesting({ providers: [provider] });
+
+    const result = await service.putFile({
+      device: { deviceId: "emulator-5554", name: "Pixel", platform: "android" },
+      target: { domain: "user_files", namespace: " run-42 ", reset: true },
+      files: [
+        { contentText: "one", destinationPath: "./one.txt" },
+        { contentBase64: Buffer.from("two").toString("base64"), destinationPath: "nested/two.txt" },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      deviceId: "emulator-5554",
+      platform: "android",
+      target: { domain: "user_files", namespace: "run-42", reset: true },
+      files: [
+        {
+          destinationPath: "one.txt",
+          byteCount: 3,
+          effects: [{ type: "media_index", status: "notRequested", reason: "not media" }],
+        },
+        {
+          destinationPath: "nested/two.txt",
+          byteCount: 3,
+          effects: [{ type: "media_index", status: "notRequested", reason: "not media" }],
+        },
+      ],
+    });
+    expect(provider.requests.map((request) => request.destinationPath)).toEqual([
+      "one.txt",
+      "nested/two.txt",
+    ]);
+    expect(provider.requests.every((request) => request.target.domain === "user_files")).toBe(true);
+    expect(provider.requests.map((request) => request.target)).toEqual([
+      { domain: "user_files", namespace: "run-42", reset: true },
+      { domain: "user_files", namespace: "run-42", reset: false },
+    ]);
+  });
+
+  test("prepares every file and rejects conflicts before provider mutation", async () => {
+    const provider = new RecordingStorageWriteProvider("android", "app_containers");
+    const service = createAppFileServiceForTesting({ providers: [provider] });
+    const device: BootedDevice = { deviceId: "emulator-5554", name: "Pixel", platform: "android" };
+
+    await expect(
+      service.putFile({
+        device,
+        target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+        files: [
+          { contentText: "first", destinationPath: "fixtures" },
+          { contentText: "second", destinationPath: "fixtures/nested.txt" },
+        ],
+      }),
+    ).rejects.toThrow("conflicts with another file");
+    expect(provider.requests).toEqual([]);
+  });
+
+  test("cleans prepared temporary sources when a provider write fails", async () => {
+    const fileSystem = new TestAppFileFileSystem();
+    const provider = new RecordingStorageWriteProvider("android", "app_containers", undefined, new Error("write failed"));
+    const service = createAppFileServiceForTesting({ providers: [provider], fileSystem });
+
+    await expect(
+      service.putFile({
+        device: { deviceId: "emulator-5554", name: "Pixel", platform: "android" },
+        target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+        files: [{ contentText: "hello", destinationPath: "fixture.txt" }],
+      }),
+    ).rejects.toThrow("write failed");
+    expect(fileSystem.removedPaths).toHaveLength(1);
   });
 
   test("rejects unsafe service input before provider selection", async () => {
@@ -964,6 +1042,7 @@ describe("AppFileService", () => {
 
 class RecordingAppFileProvider implements AppFileProvider {
   readonly putRequests: PutAppFileProviderRequest[] = [];
+  readonly domain = "app_containers" as const;
 
   constructor(readonly platform: "android" | "ios") {}
 
@@ -980,7 +1059,27 @@ class RecordingAppFileProvider implements AppFileProvider {
   }
 }
 
+class RecordingStorageWriteProvider implements AppFileWriteProvider {
+  readonly requests: PutAppFileProviderRequest[] = [];
+
+  constructor(
+    readonly platform: "android" | "ios",
+    readonly domain: "app_containers" | "user_files" | "media_library",
+    private readonly result?: { effects?: Array<{ type: string; status: "completed" | "notRequested" | "unavailable"; reason?: string }> },
+    private readonly error?: Error,
+  ) {}
+
+  async putFile(request: PutAppFileProviderRequest) {
+    this.requests.push(request);
+    if (this.error) {
+      throw this.error;
+    }
+    return this.result;
+  }
+}
+
 class TestAppFileFileSystem implements AppFileFileSystem {
+  readonly removedPaths: string[] = [];
   private readonly files = new Map<string, Buffer>();
   private readonly directories = new Set<string>(["/"]);
   private readonly symlinks = new Set<string>();
@@ -1070,6 +1169,7 @@ class TestAppFileFileSystem implements AppFileFileSystem {
   }
 
   async rm(path: string): Promise<void> {
+    this.removedPaths.push(path);
     const normalized = this.normalize(path);
     const prefix = normalized === "/" ? "/" : `${normalized}/`;
 

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -166,7 +166,12 @@ describe("AppFileService", () => {
 
   test("cleans prepared temporary sources when a provider write fails", async () => {
     const fileSystem = new TestAppFileFileSystem();
-    const provider = new RecordingStorageWriteProvider("android", "app_containers", undefined, new Error("write failed"));
+    const provider = new RecordingStorageWriteProvider(
+      "android",
+      "app_containers",
+      undefined,
+      new Error("write failed"),
+    );
     const service = createAppFileServiceForTesting({ providers: [provider], fileSystem });
 
     await expect(
@@ -1065,7 +1070,13 @@ class RecordingStorageWriteProvider implements AppFileWriteProvider {
   constructor(
     readonly platform: "android" | "ios",
     readonly domain: "app_containers" | "user_files" | "media_library",
-    private readonly result?: { effects?: Array<{ type: string; status: "completed" | "notRequested" | "unavailable"; reason?: string }> },
+    private readonly result?: {
+      effects?: Array<{
+        type: string;
+        status: "completed" | "notRequested" | "unavailable";
+        reason?: string;
+      }>;
+    },
     private readonly error?: Error,
   ) {}
 

--- a/test/server/appFileTools.test.ts
+++ b/test/server/appFileTools.test.ts
@@ -31,10 +31,14 @@ describe("App file tools", () => {
     expect(
       validate({
         target,
-        files: [{ destinationPath: "multiple-sources.txt", contentText: "x", contentBase64: "eA==" }],
+        files: [
+          { destinationPath: "multiple-sources.txt", contentText: "x", contentBase64: "eA==" },
+        ],
       }),
     ).toBe(false);
-    expect(validate({ target, files: [{ destinationPath: "one-source.txt", contentText: "x" }] })).toBe(true);
+    expect(
+      validate({ target, files: [{ destinationPath: "one-source.txt", contentText: "x" }] }),
+    ).toBe(true);
   });
 
   test("accepts a canonical local-source batch with nested destination paths", () => {

--- a/test/server/appFileTools.test.ts
+++ b/test/server/appFileTools.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import Ajv2020 from "ajv/dist/2020";
 import { registerAppFileTools } from "../../src/server/appFileTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 
@@ -18,31 +19,42 @@ describe("App file tools", () => {
       (tool) => tool.name === "putAppFile",
     );
     expect(toolDefinition).toBeDefined();
-    expect(toolDefinition!.inputSchema.properties.appId).toBeDefined();
-    expect(toolDefinition!.inputSchema.properties.container.enum).toContain("documents");
-    expect(toolDefinition!.inputSchema.properties.container.enum).toContain("externalFiles");
-    expect(toolDefinition!.inputSchema.properties.sourcePath).toBeDefined();
-    expect(toolDefinition!.inputSchema.properties.contentText).toBeDefined();
-    expect(toolDefinition!.inputSchema.properties.contentBase64).toBeDefined();
-    expect(toolDefinition!.inputSchema.properties.destinationPath).toBeDefined();
+    expect(toolDefinition!.inputSchema.properties.target).toBeDefined();
+    expect(toolDefinition!.inputSchema.properties.files).toBeDefined();
+    expect(toolDefinition!.inputSchema.properties.appId).toBeUndefined();
+    expect(toolDefinition!.inputSchema.properties.container).toBeUndefined();
+    expect(toolDefinition!.inputSchema.properties.destinationPath).toBeUndefined();
+
+    const validate = new Ajv2020({ strict: false }).compile(toolDefinition!.inputSchema);
+    const target = { domain: "app_containers", appId: "com.example.app", container: "documents" };
+    expect(validate({ target, files: [{ destinationPath: "missing-source.txt" }] })).toBe(false);
+    expect(
+      validate({
+        target,
+        files: [{ destinationPath: "multiple-sources.txt", contentText: "x", contentBase64: "eA==" }],
+      }),
+    ).toBe(false);
+    expect(validate({ target, files: [{ destinationPath: "one-source.txt", contentText: "x" }] })).toBe(true);
   });
 
-  test("accepts a local source file and nested destination path with spaces", () => {
+  test("accepts a canonical local-source batch with nested destination paths", () => {
     registerAppFileTools();
     const tool = ToolRegistry.getTool("putAppFile");
 
     expect(
       tool!.schema.parse({
         platform: "ios",
-        appId: "com.example.app",
-        container: "documents",
-        sourcePath: "/Users/me/fixtures/welcome.png",
-        destinationPath: "fixtures/onboarding/welcome image.png",
+        target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+        files: [
+          {
+            sourcePath: "/Users/me/fixtures/welcome.png",
+            destinationPath: "fixtures/onboarding/welcome image.png",
+          },
+        ],
       }),
     ).toMatchObject({
-      appId: "com.example.app",
-      container: "documents",
-      destinationPath: "fixtures/onboarding/welcome image.png",
+      target: { domain: "app_containers", appId: "com.example.app", container: "documents" },
+      files: [{ destinationPath: "fixtures/onboarding/welcome image.png" }],
     });
   });
 


### PR DESCRIPTION
## Summary

- replace the advertised `putAppFile` surface with a target-discriminated, non-empty batch contract
- add platform/domain write-provider routing with separate list/read seams, complete preflight, cleanup, per-file results, and structured effects
- preserve legacy single-file app-container calls and established app-ID aliases while retaining existing app resources

`user_files` and `media_library` are canonical targets but remain explicitly unprovided until their scoped platform-provider issues land.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `bun test test/server/toolRegistration.test.ts test/server/appFileContract.test.ts test/server/appFileTools.test.ts test/server/appFileService.test.ts`
- `git diff --check`

Closes [#5803](https://github.com/kaeawc/auto-mobile/issues/5803)
