### PR TITLE
fix(navigation): scope exported graph-summary screenshot URIs by appId (#5600)

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../utils/logger";
+import { buildNavigationNodeScreenshotUri } from "../../utils/navigationResourceUri";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { BackStackInfo } from "../../models";
 import { NavigationRepository } from "../../db/navigationRepository";
@@ -873,7 +874,10 @@ export class NavigationGraphManager implements NavigationGraphService {
       arguments: event.arguments ?? null,
       metadata: event.metadata ?? null,
       triggeringInteraction: event.triggeringInteraction ?? null,
-      screenshotUri: `automobile:navigation/nodes/${node.id}/screenshot`,
+      // Scope to `appId` (== the app that just navigated): this URI is pushed live
+      // to telemetry-dashboard subscribers, which may be foregrounding a different
+      // app when they follow it, so an unscoped form would resolve cross-app (#5600).
+      screenshotUri: buildNavigationNodeScreenshotUri(node.id, appId),
     });
   }
 
@@ -1767,9 +1771,11 @@ export class NavigationGraphManager implements NavigationGraphService {
       id: node.id,
       screenName: node.screen_name,
       visitCount: node.visit_count,
-      // Include screenshot path as resource URI if available
+      // Include screenshot path as resource URI if available, scoped to the
+      // exported app so an offline / cross-app browse resolves this app's
+      // screenshot rather than the daemon's current foreground app (#5600).
       screenshotPath: node.screenshot_path
-        ? `automobile:navigation/nodes/${node.id}/screenshot`
+        ? buildNavigationNodeScreenshotUri(node.id, appId)
         : null,
       provenance: nodeProvenanceByNodeId.get(node.id) ?? [],
     }));

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -12,6 +12,7 @@ import {
   NavigationAppListProvider,
 } from "../utils/interfaces/NavigationGraph";
 import { logger } from "../utils/logger";
