### PR TITLE
research(ios): establish a supported Files picker fixture provider

### DIFF
--- a/docs/decisions/ios-user-files-provider.md
+++ b/docs/decisions/ios-user-files-provider.md
@@ -1,0 +1,99 @@
+# iOS `user_files` provider
+
+Status: accepted for implementation in #5807. This decision records the
+research and simulator experiment from #5806; it does not add the production
+provider.
+
+## Decision
+
+Implement iOS Simulator `putAppFile` `target.domain: "user_files"` through a
+managed AutoMobile fixture-provider app. The provider app must enable both
+`UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace`; iOS then exposes
+its `Documents` directory through the local File Provider and the Files document
+picker. The staging adapter resolves the provider app's data container at runtime
+with `simctl get_app_container <udid> <provider-bundle-id> data`; it must never
+derive or persist a CoreSimulator path.
+
+The provider writes only:
+
+```text
+<resolved provider data container>/Documents/automobile/<namespace>/<relative destination>
+```
+
+`namespace` keeps its existing one-directory validation and `reset: true` may
+delete only that resolved `automobile/<namespace>` directory after checking the
+resolved target remains below the provider's `Documents/automobile` root. It
+must not reset Files, `Documents`, another namespace, or a caller-supplied host
+path.
+
+The Playground configuration and `PlaygroundFilesPickerUITests` are an
+experiment harness. #5807 must use a dedicated, internally owned fixture app
+instead of treating Playground as the runtime provider.
+
+## What is and is not supported
+
+| Target | Status | Behavior |
+| --- | --- | --- |
+| iOS Simulator | supported after #5807 | Stage in the managed provider's bounded Documents namespace. |
+| iOS physical device | unsupported | `simctl` cannot resolve or mutate an on-device app container; do not infer support from the simulator. |
+| Direct Files local-provider storage | unsupported | No public `simctl` staging command exists, and internal provider paths are not an AutoMobile API. |
+| A custom File Provider extension | not selected | Apple positions one for apps that provide and sync remote documents; it is unnecessary for local fixture sharing. |
+
+A future physical-device implementation requires explicit app integration: an
+`IosFilesFixtureClient` seam owned by the installed fixture app, with an opt-in
+on-device staging protocol and a real-device picker test. A connection, signing
+identity, or generic `app_containers` access alone is not that opt-in.
+
+## Effects, capabilities, and resources
+
+The #5807 provider should report two independent facts:
+
+- `host_stage: completed` only after the bounded copy succeeds in the resolved
+  provider container.
+- `document_picker: unavailable` unless a document-picker verifier has observed
+  the exact logical destination. A copied host file must not be reported as
+  picker-visible by inference.
+
+`user_files` does not gain a public list/read resource in this slice. Existing
+app-container resources remain scoped to an explicit app id and container; they
+are not a Files-provider browsing API. The completion payload and the
+document-picker verifier are the observation surfaces for this domain.
+
+Until #5807 lands, the storage capability descriptor must continue to report
+iOS `user_files` as unsupported. Once its managed provider is registered, an
+iOS Simulator can report the capability as available only when the fixture app
+is installed and the provider seam resolves its container. Physical iOS remains
+unsupported regardless of `iosFileIntegration`.
+
+## Verification contract for #5807
+
+The implementation needs fakes for both seams:
+
+1. `IosFilesFixtureContainer` resolves the provider data container and performs
+   bounded mkdir/copy/reset operations. Unit tests cover traversal rejection,
+   exact-namespace reset, and a physical-UDID rejection before any command.
+2. `DocumentPickerVisibilityVerifier` is responsible for the separate
+   picker-visible effect. Its simulator integration test stages one text or PDF
+   fixture, opens `UIDocumentPickerViewController`, selects that exact fixture,
+   and asserts the delegate result.
+
+Run `scripts/ios/put-app-file-picker-smoke.sh [simulator-udid]` for the
+device-backed proof. On 2026-08-28 it passed on an iPhone 15 Pro simulator
+running iOS 17.5 with Xcode 26.3 (build 17C529): the picker identified the
+source as `com.apple.FileProvider.LocalStorage`, displayed the bounded fixture,
+and returned `automobile-files-probe.txt` after selection.
+
+## Evidence
+
+Apple documents that the document picker accesses files outside an app's
+sandbox, that its `directoryURL` selects the initial location, and that enabling
+both File Sharing and open-in-place makes an app's Documents directory appear in
+Files. The `simctl` help on the tested Xcode exposes `get_app_container` and
+media-only `addmedia`, but no command for Files-provider storage.
+
+- Apple: UIDocumentPickerViewController
+  <https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller>
+- Apple: File Provider
+  <https://developer.apple.com/documentation/fileprovider>
+- Apple: Launch Services keys
+  <https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html>

