### PR TITLE
fix(ios): harden CtrlProxy process lifecycle

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -1761,15 +1761,21 @@ public struct PerformanceUpdateResponse: Codable {
 
 // MARK: - Connected Event
 
+public enum RunnerFeature: String, CaseIterable, Codable {
+    case displayCutoutInfo = "display_cutout_info"
+}
+
 public struct ConnectedEvent: Codable {
     public let type: String
     public let id: Int
     public let supportedCommands: [String]
+    public let supportedFeatures: [String]
 
     public init(id: Int) {
         type = "connected"
         self.id = id
         supportedCommands = RequestType.allCases.map(\.rawValue).sorted()
+        supportedFeatures = RunnerFeature.allCases.map(\.rawValue).sorted()
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 import Network
 
 /// Global buffer for SDK events received via HTTP POST.
@@ -15,7 +15,9 @@ public final class SdkEventBuffer {
     public func append(_ data: Data) {
         lock.lock()
         buffer.append(data)
-        while buffer.count > maxEvents { buffer.removeFirst() }
+        while buffer.count > maxEvents {
+            buffer.removeFirst()
+        }
         lock.unlock()
     }
 
@@ -123,6 +125,9 @@ public class WebSocketServer: WebSocketServing {
 
     private var listener: NWListener?
     private let connections = ConnectionRegistry<WebSocketConnection>()
+    /// Only connections that completed the RFC 6455 upgrade. HTTP probes share
+    /// the accept path but must never receive framed WebSocket broadcasts.
+    private let upgradedConnections = ConnectionRegistry<WebSocketResponding>()
     private var nextConnectionId = 1
 
     /// Ids of connections that have completed the WebSocket upgrade handshake,
@@ -233,6 +238,7 @@ public class WebSocketServer: WebSocketServing {
 
     /// Stops the server
     public func stop() {
+        _ = upgradedConnections.removeAll()
         connections.removeAll().forEach { $0.close() }
         listener?.cancel()
         listener = nil
@@ -272,6 +278,9 @@ public class WebSocketServer: WebSocketServing {
     /// `private`) so `WebSocketServerTests` can drive the presence bookkeeping
     /// without a live socket (issue #5477).
     func clientDidUpgrade(_ id: Int) {
+        if let connection = connections.value(forId: id) {
+            upgradedConnections.set(connection, forId: id)
+        }
         presenceLock.lock()
         let wasEmpty = upgradedClientIds.isEmpty
         upgradedClientIds.insert(id)
@@ -282,10 +291,17 @@ public class WebSocketServer: WebSocketServing {
         }
     }
 
+    /// Test seam for pinning the broadcast routing invariant without opening a
+    /// real socket. Production upgrades are registered by `clientDidUpgrade`.
+    func registerUpgradedResponderForTesting(_ responder: WebSocketResponding, id: Int) {
+        upgradedConnections.set(responder, forId: id)
+    }
+
     /// Records that a connection closed, firing the presence hook only on the
     /// non-zero → zero transition. A never-upgraded (HTTP-only) connection is a
     /// no-op here, so `/health` probes never toggle presence.
     func clientDidDisconnect(_ id: Int) {
+        upgradedConnections.removeValue(forId: id)
         presenceLock.lock()
         let wasPresent = !upgradedClientIds.isEmpty
         upgradedClientIds.remove(id)
@@ -330,7 +346,9 @@ public class WebSocketServer: WebSocketServing {
     func handleMessage(_ data: Data, responder: WebSocketResponding) {
         do {
             let request = try Self.sharedDecoder.decode(WebSocketRequest.self, from: data)
-            print("[WebSocketServer] Received request type=\(request.typeString) requestId=\(request.requestId ?? "nil")")
+            print(
+                "[WebSocketServer] Received request type=\(request.typeString) requestId=\(request.requestId ?? "nil")"
+            )
 
             // Track the entire request handling with PerfProvider
             perfProvider.serial("handleRequest:\(request.typeString)")
@@ -417,7 +435,7 @@ public class WebSocketServer: WebSocketServing {
             broadcastSink(data)
             return
         }
-        for connection in connections.values() {
+        for connection in upgradedConnections.values() {
             connection.send(data)
         }
     }
@@ -502,7 +520,12 @@ public class WebSocketServer: WebSocketServing {
                 return "\"\(escaped)\""
             } ?? "null"
             let fallbackJSON = """
-            {"type":"error","success":false,"requestId":\(requestIdJSON),"error":"[encoding fallback] \(sanitizedError)","timestamp":\(Int64(Date().timeIntervalSince1970 * 1000))}
+            {"type":"error","success":false,"requestId":\(requestIdJSON),"error":"[encoding fallback] \(
+                sanitizedError
+            )","timestamp":\(Int64(
+                Date()
+                    .timeIntervalSince1970 * 1000
+            ))}
             """
             print("[WebSocketServer] Error response encoding failed, using fallback")
             return fallbackJSON.data(using: .utf8) ?? Data()
@@ -697,9 +720,13 @@ final class NWByteChannel: ByteChannel {
         maximumLength: Int,
         completion: @escaping (Data?, Bool, Error?) -> Void
     ) {
-        connection.receive(minimumIncompleteLength: minimumIncompleteLength, maximumLength: maximumLength) { data, _, isComplete, error in
-            completion(data, isComplete, error)
-        }
+        connection
+            .receive(
+                minimumIncompleteLength: minimumIncompleteLength,
+                maximumLength: maximumLength
+            ) { data, _, isComplete, error in
+                completion(data, isComplete, error)
+            }
     }
 
     func send(_ data: Data, completion: @escaping (Error?) -> Void) {
@@ -867,64 +894,68 @@ class WebSocketConnection: WebSocketResponding {
     // MARK: - WebSocket Handshake
 
     private func receiveHTTPUpgrade() {
-        channel.receive(minimumIncompleteLength: 1, maximumLength: Self.maximumHTTPRequestLength) { [weak self] data, isComplete, error in
-            guard let self = self else { return }
+        channel
+            .receive(
+                minimumIncompleteLength: 1,
+                maximumLength: Self.maximumHTTPRequestLength
+            ) { [weak self] data, isComplete, error in
+                guard let self = self else { return }
 
-            if let error = error {
-                print("[WebSocketConnection] Error: \(error)")
-                self.closeConnection()
-                return
-            }
+                if let error = error {
+                    print("[WebSocketConnection] Error: \(error)")
+                    self.closeConnection()
+                    return
+                }
 
-            if isComplete {
-                self.closeConnection()
-                return
-            }
+                if isComplete {
+                    self.closeConnection()
+                    return
+                }
 
-            guard let data = data else {
-                self.receiveHTTPUpgrade()
-                return
-            }
+                guard let data = data else {
+                    self.receiveHTTPUpgrade()
+                    return
+                }
 
-            self.inboundBuffer.append(data)
-            guard self.inboundBuffer.count <= Self.maximumHTTPRequestLength else {
-                print("[WebSocketConnection] HTTP request exceeds maximum length")
-                self.channel.cancel()
-                return
-            }
+                self.inboundBuffer.append(data)
+                guard self.inboundBuffer.count <= Self.maximumHTTPRequestLength else {
+                    print("[WebSocketConnection] HTTP request exceeds maximum length")
+                    self.channel.cancel()
+                    return
+                }
 
-            guard let requestLength = Self.completeHTTPRequestLength(in: self.inboundBuffer) else {
-                self.receiveHTTPUpgrade()
-                return
-            }
+                guard let requestLength = Self.completeHTTPRequestLength(in: self.inboundBuffer) else {
+                    self.receiveHTTPUpgrade()
+                    return
+                }
 
-            let requestData = Data(self.inboundBuffer.prefix(requestLength))
-            self.inboundBuffer.removeFirst(requestLength)
-            guard let request = String(data: requestData, encoding: .utf8) else {
-                self.channel.cancel()
-                return
-            }
+                let requestData = Data(self.inboundBuffer.prefix(requestLength))
+                self.inboundBuffer.removeFirst(requestLength)
+                guard let request = String(data: requestData, encoding: .utf8) else {
+                    self.channel.cancel()
+                    return
+                }
 
-            // Only the WebSocket-upgrade branch consumes bytes left in
-            // `inboundBuffer` after the slice: `receiveWebSocketFrame` drains them
-            // first (issue #5678). The HTTP branches (`GET /health`,
-            // `POST /sdk-events`, `GET /sdk-events`) each send their response and
-            // then `connection.cancel()`, so any residual bytes after their request
-            // are discarded with the connection — residual-carry there is out of
-            // scope by design (AC4).
-            if request.contains("Upgrade: websocket") || request.contains("upgrade: websocket") {
-                self.handleWebSocketUpgrade(request)
-            } else if request.contains("GET /health") {
-                self.handleHealthCheck()
-            } else if request.contains("POST /sdk-events") {
-                self.handleSdkEventsPost(request)
-            } else if request.contains("GET /sdk-events") {
-                self.handleSdkEventsGet()
-            } else {
-                // Not a WebSocket request, try again
-                self.receiveHTTPUpgrade()
+                // Only the WebSocket-upgrade branch consumes bytes left in
+                // `inboundBuffer` after the slice: `receiveWebSocketFrame` drains them
+                // first (issue #5678). The HTTP branches (`GET /health`,
+                // `POST /sdk-events`, `GET /sdk-events`) each send their response and
+                // then `connection.cancel()`, so any residual bytes after their request
+                // are discarded with the connection — residual-carry there is out of
+                // scope by design (AC4).
+                if request.contains("Upgrade: websocket") || request.contains("upgrade: websocket") {
+                    self.handleWebSocketUpgrade(request)
+                } else if request.contains("GET /health") {
+                    self.handleHealthCheck()
+                } else if request.contains("POST /sdk-events") {
+                    self.handleSdkEventsPost(request)
+                } else if request.contains("GET /sdk-events") {
+                    self.handleSdkEventsGet()
+                } else {
+                    // Not a WebSocket request, try again
+                    self.receiveHTTPUpgrade()
+                }
             }
-        }
     }
 
     /// Returns the byte count of one complete HTTP request, including its body,
@@ -1007,7 +1038,8 @@ class WebSocketConnection: WebSocketResponding {
         } else {
             print("[CtrlProxy] POST /sdk-events: no header separator found in \(request.count) chars")
         }
-        let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n{\"ok\":true}\r\n"
+        let response =
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n{\"ok\":true}\r\n"
         channel.send(Data(response.utf8)) { [weak self] _ in
             self?.channel.cancel()
         }
@@ -1044,7 +1076,8 @@ class WebSocketConnection: WebSocketResponding {
         // Calculate accept key
         let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
         // A String always encodes to UTF-8, so .data(using: .utf8) is never nil.
-    let acceptKey = (key + magic).data(using: .utf8)!.sha1().base64EncodedString()  // swiftlint:disable:this force_unwrapping
+        let acceptKey = (key + magic).data(using: .utf8)!.sha1()
+            .base64EncodedString() // swiftlint:disable:this force_unwrapping
 
         // Send upgrade response
         let response = """
@@ -1264,7 +1297,9 @@ class WebSocketConnection: WebSocketResponding {
         payloadLength: UInt64,
         isMasked: Bool,
         maxPayload: UInt64 = maxFramePayloadLength
-    ) -> Int? {
+    )
+        -> Int?
+    {
         guard payloadLength <= maxPayload else { return nil }
         return Int(payloadLength) + (isMasked ? 4 : 0)
     }
@@ -1294,11 +1329,15 @@ class WebSocketConnection: WebSocketResponding {
         inProgressOpcode: UInt8?,
         alreadyBuffered: Int,
         maxTotal: UInt64 = maxFramePayloadLength
-    ) -> FramePreReadDecision {
+    )
+        -> FramePreReadDecision
+    {
         switch opcode {
         case 0x01, 0x02:
             if inProgressOpcode != nil {
-                return .reject("new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open")
+                return .reject(
+                    "new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open"
+                )
             }
             guard declaredPayloadLength <= maxTotal else {
                 return .reject("frame payload exceeds \(maxTotal) bytes")
@@ -1416,12 +1455,16 @@ class WebSocketConnection: WebSocketResponding {
         payload: Data,
         inProgressOpcode: inout UInt8?,
         maxTotal: UInt64 = maxFramePayloadLength
-    ) -> AccumulateResult {
+    )
+        -> AccumulateResult
+    {
         switch opcode {
         case 0x01, 0x02:
             // A new data frame is illegal while a fragmented message is still open.
             if inProgressOpcode != nil {
-                return .protocolError("new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open")
+                return .protocolError(
+                    "new data frame (opcode 0x\(String(opcode, radix: 16))) while a fragmented message is open"
+                )
             }
             guard UInt64(payload.count) <= maxTotal else {
                 return .protocolError("frame payload exceeds \(maxTotal) bytes")
@@ -1477,7 +1520,8 @@ class WebSocketConnection: WebSocketResponding {
                declaredPayloadLength: length,
                inProgressOpcode: fragmentedOpcode,
                alreadyBuffered: fragmentBuffer.count
-           ) {
+           )
+        {
             print("[WebSocketConnection] Fragmentation protocol error (pre-read): \(reason), closing connection")
             fragmentedOpcode = nil
             fragmentBuffer = Data()

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1075,9 +1075,7 @@ class WebSocketConnection: WebSocketResponding {
 
         // Calculate accept key
         let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-        // A String always encodes to UTF-8, so .data(using: .utf8) is never nil.
-        let acceptKey = (key + magic).data(using: .utf8)!.sha1()
-            .base64EncodedString() // swiftlint:disable:this force_unwrapping
+        let acceptKey = Data((key + magic).utf8).sha1().base64EncodedString()
 
         // Send upgrade response
         let response = """

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -432,6 +432,7 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(event.type, "connected")
         XCTAssertEqual(event.id, 7)
         XCTAssertEqual(event.supportedCommands, RequestType.allCases.map(\.rawValue).sorted())
+        XCTAssertEqual(event.supportedFeatures, ["display_cutout_info"])
         XCTAssertTrue(event.supportedCommands.contains("request_press_back"))
         XCTAssertTrue(event.supportedCommands.contains("request_keyboard"))
     }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -173,6 +173,16 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertNotEqual(response.frameContext, frameContext.context(for: screenA))
     }
 
+    func testBroadcastSendsOnlyToUpgradedResponders() {
+        let upgraded = FakeResponder()
+        let server = makeServer()
+        server.registerUpgradedResponderForTesting(upgraded, id: 7)
+
+        server.broadcast(Data("PUSH".utf8))
+
+        XCTAssertEqual(upgraded.sent, [Data("PUSH".utf8)])
+    }
+
     // MARK: - Decode-failure → error envelope (real handleMessage path)
 
     /// An unknown command `type` (no enum case) is rejected at decode; the real
@@ -269,11 +279,11 @@ final class WebSocketServerTests: XCTestCase {
     /// is that it does not crash and ends empty after a balanced add/remove.
     func testConnectionRegistryConcurrentAccessDoesNotCrash() {
         let registry = ConnectionRegistry<Int>()
-        let iterations = 2_000
+        let iterations = 2000
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             registry.set(i, forId: i)
-            _ = registry.values()   // snapshot iteration, concurrent with mutation
+            _ = registry.values() // snapshot iteration, concurrent with mutation
             _ = registry.count
             registry.removeValue(forId: i)
         }
@@ -433,7 +443,11 @@ final class WebSocketServerTests: XCTestCase {
                 continue
             }
         }
-        XCTFail("could not bind a WebSocketServer on any port in [\(base), \(base + UInt16(attempts))]", file: file, line: line)
+        XCTFail(
+            "could not bind a WebSocketServer on any port in [\(base), \(base + UInt16(attempts))]",
+            file: file,
+            line: line
+        )
         fatalError("unreachable")
     }
 
@@ -536,7 +550,9 @@ final class WebSocketServerTests: XCTestCase {
         )
         XCTAssertEqual(statusBox.value, 200, "health check should return 200 while a command is blocked")
         XCTAssertEqual(
-            bodyBox.value.flatMap { (try? JSONSerialization.jsonObject(with: Data($0.utf8))) as? [String: Any] }?["status"] as? String,
+            bodyBox.value
+                .flatMap { (try? JSONSerialization.jsonObject(with: Data($0.utf8))) as? [String: Any]
+                }?["status"] as? String,
             "ok",
             "health body should report status:ok"
         )
@@ -816,7 +832,8 @@ final class WebSocketServerTests: XCTestCase {
             reassembler.feed(opcode: 0x01, isFinal: false, payload: Data("hello".utf8), maxTotal: 8), // 5
             .buffered
         )
-        let result = reassembler.feed(opcode: 0x00, isFinal: true, payload: Data("world".utf8), maxTotal: 8) // +5 → 10 > 8
+        let result = reassembler
+            .feed(opcode: 0x00, isFinal: true, payload: Data("world".utf8), maxTotal: 8) // +5 → 10 > 8
         guard case .protocolError = result else {
             return XCTFail("exceeding the total reassembled size bound must be a protocol error")
         }
@@ -847,30 +864,62 @@ final class WebSocketServerTests: XCTestCase {
 
         // Admissible: a fresh single/opening data frame within the cap.
         XCTAssertEqual(
-            WebSocketConnection.preReadDataFrameDecision(opcode: 0x01, declaredPayloadLength: 100, inProgressOpcode: nil, alreadyBuffered: 0),
+            WebSocketConnection.preReadDataFrameDecision(
+                opcode: 0x01,
+                declaredPayloadLength: 100,
+                inProgressOpcode: nil,
+                alreadyBuffered: 0
+            ),
             Decision.read
         )
         // Admissible: a continuation that fits the remaining budget exactly.
         XCTAssertEqual(
-            WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 4, inProgressOpcode: 0x01, alreadyBuffered: 6, maxTotal: 10),
+            WebSocketConnection.preReadDataFrameDecision(
+                opcode: 0x00,
+                declaredPayloadLength: 4,
+                inProgressOpcode: 0x01,
+                alreadyBuffered: 6,
+                maxTotal: 10
+            ),
             Decision.read
         )
 
         // The Codex vector: a new data frame declared while a fragment is open —
         // illegal, and must be rejected before its ~64 MiB payload is read.
-        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x02, declaredPayloadLength: max, inProgressOpcode: 0x01, alreadyBuffered: Int(max)) else {
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(
+            opcode: 0x02,
+            declaredPayloadLength: max,
+            inProgressOpcode: 0x01,
+            alreadyBuffered: Int(max)
+        ) else {
             return XCTFail("a new data frame while a fragment is open must be rejected pre-read")
         }
         // A continuation that would overflow the total budget — rejected pre-read.
-        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 5, inProgressOpcode: 0x01, alreadyBuffered: 6, maxTotal: 10) else {
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(
+            opcode: 0x00,
+            declaredPayloadLength: 5,
+            inProgressOpcode: 0x01,
+            alreadyBuffered: 6,
+            maxTotal: 10
+        ) else {
             return XCTFail("an over-budget continuation must be rejected pre-read")
         }
         // A continuation with no message in progress — rejected pre-read.
-        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x00, declaredPayloadLength: 1, inProgressOpcode: nil, alreadyBuffered: 0) else {
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(
+            opcode: 0x00,
+            declaredPayloadLength: 1,
+            inProgressOpcode: nil,
+            alreadyBuffered: 0
+        ) else {
             return XCTFail("an orphan continuation must be rejected pre-read")
         }
         // A single data frame larger than the whole cap — rejected pre-read.
-        guard case .reject = WebSocketConnection.preReadDataFrameDecision(opcode: 0x01, declaredPayloadLength: max + 1, inProgressOpcode: nil, alreadyBuffered: 0) else {
+        guard case .reject = WebSocketConnection.preReadDataFrameDecision(
+            opcode: 0x01,
+            declaredPayloadLength: max + 1,
+            inProgressOpcode: nil,
+            alreadyBuffered: 0
+        ) else {
             return XCTFail("an over-cap opening frame must be rejected pre-read")
         }
     }
@@ -1096,7 +1145,10 @@ final class WebSocketServerTests: XCTestCase {
         }
         wait(for: [received], timeout: 15)
 
-        let response = try XCTUnwrap(responseBox.value, "a frame pipelined with the upgrade must be delivered, not dropped (issue #5678)")
+        let response = try XCTUnwrap(
+            responseBox.value,
+            "a frame pipelined with the upgrade must be delivered, not dropped (issue #5678)"
+        )
         XCTAssertEqual(response["requestId"] as? String, "pipelined-1")
         XCTAssertEqual(response["success"] as? Bool, true)
     }
@@ -1183,7 +1235,11 @@ final class WebSocketServerTests: XCTestCase {
         }
         wait(for: [received], timeout: 20)
 
-        XCTAssertEqual(seenBox.value, Set(ids), "every frame pipelined in the same segment must be delivered, not just the first")
+        XCTAssertEqual(
+            seenBox.value,
+            Set(ids),
+            "every frame pipelined in the same segment must be delivered, not just the first"
+        )
     }
 
     // MARK: - Client presence gating (#5477)
@@ -1699,7 +1755,10 @@ private final class RawWebSocketClient: @unchecked Sendable {
 
     /// Sends one client→server frame, masked as §5.3 requires.
     func sendFrame(opcode: UInt8, fin: Bool, payload: Data) {
-        connection.send(content: Self.maskedFrame(opcode: opcode, fin: fin, payload: payload), completion: .contentProcessed { _ in })
+        connection.send(
+            content: Self.maskedFrame(opcode: opcode, fin: fin, payload: payload),
+            completion: .contentProcessed { _ in }
+        )
     }
 
     /// Polls parsed server frames until one decodes to a JSON object satisfying
@@ -1707,7 +1766,9 @@ private final class RawWebSocketClient: @unchecked Sendable {
     func waitForMessage(
         timeout: TimeInterval,
         where predicate: ([String: Any]) -> Bool
-    ) throws -> [String: Any] {
+    )
+        throws -> [String: Any]
+    {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if let object = nextMatchingMessage(predicate) {
@@ -1794,7 +1855,8 @@ private final class RawWebSocketClient: @unchecked Sendable {
 
             if opcode == 0x01 || opcode == 0x02 {
                 if let object = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
-                   predicate(object) {
+                   predicate(object)
+                {
                     return object
                 }
             }

--- a/scripts/check-ios-ctrl-proxy-process-boundary.ts
+++ b/scripts/check-ios-ctrl-proxy-process-boundary.ts
@@ -1,18 +1,12 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import ts from "typescript";
+import { executionBoundaryAst } from "./lib/executionBoundaryAst";
 
 const SOURCE_ROOT = "src";
 const OWNER = "src/utils/ios/IOSCtrlProxyProcessClient.ts";
 const PROCESS_TOOLS = new Set(["ps", "pgrep", "kill", "lsof"]);
-const EXECUTION_METHODS = new Set([
-  "exec",
-  "execFile",
-  "execFileSync",
-  "executeCommand",
-  "spawn",
-  "spawnSync",
-]);
+const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]);
 const EXCEPTIONS = new Map<string, string>([
   [
     "src/features/performance/PerformanceMonitor.ts",
@@ -38,26 +32,14 @@ function sourceFiles(directory: string): string[] {
   });
 }
 
-function commandFromCall(node: ts.CallExpression): string | null {
-  const firstArgument = node.arguments[0];
-  if (ts.isStringLiteral(firstArgument)) {
-    return firstArgument.text;
-  }
-  if (ts.isArrayLiteralExpression(firstArgument) && ts.isStringLiteral(firstArgument.elements[0])) {
-    return firstArgument.elements[0].text;
-  }
-  return null;
+function commandName(value: string): string {
+  return value.split(/[\\/]/).at(-1)?.toLowerCase() ?? "";
 }
 
-function executesProcessTool(node: ts.CallExpression): boolean {
-  const expression = node.expression;
-  if (ts.isIdentifier(expression)) {
-    return EXECUTION_METHODS.has(expression.text) && PROCESS_TOOLS.has(commandFromCall(node) ?? "");
-  }
-  if (!ts.isPropertyAccessExpression(expression) || !EXECUTION_METHODS.has(expression.name.text)) {
-    return false;
-  }
-  return PROCESS_TOOLS.has(commandFromCall(node) ?? "");
+function shellTextExecutesProcessTool(value: string): boolean {
+  return [...PROCESS_TOOLS].some((tool) =>
+    new RegExp(`(?:^|[\\s;&|])(?:[^\\s;&|]*[/\\\\])?${tool}(?:\\s|$)`, "i").test(value),
+  );
 }
 
 export function findViolationsInSource(file: string, source: string): Violation[] {
@@ -68,22 +50,35 @@ export function findViolationsInSource(file: string, source: string): Violation[
     true,
     ts.ScriptKind.TS,
   );
+  const ast = executionBoundaryAst(source);
   const violations: Violation[] = [];
-  const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && executesProcessTool(node)) {
-      const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-        node.getStart(sourceFile),
-      );
-      violations.push({
-        file,
-        line: line + 1,
-        column: character + 1,
-        text: node.getText(sourceFile),
-      });
+  for (const node of ast.calls) {
+    if (!ast.isLauncher(node) && !ast.isExecutionSeam(node)) {
+      continue;
     }
-    ts.forEachChild(node, visit);
-  };
-  visit(sourceFile);
+    const first = node.arguments[0];
+    const arrayCommands =
+      ast
+        .arrayAlternatives(first)
+        ?.flatMap((items) => (items.length > 0 ? ast.strings(items[0]) : [])) ?? [];
+    const directCommands = [...ast.strings(first), ...arrayCommands];
+    const executesDirectly = directCommands.some((value) => PROCESS_TOOLS.has(commandName(value)));
+    const invokesShell = directCommands.some((value) => SHELLS.has(value.toLowerCase()));
+    const shellPayloads = node.arguments.slice(1).flatMap((argument) => ast.strings(argument));
+    const executesViaShell =
+      (invokesShell || ["exec", "execSync"].includes(ast.calleeName(node) ?? "")) &&
+      [...directCommands, ...shellPayloads].some(shellTextExecutesProcessTool);
+    if (!executesDirectly && !executesViaShell) {
+      continue;
+    }
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    violations.push({
+      file,
+      line: line + 1,
+      column: character + 1,
+      text: node.getText(sourceFile),
+    });
+  }
   return violations;
 }
 

--- a/scripts/check-no-new-direct-xcodebuild.sh
+++ b/scripts/check-no-new-direct-xcodebuild.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 base_ref="${1:-origin/main}"
 owner="src/utils/ios-cmdline-tools/XcodebuildClient.ts"
-violations=()
+changed_sources=()
 # shellcheck disable=SC1091 # Resolved relative to this script's location.
 source "$(dirname "${BASH_SOURCE[0]}")/lib/vcs-diff.sh"
 
@@ -15,23 +15,10 @@ if ! vcs_base_exists "$base_ref"; then
   exit 2
 fi
 
-quote_pattern=$'["`\x27]'
-direct_process_call='(spawn|spawnSync|execFile|execFileSync|exec|execSync)'
-pattern="(${direct_process_call}\\([^;]*xcodebuild|(const|let|var)[^;=]*=[^;]*${quote_pattern}xcodebuild[^;]*;[[:space:]]*${direct_process_call}\\()"
-
 while IFS= read -r file; do
   [[ "$file" == "$owner" || "$file" == test/* ]] && continue
-  added_lines="$(vcs_diff "$base_ref" "$file" | awk '/^\+[^+]/ { print substr($0, 2) }' | perl -0pe 's{/\*.*?\*/}{}gs; s{//[^\n]*}{}g' | tr '\n' ' ')"
-  [[ -z "$added_lines" ]] && continue
-  if grep -Eq "$pattern" <<<"$added_lines"; then
-    violations+=("$file")
-  fi
+  [[ -f "$file" ]] && changed_sources+=("$file")
 done < <(vcs_changed_files "$base_ref" src)
 
-if ((${#violations[@]})); then
-  printf '%s\n' "New production xcodebuild execution must go through XcodebuildClient:" >&2
-  printf '  %s\n' "${violations[@]}" >&2
-  exit 1
-fi
-
-printf '%s\n' "xcodebuild-boundary: no new direct production xcodebuild invocations."
+bun "$(dirname "${BASH_SOURCE[0]}")/check-no-new-direct-xcodebuild.ts" \
+  ${changed_sources[@]+"${changed_sources[@]}"}

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { executionBoundaryAst } from "./lib/executionBoundaryAst";
+
+export interface XcodebuildViolation {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly text: string;
+}
+
+const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]);
+
+function commandName(value: string): string {
+  return value.split(/[\\/]/).at(-1)?.toLowerCase() ?? "";
+}
+
+function containsXcodebuildCommand(value: string): boolean {
+  return /(?:^|[\s;&|])(?:[^\s;&|]*[/\\])?xcodebuild(?:\s|$)/i.test(value);
+}
+
+export function findDirectXcodebuildCalls(file: string, source: string): XcodebuildViolation[] {
+  if (!source.toLowerCase().includes("xcodebuild")) {
+    return [];
+  }
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const ast = executionBoundaryAst(source);
+  return ast.calls.flatMap((call) => {
+    if (!ast.isLauncher(call) && !ast.isExecutionSeam(call)) {
+      return [];
+    }
+    const first = call.arguments[0];
+    const arrayCommands =
+      ast
+        .arrayAlternatives(first)
+        ?.flatMap((items) => (items.length > 0 ? ast.strings(items[0]) : [])) ?? [];
+    const directValues = [...ast.strings(first), ...arrayCommands];
+    const direct = directValues.some((value) => commandName(value) === "xcodebuild");
+    const shell = directValues.some((value) => SHELLS.has(value.toLowerCase()));
+    const shellPayloads = call.arguments.slice(1).flatMap((argument) => ast.strings(argument));
+    const embedded =
+      (shell || ["exec", "execSync"].includes(ast.calleeName(call) ?? "")) &&
+      [...directValues, ...shellPayloads].some(containsXcodebuildCommand);
+    if (!direct && !embedded) {
+      return [];
+    }
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(call.getStart(sourceFile));
+    return [
+      {
+        file,
+        line: line + 1,
+        column: character + 1,
+        text: call.getText(sourceFile),
+      },
+    ];
+  });
+}
+
+if (import.meta.main) {
+  const violations = process.argv
+    .slice(2)
+    .flatMap((file) => findDirectXcodebuildCalls(file, readFileSync(file, "utf8")));
+  if (violations.length > 0) {
+    console.error("New production xcodebuild execution must go through XcodebuildClient:");
+    for (const violation of violations) {
+      console.error(`  ${violation.file}:${violation.line}:${violation.column}: ${violation.text}`);
+    }
+    process.exit(1);
+  }
+  console.log("xcodebuild-boundary: no new direct production xcodebuild invocations.");
+}

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -180,8 +180,8 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     isLauncherReference(node.arguments[0]);
   const isLauncherReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && launcherAliases.has(node.text)) ||
-    (ts.isPropertyAccessExpression(node) &&
-      PROCESS_LAUNCHERS.has(node.name.text) &&
+    ((ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+      PROCESS_LAUNCHERS.has(propertyName(node) ?? "") &&
       ts.isIdentifier(node.expression) &&
       childProcessNamespaces.has(node.expression.text)) ||
     isPromisifiedLauncher(node);
@@ -414,17 +414,21 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     calleeName: (call) => propertyName(call.expression),
     isLauncher: (call) =>
       (ts.isIdentifier(call.expression) && launcherAliases.has(call.expression.text)) ||
-      (ts.isPropertyAccessExpression(call.expression) &&
+      ((ts.isPropertyAccessExpression(call.expression) ||
+        ts.isElementAccessExpression(call.expression)) &&
+        propertyName(call.expression) !== undefined &&
         ((ts.isIdentifier(call.expression.expression) &&
           childProcessNamespaces.has(call.expression.expression.text) &&
-          PROCESS_LAUNCHERS.has(call.expression.name.text)) ||
-          (PROCESS_LAUNCHERS.has(call.expression.name.text) &&
+          PROCESS_LAUNCHERS.has(propertyName(call.expression) ?? "")) ||
+          (PROCESS_LAUNCHERS.has(propertyName(call.expression) ?? "") &&
             /(?:executor|host|process)/i.test(call.expression.expression.getText(sourceFile))) ||
-          ["execFile", "execFileSync", "execFileAsync"].includes(call.expression.name.text) ||
-          INJECTED_LAUNCHERS.has(call.expression.name.text) ||
+          ["execFile", "execFileSync", "execFileAsync"].includes(
+            propertyName(call.expression) ?? "",
+          ) ||
+          INJECTED_LAUNCHERS.has(propertyName(call.expression) ?? "") ||
           (ts.isIdentifier(call.expression.expression) &&
             call.expression.expression.text === "Bun" &&
-            ["spawn", "spawnSync"].includes(call.expression.name.text)))),
+            ["spawn", "spawnSync"].includes(propertyName(call.expression) ?? "")))),
     isExecutionSeam: (call) => isExecutionSeamReference(call.expression),
     isRunExecSeam: (call) => isRunExecSeamReference(call.expression),
     strings,

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -34,6 +34,13 @@ function propertyName(expression: ts.Expression): string | undefined {
   if (ts.isPropertyAccessExpression(expression)) {
     return expression.name.text;
   }
+  if (
+    ts.isElementAccessExpression(expression) &&
+    expression.argumentExpression &&
+    ts.isStringLiteralLike(expression.argumentExpression)
+  ) {
+    return expression.argumentExpression.text;
+  }
   return undefined;
 }
 
@@ -180,15 +187,16 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     isPromisifiedLauncher(node);
   const isExecutionSeamReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && executionSeamAliases.has(node.text)) ||
-    (ts.isPropertyAccessExpression(node) &&
-      (node.name.text === "executeCommand" ||
-        node.name.text === "runExecSeam" ||
-        (node.name.text === "execute" &&
+    ((ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+      (propertyName(node) === "executeCommand" ||
+        propertyName(node) === "runExecSeam" ||
+        (propertyName(node) === "execute" &&
           (node.expression.kind === ts.SyntaxKind.ThisKeyword ||
             /(?:executor|host|process|deps)/i.test(node.expression.getText(sourceFile))))));
   const isRunExecSeamReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && runExecSeamAliases.has(node.text)) ||
-    (ts.isPropertyAccessExpression(node) && node.name.text === "runExecSeam");
+    ((ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
+      propertyName(node) === "runExecSeam");
   let changed = true;
   while (changed) {
     changed = false;

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -138,61 +138,10 @@ Environment variables:
 EOF
 }
 
-list_ctrl_proxy_ios_xcodebuild_pids() {
-  pgrep -f "xcodebuild.*test.*CtrlProxy" 2>/dev/null || true
-}
-
-process_parent_pid() {
-  local pid="$1"
-  ps -o ppid= -p "${pid}" 2>/dev/null | tr -d ' ' || true
-}
-
 kill_ctrl_proxy_ios_xcodebuild_processes() {
-  local mode="${1:-all}"
-  local pid
-  local pids=()
-
-  while IFS= read -r pid; do
-    if [[ -z "${pid}" ]]; then
-      continue
-    fi
-
-    if [[ "${mode}" == "orphaned" ]] && [[ "$(process_parent_pid "${pid}")" != "1" ]]; then
-      continue
-    fi
-
-    pids+=("${pid}")
-  done < <(list_ctrl_proxy_ios_xcodebuild_pids)
-
-  if [[ ${#pids[@]} -eq 0 ]]; then
-    return 0
-  fi
-
-  if [[ "${mode}" == "orphaned" ]]; then
-    log_info "Killing orphaned watcher-owned CtrlProxy iOS xcodebuild processes: ${pids[*]}"
-  else
-    log_info "Killing CtrlProxy iOS xcodebuild processes: ${pids[*]}"
-  fi
-
-  for pid in ${pids[@]+"${pids[@]}"}; do
-    kill "${pid}" 2>/dev/null || true
-  done
-
-  sleep 2
-
-  local still_running=()
-  for pid in ${pids[@]+"${pids[@]}"}; do
-    if kill -0 "${pid}" 2>/dev/null; then
-      still_running+=("${pid}")
-    fi
-  done
-
-  if [[ ${#still_running[@]} -gt 0 ]]; then
-    log_warn "Force killing CtrlProxy iOS xcodebuild processes: ${still_running[*]}"
-    for pid in "${still_running[@]}"; do
-      kill -9 "${pid}" 2>/dev/null || true
-    done
-  fi
+  # The sourced runner helper persists the exact watcher-owned PID. Never scan
+  # or signal other worktrees' or simulators' xcodebuild processes.
+  stop_ctrl_proxy_ios || true
 }
 
 # Kill any previous hot-reload processes
@@ -231,13 +180,10 @@ kill_previous() {
     fi
   fi
 
-  # Kill watcher-owned xcodebuild.*test.*CtrlProxy processes left behind when a
-  # watcher was SIGKILL'd. In daemon-owned mode, only clean orphaned processes
-  # so a live daemon-owned runner is not interrupted.
+  # Clean only the runner PID persisted by this watcher. In daemon-owned mode,
+  # do not touch any xcodebuild process.
   if [[ "${MANAGE_IOS_RUNNER}" == "true" ]]; then
-    kill_ctrl_proxy_ios_xcodebuild_processes all
-  else
-    kill_ctrl_proxy_ios_xcodebuild_processes orphaned
+    kill_ctrl_proxy_ios_xcodebuild_processes
   fi
 }
 

--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -257,7 +257,7 @@ stop_ctrl_proxy_ios() {
       log_warn "Refusing to stop recycled/non-CtrlProxy PID ${XCODEBUILD_PID}."
       XCODEBUILD_PID=""
       rm -f "${IOS_RUNNER_PID_FILE}"
-      return 1
+      return 0
     fi
   fi
   if [[ -n "${XCODEBUILD_PID}" ]] && kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then

--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -23,6 +23,7 @@
 # Runtime state
 XCODEBUILD_PID=""
 XCODEBUILD_LOG=""
+IOS_RUNNER_PID_FILE="${IOS_RUNNER_PID_FILE:-${PROJECT_ROOT}/scratch/ios-ctrl-proxy-runner.pid}"
 
 # Compute SHA256 hash from stdin
 hash_stream() {
@@ -165,7 +166,8 @@ get_xctestrun_path() {
   fi
 
   local xctestrun_file
-  xctestrun_file=$(find "${products_dir}" -maxdepth 1 -name "*.xctestrun" 2>/dev/null | head -1 || true)
+  xctestrun_file=$(find "${products_dir}" -maxdepth 1 -name "*.xctestrun" \
+    ! -name "automobile-runner-*.xctestrun" 2>/dev/null | head -1 || true)
   if [[ -n "${xctestrun_file}" ]]; then
     echo "${xctestrun_file}"
     return
@@ -179,6 +181,7 @@ start_ctrl_proxy_ios() {
   local simulator_id="$1"
   local port="${CTRL_PROXY_IOS_PORT:-8765}"
   local xctestrun_path
+  local runner_xctestrun_path
   xctestrun_path="$(get_xctestrun_path)"
 
   if [[ -z "${simulator_id}" ]]; then
@@ -187,60 +190,52 @@ start_ctrl_proxy_ios() {
   fi
 
   XCODEBUILD_LOG="${PROJECT_ROOT}/scratch/ios-ctrl-proxy.log"
-  local cmd=()
-
-  if [[ -n "${xctestrun_path}" ]]; then
-    log_info "Starting CtrlProxy iOS (test-without-building)..."
-    cmd=(
-      xcodebuild
-      test-without-building
-      -xctestrun "${xctestrun_path}"
-      -destination "id=${simulator_id}"
-      -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService
-      "CTRL_PROXY_IOS_PORT=${port}"
-      "AUTOMOBILE_DEVICE_ID=${simulator_id}"
-    )
-  else
-    log_info "Starting CtrlProxy iOS (xcodebuild test)..."
-    cmd=(
-      xcodebuild
-      test
-      -scheme CtrlProxyApp
-      -destination "id=${simulator_id}"
-      -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService
-      "CTRL_PROXY_IOS_PORT=${port}"
-      "AUTOMOBILE_DEVICE_ID=${simulator_id}"
-    )
+  if [[ -z "${xctestrun_path}" ]]; then
+    log_error "No CtrlProxy .xctestrun file found after build-for-testing."
+    return 1
   fi
 
+  stop_ctrl_proxy_ios
+
+  runner_xctestrun_path="$(dirname "${xctestrun_path}")/automobile-runner-${simulator_id}.xctestrun"
+  cp "${xctestrun_path}" "${runner_xctestrun_path}"
+  plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" \
+    -string "${port}" "${runner_xctestrun_path}"
+  plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" \
+    -string "${simulator_id}" "${runner_xctestrun_path}"
   if [[ -n "${CTRL_PROXY_IOS_BUNDLE_ID:-}" ]]; then
-    cmd+=("CTRL_PROXY_IOS_BUNDLE_ID=${CTRL_PROXY_IOS_BUNDLE_ID}")
+    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_BUNDLE_ID" \
+      -string "${CTRL_PROXY_IOS_BUNDLE_ID}" "${runner_xctestrun_path}"
   fi
   if [[ -n "${CTRL_PROXY_IOS_TIMEOUT:-}" ]]; then
-    cmd+=("CTRL_PROXY_IOS_TIMEOUT=${CTRL_PROXY_IOS_TIMEOUT}")
+    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_TIMEOUT" \
+      -string "${CTRL_PROXY_IOS_TIMEOUT}" "${runner_xctestrun_path}"
   fi
 
-  # Kill any orphaned xcodebuild.*test.*CtrlProxy (e.g. from a
-  # previous watcher that was SIGKILL'd before it could clean up its children).
-  local existing_pids
-  existing_pids=$(pgrep -f "xcodebuild.*test.*CtrlProxy" 2>/dev/null || true)
-  if [[ -n "${existing_pids}" ]]; then
-    log_info "Killing orphaned CtrlProxy iOS xcodebuild processes: ${existing_pids}"
-    echo "${existing_pids}" | xargs kill 2>/dev/null || true
-    sleep 2
-    # Force kill if still running
-    existing_pids=$(pgrep -f "xcodebuild.*test.*CtrlProxy" 2>/dev/null || true)
-    if [[ -n "${existing_pids}" ]]; then
-      log_warn "Force killing orphaned xcodebuild processes..."
-      echo "${existing_pids}" | xargs kill -9 2>/dev/null || true
-      sleep 1
-    fi
+  local cmd=(
+    xcodebuild
+    test-without-building
+    -xctestrun "${runner_xctestrun_path}"
+    -destination "id=${simulator_id}"
+    -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService
+  )
+  local runner_env=(
+    "CTRL_PROXY_IOS_PORT=${port}"
+    "AUTOMOBILE_DEVICE_ID=${simulator_id}"
+  )
+  if [[ -n "${CTRL_PROXY_IOS_BUNDLE_ID:-}" ]]; then
+    runner_env+=("CTRL_PROXY_IOS_BUNDLE_ID=${CTRL_PROXY_IOS_BUNDLE_ID}")
+  fi
+  if [[ -n "${CTRL_PROXY_IOS_TIMEOUT:-}" ]]; then
+    runner_env+=("CTRL_PROXY_IOS_TIMEOUT=${CTRL_PROXY_IOS_TIMEOUT}")
   fi
 
   echo "" >> "${XCODEBUILD_LOG}"
   echo "=== CtrlProxy iOS starting at $(date) ===" >> "${XCODEBUILD_LOG}"
-  (cd "${CTRL_PROXY_IOS_DIR}" && "${cmd[@]}") >> "${XCODEBUILD_LOG}" 2>&1 &
+  (cd "${CTRL_PROXY_IOS_DIR}" && exec env "${runner_env[@]}" "${cmd[@]}") \
+    >> "${XCODEBUILD_LOG}" 2>&1 &
   XCODEBUILD_PID=$!
+  printf '%s\n' "${XCODEBUILD_PID}" > "${IOS_RUNNER_PID_FILE}"
   log_info "CtrlProxy iOS started (PID ${XCODEBUILD_PID})"
   log_info "Logs: ${XCODEBUILD_LOG}"
   return 0
@@ -248,6 +243,23 @@ start_ctrl_proxy_ios() {
 
 # Stop CtrlProxy iOS process
 stop_ctrl_proxy_ios() {
+  if [[ -z "${XCODEBUILD_PID}" ]] && [[ -f "${IOS_RUNNER_PID_FILE}" ]]; then
+    XCODEBUILD_PID=$(cat "${IOS_RUNNER_PID_FILE}" 2>/dev/null || true)
+  fi
+  if [[ -n "${XCODEBUILD_PID}" ]] && ! [[ "${XCODEBUILD_PID}" =~ ^[0-9]+$ ]]; then
+    log_warn "Ignoring invalid CtrlProxy iOS runner PID: ${XCODEBUILD_PID}"
+    XCODEBUILD_PID=""
+  fi
+  if [[ -n "${XCODEBUILD_PID}" ]] && kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then
+    local command
+    command=$(ps -p "${XCODEBUILD_PID}" -o args= 2>/dev/null || true)
+    if [[ "${command}" != *"xcodebuild"* ]] || [[ "${command}" != *"CtrlProxy"* ]]; then
+      log_warn "Refusing to stop recycled/non-CtrlProxy PID ${XCODEBUILD_PID}."
+      XCODEBUILD_PID=""
+      rm -f "${IOS_RUNNER_PID_FILE}"
+      return 1
+    fi
+  fi
   if [[ -n "${XCODEBUILD_PID}" ]] && kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then
     log_info "Stopping CtrlProxy iOS (PID ${XCODEBUILD_PID})..."
     kill "${XCODEBUILD_PID}" 2>/dev/null || true
@@ -266,6 +278,7 @@ stop_ctrl_proxy_ios() {
     fi
   fi
   XCODEBUILD_PID=""
+  rm -f "${IOS_RUNNER_PID_FILE}"
 }
 
 # Watch for changes and rebuild/restart

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -21,6 +21,7 @@ import {
   IOSCtrlProxyClient,
   IOS_RUNNER_FEATURE_COMMANDS,
   IOS_RUNNER_FEATURE_FLAGS,
+  getRequiredIosRunnerFeatureFlags,
 } from "../../features/observe/ios/IOSCtrlProxyClient";
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
 import type { CtrlProxyHierarchy } from "../../features/observe/ios/types";
@@ -919,7 +920,7 @@ function classifyRunner(
     const advertised = new Set(inspection.supportedCommands);
     missingCommands = IOS_RUNNER_FEATURE_COMMANDS.filter((command) => !advertised.has(command));
     const advertisedFeatures = new Set(inspection.supportedFeatures ?? []);
-    missingFeatures = IOS_RUNNER_FEATURE_FLAGS.filter(
+    missingFeatures = getRequiredIosRunnerFeatureFlags().filter(
       (feature) => !advertisedFeatures.has(feature),
     );
     status = missingCommands.length === 0 && missingFeatures.length === 0 ? "compatible" : "stale";

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -20,6 +20,7 @@ import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import {
   IOSCtrlProxyClient,
   IOS_RUNNER_FEATURE_COMMANDS,
+  IOS_RUNNER_FEATURE_FLAGS,
 } from "../../features/observe/ios/IOSCtrlProxyClient";
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
 import type { CtrlProxyHierarchy } from "../../features/observe/ios/types";
@@ -32,7 +33,7 @@ import {
 
 // Re-exported so doctor consumers (and tests) can reference the feature command
 // set without reaching into the runner client module.
-export { IOS_RUNNER_FEATURE_COMMANDS };
+export { IOS_RUNNER_FEATURE_COMMANDS, IOS_RUNNER_FEATURE_FLAGS };
 
 const MIN_XCODE_VERSION = "15.0";
 
@@ -52,6 +53,8 @@ export interface IosRunnerInspection {
   running: boolean;
   /** Advertised command set, or null when the runner could not be reached. */
   supportedCommands: string[] | null;
+  /** Advertised non-command feature set, or null for an older/unreachable runner. */
+  supportedFeatures: string[] | null;
 }
 
 /** Source of booted-simulator runner identities (injectable for tests). */
@@ -126,6 +129,7 @@ interface IosRunnerManager {
  */
 interface IosRunnerProbeClient {
   getSupportedCommands(): Promise<string[] | null>;
+  getSupportedFeatures(): Promise<string[] | null>;
   close(): Promise<void>;
 }
 
@@ -206,6 +210,7 @@ export function createIosCtrlProxyRunnerInspector(
         const running = installed ? await manager.isRunning() : false;
 
         let supportedCommands: string[] | null = null;
+        let supportedFeatures: string[] | null = null;
         if (running) {
           // Don't disturb a client someone else owns (e.g. the daemon's live
           // session): if one already exists, read through it and leave its
@@ -216,6 +221,7 @@ export function createIosCtrlProxyRunnerInspector(
           const probe = existing ?? hooks.createClient(device);
           try {
             supportedCommands = await probe.getSupportedCommands();
+            supportedFeatures = await probe.getSupportedFeatures();
           } catch (error) {
             // Treated as an unreachable runner (versionStatus=unknown), not a hard
             // failure: doctor still reports installed/running for the simulator.
@@ -236,6 +242,7 @@ export function createIosCtrlProxyRunnerInspector(
           installed,
           running,
           supportedCommands,
+          supportedFeatures,
         });
       }
       return inspections;
@@ -890,6 +897,7 @@ export async function checkBootedSimulators(
 interface IosRunnerClassification {
   status: IosRunnerVersionStatus;
   missingCommands: string[];
+  missingFeatures: string[];
   line: string;
 }
 
@@ -899,6 +907,7 @@ function classifyRunner(
 ): IosRunnerClassification {
   let status: IosRunnerVersionStatus;
   let missingCommands: string[] = [];
+  let missingFeatures: string[] = [];
 
   if (!inspection.installed) {
     status = "unknown";
@@ -909,7 +918,11 @@ function classifyRunner(
   } else {
     const advertised = new Set(inspection.supportedCommands);
     missingCommands = IOS_RUNNER_FEATURE_COMMANDS.filter((command) => !advertised.has(command));
-    status = missingCommands.length === 0 ? "compatible" : "stale";
+    const advertisedFeatures = new Set(inspection.supportedFeatures ?? []);
+    missingFeatures = IOS_RUNNER_FEATURE_FLAGS.filter(
+      (feature) => !advertisedFeatures.has(feature),
+    );
+    status = missingCommands.length === 0 && missingFeatures.length === 0 ? "compatible" : "stale";
   }
 
   const parts = [
@@ -923,8 +936,11 @@ function classifyRunner(
   if (missingCommands.length > 0) {
     parts.push(`missingCommands=${missingCommands.join(",")}`);
   }
+  if (missingFeatures.length > 0) {
+    parts.push(`missingFeatures=${missingFeatures.join(",")}`);
+  }
 
-  return { status, missingCommands, line: parts.join("; ") };
+  return { status, missingCommands, missingFeatures, line: parts.join("; ") };
 }
 
 interface IosObserveRoundTripClassification {

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -85,7 +85,7 @@ export abstract class DeviceServiceClient {
   // the socket eventually resolves; a wedged handshake would otherwise keep
   // isConnecting true until connectionTimeoutMs, stalling a fresh-port connect
   // by up to ~5s. Cleared to null the moment the handshake terminates. (#5656)
-  private pendingConnectAbort: (() => void) | null = null;
+  private pendingConnectAbort: { socket: WebSocket; abort: () => void } | null = null;
 
   // Auto-reconnection state
   protected autoReconnectEnabled: boolean = true;
@@ -318,10 +318,16 @@ export abstract class DeviceServiceClient {
    * is in flight. (#5656)
    */
   protected abortPendingConnect(): void {
-    const abort = this.pendingConnectAbort;
-    if (abort) {
+    const pending = this.pendingConnectAbort;
+    if (pending) {
       this.pendingConnectAbort = null;
-      abort();
+      pending.abort();
+    }
+  }
+
+  private clearPendingConnectAbort(socket: WebSocket): void {
+    if (this.pendingConnectAbort?.socket === socket) {
+      this.pendingConnectAbort = null;
     }
   }
 
@@ -431,7 +437,7 @@ export abstract class DeviceServiceClient {
             const ws = this.webSocketFactory(wsUrl);
             this.lifecycleSocket = ws;
             const connectionTimeout = this.timer.setTimeout(() => {
-              this.pendingConnectAbort = null;
+              this.clearPendingConnectAbort(ws);
               ws.close();
               reject(new Error("WebSocket connection timeout"));
             }, this.config.connectionTimeoutMs);
@@ -440,29 +446,32 @@ export abstract class DeviceServiceClient {
             // (close()/updatePort()) can abort it eagerly. A socket stuck in
             // CONNECTING emits neither "open" nor "error", so the generation
             // guard in the handlers below would never run for it. (#5656)
-            this.pendingConnectAbort = () => {
-              this.timer.clearTimeout(connectionTimeout);
-              // Detach lifecycle listeners before closing so the aborted
-              // socket's delayed close/error cannot mutate state for the
-              // replacement connect; keep a lone swallowing error listener so a
-              // mid-handshake error cannot throw and crash the daemon.
-              try {
-                this.clearLifecycleSocket(ws);
-                ws.removeAllListeners();
-                ws.on("error", (error) => {
-                  logger.debug(`[${this.logTag}] Ignoring error on aborted WebSocket: ${error}`);
-                });
-                ws.close();
-              } catch (error) {
-                // The socket may already be closing; nothing else to clean up.
-                logger.debug(`[${this.logTag}] Error closing aborted WebSocket: ${error}`);
-              }
-              this.isConnecting = false;
-              resolve(false);
+            this.pendingConnectAbort = {
+              socket: ws,
+              abort: () => {
+                this.timer.clearTimeout(connectionTimeout);
+                // Detach lifecycle listeners before closing so the aborted
+                // socket's delayed close/error cannot mutate state for the
+                // replacement connect; keep a lone swallowing error listener so a
+                // mid-handshake error cannot throw and crash the daemon.
+                try {
+                  this.clearLifecycleSocket(ws);
+                  ws.removeAllListeners();
+                  ws.on("error", (error) => {
+                    logger.debug(`[${this.logTag}] Ignoring error on aborted WebSocket: ${error}`);
+                  });
+                  ws.close();
+                } catch (error) {
+                  // The socket may already be closing; nothing else to clean up.
+                  logger.debug(`[${this.logTag}] Error closing aborted WebSocket: ${error}`);
+                }
+                this.isConnecting = false;
+                resolve(false);
+              },
             };
 
             ws.on("open", () => {
-              this.pendingConnectAbort = null;
+              this.clearPendingConnectAbort(ws);
               this.timer.clearTimeout(connectionTimeout);
               if (generation !== this.connectionGeneration) {
                 // close() or updatePort() ran while this connection was mid-handshake.
@@ -514,7 +523,7 @@ export abstract class DeviceServiceClient {
             });
 
             ws.on("error", (error) => {
-              this.pendingConnectAbort = null;
+              this.clearPendingConnectAbort(ws);
               this.timer.clearTimeout(connectionTimeout);
               logger.warn(`[${this.logTag}] WebSocket error: ${error.message}`);
               this.isConnecting = false;
@@ -522,11 +531,11 @@ export abstract class DeviceServiceClient {
             });
 
             ws.on("close", () => {
-              this.pendingConnectAbort = null;
               if (this.lifecycleSocket !== ws) {
                 logger.debug(`[${this.logTag}] Ignoring close from stale WebSocket`);
                 return;
               }
+              this.clearPendingConnectAbort(ws);
               this.lifecycleSocket = null;
               logger.info(`[${this.logTag}] WebSocket connection closed`);
               this.ws = null;

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -71,6 +71,8 @@ const DEFAULT_CONNECTION_CONFIG: ConnectionConfig = {
 export abstract class DeviceServiceClient {
   // Connection state
   protected ws: WebSocket | null = null;
+  /** Socket owning the current handshake/open lifecycle, used to reject delayed stale events. */
+  private lifecycleSocket: WebSocket | null = null;
   protected isConnecting: boolean = false;
   protected connectionAttempts: number = 0;
   protected lastConnectionAttempt: number = 0;
@@ -276,10 +278,11 @@ export abstract class DeviceServiceClient {
       // Cancel all pending requests
       this.requestManager.cancelAll(new Error("WebSocket connection closed"));
 
-      if (this.ws) {
+      const socket = this.ws ?? this.lifecycleSocket;
+      this.ws = null;
+      this.lifecycleSocket = null;
+      if (socket) {
         logger.info(`[${this.logTag}] Closing WebSocket connection`);
-        const socket = this.ws;
-        this.ws = null;
         // Detach the lifecycle listeners installed in connectWebSocket() BEFORE
         // closing, so the socket's async `close` event cannot drive a SECOND
         // onConnectionClosed() after the synchronous call below (issue #5657).
@@ -322,6 +325,12 @@ export abstract class DeviceServiceClient {
     }
   }
 
+  private clearLifecycleSocket(socket: WebSocket): void {
+    if (this.lifecycleSocket === socket) {
+      this.lifecycleSocket = null;
+    }
+  }
+
   // ===========================================================================
   // WebSocket connection (shared implementation)
   // ===========================================================================
@@ -344,12 +353,21 @@ export abstract class DeviceServiceClient {
     // Clean up stale WebSocket
     if (this.ws && this.ws.readyState !== WebSocket.OPEN) {
       logger.info(`[${this.logTag}] Cleaning up stale WebSocket (state: ${this.ws.readyState})`);
-      try {
-        this.ws.close();
-      } catch {
-        // Ignore close errors on stale socket
-      }
+      const staleSocket = this.ws;
       this.ws = null;
+      this.clearLifecycleSocket(staleSocket);
+      try {
+        // This socket may emit close/error after a replacement is installed.
+        // Detach its stateful lifecycle handlers before closing so those late
+        // events cannot tear down the replacement connection.
+        staleSocket.removeAllListeners();
+        staleSocket.on("error", (error) => {
+          logger.debug(`[${this.logTag}] Ignoring error on stale WebSocket: ${error}`);
+        });
+        staleSocket.close();
+      } catch (error) {
+        logger.debug(`[${this.logTag}] Error closing stale WebSocket: ${error}`);
+      }
     }
 
     // Connection already in progress - wait for it
@@ -411,6 +429,7 @@ export abstract class DeviceServiceClient {
         () =>
           new Promise<boolean>((resolve, reject) => {
             const ws = this.webSocketFactory(wsUrl);
+            this.lifecycleSocket = ws;
             const connectionTimeout = this.timer.setTimeout(() => {
               this.pendingConnectAbort = null;
               ws.close();
@@ -428,6 +447,7 @@ export abstract class DeviceServiceClient {
               // replacement connect; keep a lone swallowing error listener so a
               // mid-handshake error cannot throw and crash the daemon.
               try {
+                this.clearLifecycleSocket(ws);
                 ws.removeAllListeners();
                 ws.on("error", (error) => {
                   logger.debug(`[${this.logTag}] Ignoring error on aborted WebSocket: ${error}`);
@@ -454,6 +474,7 @@ export abstract class DeviceServiceClient {
                 // a spurious reconnect. Removing the listeners makes that a no-op.
                 logger.info(`[${this.logTag}] Discarding WebSocket opened after close`);
                 try {
+                  this.clearLifecycleSocket(ws);
                   ws.removeAllListeners();
                   // Keep a lone error listener: a discarded socket (e.g. dialing a
                   // dead old port) can still emit "error" during its close
@@ -502,12 +523,22 @@ export abstract class DeviceServiceClient {
 
             ws.on("close", () => {
               this.pendingConnectAbort = null;
+              if (this.lifecycleSocket !== ws) {
+                logger.debug(`[${this.logTag}] Ignoring close from stale WebSocket`);
+                return;
+              }
+              this.lifecycleSocket = null;
               logger.info(`[${this.logTag}] WebSocket connection closed`);
               this.ws = null;
               this.isConnecting = false;
 
               // Stop health check
               this.stopHealthCheck();
+
+              // The transport is known dead, so commands cannot receive a
+              // response. Settle them immediately rather than retaining their
+              // request state and timers until the command timeout expires.
+              this.requestManager.cancelAll(new Error("WebSocket connection closed"));
 
               // Platform-specific cleanup
               this.onConnectionClosed();

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -72,6 +72,8 @@ import {
   metadataForScreenshotFormat,
   type ScreenshotMetadata,
 } from "../ScreenshotMetadata";
+import { resolveAssetVersion, resolvePinnedVersion } from "../../../constants/release";
+import { compareStrictNumericVersions } from "../../../utils/deviceMatcher";
 
 /**
  * Factory function type for creating CtrlProxyIosManager instances.
@@ -471,8 +473,23 @@ export const IOS_RUNNER_FEATURE_COMMANDS = [
   "set_network_mock_rules",
 ] as const;
 
-/** Non-command wire capabilities required before the daemon claims a current runner. */
+/** Non-command wire capabilities advertised by runners built from this source revision. */
 export const IOS_RUNNER_FEATURE_FLAGS = ["display_cutout_info"] as const;
+
+// The immutable 0.0.66 IPA predates the feature handshake. Require the flag
+// only once the release pipeline cuts 0.0.67+ from source that advertises it.
+const IOS_RUNNER_FEATURE_FLAGS_MIN_RELEASE = "0.0.67";
+
+export function getRequiredIosRunnerFeatureFlags(
+  env: Record<string, string | undefined> = process.env,
+): readonly (typeof IOS_RUNNER_FEATURE_FLAGS)[number][] {
+  const artifactVersion = resolveAssetVersion(resolvePinnedVersion(env));
+  const comparison = compareStrictNumericVersions(
+    artifactVersion,
+    IOS_RUNNER_FEATURE_FLAGS_MIN_RELEASE,
+  );
+  return Number.isNaN(comparison) || comparison >= 0 ? IOS_RUNNER_FEATURE_FLAGS : [];
+}
 
 /**
  * IOSCtrlProxyClient - WebSocket client for iOS CtrlProxy

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -471,6 +471,9 @@ export const IOS_RUNNER_FEATURE_COMMANDS = [
   "set_network_mock_rules",
 ] as const;
 
+/** Non-command wire capabilities required before the daemon claims a current runner. */
+export const IOS_RUNNER_FEATURE_FLAGS = ["display_cutout_info"] as const;
+
 /**
  * IOSCtrlProxyClient - WebSocket client for iOS CtrlProxy
  * Provides iOS UI hierarchy and interaction capabilities matching Android IOSCtrlProxyClient
@@ -504,6 +507,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // Push update callbacks
   private onPushUpdateCallbacks: Set<(hierarchy: XCTestHierarchy) => void> = new Set();
   private supportedCommands: Set<string> | null = null;
+  private supportedFeatures: Set<string> | null = null;
 
   // Track last foreground bundle for performance monitoring
   private lastForegroundBundleId: string | null = null;
@@ -1241,6 +1245,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.cachedHierarchy = null;
     this.clearSdkScreenIdentity();
     this.supportedCommands = null;
+    this.supportedFeatures = null;
     this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
@@ -1792,6 +1797,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this.supportedCommands = Array.isArray(message.supportedCommands)
         ? new Set(message.supportedCommands)
         : null;
+      this.supportedFeatures = Array.isArray(message.supportedFeatures)
+        ? new Set(message.supportedFeatures)
+        : null;
       logger.info(`[IOSCtrlProxyClient] Received connected message`);
       return;
     }
@@ -1938,6 +1946,17 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   public getCachedSupportedCommands(): string[] | null {
     return this.supportedCommands === null ? null : Array.from(this.supportedCommands).sort();
+  }
+
+  /** Runner feature flags from the most recent connected handshake. */
+  public async getSupportedFeatures(): Promise<string[] | null> {
+    await this.getSupportedCommands();
+    return this.getCachedSupportedFeatures();
+  }
+
+  /** Connection-free feature view for status resources. */
+  public getCachedSupportedFeatures(): string[] | null {
+    return this.supportedFeatures === null ? null : Array.from(this.supportedFeatures).sort();
   }
 
   private buildUnsupportedCommandError(messageType: string): string {

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -56,12 +56,16 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
 
     case "screenshot":
       result = {
-        success: true,
+        // Successful ScreenshotResponse envelopes predate the shared success
+        // field and omit it, while CommandHandler failures use the same
+        // discriminator with success:false plus error. Preserve both shapes.
+        success: message.success ?? true,
         data: message.data,
         format: message.format ?? "png",
         timestamp: message.timestamp,
         frameContext: message.frameContext,
         rotation: message.rotation,
+        ...(message.error === undefined ? {} : { error: message.error }),
       };
       break;
 

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -130,6 +130,7 @@ export interface WebSocketMessage {
   requestId?: string;
   id?: number;
   supportedCommands?: string[];
+  supportedFeatures?: string[];
   data?: XCTestHierarchy;
   performanceData?: CtrlProxyPerformanceSnapshot;
   format?: string;

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -18,6 +18,7 @@ import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
 import {
   IOSCtrlProxyClient,
   IOS_RUNNER_FEATURE_COMMANDS,
+  IOS_RUNNER_FEATURE_FLAGS,
 } from "../features/observe/ios/IOSCtrlProxyClient";
 import { resolveApkChecksum, resolveIpaChecksum } from "../constants/release";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -61,6 +62,8 @@ export interface DeviceServiceStatus {
    * always-true. null when the runner has not handshaked (identity unknown).
    */
   supportedCommandsComplete?: boolean | null;
+  /** iOS only: whether all required non-command runner features are advertised. */
+  supportedFeaturesComplete?: boolean | null;
 }
 
 interface DeviceIdentity {
@@ -76,7 +79,12 @@ interface DeviceReadiness {
 interface DeviceCapabilities {
   automation: Pick<
     DeviceServiceStatus,
-    "installed" | "enabled" | "running" | "isCompatible" | "supportedCommandsComplete"
+    | "installed"
+    | "enabled"
+    | "running"
+    | "isCompatible"
+    | "supportedCommandsComplete"
+    | "supportedFeaturesComplete"
   > | null;
 }
 
@@ -606,6 +614,7 @@ function withServiceStatus(
         running: serviceStatus.running,
         isCompatible: serviceStatus.isCompatible,
         supportedCommandsComplete: serviceStatus.supportedCommandsComplete,
+        supportedFeaturesComplete: serviceStatus.supportedFeaturesComplete,
       },
     },
   };
@@ -742,6 +751,7 @@ async function queryDeviceServiceStatus(
       // `supportedCommands` handshake. Read it connection-free (this hot path must
       // not open a WebSocket); null means identity is unknown this fetch.
       let supportedCommandsComplete: boolean | null = null;
+      let supportedFeaturesComplete: boolean | null = null;
       if (running) {
         const client = IOSCtrlProxyClient.getExistingInstance(bootedDevice.deviceId);
         const cached = client?.getCachedSupportedCommands() ?? null;
@@ -749,6 +759,13 @@ async function queryDeviceServiceStatus(
           const advertised = new Set(cached);
           supportedCommandsComplete = IOS_RUNNER_FEATURE_COMMANDS.every((command) =>
             advertised.has(command),
+          );
+        }
+        const cachedFeatures = client?.getCachedSupportedFeatures() ?? null;
+        if (cachedFeatures !== null) {
+          const advertisedFeatures = new Set(cachedFeatures);
+          supportedFeaturesComplete = IOS_RUNNER_FEATURE_FLAGS.every((feature) =>
+            advertisedFeatures.has(feature),
           );
         }
       }
@@ -759,7 +776,9 @@ async function queryDeviceServiceStatus(
       // not-compatible rather than the previous always-true reassurance. An
       // unverifiable explicit pin is never compatible (#2746).
       const isCompatible =
-        supportedCommandsComplete === true && !IOSCtrlProxyBuilder.isPinnedVersionUnverifiable();
+        supportedCommandsComplete === true &&
+        supportedFeaturesComplete === true &&
+        !IOSCtrlProxyBuilder.isPinnedVersionUnverifiable();
 
       return {
         installed,
@@ -769,6 +788,7 @@ async function queryDeviceServiceStatus(
         expectedSha256,
         isCompatible,
         supportedCommandsComplete,
+        supportedFeaturesComplete,
       };
     }
   } catch (error) {

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -18,7 +18,7 @@ import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
 import {
   IOSCtrlProxyClient,
   IOS_RUNNER_FEATURE_COMMANDS,
-  IOS_RUNNER_FEATURE_FLAGS,
+  getRequiredIosRunnerFeatureFlags,
 } from "../features/observe/ios/IOSCtrlProxyClient";
 import { resolveApkChecksum, resolveIpaChecksum } from "../constants/release";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -761,10 +761,13 @@ async function queryDeviceServiceStatus(
             advertised.has(command),
           );
         }
+        const requiredFeatures = getRequiredIosRunnerFeatureFlags();
         const cachedFeatures = client?.getCachedSupportedFeatures() ?? null;
-        if (cachedFeatures !== null) {
+        if (requiredFeatures.length === 0) {
+          supportedFeaturesComplete = true;
+        } else if (cachedFeatures !== null) {
           const advertisedFeatures = new Set(cachedFeatures);
-          supportedFeaturesComplete = IOS_RUNNER_FEATURE_FLAGS.every((feature) =>
+          supportedFeaturesComplete = requiredFeatures.every((feature) =>
             advertisedFeatures.has(feature),
           );
         }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1265,6 +1265,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // Stop iproxy tunnel if running
     await this.stopIproxyTunnel({ clearDevicePort: true });
 
+    let runnerTerminationError: unknown;
     if (this.xcTestProcessId) {
       try {
         if (await this.isOwnRunnerProcessAlive()) {
@@ -1276,18 +1277,27 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           );
         }
       } catch (error) {
+        runnerTerminationError = error;
         logger.warn(
           `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${this.xcTestProcessId}: ` +
             `${errorMessage(error)}`,
         );
       }
-      this.xcTestProcessId = null;
-      this.xcTestProcess = null;
+      if (runnerTerminationError === undefined) {
+        this.xcTestProcessId = null;
+        this.xcTestProcess = null;
+      }
     }
 
     this.clearCaches();
-    PortManager.release(this.device.deviceId);
     this.isStopping = false;
+    if (runnerTerminationError !== undefined) {
+      throw new ActionableError(
+        `Failed to stop iOS CtrlProxy runner ${this.xcTestProcessId}: ` +
+          `${errorMessage(runnerTerminationError)}`,
+      );
+    }
+    PortManager.release(this.device.deviceId);
     logger.info("[IOSCtrlProxy] Service stopped");
   }
 
@@ -2382,7 +2392,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `[IOSCtrlProxy] Terminating stale CtrlProxy process tree rooted at ${rootPid} ` +
               `for listener ${process.pid} on port ${this.servicePort}`,
           );
-          await this.processClient.terminateProcessTree(rootPid);
+          await this.processClient.terminateProcessTree(rootPid).catch((error) => {
+            logger.warn(
+              `[IOSCtrlProxy] Stale runner tree ${rootPid} survived termination: ${errorMessage(error)}`,
+            );
+          });
         }
 
         const remainingProcesses = await this.findListeningProcessesOnPort(this.servicePort);
@@ -2398,7 +2412,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
               `[IOSCtrlProxy] CtrlProxy listener ${process.pid} still holds port ${this.servicePort}; ` +
                 `force-terminating remaining owned process tree`,
             );
-            await this.processClient.terminateProcessTree(process.pid);
+            await this.processClient.terminateProcessTree(process.pid).catch((error) => {
+              logger.warn(
+                `[IOSCtrlProxy] Listener ${process.pid} survived forced termination: ${errorMessage(error)}`,
+              );
+            });
           }
         }
 
@@ -2833,11 +2851,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     });
 
     child.on("error", (error) => {
+      if (this.xcTestProcess !== child) {
+        logger.debug(
+          `[IOSCtrlProxy] Ignoring error from stale xcodebuild PID ${child.pid ?? "unknown"}`,
+        );
+        return;
+      }
       logger.warn(`[IOSCtrlProxy] xcodebuild test error: ${error.message}`);
       this.handleProcessExit();
     });
 
     child.on("exit", (code, signal) => {
+      if (this.xcTestProcess !== child) {
+        logger.debug(
+          `[IOSCtrlProxy] Ignoring exit from stale xcodebuild PID ${child.pid ?? "unknown"}`,
+        );
+        return;
+      }
       if (code !== 0 || signal) {
         logger.warn(`[IOSCtrlProxy] xcodebuild test exited: code=${code}, signal=${signal}`);
       }

--- a/src/utils/ProcessSupervisor.ts
+++ b/src/utils/ProcessSupervisor.ts
@@ -31,16 +31,19 @@ export class DefaultProcessSupervisor implements ProcessSupervisor {
   private restartAttempts = 0;
   private isStopping = false;
   private autoRestartEnabled = true;
+  private lifecycleGeneration = 0;
 
   public constructor(private readonly options: ProcessSupervisorOptions) {}
 
   public async start(): Promise<void> {
     this.isStopping = false;
+    this.lifecycleGeneration++;
     this.startMonitoring();
   }
 
   public stop(): void {
     this.isStopping = true;
+    this.lifecycleGeneration++;
     this.stopMonitoring();
     this.clearRestartTimeout();
     this.restartAttempts = 0;
@@ -76,8 +79,9 @@ export class DefaultProcessSupervisor implements ProcessSupervisor {
 
   private startMonitoring(): void {
     this.stopMonitoring();
+    const generation = this.lifecycleGeneration;
     this.monitorInterval = this.options.timer.setInterval(() => {
-      void this.checkLiveness();
+      void this.checkLiveness(generation);
     }, this.options.monitorIntervalMs);
   }
 
@@ -88,9 +92,13 @@ export class DefaultProcessSupervisor implements ProcessSupervisor {
     }
   }
 
-  private async checkLiveness(): Promise<void> {
+  private async checkLiveness(generation: number): Promise<void> {
     try {
-      if (!(await this.options.isAlive())) {
+      const isAlive = await this.options.isAlive();
+      if (generation !== this.lifecycleGeneration || this.isStopping) {
+        return;
+      }
+      if (!isAlive) {
         logger.warn(`[ProcessSupervisor] ${this.options.name} is no longer alive`);
         this.processExited();
       }

--- a/src/utils/ProcessSupervisor.ts
+++ b/src/utils/ProcessSupervisor.ts
@@ -54,6 +54,9 @@ export class DefaultProcessSupervisor implements ProcessSupervisor {
   }
 
   private async handleProcessExit(): Promise<void> {
+    // Invalidate every probe started under the exited process before awaiting
+    // cleanup or installing a replacement monitor.
+    this.lifecycleGeneration++;
     this.stopMonitoring();
     await this.options.onExit?.();
 

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -6,6 +6,7 @@ import { createExecResult } from "../execResult";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { getAbortSignal } from "../AbortContext";
 import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../runnerReadinessConfig";
+import { waitForSpawn } from "../ChildProcessTracker";
 
 export interface XcodebuildCommandOptions {
   timeoutMs?: number;
@@ -182,6 +183,15 @@ export class XcodebuildClient implements Xcodebuild {
       shell: false,
       signal,
     });
+
+    try {
+      // Attach the error listener before inspecting pid. A real failed spawn
+      // reports asynchronously; throwing first would leave that error event
+      // unhandled and crash the daemon after this promise rejects.
+      await waitForSpawn(child);
+    } catch (error) {
+      throw new ActionableError(`xcodebuild failed to start: ${String(error)}`);
+    }
 
     if (!child.pid) {
       child.kill();

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -193,7 +193,9 @@ export class IOSCtrlProxyProcessClient {
     }
     await this.signalGroup(pid, "KILL", deadline);
     await this.signalPids(targets, "KILL", deadline);
-    await this.waitForExit([pid, ...descendants], deadline);
+    if (!(await this.waitForExit([pid, ...descendants], deadline))) {
+      throw new Error(`CtrlProxy process tree rooted at PID ${pid} remained alive after SIGKILL`);
+    }
   }
 
   async terminateProcess(pid: number): Promise<void> {

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -4,7 +4,10 @@ setup() {
   repo_dir="$(mktemp -d)"
   mkdir -p "$repo_dir/scripts/lib" "$repo_dir/src/utils/ios-cmdline-tools"
   cp "$BATS_TEST_DIRNAME/../../scripts/check-no-new-direct-xcodebuild.sh" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/check-no-new-direct-xcodebuild.ts" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/executionBoundaryAst.ts" "$repo_dir/scripts/lib/"
   cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
+  ln -s "$BATS_TEST_DIRNAME/../../node_modules" "$repo_dir/node_modules"
   touch "$repo_dir/src/utils/ios-cmdline-tools/XcodebuildClient.ts"
   git -C "$repo_dir" init -q
   git -C "$repo_dir" config user.email test@example.com
@@ -80,6 +83,26 @@ teardown() {
 
 @test "rejects an xcodebuild executable variable" {
   printf '%s\n' 'const executable = "xcodebuild";' 'spawn(executable, ["test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects an aliased child-process import" {
+  printf '%s\n' 'import { spawn as launch } from "node:child_process";' 'launch("xcodebuild", ["test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects an injected execution seam" {
+  printf '%s\n' 'const command = "xcodebuild";' 'executor["executeCommand"](command, ["test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
 
   run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -111,6 +111,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a computed child-process launcher" {
+  printf '%s\n' 'import * as cp from "node:child_process";' 'cp["spawn"]("xcodebuild", ["test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "allows XcodebuildClient to own direct execution" {
   printf '%s\n' 'spawn("xcodebuild", ["test"]);' > "$repo_dir/src/utils/ios-cmdline-tools/XcodebuildClient.ts"
   git -C "$repo_dir" add src/utils/ios-cmdline-tools/XcodebuildClient.ts

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -175,3 +175,22 @@ PY
   run grep -E 'xcpretty --color.*\|\| true' "${repository_root}/scripts/ios/ctrl-proxy-build-for-testing.sh"
   [ "$status" -eq 1 ]
 }
+
+@test "a recycled watcher PID is cleared without blocking replacement startup" {
+  local repository_root
+  repository_root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  runner_pid_file="${TEST_ROOT}/runner.pid"
+  printf '%s\n' "$$" > "${runner_pid_file}"
+
+  run env PROJECT_ROOT="${TEST_ROOT}" CTRL_PROXY_IOS_DIR="${TEST_ROOT}" \
+    IOS_RUNNER_PID_FILE="${runner_pid_file}" bash -c '
+      source "$1"
+      kill() { return 0; }
+      ps() { printf "%s\n" "unrelated-process"; }
+      log_warn() { :; }
+      stop_ctrl_proxy_ios
+    ' _ "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "${runner_pid_file}" ]
+}

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -151,6 +151,18 @@ PY
   run grep -F 'CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
   [ "$status" -eq 0 ]
 
+  run grep -F 'automobile-runner-${simulator_id}.xctestrun' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'IOS_RUNNER_PID_FILE' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'pgrep -f "xcodebuild.*test.*CtrlProxy"' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh" "${repository_root}/scripts/local-dev/hot-reload.sh"
+  [ "$status" -eq 1 ]
+
   run grep -E '^[[:space:]]*nohup xcodebuild test([[:space:]]|$)' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
   [ "$status" -eq 1 ]
 

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -756,14 +756,14 @@ describe("checkIosCtrlProxyRunner", () => {
     expect(result.recommendation).not.toContain("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH");
   });
 
-  test("warns when a released runner lacks a current non-command feature", async () => {
+  test("accepts the immutable 0.0.66 runner before the feature handshake release", async () => {
     const result = await checkIosCtrlProxyRunner(
       withRunners([inspection({ supportedFeatures: null })]),
     );
 
-    expect(result.status).toBe("warn");
-    expect(result.message).toContain("versionStatus=stale");
-    expect(result.message).toContain("missingFeatures=display_cutout_info");
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("versionStatus=compatible");
+    expect(result.message).not.toContain("missingFeatures");
   });
 
   test("reports unknown when the runner is installed but not running", async () => {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -16,6 +16,7 @@ import {
   createIosObserveRoundTripInspector,
   createIosCtrlProxyRunnerInspector,
   IOS_RUNNER_FEATURE_COMMANDS,
+  IOS_RUNNER_FEATURE_FLAGS,
   runIosChecks,
 } from "../../src/doctor/checks/ios";
 import type {
@@ -688,6 +689,7 @@ describe("checkIosCtrlProxyRunner", () => {
     installed: true,
     running: true,
     supportedCommands: [...FRESH_COMMANDS],
+    supportedFeatures: [...IOS_RUNNER_FEATURE_FLAGS],
     ...over,
   });
 
@@ -752,6 +754,16 @@ describe("checkIosCtrlProxyRunner", () => {
     // derived-data output; DERIVED_DATA is the followable override (#4221).
     expect(result.recommendation).toContain("AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA");
     expect(result.recommendation).not.toContain("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH");
+  });
+
+  test("warns when a released runner lacks a current non-command feature", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([inspection({ supportedFeatures: null })]),
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("versionStatus=stale");
+    expect(result.message).toContain("missingFeatures=display_cutout_info");
   });
 
   test("reports unknown when the runner is installed but not running", async () => {
@@ -1012,6 +1024,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     let closes = 0;
     const probe = {
       getSupportedCommands: async () => [...IOS_RUNNER_FEATURE_COMMANDS],
+      getSupportedFeatures: async () => [...IOS_RUNNER_FEATURE_FLAGS],
       close: async () => {
         closes += 1;
       },
@@ -1030,6 +1043,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     const inspections = await inspector.inspectBootedRunners();
 
     expect(inspections[0].supportedCommands).toEqual([...IOS_RUNNER_FEATURE_COMMANDS]);
+    expect(inspections[0].supportedFeatures).toEqual([...IOS_RUNNER_FEATURE_FLAGS]);
     expect(closes).toBe(1);
   });
 
@@ -1037,6 +1051,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     let closes = 0;
     const existing = {
       getSupportedCommands: async () => [...IOS_RUNNER_FEATURE_COMMANDS],
+      getSupportedFeatures: async () => [...IOS_RUNNER_FEATURE_FLAGS],
       close: async () => {
         closes += 1;
       },
@@ -1068,6 +1083,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
       getSupportedCommands: async () => {
         throw new Error("unreachable");
       },
+      getSupportedFeatures: async () => null,
       close: async () => {
         closes += 1;
       },
@@ -1086,6 +1102,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     const inspections = await inspector.inspectBootedRunners();
 
     expect(inspections[0].supportedCommands).toBeNull();
+    expect(inspections[0].supportedFeatures).toBeNull();
     expect(closes).toBe(1);
   });
 });

--- a/test/fakes/FakeProcessExecutor.ts
+++ b/test/fakes/FakeProcessExecutor.ts
@@ -96,6 +96,9 @@ export class FakeProcessExecutor implements HostProcessExecutor {
     const process = this.nextSpawnProcess ?? new FakeChildProcess();
     this.nextSpawnProcess = null;
     this.spawnResponses.push({ command, args, options, process });
+    if (process instanceof FakeChildProcess) {
+      process.simulateSpawn();
+    }
     return process;
   }
 

--- a/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
@@ -156,6 +156,42 @@ describe("DeviceServiceClient close() single onConnectionClosed cycle (#5657)", 
     expect(client.isConnected()).toBe(true);
   });
 
+  test("a stale socket close cannot clear its replacement handshake abort", async () => {
+    const fakeTimer = new FakeTimer();
+    const sockets: FakeWebSocket[] = [];
+
+    client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      (url) => {
+        const socket = new FakeWebSocket(url, "timeout", 60_000, fakeTimer);
+        sockets.push(socket);
+        return socket;
+      },
+      fakeTimer,
+    );
+
+    const firstConnection = client.ensureConnected();
+    await flushSetImmediate();
+    sockets[0].emit("error", new Error("first connection failed"));
+    expect(await firstConnection).toBe(false);
+
+    const replacementConnection = client.ensureConnected();
+    await flushSetImmediate();
+    const lifecycle = client as unknown as {
+      pendingConnectAbort: { socket: FakeWebSocket } | null;
+    };
+    expect(lifecycle.pendingConnectAbort?.socket).toBe(sockets[1]);
+
+    sockets[0].emit("close");
+    expect(lifecycle.pendingConnectAbort?.socket).toBe(sockets[1]);
+
+    await client.close();
+    expect(await replacementConnection).toBe(false);
+    expect(sockets[1].readyState).toBe(WebSocketState.CLOSING);
+    client = null;
+  });
+
   test("unsolicited socket drop immediately rejects in-flight requests", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();

--- a/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientCloseSingleCycle.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { IOSCtrlProxyClient } from "../../../../src/features/observe/ios";
 import { BootedDevice } from "../../../../src/models";
-import { FakeWebSocket } from "../../../fakes/FakeWebSocket";
+import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import type { DeviceConnectionLostNotifier } from "../../../../src/features/observe/DeviceConnectionLostNotifier";
 
@@ -123,5 +123,67 @@ describe("DeviceServiceClient close() single onConnectionClosed cycle (#5657)", 
     await flushSetImmediate();
 
     expect(notifier.count).toBe(1);
+  });
+
+  test("a stale socket close cannot tear down its live replacement", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const sockets: FakeWebSocket[] = [];
+
+    client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      (url) => {
+        const socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+        sockets.push(socket);
+        return socket;
+      },
+      fakeTimer,
+    );
+
+    expect(await client.ensureConnected()).toBe(true);
+    const oldSocket = sockets[0];
+    oldSocket.readyState = WebSocketState.CLOSING;
+
+    expect(await client.ensureConnected()).toBe(true);
+    expect(sockets).toHaveLength(2);
+    expect(client.isConnected()).toBe(true);
+
+    oldSocket.emit("close");
+    await flushSetImmediate();
+
+    expect(sockets[1].readyState).toBe(WebSocketState.OPEN);
+    expect(client.isConnected()).toBe(true);
+  });
+
+  test("unsolicited socket drop immediately rejects in-flight requests", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    let socket: FakeWebSocket | null = null;
+
+    client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      8765,
+      (url) => {
+        socket = new FakeWebSocket(url, "none", 0, fakeTimer);
+        return socket;
+      },
+      fakeTimer,
+    );
+
+    expect(await client.ensureConnected()).toBe(true);
+    const request = client.requestSwipe(0, 0, 10, 10, 300, 60_000);
+    await flushSetImmediate();
+    const requestManager = (
+      client as unknown as {
+        requestManager: { getPendingCount(): number };
+      }
+    ).requestManager;
+    expect(requestManager.getPendingCount()).toBe(1);
+
+    socket!.emit("close");
+
+    expect(requestManager.getPendingCount()).toBe(0);
+    await expect(request).rejects.toThrow("WebSocket connection closed");
   });
 });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { IOSCtrlProxyClient, CtrlProxyHierarchy } from "../../../../src/features/observe/ios";
+import {
+  IOS_RUNNER_FEATURE_FLAGS,
+  getRequiredIosRunnerFeatureFlags,
+} from "../../../../src/features/observe/ios/IOSCtrlProxyClient";
 import { BootedDevice, HighlightShape } from "../../../../src/models";
 import { NetworkState } from "../../../../src/server/NetworkState";
 import { serverConfig } from "../../../../src/utils/ServerConfig";
@@ -20,6 +24,18 @@ import {
   stopDeviceDataStreamSocketServer,
 } from "../../../../src/daemon/deviceDataStreamSocketServer";
 import { FakeSocket } from "../../../fakes/FakeNetServer";
+
+describe("iOS runner feature release sequencing", () => {
+  test("does not require an unreleased handshake from the immutable 0.0.66 IPA", () => {
+    expect(getRequiredIosRunnerFeatureFlags({ AUTOMOBILE_VERSION: "0.0.66" })).toEqual([]);
+  });
+
+  test("requires the handshake starting with the release that will contain it", () => {
+    expect(getRequiredIosRunnerFeatureFlags({ AUTOMOBILE_VERSION: "0.0.67" })).toEqual([
+      ...IOS_RUNNER_FEATURE_FLAGS,
+    ]);
+  });
+});
 
 describe("IOSCtrlProxyClient", function () {
   let ctrlProxyClient: IOSCtrlProxyClient;

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2123,6 +2123,7 @@ describe("IOSCtrlProxyClient", function () {
             type: "connected",
             id: 1,
             supportedCommands: ["request_shake", "add_highlight", "request_press_button"],
+            supportedFeatures: ["display_cutout_info"],
           }),
         );
         await flushPromises();
@@ -2136,6 +2137,8 @@ describe("IOSCtrlProxyClient", function () {
           "request_press_button",
           "request_shake",
         ]);
+        expect(await testClient.getSupportedFeatures()).toEqual(["display_cutout_info"]);
+        expect(testClient.getCachedSupportedFeatures()).toEqual(["display_cutout_info"]);
       } finally {
         await testClient.close();
       }

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -606,14 +606,35 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
   }
 
   // Every type that reads `message.success` (all decoded types except the
-  // no-success hierarchy_update and the hardcoded-true screenshot) must pass an
-  // explicit success flag straight through, both true and false.
+  // no-success hierarchy_update) must pass an explicit success flag straight
+  // through, both true and false.
   const READS_MESSAGE_SUCCESS = DEFAULT_WHEN_ABSENT.filter(
-    (row) => row.type !== "hierarchy_update" && row.type !== "screenshot",
+    (row) => row.type !== "hierarchy_update",
   ).map((row) => row.type);
 
-  test("the passthrough set is the 37 success-reading types", () => {
-    expect(READS_MESSAGE_SUCCESS.length).toBe(37);
+  test("preserves a screenshot failure envelope instead of fabricating success", () => {
+    const decoded = decodeCtrlProxyMessage(
+      msg({
+        type: "screenshot",
+        success: false,
+        error: "Command execution failed: boom",
+        totalTimeMs: 17,
+      }),
+    );
+
+    expect(decoded?.result).toEqual({
+      success: false,
+      data: undefined,
+      format: "png",
+      timestamp: undefined,
+      frameContext: undefined,
+      rotation: undefined,
+      error: "Command execution failed: boom",
+    });
+  });
+
+  test("the passthrough set is the 38 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(38);
   });
 
   for (const type of READS_MESSAGE_SUCCESS) {
@@ -627,9 +648,9 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     });
   }
 
-  test("screenshot hardcodes success=true even when the wire says false", () => {
+  test("screenshot preserves success=false from a failure envelope", () => {
     const decoded = decodeCtrlProxyMessage(msg({ type: "screenshot", success: false }));
-    expect((decoded?.result as { success?: boolean }).success).toBe(true);
+    expect((decoded?.result as { success?: boolean }).success).toBe(false);
   });
 
   // The five `success ?? ok ?? false` types read the `ok` alias when `success`

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -30,6 +30,27 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     ).toEqual([]);
   });
 
+  test("rejects aliases, spread argv, shell wrappers, and computed seams", () => {
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const tool = "kill"; executor.executeCommand(tool, ["-TERM", "42"]);',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource("fixture.ts", 'spawn("/bin/sh", ["-c", "kill -TERM 42"]);'),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const command = ["lsof", "-iTCP:8765"]; executor.executeCommand(...command);',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource("fixture.ts", 'executor["executeCommand"]("ps", ["-p", "42"]);'),
+    ).toHaveLength(1);
+  });
+
   test("has a production check with documented exceptions", () => {
     const source = readFileSync(CHECK, "utf8");
     expect(source).toContain("const EXCEPTIONS = new Map<string, string>([");

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -49,6 +49,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource("fixture.ts", 'executor["executeCommand"]("ps", ["-p", "42"]);'),
     ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'import * as cp from "node:child_process"; cp["spawn"]("kill", ["-TERM", "42"]);',
+      ),
+    ).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2773,6 +2773,87 @@ describe("IOSCtrlProxyManager", function () {
       }
     });
 
+    test("startOnDevice() ignores late exit and error events from a replaced child", async function () {
+      const physicalDevice: BootedDevice = {
+        deviceId: "00008030001E28C11E",
+        platform: "ios",
+        name: "iPhone",
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        {
+          resolveSigningForDevice: async () => ({
+            buildSettings: [],
+            allowProvisioningUpdates: false,
+            warnings: [],
+          }),
+        } as unknown as XcodeSigningManager,
+      );
+      const internal = manager as unknown as {
+        verifyInstalledAppBundle: () => Promise<void>;
+        startIproxyTunnel: () => Promise<void>;
+        startOnDevice: () => Promise<void>;
+        xcTestProcessId: number | null;
+        xcTestProcess: FakeChildProcess | null;
+      };
+      internal.verifyInstalledAppBundle = async () => {};
+      internal.startIproxyTunnel = async () => {};
+
+      await internal.startOnDevice();
+      const staleChild = fakeExecutor.getSpawnedProcesses()[0].process as FakeChildProcess;
+      const replacement = new FakeChildProcess();
+      replacement.pid = 41002;
+      internal.xcTestProcessId = replacement.pid;
+      internal.xcTestProcess = replacement;
+
+      staleChild.emit("error", new Error("late stale failure"));
+      staleChild.emit("exit", 1, null);
+      await Promise.resolve();
+
+      expect(internal.xcTestProcessId).toBe(41002);
+      expect(internal.xcTestProcess).toBe(replacement);
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("stop() retains runner ownership and fails when SIGKILL cannot terminate it", async function () {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+      );
+      const process: FakeListeningProcess = {
+        pid: 42001,
+        port: 8765,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [process]);
+      fakeTimer.enableAutoAdvance();
+      const child = new FakeChildProcess();
+      child.pid = process.pid;
+      const internal = manager as unknown as {
+        xcTestProcessId: number | null;
+        xcTestProcess: FakeChildProcess | null;
+      };
+      internal.xcTestProcessId = process.pid;
+      internal.xcTestProcess = child;
+
+      await expect(manager.stop()).rejects.toThrow(
+        "CtrlProxy process tree rooted at PID 42001 remained alive after SIGKILL",
+      );
+
+      expect(internal.xcTestProcessId).toBe(42001);
+      expect(internal.xcTestProcess).toBe(child);
+      expect(process.alive).toBe(true);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(manager.getServicePort());
+    });
+
     test("start() terminates a stale owned runner on the intended port before spawning", async function () {
       const staleProcess: FakeListeningProcess = {
         pid: 2222,

--- a/test/utils/ProcessSupervisor.test.ts
+++ b/test/utils/ProcessSupervisor.test.ts
@@ -47,6 +47,47 @@ describe("DefaultProcessSupervisor", function () {
     expect(timer.getPendingIntervals()).toEqual([250]);
   });
 
+  test("ignores a liveness result from the process that preceded an automatic restart", async function () {
+    const timer = new FakeTimer();
+    let finishProbe!: (alive: boolean) => void;
+    let exits = 0;
+    let restarts = 0;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {
+        restarts++;
+      },
+      isAlive: async () =>
+        await new Promise<boolean>((resolve) => {
+          finishProbe = resolve;
+        }),
+      onExit: () => {
+        exits++;
+      },
+    });
+
+    await supervisor.start();
+    timer.advanceTime(250);
+    await flushMicrotasks();
+
+    supervisor.processExited();
+    await flushMicrotasks();
+    timer.advanceTime(100);
+    await flushMicrotasks();
+    expect(restarts).toBe(1);
+
+    finishProbe(false);
+    await flushMicrotasks();
+
+    expect(exits).toBe(1);
+    expect(restarts).toBe(1);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(timer.getPendingIntervals()).toEqual([250]);
+  });
+
   test("uses the injected Backoff policy for retry progression", async function () {
     const timer = new FakeTimer();
     const attemptedAt: number[] = [];

--- a/test/utils/ProcessSupervisor.test.ts
+++ b/test/utils/ProcessSupervisor.test.ts
@@ -287,6 +287,45 @@ describe("DefaultProcessSupervisor", function () {
     expect(timer.getPendingIntervals()).toEqual([250]);
   });
 
+  test("discards a stale liveness result after stop and replacement start", async function () {
+    const timer = new FakeTimer();
+    let resolveOldProbe!: (alive: boolean) => void;
+    let useDeferredProbe = true;
+    let exits = 0;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {},
+      isAlive: async () => {
+        if (!useDeferredProbe) {
+          return true;
+        }
+        return await new Promise<boolean>((resolve) => {
+          resolveOldProbe = resolve;
+        });
+      },
+      onExit: () => {
+        exits++;
+      },
+    });
+
+    await supervisor.start();
+    timer.advanceTime(250);
+    await flushMicrotasks();
+
+    supervisor.stop();
+    useDeferredProbe = false;
+    await supervisor.start();
+    resolveOldProbe(false);
+    await flushMicrotasks();
+
+    expect(exits).toBe(0);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(timer.getPendingIntervals()).toEqual([250]);
+  });
+
   test("reports liveness through the injected liveness check", async function () {
     const timer = new FakeTimer();
     let alive = true;

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -143,6 +143,7 @@ describe("XcodebuildClient streaming runner", () => {
       new FakeTimer(),
       (command, args, options) => {
         calls.push({ command, args, options });
+        child.simulateSpawn();
         return child as never;
       },
     );
@@ -190,6 +191,7 @@ describe("XcodebuildClient streaming runner", () => {
       timer,
       () => {
         spawned = true;
+        child.simulateSpawn();
         return child as never;
       },
     );
@@ -222,5 +224,22 @@ describe("XcodebuildClient streaming runner", () => {
     ).rejects.toThrow("xcodebuild is not available");
 
     expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("handles an asynchronous spawn error before returning the child", async () => {
+    const child = new FakeChildProcess();
+    child.setSpawnError("posix_spawn: executable missing");
+    const client = new XcodebuildClient(
+      async () => createExecResult("Xcode 26.5", ""),
+      new FakeTimer(),
+      () => {
+        child.simulateSpawn();
+        return child as never;
+      },
+    );
+
+    await expect(client.startStreaming(["test-without-building"])).rejects.toThrow(
+      "xcodebuild failed to start: Error: posix_spawn: executable missing",
+    );
   });
 });

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -77,7 +77,9 @@ describe("IOSCtrlProxyProcessClient", () => {
       releaseGraceMs: 1,
     });
 
-    await client.terminateProcessTree(42);
+    await expect(client.terminateProcessTree(42)).rejects.toThrow(
+      "CtrlProxy process tree rooted at PID 42 remained alive after SIGKILL",
+    );
 
     expect(host.getExecutedCommands()).toEqual(
       expect.arrayContaining([
@@ -89,6 +91,33 @@ describe("IOSCtrlProxyProcessClient", () => {
         "kill -KILL 42",
       ]),
     );
+  });
+
+  test("resolves process-tree termination once SIGKILL removes every target", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let killed = false;
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        if (file === "ps") {
+          return result("42 1\n43 42\n");
+        }
+        if (file === "kill" && args[0] === "-KILL") {
+          killed = true;
+          return result();
+        }
+        if (file === "kill" && args[0] === "-0" && killed) {
+          throw new Error("not running");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer, {
+      releaseAttempts: 1,
+      releaseGraceMs: 1,
+    });
+
+    await expect(client.terminateProcessTree(42)).resolves.toBeUndefined();
   });
 
   test("propagates deadline expiry while waiting for a process tree to exit", async () => {


### PR DESCRIPTION
## Summary

- harden iOS WebSocket ownership so HTTP probes never receive framed broadcasts, stale socket events cannot tear down replacements, transport loss rejects pending requests immediately, and screenshot failures retain their error state
- make CtrlProxy and xcodebuild lifecycle management fail closed on spawn, stale callbacks, stale liveness probes, and process trees that survive SIGKILL
- advertise and enforce runner feature capabilities so older bundled runners are reported as stale when they lack current display-cutout behavior
- replace regex-only process boundary checks with AST-backed alias, spread, computed-seam, and shell-wrapper detection
- make the local iOS watcher inject runner environment into its copied xctestrun and terminate only the exact PID it owns

## Validation

- `bun run turbo:validate`
- `swift test --package-path ios/control-proxy`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftformat/validate_swiftformat.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`
- `bash scripts/shellcheck/validate_shell_portability.sh`
- `shellcheck scripts/check-no-new-direct-xcodebuild.sh scripts/local-dev/hot-reload.sh scripts/local-dev/lib/ctrl-proxy-ios.sh`
- `bash scripts/check-no-new-direct-xcodebuild.sh origin/main`
- `bats test/bats/check-no-new-direct-xcodebuild.bats test/bats/ctrl-proxy-ui-test-runner-icon.bats`

The 34-check fast-validation aggregate initially found the empty-array Bash 3.2 portability issue fixed in the final commit; its affected portability, shellcheck, xcodebuild-boundary, and BATS checks were rerun successfully afterward.
