### PR TITLE
feat(android): stage picker fixtures through putAppFile

### DIFF
--- a/docs/design-docs/mcp/app-file-service.md
+++ b/docs/design-docs/mcp/app-file-service.md
@@ -20,6 +20,10 @@ path; generated tool definitions advertise the canonical target-based shape.
   never promises resource operations it cannot implement.
 - Providers receive normalized targets, safe relative paths, and prepared local
   source file paths. They should not accept raw MCP arguments.
+- Android `user_files` delegates to the bounded Downloads staging service and
+  resolves the active Android profile before every write. `media_library` uses
+  the AutoMobile-owned `automobile-media` Downloads namespace and reports
+  success only after MediaStore discovery is verified.
 
 ## Shared Validation
 
@@ -51,4 +55,5 @@ example, Android rejects `library`, and iOS rejects `externalFiles`.
 3. Keep command-line details inside the provider. Return `AppFileListResult`,
    `AppFileReadResult`, and `PutAppFileResult` metadata through the service
    contract rather than leaking raw command output into MCP responses.
-4. Unit-test with fakes; do not require real Android devices or iOS simulators.
+4. Unit-test with fakes. Storage providers also need a focused device smoke test
+   when their contract promises system-picker visibility.

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -24,7 +24,7 @@ All Interactions tools — including `pinchOn`, which routes coordinate-based pi
 - 🚀 `launchApp` starts apps by package name (with optional clear-app-data support).
 - ❌ `terminateApp` force-stops an app by package name.
 - 📦 `installApp` installs an APK.
-- 📄 `putAppFile` writes a local file, UTF-8 text, or base64 binary content into logical app containers such as `documents`, `cache`, `tmp`, and `externalFiles`.
+- 📄 `putAppFile` writes a local file, UTF-8 text, or base64 binary content into logical `app_containers`, Android `user_files`, or Android `media_library` targets.
 - 📂 `stageSharedStorageFixtures` writes a batch of local, UTF-8, or base64 fixtures beneath an isolated Android `Download/<namespace>` directory for document and media picker workflows.
 - 🔗 `getDeepLinks` reads registered deep links/intent filters for an Android package.
 