--- a/docs/decisions/ios-user-files-provider.md
+++ b/docs/decisions/ios-user-files-provider.md
@@ -32,12 +32,12 @@ instead of treating Playground as the runtime provider.
 
 ## What is and is not supported
 
-| Target | Status | Behavior |
-| --- | --- | --- |
-| iOS Simulator | supported after #5807 | Stage in the managed provider's bounded Documents namespace. |
-| iOS physical device | unsupported | `simctl` cannot resolve or mutate an on-device app container; do not infer support from the simulator. |
-| Direct Files local-provider storage | unsupported | No public `simctl` staging command exists, and internal provider paths are not an AutoMobile API. |
-| A custom File Provider extension | not selected | Apple positions one for apps that provide and sync remote documents; it is unnecessary for local fixture sharing. |
+| Target                              | Status                | Behavior                                                                                                          |
+| ----------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| iOS Simulator                       | supported after #5807 | Stage in the managed provider's bounded Documents namespace.                                                      |
+| iOS physical device                 | unsupported           | `simctl` cannot resolve or mutate an on-device app container; do not infer support from the simulator.            |
+| Direct Files local-provider storage | unsupported           | No public `simctl` staging command exists, and internal provider paths are not an AutoMobile API.                 |
+| A custom File Provider extension    | not selected          | Apple positions one for apps that provide and sync remote documents; it is unnecessary for local fixture sharing. |
 
 A future physical-device implementation requires explicit app integration: an
 `IosFilesFixtureClient` seam owned by the installed fixture app, with an opt-in

--- a/ios/Playground/Fixtures/automobile-files-probe.txt
+++ b/ios/Playground/Fixtures/automobile-files-probe.txt
@@ -1,0 +1,4 @@
+AutoMobile #5806 document-picker fixture.
+
+This text file is copied only into the Playground app's
+Documents/automobile-issue-5806 namespace by the iOS smoke script.

--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		007B2120C2735B42A20C510B /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F4747AC5700DF138836D5F /* Theme.swift */; };
 		15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */; };
+		1EE5E98648A8DFD56C1EE62C /* FilesPickerProbeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C02BE035F32E984F52B8D0 /* FilesPickerProbeUITests.swift */; };
+		2F8BA3EDD179892E3C489DCB /* FilesPickerProbeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C80CB4E7FD9E92FD2A08F2F /* FilesPickerProbeView.swift */; };
 		327A28D4620038BBA8D02656 /* Shapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5122FF517804CD75B0F75CBA /* Shapes.swift */; };
 		4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */; };
 		4E220C88A805ED0A7AFDEE38 /* PlaygroundDatabaseFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */; };
@@ -32,6 +34,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5F0B8E59CC46A228D3DBC98D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DF84942AD828BBDD499F04C0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 739B1FD817D42F0264714A50;
+			remoteInfo = Playground;
+		};
 		BFE3470C534A49ECA416CB8A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DF84942AD828BBDD499F04C0 /* Project object */;