+import { buildNavigationNodeScreenshotUri } from "../utils/navigationResourceUri";
 import { defaultTimer } from "../utils/SystemTimer";
 
 export const NAVIGATION_RESOURCE_URIS = {
@@ -286,9 +287,7 @@ async function getNavigationNodeScreenshotResource(
   nodeId: number,
   appId?: string,
 ): Promise<ResourceContent> {
-  const uri = appId
-    ? `automobile:navigation/nodes/${nodeId}/screenshot?appId=${encodeURIComponent(appId)}`
-    : `automobile:navigation/nodes/${nodeId}/screenshot`;
+  const uri = buildNavigationNodeScreenshotUri(nodeId, appId);
 
   try {
     // Resolve the screenshot under the requested app, not the daemon's current

--- a/src/utils/navigationResourceUri.ts
+++ b/src/utils/navigationResourceUri.ts
@@ -1,0 +1,15 @@
+/**
+ * Single source of truth for the navigation node-screenshot resource URI shape.
+ *
+ * #5534 scoped the screenshot resource by an explicit `?appId=` so an offline /
+ * cross-app browse resolves the screenshot under the named app instead of the
+ * daemon's current foreground app (#4933). Every emitter of this URI — the
+ * resolver (navigationResources), the exported graph summary, and the live
+ * telemetry stream — must produce the identical shape, so they all build it here
+ * rather than re-inlining the literal (#5600). When `appId` is absent the caller
+ * gets the legacy unscoped form, which resolves against the current app.
+ */
+export function buildNavigationNodeScreenshotUri(nodeId: number, appId?: string | null): string {
+  const base = `automobile:navigation/nodes/${nodeId}/screenshot`;
+  return appId ? `${base}?appId=${encodeURIComponent(appId)}` : base;
+}

--- a/test/features/navigation/navigationGraphSummaryProvenance.test.ts
+++ b/test/features/navigation/navigationGraphSummaryProvenance.test.ts
@@ -98,4 +98,41 @@ describe("exportGraphSummaryForApp provenance (#4985)", () => {
     expect(summary.nodes).toEqual([]);
     expect(summary.edges).toEqual([]);
   });
+
+  /**
+   * Regression (#5600, follow-up to #5534/#4933): the exported summary for app B
+   * must carry the app-SCOPED screenshot URI (`?appId=B`), even while a different
+   * app A is foregrounded. An unscoped URI resolves against the daemon's current
+   * app, returning A's colliding screen or "No current app set" — the exact
+   * cross-app failure #5534 fixed in the resolver but left in the exporter.
+   * navigationGraph.test.ts already proves such a B-scoped URI resolves to B's
+   * screenshot regardless of the current app; this pins that the exporter emits it.
+   */
+  test("exported summary emits an app-scoped screenshot URI while another app is foregrounded", async () => {
+    const APP_B = "com.example.b";
+    await seedRepo.getOrCreateApp(APP_B);
+    // App A (this test's APP) also has a Home node/screenshot — the collision.
+    const homeA = await seedRepo.getOrCreateNode(APP, "Home", 100);
+    await seedRepo.updateNodeScreenshotById(homeA.id, "/screens/com.example.app/Home.webp");
+    const homeB = await seedRepo.getOrCreateNode(APP_B, "Home", 100);
+    await seedRepo.updateNodeScreenshotById(homeB.id, "/screens/com.example.b/Home.webp");
+
+    // Foreground app A, then export B: the classic cross-app browse.
+    await harness.manager.setCurrentApp(APP);
+    const summary = await harness.manager.exportGraphSummaryForApp(APP_B);
+
+    const node = summary.nodes.find((n) => n.screenName === "Home")!;
+    expect(node.screenshotPath).toBe(
+      `automobile:navigation/nodes/${homeB.id}/screenshot?appId=com.example.b`,
+    );
+  });
+
+  test("exported summary omits the scope suffix for a node without a screenshot", async () => {
+    // appId present but the node has no stored screenshot → screenshotPath is null,
+    // never a bare unscoped URI.
+    await seedRepo.getOrCreateNode(APP, "Home", 100);
+    const summary = await harness.manager.exportGraphSummaryForApp(APP);
+    const node = summary.nodes.find((n) => n.screenName === "Home")!;
+    expect(node.screenshotPath).toBeNull();
+  });
 });

--- a/test/utils/navigationResourceUri.test.ts
+++ b/test/utils/navigationResourceUri.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { buildNavigationNodeScreenshotUri } from "../../src/utils/navigationResourceUri";
+
+/**
+ * Single source of truth for the node-screenshot resource URI shape (#5600).
+ * Both the resolver (navigationResources) and the exporter
+ * (NavigationGraphManager.exportGraphSummaryForApp / telemetry) build the URI
+ * through this helper so the `?appId=` scoping introduced by #5534 cannot drift
+ * back to an unscoped literal in any one emitter.
+ */
+describe("buildNavigationNodeScreenshotUri (#5600)", () => {
+  test("scopes the URI with an encoded appId when appId is present", () => {
+    expect(buildNavigationNodeScreenshotUri(7, "com.example.b")).toBe(
+      "automobile:navigation/nodes/7/screenshot?appId=com.example.b",
+    );
+  });
+
+  test("percent-encodes appId characters that are unsafe in a query value", () => {
+    expect(buildNavigationNodeScreenshotUri(3, "com.foo bar&baz")).toBe(
+      "automobile:navigation/nodes/3/screenshot?appId=com.foo%20bar%26baz",
+    );
+  });
+
+  test("emits the unscoped URI when appId is null or undefined", () => {
+    expect(buildNavigationNodeScreenshotUri(9, null)).toBe(
+      "automobile:navigation/nodes/9/screenshot",
+    );
+    expect(buildNavigationNodeScreenshotUri(9)).toBe("automobile:navigation/nodes/9/screenshot");
+  });
+});


### PR DESCRIPTION
## Summary

`exportGraphSummaryForApp()` still emitted the **legacy unscoped** screenshot resource URI (`automobile:navigation/nodes/<id>/screenshot`). #5534 (for #4933) added `?appId=` scoping and a `NODE_SCREENSHOT_WITH_APP_ID` template so an offline/cross-app browse resolves the screenshot under the named app — but the graph-summary export path was never updated to use it. So an exported summary for app **B**, read while app **A** (or none) is foregrounded, follows the returned `screenshotPath`, which resolves against `getCurrentAppId()` → app A's colliding screen or `No current app set`.

This was the Codex **P1** on [#5534](https://github.com/kaeawc/auto-mobile/pull/5534) ("Include app IDs in exported screenshot links"), merged unaddressed.

## Linked Issue

Closes #5600

## Bug / Regression Context

- **Prior attempts:** #5534 scoped the *resolver* by `?appId=` but left the *exporter* emitting the bare URI.
- **Observed symptom:** exported summary thumbnails resolve cross-app — the wrong app's screenshot, or `No current app set`.
- **Repro:** read `automobile:navigation/graph?appId=B` while A is foregrounded, then follow a node's `screenshotPath`.

## Changes

- New `buildNavigationNodeScreenshotUri(nodeId, appId?)` (`src/utils/navigationResourceUri.ts`) — single source of truth for the node-screenshot URI shape (scoped when `appId` present, unscoped when null).
- Route all three emitters through it: the exporter (`NavigationGraphManager.exportGraphSummaryForApp`, line 1772), the resolver (`navigationResources`, line 290, previously a re-inlined literal), and the live telemetry emitter (`NavigationGraphManager` line 876).
- **Line-876 audit:** that `screenshotUri` is pushed **live to telemetry-dashboard subscribers** (`TelemetryRecorder.pushToSocket`), which may foreground a different app when they follow it → read cross-app → **scoped** (its `appId` is already in scope). Two *other* unscoped telemetry emitters (`IosSdkEventIngestor.ts:204`, `telemetryPushSocketServer.ts:269`) are outside this issue's named scope; noted as a possible follow-up.

## Acceptance criteria

- [x] `exportGraphSummaryForApp(appId)` emits `...screenshot?appId=<encoded>` per node when `appId` present; unscoped only when `appId` null.
- [x] URI construction goes through the shared helper (no re-inlined literal).
- [x] Line 876 emission audited → scoped (read cross-app via live push).
- [x] Regression test: exported summary for B, read while A foregrounded, yields B's scoped URI (which `navigationGraph.test.ts` already proves resolves to B, not A).

## Validation

- [x] `bun test` (full suite) — the two failures are pre-existing/environmental (worktree missing the `oxlint` `.bin` symlink; a webrtc test asserting on a subprocess's bun-output format), neither in navigation.
- [x] `bun run typecheck` — no new errors.
- [x] `bun run lint` — no new violations; boundary checks pass.
- [x] `bun run build` — success.
- [x] New code uses the in-memory nav harness; unit tests run <100ms.

## Device Verification

- N/A — pure resource-URI string construction; covered by the resolver's existing app-scoped resolution tests.
