### PR TITLE
fix: harden Android CtrlProxy transport

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -7271,9 +7271,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         } else if (entry != null) {
           append(""","success":true,"found":true""")
           if (entry.value != null) {
-            val jsonValue =
-              if (entry.type == "STRING") jsonCompact.encodeToString(entry.value) else entry.value
-            append(""","value":$jsonValue""")
+            append(""","value":${jsonCompact.encodeToString(entry.value)}""")
           } else {
             append(""","value":null""")
           }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -7277,7 +7277,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           } else {
             append(""","value":null""")
           }
-          append(""","type":${jsonCompact.encodeToString(entry.type)}""")
+          append(""","valueType":${jsonCompact.encodeToString(entry.type)}""")
         } else {
           append(""","success":true,"found":false""")
         }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -3239,7 +3239,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     if (frame == null) return
     resultBroadcaster.guard(frame.requestId, "hierarchy_extract_error") {
       if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
-        webSocketServer.broadcast(frame)
+        webSocketServer.broadcastExternallyCorrelatedResponse(frame)
       }
     }
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -228,7 +228,10 @@ class WebSocketServer(
 
     try {
       server =
-        embeddedServer(CIO, port = port) {
+        // CtrlProxy is reached exclusively through adb forward. Binding loopback
+        // prevents the accessibility-control endpoint from being exposed to the
+        // device LAN when the runner is installed on a physical device.
+        embeddedServer(CIO, host = "127.0.0.1", port = port) {
             install(WebSockets) {
               pingPeriod = 15.seconds
               timeout = 60.seconds
@@ -365,7 +368,14 @@ class WebSocketServer(
 
   /** Broadcast a message to all connected clients */
   suspend fun broadcast(message: String) {
-    forgetRequestConnectionForRawMessage(message)
+    val target =
+      extractRequestId(message)?.let { requestId ->
+        synchronized(connections) { requestConnections.remove(requestId) }
+      }
+    if (target != null) {
+      sendToClient(target, message)
+      return
+    }
     _messageFlow.emit(message)
   }
 
@@ -379,7 +389,14 @@ class WebSocketServer(
   suspend fun broadcastWithPerf(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
-    forgetRequestConnectionForRawMessage(message)
+    val target =
+      extractRequestId(message)?.let { requestId ->
+        synchronized(connections) { requestConnections.remove(requestId) }
+      }
+    if (target != null) {
+      sendToClient(target, message)
+      return
+    }
     _messageFlow.emit(message)
   }
 
@@ -393,7 +410,14 @@ class WebSocketServer(
   suspend fun broadcastWithPerfSync(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
-    forgetRequestConnectionForRawMessage(message)
+    val target =
+      extractRequestId(message)?.let { requestId ->
+        synchronized(connections) { requestConnections.remove(requestId) }
+      }
+    if (target != null) {
+      sendToClient(target, message)
+      return
+    }
     broadcastToClients(message)
   }
 
@@ -428,19 +452,15 @@ class WebSocketServer(
   ) {
     val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
     val requestId = correlationRequestId(response)
-    if (response is ErrorResponse) {
-      val target =
-        if (requestId != null) {
-          synchronized(connections) { requestConnections.remove(requestId) }
-        } else {
-          null
-        }
-      if (target != null) {
-        sendToClient(target, message)
-        return
+    val target =
+      if (requestId != null) {
+        synchronized(connections) { requestConnections.remove(requestId) }
+      } else {
+        null
       }
-    } else {
-      forgetRequestConnection(requestId)
+    if (target != null) {
+      sendToClient(target, message)
+      return
     }
 
     if (waitForClient) {
@@ -566,16 +586,6 @@ class WebSocketServer(
       else -> true
     }
 
-  private fun forgetRequestConnectionForRawMessage(message: String) {
-    forgetRequestConnection(extractRequestId(message))
-  }
-
-  private fun forgetRequestConnection(requestId: String?) {
-    requestId?.let {
-      synchronized(connections) { requestConnections.remove(requestId) }
-    }
-  }
-
   /** Get the number of active connections */
   fun getConnectionCount(): Int {
     return synchronized(connections) { connections.size }
@@ -661,8 +671,8 @@ class WebSocketServer(
 
     Log.d(TAG, "Received ${request::class.simpleName} (requestId: ${request.requestId})")
     // Only record owner mappings for request types whose normal completion carries the same
-    // requestId back over the wire (raw or typed responses that clear the entry via
-    // `forgetRequestConnection`). Hierarchy requests are the exception: the action layer never
+    // requestId back over the wire (raw or typed responses route to and clear the entry).
+    // Hierarchy requests are the exception: the action layer never
     // receives their requestId, the success `hierarchy_update` frame has no requestId, and the
     // stale-skip path emits no frame at all — so a recorded owner would never be cleared until the
     // WebSocket disconnects, recreating the long-lived-session leak and leaving a stale id

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -440,6 +440,30 @@ class WebSocketServer(
       return
     }
 
+    broadcastSerialized(message, mode, waitForClient)
+  }
+
+  /**
+   * Broadcasts a response whose correlation ID was created outside this WebSocket server.
+   *
+   * Android broadcast commands do not originate from a socket, so their IDs have no entry in
+   * [requestConnections]. Their responses must still reach the daemon that is awaiting the ID,
+   * while ordinary orphaned WebSocket responses remain protected by [routeCorrelatedResponse].
+   */
+  suspend fun broadcastExternallyCorrelatedResponse(
+    response: WebSocketResponse,
+    mode: BroadcastMode = BroadcastMode.Async,
+    waitForClient: Boolean = false,
+  ) {
+    val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
+    broadcastSerialized(message, mode, waitForClient)
+  }
+
+  private suspend fun broadcastSerialized(
+    message: String,
+    mode: BroadcastMode,
+    waitForClient: Boolean,
+  ) {
     if (waitForClient) {
       broadcastToClientsWhenClientConnected(message)
     } else {
@@ -485,14 +509,7 @@ class WebSocketServer(
     waitForClient: Boolean = false,
   ) {
     val message = responseJson.encodeToString(SdkEvent.serializer(), event)
-    if (waitForClient) {
-      broadcastToClientsWhenClientConnected(message)
-    } else {
-      when (mode) {
-        BroadcastMode.Async -> _messageFlow.emit(message)
-        BroadcastMode.Sync -> broadcastToClients(message)
-      }
-    }
+    broadcastSerialized(message, mode, waitForClient)
   }
 
   /**

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -368,12 +368,7 @@ class WebSocketServer(
 
   /** Broadcast a message to all connected clients */
   suspend fun broadcast(message: String) {
-    val target =
-      extractRequestId(message)?.let { requestId ->
-        synchronized(connections) { requestConnections.remove(requestId) }
-      }
-    if (target != null) {
-      sendToClient(target, message)
+    if (routeCorrelatedResponse(extractRequestId(message), message)) {
       return
     }
     _messageFlow.emit(message)
@@ -389,12 +384,7 @@ class WebSocketServer(
   suspend fun broadcastWithPerf(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
-    val target =
-      extractRequestId(message)?.let { requestId ->
-        synchronized(connections) { requestConnections.remove(requestId) }
-      }
-    if (target != null) {
-      sendToClient(target, message)
+    if (routeCorrelatedResponse(extractRequestId(message), message)) {
       return
     }
     _messageFlow.emit(message)
@@ -410,12 +400,7 @@ class WebSocketServer(
   suspend fun broadcastWithPerfSync(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
-    val target =
-      extractRequestId(message)?.let { requestId ->
-        synchronized(connections) { requestConnections.remove(requestId) }
-      }
-    if (target != null) {
-      sendToClient(target, message)
+    if (routeCorrelatedResponse(extractRequestId(message), message)) {
       return
     }
     broadcastToClients(message)
@@ -451,15 +436,7 @@ class WebSocketServer(
     waitForClient: Boolean = false,
   ) {
     val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
-    val requestId = correlationRequestId(response)
-    val target =
-      if (requestId != null) {
-        synchronized(connections) { requestConnections.remove(requestId) }
-      } else {
-        null
-      }
-    if (target != null) {
-      sendToClient(target, message)
+    if (routeCorrelatedResponse(correlationRequestId(response), message)) {
       return
     }
 
@@ -471,6 +448,29 @@ class WebSocketServer(
         BroadcastMode.Sync -> broadcastToClients(message)
       }
     }
+  }
+
+  /**
+   * Sends a correlated response only to its originating client.
+   *
+   * A request owner is removed when the socket disconnects and when its first terminal response is
+   * delivered. A later response with that request ID is therefore not an event: broadcasting it
+   * could leak one client's screenshot or action result to every other connected client.
+   *
+   * @return `true` when [requestId] was present and the frame was delivered or deliberately
+   *   dropped; `false` for uncorrelated frames that the caller should broadcast normally.
+   */
+  private suspend fun routeCorrelatedResponse(requestId: String?, message: String): Boolean {
+    if (requestId == null) {
+      return false
+    }
+    val target = synchronized(connections) { requestConnections.remove(requestId) }
+    if (target == null) {
+      Log.w(TAG, "Dropping response for disconnected or completed request $requestId")
+    } else {
+      sendToClient(target, message)
+    }
+    return true
   }
 
   /**

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -994,7 +994,7 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
-  fun `raw async response clears request owner mapping`() = runBlocking {
+  fun `raw async response drops later orphaned correlated frames`() = runBlocking {
     lateinit var rawSuccessServer: WebSocketServer
     rawSuccessServer =
       WebSocketServer(
@@ -1040,7 +1040,10 @@ class WebSocketServerIntegrationTest {
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedRaw.complete(Unit)
               sendLateError.await()
-              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (unexpected is Frame.Text) {
+                ownerMessages.add(unexpected.readText())
+              }
             }
           }
 
@@ -1060,9 +1063,10 @@ class WebSocketServerIntegrationTest {
               }
               bystanderReceivedRaw.complete(Unit)
               sendLateError.await()
-              bystanderMessages.add(
-                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
-              )
+              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (lateUnexpected is Frame.Text) {
+                bystanderMessages.add(lateUnexpected.readText())
+              }
             }
           }
 
@@ -1080,20 +1084,15 @@ class WebSocketServerIntegrationTest {
 
           assertEquals("""{"type":"screenshot","requestId":"req-raw-success"}""", ownerMessages[0])
           assertEquals(
-            "the bystander should receive only the later unowned error, not the raw success",
+            "a terminal raw response removes ownership, so a late same-ID frame reaches nobody",
             1,
+            ownerMessages.size,
+          )
+          assertEquals(
+            "a terminal raw response must not leak a later same-ID frame to another client",
+            0,
             bystanderMessages.size,
           )
-          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
-          val bystanderError = json.parseToJsonElement(bystanderMessages[0]).jsonObject
-          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
-          assertEquals("req-raw-success", ownerError["requestId"]?.jsonPrimitive?.content)
-          assertEquals(
-            "raw success should remove stale request ownership so later same-id errors are not targeted",
-            "error",
-            bystanderError["type"]?.jsonPrimitive?.content,
-          )
-          assertEquals("req-raw-success", bystanderError["requestId"]?.jsonPrimitive?.content)
         }
       }
     } finally {
@@ -1102,7 +1101,7 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
-  fun `typed async response clears request owner mapping`() = runBlocking {
+  fun `typed async response drops later orphaned correlated frames`() = runBlocking {
     lateinit var typedSuccessServer: WebSocketServer
     typedSuccessServer =
       WebSocketServer(
@@ -1159,7 +1158,10 @@ class WebSocketServerIntegrationTest {
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedTyped.complete(Unit)
               sendLateError.await()
-              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (unexpected is Frame.Text) {
+                ownerMessages.add(unexpected.readText())
+              }
             }
           }
 
@@ -1179,9 +1181,10 @@ class WebSocketServerIntegrationTest {
               }
               bystanderReceivedTyped.complete(Unit)
               sendLateError.await()
-              bystanderMessages.add(
-                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
-              )
+              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (lateUnexpected is Frame.Text) {
+                bystanderMessages.add(lateUnexpected.readText())
+              }
             }
           }
 
@@ -1200,17 +1203,16 @@ class WebSocketServerIntegrationTest {
           val ownerResult = json.parseToJsonElement(ownerMessages[0]).jsonObject
           assertEquals("settings_get_result", ownerResult["type"]?.jsonPrimitive?.content)
           assertEquals("req-typed-success", ownerResult["requestId"]?.jsonPrimitive?.content)
-          assertEquals("correlated typed success must not leak to another client", 1, bystanderMessages.size)
-          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
-          val bystanderError = json.parseToJsonElement(bystanderMessages[0]).jsonObject
-          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
-          assertEquals("req-typed-success", ownerError["requestId"]?.jsonPrimitive?.content)
           assertEquals(
-            "typed success should remove stale request ownership so later same-id errors are not targeted",
-            "error",
-            bystanderError["type"]?.jsonPrimitive?.content,
+            "a terminal typed response must drop later same-ID frames",
+            1,
+            ownerMessages.size,
           )
-          assertEquals("req-typed-success", bystanderError["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "a terminal typed response must not leak later same-ID frames to another client",
+            0,
+            bystanderMessages.size,
+          )
         }
       }
     } finally {
@@ -1384,13 +1386,13 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
-  fun `uncorrelated hierarchy success does not leave stale request owner`() = runBlocking {
+  fun `uncorrelated hierarchy success drops an unrelated later correlated frame`() = runBlocking {
     // Issue #3190 (follow-up to #3159): a request_hierarchy carrying a requestId completes with an
     // uncorrelated success — the action broadcasts a `hierarchy_update` frame that has NO requestId
     // (production: CtrlProxy.kt broadcasts via HierarchyDebouncer without threading the requestId
     // through). Because that frame cannot clear an owner entry, the server must NOT record one in
-    // the first place. This test proves a later same-id ErrorResponse is broadcast to ALL clients
-    // rather than being misrouted only to the original requester's connection.
+    // the first place. A later correlated frame has no owner and must be dropped rather than
+    // leaked to every connected observer.
     lateinit var hierarchyServer: WebSocketServer
     hierarchyServer =
       WebSocketServer(
@@ -1437,7 +1439,10 @@ class WebSocketServerIntegrationTest {
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedUpdate.complete(Unit)
               sendLateError.await()
-              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (unexpected is Frame.Text) {
+                ownerMessages.add(unexpected.readText())
+              }
             }
           }
 
@@ -1456,9 +1461,10 @@ class WebSocketServerIntegrationTest {
               )
               bystanderReceivedUpdate.complete(Unit)
               sendLateError.await()
-              bystanderMessages.add(
-                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
-              )
+              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (lateUnexpected is Frame.Text) {
+                bystanderMessages.add(lateUnexpected.readText())
+              }
             }
           }
 
@@ -1476,17 +1482,16 @@ class WebSocketServerIntegrationTest {
 
           assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", ownerMessages[0])
           assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", bystanderMessages[0])
-          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
-          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
-          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
-          assertEquals("req-hierarchy", ownerError["requestId"]?.jsonPrimitive?.content)
           assertEquals(
-            "an uncorrelated hierarchy success must not record owner mapping, so a later same-id " +
-              "error broadcasts to all clients instead of being targeted to the original requester",
-            "error",
-            bystanderError["type"]?.jsonPrimitive?.content,
+            "owner should not receive an unowned correlated error",
+            1,
+            ownerMessages.size,
           )
-          assertEquals("req-hierarchy", bystanderError["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "an uncorrelated hierarchy response leaves no owner, so a later same-ID frame is dropped",
+            1,
+            bystanderMessages.size,
+          )
         }
       }
     } finally {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -1054,9 +1054,10 @@ class WebSocketServerIntegrationTest {
               incoming.receive() // Connection message
               bystanderReady.complete(Unit)
               sendOwnerMessage.await()
-              bystanderMessages.add(
-                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
-              )
+              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (unexpected is Frame.Text) {
+                bystanderMessages.add(unexpected.readText())
+              }
               bystanderReceivedRaw.complete(Unit)
               sendLateError.await()
               bystanderMessages.add(
@@ -1079,11 +1080,12 @@ class WebSocketServerIntegrationTest {
 
           assertEquals("""{"type":"screenshot","requestId":"req-raw-success"}""", ownerMessages[0])
           assertEquals(
-            """{"type":"screenshot","requestId":"req-raw-success"}""",
-            bystanderMessages[0],
+            "the bystander should receive only the later unowned error, not the raw success",
+            1,
+            bystanderMessages.size,
           )
           val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
-          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
+          val bystanderError = json.parseToJsonElement(bystanderMessages[0]).jsonObject
           assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
           assertEquals("req-raw-success", ownerError["requestId"]?.jsonPrimitive?.content)
           assertEquals(
@@ -1171,9 +1173,10 @@ class WebSocketServerIntegrationTest {
               incoming.receive() // Connection message
               bystanderReady.complete(Unit)
               sendOwnerMessage.await()
-              bystanderMessages.add(
-                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
-              )
+              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
+              if (unexpected is Frame.Text) {
+                bystanderMessages.add(unexpected.readText())
+              }
               bystanderReceivedTyped.complete(Unit)
               sendLateError.await()
               bystanderMessages.add(
@@ -1195,13 +1198,11 @@ class WebSocketServerIntegrationTest {
           bystanderJob.join()
 
           val ownerResult = json.parseToJsonElement(ownerMessages[0]).jsonObject
-          val bystanderResult = json.parseToJsonElement(bystanderMessages[0]).jsonObject
           assertEquals("settings_get_result", ownerResult["type"]?.jsonPrimitive?.content)
           assertEquals("req-typed-success", ownerResult["requestId"]?.jsonPrimitive?.content)
-          assertEquals("settings_get_result", bystanderResult["type"]?.jsonPrimitive?.content)
-          assertEquals("req-typed-success", bystanderResult["requestId"]?.jsonPrimitive?.content)
+          assertEquals("correlated typed success must not leak to another client", 1, bystanderMessages.size)
           val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
-          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
+          val bystanderError = json.parseToJsonElement(bystanderMessages[0]).jsonObject
           assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
           assertEquals("req-typed-success", ownerError["requestId"]?.jsonPrimitive?.content)
           assertEquals(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -1289,6 +1289,36 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `externally correlated response broadcasts without a socket owner`() = runBlocking {
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { c ->
+      c.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        incoming.receive() // Connection message
+
+        server.broadcastExternallyCorrelatedResponse(
+          ErrorResponse(
+            timestamp = 1234,
+            requestId = "sync_1234_external",
+            error = "Hierarchy extraction failed",
+          )
+        )
+
+        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+        assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+        assertEquals("sync_1234_external", responseJson["requestId"]?.jsonPrimitive?.content)
+      }
+    }
+  }
+
+  @Test
   fun `async action failure error response is sent only to originating connection`() = runBlocking {
     lateinit var asyncServer: WebSocketServer
     val runnerHolder = arrayOfNulls<AsyncActionRunner>(1)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -1019,8 +1019,9 @@ class WebSocketServerIntegrationTest {
       val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
       val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
       val ownerReceivedRaw = kotlinx.coroutines.CompletableDeferred<Unit>()
-      val bystanderReceivedRaw = kotlinx.coroutines.CompletableDeferred<Unit>()
-      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val ownerReceivedProbe = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReceivedProbe = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val readLateSequence = kotlinx.coroutines.CompletableDeferred<Unit>()
 
       val ownerClient = HttpClient(CIO) { install(WebSockets) }
       val bystanderClient = HttpClient(CIO) { install(WebSockets) }
@@ -1039,11 +1040,10 @@ class WebSocketServerIntegrationTest {
               send(Frame.Text("""{"type":"request_screenshot","requestId":"req-raw-success"}"""))
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedRaw.complete(Unit)
-              sendLateError.await()
-              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (unexpected is Frame.Text) {
-                ownerMessages.add(unexpected.readText())
-              }
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              ownerReceivedProbe.complete(Unit)
+              readLateSequence.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
             }
           }
 
@@ -1057,16 +1057,14 @@ class WebSocketServerIntegrationTest {
               incoming.receive() // Connection message
               bystanderReady.complete(Unit)
               sendOwnerMessage.await()
-              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (unexpected is Frame.Text) {
-                bystanderMessages.add(unexpected.readText())
-              }
-              bystanderReceivedRaw.complete(Unit)
-              sendLateError.await()
-              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (lateUnexpected is Frame.Text) {
-                bystanderMessages.add(lateUnexpected.readText())
-              }
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+              bystanderReceivedProbe.complete(Unit)
+              readLateSequence.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
             }
           }
 
@@ -1074,24 +1072,34 @@ class WebSocketServerIntegrationTest {
           bystanderReady.await()
           sendOwnerMessage.complete(Unit)
           ownerReceivedRaw.await()
-          bystanderReceivedRaw.await()
+          rawSuccessServer.broadcast("""{"type":"probe","sequence":1}""")
+          ownerReceivedProbe.await()
+          bystanderReceivedProbe.await()
           rawSuccessServer.broadcast(
             ErrorResponse(requestId = "req-raw-success", error = "late correlated failure")
           )
-          sendLateError.complete(Unit)
+          rawSuccessServer.broadcast("""{"type":"probe","sequence":2}""")
+          readLateSequence.complete(Unit)
           ownerJob.join()
           bystanderJob.join()
 
           assertEquals("""{"type":"screenshot","requestId":"req-raw-success"}""", ownerMessages[0])
           assertEquals(
             "a terminal raw response removes ownership, so a late same-ID frame reaches nobody",
-            1,
-            ownerMessages.size,
+            listOf(
+              """{"type":"screenshot","requestId":"req-raw-success"}""",
+              """{"type":"probe","sequence":1}""",
+              """{"type":"probe","sequence":2}""",
+            ),
+            ownerMessages.toList(),
           )
           assertEquals(
             "a terminal raw response must not leak a later same-ID frame to another client",
-            0,
-            bystanderMessages.size,
+            listOf(
+              """{"type":"probe","sequence":1}""",
+              """{"type":"probe","sequence":2}""",
+            ),
+            bystanderMessages.toList(),
           )
         }
       }
@@ -1137,8 +1145,9 @@ class WebSocketServerIntegrationTest {
       val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
       val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
       val ownerReceivedTyped = kotlinx.coroutines.CompletableDeferred<Unit>()
-      val bystanderReceivedTyped = kotlinx.coroutines.CompletableDeferred<Unit>()
-      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val ownerReceivedProbe = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReceivedProbe = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val readLateSequence = kotlinx.coroutines.CompletableDeferred<Unit>()
 
       val ownerClient = HttpClient(CIO) { install(WebSockets) }
       val bystanderClient = HttpClient(CIO) { install(WebSockets) }
@@ -1157,11 +1166,10 @@ class WebSocketServerIntegrationTest {
               send(Frame.Text("""{"type":"request_screenshot","requestId":"req-typed-success"}"""))
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedTyped.complete(Unit)
-              sendLateError.await()
-              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (unexpected is Frame.Text) {
-                ownerMessages.add(unexpected.readText())
-              }
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              ownerReceivedProbe.complete(Unit)
+              readLateSequence.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
             }
           }
 
@@ -1175,16 +1183,14 @@ class WebSocketServerIntegrationTest {
               incoming.receive() // Connection message
               bystanderReady.complete(Unit)
               sendOwnerMessage.await()
-              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (unexpected is Frame.Text) {
-                bystanderMessages.add(unexpected.readText())
-              }
-              bystanderReceivedTyped.complete(Unit)
-              sendLateError.await()
-              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (lateUnexpected is Frame.Text) {
-                bystanderMessages.add(lateUnexpected.readText())
-              }
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+              bystanderReceivedProbe.complete(Unit)
+              readLateSequence.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
             }
           }
 
@@ -1192,11 +1198,14 @@ class WebSocketServerIntegrationTest {
           bystanderReady.await()
           sendOwnerMessage.complete(Unit)
           ownerReceivedTyped.await()
-          bystanderReceivedTyped.await()
+          typedSuccessServer.broadcast("""{"type":"probe","sequence":1}""")
+          ownerReceivedProbe.await()
+          bystanderReceivedProbe.await()
           typedSuccessServer.broadcast(
             ErrorResponse(requestId = "req-typed-success", error = "late correlated failure")
           )
-          sendLateError.complete(Unit)
+          typedSuccessServer.broadcast("""{"type":"probe","sequence":2}""")
+          readLateSequence.complete(Unit)
           ownerJob.join()
           bystanderJob.join()
 
@@ -1205,13 +1214,19 @@ class WebSocketServerIntegrationTest {
           assertEquals("req-typed-success", ownerResult["requestId"]?.jsonPrimitive?.content)
           assertEquals(
             "a terminal typed response must drop later same-ID frames",
-            1,
-            ownerMessages.size,
+            listOf(
+              """{"type":"probe","sequence":1}""",
+              """{"type":"probe","sequence":2}""",
+            ),
+            ownerMessages.drop(1),
           )
           assertEquals(
             "a terminal typed response must not leak later same-ID frames to another client",
-            0,
-            bystanderMessages.size,
+            listOf(
+              """{"type":"probe","sequence":1}""",
+              """{"type":"probe","sequence":2}""",
+            ),
+            bystanderMessages.toList(),
           )
         }
       }
@@ -1449,7 +1464,7 @@ class WebSocketServerIntegrationTest {
       val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
       val ownerReceivedUpdate = kotlinx.coroutines.CompletableDeferred<Unit>()
       val bystanderReceivedUpdate = kotlinx.coroutines.CompletableDeferred<Unit>()
-      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val readLateSequence = kotlinx.coroutines.CompletableDeferred<Unit>()
 
       val ownerClient = HttpClient(CIO) { install(WebSockets) }
       val bystanderClient = HttpClient(CIO) { install(WebSockets) }
@@ -1468,11 +1483,8 @@ class WebSocketServerIntegrationTest {
               send(Frame.Text("""{"type":"request_hierarchy","requestId":"req-hierarchy"}"""))
               ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
               ownerReceivedUpdate.complete(Unit)
-              sendLateError.await()
-              val unexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (unexpected is Frame.Text) {
-                ownerMessages.add(unexpected.readText())
-              }
+              readLateSequence.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
             }
           }
 
@@ -1490,11 +1502,10 @@ class WebSocketServerIntegrationTest {
                 (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
               )
               bystanderReceivedUpdate.complete(Unit)
-              sendLateError.await()
-              val lateUnexpected = withTimeoutOrNull(250) { incoming.receive() }
-              if (lateUnexpected is Frame.Text) {
-                bystanderMessages.add(lateUnexpected.readText())
-              }
+              readLateSequence.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
             }
           }
 
@@ -1506,21 +1517,20 @@ class WebSocketServerIntegrationTest {
           hierarchyServer.broadcast(
             ErrorResponse(requestId = "req-hierarchy", error = "late correlated failure")
           )
-          sendLateError.complete(Unit)
+          hierarchyServer.broadcast("""{"type":"probe"}""")
+          readLateSequence.complete(Unit)
           ownerJob.join()
           bystanderJob.join()
 
-          assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", ownerMessages[0])
-          assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", bystanderMessages[0])
           assertEquals(
             "owner should not receive an unowned correlated error",
-            1,
-            ownerMessages.size,
+            listOf("""{"type":"hierarchy_update","hierarchy":{}}""", """{"type":"probe"}"""),
+            ownerMessages.toList(),
           )
           assertEquals(
             "an uncorrelated hierarchy response leaves no owner, so a later same-ID frame is dropped",
-            1,
-            bystanderMessages.size,
+            listOf("""{"type":"hierarchy_update","hierarchy":{}}""", """{"type":"probe"}"""),
+            bystanderMessages.toList(),
           )
         }
       }

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -695,7 +695,7 @@ data class GetPreferenceResult(
   val fileName: String,
   val key: String,
   val value: String? = null,
-  val type: String? = null,
+  val valueType: String? = null,
   val found: Boolean = false,
   val error: String? = null,
 ) : WebSocketResponse()

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -623,7 +623,9 @@ export abstract class DeviceServiceClient {
       const parsed = JSON.parse(data.toString()) as { requestId?: unknown };
       return typeof parsed.requestId === "string" ? parsed.requestId : undefined;
     } catch (error) {
-      logger.debug(`[${this.logTag}] Could not read request ID from failed WebSocket send: ${error}`);
+      logger.debug(
+        `[${this.logTag}] Could not read request ID from failed WebSocket send: ${error}`,
+      );
       return undefined;
     }
   }

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -86,6 +86,9 @@ export abstract class DeviceServiceClient {
   // isConnecting true until connectionTimeoutMs, stalling a fresh-port connect
   // by up to ~5s. Cleared to null the moment the handshake terminates. (#5656)
   private pendingConnectAbort: { socket: WebSocket; abort: () => void } | null = null;
+  // Platform setup (notably adb port forwarding) is also part of a connection
+  // attempt. Keep its controller separately because no WebSocket exists yet.
+  private pendingPlatformSetupAbort: AbortController | null = null;
 
   // Auto-reconnection state
   protected autoReconnectEnabled: boolean = true;
@@ -154,7 +157,10 @@ export abstract class DeviceServiceClient {
    * For Android, this sets up port forwarding.
    * For iOS, this may resolve the host address.
    */
-  protected abstract setupBeforeConnect(perf: PerformanceTracker): Promise<void>;
+  protected abstract setupBeforeConnect(
+    perf: PerformanceTracker,
+    signal: AbortSignal,
+  ): Promise<void>;
 
   /**
    * Cancel any pending screenshot backoff captures.
@@ -318,6 +324,8 @@ export abstract class DeviceServiceClient {
    * is in flight. (#5656)
    */
   protected abortPendingConnect(): void {
+    this.pendingPlatformSetupAbort?.abort();
+    this.pendingPlatformSetupAbort = null;
     const pending = this.pendingConnectAbort;
     if (pending) {
       this.pendingConnectAbort = null;
@@ -414,8 +422,7 @@ export abstract class DeviceServiceClient {
     const generation = this.connectionGeneration;
 
     try {
-      // Platform-specific setup (e.g., port forwarding)
-      await perf.track("platformSetup", () => this.setupBeforeConnect(perf));
+      await this.runPlatformSetup(perf);
 
       if (generation !== this.connectionGeneration) {
         // close() ran during platform setup; do not open a socket to a
@@ -506,6 +513,7 @@ export abstract class DeviceServiceClient {
               }
               logger.info(`[${this.logTag}] WebSocket connected successfully`);
               this.ws = ws;
+              this.protectRegisteredRequestSends(ws);
               this.isConnecting = false;
               this.connectionAttempts = 0; // Reset on successful connection
 
@@ -562,6 +570,61 @@ export abstract class DeviceServiceClient {
       this.lastConnectionAttempt = this.timer.now();
       logger.warn(`[${this.logTag}] Failed to connect to WebSocket: ${error}`);
       return false;
+    }
+  }
+
+  private async runPlatformSetup(perf: PerformanceTracker): Promise<void> {
+    // Platform-specific setup (e.g., port forwarding) must be cancellable: a
+    // close while adb is hung otherwise leaves the client in-flight forever.
+    const setupAbort = new AbortController();
+    this.pendingPlatformSetupAbort = setupAbort;
+    const setupTimeout = this.timer.setTimeout(
+      () => setupAbort.abort(),
+      this.config.connectionTimeoutMs,
+    );
+    try {
+      await perf.track("platformSetup", () => this.setupBeforeConnect(perf, setupAbort.signal));
+    } finally {
+      this.timer.clearTimeout(setupTimeout);
+      if (this.pendingPlatformSetupAbort === setupAbort) {
+        this.pendingPlatformSetupAbort = null;
+      }
+    }
+  }
+
+  /**
+   * Every CtrlProxy request carries its correlation ID in the JSON payload. A
+   * synchronous ws.send failure otherwise bypasses the request awaiter's error
+   * path and leaves that registration pending until a later timeout or close.
+   */
+  private protectRegisteredRequestSends(ws: WebSocket): void {
+    const send = ws.send.bind(ws) as (data: WebSocket.Data, ...args: unknown[]) => void;
+    ws.send = ((data: WebSocket.Data, ...args: unknown[]) => {
+      try {
+        return send(data, ...args);
+      } catch (error) {
+        const requestId = this.requestIdFromWireData(data);
+        if (requestId) {
+          this.requestManager.reject(
+            requestId,
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+        logger.debug(
+          `[${this.logTag}] WebSocket send failed${requestId ? ` for request ${requestId}` : ""}: ${error}`,
+        );
+        throw error;
+      }
+    }) as WebSocket["send"];
+  }
+
+  private requestIdFromWireData(data: WebSocket.Data): string | undefined {
+    try {
+      const parsed = JSON.parse(data.toString()) as { requestId?: unknown };
+      return typeof parsed.requestId === "string" ? parsed.requestId : undefined;
+    } catch (error) {
+      logger.debug(`[${this.logTag}] Could not read request ID from failed WebSocket send: ${error}`);
+      return undefined;
     }
   }
 

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -9,6 +9,7 @@ import { errorMessage } from "../../utils/describeUnknownError";
 import type { Timer } from "../../utils/SystemTimer";
 import type { PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger, type Logger } from "../../utils/logger";
+import WebSocket from "ws";
 import type { GestureResult, TextResult, ScreenshotResult } from "./DeviceService";
 import type {
   BaseResult,
@@ -312,7 +313,18 @@ export async function sendCommand<T>(
   );
 
   const msg = createMessage(options.messageType, requestId, options.params);
-  context.getWebSocket()?.send(msg);
+  try {
+    const ws = context.getWebSocket();
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket not connected");
+    }
+    ws.send(msg);
+  } catch (error) {
+    context.requestManager.reject(
+      requestId,
+      error instanceof Error ? error : new Error(String(error)),
+    );
+  }
 
   return options.perf
     ? options.perf.track(`${options.idPrefix}.awaitResponse`, () => promise)

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3098,7 +3098,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     try {
       const previousLocalPort = this.localPort;
       await perf.track("clearPortForward", () =>
-        this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`], { signal }).catch(() => {}),
+        this.adb
+          .execute(["forward", "--remove", `tcp:${this.localPort}`], { signal })
+          .catch(() => {}),
       );
       if (this.closed) {
         return;
@@ -3111,15 +3113,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       if (this.localPort !== previousLocalPort) {
         await perf.track("clearReallocatedPortForward", () =>
-          this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`], { signal }).catch(() => {}),
+          this.adb
+            .execute(["forward", "--remove", `tcp:${this.localPort}`], { signal })
+            .catch(() => {}),
         );
       }
 
       await perf.track("setupPortForward", () =>
-        this.adb.execute(
-          ["forward", `tcp:${this.localPort}`, `tcp:${PortManager.DEVICE_PORT}`],
-          { signal },
-        ),
+        this.adb.execute(["forward", `tcp:${this.localPort}`, `tcp:${PortManager.DEVICE_PORT}`], {
+          signal,
+        }),
       );
 
       if (this.closed) {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -474,6 +474,7 @@ interface WsGetPreferenceResultMessage extends WsMessageBase {
   found?: boolean;
   key?: string;
   value?: string;
+  valueType?: KeyValueType;
   totalTimeMs?: number;
 }
 
@@ -1610,6 +1611,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   public override async ensureConnected(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<boolean> {
+    if (this.closed) {
+      return false;
+    }
     const connected = await super.ensureConnected(perf);
     if (connected) {
       this.syncAccessibilityFlagsToDevice();
@@ -1620,6 +1624,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   protected override async connectWebSocket(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<boolean> {
+    if (this.closed) {
+      return false;
+    }
     const connection = super.connectWebSocket(perf);
     this.inFlightConnection = connection;
     try {
@@ -1749,8 +1756,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     );
   }
 
-  protected async setupBeforeConnect(perf: PerformanceTracker): Promise<void> {
-    await this.setupPortForwarding(perf);
+  protected async setupBeforeConnect(perf: PerformanceTracker, signal: AbortSignal): Promise<void> {
+    await this.setupPortForwarding(perf, signal);
   }
 
   // ===========================================================================
@@ -3071,6 +3078,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private async setupPortForwarding(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
   ): Promise<void> {
     if (this.closed) {
       return;
@@ -3078,7 +3086,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // Verify port forwarding is still active even if we think it's set up
     // Port forwarding can be lost if ADB server restarts or emulator restarts
     if (this.portForwardingSetup) {
-      const isActive = await this.isPortForwardingActive();
+      const isActive = await this.isPortForwardingActive(signal);
       if (isActive) {
         logger.debug(`[CTRL_PROXY] Port forwarding already active (localhost:${this.localPort})`);
         return;
@@ -3090,7 +3098,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     try {
       const previousLocalPort = this.localPort;
       await perf.track("clearPortForward", () =>
-        this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {}),
+        this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`], { signal }).catch(() => {}),
       );
       if (this.closed) {
         return;
@@ -3103,16 +3111,19 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       if (this.localPort !== previousLocalPort) {
         await perf.track("clearReallocatedPortForward", () =>
-          this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {}),
+          this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`], { signal }).catch(() => {}),
         );
       }
 
       await perf.track("setupPortForward", () =>
-        this.adb.executeCommand(`forward tcp:${this.localPort} tcp:${PortManager.DEVICE_PORT}`),
+        this.adb.execute(
+          ["forward", `tcp:${this.localPort}`, `tcp:${PortManager.DEVICE_PORT}`],
+          { signal },
+        ),
       );
 
       if (this.closed) {
-        await this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {});
+        await this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`]).catch(() => {});
         return;
       }
 
@@ -3137,16 +3148,24 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   /**
    * Check if port forwarding is still active by querying adb forward --list
    */
-  private async isPortForwardingActive(): Promise<boolean> {
+  private async isPortForwardingActive(signal?: AbortSignal): Promise<boolean> {
     try {
-      const result = await this.adb.executeCommand("forward --list");
-      const expectedForward = `tcp:${this.localPort} tcp:${PortManager.DEVICE_PORT}`;
-      // Check if our port forward entry exists in the list
-      // Format is: "serial tcp:localPort tcp:remotePort" per line
-      const isActive = result.stdout.includes(expectedForward);
+      const result = await this.adb.execute(["forward", "--list"], { signal });
+      // Format is exactly: "serial tcp:localPort tcp:remotePort". Requiring
+      // the serial prevents another device's same-number forward from being
+      // mistaken for this client's forward.
+      const isActive = result.stdout.split(/\r?\n/).some((line) => {
+        const [serial, local, remote, ...extra] = line.trim().split(/\s+/);
+        return (
+          extra.length === 0 &&
+          serial === this.device.deviceId &&
+          local === `tcp:${this.localPort}` &&
+          remote === `tcp:${PortManager.DEVICE_PORT}`
+        );
+      });
       if (!isActive) {
         logger.debug(
-          `[CTRL_PROXY] Port forwarding not found in active forwards. Expected: ${expectedForward}`,
+          `[CTRL_PROXY] Port forwarding not found for ${this.device.deviceId} on tcp:${this.localPort}`,
         );
       }
       return isActive;
@@ -3627,7 +3646,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
             ? {
                 key: message.key,
                 value: message.value,
-                type: message.type,
+                type: message.valueType ?? "UNKNOWN",
               }
             : undefined;
         this.requestManager.resolve(message.requestId, {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1793,7 +1793,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       });
   }
 
-  protected async setupBeforeConnect(_perf: PerformanceTracker): Promise<void> {
+  protected async setupBeforeConnect(
+    _perf: PerformanceTracker,
+    _signal: AbortSignal,
+  ): Promise<void> {
     // No port forwarding needed for iOS simulator
     // For real devices, iproxy may be needed in the future
   }

--- a/src/utils/RequestManager.ts
+++ b/src/utils/RequestManager.ts
@@ -1,5 +1,6 @@
 import { logger } from "./logger";
 import { Timer, defaultTimer } from "./SystemTimer";
+import { randomUUID } from "node:crypto";
 
 /**
  * Represents a pending request with timeout handling.
@@ -38,7 +39,6 @@ type ResponseErrorFactory<T> = (error: string, totalTimeMs: number) => T;
 export class RequestManager {
   private pending: Map<string, PendingRequest<unknown>> = new Map();
   private timer: Timer;
-  private requestCounter: number = 0;
 
   constructor(timer: Timer = defaultTimer) {
     this.timer = timer;
@@ -50,8 +50,11 @@ export class RequestManager {
    * @returns Unique request ID
    */
   generateId(type: string): string {
-    this.requestCounter++;
-    return `${type}_${this.timer.now()}_${this.requestCounter}`;
+    // Request managers are deliberately per client. A time + per-instance counter
+    // collides when two daemon clients issue the same request in the same tick, and
+    // CtrlProxy uses the ID to select the response owner. A UUID keeps that routing
+    // boundary safe across clients as well as across reconnects.
+    return `${type}_${randomUUID()}`;
   }
 
   /**
@@ -69,7 +72,7 @@ export class RequestManager {
     timeoutErrorFactory: TimeoutErrorFactory<T>,
     responseErrorFactory?: ResponseErrorFactory<T>,
   ): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
+    const promise = new Promise<T>((resolve, reject) => {
       // Set up timeout
       const timeoutId = this.timer.setTimeout(() => {
         const request = this.pending.get(id);
@@ -97,6 +100,12 @@ export class RequestManager {
         `[RequestManager] Registered request: ${type} (id: ${id}, timeout: ${timeoutMs}ms)`,
       );
     });
+    // A caller can fail synchronously while writing the just-registered request
+    // to a WebSocket. Keep that abandoned promise observed until the caller's
+    // error path cancels it or its timeout resolves; otherwise close() turns a
+    // send failure into an unhandled rejection.
+    void promise.catch(() => {});
+    return promise;
   }
 
   /**

--- a/src/utils/RequestManager.ts
+++ b/src/utils/RequestManager.ts
@@ -1,6 +1,6 @@
 import { logger } from "./logger";
+import { defaultIdGenerator, type IdGenerator } from "./IdGenerator";
 import { Timer, defaultTimer } from "./SystemTimer";
-import { randomUUID } from "node:crypto";
 
 /**
  * Represents a pending request with timeout handling.
@@ -38,9 +38,12 @@ type ResponseErrorFactory<T> = (error: string, totalTimeMs: number) => T;
  */
 export class RequestManager {
   private pending: Map<string, PendingRequest<unknown>> = new Map();
-  private timer: Timer;
+  private readonly timer: Timer;
 
-  constructor(timer: Timer = defaultTimer) {
+  constructor(
+    timer: Timer = defaultTimer,
+    private readonly idGenerator: IdGenerator = defaultIdGenerator,
+  ) {
     this.timer = timer;
   }
 
@@ -54,7 +57,7 @@ export class RequestManager {
     // collides when two daemon clients issue the same request in the same tick, and
     // CtrlProxy uses the ID to select the response owner. A UUID keeps that routing
     // boundary safe across clients as well as across reconnects.
-    return `${type}_${randomUUID()}`;
+    return `${type}_${this.idGenerator.next()}`;
   }
 
   /**
@@ -239,6 +242,5 @@ export class RequestManager {
       this.timer.clearTimeout(request.timeoutId);
     }
     this.pending.clear();
-    this.requestCounter = 0;
   }
 }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -590,6 +590,11 @@ export class AdbClient implements AdbExecutor {
       throw this.getAbortError(signal);
     }
     const fullArgs = [...baseArgs, ...args];
+    const remainingTimeoutMs = this.getRemainingTimeoutMs(
+      options.timeoutMs,
+      startTime,
+      args.join(" "),
+    );
     const child = this.spawnFn(adbPath, fullArgs, { stdio: ["ignore", "pipe", "pipe"] });
     this.activeProcesses.add(child);
 
@@ -625,11 +630,6 @@ export class AdbClient implements AdbExecutor {
     child.once("exit", onExit);
     child.once("error", onError);
     signal?.addEventListener("abort", onAbort, { once: true });
-    const remainingTimeoutMs = this.getRemainingTimeoutMs(
-      options.timeoutMs,
-      startTime,
-      args.join(" "),
-    );
     if (remainingTimeoutMs !== undefined) {
       timeoutId = this.timer.setTimeout(onAbort, remainingTimeoutMs);
     }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -579,12 +579,13 @@ export class AdbClient implements AdbExecutor {
   }
 
   async spawn(args: string[], options: AdbSpawnOptions = {}): Promise<AdbProcess> {
+    const startTime = this.timer.now();
     const signal = options.signal ?? getAbortSignal();
     if (signal?.aborted) {
       throw this.getAbortError(signal);
     }
 
-    const { adbPath, baseArgs } = await this.getBaseCommandParts();
+    const { adbPath, baseArgs } = await this.getBaseCommandParts(options.timeoutMs, signal);
     if (signal?.aborted) {
       throw this.getAbortError(signal);
     }
@@ -624,8 +625,13 @@ export class AdbClient implements AdbExecutor {
     child.once("exit", onExit);
     child.once("error", onError);
     signal?.addEventListener("abort", onAbort, { once: true });
-    if (options.timeoutMs) {
-      timeoutId = this.timer.setTimeout(onAbort, options.timeoutMs);
+    const remainingTimeoutMs = this.getRemainingTimeoutMs(
+      options.timeoutMs,
+      startTime,
+      args.join(" "),
+    );
+    if (remainingTimeoutMs !== undefined) {
+      timeoutId = this.timer.setTimeout(onAbort, remainingTimeoutMs);
     }
 
     await new Promise<void>((resolve, reject) => {

--- a/test/features/observe/DeviceServiceClientCooldown.test.ts
+++ b/test/features/observe/DeviceServiceClientCooldown.test.ts
@@ -45,7 +45,10 @@ class TestDeviceServiceClient extends DeviceServiceClient {
     this.connectionClosedCount++;
   }
 
-  protected async setupBeforeConnect(_perf: PerformanceTracker): Promise<void> {}
+  protected async setupBeforeConnect(
+    _perf: PerformanceTracker,
+    _signal: AbortSignal,
+  ): Promise<void> {}
 
   getConnectionAttempts(): number {
     return this.connectionAttempts;

--- a/test/features/observe/android/CtrlProxyStorage.test.ts
+++ b/test/features/observe/android/CtrlProxyStorage.test.ts
@@ -240,6 +240,49 @@ describe("CtrlProxyStorage (Android)", function () {
     });
   });
 
+  describe("getPreference", function () {
+    test("resolves a found entry from the valueType wire field", async function () {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.getPreference("com.example", "settings.xml", "launchCount");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket!, "get_preference");
+
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "get_preference_result",
+            requestId: sent.requestId,
+            success: true,
+            found: true,
+            key: "launchCount",
+            value: "3",
+            valueType: "INT",
+            totalTimeMs: 2,
+          }),
+        );
+
+        await expect(resultPromise).resolves.toEqual({
+          key: "launchCount",
+          value: "3",
+          type: "INT",
+        });
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
   describe("listDataStores", function () {
     test("sends adapterName and resolves with the device's file list", async function () {
       const { factory, getSocket } = createCapturingFactory(fakeTimer);

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -260,6 +260,44 @@ describe("IOSCtrlProxyClient auto-setup", function () {
     }
   });
 
+  test("late close from a timed-out socket does not disrupt a replacement handshake", async function () {
+    const manualTimer = new FakeTimer();
+    const sockets: ManualCloseWebSocket[] = [];
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      (url: string): WebSocket => {
+        const socket = new ManualCloseWebSocket(url, "timeout", 60_000, manualTimer);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      manualTimer,
+      createManagerFactory(),
+    );
+    const connect = (client as unknown as { connectWebSocket: () => Promise<boolean> })
+      .connectWebSocket;
+    try {
+      const first = connect.call(client);
+      await flushPromises(8);
+      manualTimer.advanceTime(5_000);
+      await expect(first).resolves.toBe(false);
+
+      const replacement = connect.call(client);
+      await flushPromises(8);
+      expect(sockets).toHaveLength(2);
+      sockets[1].readyState = WebSocketState.OPEN;
+      sockets[1].emit("open");
+      await expect(replacement).resolves.toBe(true);
+
+      sockets[0].emit("close");
+      await flushPromises(8);
+      expect(client.isConnected()).toBe(true);
+      expect(sockets).toHaveLength(2);
+    } finally {
+      await client.close();
+    }
+  });
+
   test("updatePort eagerly aborts a hung in-flight handshake so the new-port connect proceeds immediately (#5656)", async function () {
     // Frozen manual timer: it is NEVER advanced, so neither the 5s connection
     // timeout nor the "connection already in progress" poll interval can fire.

--- a/test/helpers/iosDelegateHarness.ts
+++ b/test/helpers/iosDelegateHarness.ts
@@ -89,6 +89,7 @@ export function createIosDelegateHarness(
   let cache: CtrlProxyCachedHierarchy | null = options.initialCache ?? null;
 
   const fakeSocket = {
+    readyState: 1,
     send(data: unknown): void {
       const text = typeof data === "string" ? data : String(data);
       try {

--- a/test/utils/RequestManager.test.ts
+++ b/test/utils/RequestManager.test.ts
@@ -26,6 +26,11 @@ describe("RequestManager", () => {
     expect(id3).toContain("swipe");
   });
 
+  test("does not collide across managers created in the same tick", () => {
+    const otherManager = new RequestManager(fakeTimer);
+    expect(manager.generateId("screenshot")).not.toBe(otherManager.generateId("screenshot"));
+  });
+
   test("should register and resolve requests", async () => {
     const id = manager.generateId("test");
     const promise = manager.register<{ success: boolean }>(id, "test", 5000, () => ({
@@ -241,16 +246,14 @@ describe("RequestManager", () => {
     expect(manager.resolveError("does-not-exist", "boom", 0)).toBe(false);
   });
 
-  test("resets the counter on reset so the next id restarts from 1", () => {
+  test("keeps IDs unique after reset", () => {
     manager.generateId("test");
     manager.generateId("test");
     manager.generateId("test");
 
     manager.reset();
 
-    // FakeTimer stays at now()=0, so the next id is fully determined: the counter
-    // must restart at 1 rather than continue from 4.
     const newId = manager.generateId("test");
-    expect(newId).toBe("test_0_1");
+    expect(newId).toMatch(/^test_[0-9a-f-]{36}$/);
   });
 });

--- a/test/utils/RequestManager.test.ts
+++ b/test/utils/RequestManager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { RequestManager } from "../../src/utils/RequestManager";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("RequestManager", () => {
@@ -8,7 +9,7 @@ describe("RequestManager", () => {
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
-    manager = new RequestManager(fakeTimer);
+    manager = new RequestManager(fakeTimer, new FakeIdGenerator(["first", "second", "third"]));
   });
 
   afterEach(() => {
@@ -20,15 +21,13 @@ describe("RequestManager", () => {
     const id2 = manager.generateId("screenshot");
     const id3 = manager.generateId("swipe");
 
-    expect(id1).not.toBe(id2);
-    expect(id2).not.toBe(id3);
-    expect(id1).toContain("screenshot");
-    expect(id3).toContain("swipe");
+    expect([id1, id2, id3]).toEqual(["screenshot_first", "screenshot_second", "swipe_third"]);
   });
 
   test("does not collide across managers created in the same tick", () => {
-    const otherManager = new RequestManager(fakeTimer);
-    expect(manager.generateId("screenshot")).not.toBe(otherManager.generateId("screenshot"));
+    const otherManager = new RequestManager(fakeTimer, new FakeIdGenerator(["other"]));
+    expect(manager.generateId("screenshot")).toBe("screenshot_first");
+    expect(otherManager.generateId("screenshot")).toBe("screenshot_other");
   });
 
   test("should register and resolve requests", async () => {
@@ -254,6 +253,6 @@ describe("RequestManager", () => {
     manager.reset();
 
     const newId = manager.generateId("test");
-    expect(newId).toMatch(/^test_[0-9a-f-]{36}$/);
+    expect(newId).toBe("test_fake-1");
   });
 });

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import { PassThrough } from "stream";
 import {
   AdbClient,
+  AdbCommandTimeoutError,
   AdbUnavailableError,
   resetAdbClientCaches,
 } from "../../../src/utils/android-cmdline-tools/AdbClient";
@@ -286,6 +287,34 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     resolveBase!({ adbPath: "adb", baseArgs: [] });
 
     await expect(pending).rejects.toThrow("Operation cancelled");
+    expect(spawnCalls).toBe(0);
+  });
+
+  test("does not spawn when executable resolution exhausts the timeout budget", async () => {
+    const timer = new FakeTimer();
+    let spawnCalls = 0;
+    const adb = new AdbClient(
+      null,
+      async (): Promise<ExecResult> => createExecResult(""),
+      (() => {
+        spawnCalls++;
+        throw new Error("must not spawn");
+      }) as never,
+      undefined,
+      timer,
+    );
+    (
+      adb as unknown as {
+        getBaseCommandParts: () => Promise<{ adbPath: string; baseArgs: string[] }>;
+      }
+    ).getBaseCommandParts = async () => {
+      timer.advanceTime(100);
+      return { adbPath: "adb", baseArgs: [] };
+    };
+
+    await expect(adb.spawn(["get-state"], { timeoutMs: 100 })).rejects.toBeInstanceOf(
+      AdbCommandTimeoutError,
+    );
     expect(spawnCalls).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- bind the Android CtrlProxy WebSocket to loopback, route correlated responses only to their originating socket, and make request IDs globally unique
- repair the preference result discriminator, terminal close behavior, stale-socket teardown, and send-failure cleanup
- make ADB forwarding ownership-aware and cancellable; apply spawn cancellation and timeout budgets during executable discovery

## Validation

- `bun run build`
- `bun run lint`
- `bun test test/utils/RequestManager.test.ts test/features/observe/CtrlProxyClient.test.ts test/features/observe/android/CtrlProxyStorage.test.ts`
- `./gradlew :control-proxy:testDebugUnitTest --tests '*WebSocketServer*' --tests '*CtrlProxyMessageHandlerTest*' --console=plain`