@@ -42,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		06C02BE035F32E984F52B8D0 /* FilesPickerProbeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesPickerProbeUITests.swift; sourceTree = "<group>"; };
 		0C5B41C44C18F0045A6B61C2 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketchTests.swift; sourceTree = "<group>"; };
 		25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemosTab.swift; sourceTree = "<group>"; };
@@ -52,6 +62,7 @@
 		51580F5FC5ADCD5576885563 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		64FD18EC8D1B9A665615C374 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHighlightOverlayE2ETests.swift; sourceTree = "<group>"; };
+		8C80CB4E7FD9E92FD2A08F2F /* FilesPickerProbeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesPickerProbeView.swift; sourceTree = "<group>"; };
 		A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixtureTests.swift; sourceTree = "<group>"; };
 		AA0EB8290A6E5436B2C8CE6F /* auto-mobile-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "auto-mobile-sdk"; path = "../auto-mobile-sdk"; sourceTree = SOURCE_ROOT; };
 		BDA9169E926B14087F3B1BA2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -66,6 +77,7 @@
 		D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityRotorDemo.swift; sourceTree = "<group>"; };
 		E1B25FBAC5217DE05EA701CF /* ShantellSans.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ShantellSans.ttf; sourceTree = "<group>"; };
 		E40DD68F934F5F0D2981ACA1 /* Playground.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Playground.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAD793841AB97726998E94B5 /* PlaygroundFilesPickerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PlaygroundFilesPickerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundThemeTests.swift; sourceTree = "<group>"; };
 		FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverTab.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,10 +102,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A0CCC846A066708EBAEA795 /* FilesPickerProbeUITests */ = {
+			isa = PBXGroup;
+			children = (
+				06C02BE035F32E984F52B8D0 /* FilesPickerProbeUITests.swift */,
+			);
+			name = FilesPickerProbeUITests;
+			path = Tests/FilesPickerProbeUITests;
+			sourceTree = "<group>";
+		};
 		3F6B916872C30820F6241E84 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				E40DD68F934F5F0D2981ACA1 /* Playground.app */,
+				FAD793841AB97726998E94B5 /* PlaygroundFilesPickerUITests.xctest */,
 				CBBA4475C2A7A68AE3987086 /* PlaygroundTests.xctest */,
 			);
 			name = Products;
@@ -131,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				D01BCE22E951887741F32904 /* ContentView.swift */,
+				8C80CB4E7FD9E92FD2A08F2F /* FilesPickerProbeView.swift */,
 				BDA9169E926B14087F3B1BA2 /* Info.plist */,
 				C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */,
 				3CF899DC96DC92471BB6FC81 /* PlaygroundDatabaseFixture.swift */,
@@ -175,6 +198,7 @@
 			children = (
 				CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */,
 				C8708B4984B178C033908015 /* Configurations */,
+				0A0CCC846A066708EBAEA795 /* FilesPickerProbeUITests */,
 				75054112A41CDCE58ADACF92 /* Packages */,
 				AABC9BE64A1302199D5D2AF8 /* Sources */,
 				B500CE1A6941BEA33903C091 /* Tests */,
@@ -237,6 +261,24 @@
 			productReference = E40DD68F934F5F0D2981ACA1 /* Playground.app */;
 			productType = "com.apple.product-type.application";
 		};
+		9586904FC044DFE3B2D9C272 /* PlaygroundFilesPickerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C80713D8EF4DF8591125FE94 /* Build configuration list for PBXNativeTarget "PlaygroundFilesPickerUITests" */;
+			buildPhases = (
+				0F694132B18E1FF619AF35E3 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C55EEF7404A088DD02C8AD02 /* PBXTargetDependency */,
+			);
+			name = PlaygroundFilesPickerUITests;
+			packageProductDependencies = (
+			);
+			productName = PlaygroundFilesPickerUITests;
+			productReference = FAD793841AB97726998E94B5 /* PlaygroundFilesPickerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -251,6 +293,10 @@
 					};
 					739B1FD817D42F0264714A50 = {
 						ProvisioningStyle = Automatic;
+					};
+					9586904FC044DFE3B2D9C272 = {
+						ProvisioningStyle = Automatic;
+						TestTargetID = 739B1FD817D42F0264714A50;
 					};
 				};
 			};
@@ -273,6 +319,7 @@
 			targets = (
 				739B1FD817D42F0264714A50 /* Playground */,
 				21356511771170ED7D28D6F3 /* PlaygroundTests */,
