### PR TITLE
fix(desktop): keep picker boot guard alive during an in-flight refresh (#4881)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -120,6 +120,14 @@ class DevicePickerViewModel(
   // name heuristic in buildPickerDevices.
   private var bootedImageRuntimeIds: Map<String, String> = emptyMap()
 
+  // Source ids whose boot coroutine is still running (bootController.boot has not returned). The
+  // serialization guard in bootingIds must survive against THIS set, not only the live device list:
+  // once the daemon exposes the started device under its runtime serial but before boot() returns,
+  // a concurrent Refresh's buildPickerDevices hides the source image by name, so it is neither
+  // Shutdown nor Booted in the list and pruneState would otherwise drop the guard and permit a
+  // second startDevice (#4881).
+  private var inFlightBootIds: Set<String> = emptySet()
+
   // Monotonic load/emission generation, claimed at the start of every load()/reloadAfterBoot(). It
   // guards ONLY the stale device-LIST emission: a fetch that resumes after a newer one began does
   // not overwrite the fresher list. It never gates the persistent state above (recorded before the
@@ -276,7 +284,10 @@ class DevicePickerViewModel(
   private fun pruneState(devices: List<PickerDevice>) {
     val shutdownIds = devices.filter { it.state == DeviceState.Shutdown }.map { it.id }.toSet()
     val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
-    bootingIds = bootingIds intersect shutdownIds
+    // A boot guard survives while its boot coroutine is still in flight even when the live list no
+    // longer shows the source as Shutdown: once the daemon exposes the started runtime device its
+    // same-named card hides the source image, so the guard must not be dropped mid-boot (#4881).
+    bootingIds = bootingIds.filter { it in shutdownIds || it in inFlightBootIds }.toSet()
     bootErrors = bootErrors.filterKeys { it in shutdownIds }
     selectedIds = selectedIds intersect bootedIds
     // Keep only attributions whose runtime device is still booted (drop killed/replaced ids).
@@ -306,17 +317,23 @@ class DevicePickerViewModel(
     if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
     bootingIds = bootingIds + deviceId
     bootErrors = bootErrors - deviceId
+    // Guard against a concurrent Refresh pruning the boot guard while the boot is still running.
+    inFlightBootIds = inFlightBootIds + deviceId
     syncState()
     scope.launch {
-      val result = bootController.boot(device)
-      val runtimeDeviceId = result.getOrNull()
-      if (runtimeDeviceId != null) {
-        reloadAfterBoot(device, runtimeDeviceId)
-      } else {
-        val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
-        bootingIds = bootingIds - deviceId
-        bootErrors = bootErrors + (deviceId to message)
-        syncState()
+      try {
+        val result = bootController.boot(device)
+        val runtimeDeviceId = result.getOrNull()
+        if (runtimeDeviceId != null) {
+          reloadAfterBoot(device, runtimeDeviceId)
+        } else {
+          val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
+          bootingIds = bootingIds - deviceId
+          bootErrors = bootErrors + (deviceId to message)
+          syncState()
+        }
+      } finally {
+        inFlightBootIds = inFlightBootIds - deviceId
       }
     }
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -685,6 +685,37 @@ class DevicePickerViewModelTest {
     }
   }
 
+  @Test
+  fun `a refresh that sees the started device before boot returns keeps the serialization guard`() =
+    testScope.runTest {
+      val client =
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = THREE_IMAGES)
+      val boot =
+        FakeDeviceBootController().apply {
+          autoComplete = false // hold the boot open (boot() has not returned)
+          result = Result.success("emulator-5556")
+        }
+      val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (held)
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+
+      // The daemon exposes the started device under its runtime serial BEFORE boot() returns. Its
+      // same-named card hides the Pixel_6_API_33 source image, so a refresh's list shows that
+      // source
+      // neither booted nor shut down.
+      client.bootedJson = TWO_BOOTED_PIXEL8_AND_6
+      v.onAction(DevicePickerAction.Refresh)
+      // The guard must survive on the in-flight boot job even though the source vanished from the
+      // list — otherwise a second startDevice could fire while this boot is still running (#4881).
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+
+      // A click on a DIFFERENT shut-down card must still be a no-op: boots stay serialized.
+      v.onAction(DevicePickerAction.BootDevice("iphone-15"))
+      assertEquals(listOf("Pixel_6_API_33"), boot.bootRequests.map { it.id })
+
+      boot.complete() // release so runTest can finish
+    }
+
   private companion object {
     const val SINGLE_BOOTED_PIXEL8 =
       """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +


### PR DESCRIPTION
## Summary

Fixes **edge 1** of the device-picker boot-flow long-tail hardening tracked in [#4881](https://github.com/kaeawc/auto-mobile/issues/4881) (deferred from the boot-on-click PR #4880). `DevicePickerViewModel`-local, unit-tested.

### In-flight refresh no longer prunes the boot serialization guard

If a `Refresh` lands in the sub-second window after the daemon has exposed the started device (under its runtime serial) but before `startDevice` returns, `buildPickerDevices` hides the source image by name — so it is neither `Shutdown` nor `Booted` in the fresh list, and `pruneState`'s `bootingIds intersect shutdownIds` dropped the source id from the guard, briefly permitting a second `startDevice`.

Fix: track a boot's coroutine as in flight (`inFlightBootIds`) and keep the guard while the job runs, independent of the device list.

## Scope note — edge 2 deferred

The issue's **edge 2** (external serial reuse keeps stale attribution/selection) is intentionally **not** included here. Robustly detecting reuse requires a stable device identity, but the desktop booted resource (`BootedDeviceInfo`) surfaces only the runtime serial and a display name that the daemon degrades to `Unknown (emulator-N)` on a transient AVD-name probe timeout. A name-based identity witness would false-positive on that transient and drop a *valid* attribution — exposing a running device as a `Shutdown` card and permitting the very duplicate boot this issue guards against (as raised in the Codex review). Edge 2 should follow once the booted resource exposes a stable id; leaving #4881 open to track it.

## Validation

- `./gradlew -p android :desktop-core:test --tests "*DevicePickerViewModelTest"` — 33 passing, including a new case that fails without the fix (verified by reverting).
- `./gradlew -p android :desktop-core:test --tests "*.workspace.*" --tests "*.mcp.*"` — green.
- `scripts/ktfmt/validate_ktfmt.sh` — clean tree-wide.

Part of #4881.
