### PR TITLE
fix(ci): cover boundary analyzer call patterns

### DIFF
--- a/scripts/check-no-new-direct-xcodebuild.ts
+++ b/scripts/check-no-new-direct-xcodebuild.ts
@@ -52,15 +52,17 @@ function shellCommandPayloads(argv: readonly string[]): string[] {
 function splitEnvPayload(value: string): string[] {
   const words: string[] = [];
   let word = "";
+  let wordOpened = false;
   let wordHasExpansion = false;
   let quote: "'" | '"' | null = null;
   let escaped = false;
   const pushWord = (): void => {
-    if (!word) {
+    if (!wordOpened) {
       return;
     }
     words.push(wordHasExpansion ? OPAQUE_ARGUMENT : word);
     word = "";
+    wordOpened = false;
     wordHasExpansion = false;
   };
   for (let index = 0; index < value.length; index += 1) {
@@ -85,11 +87,13 @@ function splitEnvPayload(value: string): string[] {
                       ? "\r"
                       : " ";
           word += whitespace;
-        } else if (word) {
+          wordOpened = true;
+        } else if (wordOpened) {
           pushWord();
         }
       } else {
         word += character;
+        wordOpened = true;
       }
       escaped = false;
     } else if (character === "\\" && quote !== "'") {
@@ -109,10 +113,12 @@ function splitEnvPayload(value: string): string[] {
       }
     } else if (character === "'" || character === '"') {
       quote = character;
+      wordOpened = true;
     } else if (/\s/.test(character)) {
       pushWord();
     } else {
       word += character;
+      wordOpened = true;
       if (character === "$" && /^\{[A-Za-z_][A-Za-z0-9_]*\}/.test(value.slice(index + 1))) {
         wordHasExpansion = true;
       }
@@ -120,6 +126,7 @@ function splitEnvPayload(value: string): string[] {
   }
   if (escaped) {
     word += "\\";
+    wordOpened = true;
   }
   pushWord();
   return words;
@@ -142,6 +149,11 @@ function envDelegatesToXcodebuild(argv: readonly string[]): boolean {
     }
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(argument)) {
       continue;
+    }
+    // An empty argv slot is still the command. GNU env cannot skip it to run a
+    // later xcodebuild argument.
+    if (argument === "") {
+      return false;
     }
     if (optionsTerminated) {
       const command = commandName(argument);

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -108,7 +108,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     receiverDeclaration?: DeclarationBinding;
   }> = [];
   const classInstanceMethods: Array<{
-    className: string;
+    classDeclaration: DeclarationBinding;
     name: string;
     node: ts.MethodDeclaration;
     scope: ts.Node;
@@ -395,7 +395,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           const methodName = propertyNameOf(member.name);
           if (methodName) {
             classInstanceMethods.push({
-              className: node.name.text,
+              classDeclaration: receiverDeclaration,
               name: methodName,
               node: member,
               scope,
@@ -463,9 +463,37 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (!receiverDeclaration) {
       continue;
     }
-    const visibleScopes = scopeChain(value);
+    // A later assignment can replace the instance with an unrelated subclass.
+    // Do not associate that mutable receiver with its declaration initializer.
+    if (
+      scopedValues.some(
+        (candidate) =>
+          candidate.kind === "assignment" &&
+          candidate.name === binding.name &&
+          candidate.position > binding.position,
+      )
+    ) {
+      continue;
+    }
+    const constructorScopes = scopeChain(value.expression);
+    const classDeclaration = declarations
+      .filter(
+        (declaration) =>
+          declaration.name === value.expression.text &&
+          constructorScopes.includes(declaration.scope) &&
+          declaration.position <= value.expression.getStart(sourceFile) &&
+          classInstanceMethods.some((method) => method.classDeclaration === declaration),
+      )
+      .sort((left, right) => {
+        const scopeDelta =
+          constructorScopes.indexOf(left.scope) - constructorScopes.indexOf(right.scope);
+        return scopeDelta !== 0 ? scopeDelta : right.position - left.position;
+      })[0];
+    if (!classDeclaration) {
+      continue;
+    }
     for (const method of classInstanceMethods) {
-      if (method.className === value.expression.text && visibleScopes.includes(method.scope)) {
+      if (method.classDeclaration === classDeclaration) {
         functionBindings.push({
           name: method.name,
           node: method.node,
@@ -715,7 +743,7 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
           ts.isElementAccessExpression(combinator.expression)) &&
         ts.isIdentifier(combinator.expression.expression) &&
         combinator.expression.expression.text === "Promise" &&
-        new Set(["all", "allSettled", "any", "race"]).has(propertyName(combinator.expression) ?? "")
+        propertyName(combinator.expression) === "all"
       ) {
         current = combinator;
       }

--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -107,6 +107,13 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     position: number;
     receiverDeclaration?: DeclarationBinding;
   }> = [];
+  const classInstanceMethods: Array<{
+    className: string;
+    name: string;
+    node: ts.MethodDeclaration;
+    scope: ts.Node;
+    position: number;
+  }> = [];
   type InvocationExpression = ts.CallExpression | ts.NewExpression;
   const calls: ts.CallExpression[] = [];
   const invocations: InvocationExpression[] = [];
@@ -384,6 +391,17 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
               receiverDeclaration,
             });
           }
+        } else if (ts.isMethodDeclaration(member)) {
+          const methodName = propertyNameOf(member.name);
+          if (methodName) {
+            classInstanceMethods.push({
+              className: node.name.text,
+              name: methodName,
+              node: member,
+              scope,
+              position: member.getStart(sourceFile),
+            });
+          }
         }
       }
     }
@@ -426,6 +444,38 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     ts.forEachChild(node, collect);
   };
   collect(sourceFile);
+
+  for (const binding of scopedValues) {
+    const value = unwrapTransparentExpression(binding.value);
+    if (
+      binding.kind !== "declaration" ||
+      !ts.isNewExpression(value) ||
+      !ts.isIdentifier(value.expression)
+    ) {
+      continue;
+    }
+    const receiverDeclaration = declarations.find(
+      (declaration) =>
+        declaration.name === binding.name &&
+        declaration.scope === binding.scope &&
+        declaration.position === binding.position,
+    );
+    if (!receiverDeclaration) {
+      continue;
+    }
+    const visibleScopes = scopeChain(value);
+    for (const method of classInstanceMethods) {
+      if (method.className === value.expression.text && visibleScopes.includes(method.scope)) {
+        functionBindings.push({
+          name: method.name,
+          node: method.node,
+          scope: binding.scope,
+          position: binding.position,
+          receiverDeclaration,
+        });
+      }
+    }
+  }
 
   const receiverDeclarationCache = new Map<ts.Identifier, DeclarationBinding | null>();
   const resolveReceiverDeclaration = (
@@ -654,6 +704,21 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       ts.isSatisfiesExpression(current.parent)
     ) {
       current = current.parent;
+    }
+    if (ts.isArrayLiteralExpression(current.parent)) {
+      const array = current.parent;
+      const combinator = array.parent;
+      if (
+        ts.isCallExpression(combinator) &&
+        combinator.arguments.includes(array) &&
+        (ts.isPropertyAccessExpression(combinator.expression) ||
+          ts.isElementAccessExpression(combinator.expression)) &&
+        ts.isIdentifier(combinator.expression.expression) &&
+        combinator.expression.expression.text === "Promise" &&
+        new Set(["all", "allSettled", "any", "race"]).has(propertyName(combinator.expression) ?? "")
+      ) {
+        current = combinator;
+      }
     }
     return ts.isAwaitExpression(current.parent);
   };

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -171,6 +171,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "preserves an empty quoted env split-string command slot" {
+  printf '%s\n' "spawn(\"env\", [\"--debug\", \"-S\", \"''\", \"xcodebuild\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-xcodebuild.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct production xcodebuild invocations"* ]]
+}
+
 @test "rejects a shell wrapper produced by env split-string" {
   printf '%s\n' "spawn(\"env\", [\"-S\", \"sh -c 'xcodebuild test'\"]);" > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -227,6 +227,18 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } { class Config { configure(){} } const config=new Config(); config.configure(); runner.exec("kill"); }',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } class Other extends Config { configure(){} } let config=new Config(); config=new Other(); config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
         'let runner = /x/; function configure(){ runner = executor; } unrelated(); runner.exec("kill");',
       ),
     ).toHaveLength(0);