+				9586904FC044DFE3B2D9C272 /* PlaygroundFilesPickerUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -290,6 +337,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0F694132B18E1FF619AF35E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1EE5E98648A8DFD56C1EE62C /* FilesPickerProbeUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E40BECB45945A673BB0CC3F9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -300,6 +355,7 @@
 				4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
+				2F8BA3EDD179892E3C489DCB /* FilesPickerProbeView.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
 				C9A1977492B71CC9FE85DA16 /* PlaygroundDatabaseFixture.swift in Sources */,
 				7FDB62C4B6F0092619122928 /* SemanticLinksDemo.swift in Sources */,
@@ -325,6 +381,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		C55EEF7404A088DD02C8AD02 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 739B1FD817D42F0264714A50 /* Playground */;
+			targetProxy = 5F0B8E59CC46A228D3DBC98D /* PBXContainerItemProxy */;
+		};
 		EDB85CA665C60FA530302190 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 739B1FD817D42F0264714A50 /* Playground */;
@@ -425,6 +486,24 @@
 			};
 			name = Release;
 		};
+		41FB747DB84A62CE02DE4155 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.PlaygroundFilesPickerUITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Playground;
+			};
+			name = Debug;
+		};
 		4F8F737A22C49C70A327F32E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -442,6 +521,24 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
