### PR TITLE
fix(devices): retain iOS devices across clock rollback

### DIFF
--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -450,7 +450,7 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
 
   /** Devices the last good sweep found, while still inside the retention window. */
   private retainedDevices(now: number): BootedDevice[] {
-    if (!this.lastGood || now < this.lastGood.observedAt || now >= this.lastGood.staleAfter) {
+    if (!this.lastGood || now >= this.lastGood.staleAfter) {
       this.lastGood = null;
       return [];
     }

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -417,6 +417,36 @@ describe("DevicectlDeviceLister", () => {
     expect(stale).toEqual({ devices: [], complete: false });
   });
 
+  test("retains a physical device through a failed sweep after a clock rollback", async () => {
+    const timer = new FakeTimer();
+    let shouldFail = false;
+    const lister = makeLister({
+      timer,
+      execute: async () => {
+        if (shouldFail) {
+          throw new Error("devicectl blipped");
+        }
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    timer.setCurrentTime(1_000);
+    expect((await lister.listConnectedDevices()).devices.map((device) => device.deviceId)).toEqual([
+      PHYSICAL_UDID,
+    ]);
+
+    // A clock rollback invalidates cache freshness, but not the last known
+    // presence of hardware when the next devicectl sweep cannot complete.
+    timer.setCurrentTime(999);
+    shouldFail = true;
+    const discovery = await lister.listConnectedDevices();
+
+    expect(discovery.devices.map((device) => device.deviceId)).toEqual([PHYSICAL_UDID]);
+    expect(discovery.complete).toBe(false);
+    expect([...(discovery.retainedDeviceIds ?? [])]).toEqual([PHYSICAL_UDID]);
+  });
+
   test("removes its temp directory on both success and failure", async () => {
     const removed: string[] = [];
     const succeeding = makeLister({


### PR DESCRIPTION
## Summary

- Preserve a last-known physical iOS device during a failed `devicectl` sweep after a backward wall-clock adjustment.
- Add a deterministic `FakeTimer` regression test covering the rollback-plus-failure path.

## Root cause

The rollback freshness guard was applied to the last-good retention window. Cache freshness and hardware-presence retention have different guarantees: a rollback requires refreshing a possibly stale name, but it does not invalidate evidence that a device was connected when the next sweep fails.

## Impact

Prevents a transient `devicectl` failure coinciding with an NTP/manual clock rollback from removing a still-connected physical iPhone from discovery.

## Validation

- `bun test test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`

Closes #5771
