### PR TITLE
fix(devices): bound iOS retention after clock rollback

### DIFF
--- a/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
+++ b/src/utils/ios-cmdline-tools/DevicectlDeviceLister.ts
@@ -454,6 +454,10 @@ export class DevicectlDeviceLister implements IosPhysicalDeviceLister {
       this.lastGood = null;
       return [];
     }
+    if (now < this.lastGood.observedAt) {
+      this.lastGood.observedAt = now;
+      this.lastGood.staleAfter = now + LAST_GOOD_RETENTION_MS;
+    }
     return this.lastGood.devices;
   }
 }

--- a/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
+++ b/test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts
@@ -447,6 +447,33 @@ describe("DevicectlDeviceLister", () => {
     expect([...(discovery.retainedDeviceIds ?? [])]).toEqual([PHYSICAL_UDID]);
   });
 
+  test("bounds retained devices to one window after a large clock rollback", async () => {
+    const timer = new FakeTimer();
+    let shouldFail = false;
+    const lister = makeLister({
+      timer,
+      execute: async () => {
+        if (shouldFail) {
+          throw new Error("devicectl blipped");
+        }
+        return okExec;
+      },
+      readFile: async () => JSON.stringify(devicectlPayload([connectedIphone()])),
+    });
+
+    timer.setCurrentTime(1_000_000);
+    await lister.listConnectedDevices();
+
+    timer.setCurrentTime(0);
+    shouldFail = true;
+    expect((await lister.listConnectedDevices()).devices.map((device) => device.deviceId)).toEqual([
+      PHYSICAL_UDID,
+    ]);
+
+    timer.advanceTime(60_001);
+    expect(await lister.listConnectedDevices()).toEqual({ devices: [], complete: false });
+  });
+
   test("removes its temp directory on both success and failure", async () => {
     const removed: string[] = [];
     const succeeding = makeLister({


### PR DESCRIPTION
## Summary

- Re-anchor the physical-device retention deadline when the wall clock moves backward.
- Add regression coverage proving a large rollback does not extend retention beyond one normal window.

## Root cause

The prior fix preserved the last-good listing across rollback but left `staleAfter` anchored to the old clock. A large correction could therefore keep an unplugged device published for the rollback magnitude plus the retention window.

## Impact

Physical iPhones remain visible through the transient failed sweep that motivated #5771, while retained state still expires after the normal 60-second window.

## Validation

- `bun test test/utils/ios-cmdline-tools/DevicectlDeviceLister.test.ts` (30 passing)
- `bun run typecheck`
- `bun run turbo:validate` was attempted; the full suite stalled in unrelated `waitForDeviceReadyOrCancel` coverage. Focused behavior and static gates are green.

Closes #5771