+		};
+		8DC9C2FFC0FAB4DB86539DDE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.PlaygroundFilesPickerUITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Playground;
+			};
+			name = Release;
 		};
 		DF83FEB514DF89BC00722881 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -532,6 +629,15 @@
 			buildConfigurations = (
 				18883859C44E4AE8042B204F /* Debug */,
 				FE96C092F5D790A83D093866 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C80713D8EF4DF8591125FE94 /* Build configuration list for PBXNativeTarget "PlaygroundFilesPickerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41FB747DB84A62CE02DE4155 /* Debug */,
+				8DC9C2FFC0FAB4DB86539DDE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/Playground.xcscheme
+++ b/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/Playground.xcscheme
@@ -64,17 +64,6 @@
                ReferencedContainer = "container:Playground.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9586904FC044DFE3B2D9C272"
-               BuildableName = "PlaygroundFilesPickerUITests.xctest"
-               BlueprintName = "PlaygroundFilesPickerUITests"
-               ReferencedContainer = "container:Playground.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>

--- a/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/Playground.xcscheme
+++ b/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/Playground.xcscheme
@@ -29,6 +29,20 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9586904FC044DFE3B2D9C272"
+               BuildableName = "PlaygroundFilesPickerUITests.xctest"
+               BlueprintName = "PlaygroundFilesPickerUITests"
+               ReferencedContainer = "container:Playground.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "21356511771170ED7D28D6F3"
                BuildableName = "PlaygroundTests.xctest"
                BlueprintName = "PlaygroundTests"
@@ -61,6 +75,17 @@
                BlueprintIdentifier = "21356511771170ED7D28D6F3"
                BuildableName = "PlaygroundTests.xctest"
                BlueprintName = "PlaygroundTests"
+               ReferencedContainer = "container:Playground.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9586904FC044DFE3B2D9C272"
+               BuildableName = "PlaygroundFilesPickerUITests.xctest"
+               BlueprintName = "PlaygroundFilesPickerUITests"
                ReferencedContainer = "container:Playground.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/PlaygroundFilesPickerSmoke.xcscheme
+++ b/ios/Playground/Playground.xcodeproj/xcshareddata/xcschemes/PlaygroundFilesPickerSmoke.xcscheme
@@ -29,9 +29,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "21356511771170ED7D28D6F3"
-               BuildableName = "PlaygroundTests.xctest"
-               BlueprintName = "PlaygroundTests"
+               BlueprintIdentifier = "9586904FC044DFE3B2D9C272"
+               BuildableName = "PlaygroundFilesPickerUITests.xctest"
+               BlueprintName = "PlaygroundFilesPickerUITests"
                ReferencedContainer = "container:Playground.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -53,17 +53,6 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "21356511771170ED7D28D6F3"
-               BuildableName = "PlaygroundTests.xctest"
-               BlueprintName = "PlaygroundTests"
-               ReferencedContainer = "container:Playground.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
          <TestableReference
             skipped = "NO"
             parallelizable = "NO">

--- a/ios/Playground/Sources/ContentView.swift
+++ b/ios/Playground/Sources/ContentView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 enum Tab: String, Hashable {
     case discover
     case demos
+    case files
     case settings
 }
 
@@ -16,6 +17,7 @@ struct ContentView: View {
     private static var initialTab: Tab {
         switch ProcessInfo.processInfo.environment["PLAYGROUND_INITIAL_TAB"] {
         case "demos": return .demos
+        case "files": return .files
         case "settings": return .settings
         default: return .discover
         }
@@ -37,6 +39,12 @@ struct ContentView: View {
                     Label("Demos", systemImage: "play.fill")
                 }
                 .tag(Tab.demos)
+
+            FilesPickerProbeView()
+                .tabItem {
+                    Label("Files", systemImage: "folder")
+                }
+                .tag(Tab.files)
 
             SettingsTab()
                 .tabItem {

--- a/ios/Playground/Sources/FilesPickerProbeView.swift
+++ b/ios/Playground/Sources/FilesPickerProbeView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+/// A simulator smoke-test probe for #5806, not a production file provider.
+///
+/// The host script places a fixture only in `Documents/automobile-issue-5806`.
+/// With this app's File Sharing and open-in-place keys enabled, iOS's local File
+/// Provider exposes that directory to the real `UIDocumentPickerViewController`.
+struct FilesPickerProbeView: View {
+    @State private var selectedFixture = "No fixture selected"
+    @State private var showingPicker = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Files picker probe")
+                .font(.title2)
+            Text("The #5806 smoke stages fixtures only in this app's bounded Documents namespace.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Open document picker") {
+                showingPicker = true
+            }
+            .accessibilityIdentifier("open-document-picker")
+            .buttonStyle(.borderedProminent)
+            Text(selectedFixture)
+                .accessibilityIdentifier("selected-document")
+        }
+        .padding()
+        .sheet(isPresented: $showingPicker) {
+            FilesPickerController(selectedFixture: $selectedFixture)
+        }
+        .trackNavigation(destination: "files_picker_probe")
+    }
+}
+
+private struct FilesPickerController: UIViewControllerRepresentable {
+    @Binding var selectedFixture: String
+
+    func makeUIViewController(context: Context) -> FilesPickerHostViewController {
+        FilesPickerHostViewController { selectedFixture = $0 }
+    }
+
+    func updateUIViewController(_ uiViewController: FilesPickerHostViewController, context: Context) {}
+}
+
+private final class FilesPickerHostViewController: UIViewController, UIDocumentPickerDelegate {
+    private static let fixtureNamespace = "automobile-issue-5806"
+    private let didSelectFixture: (String) -> Void
+    private var didPresentPicker = false
+
+    init(didSelectFixture: @escaping (String) -> Void) {
+        self.didSelectFixture = didSelectFixture
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !didPresentPicker else { return }
+        didPresentPicker = true
+
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.plainText, .pdf])
+        picker.delegate = self
+        picker.directoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent(Self.fixtureNamespace, isDirectory: true)
+        present(picker, animated: false)
+    }
+
+    func documentPicker(
+        _ controller: UIDocumentPickerViewController,
+        didPickDocumentsAt urls: [URL]
+    ) {
+        didSelectFixture(urls.first?.lastPathComponent ?? "No fixture selected")
+        dismiss(animated: true)
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        dismiss(animated: true)
+    }
+}

--- a/ios/Playground/Sources/FilesPickerProbeView.swift
+++ b/ios/Playground/Sources/FilesPickerProbeView.swift
@@ -28,7 +28,10 @@ struct FilesPickerProbeView: View {
         }
         .padding()
         .sheet(isPresented: $showingPicker) {
-            FilesPickerController(selectedFixture: $selectedFixture)
+            FilesPickerController(
+                selectedFixture: $selectedFixture,
+                isPresented: $showingPicker
+            )
         }
         .trackNavigation(destination: "files_picker_probe")
     }
