### PR TITLE
fix(daemon): fence sessions after device kill

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5012,13 +5012,11 @@ export class DevicePool {
       throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
     }
     const identity = this.reserveShutdownSessionIdentity(deviceId);
-    let expectedDevice: PooledDevice | undefined;
-    try {
-      expectedDevice = await this.reserveShutdownDeviceUnderLock(deviceId, identity, abortSignal);
-    } catch (error) {
-      identity.releaseSession?.();
-      throw error;
-    }
+    const expectedDevice = await this.reserveShutdownDeviceWithAbort(
+      deviceId,
+      identity,
+      abortSignal,
+    );
     if (!expectedDevice) {
       identity.releaseSession?.();
       return undefined;
@@ -5039,6 +5037,34 @@ export class DevicePool {
       identity.releaseSession?.();
     };
     return { device: capturedDevice, session: identity.session, release };
+  }
+
+  private async reserveShutdownDeviceWithAbort(
+    deviceId: string,
+    identity: ShutdownIdentityReservation,
+    abortSignal: AbortSignal | undefined,
+  ): Promise<PooledDevice | undefined> {
+    const releaseSessionOnAbort = () => identity.releaseSession?.();
+    abortSignal?.addEventListener("abort", releaseSessionOnAbort, { once: true });
+    try {
+      const expectedDevice = await this.reserveShutdownDeviceUnderLock(
+        deviceId,
+        identity,
+        abortSignal,
+      );
+      if (abortSignal?.aborted) {
+        if (expectedDevice && this.shutdownReservations.get(deviceId) === expectedDevice) {
+          this.shutdownReservations.delete(deviceId);
+        }
+        throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
+      }
+      return expectedDevice;
+    } catch (error) {
+      identity.releaseSession?.();
+      throw error;
+    } finally {
+      abortSignal?.removeEventListener("abort", releaseSessionOnAbort);
+    }
   }
 
   private reserveShutdownSessionIdentity(deviceId: string): ShutdownIdentityReservation {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5050,7 +5050,8 @@ export class DevicePool {
     const session =
       candidate !== undefined &&
       candidate.sessionId === device?.sessionId &&
-      candidate.assignedDevice === deviceId
+      candidate.assignedDevice === deviceId &&
+      this.sessionManager.isLatestSessionIdentity(candidate)
         ? candidate
         : undefined;
     return {
@@ -5103,7 +5104,16 @@ export class DevicePool {
       return;
     }
     const session = this.pooledSessionIdentities.get(device);
-    if (session?.sessionId !== device.sessionId || session.assignedDevice !== deviceId) {
+    if (
+      session?.sessionId !== device.sessionId ||
+      session.assignedDevice !== deviceId ||
+      // Every production assignment path holds assignmentMutex. Once this
+      // callback owns it, an outer getOrCreateSession assignment can only be
+      // awaiting its finally cleanup; it can no longer publish device state.
+      !this.sessionManager.isLatestSessionIdentity(session, {
+        ignorePendingAssignment: true,
+      })
+    ) {
       return;
     }
     identity.session = session;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -173,6 +173,13 @@ type SessionAssignmentSnapshot = Pick<
   "sessionId" | "status" | "lastUsedAt" | "assignmentCount" | "errorCount" | "autolockSessionId"
 >;
 
+interface ShutdownIdentityReservation {
+  device: PooledDevice | undefined;
+  assignmentCount: number | undefined;
+  session: Session | undefined;
+  releaseSession: (() => void) | undefined;
+}
+
 /**
  * One iOS liveness sweep, carrying completeness per source (#5683).
  *
@@ -414,6 +421,8 @@ export class DevicePool {
    * as well as ordinary pool allocation.
    */
   private readonly shutdownReservations: Map<string, PooledDevice> = new Map();
+  /** Exact session incarnation last assigned to each pooled-device incarnation. */
+  private readonly pooledSessionIdentities: WeakMap<PooledDevice, Session> = new WeakMap();
   /**
    * Serials the user intentionally stopped, mapped to the pooled-device
    * incarnation that was present at mark time (or {@link INCARNATION_ANY} when
@@ -4344,6 +4353,7 @@ export class DevicePool {
           `Device '${device.id}' disconnected while its session was being created.`,
         );
       }
+      this.pooledSessionIdentities.set(device, session);
       return session;
     } catch (error) {
       if (this.devices.get(device.id) === device && device.sessionId === attemptedSessionId) {
@@ -4807,11 +4817,10 @@ export class DevicePool {
         `Session '${session.sessionId}' was released while System UI recovery was in progress.`,
       );
     }
-    const reboundSession = await this.sessionManager.rebindSession(
-      session.sessionId,
+    const reboundSession = await this.sessionManager.rebindSessionForTerminalReleaseRecovery(
+      session,
       replacementDevice.id,
       replacementDevice.platform,
-      { force: true },
     );
     if (
       this.devices.get(replacementDevice.id) !== replacementDevice ||
@@ -4824,6 +4833,7 @@ export class DevicePool {
     }
     replacementDevice.sessionId = session.sessionId;
     replacementDevice.status = "busy";
+    this.pooledSessionIdentities.set(replacementDevice, session);
     // addDevice leaves autolockSessionId undefined, which assertAutolockAccess
     // reads as "unlocked" and would let any session drive the recovered device
     // while the mcpSessionAutolockMap still points at the original. Carry the
@@ -4993,25 +5003,24 @@ export class DevicePool {
   ): Promise<
     | {
         device: PooledDevice;
+        session?: Session;
         release: () => Promise<void>;
       }
     | undefined
   > {
+    if (abortSignal?.aborted) {
+      throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
+    }
+    const identity = this.reserveShutdownSessionIdentity(deviceId);
     let expectedDevice: PooledDevice | undefined;
-    await this.assignmentMutex.runExclusive(() => {
-      if (abortSignal?.aborted) {
-        throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
-      }
-      expectedDevice = this.devices.get(deviceId);
-      if (!expectedDevice) {
-        return;
-      }
-      if (this.shutdownReservations.get(deviceId) === expectedDevice) {
-        throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
-      }
-      this.shutdownReservations.set(deviceId, expectedDevice);
-    });
+    try {
+      expectedDevice = await this.reserveShutdownDeviceUnderLock(deviceId, identity, abortSignal);
+    } catch (error) {
+      identity.releaseSession?.();
+      throw error;
+    }
     if (!expectedDevice) {
+      identity.releaseSession?.();
       return undefined;
     }
     const capturedDevice = expectedDevice;
@@ -5027,8 +5036,81 @@ export class DevicePool {
       if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
         this.shutdownReservations.delete(capturedDevice.id);
       }
+      identity.releaseSession?.();
     };
-    return { device: capturedDevice, release };
+    return { device: capturedDevice, session: identity.session, release };
+  }
+
+  private reserveShutdownSessionIdentity(deviceId: string): ShutdownIdentityReservation {
+    const device = this.devices.get(deviceId);
+    if (device && this.shutdownReservations.get(deviceId) === device) {
+      throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
+    }
+    const candidate = device ? this.pooledSessionIdentities.get(device) : undefined;
+    const session =
+      candidate !== undefined &&
+      candidate.sessionId === device?.sessionId &&
+      candidate.assignedDevice === deviceId
+        ? candidate
+        : undefined;
+    return {
+      device,
+      assignmentCount: device?.assignmentCount,
+      session,
+      releaseSession: session
+        ? this.sessionManager.reserveSessionForTerminalRelease(session, deviceId)
+        : undefined,
+    };
+  }
+
+  private async reserveShutdownDeviceUnderLock(
+    deviceId: string,
+    identity: ShutdownIdentityReservation,
+    abortSignal: AbortSignal | undefined,
+  ): Promise<PooledDevice | undefined> {
+    return await this.assignmentMutex.runExclusive(() => {
+      if (abortSignal?.aborted) {
+        throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
+      }
+      const currentDevice = this.devices.get(deviceId);
+      if (
+        identity.device &&
+        (currentDevice !== identity.device ||
+          currentDevice.assignmentCount !== identity.assignmentCount)
+      ) {
+        throw new ActionableError(
+          `Device '${deviceId}' changed while its shutdown was being reserved.`,
+        );
+      }
+      if (!currentDevice) {
+        return undefined;
+      }
+      if (this.shutdownReservations.get(deviceId) === currentDevice) {
+        throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
+      }
+      this.completeShutdownSessionIdentity(deviceId, currentDevice, identity);
+      this.shutdownReservations.set(deviceId, currentDevice);
+      return currentDevice;
+    });
+  }
+
+  private completeShutdownSessionIdentity(
+    deviceId: string,
+    device: PooledDevice,
+    identity: ShutdownIdentityReservation,
+  ): void {
+    if (identity.session) {
+      return;
+    }
+    const session = this.pooledSessionIdentities.get(device);
+    if (session?.sessionId !== device.sessionId || session.assignedDevice !== deviceId) {
+      return;
+    }
+    identity.session = session;
+    identity.releaseSession = this.sessionManager.reserveSessionForTerminalRelease(
+      session,
+      deviceId,
+    );
   }
 
   private isReservedForShutdown(device: PooledDevice): boolean {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -202,6 +202,7 @@ function isTerminalReleaseReason(releaseReason: string): boolean {
   return (
     releaseReason === "missing-first-heartbeat" ||
     releaseReason === "heartbeat-timeout" ||
+    releaseReason === "device-killed" ||
     releaseReason.startsWith("device-disconnected:")
   );
 }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -952,7 +952,7 @@ export class SessionManager {
 
     this.releasingSessions.add(session);
     const pendingRebind = this.pendingSessionRebinds.get(sessionId);
-    const reason: ReleaseReasonState = { value: releaseReason };
+    const reason = this.createReleaseReasonState(sessionId, releaseReason);
     const promise =
       pendingRebind?.session === session
         ? pendingRebind.promise.then(
@@ -1023,13 +1023,6 @@ export class SessionManager {
       finalizedRelease.finalizedSnapshot.deviceId === expectedDeviceId &&
       isTerminalReleaseReason(releaseReason)
     ) {
-      if (
-        finalizedRelease.finalizedSnapshot.terminal &&
-        finalizedRelease.terminalPersisted &&
-        !finalizedRelease.lateTerminalRelease
-      ) {
-        return finalizedRelease.finalizedSnapshot.deviceId;
-      }
       return await this.releaseFinalizedSession(finalizedRelease, releaseReason);
     }
     return null;
@@ -1042,14 +1035,7 @@ export class SessionManager {
   ): Promise<string | null> {
     const inFlightRelease = this.releasePromises.get(sessionId);
     if (inFlightRelease) {
-      if (inFlightRelease.reason.lateTerminalRelease) {
-        return await inFlightRelease.reason.lateTerminalRelease;
-      }
-      if (
-        inFlightRelease.reason.finalizedSnapshot &&
-        !inFlightRelease.reason.finalizedSnapshot.terminal &&
-        isTerminalReleaseReason(releaseReason)
-      ) {
+      if (inFlightRelease.reason.finalizedSnapshot && isTerminalReleaseReason(releaseReason)) {
         return await this.releaseFinalizedSession(inFlightRelease.reason, releaseReason);
       }
       this.upgradeReleaseReason(inFlightRelease.reason, releaseReason);
@@ -1217,7 +1203,7 @@ export class SessionManager {
       const deviceId = session.assignedDevice;
       const releasedAtMs = this.timer.now();
       const releaseReason = reason.value;
-      const releaseSnapshot: SessionReleaseSnapshot = {
+      let releaseSnapshot: SessionReleaseSnapshot = {
         sessionId,
         deviceId,
         releaseReason,
@@ -1243,6 +1229,10 @@ export class SessionManager {
       // this operation is awaiting teardown above.
       if (releaseSnapshot.terminal) {
         await this.persistTerminalReleaseIfNeeded(releaseSnapshot);
+        if (reason.value !== releaseSnapshot.releaseReason) {
+          releaseSnapshot = this.withReleaseReason(releaseSnapshot, reason.value, session);
+          await this.persistTerminalReleaseIfNeeded(releaseSnapshot);
+        }
       }
       if (!this.removeSession(sessionId, session)) {
         if (pendingCleanup.length > 0) {
@@ -1281,15 +1271,47 @@ export class SessionManager {
   }
 
   private upgradeReleaseReason(reason: ReleaseReasonState, candidate: string): void {
+    if (candidate === "device-killed" && reason.value !== candidate) {
+      reason.value = candidate;
+      return;
+    }
+    if (reason.value === "device-killed") {
+      return;
+    }
     if (!isTerminalReleaseReason(reason.value) && isTerminalReleaseReason(candidate)) {
       reason.value = candidate;
     }
+  }
+
+  private createReleaseReasonState(sessionId: string, releaseReason: string): ReleaseReasonState {
+    const reason: ReleaseReasonState = { value: releaseReason };
+    const terminalReleaseReason = this.terminalReleaseSnapshots.get(sessionId)?.releaseReason;
+    if (terminalReleaseReason) {
+      this.upgradeReleaseReason(reason, terminalReleaseReason);
+    }
+    return reason;
   }
 
   private releaseHeartbeatTimeoutMs(releaseReason: string, session: Session): number {
     return releaseReason === "missing-first-heartbeat"
       ? getDefaultPreFirstHeartbeatGraceMs()
       : session.heartbeatTimeoutMs;
+  }
+
+  private withReleaseReason(
+    snapshot: SessionReleaseSnapshot,
+    releaseReason: string,
+    session: Session,
+  ): SessionReleaseSnapshot {
+    return {
+      ...snapshot,
+      releaseReason,
+      terminal: isTerminalReleaseReason(releaseReason),
+      heartbeat: {
+        ...snapshot.heartbeat,
+        timeoutMs: this.releaseHeartbeatTimeoutMs(releaseReason, session),
+      },
+    };
   }
 
   private async completeReleasePersistence(
@@ -1308,15 +1330,7 @@ export class SessionManager {
       reason.finalizedSnapshot = snapshot;
       return snapshot;
     }
-    const upgradedSnapshot: SessionReleaseSnapshot = {
-      ...snapshot,
-      releaseReason: reason.value,
-      terminal: true,
-      heartbeat: {
-        ...snapshot.heartbeat,
-        timeoutMs: this.releaseHeartbeatTimeoutMs(reason.value, session),
-      },
-    };
+    const upgradedSnapshot = this.withReleaseReason(snapshot, reason.value, session);
     reason.finalizedSnapshot = upgradedSnapshot;
     this.recordFinalizedSessionRelease(session, reason);
     this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
@@ -1329,6 +1343,7 @@ export class SessionManager {
     reason: ReleaseReasonState,
     releaseReason: string,
   ): Promise<string | null> {
+    this.upgradeReleaseReason(reason, releaseReason);
     if (reason.lateTerminalRelease) {
       return await reason.lateTerminalRelease;
     }
@@ -1340,22 +1355,32 @@ export class SessionManager {
     if (indexedTerminalReason && indexedTerminalReason !== reason) {
       return null;
     }
-    if (snapshot.terminal && reason.terminalPersisted) {
+    if (snapshot.terminal && reason.terminalPersisted && snapshot.releaseReason === reason.value) {
       return snapshot.deviceId;
     }
-    const upgradedSnapshot: SessionReleaseSnapshot = {
+    let upgradedSnapshot: SessionReleaseSnapshot = {
       ...snapshot,
-      releaseReason,
+      releaseReason: reason.value,
       terminal: true,
     };
-    reason.value = releaseReason;
     reason.finalizedSnapshot = upgradedSnapshot;
+    reason.terminalPersisted = false;
     this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
-    const release = this.persistTerminalReleaseIfNeeded(upgradedSnapshot).then(() => {
+    const release = (async () => {
+      await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
+      if (reason.value !== upgradedSnapshot.releaseReason) {
+        upgradedSnapshot = {
+          ...upgradedSnapshot,
+          releaseReason: reason.value,
+        };
+        reason.finalizedSnapshot = upgradedSnapshot;
+        this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
+        await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
+      }
       reason.terminalPersisted = true;
       this.notifySessionRelease(upgradedSnapshot);
       return upgradedSnapshot.deviceId;
-    });
+    })();
     reason.lateTerminalRelease = release;
     try {
       return await release;

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -269,6 +269,18 @@ export class SessionManager {
   private readonly activeReleasePromises: Set<SessionReleaseOperation> = new Set();
   /** Finalized release state retained only while its exact Session identity is referenced. */
   private readonly finalizedSessionReleases: WeakMap<Session, ReleaseReasonState> = new WeakMap();
+  /** Latest finalized incarnation, weakly retained until a same-UUID replacement publishes. */
+  private readonly latestFinalizedSessionIdentities: Map<string, WeakRef<Session>> = new Map();
+  private readonly finalizedSessionIdentityRegistry = new FinalizationRegistry<{
+    sessionId: string;
+    identity: WeakRef<Session>;
+  }>(({ sessionId, identity }) => {
+    if (this.latestFinalizedSessionIdentities.get(sessionId) === identity) {
+      this.latestFinalizedSessionIdentities.delete(sessionId);
+    }
+  });
+  /** Finalized terminal state used to coalesce UUID-only recovery retries. */
+  private readonly terminalReleaseReasonStates: Map<string, ReleaseReasonState> = new Map();
   /** UUID admission fences held while a device shutdown decides its terminal outcome. */
   private readonly terminalReleaseReservations: Map<string, TerminalReleaseReservation> = new Map();
   /** Setup work that can modify device state after a session has been assigned. */
@@ -399,13 +411,24 @@ export class SessionManager {
     heartbeatTimeoutMs?: number,
   ): Promise<Session> {
     this.assertTerminalReleaseAdmission(sessionId, this.sessions.get(sessionId));
-    const terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
+    let terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
     if (terminalRelease) {
       throw new TerminalSessionError(sessionId, terminalRelease);
     }
     if (this.sessions.has(sessionId)) {
       logger.warn(`Session ${sessionId} already exists, returning existing session`);
       return this.sessions.get(sessionId)!;
+    }
+    const activeReleases = Array.from(this.activeReleasePromises)
+      .filter((release) => release.session.sessionId === sessionId)
+      .map((release) => release.promise);
+    if (activeReleases.length > 0) {
+      await Promise.all(activeReleases);
+      this.assertTerminalReleaseAdmission(sessionId, this.sessions.get(sessionId));
+      terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
+      if (terminalRelease) {
+        throw new TerminalSessionError(sessionId, terminalRelease);
+      }
     }
 
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
@@ -450,6 +473,12 @@ export class SessionManager {
     }
     await this.persistSession(session);
     this.assertTerminalReleaseAdmission(session.sessionId, session);
+    const terminalRelease = this.terminalReleaseSnapshots.get(session.sessionId);
+    if (terminalRelease) {
+      await this.persistSessionRelease(terminalRelease);
+      throw new TerminalSessionError(session.sessionId, terminalRelease);
+    }
+    this.invalidateFinalizedSessionIdentity(session.sessionId);
     this.sessions.set(session.sessionId, session);
     this.sessionDeviceMap.set(session.sessionId, session.assignedDevice);
     this.deviceSessionMap.set(session.assignedDevice, session.sessionId);
@@ -936,12 +965,21 @@ export class SessionManager {
     if (session) {
       return null;
     }
-    const inFlightRelease = this.releasePromises.get(sessionId);
     if (
-      inFlightRelease?.session === expectedSession &&
-      expectedSession.assignedDevice === expectedDeviceId
+      this.pendingSessionAssignments.has(sessionId) ||
+      this.pendingSessionCreations.has(sessionId)
     ) {
-      return await this.releaseSession(sessionId, releaseReason);
+      return null;
+    }
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (inFlightRelease) {
+      if (
+        inFlightRelease.session === expectedSession &&
+        expectedSession.assignedDevice === expectedDeviceId
+      ) {
+        return await this.releaseSession(sessionId, releaseReason);
+      }
+      return null;
     }
     return await this.releaseFinalizedSessionIfOwned(
       sessionId,
@@ -997,6 +1035,10 @@ export class SessionManager {
     }
     const terminalSnapshot = this.terminalReleaseSnapshots.get(sessionId);
     if (terminalSnapshot && isTerminalReleaseReason(releaseReason)) {
+      const terminalReason = this.terminalReleaseReasonStates.get(sessionId);
+      if (terminalReason) {
+        return await this.releaseFinalizedSession(terminalReason, releaseReason);
+      }
       await this.persistSessionRelease(terminalSnapshot);
       return terminalSnapshot.deviceId;
     }
@@ -1192,6 +1234,7 @@ export class SessionManager {
       }
       if (!releaseSnapshot.terminal) {
         this.terminalReleaseSnapshots.delete(sessionId);
+        this.terminalReleaseReasonStates.delete(sessionId);
       }
 
       this.notifySessionRelease(releaseSnapshot);
@@ -1200,7 +1243,7 @@ export class SessionManager {
         reason,
         session,
       );
-      this.finalizedSessionReleases.set(session, reason);
+      this.recordFinalizedSessionRelease(session, reason);
       if (persistedSnapshot !== releaseSnapshot) {
         this.notifySessionRelease(persistedSnapshot);
       }
@@ -1235,6 +1278,7 @@ export class SessionManager {
     if (snapshot.terminal) {
       reason.finalizedSnapshot = snapshot;
       reason.terminalPersisted = true;
+      this.terminalReleaseReasonStates.set(snapshot.sessionId, reason);
       return snapshot;
     }
     await this.persistSessionRelease(snapshot);
@@ -1251,8 +1295,10 @@ export class SessionManager {
         timeoutMs: this.releaseHeartbeatTimeoutMs(reason.value, session),
       },
     };
-    await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
     reason.finalizedSnapshot = upgradedSnapshot;
+    this.recordFinalizedSessionRelease(session, reason);
+    this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
+    await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
     reason.terminalPersisted = true;
     return upgradedSnapshot;
   }
@@ -1268,6 +1314,13 @@ export class SessionManager {
     if (!snapshot) {
       return null;
     }
+    const indexedTerminalReason = this.terminalReleaseReasonStates.get(snapshot.sessionId);
+    if (indexedTerminalReason && indexedTerminalReason !== reason) {
+      return null;
+    }
+    if (snapshot.terminal && reason.terminalPersisted) {
+      return snapshot.deviceId;
+    }
     const upgradedSnapshot: SessionReleaseSnapshot = {
       ...snapshot,
       releaseReason,
@@ -1275,6 +1328,7 @@ export class SessionManager {
     };
     reason.value = releaseReason;
     reason.finalizedSnapshot = upgradedSnapshot;
+    this.terminalReleaseReasonStates.set(upgradedSnapshot.sessionId, reason);
     const release = this.persistTerminalReleaseIfNeeded(upgradedSnapshot).then(() => {
       reason.terminalPersisted = true;
       this.notifySessionRelease(upgradedSnapshot);
@@ -1288,6 +1342,32 @@ export class SessionManager {
         reason.lateTerminalRelease = undefined;
       }
     }
+  }
+
+  private recordFinalizedSessionRelease(session: Session, reason: ReleaseReasonState): void {
+    this.finalizedSessionReleases.set(session, reason);
+    const existingIdentity = this.latestFinalizedSessionIdentities.get(session.sessionId);
+    if (existingIdentity?.deref() === session) {
+      return;
+    }
+    const identity = new WeakRef(session);
+    this.latestFinalizedSessionIdentities.set(session.sessionId, identity);
+    this.finalizedSessionIdentityRegistry.register(session, {
+      sessionId: session.sessionId,
+      identity,
+    });
+  }
+
+  private invalidateFinalizedSessionIdentity(sessionId: string): void {
+    const identity = this.latestFinalizedSessionIdentities.get(sessionId);
+    if (!identity) {
+      return;
+    }
+    const session = identity.deref();
+    if (session) {
+      this.finalizedSessionReleases.delete(session);
+    }
+    this.latestFinalizedSessionIdentities.delete(sessionId);
   }
 
   private notifySessionRelease(snapshot: SessionReleaseSnapshot): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -163,6 +163,7 @@ interface ReleaseReasonState {
   value: string;
   finalizedSnapshot?: SessionReleaseSnapshot;
   lateTerminalRelease?: Promise<string | null>;
+  terminalPersisted?: boolean;
 }
 
 interface PendingSessionRelease {
@@ -179,6 +180,12 @@ interface PendingSessionRebind {
   promise: Promise<Session>;
 }
 
+interface TerminalReleaseReservation {
+  session: Session;
+  deviceId: string;
+  owner: symbol;
+}
+
 export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
 }
@@ -189,6 +196,8 @@ export interface RebindSessionOptions {
    * state must be cleared even though the serial is unchanged.
    */
   force?: boolean;
+  /** Internal owner proving that a shutdown reservation authorized this recovery rebind. */
+  terminalReleaseReservationOwner?: symbol;
 }
 
 const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
@@ -258,6 +267,10 @@ export class SessionManager {
   private readonly releasePromises: Map<string, SessionReleaseOperation> = new Map();
   /** Every release still running, including an older session that reused a UUID. */
   private readonly activeReleasePromises: Set<SessionReleaseOperation> = new Set();
+  /** Finalized release state retained only while its exact Session identity is referenced. */
+  private readonly finalizedSessionReleases: WeakMap<Session, ReleaseReasonState> = new WeakMap();
+  /** UUID admission fences held while a device shutdown decides its terminal outcome. */
+  private readonly terminalReleaseReservations: Map<string, TerminalReleaseReservation> = new Map();
   /** Setup work that can modify device state after a session has been assigned. */
   private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> =
     new Set();
@@ -385,6 +398,7 @@ export class SessionManager {
     timeoutMs?: number,
     heartbeatTimeoutMs?: number,
   ): Promise<Session> {
+    this.assertTerminalReleaseAdmission(sessionId, this.sessions.get(sessionId));
     const terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
     if (terminalRelease) {
       throw new TerminalSessionError(sessionId, terminalRelease);
@@ -435,6 +449,7 @@ export class SessionManager {
       throw new TerminalSessionError(session.sessionId, persistedTerminalRelease);
     }
     await this.persistSession(session);
+    this.assertTerminalReleaseAdmission(session.sessionId, session);
     this.sessions.set(session.sessionId, session);
     this.sessionDeviceMap.set(session.sessionId, session.assignedDevice);
     this.deviceSessionMap.set(session.assignedDevice, session.sessionId);
@@ -588,6 +603,8 @@ export class SessionManager {
       return existing;
     }
 
+    this.assertTerminalReleaseAdmission(sessionId);
+
     const terminalRelease = this.terminalReleaseSnapshots.get(sessionId);
     if (terminalRelease) {
       throw new TerminalSessionError(sessionId, terminalRelease);
@@ -665,6 +682,7 @@ export class SessionManager {
     options: RebindSessionOptions = {},
   ): Promise<Session> {
     const existing = this.sessions.get(sessionId);
+    this.assertTerminalRebindAdmission(sessionId, options.terminalReleaseReservationOwner);
     if (!existing) {
       return await this.createSession(sessionId, assignedDevice, platform);
     }
@@ -694,6 +712,22 @@ export class SessionManager {
         this.pendingSessionRebinds.delete(sessionId);
       }
     }
+  }
+
+  /** Rebind the exact reserved session during its owner-controlled recovery handoff. */
+  async rebindSessionForTerminalReleaseRecovery(
+    session: Session,
+    assignedDevice: string,
+    platform: Platform,
+  ): Promise<Session> {
+    const reservation = this.terminalReleaseReservations.get(session.sessionId);
+    if (reservation?.session !== session) {
+      throw new Error(`Session ${session.sessionId} has no matching terminal release reservation.`);
+    }
+    return await this.rebindSession(session.sessionId, assignedDevice, platform, {
+      force: true,
+      terminalReleaseReservationOwner: reservation.owner,
+    });
   }
 
   private async persistAndPublishRebind(
@@ -778,6 +812,54 @@ export class SessionManager {
     return snapshot ? { ...snapshot, heartbeat: { ...snapshot.heartbeat } } : undefined;
   }
 
+  /** Prevent this exact session UUID from being rebound while its device shutdown is in flight. */
+  reserveSessionForTerminalRelease(session: Session, expectedDeviceId: string): () => void {
+    if (session.assignedDevice !== expectedDeviceId) {
+      throw new Error(`Session ${session.sessionId} no longer owns device ${expectedDeviceId}.`);
+    }
+    if (this.pendingSessionRebinds.has(session.sessionId)) {
+      throw new Error(
+        `Session ${session.sessionId} is rebinding devices; retry shutdown after it settles.`,
+      );
+    }
+    const existing = this.terminalReleaseReservations.get(session.sessionId);
+    if (existing) {
+      throw new Error(`Session ${session.sessionId} is already reserved for terminal release.`);
+    }
+    const reservation: TerminalReleaseReservation = {
+      session,
+      deviceId: expectedDeviceId,
+      owner: Symbol(session.sessionId),
+    };
+    this.terminalReleaseReservations.set(session.sessionId, reservation);
+    return () => {
+      if (this.terminalReleaseReservations.get(session.sessionId)?.owner === reservation.owner) {
+        this.terminalReleaseReservations.delete(session.sessionId);
+      }
+    };
+  }
+
+  private assertTerminalReleaseAdmission(sessionId: string, allowedSession?: Session): void {
+    const reservation = this.terminalReleaseReservations.get(sessionId);
+    if (reservation && reservation.session !== allowedSession) {
+      throw new Error(
+        `Session ${sessionId} is being terminally released from device ${reservation.deviceId}; use a new session UUID.`,
+      );
+    }
+  }
+
+  private assertTerminalRebindAdmission(
+    sessionId: string,
+    reservationOwner: symbol | undefined,
+  ): void {
+    const reservation = this.terminalReleaseReservations.get(sessionId);
+    if (reservation && reservation.owner !== reservationOwner) {
+      throw new Error(
+        `Session ${sessionId} is being terminally released from device ${reservation.deviceId}; use a new session UUID.`,
+      );
+    }
+  }
+
   /**
    * Get session assigned to a device (reverse lookup)
    */
@@ -860,6 +942,35 @@ export class SessionManager {
       expectedSession.assignedDevice === expectedDeviceId
     ) {
       return await this.releaseSession(sessionId, releaseReason);
+    }
+    return await this.releaseFinalizedSessionIfOwned(
+      sessionId,
+      expectedSession,
+      expectedDeviceId,
+      releaseReason,
+    );
+  }
+
+  private async releaseFinalizedSessionIfOwned(
+    sessionId: string,
+    expectedSession: Session,
+    expectedDeviceId: string,
+    releaseReason: string,
+  ): Promise<string | null> {
+    const finalizedRelease = this.finalizedSessionReleases.get(expectedSession);
+    if (
+      finalizedRelease?.finalizedSnapshot?.sessionId === sessionId &&
+      finalizedRelease.finalizedSnapshot.deviceId === expectedDeviceId &&
+      isTerminalReleaseReason(releaseReason)
+    ) {
+      if (
+        finalizedRelease.finalizedSnapshot.terminal &&
+        finalizedRelease.terminalPersisted &&
+        !finalizedRelease.lateTerminalRelease
+      ) {
+        return finalizedRelease.finalizedSnapshot.deviceId;
+      }
+      return await this.releaseFinalizedSession(finalizedRelease, releaseReason);
     }
     return null;
   }
@@ -1089,6 +1200,7 @@ export class SessionManager {
         reason,
         session,
       );
+      this.finalizedSessionReleases.set(session, reason);
       if (persistedSnapshot !== releaseSnapshot) {
         this.notifySessionRelease(persistedSnapshot);
       }
@@ -1122,6 +1234,7 @@ export class SessionManager {
   ): Promise<SessionReleaseSnapshot> {
     if (snapshot.terminal) {
       reason.finalizedSnapshot = snapshot;
+      reason.terminalPersisted = true;
       return snapshot;
     }
     await this.persistSessionRelease(snapshot);
@@ -1140,6 +1253,7 @@ export class SessionManager {
     };
     await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
     reason.finalizedSnapshot = upgradedSnapshot;
+    reason.terminalPersisted = true;
     return upgradedSnapshot;
   }
 
@@ -1162,11 +1276,18 @@ export class SessionManager {
     reason.value = releaseReason;
     reason.finalizedSnapshot = upgradedSnapshot;
     const release = this.persistTerminalReleaseIfNeeded(upgradedSnapshot).then(() => {
+      reason.terminalPersisted = true;
       this.notifySessionRelease(upgradedSnapshot);
       return upgradedSnapshot.deviceId;
     });
     reason.lateTerminalRelease = release;
-    return await release;
+    try {
+      return await release;
+    } finally {
+      if (reason.lateTerminalRelease === release) {
+        reason.lateTerminalRelease = undefined;
+      }
+    }
   }
 
   private notifySessionRelease(snapshot: SessionReleaseSnapshot): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -918,12 +918,7 @@ export class SessionManager {
 
     const reason: ReleaseReasonState = { value: releaseReason };
     const release: PendingSessionRelease = {
-      promise: this.releaseAfterPendingSessionWork(
-        sessionId,
-        reason,
-        allowExpired,
-        pendingSession,
-      ),
+      promise: this.releaseAfterPendingSessionWork(sessionId, reason, allowExpired, pendingSession),
       reason,
     };
     this.pendingSessionReleases.set(sessionId, release);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -161,6 +161,8 @@ interface PendingSessionCreation {
 
 interface ReleaseReasonState {
   value: string;
+  finalizedSnapshot?: SessionReleaseSnapshot;
+  lateTerminalRelease?: Promise<string | null>;
 }
 
 interface PendingSessionRelease {
@@ -846,10 +848,20 @@ export class SessionManager {
     releaseReason: string = "explicit-release",
   ): Promise<string | null> {
     const session = this.sessions.get(sessionId);
-    if (session !== expectedSession || session.assignedDevice !== expectedDeviceId) {
+    if (session === expectedSession && session.assignedDevice === expectedDeviceId) {
+      return await this.releaseSession(sessionId, releaseReason);
+    }
+    if (session) {
       return null;
     }
-    return await this.releaseSession(sessionId, releaseReason);
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (
+      inFlightRelease?.session === expectedSession &&
+      expectedSession.assignedDevice === expectedDeviceId
+    ) {
+      return await this.releaseSession(sessionId, releaseReason);
+    }
+    return null;
   }
 
   private async releaseUnpublishedSession(
@@ -859,8 +871,23 @@ export class SessionManager {
   ): Promise<string | null> {
     const inFlightRelease = this.releasePromises.get(sessionId);
     if (inFlightRelease) {
+      if (inFlightRelease.reason.lateTerminalRelease) {
+        return await inFlightRelease.reason.lateTerminalRelease;
+      }
+      if (
+        inFlightRelease.reason.finalizedSnapshot &&
+        !inFlightRelease.reason.finalizedSnapshot.terminal &&
+        isTerminalReleaseReason(releaseReason)
+      ) {
+        return await this.releaseFinalizedSession(inFlightRelease.reason, releaseReason);
+      }
       this.upgradeReleaseReason(inFlightRelease.reason, releaseReason);
       return await inFlightRelease.promise;
+    }
+    const terminalSnapshot = this.terminalReleaseSnapshots.get(sessionId);
+    if (terminalSnapshot && isTerminalReleaseReason(releaseReason)) {
+      await this.persistSessionRelease(terminalSnapshot);
+      return terminalSnapshot.deviceId;
     }
     const pendingAssignment = this.pendingSessionAssignments.get(sessionId);
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
@@ -1061,18 +1088,14 @@ export class SessionManager {
         this.terminalReleaseSnapshots.delete(sessionId);
       }
 
-      // In-memory ownership is already terminal, so notify bound transports
-      // before awaiting best-effort persistence. This closes the window where a
-      // released UUID could be forwarded again while the DB write is pending.
-      for (const callback of this.releaseCallbacks) {
-        try {
-          callback(sessionId, deviceId, releaseReason, releaseSnapshot);
-        } catch (error) {
-          logger.warn(`Session release callback failed for ${sessionId}: ${error}`);
-        }
-      }
-      if (!releaseSnapshot.terminal) {
-        await this.persistSessionRelease(releaseSnapshot);
+      this.notifySessionRelease(releaseSnapshot);
+      const persistedSnapshot = await this.completeReleasePersistence(
+        releaseSnapshot,
+        reason,
+        session,
+      );
+      if (persistedSnapshot !== releaseSnapshot) {
+        this.notifySessionRelease(persistedSnapshot);
       }
       logger.info(
         pendingCleanup.length > 0
@@ -1095,6 +1118,70 @@ export class SessionManager {
     return releaseReason === "missing-first-heartbeat"
       ? getDefaultPreFirstHeartbeatGraceMs()
       : session.heartbeatTimeoutMs;
+  }
+
+  private async completeReleasePersistence(
+    snapshot: SessionReleaseSnapshot,
+    reason: ReleaseReasonState,
+    session: Session,
+  ): Promise<SessionReleaseSnapshot> {
+    if (snapshot.terminal) {
+      reason.finalizedSnapshot = snapshot;
+      return snapshot;
+    }
+    await this.persistSessionRelease(snapshot);
+    if (!isTerminalReleaseReason(reason.value)) {
+      reason.finalizedSnapshot = snapshot;
+      return snapshot;
+    }
+    const upgradedSnapshot: SessionReleaseSnapshot = {
+      ...snapshot,
+      releaseReason: reason.value,
+      terminal: true,
+      heartbeat: {
+        ...snapshot.heartbeat,
+        timeoutMs: this.releaseHeartbeatTimeoutMs(reason.value, session),
+      },
+    };
+    await this.persistTerminalReleaseIfNeeded(upgradedSnapshot);
+    reason.finalizedSnapshot = upgradedSnapshot;
+    return upgradedSnapshot;
+  }
+
+  private async releaseFinalizedSession(
+    reason: ReleaseReasonState,
+    releaseReason: string,
+  ): Promise<string | null> {
+    if (reason.lateTerminalRelease) {
+      return await reason.lateTerminalRelease;
+    }
+    const snapshot = reason.finalizedSnapshot;
+    if (!snapshot) {
+      return null;
+    }
+    const upgradedSnapshot: SessionReleaseSnapshot = {
+      ...snapshot,
+      releaseReason,
+      terminal: true,
+    };
+    reason.value = releaseReason;
+    reason.finalizedSnapshot = upgradedSnapshot;
+    const release = this.persistTerminalReleaseIfNeeded(upgradedSnapshot).then(() => {
+      this.notifySessionRelease(upgradedSnapshot);
+      return upgradedSnapshot.deviceId;
+    });
+    reason.lateTerminalRelease = release;
+    return await release;
+  }
+
+  private notifySessionRelease(snapshot: SessionReleaseSnapshot): void {
+    for (const callback of this.releaseCallbacks) {
+      try {
+        callback(snapshot.sessionId, snapshot.deviceId, snapshot.releaseReason, snapshot);
+      } catch (error) {
+        logger.warn(`Session release callback failed for ${snapshot.sessionId}: ${error}`);
+      }
+    }
   }
 
   private async persistSessionRelease(snapshot: SessionReleaseSnapshot): Promise<void> {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -903,6 +903,28 @@ export class SessionManager {
     );
   }
 
+  /** Whether this is the newest published, releasing, or finalized incarnation for its UUID. */
+  isLatestSessionIdentity(
+    session: Session,
+    options: { ignorePendingAssignment?: boolean } = {},
+  ): boolean {
+    const current = this.sessions.get(session.sessionId);
+    if (current) {
+      return current === session;
+    }
+    if (
+      this.pendingSessionCreations.has(session.sessionId) ||
+      (!options.ignorePendingAssignment && this.pendingSessionAssignments.has(session.sessionId))
+    ) {
+      return false;
+    }
+    const inFlightRelease = this.releasePromises.get(session.sessionId);
+    if (inFlightRelease) {
+      return inFlightRelease.session === session;
+    }
+    return this.latestFinalizedSessionIdentities.get(session.sessionId)?.deref() === session;
+  }
+
   /**
    * Release a session and free its device
    *

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -159,8 +159,17 @@ interface PendingSessionCreation {
   promise: Promise<Session>;
 }
 
+interface ReleaseReasonState {
+  value: string;
+}
+
 interface PendingSessionRelease {
   promise: Promise<string | null>;
+  reason: ReleaseReasonState;
+}
+
+interface SessionReleaseOperation extends PendingSessionRelease {
+  session: Session;
 }
 
 interface PendingSessionRebind {
@@ -244,15 +253,9 @@ export class SessionManager {
   private releaseCallbacks: SessionReleaseCallback[] = [];
   private createdCallbacks: SessionCreatedCallback[] = [];
   private deviceUnboundCallbacks: SessionDeviceUnboundCallback[] = [];
-  private readonly releasePromises: Map<
-    string,
-    { session: Session; promise: Promise<string | null> }
-  > = new Map();
+  private readonly releasePromises: Map<string, SessionReleaseOperation> = new Map();
   /** Every release still running, including an older session that reused a UUID. */
-  private readonly activeReleasePromises: Set<{
-    session: Session;
-    promise: Promise<string | null>;
-  }> = new Set();
+  private readonly activeReleasePromises: Set<SessionReleaseOperation> = new Set();
   /** Setup work that can modify device state after a session has been assigned. */
   private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> =
     new Set();
@@ -808,19 +811,21 @@ export class SessionManager {
 
     const inFlightRelease = this.releasePromises.get(sessionId);
     if (inFlightRelease?.session === session) {
+      this.upgradeReleaseReason(inFlightRelease.reason, releaseReason);
       return await inFlightRelease.promise;
     }
 
     this.releasingSessions.add(session);
     const pendingRebind = this.pendingSessionRebinds.get(sessionId);
+    const reason: ReleaseReasonState = { value: releaseReason };
     const promise =
       pendingRebind?.session === session
         ? pendingRebind.promise.then(
-            () => this.releaseSessionInternal(sessionId, session, releaseReason),
-            () => this.releaseSessionInternal(sessionId, session, releaseReason),
+            () => this.releaseSessionInternal(sessionId, session, reason),
+            () => this.releaseSessionInternal(sessionId, session, reason),
           )
-        : this.releaseSessionInternal(sessionId, session, releaseReason);
-    const release = { session, promise };
+        : this.releaseSessionInternal(sessionId, session, reason);
+    const release = { session, promise, reason };
     this.releasePromises.set(sessionId, release);
     this.activeReleasePromises.add(release);
     try {
@@ -854,6 +859,7 @@ export class SessionManager {
   ): Promise<string | null> {
     const inFlightRelease = this.releasePromises.get(sessionId);
     if (inFlightRelease) {
+      this.upgradeReleaseReason(inFlightRelease.reason, releaseReason);
       return await inFlightRelease.promise;
     }
     const pendingAssignment = this.pendingSessionAssignments.get(sessionId);
@@ -879,16 +885,19 @@ export class SessionManager {
   ): Promise<string | null> {
     const existingRelease = this.pendingSessionReleases.get(sessionId);
     if (existingRelease) {
+      this.upgradeReleaseReason(existingRelease.reason, releaseReason);
       return await existingRelease.promise;
     }
 
+    const reason: ReleaseReasonState = { value: releaseReason };
     const release: PendingSessionRelease = {
       promise: this.releaseAfterPendingSessionWork(
         sessionId,
-        releaseReason,
+        reason,
         allowExpired,
         pendingSession,
       ),
+      reason,
     };
     this.pendingSessionReleases.set(sessionId, release);
     try {
@@ -902,13 +911,13 @@ export class SessionManager {
 
   private async releaseAfterPendingSessionWork(
     sessionId: string,
-    releaseReason: string,
+    reason: ReleaseReasonState,
     allowExpired: boolean,
     pendingSession: Promise<Session>,
   ): Promise<string | null> {
     try {
       await pendingSession;
-      return await this.releaseSession(sessionId, releaseReason, allowExpired);
+      return await this.releaseSession(sessionId, reason.value, allowExpired);
     } catch (error) {
       logger.warn(`Session ${sessionId} assignment failed before release: ${error}`);
       return null;
@@ -991,7 +1000,7 @@ export class SessionManager {
   private async releaseSessionInternal(
     sessionId: string,
     session: Session,
-    releaseReason: string,
+    reason: ReleaseReasonState,
   ): Promise<string | null> {
     try {
       const setups = Array.from(this.sessionSetupPromises, (setup) =>
@@ -1010,6 +1019,7 @@ export class SessionManager {
       ].filter((cleanup): cleanup is Promise<void> => cleanup !== null);
       const deviceId = session.assignedDevice;
       const releasedAtMs = this.timer.now();
+      const releaseReason = reason.value;
       const releaseSnapshot: SessionReleaseSnapshot = {
         sessionId,
         deviceId,
@@ -1026,15 +1036,17 @@ export class SessionManager {
           // monitor, which is constructed with default config. (A monitor given an
           // explicit `preFirstHeartbeatGraceMs`, as in tests, would diverge; drive
           // the grace via env to keep the snapshot consistent.)
-          timeoutMs:
-            releaseReason === "missing-first-heartbeat"
-              ? getDefaultPreFirstHeartbeatGraceMs()
-              : session.heartbeatTimeoutMs,
+          timeoutMs: this.releaseHeartbeatTimeoutMs(releaseReason, session),
           ageMs: Math.max(0, releasedAtMs - session.lastHeartbeat),
         },
       };
 
-      await this.persistTerminalReleaseIfNeeded(releaseSnapshot);
+      // A non-terminal release must not yield after freezing its reason: a
+      // concurrent terminal release can only upgrade the shared reason while
+      // this operation is awaiting teardown above.
+      if (releaseSnapshot.terminal) {
+        await this.persistTerminalReleaseIfNeeded(releaseSnapshot);
+      }
       if (!this.removeSession(sessionId, session)) {
         if (pendingCleanup.length > 0) {
           this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
@@ -1071,6 +1083,18 @@ export class SessionManager {
     } finally {
       this.releasingSessions.delete(session);
     }
+  }
+
+  private upgradeReleaseReason(reason: ReleaseReasonState, candidate: string): void {
+    if (!isTerminalReleaseReason(reason.value) && isTerminalReleaseReason(candidate)) {
+      reason.value = candidate;
+    }
+  }
+
+  private releaseHeartbeatTimeoutMs(releaseReason: string, session: Session): number {
+    return releaseReason === "missing-first-heartbeat"
+      ? getDefaultPreFirstHeartbeatGraceMs()
+      : session.heartbeatTimeoutMs;
   }
 
   private async persistSessionRelease(snapshot: SessionReleaseSnapshot): Promise<void> {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1541,14 +1541,16 @@ function preserveLateShutdownRetirement(
   if (
     !isShutdownTimeoutError(error) &&
     !requestAbortSignal?.aborted &&
-    sessionManager.getSessionForDevice(device.deviceId) === sessionId
+    sessionManager.getSessionForDevice(device.deviceId) === sessionId &&
+    !sessionManager.getTerminalReleaseSnapshot(sessionId)
   ) {
     return;
   }
-  // Session release removes its in-memory mapping before its durable write.
-  // It cannot be cancelled safely, so keep the captured shutdown reservation
-  // until the late release finishes its identity-guarded retirement. Otherwise
-  // a stopped device could become an idle ghost.
+  // Session release either removed its in-memory mapping or terminally fenced
+  // the UUID before a durable write failed. It cannot be cancelled safely, so
+  // keep the captured shutdown reservation until the late release finishes its
+  // identity-guarded retirement. Otherwise a stopped device could remain as a
+  // busy ghost in the pool.
   finishLateShutdownRetirement(
     release,
     device,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -390,6 +390,7 @@ export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
 const DEVICE_SHUTDOWN_TIMEOUT_MS = 30_000;
 const DEVICE_SHUTDOWN_POLL_INTERVAL_MS = 1_000;
 const DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS = 1_000;
+const DEVICE_SHUTDOWN_TERMINAL_RELEASE_RETRIES = 2;
 const TEARDOWN_OPERATION_RESULT_TTL_MS = 5 * 60 * 1_000;
 
 function getShutdownInitiatingExecutionId(): string | undefined {
@@ -1420,6 +1421,7 @@ function finishLateShutdownRetirement(
   deadlineMs: number,
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
+  terminalReleaseRetriesRemaining: number,
 ): void {
   const continueRetirement = async () => {
     await retireShutdownOwnership(
@@ -1432,11 +1434,33 @@ function finishLateShutdownRetirement(
       deadlineMs,
       undefined,
       stopPerformanceMonitoring,
-      () => undefined,
+      retainReservationUntil,
       false,
     );
   };
-  const lateRetirement = release.then(continueRetirement, continueRetirement);
+  const retryRetirement = async (error: unknown) => {
+    if (terminalReleaseRetriesRemaining <= 0) {
+      throw error;
+    }
+    await timer.sleep(DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS);
+    await retireShutdownOwnership(
+      device,
+      expectedPooledDevice,
+      expectedSession,
+      observedReplacement,
+      deviceManager,
+      timer,
+      deadlineMs,
+      undefined,
+      stopPerformanceMonitoring,
+      retainReservationUntil,
+      false,
+      false,
+      DEVICE_SHUTDOWN_TIMEOUT_MS,
+      terminalReleaseRetriesRemaining - 1,
+    );
+  };
+  const lateRetirement = release.then(continueRetirement, retryRetirement);
   lateRetirement.catch((lateError) => {
     logger.warn(
       `[DeviceTools] Failed to finish late shutdown retirement for ${device.deviceId}: ${lateError}`,
@@ -1544,6 +1568,7 @@ function preserveLateShutdownRetirement(
   deadlineMs: number,
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
+  terminalReleaseRetriesRemaining: number,
 ): void {
   if (
     !isShutdownTimeoutError(error) &&
@@ -1569,6 +1594,7 @@ function preserveLateShutdownRetirement(
     deadlineMs,
     stopPerformanceMonitoring,
     retainReservationUntil,
+    terminalReleaseRetriesRemaining,
   );
 }
 
@@ -1586,6 +1612,7 @@ async function releaseShutdownSessionOwnership(
   retainReservationUntil: (retirement: Promise<void>) => void,
   strictDeadline: boolean,
   timeoutMs: number,
+  terminalReleaseRetriesRemaining: number,
 ): Promise<void> {
   const sessionManager = daemonState.getSessionManager();
   const sessionId = expectedSession?.sessionId;
@@ -1630,6 +1657,7 @@ async function releaseShutdownSessionOwnership(
       deadlineMs,
       stopPerformanceMonitoring,
       retainReservationUntil,
+      terminalReleaseRetriesRemaining,
     );
     throw error;
   }
@@ -1649,6 +1677,7 @@ async function retireShutdownOwnership(
   retryAfterDiscoveryFailure: boolean = true,
   strictDeadline = false,
   timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
+  terminalReleaseRetriesRemaining = DEVICE_SHUTDOWN_TERMINAL_RELEASE_RETRIES,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -1678,6 +1707,7 @@ async function retireShutdownOwnership(
     retainReservationUntil,
     strictDeadline,
     timeoutMs,
+    terminalReleaseRetriesRemaining,
   );
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -51,7 +51,7 @@ import {
 } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
 import type { DevicePool, DeviceReadinessReservation, PooledDevice } from "../daemon/devicePool";
-import type { SessionManager } from "../daemon/sessionManager";
+import type { Session, SessionManager } from "../daemon/sessionManager";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
@@ -1413,6 +1413,7 @@ function finishLateShutdownRetirement(
   release: Promise<string | null>,
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  expectedSession: Session | undefined,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
@@ -1424,6 +1425,7 @@ function finishLateShutdownRetirement(
     await retireShutdownOwnership(
       device,
       expectedPooledDevice,
+      expectedSession,
       observedReplacement,
       deviceManager,
       timer,
@@ -1447,6 +1449,7 @@ function retainFailedShutdownRetirement(
   error: unknown,
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  expectedSession: Session | undefined,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
@@ -1460,6 +1463,7 @@ function retainFailedShutdownRetirement(
         await retireShutdownOwnership(
           device,
           expectedPooledDevice,
+          expectedSession,
           observedReplacement,
           deviceManager,
           timer,
@@ -1482,6 +1486,7 @@ function retainFailedShutdownRetirement(
 async function findReplacementOrRetainShutdownReservation(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  expectedSession: Session | undefined,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
@@ -1511,6 +1516,7 @@ async function findReplacementOrRetainShutdownReservation(
       error,
       device,
       expectedPooledDevice,
+      expectedSession,
       observedReplacement,
       deviceManager,
       timer,
@@ -1531,6 +1537,7 @@ function preserveLateShutdownRetirement(
   release: Promise<string | null>,
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  expectedSession: Session | undefined,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
@@ -1555,6 +1562,7 @@ function preserveLateShutdownRetirement(
     release,
     device,
     expectedPooledDevice,
+    expectedSession,
     observedReplacement,
     deviceManager,
     timer,
@@ -1567,6 +1575,7 @@ function preserveLateShutdownRetirement(
 async function releaseShutdownSessionOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  expectedSession: Session | undefined,
   daemonState: DaemonState,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
@@ -1579,8 +1588,8 @@ async function releaseShutdownSessionOwnership(
   timeoutMs: number,
 ): Promise<void> {
   const sessionManager = daemonState.getSessionManager();
-  const sessionId = expectedPooledDevice.sessionId;
-  if (!sessionId || sessionManager.getSessionForDevice(device.deviceId) !== sessionId) {
+  const sessionId = expectedSession?.sessionId;
+  if (!sessionId || expectedSession.assignedDevice !== device.deviceId) {
     return;
   }
 
@@ -1589,7 +1598,12 @@ async function releaseShutdownSessionOwnership(
     `device-disconnected:${device.deviceId}`,
     { excludeExecutionId: getShutdownInitiatingExecutionId() },
   );
-  const release = sessionManager.releaseSession(sessionId, "device-killed");
+  const release = sessionManager.releaseSessionIfOwned(
+    sessionId,
+    expectedSession,
+    device.deviceId,
+    "device-killed",
+  );
   try {
     await runWithinShutdownDeadline(
       device,
@@ -1609,6 +1623,7 @@ async function releaseShutdownSessionOwnership(
       release,
       device,
       expectedPooledDevice,
+      expectedSession,
       observedReplacement,
       deviceManager,
       timer,
@@ -1623,6 +1638,7 @@ async function releaseShutdownSessionOwnership(
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
+  expectedSession: Session | undefined,
   observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
@@ -1651,6 +1667,7 @@ async function retireShutdownOwnership(
   await releaseShutdownSessionOwnership(
     device,
     expectedPooledDevice,
+    expectedSession,
     daemonState,
     observedReplacement,
     deviceManager,
@@ -1674,6 +1691,7 @@ async function retireShutdownOwnership(
   const replacement = await findReplacementOrRetainShutdownReservation(
     device,
     expectedPooledDevice,
+    expectedSession,
     observedReplacement,
     deviceManager,
     timer,
@@ -1711,6 +1729,7 @@ async function killProcessAndRetireOwnership(
   requestAbortSignal: AbortSignal | undefined,
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
+  expectedSession: Session | undefined,
   androidObserverState: AndroidObserverShutdownState,
   shutdownDeadlineMs: number,
   retainReservationUntil: (
@@ -1793,6 +1812,7 @@ async function killProcessAndRetireOwnership(
     await retireShutdownOwnership(
       shutdownDevice,
       expectedPooledDevice,
+      expectedSession,
       observedReplacement,
       deviceManager,
       dependencies.timer,
@@ -1858,9 +1878,10 @@ async function shutdownDevice(
   perf.serial(operationName);
   const daemonState = DaemonState.getInstance();
   const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+  let expectedSession: Session | undefined;
   return await deviceShutdownService.shutdown({
-    prepare: async () =>
-      await runWithinShutdownDeadline(
+    prepare: async () => {
+      const reservation = await runWithinShutdownDeadline(
         device,
         dependencies.timer,
         shutdownDeadlineMs,
@@ -1868,7 +1889,10 @@ async function shutdownDevice(
         requestAbortSignal,
         async (signal) => await devicePool?.reserveDeviceForShutdown(device.deviceId, signal),
         timeoutMs,
-      ),
+      );
+      expectedSession = reservation?.session;
+      return reservation;
+    },
     execute: async (shutdownReservation, retainReservationUntil) => {
       const expectedPooledDevice = shutdownReservation?.device ?? null;
       const retainShutdownUntil = (
@@ -1901,6 +1925,7 @@ async function shutdownDevice(
         requestAbortSignal,
         devicePool,
         expectedPooledDevice,
+        expectedSession,
         androidObserverState,
         shutdownDeadlineMs,
         (retirement, releaseReservationAfterFailure) => {
@@ -1917,6 +1942,7 @@ async function shutdownDevice(
         await retireShutdownOwnership(
           device,
           expectedPooledDevice,
+          expectedSession,
           undefined,
           dependencies.deviceManagerFactory(),
           dependencies.timer,
@@ -2508,6 +2534,7 @@ async function retireTeardownPooledOwnership(
     await retireShutdownOwnership(
       retirementDevice,
       expectedPooledDevice,
+      reservation.session,
       undefined,
       context.deviceManager,
       context.dependencies.timer,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1587,7 +1587,7 @@ async function releaseShutdownSessionOwnership(
     `device-disconnected:${device.deviceId}`,
     { excludeExecutionId: getShutdownInitiatingExecutionId() },
   );
-  const release = sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
+  const release = sessionManager.releaseSession(sessionId, "device-killed");
   try {
     await runWithinShutdownDeadline(
       device,

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -707,6 +707,56 @@ describe("DevicePool", () => {
       expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).not.toThrow();
     });
 
+    test("captures the exact session identity after its idle deadline", async () => {
+      await bindOwnerSession("owner-session", "emulator-5554");
+      const session = sessionManager.getSession("owner-session");
+      if (!session) {
+        throw new Error("expected owner session");
+      }
+      fakeTimer.advanceTime(31 * 60 * 1_000);
+
+      const reservation = await devicePool.reserveDeviceForShutdown("emulator-5554");
+      try {
+        expect(reservation?.session).toBe(session);
+      } finally {
+        await reservation?.release();
+      }
+    });
+
+    test("captures session identity after an in-flight assignment publishes", async () => {
+      const persistence = new DeferredDeviceSessionPersistence();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+
+      const binding = devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      await persistence.waitForUpsert();
+      const reservationPromise = devicePool.reserveDeviceForShutdown(device.deviceId);
+      persistence.finishUpsert();
+      await binding;
+      const reservation = await reservationPromise;
+      try {
+        expect(reservation?.session).toBe(sessionManager.getSession("owner-session"));
+      } finally {
+        await reservation?.release();
+      }
+    });
+
     test("rejects a bound session while its device carries an intentional-shutdown marker", async () => {
       await bindOwnerSession("owner-session", "emulator-5554");
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -761,6 +761,67 @@ describe("DevicePool", () => {
       }
     });
 
+    test("releases session identity when shutdown reservation aborts behind assignment", async () => {
+      const persistence = new DeferredDeviceSessionPersistence();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const owner = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const blocker = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [owner, blocker];
+      await devicePool.initializeWithDevices([owner, blocker]);
+
+      const ownerBinding = devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        owner.deviceId,
+        "android",
+        sourceImage,
+      );
+      await persistence.waitForUpsert();
+      persistence.finishUpsert();
+      await ownerBinding;
+
+      persistence.deferNextUpsert();
+      const blockingAssignment = devicePool.bindOrReuseDeviceSession(
+        "blocking-session",
+        blocker.deviceId,
+        "android",
+        sourceImage,
+      );
+      await persistence.waitForUpsert();
+
+      const controller = new AbortController();
+      const abortedReservation = devicePool
+        .reserveDeviceForShutdown(owner.deviceId, controller.signal)
+        .then(
+          (reservation) => ({ reservation }),
+          (error: unknown) => ({ error }),
+        );
+      controller.abort(new Error("shutdown reservation cancelled"));
+      const retryReservation = devicePool.reserveDeviceForShutdown(owner.deviceId).then(
+        (reservation) => ({ reservation }),
+        (error: unknown) => ({ error }),
+      );
+
+      persistence.finishUpsert();
+      await blockingAssignment;
+      const abortedOutcome = await abortedReservation;
+      expect(abortedOutcome.error).toBeInstanceOf(Error);
+      expect((abortedOutcome.error as Error).message).toContain("cancelled");
+
+      const retryOutcome = await retryReservation;
+      expect(retryOutcome.error).toBeUndefined();
+      expect(retryOutcome.reservation?.session).toBe(sessionManager.getSession("owner-session"));
+      await retryOutcome.reservation?.release();
+    });
+
     test("rejects a bound session while its device carries an intentional-shutdown marker", async () => {
       await bindOwnerSession("owner-session", "emulator-5554");
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -309,6 +309,10 @@ describe("DevicePool", () => {
       this.writeFinished.resolve();
     }
 
+    failUpsert(error: Error): void {
+      this.writeFinished.reject(error);
+    }
+
     async upsertActiveSession(): Promise<void> {
       if (!this.deferWrite) {
         return;
@@ -2792,6 +2796,92 @@ describe("DevicePool", () => {
 
       expect(replacement?.name).toBe("Pixel 8 replacement");
       appsRepository.finishDeferredTrackingWrite();
+    });
+
+    test("captures the live same-UUID replacement while its pool identity update is pending", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession("owner-session", device.deviceId, "android");
+      const originalSession = sessionManager.getSession("owner-session");
+      if (!originalSession) {
+        throw new Error("expected original session");
+      }
+
+      await sessionManager.releaseSession("owner-session");
+      await devicePool.releaseDevice(device.deviceId, "owner-session");
+
+      const replacementPublished = Promise.withResolvers<void>();
+      const finishPoolIdentityUpdate = Promise.withResolvers<void>();
+      sessionManager.waitForSessionRelease = async () => {
+        replacementPublished.resolve();
+        await finishPoolIdentityUpdate.promise;
+      };
+
+      const replacementBinding = devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+      );
+      await replacementPublished.promise;
+      const replacementSession = sessionManager.getSession("owner-session");
+      expect(replacementSession).not.toBeNull();
+      expect(replacementSession).not.toBe(originalSession);
+
+      const shutdownReservationPromise = devicePool.reserveDeviceForShutdown(device.deviceId);
+      finishPoolIdentityUpdate.resolve();
+      await replacementBinding;
+      const shutdownReservation = await shutdownReservationPromise;
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+      try {
+        expect(shutdownReservation.session).toBe(replacementSession);
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("recaptures the latest finalized owner after a replacement assignment fails", async () => {
+      const persistence = new DeferredDeviceSessionPersistence();
+      persistence.finishUpsert();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const originalDevice = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const replacementDevice = createBootedDevice("emulator-5556", "android", "Pixel 9");
+      fakeDeviceManager.bootedDevices = [originalDevice, replacementDevice];
+      await pool.initializeWithDevices([originalDevice, replacementDevice]);
+      await pool.bindOrReuseDeviceSession("shared", originalDevice.deviceId, "android");
+      const originalSession = sessionManager.getSession("shared");
+      if (!originalSession) {
+        throw new Error("expected original session");
+      }
+      await sessionManager.releaseSession("shared");
+
+      persistence.deferNextUpsert();
+      const replacementAssignment = sessionManager.getOrCreateSession("shared", pool, "android");
+      await persistence.waitForUpsert();
+      const shutdownReservationPromise = pool.reserveDeviceForShutdown(originalDevice.deviceId);
+      persistence.failUpsert(new Error("replacement persistence failed"));
+      await expect(replacementAssignment).rejects.toThrow("replacement persistence failed");
+
+      const shutdownReservation = await shutdownReservationPromise;
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+      try {
+        expect(shutdownReservation.session).toBe(originalSession);
+      } finally {
+        await shutdownReservation.release();
+      }
     });
 
     test("allows a replacement incarnation to acquire its own shutdown reservation", async () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -50,6 +50,25 @@ class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
   async markReleased(): Promise<void> {}
 }
 
+class DeferredReleaseDeviceSessionPersistence extends FakeDeviceSessionPersistence {
+  readonly reasons: string[] = [];
+  readonly releaseStarted = Promise.withResolvers<void>();
+  readonly finishRelease = Promise.withResolvers<void>();
+
+  override async markReleased(
+    _sessionUuid: string,
+    _status: DeviceSessionStatus,
+    _releasedAtMs: number,
+    reason: string,
+  ): Promise<void> {
+    this.reasons.push(reason);
+    if (this.reasons.length === 1) {
+      this.releaseStarted.resolve();
+      await this.finishRelease.promise;
+    }
+  }
+}
+
 function makeHierarchy(label: string): ViewHierarchyResult {
   return {
     hierarchy: {
@@ -1952,6 +1971,107 @@ describe("SessionManager", () => {
       releaseReason: "device-killed",
       terminal: true,
     });
+  });
+
+  test("device-killed upgrade during release persistence remains terminal", async () => {
+    const persistence = new DeferredReleaseDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      await manager.createSession("killed-session", "emulator-5554", "android");
+      let callbackSnapshot: unknown;
+      manager.onSessionRelease((_sessionId, _deviceId, _reason, snapshot) => {
+        callbackSnapshot = snapshot;
+      });
+      const ordinaryRelease = manager.releaseSession("killed-session", "explicit-release");
+      await persistence.releaseStarted.promise;
+      const killedRelease = manager.releaseSession("killed-session", "device-killed");
+      persistence.finishRelease.resolve();
+      await Promise.all([ordinaryRelease, killedRelease]);
+      let assignmentCount = 0;
+      const assigner: SessionDeviceAssigner = {
+        async assignDeviceToSession() {
+          assignmentCount += 1;
+          return "emulator-5560";
+        },
+      };
+
+      await expect(
+        manager.getOrCreateSession("killed-session", assigner, "android"),
+      ).rejects.toThrow("terminal after device-killed");
+      expect(assignmentCount).toBe(0);
+      expect(persistence.reasons).toEqual(["explicit-release", "device-killed"]);
+      expect(callbackSnapshot).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("device-killed upgrade after release finalization remains terminal", async () => {
+    const reasons: string[] = [];
+    const persistence = new FakeDeviceSessionPersistence();
+    persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
+      reasons.push(reason);
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      await manager.createSession("killed-session", "emulator-5554", "android");
+      let killedRelease: Promise<string | null> | undefined;
+      const callbacks: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => {
+        callbacks.push(reason);
+        if (reason === "explicit-release") {
+          killedRelease = manager.releaseSession("killed-session", "device-killed");
+        }
+      });
+
+      await manager.releaseSession("killed-session", "explicit-release");
+      await killedRelease;
+
+      expect(reasons).toEqual(["explicit-release", "device-killed"]);
+      expect(callbacks).toEqual(["explicit-release", "device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("owned device-loss upgrade after release finalization remains terminal", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession(
+        "disconnected-session",
+        "emulator-5554",
+        "android",
+      );
+      let disconnectedRelease: Promise<string | null> | undefined;
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => {
+        if (reason === "explicit-release") {
+          disconnectedRelease = manager.releaseSessionIfOwned(
+            "disconnected-session",
+            session,
+            "emulator-5554",
+            "device-disconnected:emulator-5554",
+          );
+        }
+      });
+
+      await manager.releaseSession("disconnected-session", "explicit-release");
+      await disconnectedRelease;
+
+      expect(manager.getTerminalReleaseSnapshot("disconnected-session")).toMatchObject({
+        releaseReason: "device-disconnected:emulator-5554",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
   });
 
   test("terminal release fails closed when durable fencing cannot be persisted", async () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2014,6 +2014,56 @@ describe("SessionManager", () => {
     }
   });
 
+  test("retries a failed device-killed upgrade during release persistence", async () => {
+    const persistence = new DeferredReleaseDeviceSessionPersistence();
+    let failTerminalRelease = true;
+    const markReleased = persistence.markReleased.bind(persistence);
+    persistence.markReleased = async (sessionUuid, status, releasedAtMs, reason) => {
+      await markReleased(sessionUuid, status, releasedAtMs, reason);
+      if (reason === "device-killed" && failTerminalRelease) {
+        failTerminalRelease = false;
+        throw new Error("terminal write failed");
+      }
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("killed-session", "emulator-5554", "android");
+      const callbacks: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => callbacks.push(reason));
+      const ordinaryRelease = manager.releaseSession("killed-session", "explicit-release");
+      await persistence.releaseStarted.promise;
+      const killedRelease = manager.releaseSessionIfOwned(
+        "killed-session",
+        session,
+        "emulator-5554",
+        "device-killed",
+      );
+      persistence.finishRelease.resolve();
+
+      await expect(Promise.all([ordinaryRelease, killedRelease])).rejects.toThrow(
+        "Failed to persist terminal release",
+      );
+      await expect(manager.releaseSession("killed-session", "device-killed")).resolves.toBe(
+        "emulator-5554",
+      );
+      await expect(manager.releaseSession("killed-session", "device-killed")).resolves.toBe(
+        "emulator-5554",
+      );
+      await expect(
+        manager.releaseSessionIfOwned("killed-session", session, "emulator-5554", "device-killed"),
+      ).resolves.toBe("emulator-5554");
+
+      expect(persistence.reasons).toEqual(["explicit-release", "device-killed", "device-killed"]);
+      expect(callbacks).toEqual(["explicit-release", "device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("device-killed upgrade after release finalization remains terminal", async () => {
     const reasons: string[] = [];
     const terminalPersistenceStarted = Promise.withResolvers<void>();
@@ -2157,6 +2207,180 @@ describe("SessionManager", () => {
         terminal: true,
       });
     } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("stale owned retry cannot replace a newer incarnation terminal release", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const reasons: string[] = [];
+    persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
+      reasons.push(reason);
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const oldSession = await manager.createSession("reused-session", "old-device", "android");
+      await manager.releaseSession("reused-session", "explicit-release");
+      await manager.createSession("reused-session", "new-device", "android");
+      await manager.releaseSession(
+        "reused-session",
+        "device-disconnected:new-device;incident=new-loss",
+      );
+
+      await expect(
+        manager.releaseSessionIfOwned("reused-session", oldSession, "old-device", "device-killed"),
+      ).resolves.toBeNull();
+
+      expect(reasons).toEqual([
+        "explicit-release",
+        "device-disconnected:new-device;incident=new-loss",
+      ]);
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toMatchObject({
+        deviceId: "new-device",
+        releaseReason: "device-disconnected:new-device;incident=new-loss",
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("stale owned retry cannot bypass a newer incarnation release in flight", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const newerReleaseStarted = Promise.withResolvers<void>();
+    const finishNewerRelease = Promise.withResolvers<void>();
+    let releaseCount = 0;
+    persistence.markReleased = async () => {
+      releaseCount += 1;
+      if (releaseCount === 2) {
+        newerReleaseStarted.resolve();
+        await finishNewerRelease.promise;
+      }
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const oldSession = await manager.createSession("reused-session", "old-device", "android");
+      await manager.releaseSession("reused-session", "explicit-release");
+      await manager.createSession("reused-session", "new-device", "android");
+      const newerRelease = manager.releaseSession("reused-session", "explicit-release");
+      await newerReleaseStarted.promise;
+
+      await expect(
+        manager.releaseSessionIfOwned("reused-session", oldSession, "old-device", "device-killed"),
+      ).resolves.toBeNull();
+      finishNewerRelease.resolve();
+      await newerRelease;
+
+      expect(releaseCount).toBe(2);
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toBeUndefined();
+    } finally {
+      finishNewerRelease.resolve();
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("stale owned retry cannot replace a newer finalized ordinary release", async () => {
+    const persistence = new DeferredReleaseDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const oldSession = await manager.createSession("reused-session", "old-device", "android");
+      const oldRelease = manager.releaseSession("reused-session", "explicit-release");
+      await persistence.releaseStarted.promise;
+      const newerCreation = manager.createSession("reused-session", "new-device", "android");
+      persistence.finishRelease.resolve();
+      await oldRelease;
+      await expect(newerCreation).resolves.toMatchObject({ assignedDevice: "new-device" });
+      await manager.releaseSession("reused-session", "explicit-release");
+
+      await expect(
+        manager.releaseSessionIfOwned("reused-session", oldSession, "old-device", "device-killed"),
+      ).resolves.toBeNull();
+
+      expect(persistence.reasons).toEqual(["explicit-release", "explicit-release"]);
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toBeUndefined();
+    } finally {
+      persistence.finishRelease.resolve();
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("terminal upgrade blocks replacement publication until its fence is durable", async () => {
+    const persistence = new DeferredReleaseDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      await manager.createSession("reused-session", "old-device", "android");
+      const ordinaryRelease = manager.releaseSession("reused-session", "explicit-release");
+      await persistence.releaseStarted.promise;
+      const terminalRelease = manager.releaseSession("reused-session", "device-killed");
+      const newerCreation = manager.createSession("reused-session", "new-device", "android");
+      persistence.finishRelease.resolve();
+
+      await Promise.all([ordinaryRelease, terminalRelease]);
+      await expect(newerCreation).rejects.toThrow("terminal after device-killed");
+
+      expect(persistence.reasons).toEqual(["explicit-release", "device-killed"]);
+      expect(manager.getSession("reused-session")).toBeNull();
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toMatchObject({
+        deviceId: "old-device",
+        releaseReason: "device-killed",
+      });
+    } finally {
+      persistence.finishRelease.resolve();
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("stale owned retry cannot fence a newer incarnation pending creation", async () => {
+    const persistence = new DeferredDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const oldSession = await manager.createSession("reused-session", "old-device", "android");
+      await manager.releaseSession("reused-session", "explicit-release");
+      persistence.deferNextUpsert();
+      const newerCreation = manager.createSession("reused-session", "new-device", "android");
+      await persistence.waitForUpsert();
+
+      await expect(
+        manager.releaseSessionIfOwned("reused-session", oldSession, "old-device", "device-killed"),
+      ).resolves.toBeNull();
+      persistence.finishUpsert();
+      await expect(newerCreation).resolves.toMatchObject({ assignedDevice: "new-device" });
+
+      expect(manager.getSession("reused-session")).toMatchObject({ assignedDevice: "new-device" });
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toBeUndefined();
+    } finally {
+      persistence.finishUpsert();
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("stale owned retry cannot fence a newer incarnation pending assignment", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    const assignmentStarted = Promise.withResolvers<void>();
+    const finishAssignment = Promise.withResolvers<void>();
+    try {
+      const oldSession = await manager.createSession("reused-session", "old-device", "android");
+      await manager.releaseSession("reused-session", "explicit-release");
+      const assigner: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId, platform) {
+          assignmentStarted.resolve();
+          await finishAssignment.promise;
+          await manager.createSession(sessionId, "new-device", platform ?? "android");
+          return "new-device";
+        },
+      };
+      const newerAssignment = manager.getOrCreateSession("reused-session", assigner, "android");
+      await assignmentStarted.promise;
+
+      await expect(
+        manager.releaseSessionIfOwned("reused-session", oldSession, "old-device", "device-killed"),
+      ).resolves.toBeNull();
+      finishAssignment.resolve();
+      await expect(newerAssignment).resolves.toMatchObject({ assignedDevice: "new-device" });
+
+      expect(manager.getTerminalReleaseSnapshot("reused-session")).toBeUndefined();
+    } finally {
+      finishAssignment.resolve();
       manager.stopCleanupTimer();
     }
   });

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -11,7 +11,10 @@ import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
-import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
+import type {
+  DeviceSessionPersistence,
+  DeviceSessionRecord,
+} from "../../src/db/deviceSessionRepository";
 import type { DeviceSession, DeviceSessionStatus } from "../../src/db/types";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
@@ -20,6 +23,7 @@ class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
   private deferredWrite: Promise<void> | null = null;
   private resolveDeferredWrite: (() => void) | null = null;
   private readonly writeStarted = Promise.withResolvers<void>();
+  readonly upsertedDeviceIds: string[] = [];
 
   deferNextUpsert(): void {
     this.deferredWrite = new Promise<void>((resolve) => {
@@ -35,7 +39,8 @@ class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
     this.resolveDeferredWrite?.();
   }
 
-  async upsertActiveSession(): Promise<void> {
+  async upsertActiveSession(record: DeviceSessionRecord): Promise<void> {
+    this.upsertedDeviceIds.push(record.deviceId);
     const deferredWrite = this.deferredWrite;
     if (!deferredWrite) {
       return;
@@ -2091,6 +2096,112 @@ describe("SessionManager", () => {
         releaseReason: "device-disconnected:emulator-5554",
         terminal: true,
       });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("owned device-loss upgrade after an ordinary release remains terminal", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession(
+        "disconnected-session",
+        "emulator-5554",
+        "android",
+      );
+
+      await manager.releaseSession("disconnected-session", "explicit-release");
+      await manager.releaseSessionIfOwned(
+        "disconnected-session",
+        session,
+        "emulator-5554",
+        "device-disconnected:emulator-5554",
+      );
+
+      expect(manager.getTerminalReleaseSnapshot("disconnected-session")).toMatchObject({
+        releaseReason: "device-disconnected:emulator-5554",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("retries a failed owned terminal upgrade after an ordinary release", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const reasons: string[] = [];
+    let failTerminalRelease = true;
+    persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
+      reasons.push(reason);
+      if (reason === "device-killed" && failTerminalRelease) {
+        failTerminalRelease = false;
+        throw new Error("terminal write failed");
+      }
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("killed-session", "emulator-5554", "android");
+      await manager.releaseSession("killed-session", "explicit-release");
+
+      await expect(
+        manager.releaseSessionIfOwned("killed-session", session, "emulator-5554", "device-killed"),
+      ).rejects.toThrow("Failed to persist terminal release");
+      await expect(
+        manager.releaseSessionIfOwned("killed-session", session, "emulator-5554", "device-killed"),
+      ).resolves.toBe("emulator-5554");
+
+      expect(reasons).toEqual(["explicit-release", "device-killed", "device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("terminal release reservation blocks UUID reuse until shutdown settles", async () => {
+    const persistence = new FakeDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("reserved-session", "emulator-5554", "android");
+      const releaseReservation = manager.reserveSessionForTerminalRelease(session, "emulator-5554");
+      await expect(
+        manager.rebindSession("reserved-session", "emulator-5560", "android"),
+      ).rejects.toThrow("being terminally released");
+      await manager.releaseSession("reserved-session", "explicit-release");
+
+      await expect(
+        manager.createSession("reserved-session", "emulator-5560", "android"),
+      ).rejects.toThrow("being terminally released");
+
+      releaseReservation();
+      await expect(
+        manager.createSession("reserved-session", "emulator-5560", "android"),
+      ).resolves.toMatchObject({ assignedDevice: "emulator-5560" });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("terminal release reservation rejects while an ordinary rebind is in flight", async () => {
+    const persistence = new DeferredDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("reserved-session", "emulator-5554", "android");
+
+      persistence.deferNextUpsert();
+      const rebind = manager.rebindSession("reserved-session", "emulator-5560", "android");
+      await persistence.waitForUpsert();
+      expect(() => manager.reserveSessionForTerminalRelease(session, "emulator-5554")).toThrow(
+        "rebinding devices",
+      );
+      persistence.finishUpsert();
+
+      await expect(rebind).resolves.toBe(session);
+      expect(session.assignedDevice).toBe("emulator-5560");
+      expect(persistence.upsertedDeviceIds).toEqual(["emulator-5554", "emulator-5560"]);
     } finally {
       manager.stopCleanupTimer();
     }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2011,9 +2011,15 @@ describe("SessionManager", () => {
 
   test("device-killed upgrade after release finalization remains terminal", async () => {
     const reasons: string[] = [];
+    const terminalPersistenceStarted = Promise.withResolvers<void>();
+    const finishTerminalPersistence = Promise.withResolvers<void>();
     const persistence = new FakeDeviceSessionPersistence();
     persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
       reasons.push(reason);
+      if (reason === "device-killed") {
+        terminalPersistenceStarted.resolve();
+        await finishTerminalPersistence.promise;
+      }
     };
     const manager = new SessionManager(fakeTimer, persistence);
     try {
@@ -2023,13 +2029,29 @@ describe("SessionManager", () => {
       manager.onSessionRelease((_sessionId, _deviceId, reason) => {
         callbacks.push(reason);
         if (reason === "explicit-release") {
-          killedRelease = manager.releaseSession("killed-session", "device-killed");
+          // Let the ordinary persistence continuation finalize its snapshot,
+          // then escalate before releaseSession's outer finally removes the
+          // operation. This discriminates the late-finalized branch from the
+          // earlier mutable-reason upgrade path.
+          void Promise.resolve()
+            .then(() => undefined)
+            .then(() => undefined)
+            .then(() => {
+              killedRelease = manager.releaseSession("killed-session", "device-killed");
+            });
         }
       });
 
-      await manager.releaseSession("killed-session", "explicit-release");
+      const ordinaryRelease = manager.releaseSession("killed-session", "explicit-release");
+      await terminalPersistenceStarted.promise;
+      const ordinaryOutcome = await Promise.race([
+        ordinaryRelease.then(() => "released" as const),
+        new Promise<"blocked">((resolve) => setImmediate(() => resolve("blocked"))),
+      ]);
+      finishTerminalPersistence.resolve();
       await killedRelease;
 
+      expect(ordinaryOutcome).toBe("released");
       expect(reasons).toEqual(["explicit-release", "device-killed"]);
       expect(callbacks).toEqual(["explicit-release", "device-killed"]);
       expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1923,8 +1923,17 @@ describe("SessionManager", () => {
   });
 
   test("device-killed UUID cannot silently allocate another device", async () => {
-    await sessionManager.createSession("killed-session", "emulator-5554", "android");
-    await sessionManager.releaseSession("killed-session", "device-killed");
+    const session = await sessionManager.createSession(
+      "killed-session",
+      "emulator-5554",
+      "android",
+    );
+    const setup = Promise.withResolvers<void>();
+    void sessionManager.trackSessionSetup(session, () => setup.promise);
+    const ordinaryRelease = sessionManager.releaseSession("killed-session", "explicit-release");
+    const killedRelease = sessionManager.releaseSession("killed-session", "device-killed");
+    setup.resolve();
+    await Promise.all([ordinaryRelease, killedRelease]);
     let assignmentCount = 0;
     const assigner: SessionDeviceAssigner = {
       async assignDeviceToSession() {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2064,6 +2064,107 @@ describe("SessionManager", () => {
     }
   });
 
+  test("device-killed supersedes a terminal release during persistence", async () => {
+    const persistence = new DeferredReleaseDeviceSessionPersistence();
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("killed-session", "emulator-5554", "android");
+      const callbacks: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => callbacks.push(reason));
+
+      const timeoutRelease = manager.releaseSession("killed-session", "heartbeat-timeout");
+      await persistence.releaseStarted.promise;
+      const killedRelease = manager.releaseSessionIfOwned(
+        "killed-session",
+        session,
+        "emulator-5554",
+        "device-killed",
+      );
+      persistence.finishRelease.resolve();
+      await Promise.all([timeoutRelease, killedRelease]);
+
+      expect(persistence.reasons).toEqual(["heartbeat-timeout", "device-killed"]);
+      expect(callbacks).toEqual(["device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("device-killed supersedes a finalized terminal release", async () => {
+    const reasons: string[] = [];
+    const persistence = new FakeDeviceSessionPersistence();
+    persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
+      reasons.push(reason);
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      const session = await manager.createSession("killed-session", "emulator-5554", "android");
+      const callbacks: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => callbacks.push(reason));
+
+      await manager.releaseSession("killed-session", "heartbeat-timeout");
+      await manager.releaseSessionIfOwned(
+        "killed-session",
+        session,
+        "emulator-5554",
+        "device-killed",
+      );
+
+      expect(reasons).toEqual(["heartbeat-timeout", "device-killed"]);
+      expect(callbacks).toEqual(["heartbeat-timeout", "device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("device-killed remains terminal when persistence retries through ordinary release", async () => {
+    const reasons: string[] = [];
+    let failRelease = true;
+    const persistence = new FakeDeviceSessionPersistence();
+    persistence.markReleased = async (_sessionUuid, _status, _releasedAtMs, reason) => {
+      reasons.push(reason);
+      if (failRelease) {
+        failRelease = false;
+        throw new Error("terminal write failed");
+      }
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+    try {
+      await manager.createSession("killed-session", "emulator-5554", "android");
+      const callbacks: string[] = [];
+      manager.onSessionRelease((_sessionId, _deviceId, reason) => callbacks.push(reason));
+
+      await expect(manager.releaseSession("killed-session", "device-killed")).rejects.toThrow(
+        "Failed to persist terminal release",
+      );
+      await manager.releaseSession("killed-session", "explicit-release");
+
+      expect(reasons).toEqual(["device-killed", "device-killed"]);
+      expect(callbacks).toEqual(["device-killed"]);
+      expect(manager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+        releaseReason: "device-killed",
+        terminal: true,
+      });
+      await expect(
+        manager.getOrCreateSession("killed-session", {
+          async assignDeviceToSession() {
+            return "emulator-5560";
+          },
+        }),
+      ).rejects.toThrow("terminal after device-killed");
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("retries a failed device-killed upgrade during release persistence", async () => {
     const persistence = new DeferredReleaseDeviceSessionPersistence();
     let failTerminalRelease = true;

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -269,6 +269,28 @@ describe("SessionManager", () => {
         manager.stopCleanupTimer();
       }
     });
+
+    test("does not report a finalized identity as latest while its replacement is being created", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+      try {
+        const original = await manager.createSession("reused", "emulator-old", "android");
+        await manager.releaseSession("reused");
+        expect(manager.isLatestSessionIdentity(original)).toBe(true);
+
+        repository.deferNextUpsert();
+        const replacementCreation = manager.createSession("reused", "emulator-new", "android");
+        await repository.waitForUpsert();
+        expect(manager.isLatestSessionIdentity(original)).toBe(false);
+
+        repository.finishUpsert();
+        const replacement = await replacementCreation;
+        expect(manager.isLatestSessionIdentity(original)).toBe(false);
+        expect(manager.isLatestSessionIdentity(replacement)).toBe(true);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
   });
 
   describe("getOrCreateSession", () => {
@@ -367,6 +389,34 @@ describe("SessionManager", () => {
       const [first, second] = await sessionsPromise;
       expect(first.assignedDevice).toBe("device-session-a");
       expect(second.assignedDevice).toBe("device-session-b");
+    });
+
+    test("does not report a finalized identity as latest while replacement assignment is pending", async () => {
+      const original = await sessionManager.createSession("reused", "emulator-old", "android");
+      await sessionManager.releaseSession("reused");
+      const assignmentStarted = Promise.withResolvers<void>();
+      const finishAssignment = Promise.withResolvers<void>();
+      const devicePool: SessionDeviceAssigner = {
+        assignDeviceToSession: async (sessionId: string): Promise<string> => {
+          assignmentStarted.resolve();
+          await finishAssignment.promise;
+          const replacement = await sessionManager.createSession(
+            sessionId,
+            "emulator-new",
+            "android",
+          );
+          return replacement.assignedDevice;
+        },
+      };
+
+      const replacementAssignment = sessionManager.getOrCreateSession("reused", devicePool);
+      await assignmentStarted.promise;
+      expect(sessionManager.isLatestSessionIdentity(original)).toBe(false);
+
+      finishAssignment.resolve();
+      const replacement = await replacementAssignment;
+      expect(sessionManager.isLatestSessionIdentity(original)).toBe(false);
+      expect(sessionManager.isLatestSessionIdentity(replacement)).toBe(true);
     });
 
     test("allows a retry after an unseen-session assignment fails", async () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1922,6 +1922,29 @@ describe("SessionManager", () => {
     });
   });
 
+  test("device-killed UUID cannot silently allocate another device", async () => {
+    await sessionManager.createSession("killed-session", "emulator-5554", "android");
+    await sessionManager.releaseSession("killed-session", "device-killed");
+    let assignmentCount = 0;
+    const assigner: SessionDeviceAssigner = {
+      async assignDeviceToSession() {
+        assignmentCount += 1;
+        return "emulator-5560";
+      },
+    };
+
+    await expect(
+      sessionManager.getOrCreateSession("killed-session", assigner, "android"),
+    ).rejects.toThrow("terminal after device-killed");
+    expect(assignmentCount).toBe(0);
+    expect(sessionManager.getTerminalReleaseSnapshot("killed-session")).toMatchObject({
+      sessionId: "killed-session",
+      deviceId: "emulator-5554",
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+  });
+
   test("terminal release fails closed when durable fencing cannot be persisted", async () => {
     const persistence = new FakeDeviceSessionPersistence();
     const manager = new SessionManager(fakeTimer, persistence);

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -444,9 +444,13 @@ class DeferredReleaseDeviceSessionRepository extends FakeDeviceSessionRepository
 class FailFirstReleaseDeviceSessionRepository extends FakeDeviceSessionRepository {
   releaseAttempts = 0;
 
+  constructor(private readonly failedReleaseAttempts: number = 1) {
+    super();
+  }
+
   override async markReleased(): Promise<void> {
     this.releaseAttempts++;
-    if (this.releaseAttempts === 1) {
+    if (this.releaseAttempts <= this.failedReleaseAttempts) {
       throw new Error("transient release persistence failure");
     }
   }
@@ -777,7 +781,7 @@ describe("killDevice handler", () => {
 
   test("finishes device retirement after terminal release persistence retries", async () => {
     const timer = new FakeTimer();
-    const deviceSessionRepository = new FailFirstReleaseDeviceSessionRepository();
+    const deviceSessionRepository = new FailFirstReleaseDeviceSessionRepository(2);
     const successfulManager = new SuccessfulKillDeviceManager();
     manager = successfulManager;
     setDeviceToolsDependencies({
@@ -807,6 +811,22 @@ describe("killDevice handler", () => {
     );
     DaemonState.getInstance().initialize(sessionManager, pool);
     await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    let reservationReleaseCalls = 0;
+    const reserveDeviceForShutdown = pool.reserveDeviceForShutdown.bind(pool);
+    pool.reserveDeviceForShutdown = async (...args) => {
+      const reservation = await reserveDeviceForShutdown(...args);
+      if (!reservation) {
+        return undefined;
+      }
+      const release = reservation.release;
+      return {
+        ...reservation,
+        release: async () => {
+          reservationReleaseCalls++;
+          await release();
+        },
+      };
+    };
     const tool = ToolRegistry.getTool("killDevice");
     if (!tool) {
       throw new Error("killDevice not registered");
@@ -817,10 +837,92 @@ describe("killDevice handler", () => {
         device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
       }),
     ).rejects.toThrow("Failed to persist terminal release");
+    timer.advanceTime(1_000);
+    await new Promise((resolve) => setImmediate(resolve));
+    timer.advanceTime(1_000);
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(deviceSessionRepository.releaseAttempts).toBe(2);
+    expect(deviceSessionRepository.releaseAttempts).toBe(3);
+    expect(reservationReleaseCalls).toBe(1);
     expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+  });
+
+  test("bounds terminal release persistence retries while retaining shutdown ownership", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FailFirstReleaseDeviceSessionRepository(
+      Number.POSITIVE_INFINITY,
+    );
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    let reservationReleaseCalls = 0;
+    const reserveDeviceForShutdown = pool.reserveDeviceForShutdown.bind(pool);
+    pool.reserveDeviceForShutdown = async (...args) => {
+      const reservation = await reserveDeviceForShutdown(...args);
+      if (!reservation) {
+        return undefined;
+      }
+      const release = reservation.release;
+      return {
+        ...reservation,
+        release: async () => {
+          reservationReleaseCalls++;
+          await release();
+        },
+      };
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(
+      tool.handler({
+        device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+      }),
+    ).rejects.toThrow("Failed to persist terminal release");
+    timer.advanceTime(1_000);
+    await new Promise((resolve) => setImmediate(resolve));
+    timer.advanceTime(1_000);
+    await new Promise((resolve) => setImmediate(resolve));
+    timer.advanceTime(10_000);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(deviceSessionRepository.releaseAttempts).toBe(3);
+    expect(reservationReleaseCalls).toBe(0);
+    await expect(pool.reserveDeviceForShutdown(image.deviceId!)).rejects.toThrow(
+      "already shutting down",
+    );
     expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       releaseReason: "device-killed",
       terminal: true,

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -557,6 +557,12 @@ describe("killDevice handler", () => {
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
     expect(pool.getDevice("emulator-5554")).toBeNull();
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
+      sessionId: "session-1",
+      deviceId: "emulator-5554",
+      releaseReason: "device-killed",
+      terminal: true,
+    });
   });
 
   test("keeps the initiating parallel plan alive while cancelling other execution tracks", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -416,11 +416,16 @@ class ReplacingDeviceSessionRepository extends FakeDeviceSessionRepository {
 class DeferredReleaseDeviceSessionRepository extends FakeDeviceSessionRepository {
   private releaseMarkReleased: (() => void) | undefined;
   private resolveMarkReleasedStarted: (() => void) | undefined;
+  private releaseAttempts = 0;
   private readonly markReleasedStarted = new Promise<void>((resolve) => {
     this.resolveMarkReleasedStarted = resolve;
   });
 
   override async markReleased(): Promise<void> {
+    this.releaseAttempts++;
+    if (this.releaseAttempts > 1) {
+      return;
+    }
     this.resolveMarkReleasedStarted?.();
     await new Promise<void>((resolve) => {
       this.releaseMarkReleased = resolve;
@@ -701,6 +706,67 @@ describe("killDevice handler", () => {
     await tool.handler({
       device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
     });
+
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
+  test("captures a session whose ordinary release persistence is still in flight", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new DeferredReleaseDeviceSessionRepository();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+
+    const ordinaryRelease = sessionManager.releaseSession("session-1", "explicit-release");
+    await deviceSessionRepository.waitForMarkReleased();
+    const reservationStarted = Promise.withResolvers<void>();
+    const reserveDeviceForShutdown = pool.reserveDeviceForShutdown.bind(pool);
+    pool.reserveDeviceForShutdown = async (...args) => {
+      const reservation = await reserveDeviceForShutdown(...args);
+      reservationStarted.resolve();
+      return reservation;
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+    });
+    await reservationStarted.promise;
+    deviceSessionRepository.finishMarkReleased();
+    await Promise.all([ordinaryRelease, result]);
 
     expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       releaseReason: "device-killed",

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -415,6 +415,17 @@ class DeferredReleaseDeviceSessionRepository extends FakeDeviceSessionRepository
   }
 }
 
+class FailFirstReleaseDeviceSessionRepository extends FakeDeviceSessionRepository {
+  releaseAttempts = 0;
+
+  override async markReleased(): Promise<void> {
+    this.releaseAttempts++;
+    if (this.releaseAttempts === 1) {
+      throw new Error("transient release persistence failure");
+    }
+  }
+}
+
 describe("killDevice handler", () => {
   const originalPreferred = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
   const originalAlias = process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH;
@@ -560,6 +571,58 @@ describe("killDevice handler", () => {
     expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       sessionId: "session-1",
       deviceId: "emulator-5554",
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+  });
+
+  test("finishes device retirement after terminal release persistence retries", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FailFirstReleaseDeviceSessionRepository();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(
+      tool.handler({
+        device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+      }),
+    ).rejects.toThrow("Failed to persist terminal release");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(deviceSessionRepository.releaseAttempts).toBe(2);
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
       releaseReason: "device-killed",
       terminal: true,
     });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -134,6 +134,27 @@ class DelayedSuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
 }
 
+class ReleaseDuringShutdownWaitDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  private shutdownStarted = false;
+  private releasedSession = false;
+  onShutdownWait: (() => Promise<void>) | undefined;
+
+  override async killDevice(): Promise<void> {
+    this.shutdownStarted = true;
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    if (this.shutdownStarted) {
+      if (!this.releasedSession) {
+        this.releasedSession = true;
+        await this.onShutdownWait?.();
+      }
+      return { devices: [], succeededPlatforms: new Set(["android"]) };
+    }
+    return await super.getBootedDevicesDetailed(platform);
+  }
+}
+
 class FailedDiscoveryThenReplacementDeviceManager extends DelayedSuccessfulKillDeviceManager {
   private replacementSequenceStarted = false;
   private failedDiscoveryReported = false;
@@ -574,6 +595,118 @@ describe("killDevice handler", () => {
       releaseReason: "device-killed",
       terminal: true,
     });
+  });
+
+  test("terminally fences a session released while shutdown is being confirmed", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const releaseDuringWaitManager = new ReleaseDuringShutdownWaitDeviceManager();
+    manager = releaseDuringWaitManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => releaseDuringWaitManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    releaseDuringWaitManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      releaseDuringWaitManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    await pool.addDevice({
+      name: "Pixel 9",
+      platform: "android",
+      deviceId: "emulator-5560",
+    });
+    releaseDuringWaitManager.onShutdownWait = async () => {
+      await sessionManager.releaseSession("session-1", "explicit-release");
+      await pool.releaseDevice(image.deviceId!, "session-1");
+      expect(pool.getDevice(image.deviceId!)?.sessionId).toBeNull();
+      await expect(sessionManager.getOrCreateSession("session-1", pool, "android")).rejects.toThrow(
+        "being terminally released",
+      );
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+    });
+
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
+      deviceId: image.deviceId,
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
+  test("captures a session released immediately before shutdown reservation", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    await sessionManager.releaseSession("session-1", "explicit-release");
+    expect(pool.getDevice(image.deviceId!)?.sessionId).toBe("session-1");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+    });
+
+    expect(sessionManager.getTerminalReleaseSnapshot("session-1")).toMatchObject({
+      releaseReason: "device-killed",
+      terminal: true,
+    });
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
   });
 
   test("finishes device retirement after terminal release persistence retries", async () => {


### PR DESCRIPTION
## Summary

Make a successful explicit device shutdown terminally fence the exact session incarnation that owned the killed device. The kill path now records `device-killed`, and `SessionManager` treats that reason as terminal so subsequent tool calls fail instead of silently assigning the same UUID to another pool device.

Preserve that terminal reason when shutdown overlaps an existing release, including persistence-time and post-finalization races, and retain device retirement across a transient terminal-persistence failure. Shutdown now reserves the captured session identity before waiting on pool coordination, fences same-UUID allocation, and linearizes safely against ordinary session rebinds while preserving owner-authorized System UI recovery.

Validate the pooled session object against the latest current, releasing, or finalized incarnation before reserving it. Pending replacements block stale capture before pool coordination, while the assignment-mutex recheck safely chooses the published replacement or falls back to the prior owner after replacement persistence fails.

## Linked Issue

Closes #5770

## Bug / Regression Context

- **Prior attempts:** Existing unexpected-disconnect releases were terminal, but explicit `killDevice` used the non-terminal `device-stopped:<id>` reason.
- **Observed symptom:** A later tool call carrying the killed device's session UUID could create a new session on an arbitrary different device.
- **Repro steps / conditions:** Acquire a session on one device, successfully call `killDevice` for that device, then call another session-scoped tool with the old UUID while another device is available.

## Validation

- [x] `bun run turbo:validate` passes (14,691 tests passed, 14 skipped)
- [x] `bun run typecheck` reports no new errors (166 known baseline errors)
- [x] `bun test test/daemon/devicePool.test.ts test/daemon/sessionManager.test.ts test/server/deviceTools.killDevice.test.ts` passes (317 tests)
- [x] `bun run format:check` passes
- [x] `git diff --check` passes
- [x] New coverage uses existing persistence, assignment, and timer seams; no helper package or dependency added
- [x] Rebased onto freshly fetched `origin/main`

## Follow-ups

None.
