### PR TITLE
fix(daemon): clear completed terminal release promise

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1385,9 +1385,7 @@ export class SessionManager {
     try {
       return await release;
     } finally {
-      if (reason.lateTerminalRelease === release) {
-        reason.lateTerminalRelease = undefined;
-      }
+      reason.lateTerminalRelease = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

- remove an unnecessary promise-identity comparison from terminal release cleanup
- clear the completed shared promise unconditionally in the creating call's `finally` block
- address the late CodeQL finding on https://github.com/kaeawc/auto-mobile/pull/5815 without changing release serialization behavior

## Validation

- `bun test test/daemon/sessionManager.test.ts` (100 pass, 0 fail)
- `bun run turbo:validate` (14,721 pass, 14 skip, 0 fail; 7/7 tasks)
- `bun run format:check`
- `git diff --check`

Follow-up to https://github.com/kaeawc/auto-mobile/issues/5770