@@ -36,26 +39,35 @@ struct FilesPickerProbeView: View {
 
 private struct FilesPickerController: UIViewControllerRepresentable {
     @Binding var selectedFixture: String
+    @Binding var isPresented: Bool
 
-    func makeUIViewController(context: Context) -> FilesPickerHostViewController {
-        FilesPickerHostViewController { selectedFixture = $0 }
+    func makeUIViewController(context _: Context) -> FilesPickerHostViewController {
+        FilesPickerHostViewController(
+            didSelectFixture: { selectedFixture = $0 },
+            didClose: { isPresented = false }
+        )
     }
 
-    func updateUIViewController(_ uiViewController: FilesPickerHostViewController, context: Context) {}
+    func updateUIViewController(_: FilesPickerHostViewController, context _: Context) {}
 }
 
 private final class FilesPickerHostViewController: UIViewController, UIDocumentPickerDelegate {
     private static let fixtureNamespace = "automobile-issue-5806"
     private let didSelectFixture: (String) -> Void
+    private let didClose: () -> Void
     private var didPresentPicker = false
 
-    init(didSelectFixture: @escaping (String) -> Void) {
+    init(
+        didSelectFixture: @escaping (String) -> Void,
+        didClose: @escaping () -> Void
+    ) {
         self.didSelectFixture = didSelectFixture
+        self.didClose = didClose
         super.init(nibName: nil, bundle: nil)
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -73,14 +85,14 @@ private final class FilesPickerHostViewController: UIViewController, UIDocumentP
     }
 
     func documentPicker(
-        _ controller: UIDocumentPickerViewController,
+        _: UIDocumentPickerViewController,
         didPickDocumentsAt urls: [URL]
     ) {
         didSelectFixture(urls.first?.lastPathComponent ?? "No fixture selected")
-        dismiss(animated: true)
+        didClose()
     }
 
-    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        dismiss(animated: true)
+    func documentPickerWasCancelled(_: UIDocumentPickerViewController) {
+        didClose()
     }
 }

--- a/ios/Playground/Sources/Info.plist
+++ b/ios/Playground/Sources/Info.plist
@@ -20,6 +20,9 @@
     <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <!-- The #5806 smoke uses this app as a simulator-only fixture provider. -->
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
@@ -34,6 +37,8 @@
     <array>
         <string>ShantellSans.ttf</string>
     </array>
+    <key>UIFileSharingEnabled</key>
+    <true/>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UIRequiredDeviceCapabilities</key>

--- a/ios/Playground/Tests/FilesPickerProbeUITests/FilesPickerProbeUITests.swift
+++ b/ios/Playground/Tests/FilesPickerProbeUITests/FilesPickerProbeUITests.swift
@@ -20,5 +20,7 @@ final class FilesPickerProbeUITests: XCTestCase {
         let selected = app.staticTexts["selected-document"]
         XCTAssertTrue(selected.waitForExistence(timeout: 5))
         XCTAssertEqual(selected.label, "automobile-files-probe.txt")
+        XCTAssertTrue(openPicker.waitForExistence(timeout: 5))
+        XCTAssertTrue(openPicker.isHittable, app.debugDescription)
     }
 }

--- a/ios/Playground/Tests/FilesPickerProbeUITests/FilesPickerProbeUITests.swift
+++ b/ios/Playground/Tests/FilesPickerProbeUITests/FilesPickerProbeUITests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+/// Device-backed proof for the bounded local File Provider seam chosen in #5806.
+final class FilesPickerProbeUITests: XCTestCase {
+    func testSelectsFixtureFromTheLocalFilesProvider() {
+        let app = XCUIApplication()
+        app.launchEnvironment["PLAYGROUND_INITIAL_TAB"] = "files"
+        app.launch()
+
+        let openPicker = app.buttons["open-document-picker"]
+        XCTAssertTrue(openPicker.waitForExistence(timeout: 5))
+        openPicker.tap()
+
+        let fixture = app.cells.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "automobile-files-probe,")
+        ).firstMatch
+        XCTAssertTrue(fixture.waitForExistence(timeout: 10), app.debugDescription)
+        fixture.tap()
+
+        let selected = app.staticTexts["selected-document"]
+        XCTAssertTrue(selected.waitForExistence(timeout: 5))
+        XCTAssertEqual(selected.label, "automobile-files-probe.txt")
+    }
+}

