### PR TITLE
fix(ci): close execution boundary gaps

### DIFF
--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -10,6 +10,7 @@ export interface XcodebuildViolation {
 }
 
 const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]);
+const ENV_WRAPPERS = new Set(["env"]);
 
 function commandName(value: string): string {
   return value.split(/[\\/]/).at(-1)?.toLowerCase() ?? "";
@@ -17,6 +18,46 @@ function commandName(value: string): string {
 
 function containsXcodebuildCommand(value: string): boolean {
   return /(?:^|[\s;&|])(?:[^\s;&|]*[/\\])?xcodebuild(?:\s|$)/i.test(value);
+}
+
+function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
+  let index = 1;
+  while (index < argv.length) {
+    const argument = argv[index];
+    if (argument === "--") {
+      return commandName(argv[index + 1] ?? "") === "xcodebuild";
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argument)) {
+      index++;
+      continue;
+    }
+    if (["-i", "--ignore-environment", "-0", "--null"].includes(argument)) {
+      index++;
+      continue;
+    }
+    if (["-u", "--unset", "-C", "--chdir", "-P"].includes(argument)) {
+      index += 2;
+      continue;
+    }
+    if (["-S", "--split-string"].includes(argument)) {
+      return containsXcodebuildCommand(argv[index + 1] ?? "");
+    }
+    if (/^--(?:unset|chdir)=/.test(argument)) {
+      index++;
+      continue;
+    }
+    if (argument.startsWith("--split-string=")) {
+      return containsXcodebuildCommand(argument.slice("--split-string=".length));
+    }
+    if (argument.startsWith("-")) {
+      // Unknown env flags are skipped conservatively. If they take an operand,
+      // treating that operand as the command can only make the boundary louder.
+      index++;
+      continue;
+    }
+    return commandName(argument) === "xcodebuild";
+  }
+  return false;
 }
 
 export function findDirectXcodebuildCalls(file: string, source: string): XcodebuildViolation[] {
@@ -36,12 +77,24 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
       return [];
     }
     const first = call.arguments[0];
