### PR TITLE
feat(ios): stage simulator media-library fixtures

### DIFF
--- a/docs/design-docs/mcp/app-file-service.md
+++ b/docs/design-docs/mcp/app-file-service.md
@@ -24,6 +24,9 @@ path; generated tool definitions advertise the canonical target-based shape.
   resolves the active Android profile before every write. `media_library` uses
   the AutoMobile-owned `automobile-media` Downloads namespace and reports
   success only after MediaStore discovery is verified.
+- iOS Simulator `media_library` imports supported image and video filenames
+  through `simctl addmedia`. Its result confirms import, not picker visibility;
+  iOS physical devices and media list/read operations remain unsupported.
 
 ## Shared Validation
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -24,7 +24,7 @@ All Interactions tools — including `pinchOn`, which routes coordinate-based pi
 - 🚀 `launchApp` starts apps by package name (with optional clear-app-data support).
 - ❌ `terminateApp` force-stops an app by package name.
 - 📦 `installApp` installs an APK.
-- 📄 `putAppFile` writes a local file, UTF-8 text, or base64 binary content into logical `app_containers`, Android `user_files`, or Android `media_library` targets.
+- 📄 `putAppFile` writes a local file, UTF-8 text, or base64 binary content into logical `app_containers`, Android `user_files`, and Android or iOS Simulator `media_library` targets.
 - 📂 `stageSharedStorageFixtures` writes a batch of local, UTF-8, or base64 fixtures beneath an isolated Android `Download/<namespace>` directory for document and media picker workflows.
 - 🔗 `getDeepLinks` reads registered deep links/intent filters for an Android package.
 
@@ -86,10 +86,12 @@ Stage shared-storage fixtures for a system picker:
 The namespace is limited to one safe child directory; file paths must be
 relative, and reset deletes only that namespace. `putAppFile` should be used
 for new picker fixtures: `target.domain: "user_files"` uses the resolved