--- a/ios/Playground/project.yml
+++ b/ios/Playground/project.yml
@@ -76,13 +76,30 @@ schemes:
       targets:
         Playground: all
         PlaygroundTests: [test]
-        PlaygroundFilesPickerUITests: [test]
     run:
       config: Debug
     test:
       config: Debug
       targets:
         - PlaygroundTests
+        - PlaygroundFilesPickerUITests
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release
+
+  PlaygroundFilesPickerSmoke:
+    build:
+      targets:
+        Playground: all
+        PlaygroundFilesPickerUITests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
         - PlaygroundFilesPickerUITests
     profile:
       config: Release

--- a/ios/Playground/project.yml
+++ b/ios/Playground/project.yml
@@ -82,7 +82,6 @@ schemes:
       config: Debug
       targets:
         - PlaygroundTests
-        - PlaygroundFilesPickerUITests
     profile:
       config: Release
     analyze:

--- a/ios/Playground/project.yml
+++ b/ios/Playground/project.yml
@@ -43,6 +43,8 @@ targets:
     platform: iOS
     sources:
       - path: Tests
+        excludes:
+          - FilesPickerProbeUITests
     dependencies:
       - target: Playground
       - package: AutoMobileSDK
@@ -54,18 +56,34 @@ targets:
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Playground.app/Playground"
         BUNDLE_LOADER: "$(TEST_HOST)"
 
+  PlaygroundFilesPickerUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: Tests/FilesPickerProbeUITests
+    dependencies:
+      - target: Playground
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: dev.jasonpearson.automobile.PlaygroundFilesPickerUITests
+        TEST_TARGET_NAME: Playground
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: YES
+
 schemes:
   Playground:
     build:
       targets:
         Playground: all
         PlaygroundTests: [test]
+        PlaygroundFilesPickerUITests: [test]
     run:
       config: Debug
     test:
       config: Debug
       targets:
         - PlaygroundTests
+        - PlaygroundFilesPickerUITests
     profile:
       config: Release
     analyze:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,7 @@ nav:
       - "iOS Simulator Continuity Contract": release/ios-simulator-continuity.md
       - "Dependency Decisions":
           - "fast-check": decisions/fast-check.md
+          - "iOS Files picker fixture provider": decisions/ios-user-files-provider.md
           - "TypeScript 7 (tsgo)": decisions/typescript-native-preview.md
           - "oxlint": decisions/oxlint.md
           - "oxc-parser": decisions/oxc-parser.md

--- a/scripts/ios/put-app-file-picker-smoke.sh
+++ b/scripts/ios/put-app-file-picker-smoke.sh
@@ -33,7 +33,7 @@ xcrun simctl bootstatus "${device_id}" -b
 
 xcodebuild \
     -project "${repo_root}/ios/Playground/Playground.xcodeproj" \
-    -scheme Playground \
+    -scheme PlaygroundFilesPickerSmoke \
     -destination "platform=iOS Simulator,id=${device_id}" \
     -derivedDataPath "${derived_data}" \
     build-for-testing
@@ -65,7 +65,7 @@ xcrun simctl terminate "${device_id}" "${app_id}"
 
 xcodebuild \
     -project "${repo_root}/ios/Playground/Playground.xcodeproj" \
-    -scheme Playground \
+    -scheme PlaygroundFilesPickerSmoke \
     -destination "platform=iOS Simulator,id=${device_id}" \
     -derivedDataPath "${derived_data}" \
     -only-testing:PlaygroundFilesPickerUITests \

