### PR TITLE
docs: restore reviewed contributor and CI contracts

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
@@ -157,7 +157,7 @@ object DeviceKeyboardEventTranslator {
   ): Boolean {
     if (modifiers.meta || !modifiers.alt) return false
     return when {
-      isMac -> true
+      isMac -> !modifiers.ctrl
       isLinux && isAltGraphDown != null -> isAltGraphDown
       else -> modifiers.ctrl
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
@@ -113,6 +113,18 @@ class DeviceKeyboardEventTranslatorTest {
   }
 
   @Test
+  fun `on macOS plain Option composes while Control Option stays with the host`() {
+    assertTrue(
+      resolvedAltComposition(DeviceKeyModifiers(alt = true), isMac = true),
+      "plain Option composes on macOS",
+    )
+    assertFalse(
+      resolvedAltComposition(DeviceKeyModifiers(ctrl = true, alt = true), isMac = true),
+      "Control Option is a host shortcut, not composition",
+    )
+  }
+
+  @Test
   fun `on Linux only native AltGraph is composition`() {
     val modifiers = DeviceKeyModifiers(ctrl = true, alt = true)
     assertTrue(

--- a/docs/contributing/stdlib-first.md
+++ b/docs/contributing/stdlib-first.md
@@ -1,0 +1,48 @@
+# Standard library first
+
+Before adding a package or introducing a generic helper, first look for the
+JavaScript/Node standard-library API and existing code under `src/utils/`.
+AutoMobile favors small domain helpers over a general utility dependency, and
+it keeps time, randomness, I/O, concurrency, and process access behind an
+interface when a fake is needed for fast unit tests.
+
+## Decision order
+
+1. Use the standard library when it expresses the required behavior clearly.
+2. Reuse an existing AutoMobile helper or interface when it preserves an
+   established policy or test seam.
+3. Add a focused local helper only when neither option captures the required
+   domain behavior.
+4. Add a dependency only when the behavior is substantial, maintained, and
+   cannot be safely expressed by the preceding choices.
+
+Do not bypass existing `Timer`, `Random`, `IdGenerator`, retry, cache,
+filesystem, process, or download seams from production code. Inject the
+interface and use the corresponding fake in unit tests.
+
+`Map.groupBy()` is appropriate only when all records are already materialized.
+For streaming or incrementally assembled results, retain the project helper
+that appends to a `Map` bucket. Before adopting a newly available runtime API,
+verify it on the minimum Bun version declared in `package.json`, not merely the
+developer's local runtime.
+
+## Dependency decisions
+
+Every new dependency declared in `dependencies`, `devDependencies`, or
+`optionalDependencies` must have a short Markdown record in
+`docs/decisions/`. Include this exact field so `bun run check:stdlib-first` can
+verify it:
+
+```md
+# Why this dependency is needed
+
+- Dependency: `package-name`
+- Standard-library and existing-helper alternatives considered:
+- Why those alternatives do not meet the requirement:
+- Runtime, bundle, security, and maintenance impact:
+- Test strategy:
+```
+
+The check intentionally does not try to infer whether two implementations are
+semantically equivalent. Use review for that judgment; lint only bans the
+high-confidence cases (`Math.random()` in production and direct Lodash imports).

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -147,8 +147,10 @@ advertise `input/gestureStream`, a pointer drag in **Control** mode becomes
 exactly one `input/swipe`. With the experimental
 `-Dautomobile.gesture.streaming=true` client flag and a capable daemon, the
 reference client instead sends an `input/gestureStream` start/move/end sequence
-from the first move. If streaming cannot start, it falls back to the atomic
-policy below; that fallback reapplies the same threshold and duration rules.
+from the first move. If streaming cannot start, the workspace video surface
+falls back to the atomic policy below; that fallback reapplies the same threshold
+and duration rules. The inspector-control surface instead reports the rejected
+stream and does not synthesize an atomic swipe.
 Everything below is **client-side policy**: the daemon faithfully executes whatever
 endpoints and duration it is handed, so it can neither reject an accidental
 one-pixel swipe nor repair an off-screen one. Clients should converge on these

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -158,13 +158,13 @@ not rescale the gesture or map its two ends through different frames.
 
 ### Threshold
 
-| Rule                                                               | Value                                                                              |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Minimum travelled distance, frame declares `coordinateSpace: "px"` | **`24 * nativeScale` device coordinates** (physical pixels)                        |
-| Minimum travelled distance, legacy frame (no declaration)          | **24 device coordinates** (logical points)                                         |
-| Measurement                                                        | straight-line (Euclidean), in **device** coordinates, **after** the end is clamped |
-| Below the threshold                                                | send **nothing** — not a swipe, and **not** a tap either                           |
-| Duration sent                                                      | **300 ms**, a fixed client value                                                   |
+| Rule                                                               | Value                                                                                           |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Minimum travelled distance, frame declares `coordinateSpace: "px"` | **`24 * nativeScale` device coordinates** (physical pixels)                                     |
+| Minimum travelled distance, legacy frame (no declaration)          | **24 device coordinates** (logical points)                                                      |
+| Measurement                                                        | straight-line (Euclidean), in **device** coordinates, **after** the end is clamped              |
+| Below the threshold                                                | send **nothing** — not a swipe, and **not** a tap either                                        |
+| Duration sent                                                      | measured pointer-down duration, clamped to **40–1000 ms**; **300 ms** fallback when unavailable |
 
 The threshold is measured in **device** coordinates, not viewport pixels, so it
 means the same thing regardless of the client's zoom level: a viewport-space
@@ -191,11 +191,13 @@ between the UI toolkit's touch slop (where the client starts treating the gestur
 as a drag and stops treating it as a click) and this threshold there is a **dead
 band** in which a gesture sends no input at all. That is deliberate.
 
-The duration is a fixed policy value, not a measurement of the pointer gesture.
-Reproducing pointer velocity would make the same on-screen gesture behave
-differently depending on how fast the user's hand moved over a mirror whose frame
-rate is unrelated to the device's. `300` is inside the daemon's accepted
-`[1, 60000]` range for `durationMs`.
+The duration preserves the user's measured pointer-down time so a fast flick
+remains high velocity and a slow drag remains gentle. Clients clamp that
+measurement to `40–1000` ms: the lower bound still gives the device enough
+motion events to recognize a fling, while the upper bound avoids an unnaturally
+long replay. When the client cannot measure the gesture, it sends the neutral
+`300` ms fallback. Every value remains inside the daemon's accepted `[1, 60000]`
+range for `durationMs`.
 
 ### Cancellation and out-of-bounds
 

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -1,0 +1,595 @@
+# Client Screen Control: coordinate mapping contract
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
+
+Part of milestone 28 (Client Screen Control), parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099).
+New to screen control? Start at the [daemon overview](../daemon.md), then use
+this contract for the coordinate, gesture, keyboard, frame, and refresh rules.
+This document specifies how a mirrored device screen converts a **viewport point**
+(a pixel the user clicked/dragged on the rendered canvas) into a **device
+coordinate** suitable for the typed daemon input helpers (`inputTap`,
+`inputSwipe`), and the client-side policies that decide which pointer and
+keyboard gestures become daemon input at all. It is written so a third-party
+daemon client can reproduce all of it without reading any Compose code.
+
+The reference implementation is the Compose-free
+`DeviceScreenCoordinateMapper` in the `desktop-domain` module
+(`dev.jasonpearson.automobile.desktop.domain`). The desktop inspector's
+`DeviceScreenView` delegates to it; a client in any language can port the same
+formulas.
+
+## Interaction modes
+
+A device-screen view honors one of two modes (`DeviceScreenControlMode`):
+
+- **Inspector** (default) — a click selects the deepest UI element under the
+  cursor and hover highlights elements. This is the historical layout-inspector
+  behavior. It is the default so existing consumers (including the Android IDE
+  plugin, which shares `desktop-core`) are unaffected with no source change.
+- **Control** — a click maps to a device coordinate that the client forwards to
+  the daemon input helpers as a tap, a drag maps to a start/end pair the client
+  forwards as a swipe (see [Drag-to-swipe policy](#drag-to-swipe-policy)), and a
+  keystroke received **while the view holds focus** maps to a button press, a
+  discrete key or typed text (see
+  [Keyboard forwarding policy](#keyboard-forwarding-policy)). Element selection
+  and hover highlighting are suppressed.
+
+Control mode is strictly opt-in. The view itself never sends daemon input; it
+only reports the mapped coordinate or keystroke to a caller-supplied callback.
+Wiring that to `inputTap`/`inputSwipe`/`inputPressButton`/`inputTypeText`/
+`inputKey` is the client's responsibility
+([#3347](https://github.com/kaeawc/auto-mobile/issues/3347),
+[#3350](https://github.com/kaeawc/auto-mobile/issues/3350),
+[#3351](https://github.com/kaeawc/auto-mobile/issues/3351)).
+
+## Coordinate spaces
+
+| Space        | Origin                              | Units                                                            |
+| ------------ | ----------------------------------- | ---------------------------------------------------------------- |
+| **Viewport** | top-left of the rendered canvas     | canvas pixels, before pan/zoom are removed                       |
+| **Frame**    | top-left of the fitted device frame | frame pixels at zoom 1.0                                         |
+| **Device**   | top-left of the device screen       | same space as hierarchy `bounds` — **canonical physical pixels** |
+
+Device coordinates share the hierarchy `bounds` coordinate system, so a mapped
+point can be handed directly to element hit-testing (inspector) or to the daemon
+input helpers (control).
+
+### One unit, both platforms
+
+There is **one** device unit and it is the same on Android and iOS: physical
+pixels in the current device orientation. A message that carries
+`coordinateSpace: "px"` states this explicitly for its `bounds` and its
+`screenWidth`/`screenHeight`, and the daemon accepts pixels on `input/tap` and
+`input/swipe` for that device. **A client author needs no platform-specific unit
+knowledge**: read the numbers, map them with the formulas below, send them back.
+Nothing on this page branches on the platform.
+
+The daemon does the platform work internally. iOS runners report logical points,
+so the daemon multiplies by the runner-reported `nativeScale` when publishing and
+divides by it (exactly, without rounding) when dispatching input. Android runners
+are already physical pixels (`nativeScale` 1), so its conversion is the identity.
+
+> **Legacy fallback.** A message with **no** `coordinateSpace` comes from a daemon
+> or runner that predates canonical pixels ([#4548](https://github.com/kaeawc/auto-mobile/issues/4548)).
+> There, and only there, iOS `bounds` are logical points while the screenshot is
+> pixels, so the two are not directly comparable and input coordinates are passed
+> through untouched. Everything in this document still applies — the mapping
+> formulas are ratio-based and unit-agnostic — but a client must not compare the
+> frame's absolute dimensions against the bounds' declared coordinate space.
+> Never infer pixels from a missing field — and never treat an _unrecognized_
+> declaration as this fallback. A space the client does not implement means a
+> daemon newer than the client, so control must fail closed on that frame; only
+> an absent field is the legacy point space.
+
+## Rendering pipeline
+
+1. **Rotation alignment.** The raw screenshot may arrive in native pixel
+   orientation (portrait) even when the device is landscape, while hierarchy
+   bounds are always in display orientation. The screenshot is rotated to match
+   the hierarchy before anything else, so the rest of the pipeline needs no
+   further rotation. See [Rotation](#rotation).
+2. **Aspect fit.** The rotation-aligned image is sized to fit the viewport
+   (minus a per-side padding) while preserving its aspect ratio. See
+   [Fit-to-viewport sizing](#fit-to-viewport-sizing).
+3. **Zoom + pan.** A uniform zoom `scale` and a pan `offset` (in viewport
+   pixels) are applied on top of the fitted frame.
+
+Because step 1 pre-rotates the screenshot, the viewport↔device mapping is a
+plain scale + translate.
+
+## Geometry inputs
+
+A client builds a geometry snapshot once per rendered frame:
+
+| Field                           | Meaning                                                                |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `frameWidthPx`, `frameHeightPx` | fitted frame size at zoom 1.0 (from fit-to-viewport)                   |
+| `scale`                         | current zoom multiplier                                                |
+| `offsetX`, `offsetY`            | current pan offset, in viewport pixels                                 |
+| `deviceWidth`, `deviceHeight`   | device coordinate-space size (root hierarchy bounds, rotation-aligned) |
+
+## Viewport → device mapping
+
+```text
+frameX = (viewportX - offsetX) / scale
+frameY = (viewportY - offsetY) / scale
+
+frameToDevice = deviceWidth / frameWidthPx          // guard: 1.0 if frameWidthPx <= 0
+
+deviceX = round(frameX * frameToDevice)
+deviceY = round(frameY * frameToDevice)
+```
+
+Notes and rules a client must reproduce:
+
+- **Width-based scale for both axes.** The single ratio `deviceWidth /
+frameWidthPx` scales _both_ x and y. This is exact because the frame is fitted
+  to the device aspect ratio, so the height ratio equals the width ratio.
+- **Rounding.** `round` is round-to-nearest with halves rounding **up** (Kotlin
+  `roundToInt` / `Math.round`: `0.5 -> 1`, `-0.5 -> 0`).
+- **Out of bounds.** The mapping **never clamps**. It returns the raw rounded
+  coordinate and a boolean `inBounds`, true iff
+  `0 <= deviceX < deviceWidth && 0 <= deviceY < deviceHeight` (right/bottom edges
+  are exclusive). Inspector hit-testing depends on this: a click outside the
+  screen produces an out-of-range coordinate that matches no element, clearing
+  the selection. A **control** client must not tap an out-of-bounds point — drop
+  it, or clamp it to the last addressable pixel `(deviceWidth - 1,
+deviceHeight - 1)` if pinning to the edge is desired. Clamping is only valid
+  when **both** device dimensions are positive: with a zero dimension
+  `(deviceWidth - 1, deviceHeight - 1)` is negative and addresses no pixel, so a
+  client must **drop** the point instead. The reference `DevicePoint.clampedTo`
+  mirrors this — it reports `inBounds = false` for a zero-dimension screen.
+
+## Drag-to-swipe policy
+
+A pointer drag in **Control** mode becomes exactly one `input/swipe`. Everything
+below is **client-side policy**: the daemon faithfully executes whatever
+endpoints and duration it is handed, so it can neither reject an accidental
+one-pixel swipe nor repair an off-screen one. Clients should converge on these
+rules rather than each inventing their own. The reference implementation is the
+Compose-free `DeviceDragGesturePolicy` in the `desktop-domain` module
+([#3350](https://github.com/kaeawc/auto-mobile/issues/3350)).
+
+### One frame for the whole drag
+
+Both endpoints are mapped through the **same** frame snapshot, pinned when the
+drag begins — the one the drag _started_ on. A snapshot arriving mid-drag must
+not rescale the gesture or map its two ends through different frames.
+
+### Threshold
+
+| Rule                                                               | Value                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Minimum travelled distance, frame declares `coordinateSpace: "px"` | **`24 * nativeScale` device coordinates** (physical pixels)                        |
+| Minimum travelled distance, legacy frame (no declaration)          | **24 device coordinates** (logical points)                                         |
+| Measurement                                                        | straight-line (Euclidean), in **device** coordinates, **after** the end is clamped |
+| Below the threshold                                                | send **nothing** — not a swipe, and **not** a tap either                           |
+| Duration sent                                                      | **300 ms**, a fixed client value                                                   |
+
+The threshold is measured in **device** coordinates, not viewport pixels, so it
+means the same thing regardless of the client's zoom level: a viewport-space
+threshold would send a swipe for one hand movement at one zoom and not at
+another, and would let a few pixels of pointer jitter become a large device
+gesture when zoomed out.
+
+**One physical intent in two coordinate spaces.** In the legacy point space,
+`24` sits just above both platforms' touch slop. A canonical-pixel frame publishes
+the matching finite, positive `nativeScale` on both its hierarchy and screenshot
+messages, so the client uses `24 * nativeScale`. The daemon divides those pixels
+by the same scale before sending an iOS gesture to the point-based runner, which
+preserves a 24-point threshold at every supported scale. Android publishes
+`nativeScale: 1`, so it keeps the 24-pixel threshold.
+
+A pixel frame without matching finite, positive scale metadata is not safe for
+control. The client must fail closed rather than guess a threshold or retain a
+frame after its scale changes.
+
+A below-threshold drag is **not** promoted to a tap. Actuating an input the user
+did not ask for is worse than ignoring an ambiguous one, and a click that barely
+moved is already covered by the client's own tap detection. Note the consequence:
+between the UI toolkit's touch slop (where the client starts treating the gesture
+as a drag and stops treating it as a click) and this threshold there is a **dead
+band** in which a gesture sends no input at all. That is deliberate.
+
+The duration is a fixed policy value, not a measurement of the pointer gesture.
+Reproducing pointer velocity would make the same on-screen gesture behave
+differently depending on how fast the user's hand moved over a mirror whose frame
+rate is unrelated to the device's. `300` is inside the daemon's accepted
+`[1, 60000]` range for `durationMs`.
+
+### Cancellation and out-of-bounds
+
+| Situation                                                     | Behavior                                                            |
+| ------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Drag **cancelled** (pointer capture lost, window deactivated) | send nothing                                                        |
+| Drag **started** outside the device screen                    | send nothing — clamping would invent a start the user never touched |
+| Drag **ended** outside the device screen                      | **clamp** the end to the last addressable pixel and send            |
+| Device screen has a non-positive dimension                    | send nothing (no addressable pixel to clamp to)                     |
+| Drag outside Control mode                                     | send nothing; a drag means viewport pan                             |
+
+Dragging _past_ an edge is the ordinary way to scroll to the end of a list, so an
+out-of-bounds end is clamped rather than dropped — this is the clamping option
+the [out-of-bounds rule](#viewport-device-mapping) already sanctions, and it
+yields well-formed input. Clamping happens **before** the distance check, so the
+threshold is applied to what would actually be sent.
+
+Nothing here is a failure: an ignored drag surfaces no error, and it must not
+start a post-input refresh wait — the device did not change.
+
+### Viewport pan in Control mode
+
+A plain drag means a device swipe in Control mode, so viewport pan moves onto the
+modifier that already gates zoom (Cmd on macOS, Ctrl elsewhere): **modifier +
+drag pans, plain drag swipes**. The modifier is read once at pointer-down, so
+releasing it mid-drag cannot turn a pan into a swipe. In **Inspector** mode a
+plain drag still pans and never produces daemon input, which is why the IDE
+plugin — inspector-only — is unaffected.
+
+### Device → viewport (inverse)
+
+For placing overlays or touch-feedback markers, the inverse is:
+
+```text
+deviceToFrame = frameWidthPx / deviceWidth          // guard: 1.0 if deviceWidth <= 0
+viewportX = deviceX * deviceToFrame * scale + offsetX
+viewportY = deviceY * deviceToFrame * scale + offsetY
+```
+
+Modulo integer rounding, `deviceToViewport` and `viewportToDevice` round-trip.
+
+## Keyboard forwarding policy
+
+Keyboard, text and device-button forwarding is **client-side policy** in exactly
+the same sense as the drag rules above: `input/pressButton`, `input/typeText` and
+`input/key` faithfully execute whatever they are handed, so deciding _which
+keystrokes reach the device at all_ is entirely the client's job. The reference
+implementation is the Compose-free `DeviceKeyboardInputPolicy` in the
+`desktop-domain` module
+([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)).
+
+This section is written for a client author embedding control mode in **their
+own** host — the desktop app, or something else entirely. It deliberately does
+not enumerate any one host's keymap, because the host is not knowable from the
+policy.
+
+### When keyboard input forwards at all
+
+Two conditions, both required:
+
+| Condition                                       | Why                                                                                                                             |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| The device-screen view **holds keyboard focus** | Forwarding without it would type into the device while the user is filling in a field elsewhere in the host                     |
+| The view is in **Control** mode                 | Inspector mode produces no daemon input of any kind, which is what keeps an inspector-only embedder (the IDE plugin) unaffected |
+
+Focus is the _only_ place a global-capture design would be tempting; do not take
+it. Use the toolkit's own focus routing — the reference client attaches its
+handler to the focusable device-screen node, so a keystroke reaches the policy
+only when that node is on the focus path, and nothing has to be re-checked. The
+view takes focus when it **enters** control mode, **and again when the canvas is
+clicked**; the second is not optional, because once anything else takes focus
+(a pane-navigation shortcut, a side panel) clicking the mirrored screen is the
+only affordance a user has to get it back.
+
+**Beware ancestor preview handlers.** If your host resolves its own navigation
+shortcuts in a _preview_/capture-phase handler — one that runs before the focused
+descendant — it will consume Tab, the arrows, Enter and Escape before the device
+canvas ever sees them, and Escape is the client's only device-button binding. The
+host must stand that handler down while the device canvas holds focus — but only
+for **keystrokes the policy will actually claim**, decided per event with this
+same policy, not with a blanket "canvas is focused" flag. The blanket version
+creates a dead zone: toolkits do not rerun a preview handler while an unconsumed
+event bubbles back up, so any keystroke the canvas then _declines_ (a printable
+character on a platform whose daemon cannot append, a shifted device key) would
+reach neither the device nor the host binding it used to trigger. The reference
+client asks `DeviceControlSession.wouldForwardKey` — the same decision the
+dispatch path makes — per event; chords answer "no" there, so chorded host
+shortcuts keep working, consistent with the chord rule below.
+
+Control mode is additionally **inert without a frame snapshot**, the same
+fail-closed rule taps and drags follow: with no snapshot there is no frame the
+keystroke belongs to.
+
+### Host shortcuts
+
+**A keystroke with Ctrl, Alt or Meta (Cmd/Win) held belongs to the host and is
+not forwarded.** Ctrl/Alt/Meta are what hosts build menu accelerators and window
+shortcuts out of on every desktop platform, so refusing all of them is the only
+rule that is correct for every host. Shift is **not** a chord modifier: it is how
+a capital letter or a shifted symbol is produced, and treating it as one would
+make control mode unable to type half the keyboard.
+
+One documented exception is built in: **Alt-family character composition** — AltGr
+and macOS Option — and it is **platform-dependent**, so the host (not the pure
+policy) must resolve it. The rule is:
+
+```text
+altComposesText = printable && !meta && when {
+  isMac -> alt
+  isLinux && nativeAltGraph != null -> alt && nativeAltGraph
+  else -> ctrl && alt
+}
+```
+
+- **Linux:** composition is **AltGr**, identified by AWT's native
+  `isAltGraphDown()` signal. A genuine Ctrl+Alt shortcut has AltGraph unset, so
+  it stays with the host rather than typing its printable character into the
+  device.
+- **Windows:** composition is **AltGr**, but many JDKs surface it only as
+  **Ctrl+Alt** (`@`, `€`, `{`, `\`) and leave the native AltGraph flag unset. The
+  Ctrl+Alt fallback is therefore retained. A _plain_ Alt (no Ctrl) is a **menu
+  accelerator** — `Alt+F` opens File — and AWT reports a printable `keyChar` for
+  it too, so it must not count as composition.
+- **macOS:** composition is the **Option** key, which is plain **Alt** (Option+L =
+  `@`, Option+5 = `[`), and macOS menus use **Cmd/Meta, never Alt** — so plain Alt
+  is safe to treat as composition on macOS only.
+
+**Meta held never qualifies** on any platform: `Cmd`/`Meta` shortcuts never compose
+characters, so Meta-held is the reliable "this is a shortcut, not typing" signal.
+A real accelerator that produces no character (or carries Meta) always stays with
+the host, which keeps the exception from being a hole.
+
+Because the pure policy cannot know the host OS, the toolkit adapter resolves this
+boolean where the platform and AWT masks are visible (the reference client does it
+in `DeviceKeyboardEventTranslator`) and passes it to the policy as
+`DeviceKeyStroke.altComposesText`. The policy then forwards such a keystroke only
+when it also produced a **typable ASCII** character. A porting client on another
+host must make the same platform-aware decision rather than inferring composition
+from `alt && printable`.
+
+**Known limitation (Windows).** The `ctrl && alt` fallback is a heuristic, not a
+true AltGraph detector. AWT exposes an AltGraph signal (the native
+`java.awt.event.KeyEvent.isAltGraphDown()` behind Compose's `KeyEvent.nativeKeyEvent`,
+mirrored by `PointerKeyboardModifiers.isAltGraphPressed`), but many Windows JDKs
+report a real AltGr keystroke as plain Ctrl+Alt with the `ALT_GRAPH` mask **unset**.
+Requiring the mask would regress common AltGr typing (`@`, `€`, `{`) on those JDKs.
+The accepted consequence is that **a genuine Ctrl+Alt host shortcut that produces a
+printable character may still be forwarded to the device rather than reaching the
+host** on Windows. Linux uses the reliable native signal.
+
+A client that knows its own host leaves a particular chord unclaimed may opt it in
+explicitly (`forwardedChords`). The default list is **empty**. Entries match
+either a device key **or a produced character**, case-insensitively — the latter
+matters because the chords a client actually wants to opt in are letter chords
+like Ctrl-S, and an ordinary letter deliberately carries no device key at all, so
+a key-only allowlist could never name one.
+
+Each entry also names the **exact chord-modifier set** it forwards (`ctrl`/`alt`/
+`meta`). This is required, not optional: an entry that matched a character alone
+would forward Ctrl-S **and** Meta-S **and** Alt-S, so opting in one chord would
+silently swallow the host's other shortcuts on the same key. `OfCharacter('s',
+ctrl = true)` therefore forwards Ctrl-S only; Meta-S and Alt-S stay with the host.
+Shift is not part of the match (character comparison is already case-insensitive,
+so Ctrl-S and Ctrl-Shift-S name the same opt-in).
+
+The mechanism matters as much as the rule: a declined keystroke must be left
+**unconsumed** so it continues to the host's own shortcut handling. In the
+reference client the view returns the client's own "did you forward it?" answer
+as its key-event result, so there is no separate pass-it-on path that could fall
+out of step with the policy.
+
+### What each keystroke sends
+
+Applied in this order:
+
+| Keystroke                                                                            | Sends                                                                                                             |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Any chord modifier held, key not explicitly opted in                                 | **nothing**; leave unconsumed                                                                                     |
+| `Escape`                                                                             | one `input/pressButton` with `back`                                                                               |
+| `Enter`, `Tab`, `Backspace`, `Delete`, `ArrowUp/Down/Left/Right` — **without Shift** | one `input/key` with `enter`, `tab`, `backspace`, `delete`, `arrow_up`, `arrow_down`, `arrow_left`, `arrow_right` |
+| Any of those keys **with Shift held** (Shift-Tab, Shift-arrow, …)                    | **nothing**; leave unconsumed                                                                                     |
+| A printable **ASCII** character (`U+0020`–`U+007E`)                                  | one `input/typeText` with that single character, in **append** mode                                               |
+| A printable character outside that range (`é`, `€`, CJK, emoji)                      | **nothing**; leave unconsumed                                                                                     |
+| Anything else (function keys, a modifier pressed alone, a dead key)                  | **nothing**; leave unconsumed                                                                                     |
+
+A key with a device meaning **wins over the character it produced**. Hosts report
+a control character for Enter, Tab and Backspace; typing those as text would put
+a literal newline in a text field instead of pressing the key.
+
+**Shifted device keys are declined, never downgraded.** `input/key` transmits no
+modifiers — its contract rejects them — so the only thing that _could_ be sent
+for Shift-Tab is bare `tab`, and that is a semantically different keystroke:
+Shift-Tab moves focus **backward**, `tab` moves it forward; Shift-arrow extends a
+selection, a bare arrow abandons it. The same governing rule as characters
+applies — never deliver a different keystroke than the user pressed — so the
+stroke is left unconsumed and the host (which can honor the shifted form) keeps
+it. Shifted _characters_ (`A`, `?`) are unaffected: they arrive as characters
+that already encode the shift.
+
+**Text must be appended, never set.** `input/typeText`'s default Android path is
+`ACTION_SET_TEXT`, which _replaces_ the focused field's contents. A client sending
+one character per keystroke through it would type `abc` as "a", then "b", then
+"c" — final value `c` — and would wipe any text already in the field on the first
+key. Pass `mode: "append"`, which routes through the platform's non-destructive
+append primitive and adds to the field instead. This is a hard requirement, not a
+tuning knob.
+
+`mode: "append"` is supported on both platforms. Android realizes it with real
+key events; iOS routes it to CtrlProxy's focused-field insert primitive, which
+calls XCUITest `typeText` at the current caret without clearing or resolving a
+resource id. The desktop client therefore forwards printable text on both
+platforms and marks every per-keystroke request as append.
+
+**Only printable ASCII is forwarded, because that is exactly what append can
+type.** Append works by injecting real Android key events, and the daemon's
+character→keycode table (`src/features/action/asciiKeyEvents.ts`) covers
+`U+0020`–`U+007E` and nothing else. Forwarding a character outside that range
+would lose the keystroke _twice_: consumed at the host, then rejected by the
+device. So a non-ASCII character is declined and left unconsumed — never
+swallowed. The governing rule for a porting client is: **never consume a
+keystroke you cannot deliver.** Typing accented or non-Latin text on a device
+belongs to the device's own IME, not to keystroke mirroring.
+
+One gap is deliberately left to the daemon rather than to the client. Uppercase
+letters and shifted symbols need `input keycombination`, which exists only on
+Android 12 (API 31) and newer, and a client cannot see the device's API level.
+Refusing every shifted character would make capitals untypable on _every_ device
+in order to protect the older ones, so those characters are forwarded; on an
+older device the daemon answers with an actionable error
+(`append cannot type "A" with Android key events`) that the client surfaces
+through its normal error path. A reported failure, not a silent loss.
+
+`Escape` is the only key bound to a device _button_, and deliberately so.
+Escape→back is the mapping Android itself applies to a hardware ESC key, and
+`pressButton` works on both platforms. Every other device button — `home`,
+`recent`, `power`, `volume_up`, `volume_down`, `menu` — has no unambiguous
+keyboard key; binding `home` to the Home key would make a keystroke that means
+"move to line start" everywhere else silently throw the user out of the app under
+test. Buttons with no natural key belong on an explicit on-screen affordance.
+
+### Unsupported keys
+
+Two different situations, handled differently:
+
+- **The client has no mapping** (a function key, a dead key, a supplementary code
+  point that cannot be one UTF-16 unit). Send nothing, show nothing, leave the
+  event unconsumed. Silence is correct: the user did not ask for a device action,
+  and the host may still want the key.
+- **The client maps it but the device cannot accept it.** `input/key` is
+  Android-only; on iOS the daemon answers with an actionable error. Surface it
+  through the same error path as any other failed input rather than swallowing
+  it.
+- **The character is outside printable ASCII.** Dropped before any request is
+  made, for the same reason and with the same handling: the append path has no
+  key event for it, so consuming the keystroke would lose it at both ends.
+
+### Scope
+
+One keystroke produces at most one daemon request. This is **not** IME
+composition: dead keys, multi-keystroke composition and supplementary-plane
+characters are out of scope, and a code point that cannot be expressed as a
+single UTF-16 unit is dropped rather than sent as half a surrogate pair.
+
+Only the key **press** forwards. The matching release is left unconsumed, so a
+host that tracks key releases still sees them and no keystroke is sent twice.
+
+### Ordering and refresh
+
+Keyboard, text and button inputs travel the **same** ordered, bounded dispatch
+queue as taps and swipes, so a tap-then-type sequence reaches the device in the
+order the user made it, and a successful keystroke starts the same post-input
+refresh wait a successful tap does. A
+keystroke the policy ignored is **not** an input: it starts no wait and shows no
+error.
+
+One consequence of sharing the bounded queue: **consumption is not the same
+question as "did it reach the device"**. A keystroke the policy accepted is
+consumed even when the queue rejected it — the overload error has already been
+surfaced, and letting the key fall through to the host afterwards would type into
+the host's own UI as a consolation prize for a dropped device input. The boolean a
+client's key handler returns should therefore be read as _"should this event be
+consumed"_, not as _"was this forwarded"_.
+
+## Fit-to-viewport sizing
+
+Given the rotation-aligned image size (`imageWidth`, `imageHeight`), the viewport
+size, and a per-side `padding` (default `32`):
+
+```text
+aspect = imageHeight / imageWidth                   // fallback 2.16 if imageWidth <= 0
+maxW = max(viewportWidth  - padding*2, 1)
+maxH = max(viewportHeight - padding*2, 1)
+
+if (maxW * aspect <= maxH) {                         // width-constrained
+  frameWidthPx  = maxW
+  frameHeightPx = maxW * aspect
+} else {                                             // height-constrained
+  frameHeightPx = maxH
+  frameWidthPx  = maxH / aspect
+}
+```
+
+The initial "fit to screen" zoom scale is:
+
+```text
+fitScale = clamp( min( viewportWidth  / (frameWidthPx  + padding*2),
+                       viewportHeight / (frameHeightPx + padding*2),
+                       1.0 ),
+                  0.3, 1.0 )
+```
+
+The frame is never scaled above `1.0`, and the scale floor is `0.3`.
+
+## Rotation
+
+Rotation is resolved up front by comparing the screenshot's portrait/landscape
+orientation to the hierarchy root's, and rotating the screenshot to match:
+
+| Screenshot | Hierarchy bounds | Rotation applied to screenshot |
+| ---------- | ---------------- | ------------------------------ |
+| portrait   | portrait         | none (`0`)                     |
+| landscape  | landscape        | none (`0`)                     |
+| portrait   | landscape        | 90° clockwise (code `3`)       |
+| landscape  | portrait         | 270° clockwise (code `1`)      |
+
+Any non-positive dimension yields `0`. A 180° flip (code `2`) is never inferred
+from orientation alone. After this step, `deviceWidth`/`deviceHeight` are the
+rotation-aligned dimensions, and the mapping formulas above apply with no further
+rotation term.
+
+## Testing
+
+The mapper is pure Kotlin with no Compose or daemon dependency, so it is unit
+tested directly (`DeviceScreenCoordinateMapperTest`) without rendering a device
+or opening a socket: scale, pan, aspect fit, rotation detection, rounding,
+out-of-bounds, round-trip, and the inspector selection/deselection path.
+
+The unit change is pinned from both ends. `DeviceControlPolicyTest` asserts that
+the _same_ geometry pair is rejected under `coordinateSpace: "px"` and accepted
+without it, that the rotation transpose still passes in exact mode, and that a
+declaration on only one of the two messages falls back to the legacy comparison.
+`CanonicalPixelClientMigrationTest` pins the inspector side: overlay placement,
+hit-testing and rotation detection all come out identical whether bounds arrive as
+iOS points or as the same screen's canonical pixels, because every mapping ratio
+has hierarchy geometry on both sides.
+
+The drag policy is likewise pure and unit tested directly
+(`DeviceDragGesturePolicyTest`), pinning the threshold from **both** sides — one
+coordinate below it must not swipe and exactly at it must — plus end-clamping,
+the off-screen start, and the degenerate-screen case. View-level routing
+(`DeviceScreenViewControlTest`) renders the real view with fakes and covers a
+control-mode drag reporting exactly one swipe and **no** tap, a sub-threshold
+movement still reporting a tap and no swipe, and an inspector-mode drag reporting
+nothing.
+
+The keyboard policy is pure too (`DeviceKeyboardInputPolicyTest`), pinning the
+chord rule from **both** sides — every chord modifier must stay with the host,
+and Shift must **not**, or capitals become untypable — plus the Alt-composition
+allowance keyed on the host-resolved `altComposesText` flag (a resolved composition
+with a typable character types; one the host did not resolve — a Windows/Linux
+`Alt+F` menu accelerator — stays with the host even though it reports a printable
+char),
+key-over-character precedence, the control-character filter, the character-keyed
+chord allowlist, and the printable-ASCII range from both
+sides (every character in `U+0020`–`U+007E` forwards; `é`/`€`/CJK are declined and
+left unconsumed). `DeviceKeyboardEventTranslatorTest` pins the platform-aware
+resolution of that flag (native AltGraph composes on Linux; Ctrl+Alt remains the
+Windows fallback; plain Alt composes on macOS; Meta never does) end-to-end through
+the policy, parameterized by injected platform and AltGraph inputs so every branch
+is deterministic. `InputText.test.ts` pins the daemon append mode itself: it
+issues key events and makes **no** `ACTION_SET_TEXT` call and **no** clear, so N
+single-character calls accumulate; that uppercase fails with an actionable error
+below API 31 and succeeds at 31+; and that every adb round trip is charged against
+the caller's timeout budget. `socketServerInputTypeText.test.ts` pins the same
+through the socket against a fake adb, including that a stalled adb call answers
+inside the request budget and leaves the per-device queue free for the next input.
+The same socket suite and CtrlProxy command-handler tests pin the iOS append route:
+three single-character calls reach the focused-field insert primitive in order and
+never use the resource-targeted replace operation.
+`DeviceKeyboardEventTranslatorTest` pins the toolkit-key translation.
+`DeviceControlSessionKeyboardTest` asserts the exact daemon payloads a keystroke
+produces against a fake client, that keyboard shares the one ordered queue with
+taps, and that a successful keystroke starts the same post-input refresh wait.
+View-level routing (`DeviceScreenViewKeyboardTest`) observes **both** what the
+view forwarded and what an ancestor host handler still received, so
+"host shortcuts are not swallowed" is checked rather than assumed, alongside the
+focus and mode gates, click-to-refocus, and — composed under an ancestor with the
+shell's real preview handler — that Escape/Enter/arrows/Tab actually survive it.
+
+## Which frame the mapping runs against
+
+This document defines the mapping. It deliberately says nothing about _which_
+frame a control client is allowed to map against, or what the client shows after
+it forwards an input — a coordinate mapped correctly through a stale frame still
+taps the wrong pixel. Use one coherent screenshot-and-hierarchy snapshot from
+the selected device, pin that snapshot for the complete gesture, and wait for a
+newer coherent frame after dispatch before presenting the input as complete.

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -142,8 +142,14 @@ deviceHeight - 1)` if pinning to the edge is desired. Clamping is only valid
 
 ## Drag-to-swipe policy
 
-A pointer drag in **Control** mode becomes exactly one `input/swipe`. Everything
-below is **client-side policy**: the daemon faithfully executes whatever
+With gesture streaming disabled (the default), or when the daemon does not
+advertise `input/gestureStream`, a pointer drag in **Control** mode becomes
+exactly one `input/swipe`. With the experimental
+`-Dautomobile.gesture.streaming=true` client flag and a capable daemon, the
+reference client instead sends an `input/gestureStream` start/move/end sequence
+from the first move. If streaming cannot start, it falls back to the atomic
+policy below; that fallback reapplies the same threshold and duration rules.
+Everything below is **client-side policy**: the daemon faithfully executes whatever
 endpoints and duration it is handed, so it can neither reject an accidental
 one-pixel swipe nor repair an off-screen one. Clients should converge on these
 rules rather than each inventing their own. The reference implementation is the
@@ -549,9 +555,10 @@ The drag policy is likewise pure and unit tested directly
 coordinate below it must not swipe and exactly at it must — plus end-clamping,
 the off-screen start, and the degenerate-screen case. View-level routing
 (`DeviceScreenViewControlTest`) renders the real view with fakes and covers a
-control-mode drag reporting exactly one swipe and **no** tap, a sub-threshold
-movement still reporting a tap and no swipe, and an inspector-mode drag reporting
-nothing.
+control-mode drag reporting exactly one swipe and **no** tap, a movement below
+Compose touch slop still reporting a tap and no swipe, and an inspector-mode drag
+reporting nothing. The pure policy tests, rather than this view test, cover the
+dead band between touch slop and the 24-device-coordinate swipe threshold.
 
 The keyboard policy is pure too (`DeviceKeyboardInputPolicyTest`), pinning the
 chord rule from **both** sides — every chord modifier must stay with the host,

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -106,9 +106,9 @@ A client builds a geometry snapshot once per rendered frame:
 | `frameWidthPx`, `frameHeightPx` | fitted frame size at zoom 1.0 (from fit-to-viewport)                   |
 | `scale`                         | current zoom multiplier                                                |
 | `offsetX`, `offsetY`            | current pan offset, in viewport pixels                                 |
-| `deviceWidth`, `deviceHeight`   | device coordinate-space size (root hierarchy bounds, rotation-aligned) |
+| `deviceWidth`, `deviceHeight`   | coordinate-space size: positive root bounds or paired screen dimensions |
 
-## Viewport → device mapping
+## Viewport-to-device mapping
 
 ```text
 frameX = (viewportX - offsetX) / scale
@@ -219,7 +219,7 @@ range for `durationMs`.
 
 Dragging _past_ an edge is the ordinary way to scroll to the end of a list, so an
 out-of-bounds end is clamped rather than dropped — this is the clamping option
-the [out-of-bounds rule](#viewport-device-mapping) already sanctions, and it
+the [out-of-bounds rule](#viewport-to-device-mapping) already sanctions, and it
 yields well-formed input. Clamping happens **before** the distance check, so the
 threshold is applied to what would actually be sent.
 
@@ -314,7 +314,7 @@ policy) must resolve it. The rule is:
 
 ```text
 altComposesText = printable && !meta && when {
-  isMac -> alt
+  isMac -> alt && !ctrl
   isLinux && nativeAltGraph != null -> alt && nativeAltGraph
   else -> ctrl && alt
 }
@@ -331,7 +331,8 @@ altComposesText = printable && !meta && when {
   it too, so it must not count as composition.
 - **macOS:** composition is the **Option** key, which is plain **Alt** (Option+L =
   `@`, Option+5 = `[`), and macOS menus use **Cmd/Meta, never Alt** — so plain Alt
-  is safe to treat as composition on macOS only.
+  without Ctrl is safe to treat as composition on macOS only. Ctrl+Option remains
+  with the host as a shortcut.
 
 **Meta held never qualifies** on any platform: `Cmd`/`Meta` shortcuts never compose
 characters, so Meta-held is the reliable "this is a shortcut, not typing" signal.

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -101,11 +101,11 @@ plain scale + translate.
 
 A client builds a geometry snapshot once per rendered frame:
 
-| Field                           | Meaning                                                                |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| `frameWidthPx`, `frameHeightPx` | fitted frame size at zoom 1.0 (from fit-to-viewport)                   |
-| `scale`                         | current zoom multiplier                                                |
-| `offsetX`, `offsetY`            | current pan offset, in viewport pixels                                 |
+| Field                           | Meaning                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `frameWidthPx`, `frameHeightPx` | fitted frame size at zoom 1.0 (from fit-to-viewport)                    |
+| `scale`                         | current zoom multiplier                                                 |
+| `offsetX`, `offsetY`            | current pan offset, in viewport pixels                                  |
 | `deviceWidth`, `deviceHeight`   | coordinate-space size: positive root bounds or paired screen dimensions |
 
 ## Viewport-to-device mapping
@@ -191,6 +191,17 @@ preserves a 24-point threshold at every supported scale. Android publishes
 A pixel frame without matching finite, positive scale metadata is not safe for
 control. The client must fail closed rather than guess a threshold or retain a
 frame after its scale changes.
+
+**Paired declarations are all-or-nothing.** A screenshot/hierarchy pair is a
+canonical-pixel frame only when **both** messages declare `coordinateSpace:
+"px"` and carry the same finite, positive `nativeScale`. If one message omits
+the declaration or the two declarations differ, the reference client binds
+neither `coordinateSpace` nor `nativeScale` into the snapshot: it uses the
+legacy aspect-only geometry check and the unscaled 24-unit threshold. It never
+combines the `px` message's scale with an undeclared counterpart. That is the
+conservative transition behavior for a pair that cannot prove one common unit;
+when both messages declare pixels but their scale metadata is absent, invalid,
+or unequal, control instead fails closed as described above.
 
 A below-threshold drag is **not** promoted to a tap. Actuating an input the user
 did not ask for is worse than ignoring an ambiguous one, and a click that barely

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -1,0 +1,302 @@
+# CI Integration
+
+This page covers running AutoMobile XCTestRunner tests in GitHub Actions using a macOS runner with
+a built-in iOS Simulator. The `automobile-tests` job shown here is the reference workflow used in
+the `ios-build` repository.
+
+## Overview
+
+AutoMobile tests need:
+
+1. A **pre-built `.xctestrun`** containing the `YourAppAutoMobileTests` bundle
+2. A **booted iOS Simulator** on the runner
+3. A **running AutoMobile daemon** reachable over the Unix socket
+4. The **CtrlProxy iOS app** installed in the simulator
+
+The sections below walk through each step.
+
+!!! note "No cloud device service required"
+Unlike Android — which uses [emulator.wtf](https://emulator.wtf) to provision managed cloud
+emulators — iOS AutoMobile tests run on the macOS runner's built-in iOS Simulator. No external
+device service or additional secrets are needed.
+
+## Job structure
+
+The reference workflow splits testing into two independent jobs that share the same build artifact:
+
+```
+build-for-testing ──┬──► simulator-tests      (unit tests, skips AutoMobile bundle)
+                    └──► automobile-tests      (AutoMobile tests only)
+```
+
+Both jobs download the same `.xctestrun` artifact from `build-for-testing` and run
+`xcodebuild test-without-building` with different filtering flags, so there is no duplicate
+compilation.
+
+## Full workflow job
+
+```yaml
+automobile-tests:
+  name: "AutoMobile XCTestRunner Tests"
+  runs-on: macos-26
+  needs: [build-for-testing]
+  timeout-minutes: 30
+  steps:
+    - uses: actions/checkout@v6
+
+    - name: Select Xcode 26.2
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "26.2"
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Install auto-mobile CLI
+      run: bun install -g @kaeawc/auto-mobile
+
+    - name: Ensure iOS Simulator runtime
+      uses: ./.github/actions/ensure-ios-simulator-runtime
+
+    - name: Download build products
+      uses: actions/download-artifact@v7
+      with:
+        name: build-for-testing-macos-26
+        path: build/DerivedData/Build/Products/
+
+    - name: Boot iOS Simulator
+      run: |
+        ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
+        auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \\
+          --min-os-version "${ios_version}" --max-os-version "${ios_version}"
+
+    - name: Start simulator log stream
+      run: |
+        mkdir -p build
+        xcrun simctl spawn booted log stream \
+          --level debug --style compact --color none \
+          --predicate 'subsystem BEGINSWITH "com.example.ios"' \
+          > build/automobile-simulator.log 2>&1 &
+        echo "LOG_STREAM_PID=$!" >> "$GITHUB_ENV"
+
+    - name: Start AutoMobile daemon
+      run: |
+        auto-mobile --daemon start &
+        echo "AUTOMOBILE_DAEMON_PID=$!" >> "$GITHUB_ENV"
+
+    - name: Wait for daemon and register simulator
+      run: auto-mobile --cli observe --platform ios
+
+    - name: Run AutoMobile tests
+      run: bash scripts/ios/xcode-automobile-tests.sh
+
+    - name: Stop AutoMobile daemon
+      if: always()
+      run: kill "$AUTOMOBILE_DAEMON_PID" 2>/dev/null || true
+
+    - name: Stop simulator log stream
+      if: always()
+      run: kill "$LOG_STREAM_PID" 2>/dev/null || true
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: automobile-test-results
+        path: build/automobile-tests.xcresult
+        retention-days: 7
+
+    - name: Upload simulator logs on failure
+      uses: actions/upload-artifact@v6
+      if: failure()
+      with:
+        name: automobile-simulator-logs
+        path: build/automobile-simulator.log
+        retention-days: 7
+```
+
+## Step-by-step breakdown
+
+### 1. Bun and auto-mobile
+
+The daemon is a Node/Bun application. `setup-bun` ensures the Bun runtime is available on the
+runner so `auto-mobile --daemon start` works correctly.
+
+```yaml
+- uses: oven-sh/setup-bun@v2
+- run: bun install -g @kaeawc/auto-mobile
+```
+
+### 2. Build products artifact
+
+AutoMobile tests run `test-without-building` against the `.xctestrun` produced by the
+`build-for-testing` job. Downloading the artifact avoids recompiling on the test runner:
+
+```yaml
+- uses: actions/download-artifact@v7
+  with:
+    name: build-for-testing-macos-26
+    path: build/DerivedData/Build/Products/
+```
+
+The artifact contains both test bundles (`YourAppTests.xctest` and
+`YourAppAutoMobileTests.xctest`) and a `.xctestrun` file that references them.
+
+### 3. Boot the simulator
+
+```bash
+ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
+auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \
+  --min-os-version "${ios_version}" --max-os-version "${ios_version}"
+```
+
+AutoMobile product boot finds the simulator that matches the current Xcode SDK, creates it if
+missing, and boots it. Alternatively:
+
+```bash
+xcrun simctl boot "iPhone 16"
+open -a Simulator
+xcrun simctl list devices booted   # confirm it booted
+```
+
+### 4. Daemon startup
+
+Start the daemon in the background and save its PID for clean shutdown:
+
+```bash
+auto-mobile --daemon start &
+echo "AUTOMOBILE_DAEMON_PID=$!" >> "$GITHUB_ENV"
+```
+
+The `--cli observe` step below implicitly waits for the daemon to be ready, so no explicit socket
+poll is needed here.
+
+### 5. CtrlProxy pre-installation
+
+```bash
+auto-mobile --cli observe --platform ios
+```
+
+This step does two things:
+
+1. **Waits** for the daemon socket to become available (blocks until the daemon is up).
+2. **Installs** the CtrlProxy iOS app into the booted simulator if it is not already present, so
+   the first `observe` step in a test plan does not pay the installation cost.
+
+Running this once before the test task ensures CtrlProxy is ready before `observe` steps in test
+plans execute.
+
+### 6. Run AutoMobile tests
+
+```bash
+bash scripts/ios/xcode-automobile-tests.sh
+```
+
+The script finds the `.xctestrun`, identifies the booted simulator, and runs:
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun "$xctestrun_file" \
+  -destination "platform=iOS Simulator,id=$booted_udid" \
+  -only-testing:YourAppAutoMobileTests \
+  -enableCodeCoverage NO \
+  -skipMacroValidation
+```
+
+`-only-testing:YourAppAutoMobileTests` limits execution to the AutoMobile bundle. Unit tests in
+`YourAppTests` are handled by the separate `simulator-tests` job.
+
+### 7. Cleanup
+
+The `if: always()` guards ensure cleanup runs even when tests fail:
+
+```bash
+kill "$AUTOMOBILE_DAEMON_PID" 2>/dev/null || true
+kill "$LOG_STREAM_PID" 2>/dev/null || true
+```
+
+The daemon process exits cleanly; the simulator remains booted for the remainder of the runner's
+lifetime (macOS runners are ephemeral so no explicit teardown is needed).
+
+### 8. Artifacts
+
+| Artifact                    | When uploaded | Contents                                                                                 |
+| --------------------------- | ------------- | ---------------------------------------------------------------------------------------- |
+| `automobile-test-results`   | Always        | `build/automobile-tests.xcresult` — pass/fail, timing, screenshots                       |
+| `automobile-simulator-logs` | On failure    | `build/automobile-simulator.log` — simulator log stream filtered to your app's subsystem |
+
+## Keeping unit tests and AutoMobile tests separate
+
+The `simulator-tests` job runs unit tests using `-skip-testing:YourAppAutoMobileTests`:
+
+```bash
+# scripts/ios/xcode-test-without-building.sh
+# -skip-testing:YourAppAutoMobileTests excludes the AutoMobile bundle
+xcodebuild test-without-building \
+  -xctestrun "$xctestrun_file" \
+  -destination "platform=iOS Simulator,id=$booted_udid" \
+  -skip-testing:YourAppAutoMobileTests \
+  -enableCodeCoverage NO \
+  -parallel-testing-enabled YES \
+  -skipMacroValidation
+```
+
+The `automobile-tests` job runs the complement using `-only-testing:YourAppAutoMobileTests`.
+This mirrors the Android pattern where `testDebugUnitTest -PexcludeAutoMobileTests` runs unit tests
+and `testDebugUnitTest --tests '*.automobiletest.*'` runs the AutoMobile tests.
+
+## Caching strategy
+
+The `build-for-testing` job uses two cache layers that the `automobile-tests` job benefits from
+indirectly through the artifact:
+
+| Cache                     | Key                                                       | What it stores                                                         |
+| ------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| SPM packages              | `runner-xcode<ver>-spm-<hash(project.yml)>`               | Alamofire, XCTestRunner, etc. — avoids re-cloning                      |
+| DerivedData intermediates | `runner-xcode<ver>-intermediates-<hash(sources+configs)>` | Compiled `.o` and `.swiftmodule` files — makes incremental builds fast |
+
+Both caches are keyed so a clean rebuild only triggers when sources actually change.
+
+## Required secrets
+
+No additional secrets are required for a basic AutoMobile test run. The macOS runner has Xcode
+and iOS Simulator built in, and the daemon communicates entirely over a local Unix socket.
+
+If you add features that require external services (e.g., a staging backend with an API key), pass
+them as environment variables through the test scheme:
+
+```yaml
+- name: Run AutoMobile tests
+  env:
+    AUTOMOBILE_TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+  run: bash scripts/ios/xcode-automobile-tests.sh
+```
+
+Resolve them from the environment in the test target before executing the plan.
+
+## Conditional execution
+
+To skip the job on draft pull requests or when a specific label is absent:
+
+```yaml
+automobile-tests:
+  if: github.event.pull_request.draft != true
+```
+
+## Reading results from CI
+
+Download the `automobile-test-results` artifact and inspect with xcresulttool:
+
+```bash
+xcrun xcresulttool get test-results summary \
+  --path automobile-tests.xcresult
+
+xcrun xcresulttool get test-results tests \
+  --path automobile-tests.xcresult --format json \
+  | jq '[.. | objects | select(.testStatus? == "Failure") | .nodeIdentifier]'
+```
+
+## See also
+
+- [UI tests](../../../../using/ui-tests.md) — dependency setup, YAML plans, and
+  `AutoMobileTestCase` usage

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -41,6 +41,9 @@ automobile-tests:
   runs-on: macos-26
   needs: [build-for-testing]
   timeout-minutes: 30
+  env:
+    # Match the AutoMobile version pinned by the XCTestRunner package resolution.
+    AUTOMOBILE_VERSION: "<runner-version>"
   steps:
     - uses: actions/checkout@v6
 
@@ -53,7 +56,7 @@ automobile-tests:
       uses: oven-sh/setup-bun@v2
 
     - name: Install auto-mobile CLI
-      run: bun install -g @kaeawc/auto-mobile
+      run: bun install -g "@kaeawc/auto-mobile@${AUTOMOBILE_VERSION}"
 
     - name: Ensure iOS Simulator runtime
       uses: ./.github/actions/ensure-ios-simulator-runtime
@@ -67,7 +70,7 @@ automobile-tests:
     - name: Boot iOS Simulator
       run: |
         ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-        auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \\
+        auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \
           --min-os-version "${ios_version}" --max-os-version "${ios_version}"
 
     - name: Start simulator log stream

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -80,9 +80,7 @@ automobile-tests:
         echo "LOG_STREAM_PID=$!" >> "$GITHUB_ENV"
 
     - name: Start AutoMobile daemon
-      run: |
-        auto-mobile --daemon start &
-        echo "AUTOMOBILE_DAEMON_PID=$!" >> "$GITHUB_ENV"
+      run: auto-mobile --daemon start
 
     - name: Wait for daemon and register simulator
       run: auto-mobile --cli observe --platform ios
@@ -92,7 +90,7 @@ automobile-tests:
 
     - name: Stop AutoMobile daemon
       if: always()
-      run: kill "$AUTOMOBILE_DAEMON_PID" 2>/dev/null || true
+      run: auto-mobile --daemon stop || true
 
     - name: Stop simulator log stream
       if: always()
@@ -161,15 +159,15 @@ xcrun simctl list devices booted   # confirm it booted
 
 ### 4. Daemon startup
 
-Start the daemon in the background and save its PID for clean shutdown:
+Start the daemon and wait for its detached process to become ready:
 
 ```bash
-auto-mobile --daemon start &
-echo "AUTOMOBILE_DAEMON_PID=$!" >> "$GITHUB_ENV"
+auto-mobile --daemon start
 ```
 
-The `--cli observe` step below implicitly waits for the daemon to be ready, so no explicit socket
-poll is needed here.
+The start command launches the managed daemon process, waits for readiness, and
+then exits. Its launcher PID is not the daemon PID, so it must not be saved for
+cleanup.
 
 ### 5. CtrlProxy pre-installation
 
@@ -211,12 +209,13 @@ xcodebuild test-without-building \
 The `if: always()` guards ensure cleanup runs even when tests fail:
 
 ```bash
-kill "$AUTOMOBILE_DAEMON_PID" 2>/dev/null || true
+auto-mobile --daemon stop || true
 kill "$LOG_STREAM_PID" 2>/dev/null || true
 ```
 
-The daemon process exits cleanly; the simulator remains booted for the remainder of the runner's
-lifetime (macOS runners are ephemeral so no explicit teardown is needed).
+The daemon manager resolves and stops the detached process recorded in its PID
+file. The simulator remains booted for the remainder of the runner's lifetime
+(macOS runners are ephemeral so no explicit teardown is needed).
 
 ### 8. Artifacts
 

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -24,7 +24,7 @@ device service or additional secrets are needed.
 
 The reference workflow splits testing into two independent jobs that share the same build artifact:
 
-```
+```text
 build-for-testing ──┬──► simulator-tests      (unit tests, skips AutoMobile bundle)
                     └──► automobile-tests      (AutoMobile tests only)
 ```
@@ -125,10 +125,12 @@ runner so `auto-mobile --daemon start` works correctly.
 
 ```yaml
 - uses: oven-sh/setup-bun@v2
+
+- name: Install matching auto-mobile CLI
   env:
     # Match the AutoMobile version pinned by the XCTestRunner package resolution.
     AUTOMOBILE_VERSION: "<runner-version>"
-- run: bun install -g "@kaeawc/auto-mobile@${AUTOMOBILE_VERSION}"
+  run: bun install -g "@kaeawc/auto-mobile@${AUTOMOBILE_VERSION}"
 ```
 
 ### 2. Build products artifact

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -125,7 +125,10 @@ runner so `auto-mobile --daemon start` works correctly.
 
 ```yaml
 - uses: oven-sh/setup-bun@v2
-- run: bun install -g @kaeawc/auto-mobile
+  env:
+    # Match the AutoMobile version pinned by the XCTestRunner package resolution.
+    AUTOMOBILE_VERSION: "<runner-version>"
+- run: bun install -g "@kaeawc/auto-mobile@${AUTOMOBILE_VERSION}"
 ```
 
 ### 2. Build products artifact

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,10 +57,12 @@ or simulators.
 
 ## Where is AutoMobile data stored?
 
-By default, AutoMobile stores its database, caches, screenshots, and logs under
-`~/.auto-mobile`. Set `AUTOMOBILE_DATA_DIR` to move non-log state or
-`AUTOMOBILE_LOG_DIR` to move logs. See [environment variables](using/environment-variables.md)
-for the complete list.
+By default, AutoMobile stores its database, caches, snapshots, video archives,
+and logs under `~/.auto-mobile`. `AUTOMOBILE_DATA_DIR` relocates temporary
+artifacts used by observation, accessibility, navigation, CtrlProxy builds,
+screen streaming, WebRTC, tool output, and daemon failure tracking;
+`AUTOMOBILE_LOG_DIR` relocates logs. Some persistent stores retain fixed paths.
+See [environment variables](using/environment-variables.md) for the exact scope.
 
 ## Does AutoMobile send my app data anywhere?
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -7,12 +7,12 @@ state directory, logs, tool set, or device behavior.
 
 <div class="environment-variable-table" markdown>
 
-| Variable                | Use                                                                  | Default               |
-| ----------------------- | -------------------------------------------------------------------- | --------------------- |
-| `AUTOMOBILE_DATA_DIR`   | Base directory for caches, screenshots, and other non-database state | `~/.auto-mobile`      |
-| `AUTOMOBILE_LOG_DIR`    | Directory for daemon and client logs                                 | `~/.auto-mobile/logs` |
-| `AUTOMOBILE_LOG_FORMAT` | `text` or newline-delimited `json`                                   | `text`                |
-| `AUTOMOBILE_LOG_SINK`   | `file`, `stderr`, or `both`                                          | `file`                |
+| Variable                | Use                                                                                                                                         | Default               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `AUTOMOBILE_DATA_DIR`   | Base directory for observe, accessibility, navigation, CtrlProxy-build, screen-streaming, WebRTC, tool-output, and daemon-failure artifacts | `~/.auto-mobile`      |
+| `AUTOMOBILE_LOG_DIR`    | Directory for daemon and client logs                                                                                                        | `~/.auto-mobile/logs` |
+| `AUTOMOBILE_LOG_FORMAT` | `text` or newline-delimited `json`                                                                                                          | `text`                |
+| `AUTOMOBILE_LOG_SINK`   | `file`, `stderr`, or `both`                                                                                                                 | `file`                |
 
 </div>
 
@@ -23,6 +23,11 @@ export AUTOMOBILE_DATA_DIR=/var/lib/automobile
 export AUTOMOBILE_LOG_FORMAT=json
 export AUTOMOBILE_LOG_SINK=stderr
 ```
+
+Some persistent stores still use fixed paths under `~/.auto-mobile`, including
+device snapshots, video archives, and downloaded libwebp tools. Set their
+feature-specific options where available; `AUTOMOBILE_DATA_DIR` does not
+currently relocate them.
 
 ## Database
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,10 +98,14 @@ nav:
       - "Runtime dependency pinning": design-docs/release/runtime-dependency-pinning.md
       - "Interaction loop": design-docs/mcp/interaction-loop.md
       - "Daemon": design-docs/mcp/daemon.md
+      - "Screen control mapping": design-docs/mcp/daemon/screen-control-mapping.md
       - "Android JUnit runner": design-docs/plat/android/junit-runner/index.md
       - "Android system tray": design-docs/plat/android/system-tray-lookfor.md
       - "Desktop App": design-docs/plat/android/desktop-app.md
       - "iOS Simulator continuity": release/ios-simulator-continuity.md
+      - "XCTestRunner CI integration": design-docs/plat/ios/xctestrunner/ci-integration.md
       - "iOS Files picker provider": decisions/ios-user-files-provider.md
+  - "Contributing":
+      - "Standard library first": contributing/stdlib-first.md
   - "Usage Data": metrics/usage-data.md
   - "FAQ": faq.md

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -288,6 +288,11 @@ patterns = (
     (r"(AUTOMOBILE_VERSION=)\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", rf"\g<1>{version}"),
     (r"(@kaeawc/auto-mobile@)\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", rf"\g<1>{version}"),
     (
+        r'(\.package\(url: "https://github\.com/kaeawc/auto-mobile\.git", from: ")'
+        r'\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?(?=")',
+        rf"\g<1>{version}",
+    ),
+    (
         r"(Replace `)\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?(` with the version used by your test runner dependency\.)",
         rf"\g<1>{version}\g<2>",
     ),

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -60,6 +60,7 @@ https://github.com/kaeawc/auto-mobile/releases/download/0.0.1/AutoMobile-0.0.1-m
 EOF
   cat > "${TEST_ROOT}/docs/using/ui-tests.md" <<'EOF'
 testImplementation("dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:0.0.1")
+.package(url: "https://github.com/kaeawc/auto-mobile.git", from: "0.0.1")
 export AUTOMOBILE_VERSION=0.0.1
 Replace `0.0.1` with the version used by your test runner dependency.
 EOF
@@ -118,6 +119,8 @@ run_bump() {
   grep -q "releases/download/${VERSION}/AutoMobile-${VERSION}-macos.dmg" \
     "${TEST_ROOT}/docs/index.md"
   grep -q "auto-mobile-junit-runner:${VERSION}" "${TEST_ROOT}/docs/using/ui-tests.md"
+  grep -Fq ".package(url: \"https://github.com/kaeawc/auto-mobile.git\", from: \"${VERSION}\")" \
+    "${TEST_ROOT}/docs/using/ui-tests.md"
   grep -q "AUTOMOBILE_VERSION=${VERSION}" "${TEST_ROOT}/docs/using/ui-tests.md"
   grep -q "Replace \`${VERSION}\` with the version used by your test runner dependency" \
     "${TEST_ROOT}/docs/using/ui-tests.md"


### PR DESCRIPTION
## Summary

- restore the contributor dependency-decision template and the screen-control and XCTestRunner CI contracts still referenced by live code and scripts
- narrow `AUTOMOBILE_DATA_DIR` documentation to the artifacts routed through its resolver
- keep the Swift Package Manager UI-test example synchronized by the release version bump

## Review follow-up

This is the narrow follow-up for the five post-merge review findings on [PR #5814](https://github.com/kaeawc/auto-mobile/pull/5814).

## Validation

- `bats test/bats/bump-versions.bats` (11 passed)
- `mkdocs build --strict --site-dir scratch/site-pr-5814-followup`
- `bun run format:check`
- `scripts/all_fast_validate_checks.sh` (34 passed)
- `git diff --check`
