### PR TITLE
fix(ci): preserve execution argument structure

### DIFF
--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -20,53 +20,110 @@ function containsXcodebuildCommand(value: string): boolean {
   return /(?:^|[\s;&|])(?:[^\s;&|]*[/\\])?xcodebuild(?:\s|$)/i.test(value);
 }
 
+function splitEnvPayload(value: string): string[] {
+  const words: string[] = [];
+  let word = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      word += character;
+      escaped = false;
+    } else if (character === "\\" && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        word += character;
+      }
+    } else if (character === "'" || character === '"') {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      if (word) {
+        words.push(word);
+        word = "";
+      }
+    } else {
+      word += character;
+    }
+  }
+  if (escaped) {
+    word += "\\";
+  }
+  if (word) {
+    words.push(word);
+  }
+  return words;
+}
+
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
-  let index = 1;
+  const pending = argv.slice(1);
   let optionsTerminated = false;
-  while (index < argv.length) {
-    const argument = argv[index];
+  let steps = 0;
+  while (pending.length > 0 && steps++ < 1_000) {
+    const argument = pending.shift()!;
     if (!optionsTerminated && argument === "--") {
       optionsTerminated = true;
-      index++;
       continue;
     }
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argument)) {
-      index++;
       continue;
     }
     if (optionsTerminated) {
       return commandName(argument) === "xcodebuild";
     }
     if (["-i", "--ignore-environment", "-0", "--null"].includes(argument)) {
-      index++;
       continue;
     }
     if (["-u", "--unset", "-C", "--chdir", "-P"].includes(argument)) {
-      index += 2;
+      pending.shift();
       continue;
     }
     if (["-S", "--split-string"].includes(argument)) {
-      return containsXcodebuildCommand(argv[index + 1] ?? "");
+      pending.unshift(...splitEnvPayload(pending.shift() ?? ""));
+      continue;
     }
     if (argument.startsWith("-S") && argument.length > 2) {
-      return containsXcodebuildCommand(argument.slice(2));
+      pending.unshift(...splitEnvPayload(argument.slice(2)));
+      continue;
     }
     if (/^--(?:unset|chdir)=/.test(argument)) {
-      index++;
       continue;
     }
     if (argument.startsWith("--split-string=")) {
-      return containsXcodebuildCommand(argument.slice("--split-string=".length));
+      pending.unshift(...splitEnvPayload(argument.slice("--split-string=".length)));
+      continue;
     }
     if (argument.startsWith("-")) {
       // Unknown env flags are skipped conservatively. If they take an operand,
       // treating that operand as the command can only make the boundary louder.
-      index++;
       continue;
     }
     return commandName(argument) === "xcodebuild";
   }
   return false;
+}
+
+function argumentSlotAlternatives(
+  ast: ReturnType<typeof executionBoundaryAst>,
+  node: ts.Expression,
+) {
+  const values = ast.strings(node);
+  return values.includes("\u0000") ? [values.join("")] : values;
+}
+
+function argvAlternatives(
+  ast: ReturnType<typeof executionBoundaryAst>,
+  items: readonly ts.Expression[],
+): string[][] {
+  return items.reduce<string[][]>(
+    (alternatives, item) =>
+      alternatives.flatMap((prefix) =>
+        argumentSlotAlternatives(ast, item).map((value) => [...prefix, value]),
+      ),
+    [[]],
+  );
 }
 
 export function findDirectXcodebuildCalls(file: string, source: string): XcodebuildViolation[] {
@@ -88,18 +145,17 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const first = call.arguments[0];
     const firstArrayAlternatives = ast.arrayAlternatives(first);
     const argumentArrayAlternatives = ast.arrayAlternatives(call.arguments[1]);
-    const argvAlternatives = firstArrayAlternatives
-      ? firstArrayAlternatives.map((items) => items.flatMap((item) => ast.strings(item)))
+    const possibleArgv = firstArrayAlternatives
+      ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
       : ast
           .strings(first)
           .flatMap((command) =>
-            (argumentArrayAlternatives ?? [[]]).map((items) => [
-              command,
-              ...items.flatMap((item) => ast.strings(item)),
-            ]),
+            (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
+              argvAlternatives(ast, items).map((arguments_) => [command, ...arguments_]),
+            ),
           );
-    const directValues = argvAlternatives.flatMap((argv) => argv.slice(0, 1));
-    const direct = argvAlternatives.some(
+    const directValues = possibleArgv.flatMap((argv) => argv.slice(0, 1));
+    const direct = possibleArgv.some(
       (argv) =>
         commandName(argv[0] ?? "") === "xcodebuild" ||
         (ENV_WRAPPERS.has(commandName(argv[0] ?? "")) && envDelegatesToXcodebuild(argv)),

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -39,6 +39,13 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
     if (argument.startsWith("-c") && argument.length > 2) {
       return [argument.slice(2)];
     }
+    if (argument.startsWith("-") && !argument.startsWith("--")) {
+      const commandFlagIndex = argument.indexOf("c", 1);
+      if (commandFlagIndex >= 1) {
+        const attached = argument.slice(commandFlagIndex + 1);
+        return [attached || argv[index + 1] || OPAQUE_ARGUMENT];
+      }
+    }
   }
   return [];
 }
@@ -137,14 +144,13 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       }
       return false;
     }