--- a/scripts/ios/put-app-file-picker-smoke.sh
+++ b/scripts/ios/put-app-file-picker-smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Proves the bounded iOS Files-picker fixture seam selected in #5806.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+device_id="${1:-}"
+app_id="dev.jasonpearson.automobile.Playground"
+fixture_namespace="automobile-issue-5806"
+fixture_name="automobile-files-probe.txt"
+fixture_source="${repo_root}/ios/Playground/Fixtures/${fixture_name}"
+derived_data="$(mktemp -d "${TMPDIR:-/tmp}/auto-mobile-ios-files-picker.XXXXXX")"
+
+cleanup() {
+    find "${derived_data}" -depth -delete
+}
+trap cleanup EXIT
+
+if [[ -z "${device_id}" ]]; then
+    device_id="$(xcrun simctl list devices booted | awk -F '[()]' '/iPhone|iPad/ { print $2; exit }')"
+fi
+
+if [[ -z "${device_id}" ]]; then
+    echo "No booted iOS Simulator found. Pass its UDID as the first argument." >&2
+    exit 1
+fi
+
+if [[ ! -f "${fixture_source}" ]]; then
+    echo "Missing fixture source: ${fixture_source}" >&2
+    exit 1
+fi
+
+xcrun simctl bootstatus "${device_id}" -b
+
+xcodebuild \
+    -project "${repo_root}/ios/Playground/Playground.xcodeproj" \
+    -scheme Playground \
+    -destination "platform=iOS Simulator,id=${device_id}" \
+    -derivedDataPath "${derived_data}" \
+    build-for-testing
+
+app_path="${derived_data}/Build/Products/Debug-iphonesimulator/Playground.app"
+xcrun simctl install "${device_id}" "${app_path}"
+
+data_container="$(xcrun simctl get_app_container "${device_id}" "${app_id}" data)"
+documents_root="${data_container}/Documents"
+fixture_root="${documents_root}/${fixture_namespace}"
+
+if [[ "${fixture_root}" != "${documents_root}/${fixture_namespace}" ]]; then
+    echo "Refusing to reset a path outside the declared fixture namespace." >&2
+    exit 1
+fi
+
+# The reset target is one fixed child of the managed fixture app's Documents
+# directory; it never reaches the simulator's Files-provider implementation.
+if [[ -e "${fixture_root}" ]]; then
+    find "${fixture_root}" -depth -delete
+fi
+mkdir -p "${fixture_root}"
+cp "${fixture_source}" "${fixture_root}/${fixture_name}"
+
+# Launching after staging gives the managed app a chance to observe its Documents
+# directory before the real document-picker test starts.
+xcrun simctl launch "${device_id}" "${app_id}" >/dev/null
+xcrun simctl terminate "${device_id}" "${app_id}"
+
+xcodebuild \
+    -project "${repo_root}/ios/Playground/Playground.xcodeproj" \
+    -scheme Playground \
+    -destination "platform=iOS Simulator,id=${device_id}" \
+    -derivedDataPath "${derived_data}" \
+    -only-testing:PlaygroundFilesPickerUITests \
+    test-without-building
+
+echo "iOS Files picker smoke passed for ${device_id}"


### PR DESCRIPTION
## Summary

- establish the supported iOS Simulator `user_files` direction: a managed fixture app with File Sharing and open-in-place enabled, resolved through documented `simctl get_app_container`
- add a device-backed Playground probe and smoke that stages only `Documents/automobile-issue-5806`, opens the real document picker, and asserts selection of the exact text fixture
- record the provider boundary, reset policy, effect semantics, physical-device non-support, resource behavior, and the implementation seams for [#5807](https://github.com/kaeawc/auto-mobile/issues/5807)

## Why

The simulator has no supported generic Files-provider staging command. A copied host file is not proof that a document picker can see it, so the supported path must be bounded to an AutoMobile-owned app and verify picker visibility independently.

## Validation

- `scripts/ios/put-app-file-picker-smoke.sh 095E32B8-2B40-4ECA-9839-ABFC6EDC3915`
- `shellcheck scripts/ios/put-app-file-picker-smoke.sh`
- `plutil -lint ios/Playground/Sources/Info.plist`
- `bun run lint` (passes with existing baseline warnings)

Fixes [#5806](https://github.com/kaeawc/auto-mobile/issues/5806)