@@ -272,6 +284,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner = executor; async function configure(){ await Promise.resolve(); runner = /x/; } await Promise.all([configure()]); runner.exec("kill");',
       ),
     ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = executor; async function configure(){ await Promise.resolve(); runner = /x/; } await Promise.race([configure(), Promise.resolve()]); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
     expect(
       findViolationsInSource(
         "fixture.ts",

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -221,6 +221,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } const config=new Config(); config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
         'let runner = /x/; function configure(){ runner = executor; } unrelated(); runner.exec("kill");',
       ),
     ).toHaveLength(0);
@@ -260,6 +266,12 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
         'let runner = /x/; async function configure(){ await Promise.resolve(); runner = executor; } await configure(); runner.exec("kill");',
       ),
     ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner = executor; async function configure(){ await Promise.resolve(); runner = /x/; } await Promise.all([configure()]); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
     expect(
       findViolationsInSource(
         "fixture.ts",


### PR DESCRIPTION
## Summary

- preserve empty quoted `env -S` command operands in the direct-xcodebuild guard
- follow directly invoked instance methods and awaited Promise combinators in the shared boundary analyzer
- add regressions for each reviewer-reported execution-flow case

Follow-up to [#5842](https://github.com/kaeawc/auto-mobile/pull/5842).

## Validation

- `bun test test/lint/iosCtrlProxyProcessBoundary.test.ts`
- `bats test/bats/check-no-new-direct-xcodebuild.bats`
- `bun run lint`