@@ -84,11 +84,12 @@ Stage shared-storage fixtures for a system picker:
 ```
 
 The namespace is limited to one safe child directory; file paths must be
-relative, and reset deletes only that namespace. The supported shared location
-is `/sdcard/Download/<namespace>`. Media extensions receive a media-scan request
-and report `verified` when MediaStore reports the file, or `dispatched` with a
-timeout reason when the asynchronous scan does not complete in time. Non-media
-files are intended for the Downloads document picker.
+relative, and reset deletes only that namespace. `putAppFile` should be used
+for new picker fixtures: `target.domain: "user_files"` uses the resolved
+profile's `Download/<namespace>` location, while `media_library` uses the
+bounded AutoMobile media namespace and reports success only once MediaStore
+discovers the file. `stageSharedStorageFixtures` remains a compatibility alias
+for existing callers.
 
 Android app files support `externalFiles` through `/sdcard/Android/data/{appId}/files`. Use this for app-readable fixture files that do not require private app storage:
 

--- a/docs/using/android-shared-storage-fixtures.md
+++ b/docs/using/android-shared-storage-fixtures.md
@@ -1,17 +1,22 @@
 # Android shared-storage fixtures
 
-Use `stageSharedStorage` to place fixtures where Android system document and
-media pickers can discover them. It is Android-only and resolves its target
-through the normal device/session selection fields; callers do not need to use
-ADB or choose a transport endpoint.
+Use `putAppFile` to place fixtures where Android system document and media
+pickers can discover them. It is Android-only and resolves its target through
+the normal device/session selection fields; callers do not need to use ADB or
+choose a transport endpoint. `stageSharedStorage` remains available while
+existing callers migrate and continues to use the same bounded Downloads
+implementation.
 
 ```json
 {
-  "name": "stageSharedStorage",
+  "name": "putAppFile",
   "arguments": {
     "platform": "android",
-    "namespace": "checkout-20260823",
-    "reset": true,
+    "target": {
+      "domain": "user_files",
+      "namespace": "checkout-20260823",
+      "reset": true
+    },
     "files": [
       {
         "destinationPath": "documents/terms.txt",
@@ -32,21 +37,33 @@ result lists every logical destination, byte count, and media-indexing outcome.
 Media files receive an Android media-scanner request by default, and the tool
 waits until the corresponding media-provider row is visible before reporting
 indexing as complete. Documents report that indexing was not requested because
-the document picker discovers files directly from Downloads. Set
-`indexMedia: false` to skip that request.
+the document picker discovers files directly from Downloads. The legacy
+`stageSharedStorage` tool alone accepts `indexMedia: false`; `putAppFile`
+always verifies media-library targets before reporting success.
 
 ## Location and safety limits
 
-The only supported destination is `/sdcard/Download/<namespace>`. A namespace
+The only supported document-fixture destination is
+`/storage/emulated/<resolved-user>/Download/<namespace>`. A namespace
 is one non-empty directory name—slashes, backslashes, and traversal segments
 are rejected. File paths are relative to that namespace and cannot contain
 `.` or `..` segments. With `reset: true`, AutoMobile removes only the exact
 declared namespace before writing; it never resets Downloads itself or another
 namespace.
 
+For an image, video, or audio fixture intended for Android's media picker, use
+`target: { "domain": "media_library" }`. AutoMobile writes it beneath its
+bounded `Download/automobile-media` namespace, requests a media scan, and only
+reports the `media_index` effect as `completed` after MediaStore exposes the
+file. The `user_files` result instead reports `document_picker` availability;
+it also includes a media-index effect when the staged filename is media.
+
 This operation stages a known, small fixture set. It is not a general Android
 filesystem API and does not provide arbitrary storage access or recursive
 deletion outside its declared namespace.
+
+To run the device-backed picker smoke on a booted emulator, use
+`scripts/android/put-app-file-picker-smoke.sh [device-id]`.
 
 ## Diagnosing a target app
 

--- a/scripts/android/put-app-file-picker-smoke.sh
+++ b/scripts/android/put-app-file-picker-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verifies the Android putAppFile picker-fixture providers on a booted emulator.
+set -euo pipefail
+
+device_id="${1:-emulator-5554}"
+document_name="issue-5804-document.txt"
+media_name="issue-5804-image.png"
+document_dump="/sdcard/automobile-issue-5804-document.xml"
+media_dump="/sdcard/automobile-issue-5804-media.xml"
+
+if ! adb -s "$device_id" get-state | grep -qx "device"; then
+  echo "Android device is not ready: $device_id" >&2
+  exit 1
+fi
+
+bun -e '
+  import { createAppFileServiceForTesting } from "./src/server/appFileService";
+  const deviceId = process.argv[1];
+  if (!deviceId) throw new Error("device ID is required");
+  const service = createAppFileServiceForTesting();
+  const device = { deviceId, name: deviceId, platform: "android" as const };
+  const document = await service.putFile({
+    device,
+    target: { domain: "user_files", namespace: "issue-5804-smoke", reset: true },
+    files: [{ destinationPath: "documents/issue-5804-document.txt", contentText: "picker fixture" }],
+  });
+  const media = await service.putFile({
+    device,
+    target: { domain: "media_library" },
+    files: [{
+      destinationPath: "issue-5804-image.png",
+      contentBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScL6WQAAAABJRU5ErkJggg==",
+    }],
+  });
+  if (document.files[0]?.effects[0]?.type !== "document_picker") {
+    throw new Error("putAppFile did not report document-picker availability");
+  }
+  if (media.files[0]?.effects[0]?.status !== "completed") {
+    throw new Error("putAppFile did not verify MediaStore discovery");
+  }
+' "$device_id"
+
+adb -s "$device_id" shell am force-stop com.google.android.documentsui
+adb -s "$device_id" shell am start \
+  -a android.intent.action.OPEN_DOCUMENT \
+  -c android.intent.category.OPENABLE \
+  -t text/plain \
+  --eu android.provider.extra.INITIAL_URI \
+  content://com.android.externalstorage.documents/document/primary%3ADownload%2Fissue-5804-smoke%2Fdocuments >/dev/null
+adb -s "$device_id" shell uiautomator dump "$document_dump" >/dev/null
+adb -s "$device_id" shell cat "$document_dump" | grep -Fq "${document_name}"
+
+adb -s "$device_id" shell "content query --uri content://media/external_primary/images/media --projection _id:_display_name:relative_path --where \"_display_name='${media_name}' AND relative_path='Download/automobile-media/'\"" | grep -Fq "$media_name"
+adb -s "$device_id" shell am start -a android.provider.action.PICK_IMAGES >/dev/null
+adb -s "$device_id" shell uiautomator dump "$media_dump" >/dev/null
+adb -s "$device_id" shell cat "$media_dump" | grep -Fq "com.google.android.providers.media.module"
+adb -s "$device_id" shell cat "$media_dump" | grep -Fq 'content-desc="Photo taken on'
+
+echo "putAppFile picker smoke passed for $device_id"

--- a/scripts/android/put-app-file-picker-smoke.sh
+++ b/scripts/android/put-app-file-picker-smoke.sh
@@ -54,6 +54,14 @@ adb -s "$device_id" shell "content query --uri content://media/external_primary/
 adb -s "$device_id" shell am start -a android.provider.action.PICK_IMAGES >/dev/null
 adb -s "$device_id" shell uiautomator dump "$media_dump" >/dev/null
 adb -s "$device_id" shell cat "$media_dump" | grep -Fq "com.google.android.providers.media.module"
-adb -s "$device_id" shell cat "$media_dump" | grep -Fq 'content-desc="Photo taken on'
+adb -s "$device_id" shell am force-stop com.google.android.documentsui
+adb -s "$device_id" shell am start \
+  -a android.intent.action.OPEN_DOCUMENT \
+  -c android.intent.category.OPENABLE \
+  -t image/png \
+  --eu android.provider.extra.INITIAL_URI \
+  content://com.android.externalstorage.documents/document/primary%3ADownload%2Fautomobile-media >/dev/null
+adb -s "$device_id" shell uiautomator dump "$media_dump" >/dev/null
+adb -s "$device_id" shell cat "$media_dump" | grep -Fq "${media_name}"
 
 echo "putAppFile picker smoke passed for $device_id"

--- a/src/features/storage/storageCapabilities.ts
+++ b/src/features/storage/storageCapabilities.ts
@@ -277,7 +277,7 @@ function userFilesDomain(ctx: StorageCapabilityContext): DomainCapability {
     domain: "user_files",
     portable: false,
     platformScope: "android",
-    note: "Android user-visible / shared storage. Staging files into shared storage is supported (stageSharedStorage); a listing/read surface is not yet exposed.",
+    note: "Android user-visible shared storage. putAppFile writes bounded Downloads fixture namespaces; a listing/read surface is not yet exposed.",
     operations: [
       unavailableOperation(
         "list",
@@ -294,9 +294,11 @@ function userFilesDomain(ctx: StorageCapabilityContext): DomainCapability {
 
 function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
   // No AutoMobile tool browses or reads the media library on either platform.
-  // On Android, indexing happens only as a side effect of staging a file into
-  // shared storage (there is no standalone index operation); iOS has no
-  // host-triggered indexer at all.
+  // Android writes are intentionally bounded and report MediaStore verification
+  // as part of putAppFile; iOS has no equivalent provider yet.
+  const androidWrite = deriveOperation("write", undefined, [
+    req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile),
+  ]);
   const indexing =
     ctx.platform === "ios"
       ? deriveOperation(
@@ -304,15 +306,20 @@ function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
           "iOS has no MediaScanner-style host-triggered indexing equivalent.",
           [],
         )
-      : unavailableOperation(
+      : deriveOperation(
           "media_indexing",
-          "Media indexing currently occurs only as a side effect of staging a file into shared storage; no standalone indexing operation is exposed.",
+          undefined,
+          [req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile)],
+          "Verified as part of Android putAppFile media_library writes.",
         );
   return {
     domain: "media_library",
     portable: false,
     platformScope: "cross-platform",
-    note: "Media-library browse/read is not yet exposed as an AutoMobile capability.",
+    note:
+      ctx.platform === "android"
+        ? "Android putAppFile writes bounded media fixtures and verifies MediaStore discovery; browse/read is not exposed."
+        : "Media-library browse/read and writes are not exposed on iOS.",
     operations: [
       unavailableOperation(
         "list",
@@ -322,6 +329,13 @@ function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
         "read",
         "No AutoMobile media-library read surface is currently exposed.",
       ),
+      ctx.platform === "ios"
+        ? deriveOperation(
+            "write",
+            "iOS has no media-library fixture provider; use the Android media_library target only.",
+            [],
+          )
+        : androidWrite,
       indexing,
     ],
   };

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -35,6 +35,7 @@ import { shellQuote } from "../utils/shellQuote";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { logger } from "../utils/logger";
 import { prepareFileSource } from "./fileSourcePreparation";
+import { getSharedStorageService, type SharedStorageService } from "./sharedStorageService";
 
 export type PutAppFileRequest = Omit<PutAppFileArgs, "device"> & {
   device: BootedDevice;
@@ -123,6 +124,7 @@ export interface AppFileServiceDependencies {
   providers?: AppFileProvider[];
   deviceResolver?: (deviceId: string) => Promise<BootedDevice>;
   idGenerator?: IdGenerator;
+  sharedStorageService?: SharedStorageService;
 }
 
 const nodeAppFileFileSystem: AppFileFileSystem = {
@@ -187,7 +189,12 @@ export function createAppFileServiceForTesting(
     deviceResolver: deps.deviceResolver ?? defaultDependencies.deviceResolver,
   };
   return new DefaultAppFileService(
-    deps.providers ?? createDefaultProviders(resolvedDeps, deps.idGenerator ?? defaultIdGenerator),
+    deps.providers ??
+      createDefaultProviders(
+        resolvedDeps,
+        deps.idGenerator ?? defaultIdGenerator,
+        deps.sharedStorageService ?? getSharedStorageService(),
+      ),
     resolvedDeps.deviceResolver,
     resolvedDeps.fileSystem,
   );
@@ -196,9 +203,12 @@ export function createAppFileServiceForTesting(
 function createDefaultProviders(
   deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem">>,
   idGenerator: IdGenerator = defaultIdGenerator,
+  sharedStorageService: SharedStorageService = getSharedStorageService(),
 ): AppFileProvider[] {
   return [
     new AndroidAppFileProvider(deps.adbFactory, idGenerator),
+    new AndroidUserFilesProvider(sharedStorageService),
+    new AndroidMediaLibraryProvider(sharedStorageService),
     new IosSimulatorAppFileProvider(deps.simctlFactory, deps.fileSystem),
   ];
 }
@@ -690,6 +700,89 @@ class AndroidAppFileProvider
       ...(text === undefined
         ? { mimeType: "application/octet-stream", blob }
         : { mimeType: "text/plain; charset=utf-8", text }),
+    };
+  }
+}
+
+const ANDROID_MEDIA_LIBRARY_NAMESPACE = "automobile-media";
+
+class AndroidUserFilesProvider implements AppFileWriteProvider {
+  readonly platform = "android" as const;
+  readonly domain = "user_files" as const;
+
+  constructor(private readonly sharedStorageService: SharedStorageService) {}
+
+  async putFile(request: PutAppFileProviderRequest) {
+    if (request.target.domain !== "user_files") {
+      throw new ActionableError(
+        `Android user-files provider received unsupported target domain: ${request.target.domain}`,
+      );
+    }
+    const result = await this.sharedStorageService.stage({
+      device: request.device,
+      namespace: request.target.namespace,
+      reset: request.target.reset,
+      files: [{ sourcePath: request.sourcePath, destinationPath: request.destinationPath }],
+      signal: request.signal,
+    });
+    const staged = result.files[0]!;
+    return {
+      effects: [
+        {
+          type: "document_picker",
+          status: "completed" as const,
+          reason:
+            `document fixture is available in Downloads for device ${result.deviceId}, ` +
+            `resolved profile ${result.userId}, namespace ${result.namespace}`,
+        },
+        {
+          type: "media_index",
+          status: staged.mediaIndexing.status,
+          ...(staged.mediaIndexing.reason === undefined
+            ? {}
+            : { reason: staged.mediaIndexing.reason }),
+        },
+      ],
+    };
+  }
+}
+
+class AndroidMediaLibraryProvider implements AppFileWriteProvider {
+  readonly platform = "android" as const;
+  readonly domain = "media_library" as const;
+
+  constructor(private readonly sharedStorageService: SharedStorageService) {}
+
+  async putFile(request: PutAppFileProviderRequest) {
+    if (request.target.domain !== "media_library") {
+      throw new ActionableError(
+        `Android media-library provider received unsupported target domain: ${request.target.domain}`,
+      );
+    }
+    const result = await this.sharedStorageService.stage({
+      device: request.device,
+      namespace: ANDROID_MEDIA_LIBRARY_NAMESPACE,
+      files: [{ sourcePath: request.sourcePath, destinationPath: request.destinationPath }],
+      signal: request.signal,
+    });
+    const staged = result.files[0]!;
+    if (staged.mediaIndexing.status !== "completed") {
+      throw new ActionableError(
+        `Android media-library fixture ${request.destinationPath} on device ${result.deviceId}, ` +
+          `resolved profile ${result.userId}, was not indexed. ` +
+          "Recovery: use an image, video, or audio filename supported by Android MediaStore.",
+      );
+    }
+    return {
+      effects: [
+        {
+          type: "media_index",
+          status: "completed" as const,
+          reason:
+            `MediaStore verified fixture discovery for device ${result.deviceId}, ` +
+            `resolved profile ${result.userId}, namespace ${result.namespace}`,
+        },
+      ],
     };
   }
 }

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -71,6 +71,13 @@ export interface AppFileWriteProvider {
   putFile(
     request: PutAppFileProviderRequest,
   ): Promise<void | { effects?: PutAppFileWriteResult["effects"] }>;
+  /**
+   * Optional batch path for providers whose device operation must use one
+   * consistent target (for example, a single Android user profile).
+   */
+  putFiles?(
+    requests: PutAppFileProviderRequest[],
+  ): Promise<Array<void | { effects?: PutAppFileWriteResult["effects"] }>>;
 }
 
 export interface AppFileListProvider {
@@ -290,6 +297,39 @@ async function prepareSources(
   }
 }
 
+function buildProviderRequests(
+  request: PutAppFileRequest | LegacyPutAppFileRequest,
+  target: PutAppFileTarget,
+  files: PutAppFileInput[],
+  prepared: Awaited<ReturnType<typeof prepareFileSource>>[],
+): PutAppFileProviderRequest[] {
+  return files.map((file, index) => {
+    const source = prepared[index]!;
+    const providerTarget =
+      target.domain === "user_files" && target.reset === true && index > 0
+        ? { ...target, reset: false }
+        : target;
+    return {
+      device: request.device,
+      target: providerTarget,
+      destinationPath: file.destinationPath,
+      sourcePath: source.path,
+      byteCount: source.byteCount,
+      signal: request.signal,
+    };
+  });
+}
+
+async function writeProviderFiles(
+  provider: AppFileWriteProvider,
+  requests: PutAppFileProviderRequest[],
+) {
+  if (provider.putFiles) {
+    return provider.putFiles(requests);
+  }
+  return Promise.all(requests.map((request) => provider.putFile(request)));
+}
+
 class DefaultAppFileService implements AppFileService {
   private readonly writeProviders = new Map<string, AppFileWriteProvider>();
   private readonly listProviders = new Map<string, AppFileListProvider>();
@@ -330,22 +370,13 @@ class DefaultAppFileService implements AppFileService {
     const prepared = await prepareSources(files, this.fileSystem);
     try {
       const provider = this.getWriteProvider(request.device.platform, target.domain);
+      const providerRequests = buildProviderRequests(request, target, files, prepared);
+      const providerResults = await writeProviderFiles(provider, providerRequests);
       const results: PutAppFileWriteResult[] = [];
       for (let index = 0; index < files.length; index += 1) {
         const file = files[index]!;
         const source = prepared[index]!;
-        const providerTarget =
-          target.domain === "user_files" && target.reset === true && index > 0
-            ? { ...target, reset: false }
-            : target;
-        const providerResult = await provider.putFile({
-          device: request.device,
-          target: providerTarget,
-          destinationPath: file.destinationPath,
-          sourcePath: source.path,
-          byteCount: source.byteCount,
-          signal: request.signal,
-        });
+        const providerResult = providerResults[index];
         results.push({
           destinationPath: file.destinationPath,
           byteCount: source.byteCount,
@@ -713,6 +744,14 @@ class AndroidUserFilesProvider implements AppFileWriteProvider {
   constructor(private readonly sharedStorageService: SharedStorageService) {}
 
   async putFile(request: PutAppFileProviderRequest) {
+    return (await this.putFiles([request]))[0];
+  }
+
+  async putFiles(requests: PutAppFileProviderRequest[]) {
+    if (requests.length === 0) {
+      return [];
+    }
+    const request = requests[0]!;
     if (request.target.domain !== "user_files") {
       throw new ActionableError(
         `Android user-files provider received unsupported target domain: ${request.target.domain}`,
@@ -722,11 +761,13 @@ class AndroidUserFilesProvider implements AppFileWriteProvider {
       device: request.device,
       namespace: request.target.namespace,
       reset: request.target.reset,
-      files: [{ sourcePath: request.sourcePath, destinationPath: request.destinationPath }],
+      files: requests.map((file) => ({
+        sourcePath: file.sourcePath,
+        destinationPath: file.destinationPath,
+      })),
       signal: request.signal,
     });
-    const staged = result.files[0]!;
-    return {
+    return result.files.map((staged) => ({
       effects: [
         {
           type: "document_picker",
@@ -743,7 +784,7 @@ class AndroidUserFilesProvider implements AppFileWriteProvider {
             : { reason: staged.mediaIndexing.reason }),
         },
       ],
-    };
+    }));
   }
 }
 
@@ -754,6 +795,14 @@ class AndroidMediaLibraryProvider implements AppFileWriteProvider {
   constructor(private readonly sharedStorageService: SharedStorageService) {}
 
   async putFile(request: PutAppFileProviderRequest) {
+    return (await this.putFiles([request]))[0];
+  }
+
+  async putFiles(requests: PutAppFileProviderRequest[]) {
+    if (requests.length === 0) {
+      return [];
+    }
+    const request = requests[0]!;
     if (request.target.domain !== "media_library") {
       throw new ActionableError(
         `Android media-library provider received unsupported target domain: ${request.target.domain}`,
@@ -762,28 +811,32 @@ class AndroidMediaLibraryProvider implements AppFileWriteProvider {
     const result = await this.sharedStorageService.stage({
       device: request.device,
       namespace: ANDROID_MEDIA_LIBRARY_NAMESPACE,
-      files: [{ sourcePath: request.sourcePath, destinationPath: request.destinationPath }],
+      files: requests.map((file) => ({
+        sourcePath: file.sourcePath,
+        destinationPath: file.destinationPath,
+      })),
       signal: request.signal,
     });
-    const staged = result.files[0]!;
-    if (staged.mediaIndexing.status !== "completed") {
-      throw new ActionableError(
-        `Android media-library fixture ${request.destinationPath} on device ${result.deviceId}, ` +
-          `resolved profile ${result.userId}, was not indexed. ` +
-          "Recovery: use an image, video, or audio filename supported by Android MediaStore.",
-      );
-    }
-    return {
-      effects: [
-        {
-          type: "media_index",
-          status: "completed" as const,
-          reason:
-            `MediaStore verified fixture discovery for device ${result.deviceId}, ` +
-            `resolved profile ${result.userId}, namespace ${result.namespace}`,
-        },
-      ],
-    };
+    return result.files.map((staged) => {
+      if (staged.mediaIndexing.status !== "completed") {
+        throw new ActionableError(
+          `Android media-library fixture ${staged.destinationPath} on device ${result.deviceId}, ` +
+            `resolved profile ${result.userId}, was not indexed. ` +
+            "Recovery: use an image, video, or audio filename supported by Android MediaStore.",
+        );
+      }
+      return {
+        effects: [
+          {
+            type: "media_index",
+            status: "completed" as const,
+            reason:
+              `MediaStore verified fixture discovery for device ${result.deviceId}, ` +
+              `resolved profile ${result.userId}, namespace ${result.namespace}`,
+          },
+        ],
+      };
+    });
   }
 }
 

--- a/src/server/sharedStorageContract.ts
+++ b/src/server/sharedStorageContract.ts
@@ -38,6 +38,8 @@ export interface StageSharedStorageResult {
   deviceId: string;
   platform: "android";
   namespace: string;
+  userId: number;
+  userSource: "explicit" | "foregroundPackage" | "managedProfile" | "primary";
   destinationDirectory: string;
   reset: boolean;
   files: StagedSharedStorageFile[];

--- a/src/server/sharedStorageContract.ts
+++ b/src/server/sharedStorageContract.ts
@@ -39,7 +39,7 @@ export interface StageSharedStorageResult {
   platform: "android";
   namespace: string;
   userId: number;
-  userSource: "explicit" | "foregroundPackage" | "managedProfile" | "primary";
+  userSource: "explicit" | "currentUser" | "foregroundPackage" | "managedProfile" | "primary";
   destinationDirectory: string;
   reset: boolean;
   files: StagedSharedStorageFile[];

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -109,10 +109,14 @@ class DefaultSharedStorageService implements SharedStorageService {
       throw new ActionableError("stageSharedStorage is only supported on Android devices.");
     }
     const namespace = normalizeSharedStorageNamespace(request.namespace);
+    const preparedFiles = await this.prepareFiles(request.files);
     const adb = this.adbFactory.create(request.device);
     let user: ResolvedUserTarget;
     try {
-      user = await this.createUserResolver(adb).resolve({ signal: request.signal });
+      user = await this.createUserResolver(adb).resolve({
+        currentUser: true,
+        signal: request.signal,
+      });
     } catch (error) {
       throw new ActionableError(
         `Android shared-storage could not resolve an active profile for device ${request.device.deviceId} ` +
@@ -121,7 +125,6 @@ class DefaultSharedStorageService implements SharedStorageService {
       );
     }
     const destinationDirectory = downloadsDirectory(user.userId, namespace);
-    const preparedFiles = await this.prepareFiles(request.files);
     try {
       if (request.reset) {
         // namespace has exactly one safe segment, so this can only remove Downloads/<namespace>.

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -14,6 +14,11 @@ import { errorMessage } from "../utils/describeUnknownError";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { readAndroidDeviceApiLevel } from "../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import {
+  AndroidUserTargetResolver,
+  type ResolvedUserTarget,
+  type UserTargetRequest,
+} from "../utils/android-cmdline-tools/AndroidUserTargetResolver";
+import {
   normalizeSharedStorageNamespace,
   normalizeSharedStorageRelativePath,
   type SharedStorageFileInput,
@@ -22,7 +27,7 @@ import {
   type StagedSharedStorageFile,
 } from "./sharedStorageContract";
 
-const DOWNLOADS_ROOT = "/sdcard/Download";
+const DOWNLOADS_DIRECTORY = "Download";
 
 interface SharedStorageStats {
   size: number;
@@ -47,6 +52,11 @@ export interface SharedStorageServiceDependencies {
   adbFactory?: AdbClientFactory;
   fileSystem?: SharedStorageFileSystem;
   timer?: Timer;
+  createUserResolver?: (adb: AdbExecutor) => SharedStorageUserResolver;
+}
+
+export interface SharedStorageUserResolver {
+  resolve(request?: UserTargetRequest): Promise<ResolvedUserTarget>;
 }
 
 export interface StageSharedStorageRequest extends Omit<StageSharedStorageArgs, "device"> {
@@ -82,6 +92,7 @@ export function createSharedStorageServiceForTesting(
     dependencies.adbFactory ?? defaultAdbClientFactory,
     dependencies.fileSystem ?? defaultFileSystem,
     dependencies.timer ?? defaultTimer,
+    dependencies.createUserResolver ?? ((adb) => new AndroidUserTargetResolver(adb)),
   );
 }
 
@@ -90,6 +101,7 @@ class DefaultSharedStorageService implements SharedStorageService {
     private readonly adbFactory: AdbClientFactory,
     private readonly fileSystem: SharedStorageFileSystem,
     private readonly timer: Timer,
+    private readonly createUserResolver: (adb: AdbExecutor) => SharedStorageUserResolver,
   ) {}
 
   async stage(request: StageSharedStorageRequest): Promise<StageSharedStorageResult> {
@@ -97,8 +109,18 @@ class DefaultSharedStorageService implements SharedStorageService {
       throw new ActionableError("stageSharedStorage is only supported on Android devices.");
     }
     const namespace = normalizeSharedStorageNamespace(request.namespace);
-    const destinationDirectory = posix.join(DOWNLOADS_ROOT, namespace);
     const adb = this.adbFactory.create(request.device);
+    let user: ResolvedUserTarget;
+    try {
+      user = await this.createUserResolver(adb).resolve({ signal: request.signal });
+    } catch (error) {
+      throw new ActionableError(
+        `Android shared-storage could not resolve an active profile for device ${request.device.deviceId} ` +
+          `and namespace ${namespace}: ${errorMessage(error)}. ` +
+          "Recovery: boot the intended Android profile and retry.",
+      );
+    }
+    const destinationDirectory = downloadsDirectory(user.userId, namespace);
     const preparedFiles = await this.prepareFiles(request.files);
     try {
       if (request.reset) {
@@ -109,13 +131,17 @@ class DefaultSharedStorageService implements SharedStorageService {
 
       const files: StagedSharedStorageFile[] = [];
       for (const file of preparedFiles) {
-        files.push(await this.stageFile(adb, request, namespace, destinationDirectory, file));
+        files.push(
+          await this.stageFile(adb, request, namespace, destinationDirectory, user.userId, file),
+        );
       }
       return {
         success: true,
         deviceId: request.device.deviceId,
         platform: "android",
         namespace,
+        userId: user.userId,
+        userSource: user.source,
         destinationDirectory,
         reset: request.reset ?? false,
         files,
@@ -162,6 +188,7 @@ class DefaultSharedStorageService implements SharedStorageService {
     request: StageSharedStorageRequest,
     namespace: string,
     destinationDirectory: string,
+    userId: number,
     file: PreparedSharedStorageFile,
   ): Promise<StagedSharedStorageFile> {
     const destinationPath = file.destinationPath;
@@ -173,7 +200,7 @@ class DefaultSharedStorageService implements SharedStorageService {
     await execute(adb, `shell mkdir -p ${shellQuote(posix.dirname(destination))}`, request.signal);
     await executeArgs(adb, ["push", file.source.path, destination], request.signal);
     const mediaIndexing = shouldIndexMedia(destinationPath, request.indexMedia ?? true)
-      ? await indexMediaFile(adb, destination, destinationPath, this.timer, request.signal)
+      ? await indexMediaFile(adb, destination, destinationPath, userId, this.timer, request.signal)
       : {
           status: "notRequested" as const,
           reason: indexingNotRequestedReason(destinationPath, request.indexMedia ?? true),
@@ -228,18 +255,24 @@ async function indexMediaFile(
   adb: AdbExecutor,
   destination: string,
   destinationPath: string,
+  userId: number,
   timer: Timer,
   signal?: AbortSignal,
 ): Promise<{ status: "completed" }> {
   await execute(
     adb,
-    `shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d ${shellQuote(`file://${destination}`)}`,
+    `shell am broadcast --user ${userId} -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d ${shellQuote(`file://${destination}`)}`,
     signal,
   );
   const collection = mediaCollectionFor(destinationPath);
   const apiLevel = await readAndroidDeviceApiLevel(adb);
   const modernQuery = apiLevel === null || apiLevel >= 29;
-  const deviceRelativePath = destination.slice(`${DOWNLOADS_ROOT}/`.length);
+  const downloadsPrefix = `/${DOWNLOADS_DIRECTORY}/`;
+  const downloadsIndex = destination.indexOf(downloadsPrefix);
+  if (downloadsIndex < 0) {
+    throw new ActionableError(`Android media fixture is outside Downloads: ${destination}`);
+  }
+  const deviceRelativePath = destination.slice(downloadsIndex + downloadsPrefix.length);
   const deviceRelativeDirectory = posix.dirname(deviceRelativePath);
   const relativePath =
     deviceRelativeDirectory === "." ? "Download/" : `Download/${deviceRelativeDirectory}/`;
@@ -250,7 +283,7 @@ async function indexMediaFile(
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const result = await executeResult(
       adb,
-      `shell content query --uri content://media/${volume}/${collection}/media --projection _id --where ${shellQuote(selection)}`,
+      `shell content query --user ${userId} --uri content://media/${volume}/${collection}/media --projection _id --where ${shellQuote(selection)}`,
       signal,
     );
     if (/^Row:/m.test(result.stdout)) {
@@ -297,4 +330,8 @@ function indexingNotRequestedReason(path: string, indexMedia: boolean): string {
     return "media indexing was disabled by indexMedia=false";
   }
   return `media indexing was not requested for ${path}; Android document pickers discover files directly from Downloads`;
+}
+
+function downloadsDirectory(userId: number, namespace: string): string {
+  return posix.join(`/storage/emulated/${userId}`, DOWNLOADS_DIRECTORY, namespace);
 }

--- a/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
+++ b/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
@@ -1,7 +1,12 @@
 import type { AdbExecutor } from "./interfaces/AdbExecutor";
 import { classifyAndroidUser } from "../../models/AndroidUser";
 
-export type UserTargetSource = "explicit" | "foregroundPackage" | "managedProfile" | "primary";
+export type UserTargetSource =
+  | "explicit"
+  | "currentUser"
+  | "foregroundPackage"
+  | "managedProfile"
+  | "primary";
 
 export interface ResolvedUserTarget {
   userId: number;
@@ -11,6 +16,8 @@ export interface ResolvedUserTarget {
 export interface UserTargetRequest {
   packageName?: string;
   explicitUserId?: number;
+  /** Resolve Android's current user before applying package/profile heuristics. */
+  currentUser?: boolean;
   signal?: AbortSignal;
 }
 
@@ -28,6 +35,20 @@ export class AndroidUserTargetResolver {
   async resolve(request: UserTargetRequest = {}): Promise<ResolvedUserTarget> {
     if (request.explicitUserId !== undefined) {
       return { userId: request.explicitUserId, source: "explicit" };
+    }
+
+    if (request.currentUser) {
+      const result = await this.adb.executeCommand(
+        "shell am get-current-user",
+        undefined,
+        undefined,
+        true,
+        request.signal,
+      );
+      const currentUserId = Number.parseInt(result.stdout.trim(), 10);
+      if (Number.isSafeInteger(currentUserId) && currentUserId >= 0) {
+        return { userId: currentUserId, source: "currentUser" };
+      }
     }
 
     if (request.packageName) {

--- a/test/features/storage/storageCapabilities.test.ts
+++ b/test/features/storage/storageCapabilities.test.ts
@@ -108,7 +108,7 @@ describe("AC2: platform-qualified domains", () => {
     const report = computeStorageCapabilities(
       ctx({ platform: "android", activeUserProfile: true }),
     );
-    // Staging into shared storage is backed by stageSharedStorage.
+    // Staging into shared storage is backed by putAppFile user_files providers.
     expect(isStorageOperationAvailable(report, "user_files", "write")).toBe(true);
     // No AutoMobile listing/read surface exists for shared storage yet.
     expect(findOperationCapability(report, "user_files", "list")?.state).toBe("unavailable");
@@ -220,6 +220,17 @@ describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
     expect(findOperationCapability(report, "media_library", "list")?.state).toBe("unavailable");
     expect(findOperationCapability(report, "media_library", "read")?.state).toBe("unavailable");
     expect(isStorageOperationAvailable(report, "media_library", "list")).toBe(false);
+  });
+
+  it("advertises Android media_library writes only when an active profile is available", () => {
+    const available = computeStorageCapabilities(ctx({ activeUserProfile: true }));
+    expect(isStorageOperationAvailable(available, "media_library", "write")).toBe(true);
+    expect(findOperationCapability(available, "media_library", "media_indexing")?.state).toBe(
+      "supported",
+    );
+
+    const ios = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "simulator" }));
+    expect(findOperationCapability(ios, "media_library", "write")?.state).toBe("unsupported");
   });
 
   it("secure_state read is unavailable pending the #5161 host policy, not unsupported", () => {

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -15,6 +15,7 @@ import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
+import { createSharedStorageServiceForTesting } from "../../src/server/sharedStorageService";
 
 function execResult(stdout: string, stderr = "") {
   return {
@@ -144,6 +145,89 @@ describe("AppFileService", () => {
       { domain: "user_files", namespace: "run-42", reset: true },
       { domain: "user_files", namespace: "run-42", reset: false },
     ]);
+  });
+
+  test("stages user_files in the resolved profile Downloads namespace with document-picker effects", async () => {
+    const executor = new FakeAdbExecutor();
+    const sharedStorageService = createSharedStorageServiceForTesting({
+      adbFactory: adbFactoryFor(executor),
+      createUserResolver: () => ({
+        resolve: async () => ({ userId: 10, source: "managedProfile" }),
+      }),
+    });
+    const service = createAppFileServiceForTesting({ sharedStorageService });
+
+    const result = await service.putFile({
+      device: { deviceId: "emulator-5554", name: "Pixel", platform: "android" },
+      target: { domain: "user_files", namespace: "picker-run", reset: true },
+      files: [
+        { contentText: "one", destinationPath: "docs/one.txt" },
+        { contentText: "two", destinationPath: "docs/two.txt" },
+      ],
+    });
+
+    expect(result.files.map((file) => file.effects[0])).toEqual([
+      {
+        type: "document_picker",
+        status: "completed",
+        reason:
+          "document fixture is available in Downloads for device emulator-5554, resolved profile 10, namespace picker-run",
+      },
+      {
+        type: "document_picker",
+        status: "completed",
+        reason:
+          "document fixture is available in Downloads for device emulator-5554, resolved profile 10, namespace picker-run",
+      },
+    ]);
+    expect(
+      executor
+        .getExecutedCommands()
+        .filter((command) => command === "shell rm -rf '/storage/emulated/10/Download/picker-run'"),
+    ).toHaveLength(1);
+    expect(
+      executor
+        .getExecutedArgv()
+        .filter((args) => args[0] === "push")
+        .every((args) => args[2]?.startsWith("/storage/emulated/10/Download/picker-run/")),
+    ).toBe(true);
+  });
+
+  test("stages media_library fixtures through the bounded AutoMobile namespace after MediaStore verification", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("content query", execResult("Row: 0 _id=42"));
+    const sharedStorageService = createSharedStorageServiceForTesting({
+      adbFactory: adbFactoryFor(executor),
+      createUserResolver: () => ({
+        resolve: async () => ({ userId: 12, source: "managedProfile" }),
+      }),
+    });
+    const service = createAppFileServiceForTesting({ sharedStorageService });
+
+    const result = await service.putFile({
+      device: { deviceId: "emulator-5554", name: "Pixel", platform: "android" },
+      target: { domain: "media_library" },
+      files: [
+        { contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "photo.png" },
+      ],
+    });
+
+    expect(result.files[0]?.effects).toEqual([
+      {
+        type: "media_index",
+        status: "completed",
+        reason:
+          "MediaStore verified fixture discovery for device emulator-5554, resolved profile 12, namespace automobile-media",
+      },
+    ]);
+    expect(executor.getExecutedArgv()).toContainEqual([
+      "push",
+      expect.stringContaining("automobile-app-file-"),
+      "/storage/emulated/12/Download/automobile-media/photo.png",
+    ]);
+    expect(
+      executor.getExecutedCommands().some((command) => command.includes("content query")),
+    ).toBe(true);
   });
 
   test("prepares every file and rejects conflicts before provider mutation", async () => {

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -149,10 +149,14 @@ describe("AppFileService", () => {
 
   test("stages user_files in the resolved profile Downloads namespace with document-picker effects", async () => {
     const executor = new FakeAdbExecutor();
+    let resolveCalls = 0;
     const sharedStorageService = createSharedStorageServiceForTesting({
       adbFactory: adbFactoryFor(executor),
       createUserResolver: () => ({
-        resolve: async () => ({ userId: 10, source: "managedProfile" }),
+        resolve: async () => {
+          resolveCalls += 1;
+          return { userId: 10, source: "managedProfile" };
+        },
       }),
     });
     const service = createAppFileServiceForTesting({ sharedStorageService });
@@ -191,6 +195,7 @@ describe("AppFileService", () => {
         .filter((args) => args[0] === "push")
         .every((args) => args[2]?.startsWith("/storage/emulated/10/Download/picker-run/")),
     ).toBe(true);
+    expect(resolveCalls).toBe(1);
   });
 
   test("stages media_library fixtures through the bounded AutoMobile namespace after MediaStore verification", async () => {

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -50,7 +50,9 @@ describe("SharedStorageService", () => {
       deviceId: "emulator-5554",
       platform: "android",
       namespace: "run-42",
-      destinationDirectory: "/sdcard/Download/run-42",
+      userId: 0,
+      userSource: "primary",
+      destinationDirectory: "/storage/emulated/0/Download/run-42",
       reset: true,
       files: [
         {
@@ -71,26 +73,27 @@ describe("SharedStorageService", () => {
     });
 
     const commands = executor.getExecutedCommands();
-    expect(commands[0]).toBe("shell rm -rf '/sdcard/Download/run-42'");
-    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42'");
-    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/docs'");
-    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/media'");
+    expect(commands[0]).toBe("shell rm -rf '/storage/emulated/0/Download/run-42'");
+    expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42'");
+    expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42/docs'");
+    expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42/media'");
     expect(
       commands.some(
         (command) =>
-          command.includes("push ") && command.includes("/sdcard/Download/run-42/docs/read me.txt"),
+          command.includes("push ") &&
+          command.includes("/storage/emulated/0/Download/run-42/docs/read me.txt"),
       ),
     ).toBe(true);
     expect(executor.getExecutedArgv()).toContainEqual([
       "push",
       expect.stringContaining("automobile-shared-storage-"),
-      "/sdcard/Download/run-42/docs/read me.txt",
+      "/storage/emulated/0/Download/run-42/docs/read me.txt",
     ]);
     expect(
       commands.some(
         (command) =>
           command.includes("MEDIA_SCANNER_SCAN_FILE") &&
-          command.includes("file:///sdcard/Download/run-42/media/photo.png"),
+          command.includes("file:///storage/emulated/0/Download/run-42/media/photo.png"),
       ),
     ).toBe(true);
     expect(
@@ -99,7 +102,72 @@ describe("SharedStorageService", () => {
           command.includes("content query") && command.includes("external_primary/images/media"),
       ),
     ).toBe(true);
+    expect(
+      commands.some(
+        (command) =>
+          command.includes("relative_path=") &&
+          command.includes("Download") &&
+          !command.includes("Download/Download/"),
+      ),
+    ).toBe(true);
     expect(commands.every((command) => !command.includes(".."))).toBe(true);
+  });
+
+  test("uses the resolved active profile rather than assuming Android user zero", async () => {
+    const executor = new FakeAdbExecutor();
+    const service = createSharedStorageServiceForTesting({
+      adbFactory: adbFactoryFor(executor),
+      createUserResolver: () => ({
+        resolve: async () => ({ userId: 12, source: "managedProfile" }),
+      }),
+    });
+
+    const result = await service.stage({
+      device: androidDevice,
+      namespace: "work-fixtures",
+      reset: true,
+      files: [{ contentText: "picker", destinationPath: "document.txt" }],
+    });
+
+    expect(result).toMatchObject({
+      userId: 12,
+      userSource: "managedProfile",
+      destinationDirectory: "/storage/emulated/12/Download/work-fixtures",
+    });
+    expect(executor.getExecutedCommands()).toContain(
+      "shell rm -rf '/storage/emulated/12/Download/work-fixtures'",
+    );
+    expect(executor.getExecutedArgv()).toContainEqual([
+      "push",
+      expect.stringContaining("automobile-shared-storage-"),
+      "/storage/emulated/12/Download/work-fixtures/document.txt",
+    ]);
+  });
+
+  test("scopes MediaStore scanning and verification to the resolved profile", async () => {
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("content query", execResult("Row: 0 _id=42"));
+    const service = createSharedStorageServiceForTesting({
+      adbFactory: adbFactoryFor(executor),
+      createUserResolver: () => ({
+        resolve: async () => ({ userId: 12, source: "managedProfile" }),
+      }),
+    });
+
+    await service.stage({
+      device: androidDevice,
+      namespace: "work-media",
+      files: [{ contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "photo.png" }],
+    });
+
+    expect(executor.getExecutedCommands()).toContain(
+      "shell am broadcast --user 12 -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d 'file:///storage/emulated/12/Download/work-media/photo.png'",
+    );
+    expect(
+      executor
+        .getExecutedCommands()
+        .some((command) => command.startsWith("shell content query --user 12 --uri ")),
+    ).toBe(true);
   });
 
   test("reports why indexing was not requested when the caller opts out", async () => {

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -157,7 +157,9 @@ describe("SharedStorageService", () => {
     await service.stage({
       device: androidDevice,
       namespace: "work-media",
-      files: [{ contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "photo.png" }],
+      files: [
+        { contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "photo.png" },
+      ],
     });
 
     expect(executor.getExecutedCommands()).toContain(

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -73,7 +73,8 @@ describe("SharedStorageService", () => {
     });
 
     const commands = executor.getExecutedCommands();
-    expect(commands[0]).toBe("shell rm -rf '/storage/emulated/0/Download/run-42'");
+    expect(commands[0]).toBe("shell am get-current-user");
+    expect(commands[1]).toBe("shell rm -rf '/storage/emulated/0/Download/run-42'");
     expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42'");
     expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42/docs'");
     expect(commands).toContain("shell mkdir -p '/storage/emulated/0/Download/run-42/media'");

--- a/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
@@ -88,6 +88,28 @@ const cases: ResolveCase[] = [
 ];
 
 describe("AndroidUserTargetResolver.resolve", () => {
+  test("uses Android's current user before managed-profile fallback when requested", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setUsers([
+      { userId: 0, name: "Owner", flags: 13, running: true },
+      { userId: 10, name: "Work", flags: 32, running: true },
+    ]);
+    adb.setCommandResponse("am get-current-user", {
+      stdout: "0",
+      stderr: "",
+      toString: () => "0",
+      trim: () => "0",
+      includes: (value) => value === "0",
+    });
+
+    await expect(
+      new AndroidUserTargetResolver(adb).resolve({ currentUser: true }),
+    ).resolves.toEqual({
+      userId: 0,
+      source: "currentUser",
+    });
+  });
+
   test.each(cases)("$name", async ({ request, users, foreground, expected }) => {
     const adb = new FakeAdbExecutor();
     if (users) {


### PR DESCRIPTION
## Summary

- register Android `putAppFile` providers for `user_files` and `media_library`, reusing the bounded Downloads staging service
- resolve the active Android profile for writes, reset, MediaStore scan, and verification; report document-picker and verified media-index effects per file
- retain `stageSharedStorage` compatibility while documenting the canonical target-based API and updating capability reporting
- add fake-backed profile/reset/indexing coverage plus a repeatable Android emulator picker smoke

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `shellcheck scripts/android/put-app-file-picker-smoke.sh`
- `scripts/android/put-app-file-picker-smoke.sh emulator-5554`
- `(cd android && ./gradlew :test-plan-validation:test --tests '*ValidTools*' --tests '*TestPlanValidatorTest*')`

Closes [#5804](https://github.com/kaeawc/auto-mobile/issues/5804).