-    const arrayCommands =
-      ast
-        .arrayAlternatives(first)
-        ?.flatMap((items) => (items.length > 0 ? ast.strings(items[0]) : [])) ?? [];
-    const directValues = [...ast.strings(first), ...arrayCommands];
-    const direct = directValues.some((value) => commandName(value) === "xcodebuild");
+    const firstArrayAlternatives = ast.arrayAlternatives(first);
+    const argumentArrayAlternatives = ast.arrayAlternatives(call.arguments[1]);
+    const argvAlternatives = firstArrayAlternatives
+      ? firstArrayAlternatives.map((items) => items.flatMap((item) => ast.strings(item)))
+      : ast
+          .strings(first)
+          .flatMap((command) =>
+            (argumentArrayAlternatives ?? [[]]).map((items) => [
+              command,
+              ...items.flatMap((item) => ast.strings(item)),
+            ]),
+          );
+    const directValues = argvAlternatives.flatMap((argv) => argv.slice(0, 1));
+    const direct = argvAlternatives.some(
+      (argv) =>
+        commandName(argv[0] ?? "") === "xcodebuild" ||
+        (ENV_WRAPPERS.has(commandName(argv[0] ?? "")) && envDelegatesToXcodebuild(argv)),
+    );
     const shell = directValues.some((value) => SHELLS.has(value.toLowerCase()));
     const shellPayloads = call.arguments.slice(1).flatMap((argument) => ast.strings(argument));
     const embedded =

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -22,14 +22,20 @@ function containsXcodebuildCommand(value: string): boolean {
 
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
   let index = 1;
+  let optionsTerminated = false;
   while (index < argv.length) {
     const argument = argv[index];
-    if (argument === "--") {
-      return commandName(argv[index + 1] ?? "") === "xcodebuild";
+    if (!optionsTerminated && argument === "--") {
+      optionsTerminated = true;
+      index++;
+      continue;
     }
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argument)) {
       index++;
       continue;
+    }
+    if (optionsTerminated) {
+      return commandName(argument) === "xcodebuild";
     }
     if (["-i", "--ignore-environment", "-0", "--null"].includes(argument)) {
       index++;
@@ -41,6 +47,9 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
     }
     if (["-S", "--split-string"].includes(argument)) {
       return containsXcodebuildCommand(argv[index + 1] ?? "");
+    }
+    if (argument.startsWith("-S") && argument.length > 2) {
+      return containsXcodebuildCommand(argument.slice(2));
     }
     if (/^--(?:unset|chdir)=/.test(argument)) {
       index++;

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -188,7 +188,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   const isExecutionSeamReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && executionSeamAliases.has(node.text)) ||
     ((ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
-      (propertyName(node) === "executeCommand" ||
+      (propertyName(node) === "exec" ||
+        propertyName(node) === "execSync" ||
+        propertyName(node) === "executeCommand" ||
         propertyName(node) === "runExecSeam" ||
         (propertyName(node) === "execute" &&
           (node.expression.kind === ts.SyntaxKind.ThisKeyword ||

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -185,10 +185,29 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       ts.isIdentifier(node.expression) &&
       childProcessNamespaces.has(node.expression.text)) ||
     isPromisifiedLauncher(node);
+  const isRegExpReference = (node: ts.Expression, seen = new Set<string>()): boolean => {
+    node = unwrapTransparentExpression(node);
+    if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+      return true;
+    }
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "RegExp"
+    ) {
+      return true;
+    }
+    if (ts.isIdentifier(node) && !seen.has(node.text)) {
+      return (initializers.get(node.text) ?? []).some((value) =>
+        isRegExpReference(value, new Set([...seen, node.text])),
+      );
+    }
+    return false;
+  };
   const isExecutionSeamReference = (node: ts.Expression): boolean =>
     (ts.isIdentifier(node) && executionSeamAliases.has(node.text)) ||
     ((ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
-      (propertyName(node) === "exec" ||
+      ((propertyName(node) === "exec" && !isRegExpReference(node.expression)) ||
         propertyName(node) === "execSync" ||
         propertyName(node) === "executeCommand" ||
         propertyName(node) === "runExecSeam" ||

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -121,6 +121,36 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects xcodebuild behind an env wrapper" {
+  printf '%s\n' 'spawn("env", ["-i", "DEVELOPER_DIR=/Applications/Xcode.app", "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects xcodebuild behind an absolute env wrapper" {
+  printf '%s\n' 'execFile("/usr/bin/env", ["--unset", "SDKROOT", "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects a neutral injected exec seam" {
+  printf '%s\n' 'runner.exec("xcodebuild -version");' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "allows XcodebuildClient to own direct execution" {
   printf '%s\n' 'spawn("xcodebuild", ["test"]);' > "$repo_dir/src/utils/ios-cmdline-tools/XcodebuildClient.ts"
   git -C "$repo_dir" add src/utils/ios-cmdline-tools/XcodebuildClient.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -141,6 +141,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects env assignments after the option terminator" {
+  printf '%s\n' 'spawn("env", ["--", "DEVELOPER_DIR=/Applications/Xcode.app", "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects an attached env split-string payload" {
+  printf '%s\n' 'spawn("env", ["-Sxcodebuild -version"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a neutral injected exec seam" {
   printf '%s\n' 'runner.exec("xcodebuild -version");' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -55,6 +55,7 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'import * as cp from "node:child_process"; cp["spawn"]("kill", ["-TERM", "42"]);',
       ),
     ).toHaveLength(1);
+    expect(findViolationsInSource("fixture.ts", 'runner.exec("kill", ["42"]);')).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {


### PR DESCRIPTION
## Summary

- follow `env` wrappers through options and environment assignments when enforcing the xcodebuild ownership boundary
- recognize injected `.exec` and `.execSync` seams independently of receiver naming
- add regression coverage for both late review findings from #5830

## Why

#5830 merged before its final two review threads arrived. Those findings identified valid ways to bypass the AST-based process boundary: launching `xcodebuild` through `/usr/bin/env`, and using a neutrally named injected `.exec` seam.

## Validation

- `bun test test/lint/iosCtrlProxyProcessBoundary.test.ts`
- `bats test/bats/check-no-new-direct-xcodebuild.bats`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