-    if (["-i", "--ignore-environment", "-0", "--null", "-v", "--debug"].includes(argument)) {
+    if (["-", "-i", "--ignore-environment", "-0", "--null", "-v", "--debug"].includes(argument)) {
       continue;
     }
     if (argument === "--list-signal-handling") {
       continue;
     }
     if (/^--(?:block-signal|default-signal|ignore-signal)$/.test(argument)) {
-      pending.shift();
       continue;
     }
     if (/^--(?:block-signal|default-signal|ignore-signal)=/.test(argument)) {

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -110,9 +110,19 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       continue;
     }
     if (optionsTerminated) {
-      return commandName(argument) === "xcodebuild";
+      const command = commandName(argument);
+      if (command === "xcodebuild") {
+        return true;
+      }
+      if (SHELLS.has(command)) {
+        return pending.some(containsXcodebuildCommand);
+      }
+      if (ENV_WRAPPERS.has(command)) {
+        return envDelegatesToXcodebuild([argument, ...pending]);
+      }
+      return false;
     }
-    if (["-i", "--ignore-environment", "-0", "--null"].includes(argument)) {
+    if (["-i", "--ignore-environment", "-0", "--null", "-v", "--debug"].includes(argument)) {
       continue;
     }
     if (["-u", "--unset", "-C", "--chdir", "-P"].includes(argument)) {
@@ -167,7 +177,7 @@ function argumentSlotAlternatives(
     if (value === STRING_ANALYSIS_OVERFLOW) {
       return ANALYSIS_OVERFLOW;
     }
-    return value === DYNAMIC_BOUNDARY ? OPAQUE_ARGUMENT : value;
+    return value.includes(DYNAMIC_BOUNDARY) ? OPAQUE_ARGUMENT : value;
   });
 }
 
@@ -212,7 +222,11 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
           (command) =>
             (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
               argvAlternatives(ast, items).map((arguments_) => [
-                command === STRING_ANALYSIS_OVERFLOW ? ANALYSIS_OVERFLOW : command,
+                command === STRING_ANALYSIS_OVERFLOW
+                  ? ANALYSIS_OVERFLOW
+                  : command.includes(DYNAMIC_BOUNDARY)
+                    ? OPAQUE_ARGUMENT
+                    : command,
                 ...arguments_,
               ]),
             ),

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -185,10 +185,13 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     let possibleArgv = firstArrayAlternatives
       ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
       : ast
-          .strings(first)
+          .stringAlternatives(first)
           .flatMap((command) =>
             (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
-              argvAlternatives(ast, items).map((arguments_) => [command, ...arguments_]),
+              argvAlternatives(ast, items).map((arguments_) => [
+                command === STRING_ANALYSIS_OVERFLOW ? ANALYSIS_OVERFLOW : command,
+                ...arguments_,
+              ]),
             ),
           );
     if (possibleArgv.length > MAX_ARGV_ALTERNATIVES) {

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -116,11 +116,11 @@ function argumentSlotAlternatives(
   ast: ReturnType<typeof executionBoundaryAst>,
   node: ts.Expression,
 ) {
-  const values = ast.strings(node);
+  const values = ast.stringAlternatives(node);
   if (values.length === 0) {
     return [OPAQUE_ARGUMENT];
   }
-  return values.includes("\u0000") ? [values.join("")] : values;
+  return values;
 }
 
 function argvAlternatives(

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -13,6 +13,7 @@ const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]
 const ENV_WRAPPERS = new Set(["env"]);
 const OPAQUE_ARGUMENT = "\u0001";
 const ANALYSIS_OVERFLOW = "\u0002";
+const STRING_ANALYSIS_OVERFLOW = "\u0003";
 const MAX_ARGV_ALTERNATIVES = 256;
 
 function commandName(value: string): string {
@@ -111,7 +112,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
     if (command === "xcodebuild") {
       return true;
     }
-    if (SHELLS.has(argument.toLowerCase())) {
+    if (SHELLS.has(command)) {
       return pending.some(containsXcodebuildCommand);
     }
     if (ENV_WRAPPERS.has(command)) {
@@ -130,7 +131,12 @@ function argumentSlotAlternatives(
   if (values.length === 0) {
     return [OPAQUE_ARGUMENT];
   }
-  return values;
+  return values.map((value) => {
+    if (value === STRING_ANALYSIS_OVERFLOW) {
+      return ANALYSIS_OVERFLOW;
+    }
+    return value === "\u0000" ? OPAQUE_ARGUMENT : value;
+  });
 }
 
 function argvAlternatives(

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -27,6 +27,22 @@ function containsXcodebuildCommand(value: string): boolean {
   return /(?:^|[\s;&|])(?:[^\s;&|]*[/\\])?xcodebuild(?:\s|$)/i.test(value);
 }
 
+function shellCommandPayloads(argv: readonly string[]): string[] {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === OPAQUE_ARGUMENT) {
+      return [OPAQUE_ARGUMENT];
+    }
+    if (argument === "-c" || argument === "--command") {
+      return [argv[index + 1] ?? OPAQUE_ARGUMENT];
+    }
+    if (argument.startsWith("-c") && argument.length > 2) {
+      return [argument.slice(2)];
+    }
+  }
+  return [];
+}
+
 function splitEnvPayload(value: string): string[] {
   const words: string[] = [];
   let word = "";
@@ -114,7 +130,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
         return true;
       }
       if (SHELLS.has(command)) {
-        return pending.some(containsXcodebuildCommand);
+        return shellCommandPayloads(pending).some(containsXcodebuildCommand);
       }
       if (ENV_WRAPPERS.has(command)) {
         return envDelegatesToXcodebuild([argument, ...pending]);
@@ -122,6 +138,16 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       return false;
     }
     if (["-i", "--ignore-environment", "-0", "--null", "-v", "--debug"].includes(argument)) {
+      continue;
+    }
+    if (argument === "--list-signal-handling") {
+      continue;
+    }
+    if (/^--(?:block-signal|default-signal|ignore-signal)$/.test(argument)) {
+      pending.shift();
+      continue;
+    }
+    if (/^--(?:block-signal|default-signal|ignore-signal)=/.test(argument)) {
       continue;
     }
     if (["-u", "--unset", "-C", "--chdir", "-P"].includes(argument)) {
@@ -154,7 +180,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       return true;
     }
     if (SHELLS.has(command)) {
-      return pending.some(containsXcodebuildCommand);
+      return shellCommandPayloads(pending).some(containsXcodebuildCommand);
     }
     if (ENV_WRAPPERS.has(command)) {
       return envDelegatesToXcodebuild([argument, ...pending]);
@@ -176,7 +202,11 @@ function argumentSlotAlternatives(
     if (value === STRING_ANALYSIS_OVERFLOW) {
       return ANALYSIS_OVERFLOW;
     }
-    return value.includes(DYNAMIC_BOUNDARY) ? OPAQUE_ARGUMENT : value;
+    if (!value.includes(DYNAMIC_BOUNDARY)) {
+      return value;
+    }
+    const assignmentPrefix = value.slice(0, value.indexOf(DYNAMIC_BOUNDARY));
+    return /^[A-Za-z_][A-Za-z0-9_]*=$/.test(assignmentPrefix) ? value : OPAQUE_ARGUMENT;
   });
 }
 
@@ -215,20 +245,26 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const firstArrayAlternatives = ast.arrayAlternatives(first);
     const argumentArrayAlternatives = ast.arrayAlternatives(call.arguments[1]);
     const commandAlternatives = firstArrayAlternatives ? [] : ast.stringAlternatives(first);
+    const unresolvedLauncherCommand =
+      !firstArrayAlternatives && commandAlternatives.length === 0 && ast.isLauncher(call);
     let possibleArgv = firstArrayAlternatives
       ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
-      : (commandAlternatives.length > 0 ? commandAlternatives : [OPAQUE_ARGUMENT]).flatMap(
-          (command) =>
-            (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
-              argvAlternatives(ast, items).map((arguments_) => [
-                command === STRING_ANALYSIS_OVERFLOW
-                  ? ANALYSIS_OVERFLOW
-                  : command.includes(DYNAMIC_BOUNDARY)
-                    ? OPAQUE_ARGUMENT
-                    : command,
-                ...arguments_,
-              ]),
-            ),
+      : (commandAlternatives.length > 0
+          ? commandAlternatives
+          : unresolvedLauncherCommand
+            ? [OPAQUE_ARGUMENT]
+            : []
+        ).flatMap((command) =>
+          (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
+            argvAlternatives(ast, items).map((arguments_) => [
+              command === STRING_ANALYSIS_OVERFLOW
+                ? ANALYSIS_OVERFLOW
+                : command.includes(DYNAMIC_BOUNDARY)
+                  ? OPAQUE_ARGUMENT
+                  : command,
+              ...arguments_,
+            ]),
+          ),
         );
     if (possibleArgv.length > MAX_ARGV_ALTERNATIVES) {
       possibleArgv = [[ANALYSIS_OVERFLOW]];

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -107,7 +107,17 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       // treating that operand as the command can only make the boundary louder.
       continue;
     }
-    return commandName(argument) === "xcodebuild";
+    const command = commandName(argument);
+    if (command === "xcodebuild") {
+      return true;
+    }
+    if (SHELLS.has(argument.toLowerCase())) {
+      return pending.some(containsXcodebuildCommand);
+    }
+    if (ENV_WRAPPERS.has(command)) {
+      return envDelegatesToXcodebuild([argument, ...pending]);
+    }
+    return false;
   }
   return false;
 }

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -157,6 +157,9 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       pending.shift();
       continue;
     }
+    if (/^-(?:u|C|P).+/.test(argument)) {
+      continue;
+    }
     if (["-S", "--split-string"].includes(argument)) {
       splitStringSeen = true;
       pending.unshift(...splitEnvPayload(pending.shift() ?? ""));

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -33,6 +33,9 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
     if (argument === OPAQUE_ARGUMENT) {
       return [OPAQUE_ARGUMENT];
     }
+    if (argument === "--") {
+      return [];
+    }
     if (argument === "-c" || argument === "--command") {
       return [argv[index + 1] ?? OPAQUE_ARGUMENT];
     }
@@ -48,6 +51,10 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
 
 function splitEnvPayload(value: string): string[] {
   const words: string[] = [];
+  const withOpaqueExpansions = (values: string[]): string[] =>
+    values.map((candidate) =>
+      /\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(candidate) ? OPAQUE_ARGUMENT : candidate,
+    );
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -57,7 +64,7 @@ function splitEnvPayload(value: string): string[] {
         if (word) {
           words.push(word);
         }
-        return words;
+        return withOpaqueExpansions(words);
       }
       if (["_", "t", "n", "v", "f", "r"].includes(character)) {
         if (quote === '"') {
@@ -107,7 +114,7 @@ function splitEnvPayload(value: string): string[] {
   if (word) {
     words.push(word);
   }
-  return words;
+  return withOpaqueExpansions(words);
 }
 
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -31,7 +31,16 @@ function splitEnvPayload(value: string): string[] {
   let escaped = false;
   for (const character of value) {
     if (escaped) {
-      word += character;
+      if (character === "_") {
+        if (quote === '"') {
+          word += " ";
+        } else if (word) {
+          words.push(word);
+          word = "";
+        }
+      } else {
+        word += character;
+      }
       escaped = false;
     } else if (character === "\\" && quote !== "'") {
       escaped = true;

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -36,14 +36,10 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
     if (argument === "-c" || argument === "--command") {
       return [argv[index + 1] ?? OPAQUE_ARGUMENT];
     }
-    if (argument.startsWith("-c") && argument.length > 2) {
-      return [argument.slice(2)];
-    }
     if (argument.startsWith("-") && !argument.startsWith("--")) {
       const commandFlagIndex = argument.indexOf("c", 1);
       if (commandFlagIndex >= 1) {
-        const attached = argument.slice(commandFlagIndex + 1);
-        return [attached || argv[index + 1] || OPAQUE_ARGUMENT];
+        return [argv[index + 1] ?? OPAQUE_ARGUMENT];
       }
     }
   }

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -51,20 +51,24 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
 
 function splitEnvPayload(value: string): string[] {
   const words: string[] = [];
-  const withOpaqueExpansions = (values: string[]): string[] =>
-    values.map((candidate) =>
-      /\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(candidate) ? OPAQUE_ARGUMENT : candidate,
-    );
   let word = "";
+  let wordHasExpansion = false;
   let quote: "'" | '"' | null = null;
   let escaped = false;
-  for (const character of value) {
+  const pushWord = (): void => {
+    if (!word) {
+      return;
+    }
+    words.push(wordHasExpansion ? OPAQUE_ARGUMENT : word);
+    word = "";
+    wordHasExpansion = false;
+  };
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
     if (escaped) {
       if (character === "c") {
-        if (word) {
-          words.push(word);
-        }
-        return withOpaqueExpansions(words);
+        pushWord();
+        return words;
       }
       if (["_", "t", "n", "v", "f", "r"].includes(character)) {
         if (quote === '"') {
@@ -82,8 +86,7 @@ function splitEnvPayload(value: string): string[] {
                       : " ";
           word += whitespace;
         } else if (word) {
-          words.push(word);
-          word = "";
+          pushWord();
         }
       } else {
         word += character;
@@ -96,25 +99,30 @@ function splitEnvPayload(value: string): string[] {
         quote = null;
       } else {
         word += character;
+        if (
+          quote !== "'" &&
+          character === "$" &&
+          /^\{[A-Za-z_][A-Za-z0-9_]*\}/.test(value.slice(index + 1))
+        ) {
+          wordHasExpansion = true;
+        }
       }
     } else if (character === "'" || character === '"') {
       quote = character;
     } else if (/\s/.test(character)) {
-      if (word) {
-        words.push(word);
-        word = "";
-      }
+      pushWord();
     } else {
       word += character;
+      if (character === "$" && /^\{[A-Za-z_][A-Za-z0-9_]*\}/.test(value.slice(index + 1))) {
+        wordHasExpansion = true;
+      }
     }
   }
   if (escaped) {
     word += "\\";
   }
-  if (word) {
-    words.push(word);
-  }
-  return withOpaqueExpansions(words);
+  pushWord();
+  return words;
 }
 
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -208,15 +208,15 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const commandAlternatives = firstArrayAlternatives ? [] : ast.stringAlternatives(first);
     let possibleArgv = firstArrayAlternatives
       ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
-      : (commandAlternatives.length > 0 ? commandAlternatives : [OPAQUE_ARGUMENT])
-          .flatMap((command) =>
+      : (commandAlternatives.length > 0 ? commandAlternatives : [OPAQUE_ARGUMENT]).flatMap(
+          (command) =>
             (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
               argvAlternatives(ast, items).map((arguments_) => [
                 command === STRING_ANALYSIS_OVERFLOW ? ANALYSIS_OVERFLOW : command,
                 ...arguments_,
               ]),
             ),
-          );
+        );
     if (possibleArgv.length > MAX_ARGV_ALTERNATIVES) {
       possibleArgv = [[ANALYSIS_OVERFLOW]];
     }

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -11,6 +11,9 @@ export interface XcodebuildViolation {
 
 const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]);
 const ENV_WRAPPERS = new Set(["env"]);
+const OPAQUE_ARGUMENT = "\u0001";
+const ANALYSIS_OVERFLOW = "\u0002";
+const MAX_ARGV_ALTERNATIVES = 256;
 
 function commandName(value: string): string {
   return value.split(/[\\/]/).at(-1)?.toLowerCase() ?? "";
@@ -60,9 +63,13 @@ function splitEnvPayload(value: string): string[] {
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
   const pending = argv.slice(1);
   let optionsTerminated = false;
-  let steps = 0;
-  while (pending.length > 0 && steps++ < 1_000) {
+  while (pending.length > 0) {
     const argument = pending.shift()!;
+    if (argument === OPAQUE_ARGUMENT) {
+      // The value may be another environment assignment. Keep scanning known
+      // later slots so an unresolved value cannot hide a prohibited command.
+      continue;
+    }
     if (!optionsTerminated && argument === "--") {
       optionsTerminated = true;
       continue;
@@ -110,6 +117,9 @@ function argumentSlotAlternatives(
   node: ts.Expression,
 ) {
   const values = ast.strings(node);
+  if (values.length === 0) {
+    return [OPAQUE_ARGUMENT];
+  }
   return values.includes("\u0000") ? [values.join("")] : values;
 }
 
@@ -117,13 +127,15 @@ function argvAlternatives(
   ast: ReturnType<typeof executionBoundaryAst>,
   items: readonly ts.Expression[],
 ): string[][] {
-  return items.reduce<string[][]>(
-    (alternatives, item) =>
-      alternatives.flatMap((prefix) =>
-        argumentSlotAlternatives(ast, item).map((value) => [...prefix, value]),
-      ),
-    [[]],
-  );
+  let alternatives: string[][] = [[]];
+  for (const item of items) {
+    const values = argumentSlotAlternatives(ast, item);
+    if (alternatives.length * values.length > MAX_ARGV_ALTERNATIVES) {
+      return [[ANALYSIS_OVERFLOW]];
+    }
+    alternatives = alternatives.flatMap((prefix) => values.map((value) => [...prefix, value]));
+  }
+  return alternatives;
 }
 
 export function findDirectXcodebuildCalls(file: string, source: string): XcodebuildViolation[] {
@@ -145,7 +157,7 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const first = call.arguments[0];
     const firstArrayAlternatives = ast.arrayAlternatives(first);
     const argumentArrayAlternatives = ast.arrayAlternatives(call.arguments[1]);
-    const possibleArgv = firstArrayAlternatives
+    let possibleArgv = firstArrayAlternatives
       ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
       : ast
           .strings(first)
@@ -154,9 +166,13 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
               argvAlternatives(ast, items).map((arguments_) => [command, ...arguments_]),
             ),
           );
+    if (possibleArgv.length > MAX_ARGV_ALTERNATIVES) {
+      possibleArgv = [[ANALYSIS_OVERFLOW]];
+    }
     const directValues = possibleArgv.flatMap((argv) => argv.slice(0, 1));
     const direct = possibleArgv.some(
       (argv) =>
+        argv.includes(ANALYSIS_OVERFLOW) ||
         commandName(argv[0] ?? "") === "xcodebuild" ||
         (ENV_WRAPPERS.has(commandName(argv[0] ?? "")) && envDelegatesToXcodebuild(argv)),
     );

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -98,9 +98,8 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
   while (pending.length > 0) {
     const argument = pending.shift()!;
     if (argument === OPAQUE_ARGUMENT) {
-      // The value may be another environment assignment. Keep scanning known
-      // later slots so an unresolved value cannot hide a prohibited command.
-      continue;
+      // The value may itself be the command, so skipping it would fail open.
+      return true;
     }
     if (!optionsTerminated && argument === "--") {
       optionsTerminated = true;

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import ts from "typescript";
-import { executionBoundaryAst } from "./lib/executionBoundaryAst";
+import {
+  DYNAMIC_BOUNDARY,
+  executionBoundaryAst,
+  STRING_ANALYSIS_OVERFLOW,
+} from "./lib/executionBoundaryAst";
 
 export interface XcodebuildViolation {
   readonly file: string;
@@ -13,7 +17,6 @@ const SHELLS = new Set(["sh", "/bin/sh", "bash", "/bin/bash", "zsh", "/bin/zsh"]
 const ENV_WRAPPERS = new Set(["env"]);
 const OPAQUE_ARGUMENT = "\u0001";
 const ANALYSIS_OVERFLOW = "\u0002";
-const STRING_ANALYSIS_OVERFLOW = "\u0003";
 const MAX_ARGV_ALTERNATIVES = 256;
 
 function commandName(value: string): string {
@@ -31,9 +34,27 @@ function splitEnvPayload(value: string): string[] {
   let escaped = false;
   for (const character of value) {
     if (escaped) {
-      if (character === "_") {
+      if (character === "c") {
+        if (word) {
+          words.push(word);
+        }
+        return words;
+      }
+      if (["_", "t", "n", "v", "f", "r"].includes(character)) {
         if (quote === '"') {
-          word += " ";
+          const whitespace =
+            character === "t"
+              ? "\t"
+              : character === "n"
+                ? "\n"
+                : character === "v"
+                  ? "\v"
+                  : character === "f"
+                    ? "\f"
+                    : character === "r"
+                      ? "\r"
+                      : " ";
+          word += whitespace;
         } else if (word) {
           words.push(word);
           word = "";
@@ -73,6 +94,7 @@ function splitEnvPayload(value: string): string[] {
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
   const pending = argv.slice(1);
   let optionsTerminated = false;
+  let unknownFlagSeen = false;
   while (pending.length > 0) {
     const argument = pending.shift()!;
     if (argument === OPAQUE_ARGUMENT) {
@@ -113,8 +135,9 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       continue;
     }
     if (argument.startsWith("-")) {
-      // Unknown env flags are skipped conservatively. If they take an operand,
-      // treating that operand as the command can only make the boundary louder.
+      // Unknown flags may bundle -S or consume an operand. Remember them so a
+      // later unrecognized word cannot make the boundary silently fail open.
+      unknownFlagSeen = true;
       continue;
     }
     const command = commandName(argument);
@@ -127,7 +150,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
     if (ENV_WRAPPERS.has(command)) {
       return envDelegatesToXcodebuild([argument, ...pending]);
     }
-    return false;
+    return unknownFlagSeen && [argument, ...pending].some(containsXcodebuildCommand);
   }
   return false;
 }
@@ -144,7 +167,7 @@ function argumentSlotAlternatives(
     if (value === STRING_ANALYSIS_OVERFLOW) {
       return ANALYSIS_OVERFLOW;
     }
-    return value === "\u0000" ? OPAQUE_ARGUMENT : value;
+    return value === DYNAMIC_BOUNDARY ? OPAQUE_ARGUMENT : value;
   });
 }
 
@@ -182,10 +205,10 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const first = call.arguments[0];
     const firstArrayAlternatives = ast.arrayAlternatives(first);
     const argumentArrayAlternatives = ast.arrayAlternatives(call.arguments[1]);
+    const commandAlternatives = firstArrayAlternatives ? [] : ast.stringAlternatives(first);
     let possibleArgv = firstArrayAlternatives
       ? firstArrayAlternatives.flatMap((items) => argvAlternatives(ast, items))
-      : ast
-          .stringAlternatives(first)
+      : (commandAlternatives.length > 0 ? commandAlternatives : [OPAQUE_ARGUMENT])
           .flatMap((command) =>
             (argumentArrayAlternatives ?? [[]]).flatMap((items) =>
               argvAlternatives(ast, items).map((arguments_) => [

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -173,6 +173,7 @@ export function findDirectXcodebuildCalls(file: string, source: string): Xcodebu
     const direct = possibleArgv.some(
       (argv) =>
         argv.includes(ANALYSIS_OVERFLOW) ||
+        argv[0] === OPAQUE_ARGUMENT ||
         commandName(argv[0] ?? "") === "xcodebuild" ||
         (ENV_WRAPPERS.has(commandName(argv[0] ?? "")) && envDelegatesToXcodebuild(argv)),
     );

--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -117,6 +117,7 @@ function splitEnvPayload(value: string): string[] {
 function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
   const pending = argv.slice(1);
   let optionsTerminated = false;
+  let splitStringSeen = false;
   let unknownFlagSeen = false;
   while (pending.length > 0) {
     const argument = pending.shift()!;
@@ -142,7 +143,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       if (ENV_WRAPPERS.has(command)) {
         return envDelegatesToXcodebuild([argument, ...pending]);
       }
-      return false;
+      return splitStringSeen && [argument, ...pending].some(containsXcodebuildCommand);
     }
     if (["-", "-i", "--ignore-environment", "-0", "--null", "-v", "--debug"].includes(argument)) {
       continue;
@@ -161,10 +162,12 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       continue;
     }
     if (["-S", "--split-string"].includes(argument)) {
+      splitStringSeen = true;
       pending.unshift(...splitEnvPayload(pending.shift() ?? ""));
       continue;
     }
     if (argument.startsWith("-S") && argument.length > 2) {
+      splitStringSeen = true;
       pending.unshift(...splitEnvPayload(argument.slice(2)));
       continue;
     }
@@ -172,6 +175,7 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
       continue;
     }
     if (argument.startsWith("--split-string=")) {
+      splitStringSeen = true;
       pending.unshift(...splitEnvPayload(argument.slice("--split-string=".length)));
       continue;
     }
@@ -191,7 +195,9 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
     if (ENV_WRAPPERS.has(command)) {
       return envDelegatesToXcodebuild([argument, ...pending]);
     }
-    return unknownFlagSeen && [argument, ...pending].some(containsXcodebuildCommand);
+    return (
+      (unknownFlagSeen || splitStringSeen) && [argument, ...pending].some(containsXcodebuildCommand)
+    );
   }
   return false;
 }

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -13,6 +13,8 @@ export const PROCESS_LAUNCHERS = new Set([
 const CHILD_PROCESS_MODULES = new Set(["child_process", "node:child_process"]);
 const INJECTED_LAUNCHERS = new Set(["spawn", "spawnSync"]);
 const DYNAMIC_BOUNDARY = "\u0000";
+const STRING_ANALYSIS_OVERFLOW = "\u0003";
+const MAX_STRING_ALTERNATIVES = 256;
 
 export interface ExecutionBoundaryAst {
   readonly calls: readonly ts.CallExpression[];
@@ -246,6 +248,23 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         CHILD_PROCESS_MODULES.has(node.initializer.arguments[0].text)
       ) {
         childProcessNamespaces.add(node.name.text);
+      }
+    }
+    if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+      const scope = functionScope(node);
+      declarations.push({ name: node.name.text, scope, position: node.getStart(sourceFile) });
+      if (node.initializer) {
+        initializers.set(node.name.text, [
+          ...(initializers.get(node.name.text) ?? []),
+          node.initializer,
+        ]);
+        scopedValues.push({
+          name: node.name.text,
+          value: node.initializer,
+          kind: "declaration",
+          scope,
+          position: node.getStart(sourceFile),
+        });
       }
     }
     if (
@@ -491,6 +510,15 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       const right = stringAlternatives(node.right, seen);
       const leftValues = left.length > 0 ? left : [DYNAMIC_BOUNDARY];
       const rightValues = right.length > 0 ? right : [DYNAMIC_BOUNDARY];
+      if (
+        leftValues.includes(STRING_ANALYSIS_OVERFLOW) ||
+        rightValues.includes(STRING_ANALYSIS_OVERFLOW)
+      ) {
+        return [STRING_ANALYSIS_OVERFLOW];
+      }
+      if (leftValues.length * rightValues.length > MAX_STRING_ALTERNATIVES) {
+        return [STRING_ANALYSIS_OVERFLOW];
+      }
       return leftValues.flatMap((prefix) => rightValues.map((suffix) => prefix + suffix));
     }
     if (ts.isTemplateExpression(node)) {
@@ -498,6 +526,12 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       for (const span of node.templateSpans) {
         const interpolation = stringAlternatives(span.expression, seen);
         const values = interpolation.length > 0 ? interpolation : [DYNAMIC_BOUNDARY];
+        if (values.includes(STRING_ANALYSIS_OVERFLOW)) {
+          return [STRING_ANALYSIS_OVERFLOW];
+        }
+        if (alternatives.length * values.length > MAX_STRING_ALTERNATIVES) {
+          return [STRING_ANALYSIS_OVERFLOW];
+        }
         alternatives = alternatives.flatMap((prefix) =>
           values.map((value) => prefix + value + span.literal.text),
         );

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -12,8 +12,8 @@ export const PROCESS_LAUNCHERS = new Set([
 ]);
 const CHILD_PROCESS_MODULES = new Set(["child_process", "node:child_process"]);
 const INJECTED_LAUNCHERS = new Set(["spawn", "spawnSync"]);
-const DYNAMIC_BOUNDARY = "\u0000";
-const STRING_ANALYSIS_OVERFLOW = "\u0003";
+export const DYNAMIC_BOUNDARY = "\u0000";
+export const STRING_ANALYSIS_OVERFLOW = "\u0003";
 const MAX_STRING_ALTERNATIVES = 256;
 
 export interface ExecutionBoundaryAst {

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -101,6 +101,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       if (
         ts.isSourceFile(current) ||
         ts.isBlock(current) ||
+        ts.isModuleBlock(current) ||
         ts.isCaseBlock(current) ||
         ts.isForStatement(current) ||
         ts.isForInStatement(current) ||
@@ -115,8 +116,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   const functionScope = (node: ts.Node): ts.Node => {
     let current: ts.Node | undefined = node.parent;
     while (current) {
-      if (ts.isFunctionLike(current) && current.body && ts.isBlock(current.body)) {
-        return current.body;
+      if (ts.isFunctionLike(current)) {
+        return current;
+      }
+      if (ts.isModuleBlock(current)) {
+        return current;
       }
       if (ts.isSourceFile(current)) {
         return current;
@@ -137,7 +141,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       if (
         ts.isSourceFile(current) ||
         ts.isBlock(current) ||
+        ts.isModuleBlock(current) ||
         ts.isCaseBlock(current) ||
+        ts.isFunctionLike(current) ||
         ts.isForStatement(current) ||
         ts.isForInStatement(current) ||
         ts.isForOfStatement(current)
@@ -253,19 +259,6 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
       const scope = functionScope(node);
       declarations.push({ name: node.name.text, scope, position: node.getStart(sourceFile) });
-      if (node.initializer) {
-        initializers.set(node.name.text, [
-          ...(initializers.get(node.name.text) ?? []),
-          node.initializer,
-        ]);
-        scopedValues.push({
-          name: node.name.text,
-          value: node.initializer,
-          kind: "declaration",
-          scope,
-          position: node.getStart(sourceFile),
-        });
-      }
     }
     if (
       ts.isBinaryExpression(node) &&

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -573,6 +573,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (!name) {
       return finish(false);
     }
+    if (receiver !== undefined && propertyName(callee) !== name) {
+      return finish(false);
+    }
     const receiverDeclaration = receiver
       ? resolveReceiverDeclaration(receiver, callScopes)
       : undefined;
@@ -594,6 +597,67 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   };
 
   const callExecutionCache = new Map<InvocationExpression, Map<number, boolean>>();
+
+  const statementDefinitelyAwaits = (statement: ts.Statement): boolean => {
+    if (ts.isExpressionStatement(statement)) {
+      return ts.isAwaitExpression(unwrapTransparentExpression(statement.expression));
+    }
+    if (ts.isVariableStatement(statement)) {
+      return statement.declarationList.declarations.some(
+        (declaration) =>
+          declaration.initializer !== undefined &&
+          ts.isAwaitExpression(unwrapTransparentExpression(declaration.initializer)),
+      );
+    }
+    return false;
+  };
+
+  const assignmentRequiresCompletedAsyncCall = (
+    assignment: ts.Expression,
+    owner: ts.FunctionLikeDeclaration,
+  ): boolean => {
+    if (!owner.body || !ts.isBlock(owner.body)) {
+      return false;
+    }
+    let containingStatement: ts.Statement | undefined;
+    let current: ts.Node | undefined = assignment;
+    while (current && current.parent !== owner.body) {
+      current = current.parent;
+    }
+    if (current && ts.isStatement(current)) {
+      containingStatement = current;
+    }
+    if (!containingStatement) {
+      return false;
+    }
+    for (const statement of owner.body.statements) {
+      if (statement === containingStatement) {
+        return false;
+      }
+      // Only a direct, unconditional top-level await is enough evidence that an
+      // unawaited invocation has suspended. Conditional/nested awaits stay
+      // conservative so the boundary check cannot silently miss a launcher.
+      if (statementDefinitelyAwaits(statement)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const invocationIsAwaited = (invocation: InvocationExpression): boolean => {
+    let current: ts.Node = invocation;
+    while (
+      ts.isParenthesizedExpression(current.parent) ||
+      ts.isAsExpression(current.parent) ||
+      ts.isTypeAssertionExpression(current.parent) ||
+      ts.isNonNullExpression(current.parent) ||
+      ts.isSatisfiesExpression(current.parent)
+    ) {
+      current = current.parent;
+    }
+    return ts.isAwaitExpression(current.parent);
+  };
+
   const callCanExecuteBefore = (
     call: InvocationExpression,
     beforePosition: number,
@@ -716,6 +780,8 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
                   (call) =>
                     callResolvesToFunction(call, candidateFunction!) &&
                     callCanExecuteBefore(call, useExecutionPosition) &&
+                    (!assignmentRequiresCompletedAsyncCall(candidate.value, candidateFunction!) ||
+                      invocationIsAwaited(call)) &&
                     (call.getStart(sourceFile) < useExecutionPosition ||
                       (candidateFunction === useFunction &&
                         useInvocationPositions.includes(call.getStart(sourceFile)))),

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -95,6 +95,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
   const runExecSeamAliases = new Set(["runExecSeam"]);
   const childProcessNamespaces = new Set<string>();
+  const functionName = (node: ts.FunctionLikeDeclaration): string | undefined => {
+    if (node.name && ts.isIdentifier(node.name)) {
+      return node.name.text;
+    }
+    return ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)
+      ? node.parent.name.text
+      : undefined;
+  };
   const lexicalScope = (node: ts.Node): ts.Node => {
     let current: ts.Node | undefined = node.parent;
     while (current) {
@@ -316,27 +324,32 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
               .find((item) => item !== undefined);
             candidateScope = declaration?.scope ?? candidateScope;
           }
-          let crossesFunctionBoundary = false;
+          const crossedFunctions: ts.FunctionLikeDeclaration[] = [];
           let current: ts.Node | undefined = node.parent;
           while (current && current !== candidateScope) {
             if (ts.isFunctionLike(current)) {
-              crossesFunctionBoundary = true;
-              break;
+              crossedFunctions.push(current);
             }
             current = current.parent;
           }
+          const outermostFunction = crossedFunctions.at(-1);
+          const closureName = outermostFunction ? functionName(outermostFunction) : undefined;
+          const invocationPositions = closureName
+            ? calls
+                .filter(
+                  (call) => ts.isIdentifier(call.expression) && call.expression.text === closureName,
+                )
+                .map((call) => call.getStart(sourceFile))
+            : [];
+          const executesBeforeClosure =
+            invocationPositions.length > 0 && candidate.position < Math.min(...invocationPositions);
           return (
             candidate.name === node.text &&
             candidateScope === scope &&
-            (candidate.kind === "declaration" ||
-              candidate.position < usePosition ||
-              crossesFunctionBoundary)
+            (candidate.position < usePosition || executesBeforeClosure)
           );
         });
-        const assignment = candidates
-          .filter((candidate) => candidate.kind === "assignment")
-          .sort((left, right) => right.position - left.position)[0];
-        binding = assignment ?? candidates.find((candidate) => candidate.kind === "declaration");
+        binding = candidates.sort((left, right) => right.position - left.position)[0];
         if (binding) {
           break;
         }
@@ -462,10 +475,26 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     return [];
   };
 
+  const stringAlternativeCache = new Map<string, string[]>();
   const stringAlternatives = (
     node: ts.Expression | undefined,
     seen = new Set<string>(),
   ): string[] => {
+    const boundedUnion = (...groups: readonly string[][]): string[] => {
+      const values = new Set<string>();
+      for (const group of groups) {
+        for (const value of group) {
+          if (value === STRING_ANALYSIS_OVERFLOW) {
+            return [STRING_ANALYSIS_OVERFLOW];
+          }
+          values.add(value);
+          if (values.size > MAX_STRING_ALTERNATIVES) {
+            return [STRING_ANALYSIS_OVERFLOW];
+          }
+        }
+      }
+      return [...values];
+    };
     if (!node) {
       return [];
     }
@@ -483,10 +512,10 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return stringAlternatives(node.template, seen);
     }
     if (ts.isConditionalExpression(node)) {
-      return [
-        ...stringAlternatives(node.whenTrue, seen),
-        ...stringAlternatives(node.whenFalse, seen),
-      ];
+      return boundedUnion(
+        stringAlternatives(node.whenTrue, seen),
+        stringAlternatives(node.whenFalse, seen),
+      );
     }
     if (
       ts.isBinaryExpression(node) &&
@@ -496,7 +525,10 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         ts.SyntaxKind.AmpersandAmpersandToken,
       ].includes(node.operatorToken.kind)
     ) {
-      return [...stringAlternatives(node.left, seen), ...stringAlternatives(node.right, seen)];
+      return boundedUnion(
+        stringAlternatives(node.left, seen),
+        stringAlternatives(node.right, seen),
+      );
     }
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
       const left = stringAlternatives(node.left, seen);
@@ -535,13 +567,23 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       if (seen.has(node.text)) {
         return [];
       }
-      return (initializers.get(node.text) ?? []).flatMap((value) =>
-        stringAlternatives(value, new Set([...seen, node.text])),
+      const cacheKey = `${node.text}\u0000${[...seen].sort().join("\u0000")}`;
+      const cached = stringAlternativeCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+      const alternatives = boundedUnion(
+        ...(initializers.get(node.text) ?? []).map((value) =>
+          stringAlternatives(value, new Set([...seen, node.text])),
+        ),
       );
+      stringAlternativeCache.set(cacheKey, alternatives);
+      return alternatives;
     }
     return [];
   };
 
+  const arrayAlternativeCache = new Map<string, ts.Expression[][] | undefined>();
   const arrayAlternatives = (
     node: ts.Expression | undefined,
     seen = new Set<string>(),
@@ -575,12 +617,18 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return alternatives;
     }
     if (ts.isIdentifier(node) && !seen.has(node.text)) {
+      const cacheKey = `${node.text}\u0000${[...seen].sort().join("\u0000")}`;
+      if (arrayAlternativeCache.has(cacheKey)) {
+        return arrayAlternativeCache.get(cacheKey);
+      }
       const next = new Set([...seen, node.text]);
       const values = initializers.get(node.text) ?? [];
       const arrays = values
         .map((value) => arrayAlternatives(value, next))
         .filter((value): value is ts.Expression[][] => value !== undefined);
-      return arrays.length > 0 ? arrays.flat() : undefined;
+      const alternatives = arrays.length > 0 ? arrays.flat() : undefined;
+      arrayAlternativeCache.set(cacheKey, alternatives);
+      return alternatives;
     }
     return undefined;
   };

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -337,7 +337,8 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           const invocationPositions = closureName
             ? calls
                 .filter(
-                  (call) => ts.isIdentifier(call.expression) && call.expression.text === closureName,
+                  (call) =>
+                    ts.isIdentifier(call.expression) && call.expression.text === closureName,
                 )
                 .map((call) => call.getStart(sourceFile))
             : [];

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -358,7 +358,8 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     const name = functionName(target);
     const callee = unwrapTransparentExpression(call.expression);
     const receiver =
-      ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression)
+      (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) &&
+      ts.isIdentifier(callee.expression)
         ? callee.expression.text
         : undefined;
     if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
@@ -544,6 +545,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       node.tag.expression.text === "String" &&
       node.tag.name.text === "raw"
     ) {
+      if (ts.isNoSubstitutionTemplateLiteral(node.template)) {
+        return [node.template.rawText ?? node.template.text];
+      }
       return strings(node.template, seen);
     }
     if (ts.isTemplateExpression(node)) {
@@ -644,6 +648,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       node.tag.expression.text === "String" &&
       node.tag.name.text === "raw"
     ) {
+      if (ts.isNoSubstitutionTemplateLiteral(node.template)) {
+        return [node.template.rawText ?? node.template.text];
+      }
       return stringAlternatives(node.template, seen);
     }
     if (ts.isConditionalExpression(node)) {

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -98,13 +98,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     scope: ts.Node;
     position: number;
   }> = [];
-  const declarations: Array<{ name: string; scope: ts.Node; position: number }> = [];
+  type DeclarationBinding = { name: string; scope: ts.Node; position: number };
+  const declarations: DeclarationBinding[] = [];
   const functionBindings: Array<{
     name: string;
     node: ts.FunctionLikeDeclaration;
     scope: ts.Node;
     position: number;
-    receiver?: string;
+    receiverDeclaration?: DeclarationBinding;
   }> = [];
   const calls: ts.CallExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
@@ -112,12 +113,19 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   const runExecSeamAliases = new Set(["runExecSeam"]);
   const childProcessNamespaces = new Set<string>();
   const functionName = (node: ts.FunctionLikeDeclaration): string | undefined => {
+    if (ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)) {
+      return node.parent.name.text;
+    }
+    if (ts.isPropertyAssignment(node.parent)) {
+      const assignedName = propertyNameOf(node.parent.name);
+      if (assignedName) {
+        return assignedName;
+      }
+    }
     if (node.name && ts.isIdentifier(node.name)) {
       return node.name.text;
     }
-    return ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)
-      ? node.parent.name.text
-      : undefined;
+    return undefined;
   };
   const lexicalScope = (node: ts.Node): ts.Node => {
     let current: ts.Node | undefined = node.parent;
@@ -223,6 +231,15 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     if (ts.isVariableDeclaration(node)) {
       const scope = variableDeclarationScope(node);
+      const variableDeclarations = bindingIdentifiers(node.name).map((identifier) => ({
+        name: identifier.text,
+        scope,
+        position: node.getStart(sourceFile),
+      }));
+      declarations.push(...variableDeclarations);
+      const receiverDeclaration = ts.isIdentifier(node.name)
+        ? variableDeclarations.find((declaration) => declaration.name === node.name.text)
+        : undefined;
       if (ts.isIdentifier(node.name) && node.initializer && ts.isFunctionLike(node.initializer)) {
         functionBindings.push({
           name: node.name.text,
@@ -242,19 +259,20 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
             : ts.isPropertyAssignment(property) && ts.isFunctionLike(property.initializer)
               ? property.initializer
               : undefined;
-          if (method?.name && ts.isIdentifier(method.name)) {
+          const methodName =
+            ts.isMethodDeclaration(property) || ts.isPropertyAssignment(property)
+              ? propertyNameOf(property.name)
+              : undefined;
+          if (method && methodName) {
             functionBindings.push({
-              name: method.name.text,
+              name: methodName,
               node: method,
               scope,
               position: node.getStart(sourceFile),
-              receiver: node.name.text,
+              receiverDeclaration,
             });
           }
         }
-      }
-      for (const identifier of bindingIdentifiers(node.name)) {
-        declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
       }
       if (ts.isIdentifier(node.name)) {
         if (node.initializer) {
@@ -326,6 +344,15 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
       }
     }
+    if (ts.isCatchClause(node) && node.variableDeclaration) {
+      for (const identifier of bindingIdentifiers(node.variableDeclaration.name)) {
+        declarations.push({
+          name: identifier.text,
+          scope: node.block,
+          position: node.variableDeclaration.getStart(sourceFile),
+        });
+      }
+    }
     if (
       ts.isBinaryExpression(node) &&
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
@@ -352,6 +379,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     call: ts.CallExpression,
     target: ts.FunctionLikeDeclaration,
   ): boolean => {
+    if (target.asteriskToken) {
+      return false;
+    }
     if (unwrapTransparentExpression(call.expression) === target) {
       return true;
     }
@@ -360,19 +390,32 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     const receiver =
       (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) &&
       ts.isIdentifier(callee.expression)
-        ? callee.expression.text
+        ? callee.expression
         : undefined;
     if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
       return false;
     }
     const callScopes = scopeChain(call);
+    const receiverDeclaration = receiver
+      ? declarations
+          .filter(
+            (declaration) =>
+              declaration.name === receiver.text &&
+              callScopes.includes(declaration.scope) &&
+              declaration.position <= receiver.getStart(sourceFile),
+          )
+          .sort((left, right) => {
+            const scopeDelta = callScopes.indexOf(left.scope) - callScopes.indexOf(right.scope);
+            return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
+          })[0]
+      : undefined;
     const candidates = functionBindings
       .filter(
         (binding) =>
           binding.name === name &&
           (receiver === undefined
-            ? binding.receiver === undefined
-            : binding.receiver === receiver) &&
+            ? binding.receiverDeclaration === undefined
+            : binding.receiverDeclaration === receiverDeclaration) &&
           callScopes.includes(binding.scope) &&
           (ts.isFunctionDeclaration(binding.node) || binding.position < call.getStart(sourceFile)),
       )

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -104,6 +104,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     node: ts.FunctionLikeDeclaration;
     scope: ts.Node;
     position: number;
+    receiver?: string;
   }> = [];
   const calls: ts.CallExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
@@ -230,6 +231,28 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           position: node.getStart(sourceFile),
         });
       }
+      if (
+        ts.isIdentifier(node.name) &&
+        node.initializer &&
+        ts.isObjectLiteralExpression(node.initializer)
+      ) {
+        for (const property of node.initializer.properties) {
+          const method = ts.isMethodDeclaration(property)
+            ? property
+            : ts.isPropertyAssignment(property) && ts.isFunctionLike(property.initializer)
+              ? property.initializer
+              : undefined;
+          if (method?.name && ts.isIdentifier(method.name)) {
+            functionBindings.push({
+              name: method.name.text,
+              node: method,
+              scope,
+              position: node.getStart(sourceFile),
+              receiver: node.name.text,
+            });
+          }
+        }
+      }
       for (const identifier of bindingIdentifiers(node.name)) {
         declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
       }
@@ -325,7 +348,12 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return true;
     }
     const name = functionName(target);
-    if (!name || !ts.isIdentifier(unwrapTransparentExpression(call.expression))) {
+    const callee = unwrapTransparentExpression(call.expression);
+    const receiver =
+      ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression)
+        ? callee.expression.text
+        : undefined;
+    if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
       return false;
     }
     const callScopes = scopeChain(call);
@@ -333,6 +361,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       .filter(
         (binding) =>
           binding.name === name &&
+          (receiver === undefined
+            ? binding.receiver === undefined
+            : binding.receiver === receiver) &&
           callScopes.includes(binding.scope) &&
           (ts.isFunctionDeclaration(binding.node) || binding.position < call.getStart(sourceFile)),
       )

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -332,6 +332,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       ts.isIdentifier(node.left)
     ) {
       bind(node.left.text, node.right, node, "assignment");
+      if (ts.isFunctionLike(node.right)) {
+        functionBindings.push({
+          name: node.left.text,
+          node: node.right,
+          scope: lexicalScope(node),
+          position: node.getStart(sourceFile),
+        });
+      }
     }
     if (ts.isCallExpression(node)) {
       calls.push(node);

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -96,7 +96,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   const lexicalScope = (node: ts.Node): ts.Node => {
     let current: ts.Node | undefined = node.parent;
     while (current) {
-      if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
+      if (
+        ts.isSourceFile(current) ||
+        ts.isBlock(current) ||
+        ts.isCaseBlock(current) ||
+        ts.isForStatement(current) ||
+        ts.isForInStatement(current) ||
+        ts.isForOfStatement(current)
+      ) {
         return current;
       }
       current = current.parent;
@@ -125,7 +132,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     const scopes: ts.Node[] = [];
     let current: ts.Node | undefined = node.parent;
     while (current) {
-      if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
+      if (
+        ts.isSourceFile(current) ||
+        ts.isBlock(current) ||
+        ts.isCaseBlock(current) ||
+        ts.isForStatement(current) ||
+        ts.isForInStatement(current) ||
+        ts.isForOfStatement(current)
+      ) {
         scopes.push(current);
       }
       current = current.parent;
@@ -446,6 +460,15 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     node = unwrapTransparentExpression(node);
     if (ts.isStringLiteralLike(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
       return [node.text];
+    }
+    if (
+      ts.isTaggedTemplateExpression(node) &&
+      ts.isPropertyAccessExpression(node.tag) &&
+      ts.isIdentifier(node.tag.expression) &&
+      node.tag.expression.text === "String" &&
+      node.tag.name.text === "raw"
+    ) {
+      return stringAlternatives(node.template, seen);
     }
     if (ts.isConditionalExpression(node)) {
       return [

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -21,6 +21,7 @@ export interface ExecutionBoundaryAst {
   isExecutionSeam(call: ts.CallExpression): boolean;
   isRunExecSeam(call: ts.CallExpression): boolean;
   strings(node: ts.Expression | undefined): string[];
+  stringAlternatives(node: ts.Expression | undefined): string[];
   arrayAlternatives(node: ts.Expression | undefined): ts.Expression[][] | undefined;
   arrayElements(node: ts.Expression | undefined): ts.Expression[] | undefined;
   objectPropertyValues(node: ts.Expression | undefined, propertyName: string): ts.Expression[];
@@ -289,10 +290,21 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
               .find((item) => item !== undefined);
             candidateScope = declaration?.scope ?? candidateScope;
           }
+          let crossesFunctionBoundary = false;
+          let current: ts.Node | undefined = node.parent;
+          while (current && current !== candidateScope) {
+            if (ts.isFunctionLike(current)) {
+              crossesFunctionBoundary = true;
+              break;
+            }
+            current = current.parent;
+          }
           return (
             candidate.name === node.text &&
             candidateScope === scope &&
-            (candidate.kind === "declaration" || candidate.position < usePosition)
+            (candidate.kind === "declaration" ||
+              candidate.position < usePosition ||
+              crossesFunctionBoundary)
           );
         });
         const assignment = candidates
@@ -419,6 +431,62 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       }
       return (initializers.get(node.text) ?? []).flatMap((value) =>
         strings(value, new Set([...seen, node.text])),
+      );
+    }
+    return [];
+  };
+
+  const stringAlternatives = (
+    node: ts.Expression | undefined,
+    seen = new Set<string>(),
+  ): string[] => {
+    if (!node) {
+      return [];
+    }
+    node = unwrapTransparentExpression(node);
+    if (ts.isStringLiteralLike(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      return [node.text];
+    }
+    if (ts.isConditionalExpression(node)) {
+      return [
+        ...stringAlternatives(node.whenTrue, seen),
+        ...stringAlternatives(node.whenFalse, seen),
+      ];
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      [
+        ts.SyntaxKind.QuestionQuestionToken,
+        ts.SyntaxKind.BarBarToken,
+        ts.SyntaxKind.AmpersandAmpersandToken,
+      ].includes(node.operatorToken.kind)
+    ) {
+      return [...stringAlternatives(node.left, seen), ...stringAlternatives(node.right, seen)];
+    }
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const left = stringAlternatives(node.left, seen);
+      const right = stringAlternatives(node.right, seen);
+      const leftValues = left.length > 0 ? left : [DYNAMIC_BOUNDARY];
+      const rightValues = right.length > 0 ? right : [DYNAMIC_BOUNDARY];
+      return leftValues.flatMap((prefix) => rightValues.map((suffix) => prefix + suffix));
+    }
+    if (ts.isTemplateExpression(node)) {
+      let alternatives = [node.head.text];
+      for (const span of node.templateSpans) {
+        const interpolation = stringAlternatives(span.expression, seen);
+        const values = interpolation.length > 0 ? interpolation : [DYNAMIC_BOUNDARY];
+        alternatives = alternatives.flatMap((prefix) =>
+          values.map((value) => prefix + value + span.literal.text),
+        );
+      }
+      return alternatives;
+    }
+    if (ts.isIdentifier(node)) {
+      if (seen.has(node.text)) {
+        return [];
+      }
+      return (initializers.get(node.text) ?? []).flatMap((value) =>
+        stringAlternatives(value, new Set([...seen, node.text])),
       );
     }
     return [];
@@ -556,6 +624,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     isExecutionSeam: (call) => isExecutionSeamReference(call.expression),
     isRunExecSeam: (call) => isRunExecSeamReference(call.expression),
     strings,
+    stringAlternatives,
     arrayAlternatives,
     arrayElements,
     objectPropertyValues,

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -86,6 +86,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     scope: ts.Node;
     position: number;
   }> = [];
+  const declarations: Array<{ name: string; scope: ts.Node; position: number }> = [];
   const calls: ts.CallExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
@@ -100,6 +101,35 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       current = current.parent;
     }
     return sourceFile;
+  };
+  const functionScope = (node: ts.Node): ts.Node => {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+      if (ts.isFunctionLike(current) && current.body && ts.isBlock(current.body)) {
+        return current.body;
+      }
+      if (ts.isSourceFile(current)) {
+        return current;
+      }
+      current = current.parent;
+    }
+    return sourceFile;
+  };
+  const variableDeclarationScope = (node: ts.VariableDeclaration): ts.Node =>
+    ts.isVariableDeclarationList(node.parent) &&
+    (node.parent.flags & ts.NodeFlags.BlockScoped) !== 0
+      ? lexicalScope(node)
+      : functionScope(node);
+  const scopeChain = (node: ts.Node): ts.Node[] => {
+    const scopes: ts.Node[] = [];
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+      if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
+        scopes.push(current);
+      }
+      current = current.parent;
+    }
+    return scopes;
   };
   const bind = (
     name: string,
@@ -145,8 +175,22 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       childProcessNamespaces.add(node.name.text);
     }
     if (ts.isVariableDeclaration(node)) {
-      if (ts.isIdentifier(node.name) && node.initializer) {
-        bind(node.name.text, node.initializer, node, "declaration");
+      if (ts.isIdentifier(node.name)) {
+        const scope = variableDeclarationScope(node);
+        declarations.push({ name: node.name.text, scope, position: node.getStart(sourceFile) });
+        if (node.initializer) {
+          initializers.set(node.name.text, [
+            ...(initializers.get(node.name.text) ?? []),
+            node.initializer,
+          ]);
+          scopedValues.push({
+            name: node.name.text,
+            value: node.initializer,
+            kind: "declaration",
+            scope,
+            position: node.getStart(sourceFile),
+          });
+        }
       }
       if (ts.isObjectBindingPattern(node.name)) {
         const initializer = node.initializer;
@@ -228,23 +272,29 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return true;
     }
     if (ts.isIdentifier(node) && !seen.has(node.text)) {
-      const scopes: ts.Node[] = [];
-      let current: ts.Node | undefined = node.parent;
-      while (current) {
-        if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
-          scopes.push(current);
-        }
-        current = current.parent;
-      }
+      const scopes = scopeChain(node);
       const usePosition = node.getStart(sourceFile);
       let binding: (typeof scopedValues)[number] | undefined;
       for (const scope of scopes) {
-        const candidates = scopedValues.filter(
-          (candidate) =>
+        const candidates = scopedValues.filter((candidate) => {
+          let candidateScope = candidate.scope;
+          if (candidate.kind === "assignment") {
+            const assignmentScopes = scopeChain(candidate.value);
+            const declaration = assignmentScopes
+              .map((assignmentScope) =>
+                declarations.find(
+                  (item) => item.name === candidate.name && item.scope === assignmentScope,
+                ),
+              )
+              .find((item) => item !== undefined);
+            candidateScope = declaration?.scope ?? candidateScope;
+          }
+          return (
             candidate.name === node.text &&
-            candidate.scope === scope &&
-            (candidate.kind === "declaration" || candidate.position < usePosition),
-        );
+            candidateScope === scope &&
+            (candidate.kind === "declaration" || candidate.position < usePosition)
+          );
+        });
         const assignment = candidates
           .filter((candidate) => candidate.kind === "assignment")
           .sort((left, right) => right.position - left.position)[0];

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -80,6 +80,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   );
   const initializers = new Map<string, ts.Expression[]>();
   const scopedValues: Array<{
+    kind: "assignment" | "declaration";
     name: string;
     value: ts.Expression;
     scope: ts.Node;
@@ -100,11 +101,17 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     return sourceFile;
   };
-  const bind = (name: string, value: ts.Expression, owner: ts.Node): void => {
+  const bind = (
+    name: string,
+    value: ts.Expression,
+    owner: ts.Node,
+    kind: "assignment" | "declaration",
+  ): void => {
     initializers.set(name, [...(initializers.get(name) ?? []), value]);
     scopedValues.push({
       name,
       value,
+      kind,
       scope: lexicalScope(owner),
       position: owner.getStart(sourceFile),
     });
@@ -139,7 +146,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     if (ts.isVariableDeclaration(node)) {
       if (ts.isIdentifier(node.name) && node.initializer) {
-        bind(node.name.text, node.initializer, node);
+        bind(node.name.text, node.initializer, node, "declaration");
       }
       if (ts.isObjectBindingPattern(node.name)) {
         const initializer = node.initializer;
@@ -187,7 +194,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)
     ) {
-      bind(node.left.text, node.right, node);
+      bind(node.left.text, node.right, node, "assignment");
     }
     if (ts.isCallExpression(node)) {
       calls.push(node);
@@ -221,22 +228,31 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return true;
     }
     if (ts.isIdentifier(node) && !seen.has(node.text)) {
-      const scopes = new Set<ts.Node>();
+      const scopes: ts.Node[] = [];
       let current: ts.Node | undefined = node.parent;
       while (current) {
         if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
-          scopes.add(current);
+          scopes.push(current);
         }
         current = current.parent;
       }
-      const binding = scopedValues
-        .filter(
+      const usePosition = node.getStart(sourceFile);
+      let binding: (typeof scopedValues)[number] | undefined;
+      for (const scope of scopes) {
+        const candidates = scopedValues.filter(
           (candidate) =>
             candidate.name === node.text &&
-            candidate.position < node.getStart(sourceFile) &&
-            scopes.has(candidate.scope),
-        )
-        .sort((left, right) => right.position - left.position)[0];
+            candidate.scope === scope &&
+            (candidate.kind === "declaration" || candidate.position < usePosition),
+        );
+        const assignment = candidates
+          .filter((candidate) => candidate.kind === "assignment")
+          .sort((left, right) => right.position - left.position)[0];
+        binding = assignment ?? candidates.find((candidate) => candidate.kind === "declaration");
+        if (binding) {
+          break;
+        }
+      }
       return binding ? isRegExpReference(binding.value, new Set([...seen, node.text])) : false;
     }
     return false;

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -166,7 +166,12 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     (node.parent.flags & ts.NodeFlags.BlockScoped) !== 0
       ? lexicalScope(node)
       : functionScope(node);
+  const scopeChainCache = new Map<ts.Node, ts.Node[]>();
   const scopeChain = (node: ts.Node): ts.Node[] => {
+    const cached = scopeChainCache.get(node);
+    if (cached) {
+      return cached;
+    }
     const scopes: ts.Node[] = [];
     let current: ts.Node | undefined = node.parent;
     while (current) {
@@ -184,6 +189,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       }
       current = current.parent;
     }
+    scopeChainCache.set(node, scopes);
     return scopes;
   };
   const bind = (
@@ -375,15 +381,60 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   };
   collect(sourceFile);
 
+  const receiverDeclarationCache = new Map<ts.Identifier, DeclarationBinding | null>();
+  const resolveReceiverDeclaration = (
+    receiver: ts.Identifier,
+    callScopes: readonly ts.Node[],
+  ): DeclarationBinding | undefined => {
+    const cached = receiverDeclarationCache.get(receiver);
+    if (cached !== undefined) {
+      return cached ?? undefined;
+    }
+    const usePosition = receiver.getStart(sourceFile);
+    for (const scope of callScopes) {
+      let nearest: DeclarationBinding | undefined;
+      for (const declaration of declarations) {
+        if (
+          declaration.name === receiver.text &&
+          declaration.scope === scope &&
+          declaration.position <= usePosition &&
+          (!nearest || declaration.position > nearest.position)
+        ) {
+          nearest = declaration;
+        }
+      }
+      if (nearest) {
+        receiverDeclarationCache.set(receiver, nearest);
+        return nearest;
+      }
+    }
+    receiverDeclarationCache.set(receiver, null);
+    return undefined;
+  };
+  const callResolutionCache = new Map<
+    ts.CallExpression,
+    Map<ts.FunctionLikeDeclaration, boolean>
+  >();
+
   const callResolvesToFunction = (
     call: ts.CallExpression,
     target: ts.FunctionLikeDeclaration,
   ): boolean => {
+    const cached = callResolutionCache.get(call)?.get(target);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const finish = (result: boolean): boolean => {
+      const resolutions = callResolutionCache.get(call) ?? new Map();
+      resolutions.set(target, result);
+      callResolutionCache.set(call, resolutions);
+      return result;
+    };
     if (target.asteriskToken) {
-      return false;
+      return finish(false);
     }
     if (unwrapTransparentExpression(call.expression) === target) {
-      return true;
+      return finish(true);
     }
     const name = functionName(target);
     const callee = unwrapTransparentExpression(call.expression);
@@ -393,21 +444,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         ? callee.expression
         : undefined;
     if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
-      return false;
+      return finish(false);
     }
     const callScopes = scopeChain(call);
     const receiverDeclaration = receiver
-      ? declarations
-          .filter(
-            (declaration) =>
-              declaration.name === receiver.text &&
-              callScopes.includes(declaration.scope) &&
-              declaration.position <= receiver.getStart(sourceFile),
-          )
-          .sort((left, right) => {
-            const scopeDelta = callScopes.indexOf(left.scope) - callScopes.indexOf(right.scope);
-            return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
-          })[0]
+      ? resolveReceiverDeclaration(receiver, callScopes)
       : undefined;
     const candidates = functionBindings
       .filter(
@@ -423,7 +464,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         const scopeDelta = callScopes.indexOf(left.scope) - callScopes.indexOf(right.scope);
         return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
       });
-    return candidates[0]?.node === target;
+    return finish(candidates[0]?.node === target);
   };
 
   const isPromisifiedLauncher = (node: ts.Expression): boolean =>

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -99,6 +99,12 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     position: number;
   }> = [];
   const declarations: Array<{ name: string; scope: ts.Node; position: number }> = [];
+  const functionBindings: Array<{
+    name: string;
+    node: ts.FunctionLikeDeclaration;
+    scope: ts.Node;
+    position: number;
+  }> = [];
   const calls: ts.CallExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
@@ -216,6 +222,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     if (ts.isVariableDeclaration(node)) {
       const scope = variableDeclarationScope(node);
+      if (ts.isIdentifier(node.name) && node.initializer && ts.isFunctionLike(node.initializer)) {
+        functionBindings.push({
+          name: node.name.text,
+          node: node.initializer,
+          scope,
+          position: node.getStart(sourceFile),
+        });
+      }
       for (const identifier of bindingIdentifiers(node.name)) {
         declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
       }
@@ -275,6 +289,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         childProcessNamespaces.add(node.name.text);
       }
     }
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      functionBindings.push({
+        name: node.name.text,
+        node,
+        scope: lexicalScope(node),
+        position: node.getStart(sourceFile),
+      });
+    }
     if (ts.isParameter(node)) {
       const scope = functionScope(node);
       for (const identifier of bindingIdentifiers(node.name)) {
@@ -294,6 +316,32 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     ts.forEachChild(node, collect);
   };
   collect(sourceFile);
+
+  const callResolvesToFunction = (
+    call: ts.CallExpression,
+    target: ts.FunctionLikeDeclaration,
+  ): boolean => {
+    if (unwrapTransparentExpression(call.expression) === target) {
+      return true;
+    }
+    const name = functionName(target);
+    if (!name || !ts.isIdentifier(unwrapTransparentExpression(call.expression))) {
+      return false;
+    }
+    const callScopes = scopeChain(call);
+    const candidates = functionBindings
+      .filter(
+        (binding) =>
+          binding.name === name &&
+          callScopes.includes(binding.scope) &&
+          (ts.isFunctionDeclaration(binding.node) || binding.position < call.getStart(sourceFile)),
+      )
+      .sort((left, right) => {
+        const scopeDelta = callScopes.indexOf(left.scope) - callScopes.indexOf(right.scope);
+        return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
+      });
+    return candidates[0]?.node === target;
+  };
 
   const isPromisifiedLauncher = (node: ts.Expression): boolean =>
     ts.isCallExpression(node) &&
@@ -349,10 +397,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           const useFunctionName = useFunction ? functionName(useFunction) : undefined;
           const useInvocationPositions = useFunctionName
             ? calls
-                .filter(
-                  (call) =>
-                    ts.isIdentifier(call.expression) && call.expression.text === useFunctionName,
-                )
+                .filter((call) => callResolvesToFunction(call, useFunction!))
                 .map((call) => call.getStart(sourceFile))
             : [];
           const useExecutionPosition =
@@ -374,12 +419,17 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
             ? calls
                 .filter(
                   (call) =>
-                    ts.isIdentifier(call.expression) &&
-                    call.expression.text === candidateFunctionName &&
+                    callResolvesToFunction(call, candidateFunction!) &&
                     call.getStart(sourceFile) < useExecutionPosition,
                 )
                 .map((call) => call.getStart(sourceFile))
-            : [];
+            : calls
+                .filter(
+                  (call) =>
+                    unwrapTransparentExpression(call.expression) === candidateFunction &&
+                    call.getStart(sourceFile) < useExecutionPosition,
+                )
+                .map((call) => call.getStart(sourceFile));
           if (candidateFunction && candidateInvocationPositions.length === 0) {
             return [];
           }

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -79,13 +79,36 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     ts.ScriptKind.TS,
   );
   const initializers = new Map<string, ts.Expression[]>();
+  const scopedValues: Array<{
+    name: string;
+    value: ts.Expression;
+    scope: ts.Node;
+    position: number;
+  }> = [];
   const calls: ts.CallExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
   const runExecSeamAliases = new Set(["runExecSeam"]);
   const childProcessNamespaces = new Set<string>();
-  const bind = (name: string, value: ts.Expression): void =>
+  const lexicalScope = (node: ts.Node): ts.Node => {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+      if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
+        return current;
+      }
+      current = current.parent;
+    }
+    return sourceFile;
+  };
+  const bind = (name: string, value: ts.Expression, owner: ts.Node): void => {
     initializers.set(name, [...(initializers.get(name) ?? []), value]);
+    scopedValues.push({
+      name,
+      value,
+      scope: lexicalScope(owner),
+      position: owner.getStart(sourceFile),
+    });
+  };
   const collect = (node: ts.Node): void => {
     if (
       ts.isImportDeclaration(node) &&
@@ -116,7 +139,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     if (ts.isVariableDeclaration(node)) {
       if (ts.isIdentifier(node.name) && node.initializer) {
-        bind(node.name.text, node.initializer);
+        bind(node.name.text, node.initializer, node);
       }
       if (ts.isObjectBindingPattern(node.name)) {
         const initializer = node.initializer;
@@ -164,7 +187,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)
     ) {
-      bind(node.left.text, node.right);
+      bind(node.left.text, node.right, node);
     }
     if (ts.isCallExpression(node)) {
       calls.push(node);
@@ -198,9 +221,23 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return true;
     }
     if (ts.isIdentifier(node) && !seen.has(node.text)) {
-      return (initializers.get(node.text) ?? []).some((value) =>
-        isRegExpReference(value, new Set([...seen, node.text])),
-      );
+      const scopes = new Set<ts.Node>();
+      let current: ts.Node | undefined = node.parent;
+      while (current) {
+        if (ts.isSourceFile(current) || ts.isBlock(current) || ts.isCaseBlock(current)) {
+          scopes.add(current);
+        }
+        current = current.parent;
+      }
+      const binding = scopedValues
+        .filter(
+          (candidate) =>
+            candidate.name === node.text &&
+            candidate.position < node.getStart(sourceFile) &&
+            scopes.has(candidate.scope),
+        )
+        .sort((left, right) => right.position - left.position)[0];
+      return binding ? isRegExpReference(binding.value, new Set([...seen, node.text])) : false;
     }
     return false;
   };

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -344,6 +344,32 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         position: node.getStart(sourceFile),
       });
     }
+    if (ts.isClassDeclaration(node) && node.name) {
+      const scope = lexicalScope(node);
+      const receiverDeclaration: DeclarationBinding = {
+        name: node.name.text,
+        scope,
+        position: node.getStart(sourceFile),
+      };
+      declarations.push(receiverDeclaration);
+      for (const member of node.members) {
+        if (
+          ts.isMethodDeclaration(member) &&
+          member.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword)
+        ) {
+          const methodName = propertyNameOf(member.name);
+          if (methodName) {
+            functionBindings.push({
+              name: methodName,
+              node: member,
+              scope,
+              position: member.getStart(sourceFile),
+              receiverDeclaration,
+            });
+          }
+        }
+      }
+    }
     if (ts.isParameter(node)) {
       const scope = functionScope(node);
       for (const identifier of bindingIdentifiers(node.name)) {

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -472,6 +472,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
       return finish(false);
     }
+    if (receiver === undefined && ts.isIdentifier(callee) && callee.text !== name) {
+      return finish(false);
+    }
     const callScopes = scopeChain(call);
     const receiverDeclaration = receiver
       ? resolveReceiverDeclaration(receiver, callScopes)
@@ -491,6 +494,47 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
       });
     return finish(candidates[0]?.node === target);
+  };
+
+  const callExecutionCache = new Map<ts.CallExpression, Map<number, boolean>>();
+  const callCanExecuteBefore = (
+    call: ts.CallExpression,
+    beforePosition: number,
+    seenFunctions = new Set<ts.FunctionLikeDeclaration>(),
+  ): boolean => {
+    const cached =
+      seenFunctions.size === 0 ? callExecutionCache.get(call)?.get(beforePosition) : undefined;
+    if (cached !== undefined) {
+      return cached;
+    }
+    let current: ts.Node | undefined = call.parent;
+    while (current && !ts.isFunctionLike(current)) {
+      current = current.parent;
+    }
+    if (!current || !ts.isFunctionLike(current)) {
+      if (seenFunctions.size === 0) {
+        const positions = callExecutionCache.get(call) ?? new Map();
+        positions.set(beforePosition, true);
+        callExecutionCache.set(call, positions);
+      }
+      return true;
+    }
+    if (seenFunctions.has(current)) {
+      return false;
+    }
+    const nextSeen = new Set([...seenFunctions, current]);
+    const executable = calls.some(
+      (invocation) =>
+        invocation.getStart(sourceFile) < beforePosition &&
+        callResolvesToFunction(invocation, current) &&
+        callCanExecuteBefore(invocation, beforePosition, nextSeen),
+    );
+    if (seenFunctions.size === 0) {
+      const positions = callExecutionCache.get(call) ?? new Map();
+      positions.set(beforePosition, executable);
+      callExecutionCache.set(call, positions);
+    }
+    return executable;
   };
 
   const isPromisifiedLauncher = (node: ts.Expression): boolean =>
@@ -547,7 +591,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           const useFunctionName = useFunction ? functionName(useFunction) : undefined;
           const useInvocationPositions = useFunctionName
             ? calls
-                .filter((call) => callResolvesToFunction(call, useFunction!))
+                .filter(
+                  (call) =>
+                    callResolvesToFunction(call, useFunction!) &&
+                    callCanExecuteBefore(call, Number.POSITIVE_INFINITY),
+                )
                 .map((call) => call.getStart(sourceFile))
             : [];
           const useExecutionPosition =
@@ -570,6 +618,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
                 .filter(
                   (call) =>
                     callResolvesToFunction(call, candidateFunction!) &&
+                    callCanExecuteBefore(call, useExecutionPosition) &&
                     call.getStart(sourceFile) < useExecutionPosition,
                 )
                 .map((call) => call.getStart(sourceFile))

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -53,6 +53,15 @@ function propertyNameOf(name: ts.PropertyName): string | undefined {
     : undefined;
 }
 
+function bindingIdentifiers(name: ts.BindingName): ts.Identifier[] {
+  if (ts.isIdentifier(name)) {
+    return [name];
+  }
+  return name.elements.flatMap((element) =>
+    ts.isBindingElement(element) ? bindingIdentifiers(element.name) : [],
+  );
+}
+
 function unwrapTransparentExpression(expression: ts.Expression): ts.Expression {
   let current = expression;
   while (
@@ -206,9 +215,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       childProcessNamespaces.add(node.name.text);
     }
     if (ts.isVariableDeclaration(node)) {
+      const scope = variableDeclarationScope(node);
+      for (const identifier of bindingIdentifiers(node.name)) {
+        declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
+      }
       if (ts.isIdentifier(node.name)) {
-        const scope = variableDeclarationScope(node);
-        declarations.push({ name: node.name.text, scope, position: node.getStart(sourceFile) });
         if (node.initializer) {
           initializers.set(node.name.text, [
             ...(initializers.get(node.name.text) ?? []),
@@ -264,9 +275,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         childProcessNamespaces.add(node.name.text);
       }
     }
-    if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+    if (ts.isParameter(node)) {
       const scope = functionScope(node);
-      declarations.push({ name: node.name.text, scope, position: node.getStart(sourceFile) });
+      for (const identifier of bindingIdentifiers(node.name)) {
+        declarations.push({ name: identifier.text, scope, position: node.getStart(sourceFile) });
+      }
     }
     if (
       ts.isBinaryExpression(node) &&
@@ -311,7 +324,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       const usePosition = node.getStart(sourceFile);
       let binding: (typeof scopedValues)[number] | undefined;
       for (const scope of scopes) {
-        const candidates = scopedValues.filter((candidate) => {
+        const candidates = scopedValues.flatMap((candidate) => {
           let candidateScope = candidate.scope;
           if (candidate.kind === "assignment") {
             const assignmentScopes = scopeChain(candidate.value);
@@ -324,33 +337,65 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
               .find((item) => item !== undefined);
             candidateScope = declaration?.scope ?? candidateScope;
           }
-          const crossedFunctions: ts.FunctionLikeDeclaration[] = [];
+          const useFunctions: ts.FunctionLikeDeclaration[] = [];
           let current: ts.Node | undefined = node.parent;
           while (current && current !== candidateScope) {
             if (ts.isFunctionLike(current)) {
-              crossedFunctions.push(current);
+              useFunctions.push(current);
             }
             current = current.parent;
           }
-          const outermostFunction = crossedFunctions.at(-1);
-          const closureName = outermostFunction ? functionName(outermostFunction) : undefined;
-          const invocationPositions = closureName
+          const useFunction = useFunctions.at(-1);
+          const useFunctionName = useFunction ? functionName(useFunction) : undefined;
+          const useInvocationPositions = useFunctionName
             ? calls
                 .filter(
                   (call) =>
-                    ts.isIdentifier(call.expression) && call.expression.text === closureName,
+                    ts.isIdentifier(call.expression) && call.expression.text === useFunctionName,
                 )
                 .map((call) => call.getStart(sourceFile))
             : [];
-          const executesBeforeClosure =
-            invocationPositions.length > 0 && candidate.position < Math.min(...invocationPositions);
-          return (
-            candidate.name === node.text &&
+          const useExecutionPosition =
+            useInvocationPositions.length > 0 ? Math.max(...useInvocationPositions) : usePosition;
+
+          const candidateFunctions: ts.FunctionLikeDeclaration[] = [];
+          current = candidate.value.parent;
+          while (current && current !== candidateScope) {
+            if (ts.isFunctionLike(current)) {
+              candidateFunctions.push(current);
+            }
+            current = current.parent;
+          }
+          const candidateFunction = candidateFunctions.at(-1);
+          const candidateFunctionName = candidateFunction
+            ? functionName(candidateFunction)
+            : undefined;
+          const candidateInvocationPositions = candidateFunctionName
+            ? calls
+                .filter(
+                  (call) =>
+                    ts.isIdentifier(call.expression) &&
+                    call.expression.text === candidateFunctionName &&
+                    call.getStart(sourceFile) < useExecutionPosition,
+                )
+                .map((call) => call.getStart(sourceFile))
+            : [];
+          if (candidateFunction && candidateInvocationPositions.length === 0) {
+            return [];
+          }
+          const effectivePosition =
+            candidateInvocationPositions.length > 0
+              ? Math.max(...candidateInvocationPositions)
+              : candidate.position;
+          return candidate.name === node.text &&
             candidateScope === scope &&
-            (candidate.position < usePosition || executesBeforeClosure)
-          );
+            effectivePosition < useExecutionPosition
+            ? [{ candidate, effectivePosition }]
+            : [];
         });
-        binding = candidates.sort((left, right) => right.position - left.position)[0];
+        binding = candidates.sort(
+          (left, right) => right.effectivePosition - left.effectivePosition,
+        )[0]?.candidate;
         if (binding) {
           break;
         }

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -107,12 +107,21 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     position: number;
     receiverDeclaration?: DeclarationBinding;
   }> = [];
+  type InvocationExpression = ts.CallExpression | ts.NewExpression;
   const calls: ts.CallExpression[] = [];
+  const invocations: InvocationExpression[] = [];
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
   const runExecSeamAliases = new Set(["runExecSeam"]);
   const childProcessNamespaces = new Set<string>();
   const functionName = (node: ts.FunctionLikeDeclaration): string | undefined => {
+    if (
+      ts.isConstructorDeclaration(node) &&
+      ts.isClassDeclaration(node.parent) &&
+      node.parent.name
+    ) {
+      return node.parent.name.text;
+    }
     if (ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)) {
       return node.parent.name.text;
     }
@@ -353,6 +362,14 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       };
       declarations.push(receiverDeclaration);
       for (const member of node.members) {
+        if (ts.isConstructorDeclaration(member)) {
+          functionBindings.push({
+            name: node.name.text,
+            node: member,
+            scope,
+            position: member.getStart(sourceFile),
+          });
+        }
         if (
           ts.isMethodDeclaration(member) &&
           member.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword)
@@ -402,6 +419,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     }
     if (ts.isCallExpression(node)) {
       calls.push(node);
+      invocations.push(node);
+    } else if (ts.isNewExpression(node)) {
+      invocations.push(node);
     }
     ts.forEachChild(node, collect);
   };
@@ -437,13 +457,85 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     receiverDeclarationCache.set(receiver, null);
     return undefined;
   };
+  const identifierResolvesToFunction = (
+    name: string,
+    target: ts.FunctionLikeDeclaration,
+    callScopes: readonly ts.Node[],
+    beforePosition: number,
+    seen = new Set<string>(),
+  ): boolean => {
+    if (seen.has(name)) {
+      return false;
+    }
+    const nextSeen = new Set([...seen, name]);
+    const definitions: Array<
+      | { kind: "function"; node: ts.FunctionLikeDeclaration; scope: ts.Node; position: number }
+      | { kind: "value"; value: ts.Expression; scope: ts.Node; position: number }
+    > = [
+      ...functionBindings
+        .filter(
+          (binding) =>
+            binding.name === name &&
+            binding.receiverDeclaration === undefined &&
+            callScopes.includes(binding.scope) &&
+            (ts.isFunctionDeclaration(binding.node) || binding.position < beforePosition),
+        )
+        .map((binding) => ({
+          kind: "function" as const,
+          node: binding.node,
+          scope: binding.scope,
+          position:
+            ts.isFunctionDeclaration(binding.node) && binding.position >= beforePosition
+              ? -1
+              : binding.position,
+        })),
+      ...scopedValues
+        .filter(
+          (binding) =>
+            binding.name === name &&
+            callScopes.includes(binding.scope) &&
+            binding.position < beforePosition,
+        )
+        .map((binding) => ({
+          kind: "value" as const,
+          value: binding.value,
+          scope: binding.scope,
+          position: binding.position,
+        })),
+    ].sort((left, right) => {
+      const scopeDelta = callScopes.indexOf(left.scope) - callScopes.indexOf(right.scope);
+      if (scopeDelta !== 0) {
+        return scopeDelta;
+      }
+      const positionDelta = right.position - left.position;
+      if (positionDelta !== 0) {
+        return positionDelta;
+      }
+      return left.kind === "function" ? -1 : 1;
+    });
+    const definition = definitions[0];
+    if (!definition) {
+      return false;
+    }
+    if (definition.kind === "function") {
+      return definition.node === target;
+    }
+    const value = unwrapTransparentExpression(definition.value);
+    if (value === target) {
+      return true;
+    }
+    return ts.isIdentifier(value)
+      ? identifierResolvesToFunction(value.text, target, callScopes, definition.position, nextSeen)
+      : false;
+  };
+
   const callResolutionCache = new Map<
-    ts.CallExpression,
+    InvocationExpression,
     Map<ts.FunctionLikeDeclaration, boolean>
   >();
 
   const callResolvesToFunction = (
-    call: ts.CallExpression,
+    call: InvocationExpression,
     target: ts.FunctionLikeDeclaration,
   ): boolean => {
     const cached = callResolutionCache.get(call)?.get(target);
@@ -462,20 +554,25 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (unwrapTransparentExpression(call.expression) === target) {
       return finish(true);
     }
-    const name = functionName(target);
     const callee = unwrapTransparentExpression(call.expression);
     const receiver =
       (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) &&
       ts.isIdentifier(callee.expression)
         ? callee.expression
         : undefined;
-    if (!name || (!ts.isIdentifier(callee) && receiver === undefined)) {
-      return finish(false);
-    }
-    if (receiver === undefined && ts.isIdentifier(callee) && callee.text !== name) {
+    if (!ts.isIdentifier(callee) && receiver === undefined) {
       return finish(false);
     }
     const callScopes = scopeChain(call);
+    if (receiver === undefined && ts.isIdentifier(callee)) {
+      return finish(
+        identifierResolvesToFunction(callee.text, target, callScopes, call.getStart(sourceFile)),
+      );
+    }
+    const name = functionName(target);
+    if (!name) {
+      return finish(false);
+    }
     const receiverDeclaration = receiver
       ? resolveReceiverDeclaration(receiver, callScopes)
       : undefined;
@@ -496,9 +593,9 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     return finish(candidates[0]?.node === target);
   };
 
-  const callExecutionCache = new Map<ts.CallExpression, Map<number, boolean>>();
+  const callExecutionCache = new Map<InvocationExpression, Map<number, boolean>>();
   const callCanExecuteBefore = (
-    call: ts.CallExpression,
+    call: InvocationExpression,
     beforePosition: number,
     seenFunctions = new Set<ts.FunctionLikeDeclaration>(),
   ): boolean => {
@@ -523,7 +620,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       return false;
     }
     const nextSeen = new Set([...seenFunctions, current]);
-    const executable = calls.some(
+    const executable = invocations.some(
       (invocation) =>
         invocation.getStart(sourceFile) < beforePosition &&
         callResolvesToFunction(invocation, current) &&
@@ -590,7 +687,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           const useFunction = useFunctions.at(-1);
           const useFunctionName = useFunction ? functionName(useFunction) : undefined;
           const useInvocationPositions = useFunctionName
-            ? calls
+            ? invocations
                 .filter(
                   (call) =>
                     callResolvesToFunction(call, useFunction!) &&
@@ -614,15 +711,17 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
             ? functionName(candidateFunction)
             : undefined;
           const candidateInvocationPositions = candidateFunctionName
-            ? calls
+            ? invocations
                 .filter(
                   (call) =>
                     callResolvesToFunction(call, candidateFunction!) &&
                     callCanExecuteBefore(call, useExecutionPosition) &&
-                    call.getStart(sourceFile) < useExecutionPosition,
+                    (call.getStart(sourceFile) < useExecutionPosition ||
+                      (candidateFunction === useFunction &&
+                        useInvocationPositions.includes(call.getStart(sourceFile)))),
                 )
                 .map((call) => call.getStart(sourceFile))
-            : calls
+            : invocations
                 .filter(
                   (call) =>
                     unwrapTransparentExpression(call.expression) === candidateFunction &&
@@ -636,14 +735,23 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
             candidateInvocationPositions.length > 0
               ? Math.max(...candidateInvocationPositions)
               : candidate.position;
+          const earlierInSameInvocation =
+            candidateFunction === useFunction &&
+            candidate.position < usePosition &&
+            candidateInvocationPositions.some((position) =>
+              useInvocationPositions.includes(position),
+            );
           return candidate.name === node.text &&
             candidateScope === scope &&
-            effectivePosition < useExecutionPosition
-            ? [{ candidate, effectivePosition }]
+            (effectivePosition < useExecutionPosition || earlierInSameInvocation)
+            ? [{ candidate, effectivePosition, earlierInSameInvocation }]
             : [];
         });
         binding = candidates.sort(
-          (left, right) => right.effectivePosition - left.effectivePosition,
+          (left, right) =>
+            right.effectivePosition - left.effectivePosition ||
+            Number(right.earlierInSameInvocation) - Number(left.earlierInSameInvocation) ||
+            right.candidate.position - left.candidate.position,
         )[0]?.candidate;
         if (binding) {
           break;

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -331,6 +331,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "recognizes attached env unset and chdir operands" {
+  printf '%s\n' 'spawn("env", ["-uPATH", "-C/tmp", "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
 @test "recognizes bundled shell command flags" {
   printf '%s\n' "spawn(\"env\", [\"-S\", \"bash -lc 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -271,6 +271,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "fails closed for a dynamic env command slot" {
+  printf '%s\n' 'spawn("env", [`xcodebuild${suffix}`, "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "preserves an unresolved environment argument before xcodebuild" {
   printf '%s\n' 'spawn("env", [environmentArgument, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -251,6 +251,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects an unrecognized wrapper produced by env split-string" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"dash -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "preserves String.raw split-string options" {
   printf '%s\n' 'spawn("env", [String.raw`--split-string=xcodebuild -version`]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -341,6 +341,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "recognizes a shell command flag before another bundled flag" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"bash -cl 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "allows env dash operandless mode" {
   printf '%s\n' 'spawn("env", ["-", "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -181,6 +181,48 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves an unresolved environment argument before xcodebuild" {
+  printf '%s\n' 'spawn("env", [environmentArgument, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "fails closed when conditional argv alternatives exceed the analysis bound" {
+  {
+    printf '%s' 'spawn("env", ['
+    for index in $(seq 1 20); do
+      printf '%s' "condition${index} ? \"NAME${index}=a\" : \"NAME${index}=b\","
+    done
+    printf '%s\n' '"xcodebuild", "test"]);'
+  } > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "does not stop before xcodebuild after one thousand env assignments" {
+  {
+    printf '%s' 'spawn("env", ['
+    for index in $(seq 1 1000); do
+      printf '"NAME%s=value",' "$index"
+    done
+    printf '%s\n' '"xcodebuild", "test"]);'
+  } > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a neutral injected exec seam" {
   printf '%s\n' 'runner.exec("xcodebuild -version");' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -161,6 +161,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "continues after a split-string assignment" {
+  printf '%s\n' 'spawn("env", ["-S", "DEVELOPER_DIR=/Applications/Xcode.app", "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "preserves a dynamic environment assignment as one argv slot" {
+  printf '%s\n' 'spawn("env", [`DEVELOPER_DIR=${developerDir}`, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a neutral injected exec seam" {
   printf '%s\n' 'runner.exec("xcodebuild -version");' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -181,6 +181,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a path-qualified shell produced by env split-string" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"/usr/bin/bash -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "preserves String.raw split-string options" {
   printf '%s\n' 'spawn("env", [String.raw`--split-string=xcodebuild -version`]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
@@ -236,6 +246,22 @@ teardown() {
     printf '%s' 'spawn("env", ['
     for index in $(seq 1 20); do
       printf '%s' "condition${index} ? \"NAME${index}=a\" : \"NAME${index}=b\","
+    done
+    printf '%s\n' '"xcodebuild", "test"]);'
+  } > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "fails closed when one concatenated slot exceeds the analysis bound" {
+  {
+    printf '%s' 'Bun.spawn(['
+    for index in $(seq 1 20); do
+      printf '%s' "(condition${index} ? \"a\" : \"b\") + "
     done
     printf '%s\n' '"xcodebuild", "test"]);'
   } > "$repo_dir/src/bypass.ts"

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -171,6 +171,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a shell wrapper produced by env split-string" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"sh -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "preserves String.raw split-string options" {
+  printf '%s\n' 'spawn("env", [String.raw`--split-string=xcodebuild -version`]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "preserves a dynamic environment assignment as one argv slot" {
   printf '%s\n' 'spawn("env", [`DEVELOPER_DIR=${developerDir}`, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -211,6 +211,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "fails closed for env split-string variable expansion" {
+  printf '%s\n' 'spawn("env", ["-S", "${BUILD_TOOL} test"], { env: { BUILD_TOOL: "xcodebuild" } });' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "honors GNU env split-string termination" {
   printf '%s\n' 'spawn("env", ["-S", String.raw`tool \c xcodebuild test`]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
@@ -303,6 +313,16 @@ teardown() {
 
 @test "inspects only a shell command operand" {
   printf '%s\n' 'spawn("env", ["sh", "-c", "printf %s $1", "_", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
+@test "stops parsing shell options at the option terminator" {
+  printf '%s\n' 'spawn("env", ["bash", "--", "-c", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
 
   run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -201,6 +201,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves a literal command branch beside a dynamic template" {
+  printf '%s\n' 'Bun.spawn([condition ? "xcodebuild" : `tool-${name}`, "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "fails closed when conditional argv alternatives exceed the analysis bound" {
   {
     printf '%s' 'spawn("env", ['

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -181,6 +181,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a shell wrapper after a split-string option terminator" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"-- sh -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "preserves GNU env escaped split-string separators" {
   printf '%s\n' 'spawn("env", ["-S", "FOO=bar \\_ xcodebuild test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
@@ -219,6 +229,16 @@ teardown() {
 
   [ "$status" -eq 1 ]
   [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "recognizes GNU env debug as a no-operand option" {
+  printf '%s\n' 'spawn("env", ["--debug", "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
 }
 
 @test "rejects a path-qualified shell produced by env split-string" {
@@ -283,6 +303,16 @@ teardown() {
 
 @test "preserves a literal command branch beside a dynamic template" {
   printf '%s\n' 'Bun.spawn([condition ? "xcodebuild" : `tool-${name}`, "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "fails closed for an embedded dynamic command marker" {
+  printf '%s\n' 'spawn("xcodebuild" + suffix, ["test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
 
   run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -191,6 +191,36 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves GNU env escaped whitespace separators" {
+  printf '%s\n' 'spawn("env", ["-S", String.raw`FOO=bar\txcodebuild test`]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "honors GNU env split-string termination" {
+  printf '%s\n' 'spawn("env", ["-S", String.raw`tool \c xcodebuild test`]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
+@test "fails closed for bundled env short options" {
+  printf '%s\n' 'spawn("env", ["-iS", "xcodebuild test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a path-qualified shell produced by env split-string" {
   printf '%s\n' "spawn(\"env\", [\"-S\", \"/usr/bin/bash -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
@@ -233,6 +263,16 @@ teardown() {
 
 @test "fails closed for an unresolved array-form command" {
   printf '%s\n' 'Bun.spawn([wrapper, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "fails closed for an unresolved string-form command" {
+  printf '%s\n' 'spawn(commandVariable, ["-S", "xcodebuild test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
 
   run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -283,6 +283,23 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "bounds repeated conditional alias branches" {
+  {
+    printf '%s\n' 'const a0 = condition ? "xcodebuild" : "tool";'
+    for index in $(seq 1 25); do
+      previous=$((index - 1))
+      printf 'const a%s = condition ? a%s : a%s;\n' "$index" "$previous" "$previous"
+    done
+    printf '%s\n' 'spawn(a25, ["test"]);'
+  } > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "does not stop before xcodebuild after one thousand env assignments" {
   {
     printf '%s' 'spawn("env", ['

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -181,6 +181,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves GNU env escaped split-string separators" {
+  printf '%s\n' 'spawn("env", ["-S", "FOO=bar \\_ xcodebuild test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a path-qualified shell produced by env split-string" {
   printf '%s\n' "spawn(\"env\", [\"-S\", \"/usr/bin/bash -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -281,6 +281,36 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves a dynamic env assignment prefix" {
+  printf '%s\n' 'spawn("env", [`LABEL=${label}`, "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
+@test "inspects only a shell command operand" {
+  printf '%s\n' 'spawn("env", ["sh", "-c", "printf %s $1", "_", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
+@test "recognizes GNU env signal options" {
+  printf '%s\n' 'spawn("env", ["--block-signal=PIPE", "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
 @test "preserves an unresolved environment argument before xcodebuild" {
   printf '%s\n' 'spawn("env", [environmentArgument, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts
@@ -309,6 +339,16 @@ teardown() {
 
   [ "$status" -eq 1 ]
   [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "allows callback-based execution seams" {
+  printf '%s\n' 'retryExecutor.execute(async () => {}, { command: "xcodebuild" });' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
 }
 
 @test "preserves a literal command branch beside a dynamic template" {

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -221,6 +221,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "keeps single-quoted env split-string variables literal" {
+  printf '%s\n' 'spawn("env", ["-S", "'\''${BUILD_TOOL}'\'' test"], { env: { BUILD_TOOL: "xcodebuild" } });' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
+@test "keeps escaped env split-string variables literal" {
+  printf '%s\n' 'spawn("env", ["-S", String.raw`\${BUILD_TOOL} test`], { env: { BUILD_TOOL: "xcodebuild" } });' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
 @test "honors GNU env split-string termination" {
   printf '%s\n' 'spawn("env", ["-S", String.raw`tool \c xcodebuild test`]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -191,6 +191,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "fails closed for an unresolved array-form command" {
+  printf '%s\n' 'Bun.spawn([wrapper, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "fails closed when conditional argv alternatives exceed the analysis bound" {
   {
     printf '%s' 'spawn("env", ['

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -311,6 +311,36 @@ teardown() {
   [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
 }
 
+@test "preserves signal-option command operands" {
+  printf '%s\n' 'spawn("env", ["--block-signal", "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "recognizes bundled shell command flags" {
+  printf '%s\n' "spawn(\"env\", [\"-S\", \"bash -lc 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "allows env dash operandless mode" {
+  printf '%s\n' 'spawn("env", ["-", "echo", "xcodebuild"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
 @test "preserves an unresolved environment argument before xcodebuild" {
   printf '%s\n' 'spawn("env", [environmentArgument, "xcodebuild", "test"]);' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -176,6 +176,36 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner: RegExp; let configure = () => { runner = /x/; }; configure = () => {}; configure(); runner.exec("kill");',
       ),
     ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; const configure = function inner(){ runner = /x/; }; configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; try { throw executor; } catch (runner) { runner = executor; } runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; function* configure(){ runner = executor; } configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = executor; const config = { configure(){ runner = /x/; } }; function invoke(config: unknown){ config.configure(); } invoke(other); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const base = {}; const config = { ...base }; runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -68,6 +68,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'function regex(){ return runner.exec("kill"); } const runner = /x/; regex();',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; { runner = /x/; } runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'function regex(){ { var runner = /x/; } return runner.exec("kill"); }',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -86,6 +86,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner: RegExp; function regex(){ return runner.exec("kill"); } runner = /x/; regex();',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const runner = executor; for (let runner = /x/; condition;) { runner.exec("kill"); }',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -92,6 +92,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'const runner = executor; for (let runner = /x/; condition;) { runner.exec("kill"); }',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'function regex(runner: unknown) { { runner = /x/; } return (runner as RegExp).exec("kill"); }',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -224,6 +224,24 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner = /x/; function regex(){ runner.exec("kill"); } regex(); runner = executor; function unused(){ regex(); }',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; function configure(){runner=/x/;} const run=configure; run(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; function regex(){runner=/x/; runner.exec("kill");} regex();',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; class Config { constructor(){runner=/x/;} } new Config(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -56,6 +56,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
       ),
     ).toHaveLength(1);
     expect(findViolationsInSource("fixture.ts", 'runner.exec("kill", ["42"]);')).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'function regex(){ const runner = /x/; runner.exec("kill"); } function process(){ runner.exec("kill", ["42"]); }',
+      ),
+    ).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -158,6 +158,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner = /x/; { function configure(){ runner = executor; } } runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; const config = { configure() { runner = /x/; } }; config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -146,6 +146,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner = /x/; function configure(){ runner = executor; } runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; (() => { runner = /x/; })(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; { function configure(){ runner = executor; } } runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -212,6 +212,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner: RegExp; class Config { static configure(){ runner = /x/; } } Config.configure(); runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; function configure(){ runner = executor; } unrelated(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; function regex(){ runner.exec("kill"); } regex(); runner = executor; function unused(){ regex(); }',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -122,6 +122,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'const regex = (runner = /x/) => runner.exec("kill"); const launch = (runner = executor) => runner.exec("kill");',
       ),
     ).toHaveLength(2);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; function regex(){ runner.exec("kill"); } regex(); runner = executor;',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'var runner = executor; var runner = /x/; runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -134,6 +134,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'var runner = executor; var runner = /x/; runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let { runner } = source; { runner = /x/; } runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; function configure(){ runner = executor; } runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -164,6 +164,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner: RegExp; const config = { configure() { runner = /x/; } }; config.configure(); runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; let configure = () => { runner = /x/; }; configure = () => {}; configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -173,6 +173,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
+        'let runner = executor; const config = { configure(){ runner = /x/; }, unrelated(){} }; config.unrelated(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
         'let runner: RegExp; let configure = () => { runner = /x/; }; configure = () => {}; configure(); runner.exec("kill");',
       ),
     ).toHaveLength(1);
@@ -242,6 +248,30 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner=executor; class Config { constructor(){runner=/x/;} } new Config(); runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; async function configure(){ await Promise.resolve(); runner = executor; } configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; async function configure(){ await Promise.resolve(); runner = executor; } await configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; async function configure(){ runner = executor; await Promise.resolve(); } configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = /x/; async function configure(flag: boolean){ if (flag) await Promise.resolve(); runner = executor; } configure(false); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -98,6 +98,30 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'function regex(runner: unknown) { { runner = /x/; } return (runner as RegExp).exec("kill"); }',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const runner = executor; namespace N { const runner = /x/; runner.exec("kill"); }',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'function configure(run = exec) {} const run = (label: string) => label; run("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'interface Runner { exec(command: string): unknown } function run(runner: Runner = /x/) { runner.exec("kill"); } run(executor);',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'const regex = (runner = /x/) => runner.exec("kill"); const launch = (runner = executor) => runner.exec("kill");',
+      ),
+    ).toHaveLength(2);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -206,6 +206,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'const base = {}; const config = { ...base }; runner.exec("kill");',
       ),
     ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; class Config { static configure(){ runner = /x/; } } Config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -62,6 +62,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'function regex(){ const runner = /x/; runner.exec("kill"); } function process(){ runner.exec("kill", ["42"]); }',
       ),
     ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'function regex(){ return runner.exec("kill"); } const runner = /x/; regex();',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -80,6 +80,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'function regex(){ { var runner = /x/; } return runner.exec("kill"); }',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner: RegExp; function regex(){ return runner.exec("kill"); } runner = /x/; regex();',
+      ),
+    ).toHaveLength(0);
   });
 
   test("has a production check with documented exceptions", () => {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -167,6 +167,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
+        'let runner: RegExp; const config = { configure() { runner = /x/; } }; config["configure"](); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
         'let runner: RegExp; let configure = () => { runner = /x/; }; configure = () => {}; configure(); runner.exec("kill");',
       ),
     ).toHaveLength(1);


### PR DESCRIPTION
## Summary

- splice `env -S` payloads back into argv so assignments and options cannot hide a later `xcodebuild`
- preserve each dynamic or conditional source argument as one argv slot while analyzing wrapper commands
- scope `RegExp.exec` exclusions to the receiver's actual lexical binding
- add regression coverage for the final review findings from #5832

## Why

#5832 merged after CI completed but before its final automated review arrived. The late findings identified three valid fail-open cases in the execution-boundary analyzer. This PR contains only those final fixes, rebased onto the #5832 squash merge.

## Validation

- `bun test test/lint/hostDefaultsExecutionBoundary.test.ts test/lint/iosCtrlProxyProcessBoundary.test.ts`
- `bats test/bats/check-no-new-direct-xcodebuild.bats`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