-profile's `Download/<namespace>` location, while `media_library` uses the
-bounded AutoMobile media namespace and reports success only once MediaStore
-discovers the file. `stageSharedStorageFixtures` remains a compatibility alias
-for existing callers.
+profile's `Download/<namespace>` location. On Android, `media_library` uses
+the bounded AutoMobile media namespace and reports success only once MediaStore
+discovers the file. On iOS Simulators, it imports a supported image or video
+filename through `simctl addmedia` and reports import separately from
+unverified picker visibility. `stageSharedStorageFixtures` remains a
+compatibility alias for existing callers.
 
 Android app files support `externalFiles` through `/sdcard/Android/data/{appId}/files`. Use this for app-readable fixture files that do not require private app storage:
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7369,7 +7369,7 @@
             "items": {
               "properties": {
                 "destinationPath": {
-                  "pattern": "\\.(?:[aA][aA][cC]|[aA][iI][fF][fF]|[aA][vV][iI][fF]|[bB][mM][pP]|[fF][lL][aA][cC]|[gG][iI][fF]|[hH][eE][iI][cC]|[jJ][pP][eE][gG]|[jJ][pP][gG]|[mM]4[aA]|[mM][oO][vV]|[mM][pP]4|[mM]4[vV]|[mM][pP]3|[oO][gG][gG]|[pP][nN][gG]|[tT][iI][fF]|[tT][iI][fF][fF]|[wW][aA][vV]|[wW][eE][bB][pP])$"
+                  "pattern": "\\.(?:[aA][aA][cC]|[aA][iI][fF][fF]|[aA][vV][iI][fF]|[bB][mM][pP]|[fF][lL][aA][cC]|[gG][iI][fF]|[hH][eE][iI][cC]|[jJ][pP][eE][gG]|[jJ][pP][gG]|[mM]4[aA]|[mM][kK][vV]|[mM][oO][vV]|[mM][pP]4|[mM]4[vV]|[mM][pP]3|[oO][gG][gG]|[pP][nN][gG]|[tT][iI][fF]|[tT][iI][fF][fF]|[wW][aA][vV]|[wW][eE][bB][mM]|[wW][eE][bB][pP])$"
                 }
               }
             }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7349,7 +7349,33 @@
         }
       },
       "required": ["target", "files"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "target": {
+            "properties": {
+              "domain": {
+                "const": "media_library"
+              }
+            },
+            "required": ["domain"]
+          }
+        },
+        "required": ["target"]
+      },
+      "then": {
+        "properties": {
+          "files": {
+            "items": {
+              "properties": {
+                "destinationPath": {
+                  "pattern": "\\.(?:[aA][aA][cC]|[aA][iI][fF][fF]|[aA][vV][iI][fF]|[bB][mM][pP]|[fF][lL][aA][cC]|[gG][iI][fF]|[hH][eE][iI][cC]|[jJ][pP][eE][gG]|[jJ][pP][gG]|[mM]4[aA]|[mM][oO][vV]|[mM][pP]4|[mM]4[vV]|[mM][pP]3|[oO][gG][gG]|[pP][nN][gG]|[tT][iI][fF]|[tT][iI][fF][fF]|[wW][aA][vV]|[wW][eE][bB][pP])$"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   {

--- a/src/features/storage/storageCapabilities.ts
+++ b/src/features/storage/storageCapabilities.ts
@@ -312,6 +312,14 @@ function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
           [req(PREREQ_ACTIVE_PROFILE, ctx.activeUserProfile)],
           "Verified as part of Android putAppFile media_library writes.",
         );
+  const iosWrite = deriveOperation(
+    "write",
+    ctx.deviceType === "simulator"
+      ? undefined
+      : "iOS media-library fixture staging is only supported on iOS Simulators.",
+    [],
+    "Imports image and video fixtures through xcrun simctl addmedia; picker visibility is unverified.",
+  );
   return {
     domain: "media_library",
     portable: false,
@@ -319,7 +327,9 @@ function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
     note:
       ctx.platform === "android"
         ? "Android putAppFile writes bounded media fixtures and verifies MediaStore discovery; browse/read is not exposed."
-        : "Media-library browse/read and writes are not exposed on iOS.",
+        : ctx.deviceType === "simulator"
+          ? "iOS Simulator putAppFile imports image and video fixtures through simctl addmedia; browse/read is not exposed."
+          : "iOS physical media-library mutation is not exposed.",
     operations: [
       unavailableOperation(
         "list",
@@ -329,13 +339,7 @@ function mediaLibraryDomain(ctx: StorageCapabilityContext): DomainCapability {
         "read",
         "No AutoMobile media-library read surface is currently exposed.",
       ),
-      ctx.platform === "ios"
-        ? deriveOperation(
-            "write",
-            "iOS has no media-library fixture provider; use the Android media_library target only.",
-            [],
-          )
-        : androidWrite,
+      ctx.platform === "ios" ? iosWrite : androidWrite,
       indexing,
     ],
   };

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -59,9 +59,7 @@ const MEDIA_LIBRARY_EXTENSION_PATTERN = `\\.(?:${MEDIA_LIBRARY_EXTENSION_NAMES.m
   extension
     .split("")
     .map((character) =>
-      character >= "a" && character <= "z"
-        ? `[${character}${character.toUpperCase()}]`
-        : character,
+      character >= "a" && character <= "z" ? `[${character}${character.toUpperCase()}]` : character,
     )
     .join(""),
 ).join("|")})$`;

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -1,3 +1,4 @@
+import { extname } from "node:path";
 import { z } from "zod/v4";
 import {
   addDeviceTargetingToSchema,
@@ -42,6 +43,7 @@ const MEDIA_LIBRARY_EXTENSION_NAMES = [
   "jpeg",
   "jpg",
   "m4a",
+  "mkv",
   "mov",
   "mp4",
   "m4v",
@@ -51,6 +53,7 @@ const MEDIA_LIBRARY_EXTENSION_NAMES = [
   "tif",
   "tiff",
   "wav",
+  "webm",
   "webp",
 ] as const;
 
@@ -81,7 +84,8 @@ const SIMULATOR_MEDIA_EXTENSIONS = new Set([
 ]);
 
 function extensionFor(path: string): string | undefined {
-  return path.split("/").at(-1)?.split(".").at(-1)?.toLowerCase();
+  const extension = extname(path);
+  return extension.length > 1 ? extension.slice(1).toLowerCase() : undefined;
 }
 
 export function hasSupportedMediaLibraryExtension(path: string): boolean {

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -31,6 +31,71 @@ export interface AppFileResourceParts {
 
 export type StorageDomain = "app_containers" | "user_files" | "media_library";
 
+const MEDIA_LIBRARY_EXTENSION_NAMES = [
+  "aac",
+  "aiff",
+  "avif",
+  "bmp",
+  "flac",
+  "gif",
+  "heic",
+  "jpeg",
+  "jpg",
+  "m4a",
+  "mov",
+  "mp4",
+  "m4v",
+  "mp3",
+  "ogg",
+  "png",
+  "tif",
+  "tiff",
+  "wav",
+  "webp",
+] as const;
+
+const MEDIA_LIBRARY_EXTENSIONS = new Set<string>(MEDIA_LIBRARY_EXTENSION_NAMES);
+const MEDIA_LIBRARY_EXTENSION_PATTERN = `\\.(?:${MEDIA_LIBRARY_EXTENSION_NAMES.map((extension) =>
+  extension
+    .split("")
+    .map((character) =>
+      character >= "a" && character <= "z"
+        ? `[${character}${character.toUpperCase()}]`
+        : character,
+    )
+    .join(""),
+).join("|")})$`;
+
+const SIMULATOR_MEDIA_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "heic",
+  "jpeg",
+  "jpg",
+  "mov",
+  "mp4",
+  "m4v",
+  "png",
+  "tif",
+  "tiff",
+  "webp",
+]);
+
+function extensionFor(path: string): string | undefined {
+  return path.split("/").at(-1)?.split(".").at(-1)?.toLowerCase();
+}
+
+export function hasSupportedMediaLibraryExtension(path: string): boolean {
+  const extension = extensionFor(path);
+  return extension !== undefined && MEDIA_LIBRARY_EXTENSIONS.has(extension);
+}
+
+export function hasSupportedSimulatorMediaExtension(path: string): boolean {
+  const extension = extensionFor(path);
+  return extension !== undefined && SIMULATOR_MEDIA_EXTENSIONS.has(extension);
+}
+
 export interface AppContainersTarget {
   domain: "app_containers";
   appId: string;
@@ -304,7 +369,20 @@ const canonicalPutAppFileSchema = addDeviceTargetingToSchema(
       legacySingleFile: z.literal(true).optional(),
     })
     .strict(),
-);
+).superRefine((args, ctx) => {
+  if (args.target.domain !== "media_library") {
+    return;
+  }
+  for (const [index, file] of args.files.entries()) {
+    if (!hasSupportedMediaLibraryExtension(file.destinationPath)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "media_library destinationPath must end in a supported image or video extension.",
+        path: ["files", index, "destinationPath"],
+      });
+    }
+  }
+});
 
 function preprocessLegacyPutAppFileArgs(input: unknown): unknown {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
@@ -356,6 +434,27 @@ export const putAppFileSchema = withJsonSchemaOverride(
           { required: ["contentBase64"] },
         ];
       }
+
+      jsonSchema.if = {
+        properties: {
+          target: {
+            properties: { domain: { const: "media_library" } },
+            required: ["domain"],
+          },
+        },
+        required: ["target"],
+      };
+      jsonSchema.then = {
+        properties: {
+          files: {
+            items: {
+              properties: {
+                destinationPath: { pattern: MEDIA_LIBRARY_EXTENSION_PATTERN },
+              },
+            },
+          },
+        },
+      };
     }
     if (Array.isArray(jsonSchema.required)) {
       jsonSchema.required = jsonSchema.required.filter((field) => field !== "legacySingleFile");

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -1,6 +1,7 @@
 import { errorMessage } from "../utils/describeUnknownError";
 import { promises as nodeFs } from "node:fs";
-import { dirname, join, posix, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, posix, relative } from "node:path";
 import { TextDecoder } from "node:util";
 import {
   AppFileContainer,
@@ -19,6 +20,7 @@ import {
   PutAppFileWriteResult,
   StorageDomain,
   buildAppFileResourceUri,
+  hasSupportedSimulatorMediaExtension,
   normalizeAppFileRelativePath,
   normalizePutAppFileTarget,
 } from "./appFileContract";
@@ -36,6 +38,10 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { logger } from "../utils/logger";
 import { prepareFileSource } from "./fileSourcePreparation";
 import { getSharedStorageService, type SharedStorageService } from "./sharedStorageService";
+import {
+  SimctlIosSimulatorMediaClient,
+  type IosSimulatorMediaClient,
+} from "./iosSimulatorMediaClient";
 
 export type PutAppFileRequest = Omit<PutAppFileArgs, "device"> & {
   device: BootedDevice;
@@ -132,6 +138,7 @@ export interface AppFileServiceDependencies {
   deviceResolver?: (deviceId: string) => Promise<BootedDevice>;
   idGenerator?: IdGenerator;
   sharedStorageService?: SharedStorageService;
+  iosSimulatorMediaClient?: IosSimulatorMediaClient;
 }
 
 const nodeAppFileFileSystem: AppFileFileSystem = {
@@ -201,6 +208,8 @@ export function createAppFileServiceForTesting(
         resolvedDeps,
         deps.idGenerator ?? defaultIdGenerator,
         deps.sharedStorageService ?? getSharedStorageService(),
+        deps.iosSimulatorMediaClient ??
+          new SimctlIosSimulatorMediaClient(resolvedDeps.simctlFactory),
       ),
     resolvedDeps.deviceResolver,
     resolvedDeps.fileSystem,
@@ -211,12 +220,16 @@ function createDefaultProviders(
   deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem">>,
   idGenerator: IdGenerator = defaultIdGenerator,
   sharedStorageService: SharedStorageService = getSharedStorageService(),
+  iosSimulatorMediaClient: IosSimulatorMediaClient = new SimctlIosSimulatorMediaClient(
+    deps.simctlFactory,
+  ),
 ): AppFileProvider[] {
   return [
     new AndroidAppFileProvider(deps.adbFactory, idGenerator),
     new AndroidUserFilesProvider(sharedStorageService),
     new AndroidMediaLibraryProvider(sharedStorageService),
     new IosSimulatorAppFileProvider(deps.simctlFactory, deps.fileSystem),
+    new IosSimulatorMediaLibraryProvider(iosSimulatorMediaClient, deps.fileSystem),
   ];
 }
 
@@ -837,6 +850,69 @@ class AndroidMediaLibraryProvider implements AppFileWriteProvider {
         ],
       };
     });
+  }
+}
+
+class IosSimulatorMediaLibraryProvider implements AppFileWriteProvider {
+  readonly platform = "ios" as const;
+  readonly domain = "media_library" as const;
+
+  constructor(
+    private readonly mediaClient: IosSimulatorMediaClient,
+    private readonly fileSystem: AppFileFileSystem,
+  ) {}
+
+  async putFile(request: PutAppFileProviderRequest) {
+    return (await this.putFiles([request]))[0];
+  }
+
+  async putFiles(requests: PutAppFileProviderRequest[]) {
+    if (requests.length === 0) {
+      return [];
+    }
+    const request = requests[0]!;
+    if (!isIosSimulatorUdid(request.device.deviceId)) {
+      throw new ActionableError(
+        `iOS media-library staging is only supported on iOS simulators. Device ${request.device.deviceId} looks like a physical iOS device.`,
+      );
+    }
+    for (const file of requests) {
+      if (!hasSupportedSimulatorMediaExtension(file.destinationPath)) {
+        throw new ActionableError(
+          `iOS Simulator media fixture requires a supported image or video extension: ${file.destinationPath}`,
+        );
+      }
+    }
+    const directory = await this.fileSystem.mkdtemp(join(tmpdir(), "automobile-ios-media-"));
+    try {
+      const paths = await Promise.all(
+        requests.map(async (file, index) => {
+          // Keep the requested filename for media-type inference while isolating
+          // duplicate basenames from separate destination directories.
+          const path = join(directory, String(index), basename(file.destinationPath));
+          await this.fileSystem.mkdir(dirname(path));
+          await this.fileSystem.copyFile(file.sourcePath, path);
+          return path;
+        }),
+      );
+      await this.mediaClient.importMedia(request.device, paths, request.signal);
+      return requests.map(() => ({
+        effects: [
+          {
+            type: "media_import",
+            status: "completed" as const,
+            reason: "Imported into the iOS Simulator media library through simctl addmedia.",
+          },
+          {
+            type: "picker_visibility",
+            status: "unavailable" as const,
+            reason: "Picker visibility is not verified by simctl addmedia.",
+          },
+        ],
+      }));
+    } finally {
+      await this.fileSystem.rm(directory);
+    }
   }
 }
 

--- a/src/server/iosSimulatorMediaClient.ts
+++ b/src/server/iosSimulatorMediaClient.ts
@@ -1,0 +1,19 @@
+import type { BootedDevice } from "../models";
+import type { SimCtl } from "../utils/ios-cmdline-tools/SimCtlClient";
+
+/** Narrow seam for importing fixture media into an iOS Simulator Photos library. */
+export interface IosSimulatorMediaClient {
+  importMedia(device: BootedDevice, paths: string[], signal?: AbortSignal): Promise<void>;
+}
+
+export class SimctlIosSimulatorMediaClient implements IosSimulatorMediaClient {
+  constructor(private readonly simctlFactory: (device: BootedDevice) => SimCtl) {}
+
+  async importMedia(device: BootedDevice, paths: string[], signal?: AbortSignal): Promise<void> {
+    await this.simctlFactory(device).executeCommandArgs(
+      ["addmedia", device.deviceId, ...paths],
+      undefined,
+      signal,
+    );
+  }
+}

--- a/test/features/storage/storageCapabilities.test.ts
+++ b/test/features/storage/storageCapabilities.test.ts
@@ -230,7 +230,14 @@ describe("AC4: partial / disabled / unsupported / conflicting inputs", () => {
     );
 
     const ios = computeStorageCapabilities(ctx({ platform: "ios", deviceType: "simulator" }));
-    expect(findOperationCapability(ios, "media_library", "write")?.state).toBe("unsupported");
+    expect(findOperationCapability(ios, "media_library", "write")?.state).toBe("supported");
+    expect(
+      findOperationCapability(
+        computeStorageCapabilities(ctx({ platform: "ios", deviceType: "physical" })),
+        "media_library",
+        "write",
+      )?.state,
+    ).toBe("unsupported");
   });
 
   it("secure_state read is unavailable pending the #5161 host policy, not unsupported", () => {

--- a/test/server/appFileContract.test.ts
+++ b/test/server/appFileContract.test.ts
@@ -129,6 +129,27 @@ describe("putAppFile canonical target contract (#5803)", () => {
     ).toBe(false);
   });
 
+  test.each(["clip.mkv", "clip.webm"])(
+    "keeps Android media-library fixture format %s available",
+    (destinationPath) => {
+      expect(
+        putAppFileSchema.safeParse({
+          target: { domain: "media_library" },
+          files: [{ destinationPath, contentBase64: "AQID" }],
+        }).success,
+      ).toBe(true);
+    },
+  );
+
+  test("rejects extensionless media-library fixture names that look like an extension", () => {
+    expect(
+      putAppFileSchema.safeParse({
+        target: { domain: "media_library" },
+        files: [{ destinationPath: "fixtures/png", contentText: "not a media filename" }],
+      }).success,
+    ).toBe(false);
+  });
+
   test("advertises the media-library filename requirement in generated tool definitions", () => {
     const definitions = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
       name: string;

--- a/test/server/appFileContract.test.ts
+++ b/test/server/appFileContract.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   APP_FILE_RESOURCE_TEMPLATES,
   buildAppFileResourceUri,
@@ -111,9 +112,52 @@ describe("putAppFile canonical target contract (#5803)", () => {
       files: [textFile],
     },
     { target: { domain: "user_files", namespace: "run-42", reset: true }, files: [textFile] },
-    { target: { domain: "media_library" }, files: [textFile] },
+    {
+      target: { domain: "media_library" },
+      files: [{ destinationPath: "fixtures/welcome.png", contentBase64: "iVBORw0KGgo=" }],
+    },
   ])("accepts target branch %#", (args) => {
     expect(putAppFileSchema.safeParse(args).success).toBe(true);
+  });
+
+  test("rejects media-library fixture names without a supported media extension", () => {
+    expect(
+      putAppFileSchema.safeParse({
+        target: { domain: "media_library" },
+        files: [{ destinationPath: "fixtures/payload", contentText: "not a media filename" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  test("advertises the media-library filename requirement in generated tool definitions", () => {
+    const definitions = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
+      name: string;
+      inputSchema?: { if?: unknown; then?: unknown };
+    }>;
+    const putAppFile = definitions.find((definition) => definition.name === "putAppFile");
+
+    expect(putAppFile?.inputSchema?.if).toEqual({
+      properties: {
+        target: {
+          properties: { domain: { const: "media_library" } },
+          required: ["domain"],
+        },
+      },
+      required: ["target"],
+    });
+    expect(putAppFile?.inputSchema?.then).toEqual({
+      properties: {
+        files: {
+          items: {
+            properties: {
+              destinationPath: {
+                pattern: expect.stringContaining("[pP][nN][gG]"),
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   test("normalizes the legacy single-file app-container shape into the canonical batch", () => {

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -235,6 +235,65 @@ describe("AppFileService", () => {
     ).toBe(true);
   });
 
+  test("imports iOS Simulator media through an injected argv-safe client and preserves filenames", async () => {
+    const fileSystem = new TestAppFileFileSystem();
+    const imports: Array<{ deviceId: string; paths: string[] }> = [];
+    const service = createAppFileServiceForTesting({
+      fileSystem,
+      iosSimulatorMediaClient: {
+        importMedia: async (device, paths) => {
+          imports.push({ deviceId: device.deviceId, paths: [...paths] });
+        },
+      },
+    });
+
+    const result = await service.putFile({
+      device: iosSimulatorDevice,
+      target: { domain: "media_library" },
+      files: [
+        { destinationPath: "fixtures/photo.png", contentBase64: "AQID" },
+        { destinationPath: "clips/demo.mov", contentBase64: "BAUG" },
+      ],
+    });
+
+    expect(imports).toEqual([
+      {
+        deviceId: iosSimulatorDevice.deviceId,
+        paths: [expect.stringMatching(/photo\.png$/), expect.stringMatching(/demo\.mov$/)],
+      },
+    ]);
+    expect(result.files.map((file) => file.effects)).toEqual([
+      [
+        expect.objectContaining({ type: "media_import", status: "completed" }),
+        expect.objectContaining({ type: "picker_visibility", status: "unavailable" }),
+      ],
+      [
+        expect.objectContaining({ type: "media_import", status: "completed" }),
+        expect.objectContaining({ type: "picker_visibility", status: "unavailable" }),
+      ],
+    ]);
+  });
+
+  test("rejects iOS physical-device media-library mutation before importing", async () => {
+    let importCalls = 0;
+    const service = createAppFileServiceForTesting({
+      iosSimulatorMediaClient: {
+        importMedia: async () => {
+          importCalls += 1;
+        },
+      },
+    });
+
+    await expect(
+      service.putFile({
+        device: { deviceId: "00008110-001234567890801E", name: "iPhone", platform: "ios" },
+        target: { domain: "media_library" },
+        files: [{ destinationPath: "photo.png", contentBase64: "AQID" }],
+      }),
+    ).rejects.toThrow("only supported on iOS simulators");
+    expect(importCalls).toBe(0);
+  });
+
   test("prepares every file and rejects conflicts before provider mutation", async () => {
     const provider = new RecordingStorageWriteProvider("android", "app_containers");
     const service = createAppFileServiceForTesting({ providers: [provider] });

--- a/test/server/iosSimulatorMediaClient.test.ts
+++ b/test/server/iosSimulatorMediaClient.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { SimctlIosSimulatorMediaClient } from "../../src/server/iosSimulatorMediaClient";
+import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
+
+describe("SimctlIosSimulatorMediaClient", () => {
+  test("imports media with exact simctl argv boundaries", async () => {
+    const simctl = new FakeSimCtlClient();
+    const client = new SimctlIosSimulatorMediaClient(() => simctl as never);
+    const device = {
+      deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+      name: "iPhone",
+      platform: "ios" as const,
+    };
+
+    await client.importMedia(device, ["/tmp/photo one.png", "/tmp/video;two.mov"]);
+
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([
+      {
+        args: ["addmedia", device.deviceId, "/tmp/photo one.png", "/tmp/video;two.mov"],
+        timeoutMs: undefined,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- stage supported image and video fixtures in an iOS Simulator Photos library through argv-safe `simctl addmedia`
- reject unsupported media-library filenames in the runtime and advertised tool schema
- expose simulator-only capability support and distinguish completed import from unverified picker visibility

## Validation

- `bun run turbo:validate` — 14,669 passed, 14 skipped
- focused app-file, schema, capability, and simulator-client tests — 100 passed
- `bun run lint`
- `bun run typecheck`
- booted iOS 17.5 Simulator import of one PNG and one MP4

## Remaining device check

The implementation imports both real fixtures into a booted simulator. The available simulator was blocked by first-run Photos onboarding and host accessibility permission prevented automating the system picker, so picker selection has not yet been proven. The result deliberately reports that visibility as unavailable rather than claiming it.

Closes #5805
