### PR TITLE
fix(schema): resync Android test-plan.schema.json copy and gate drift

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -825,7 +825,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,bun-version-coherence,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,sharp-matrix,runtime-pins,shell-quote-boundary,security-boundary,app-bundle-metadata-boundary,ios-ctrl-proxy-process-boundary,mkdocs-nav,ktfmt,claude-plugin,codex-skills,github-python-lock \
+            --only yaml,schema-copy-drift,xml,bun-version-coherence,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,sharp-matrix,runtime-pins,shell-quote-boundary,security-boundary,app-bundle-metadata-boundary,ios-ctrl-proxy-process-boundary,mkdocs-nav,ktfmt,claude-plugin,codex-skills,github-python-lock \
             --max-parallel 4
 
       # The BATS suite (913 tests, ~3.5min serially) is NOT run here. It ran a

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -18,10 +18,7 @@
     },
     "platform": {
       "type": "string",
-      "enum": [
-        "android",
-        "ios"
-      ],
+      "enum": ["android", "ios"],
       "description": "Optional platform hint for plan execution"
     },
     "devices": {
@@ -140,10 +137,7 @@
         },
         "platform": {
           "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
+          "enum": ["android", "ios"],
           "description": "Target platform for this device"
         },
         "simulatorType": {
@@ -178,6 +172,10 @@
           "type": "string",
           "description": "Human-readable description of what this step does"
         },
+        "optional": {
+          "type": "boolean",
+          "description": "Best-effort step: if the tool fails (returns success:false, an observe waitFor times out, or throws), the executor logs it, records the step as skipped, and continues instead of aborting the plan. Use for steps that guard against intermittent UI (e.g. dismissing a dialog that may or may not be present)."
+        },
         "description": {
           "type": "string",
           "description": "DEPRECATED: Use 'label' instead (legacy field)"
@@ -199,9 +197,7 @@
                 "const": "dragAndDrop"
               }
             },
-            "required": [
-              "tool"
-            ]
+            "required": ["tool"]
           },
           "then": {
             "properties": {
@@ -234,10 +230,7 @@
               },
               "platform": {
                 "type": "string",
-                "enum": [
-                  "android",
-                  "ios"
-                ],
+                "enum": ["android", "ios"],
                 "description": "Platform"
               },
               "sessionUuid": {
@@ -253,42 +246,30 @@
               {
                 "anyOf": [
                   {
-                    "required": [
-                      "source"
-                    ]
+                    "required": ["source"]
                   },
                   {
                     "properties": {
                       "params": {
-                        "required": [
-                          "source"
-                        ]
+                        "required": ["source"]
                       }
                     },
-                    "required": [
-                      "params"
-                    ]
+                    "required": ["params"]
                   }
                 ]
               },
               {
                 "anyOf": [
                   {
-                    "required": [
-                      "target"
-                    ]
+                    "required": ["target"]
                   },
                   {
                     "properties": {
                       "params": {
-                        "required": [
-                          "target"
-                        ]
+                        "required": ["target"]
                       }
                     },
-                    "required": [
-                      "params"
-                    ]
+                    "required": ["params"]
                   }
                 ]
               }
@@ -302,9 +283,7 @@
                 "const": "highlight"
               }
             },
-            "required": [
-              "tool"
-            ]
+            "required": ["tool"]
           },
           "then": {
             "properties": {
@@ -323,15 +302,24 @@
                 "type": "string",
                 "description": "Element text content to match"
               },
+              "container": {
+                "$ref": "#/$defs/highlightContainer"
+              },
+              "containerOf": {
+                "type": "boolean",
+                "description": "Whether to highlight the container of the selected element"
+              },
               "shape": {
                 "$ref": "#/$defs/highlightShape"
               },
+              "selectionStrategy": {
+                "type": "string",
+                "enum": ["first", "random"],
+                "description": "Element selection strategy when multiple matches are found (default: first)"
+              },
               "platform": {
                 "type": "string",
-                "enum": [
-                  "android",
-                  "ios"
-                ],
+                "enum": ["android", "ios"],
                 "description": "Platform"
               },
               "timeoutMs": {
@@ -351,55 +339,37 @@
               {
                 "anyOf": [
                   {
-                    "required": [
-                      "shape"
-                    ]
+                    "required": ["shape"]
                   },
                   {
-                    "required": [
-                      "id"
-                    ]
+                    "required": ["id"]
                   },
                   {
-                    "required": [
-                      "text"
-                    ]
+                    "required": ["text"]
                   },
                   {
                     "properties": {
                       "params": {
-                        "required": [
-                          "shape"
-                        ]
+                        "required": ["shape"]
                       }
                     },
-                    "required": [
-                      "params"
-                    ]
+                    "required": ["params"]
                   },
                   {
                     "properties": {
                       "params": {
-                        "required": [
-                          "id"
-                        ]
+                        "required": ["id"]
                       }
                     },
-                    "required": [
-                      "params"
-                    ]
+                    "required": ["params"]
                   },
                   {
                     "properties": {
                       "params": {
-                        "required": [
-                          "text"
-                        ]
+                        "required": ["text"]
                       }
                     },
-                    "required": [
-                      "params"
-                    ]
+                    "required": ["params"]
                   }
                 ]
               }
@@ -413,9 +383,7 @@
                 "const": "setAppPermissions"
               }
             },
-            "required": [
-              "tool"
-            ]
+            "required": ["tool"]
           },
           "then": {
             "properties": {
@@ -429,11 +397,7 @@
               },
               "action": {
                 "type": "string",
-                "enum": [
-                  "grant",
-                  "revoke",
-                  "reset"
-                ],
+                "enum": ["grant", "revoke", "reset"],
                 "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
               },
               "permissions": {
@@ -460,18 +424,12 @@
               },
               "scheduleExactAlarm": {
                 "type": "string",
-                "enum": [
-                  "allow",
-                  "deny"
-                ],
+                "enum": ["allow", "deny"],
                 "description": "Android only: set UID-level SCHEDULE_EXACT_ALARM appop"
               },
               "platform": {
                 "type": "string",
-                "enum": [
-                  "android",
-                  "ios"
-                ],
+                "enum": ["android", "ios"],
                 "description": "Platform"
               },
               "sessionUuid": {
@@ -493,33 +451,19 @@
             },
             "anyOf": [
               {
-                "required": [
-                  "appId",
-                  "permissions"
-                ]
+                "required": ["appId", "permissions"]
               },
               {
-                "required": [
-                  "appId",
-                  "notificationsEnabled"
-                ]
+                "required": ["appId", "notificationsEnabled"]
               },
               {
-                "required": [
-                  "appId",
-                  "notificationPolicyAccess"
-                ]
+                "required": ["appId", "notificationPolicyAccess"]
               },
               {
-                "required": [
-                  "appId",
-                  "scheduleExactAlarm"
-                ]
+                "required": ["appId", "scheduleExactAlarm"]
               },
               {
-                "required": [
-                  "params"
-                ]
+                "required": ["params"]
               }
             ],
             "allOf": [
@@ -530,18 +474,12 @@
                       "const": "reset"
                     }
                   },
-                  "required": [
-                    "action"
-                  ]
+                  "required": ["action"]
                 },
                 "then": {
-                  "required": [
-                    "permissions"
-                  ],
+                  "required": ["permissions"],
                   "not": {
-                    "required": [
-                      "userId"
-                    ]
+                    "required": ["userId"]
                   }
                 }
               },
@@ -555,10 +493,7 @@
                       "const": "android"
                     }
                   },
-                  "required": [
-                    "action",
-                    "platform"
-                  ]
+                  "required": ["action", "platform"]
                 },
                 "then": {
                   "properties": {
@@ -572,6 +507,190 @@
                     }
                   }
                 }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "getAppPermissions"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/getAppPermissionsParams"
+              },
+              "appId": {
+                "type": "string",
+                "description": "App package ID or bundle identifier",
+                "minLength": 1
+              },
+              "permissions": {
+                "type": "array",
+                "description": "Optional permission names or simulator privacy services to query",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "platform": {
+                "type": "string",
+                "enum": ["android", "ios"],
+                "description": "Platform"
+              },
+              "sessionUuid": {
+                "type": "string",
+                "description": "Session UUID for device targeting"
+              },
+              "keepScreenAwake": {
+                "type": "boolean",
+                "description": "Keep physical Android devices awake during the session (default: true)"
+              },
+              "device": {
+                "type": "string",
+                "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+              },
+              "deviceId": {
+                "type": "string",
+                "description": "Device ID override"
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["appId"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "getNotificationPolicy"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/getNotificationPolicyParams"
+              },
+              "appId": {
+                "type": "string",
+                "description": "App package ID or bundle identifier",
+                "minLength": 1
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["appId"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "setNotificationPolicy"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/setNotificationPolicyParams"
+              },
+              "appId": {
+                "type": "string",
+                "description": "App package ID or bundle identifier",
+                "minLength": 1
+              },
+              "policyAccess": {
+                "type": "boolean",
+                "description": "Android only: allow or revoke app notification policy / DND access"
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["appId", "policyAccess"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "getDeviceState"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/getDeviceStateParams"
+              },
+              "include": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Optional device state fields to read",
+                "items": {
+                  "type": "string",
+                  "enum": ["doNotDisturb", "biometrics"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "setDeviceState"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/setDeviceStateParams"
+              },
+              "doNotDisturb": {
+                "$ref": "#/$defs/doNotDisturbStateInput"
+              },
+              "biometrics": {
+                "$ref": "#/$defs/biometricStateInput"
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["doNotDisturb"]
+              },
+              {
+                "required": ["biometrics"]
+              },
+              {
+                "required": ["params"]
               }
             ]
           }
@@ -596,14 +715,10 @@
       "description": "Selector for dragAndDrop elements",
       "oneOf": [
         {
-          "required": [
-            "text"
-          ]
+          "required": ["text"]
         },
         {
-          "required": [
-            "elementId"
-          ]
+          "required": ["elementId"]
         }
       ]
     },
@@ -638,10 +753,7 @@
         },
         "platform": {
           "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
+          "enum": ["android", "ios"],
           "description": "Platform"
         },
         "sessionUuid": {
@@ -682,36 +794,22 @@
           "description": "Bounds height"
         },
         "sourceWidth": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": ["number", "null"],
           "exclusiveMinimum": 0,
           "description": "Optional source width for coordinate normalization"
         },
         "sourceHeight": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": ["number", "null"],
           "exclusiveMinimum": 0,
           "description": "Optional source height for coordinate normalization"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "width",
-        "height"
-      ],
+      "required": ["x", "y", "width", "height"],
       "additionalProperties": false,
       "description": "Highlight bounds"
     },
     "highlightStyle": {
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
         "strokeColor": {
           "type": "string",
@@ -743,10 +841,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "box",
-            "circle"
-          ],
+          "enum": ["box", "circle"],
           "description": "Highlight shape type"
         },
         "bounds": {
@@ -756,12 +851,59 @@
           "$ref": "#/$defs/highlightStyle"
         }
       },
-      "required": [
-        "type",
-        "bounds"
-      ],
+      "required": ["type", "bounds"],
       "additionalProperties": false,
       "description": "Highlight shape definition"
+    },
+    "highlightSelector": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Element text",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "description": "Element ID",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "description": "Selector for highlight elements",
+      "oneOf": [
+        {
+          "required": ["text"]
+        },
+        {
+          "required": ["id"]
+        }
+      ]
+    },
+    "highlightContainer": {
+      "type": "object",
+      "properties": {
+        "elementId": {
+          "type": "string",
+          "description": "Container element ID",
+          "minLength": 1
+        },
+        "text": {
+          "type": "string",
+          "description": "Container text",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "description": "Container selector to scope highlight search",
+      "oneOf": [
+        {
+          "required": ["elementId"]
+        },
+        {
+          "required": ["text"]
+        }
+      ]
     },
     "highlightParams": {
       "type": "object",
@@ -778,15 +920,24 @@
           "type": "string",
           "description": "Element text content to match"
         },
+        "container": {
+          "$ref": "#/$defs/highlightContainer"
+        },
+        "containerOf": {
+          "type": "boolean",
+          "description": "Whether to highlight the container of the selected element"
+        },
         "shape": {
           "$ref": "#/$defs/highlightShape"
         },
+        "selectionStrategy": {
+          "type": "string",
+          "enum": ["first", "random"],
+          "description": "Element selection strategy when multiple matches are found (default: first)"
+        },
         "platform": {
           "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
+          "enum": ["android", "ios"],
           "description": "Platform"
         },
         "timeoutMs": {
@@ -813,11 +964,113 @@
       "additionalProperties": true,
       "description": "Parameters for highlight"
     },
+    "doNotDisturbStateInput": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable Do Not Disturb"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["off", "none", "priority", "alarms"],
+          "description": "Do Not Disturb mode"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["enabled"]
+        },
+        {
+          "required": ["mode"]
+        }
+      ],
+      "description": "Do Not Disturb state input"
+    },
+    "biometricStateInput": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["enrollment"],
+      "properties": {
+        "enrollment": {
+          "type": "string",
+          "enum": ["enrolled", "not_enrolled"],
+          "description": "iOS Simulator biometric enrollment state"
+        }
+      },
+      "description": "iOS Simulator biometric state input"
+    },
+    "getDeviceStateParams": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "include": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["doNotDisturb", "biometrics"]
+          },
+          "description": "Optional device state fields to read"
+        }
+      },
+      "description": "Parameters for getDeviceState"
+    },
+    "setDeviceStateParams": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "doNotDisturb": {
+          "$ref": "#/$defs/doNotDisturbStateInput"
+        },
+        "biometrics": {
+          "$ref": "#/$defs/biometricStateInput"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["doNotDisturb"]
+        },
+        {
+          "required": ["biometrics"]
+        }
+      ],
+      "description": "Parameters for setDeviceState"
+    },
+    "getNotificationPolicyParams": {
+      "type": "object",
+      "required": ["appId"],
+      "additionalProperties": true,
+      "properties": {
+        "appId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "App package ID or bundle identifier"
+        }
+      },
+      "description": "Parameters for getNotificationPolicy"
+    },
+    "setNotificationPolicyParams": {
+      "type": "object",
+      "required": ["appId", "policyAccess"],
+      "additionalProperties": true,
+      "properties": {
+        "appId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "App package ID or bundle identifier"
+        },
+        "policyAccess": {
+          "type": "boolean",
+          "description": "Android only: allow or revoke app notification policy / DND access"
+        }
+      },
+      "description": "Parameters for setNotificationPolicy"
+    },
     "setAppPermissionsParams": {
       "type": "object",
-      "required": [
-        "appId"
-      ],
+      "required": ["appId"],
       "additionalProperties": true,
       "properties": {
         "appId": {
@@ -827,11 +1080,7 @@
         },
         "action": {
           "type": "string",
-          "enum": [
-            "grant",
-            "revoke",
-            "reset"
-          ],
+          "enum": ["grant", "revoke", "reset"],
           "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
         },
         "permissions": {
@@ -858,18 +1107,12 @@
         },
         "scheduleExactAlarm": {
           "type": "string",
-          "enum": [
-            "allow",
-            "deny"
-          ],
+          "enum": ["allow", "deny"],
           "description": "Android only: set UID-level SCHEDULE_EXACT_ALARM appop"
         },
         "platform": {
           "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
+          "enum": ["android", "ios"],
           "description": "Platform"
         },
         "sessionUuid": {
@@ -891,24 +1134,16 @@
       },
       "anyOf": [
         {
-          "required": [
-            "notificationsEnabled"
-          ]
+          "required": ["notificationsEnabled"]
         },
         {
-          "required": [
-            "permissions"
-          ]
+          "required": ["permissions"]
         },
         {
-          "required": [
-            "notificationPolicyAccess"
-          ]
+          "required": ["notificationPolicyAccess"]
         },
         {
-          "required": [
-            "scheduleExactAlarm"
-          ]
+          "required": ["scheduleExactAlarm"]
         }
       ],
       "allOf": [
@@ -919,18 +1154,12 @@
                 "const": "reset"
               }
             },
-            "required": [
-              "action"
-            ]
+            "required": ["action"]
           },
           "then": {
-            "required": [
-              "permissions"
-            ],
+            "required": ["permissions"],
             "not": {
-              "required": [
-                "userId"
-              ]
+              "required": ["userId"]
             }
           }
         },
@@ -944,10 +1173,7 @@
                 "const": "android"
               }
             },
-            "required": [
-              "action",
-              "platform"
-            ]
+            "required": ["action", "platform"]
           },
           "then": {
             "properties": {
@@ -964,6 +1190,49 @@
         }
       ],
       "description": "Parameters for setAppPermissions"
+    },
+    "getAppPermissionsParams": {
+      "type": "object",
+      "required": ["appId"],
+      "additionalProperties": true,
+      "properties": {
+        "appId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "App package ID or bundle identifier"
+        },
+        "permissions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Optional permission names or simulator privacy services to query"
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
+        }
+      },
+      "description": "Parameters for getAppPermissions"
     },
     "expectation": {
       "type": "object",

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -35,6 +35,7 @@ add_check() {
 
 add_check "ktfmt" "ONLY_TOUCHED_FILES=${KTFMT_ONLY_TOUCHED_FILES:-true} \"$PROJECT_ROOT/scripts/ktfmt/validate_ktfmt.sh\"" "format,kotlin" "Validate Kotlin formatting"
 add_check "yaml" "bun \"$PROJECT_ROOT/scripts/validate-yaml.ts\"" "config,yaml" "Validate test plan YAML files"
+add_check "schema-copy-drift" "bun \"$PROJECT_ROOT/scripts/check-schema-copy-drift.ts\"" "config,schema" "Detect drift between the canonical and Android copies of test-plan.schema.json"
 add_check "bun-version-coherence" "bun \"$PROJECT_ROOT/scripts/check-bun-version-coherence.ts\"" "config,dependencies" "Keep Bun versions aligned across package, workflows, Docker, and local development"
 add_check "xml" "\"$PROJECT_ROOT/scripts/xml/validate_xml.sh\"" "config,xml" "Validate XML files"
 add_check "shellcheck" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell_scripts.sh\"" "lint,shell" "Validate shell scripts with shellcheck"

--- a/scripts/check-schema-copy-drift.ts
+++ b/scripts/check-schema-copy-drift.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `test-plan.schema.json` exists twice: the canonical copy under `schemas/`
+ * (the source of truth every TypeScript-side validator and feature PR edits)
+ * and a hand-maintained duplicate bundled as an Android classpath resource
+ * under `android/test-plan-validation/src/main/resources/schemas/`, loaded at
+ * runtime by `TestPlanValidator`/`TestPlanSchemaStore`. Nothing copies one from
+ * the other, so they silently drift — by #5784 the Android copy had already
+ * fallen behind (missing the `optional` step field and several `$defs`).
+ *
+ * This gate compares the two copies STRUCTURALLY (parse then deep-equal) rather
+ * than byte-for-byte, so a purely cosmetic formatting difference is tolerated
+ * while a real divergence — a missing field, a changed enum, an added `$def` —
+ * fails CI (#5819). The Android tree is excluded from `oxfmt`, so the copies are
+ * free to differ in whitespace; only their meaning must match.
+ */
+
+const repoRoot = join(import.meta.dir ?? ".", "..");
+
+export const CANONICAL_SCHEMA_PATH = join(repoRoot, "schemas/test-plan.schema.json");
+export const ANDROID_SCHEMA_PATH = join(
+  repoRoot,
+  "android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json",
+);
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+function isObject(value: JsonValue): value is { readonly [key: string]: JsonValue } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Collect every structural difference between two parsed JSON documents as a
+ * list of human-readable paths. Object keys are compared order-insensitively
+ * (JSON objects are unordered), arrays element-wise in order (order is
+ * significant in JSON Schema constructs like `allOf`/`anyOf`). An empty result
+ * means the documents are structurally identical.
+ */
+export function structuralDiffPaths(
+  canonical: JsonValue,
+  android: JsonValue,
+  path = "$",
+): string[] {
+  if (Array.isArray(canonical) && Array.isArray(android)) {
+    if (canonical.length !== android.length) {
+      return [
+        `${path}: array length ${canonical.length} (canonical) vs ${android.length} (android)`,
+      ];
+    }
+    const diffs: string[] = [];
+    for (let i = 0; i < canonical.length; i++) {
+      diffs.push(...structuralDiffPaths(canonical[i], android[i], `${path}[${i}]`));
+    }
+    return diffs;
+  }
+
+  if (isObject(canonical) && isObject(android)) {
+    const diffs: string[] = [];
+    const keys = new Set([...Object.keys(canonical), ...Object.keys(android)]);
+    for (const key of [...keys].sort()) {
+      const childPath = `${path}.${key}`;
+      const inCanonical = Object.prototype.hasOwnProperty.call(canonical, key);
+      const inAndroid = Object.prototype.hasOwnProperty.call(android, key);
+      if (inCanonical && !inAndroid) {
+        diffs.push(`${childPath}: present in canonical, missing from android`);
+      } else if (!inCanonical && inAndroid) {
+        diffs.push(`${childPath}: present in android, missing from canonical`);
+      } else {
+        diffs.push(...structuralDiffPaths(canonical[key], android[key], childPath));
+      }
+    }
+    return diffs;
+  }
+
+  if (canonical !== android) {
+    // Distinguish type mismatches from value mismatches only in the message.
+    return [
+      `${path}: ${JSON.stringify(canonical)} (canonical) vs ${JSON.stringify(android)} (android)`,
+    ];
+  }
+
+  return [];
+}
+
+export function schemasStructurallyEqual(canonical: JsonValue, android: JsonValue): boolean {
+  return structuralDiffPaths(canonical, android).length === 0;
+}
+
+function readJson(filePath: string): JsonValue {
+  return JSON.parse(readFileSync(filePath, "utf8")) as JsonValue;
+}
+
+/**
+ * Compare the two on-disk copies. Returns the list of structural differences
+ * (empty when they match). Throws if either file is missing or unparseable.
+ */
+export function diffSchemaCopies(
+  canonicalPath: string = CANONICAL_SCHEMA_PATH,
+  androidPath: string = ANDROID_SCHEMA_PATH,
+): string[] {
+  return structuralDiffPaths(readJson(canonicalPath), readJson(androidPath));
+}
+
+if (import.meta.main) {
+  const [canonicalArg, androidArg] = process.argv.slice(2);
+  const canonicalPath = canonicalArg ?? CANONICAL_SCHEMA_PATH;
+  const androidPath = androidArg ?? ANDROID_SCHEMA_PATH;
+
+  let diffs: string[];
+  try {
+    diffs = diffSchemaCopies(canonicalPath, androidPath);
+  } catch (error) {
+    console.error(
+      `error: could not compare test-plan.schema.json copies (${canonicalPath} vs ${androidPath}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exit(1);
+  }
+
+  if (diffs.length > 0) {
+    console.error("error: the two copies of test-plan.schema.json have structurally diverged:");
+    console.error(`  canonical: ${canonicalPath}`);
+    console.error(`  android:   ${androidPath}`);
+    for (const diff of diffs) {
+      console.error(`  - ${diff}`);
+    }
+    console.error(
+      "Resync the Android copy by replacing it with the canonical schema, then re-run this check.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    "schema-copy-drift: the two test-plan.schema.json copies are structurally identical.",
+  );
+}

--- a/scripts/check-schema-copy-drift.ts
+++ b/scripts/check-schema-copy-drift.ts
@@ -94,8 +94,33 @@ export function schemasStructurallyEqual(canonical: JsonValue, android: JsonValu
   return structuralDiffPaths(canonical, android).length === 0;
 }
 
+// Integers beyond 2^53 lose precision as IEEE-754 doubles, so `JSON.parse`
+// collapses distinct large-integer literals (e.g. a `const` or `enum` bound)
+// to the same `number` — which would let a real divergence slip past the
+// structural comparison. `JSON.parse`'s reviver `context.source` (TC39
+// JSON-parse-with-source, supported by Bun's engine) hands back the original
+// numeric token, so we preserve any unsafe integer as a NUL-tagged sentinel
+// string: distinct tokens then compare unequal and identical ones compare
+// equal, losslessly. Normal (safe) numbers and floats are left untouched, and
+// on a runtime that does not expose `source` this degrades to plain parsing.
+const BIGINT_SENTINEL_PREFIX = `${String.fromCharCode(0)}bigint:`;
+
+export function parseSchemaJson(text: string): JsonValue {
+  return JSON.parse(text, function (_key, value, context?: { source?: string }) {
+    if (
+      typeof value === "number" &&
+      !Number.isSafeInteger(value) &&
+      typeof context?.source === "string" &&
+      /^-?\d+$/.test(context.source)
+    ) {
+      return `${BIGINT_SENTINEL_PREFIX}${context.source}`;
+    }
+    return value;
+  }) as JsonValue;
+}
+
 function readJson(filePath: string): JsonValue {
-  return JSON.parse(readFileSync(filePath, "utf8")) as JsonValue;
+  return parseSchemaJson(readFileSync(filePath, "utf8"));
 }
 
 /**

--- a/test/scripts/schemaCopyDrift.test.ts
+++ b/test/scripts/schemaCopyDrift.test.ts
@@ -5,6 +5,7 @@ import {
   ANDROID_SCHEMA_PATH,
   CANONICAL_SCHEMA_PATH,
   diffSchemaCopies,
+  parseSchemaJson,
   schemasStructurallyEqual,
   structuralDiffPaths,
 } from "../../scripts/check-schema-copy-drift";
@@ -57,6 +58,37 @@ describe("#5819 structuralDiffPaths — structural, not byte-for-byte", () => {
     const android = JSON.parse(`{ "allOf": [1, 2] }`);
     const diffs = structuralDiffPaths(canonical, android);
     expect(diffs.some((d) => d.includes("array length"))).toBe(true);
+  });
+});
+
+// AC2 (hardening): `JSON.parse` collapses integers beyond 2^53 to the same
+// IEEE-754 double, which would let a divergence in a large numeric literal slip
+// past the structural comparison. `parseSchemaJson` preserves the original token.
+describe("#5819 parseSchemaJson preserves large-integer precision", () => {
+  test("two consts differing only past 2^53 are NOT judged equal", () => {
+    const canonical = parseSchemaJson(`{ "const": 9007199254740992 }`);
+    const android = parseSchemaJson(`{ "const": 9007199254740993 }`);
+    // Sanity: a plain JSON.parse would collapse these to the same number.
+    expect(JSON.parse(`9007199254740992`)).toBe(JSON.parse(`9007199254740993`));
+    expect(schemasStructurallyEqual(canonical, android)).toBe(false);
+  });
+
+  test("identical large integers remain equal", () => {
+    const a = parseSchemaJson(`{ "const": 9007199254740993 }`);
+    const b = parseSchemaJson(`{ "const": 9007199254740993 }`);
+    expect(schemasStructurallyEqual(a, b)).toBe(true);
+  });
+
+  test("safe integers and floats are left as plain numbers", () => {
+    expect(parseSchemaJson(`{ "minItems": 1 }`)).toEqual({ minItems: 1 });
+    expect(parseSchemaJson(`{ "x": 1.5 }`)).toEqual({ x: 1.5 });
+    // A safe integer compared across two documents still behaves normally.
+    expect(
+      schemasStructurallyEqual(parseSchemaJson(`{ "n": 42 }`), parseSchemaJson(`{ "n": 42 }`)),
+    ).toBe(true);
+    expect(
+      schemasStructurallyEqual(parseSchemaJson(`{ "n": 42 }`), parseSchemaJson(`{ "n": 43 }`)),
+    ).toBe(false);
   });
 });
 

--- a/test/scripts/schemaCopyDrift.test.ts
+++ b/test/scripts/schemaCopyDrift.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  ANDROID_SCHEMA_PATH,
+  CANONICAL_SCHEMA_PATH,
+  diffSchemaCopies,
+  schemasStructurallyEqual,
+  structuralDiffPaths,
+} from "../../scripts/check-schema-copy-drift";
+import { loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+const repoRoot = join(import.meta.dir, "../..");
+
+// AC2: the comparator must judge STRUCTURE, not bytes — a purely cosmetic
+// formatting difference is not drift, but a missing field or changed value is.
+describe("#5819 structuralDiffPaths — structural, not byte-for-byte", () => {
+  test("object key order does not count as drift", () => {
+    const a = JSON.parse(`{ "a": 1, "b": 2 }`);
+    const b = JSON.parse(`{ "b": 2, "a": 1 }`);
+    expect(schemasStructurallyEqual(a, b)).toBe(true);
+    expect(structuralDiffPaths(a, b)).toEqual([]);
+  });
+
+  test("whitespace/array-formatting differences do not count as drift", () => {
+    // The Android copy historically expands inline enums onto multiple lines.
+    // Once parsed, the two must be equal.
+    const inline = JSON.parse(`{ "enum": ["android", "ios"] }`);
+    const expanded = JSON.parse(`{\n  "enum": [\n    "android",\n    "ios"\n  ]\n}`);
+    expect(schemasStructurallyEqual(inline, expanded)).toBe(true);
+  });
+
+  test("a field present in canonical but missing from android is flagged", () => {
+    const canonical = JSON.parse(`{ "optional": { "type": "boolean" }, "tool": {} }`);
+    const android = JSON.parse(`{ "tool": {} }`);
+    const diffs = structuralDiffPaths(canonical, android);
+    expect(diffs.length).toBeGreaterThan(0);
+    expect(diffs.some((d) => d.includes("optional") && d.includes("missing from android"))).toBe(
+      true,
+    );
+  });
+
+  test("a changed scalar value is flagged", () => {
+    const canonical = JSON.parse(`{ "const": "getAppPermissions" }`);
+    const android = JSON.parse(`{ "const": "setAppPermissions" }`);
+    expect(schemasStructurallyEqual(canonical, android)).toBe(false);
+  });
+
+  test("array order IS significant (ordered constructs like allOf)", () => {
+    const a = JSON.parse(`[1, 2, 3]`);
+    const b = JSON.parse(`[3, 2, 1]`);
+    expect(schemasStructurallyEqual(a, b)).toBe(false);
+  });
+
+  test("array length differences are flagged", () => {
+    const canonical = JSON.parse(`{ "allOf": [1, 2, 3] }`);
+    const android = JSON.parse(`{ "allOf": [1, 2] }`);
+    const diffs = structuralDiffPaths(canonical, android);
+    expect(diffs.some((d) => d.includes("array length"))).toBe(true);
+  });
+});
+
+// AC1: the on-disk Android copy must be resynced to the canonical schema.
+describe("#5819 the two on-disk copies are in sync", () => {
+  test("the canonical and Android copies are structurally identical", () => {
+    const diffs = diffSchemaCopies();
+    expect(diffs).toEqual([]);
+  });
+
+  test("the Android copy carries the `optional` step field (the drift called out in #5784)", () => {
+    const android = readFileSync(ANDROID_SCHEMA_PATH, "utf8");
+    // The `optional` best-effort step field was the concrete drift flagged in
+    // the deferred item; assert it made it back into the Android copy.
+    expect(android).toContain(`"optional"`);
+    const parsed = JSON.parse(android) as { $defs?: Record<string, unknown> };
+    // Structural spot-check: a $def that only exists in the canonical copy
+    // before the resync must now be present in the Android copy too.
+    expect(parsed.$defs).toBeDefined();
+    expect(Object.keys(parsed.$defs ?? {})).toContain("highlightSelector");
+  });
+
+  test("both copies exist and parse as JSON", () => {
+    expect(() => JSON.parse(readFileSync(CANONICAL_SCHEMA_PATH, "utf8"))).not.toThrow();
+    expect(() => JSON.parse(readFileSync(ANDROID_SCHEMA_PATH, "utf8"))).not.toThrow();
+  });
+});
+
+// AC2: the gate must actually run in CI. It is registered in the fast-validation
+// aggregator and included in the required Fast Validation job's `--only` list.
+describe("#5819 the drift gate is wired into CI", () => {
+  const CHECK_NAME = "schema-copy-drift";
+
+  test("all_fast_validate_checks.sh registers the schema-copy-drift check", () => {
+    const aggregator = readFileSync(join(repoRoot, "scripts/all_fast_validate_checks.sh"), "utf8");
+    expect(aggregator).toContain(`add_check "${CHECK_NAME}"`);
+    expect(aggregator).toContain("scripts/check-schema-copy-drift.ts");
+  });
+
+  test("the required Fast Validation job runs the check in its --only list", () => {
+    const steps = loadJobSteps(".github/workflows/pull_request.yml", "fast-validation");
+    const runStep = stepNamed(steps, "Run fast validation checks");
+    expect(runStep).toBeDefined();
+    expect(runStep?.run ?? "").toContain(CHECK_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

`test-plan.schema.json` exists in two places: the canonical copy under `schemas/` (the source of truth every TypeScript-side validator and feature PR edits) and a hand-maintained duplicate bundled as an Android classpath resource under `android/test-plan-validation/src/main/resources/schemas/`, loaded at runtime by `TestPlanValidator`/`TestPlanSchemaStore`. Nothing kept them in sync, so the Android copy had silently drifted behind the canonical one — as [called out in PR #5784](https://github.com/kaeawc/auto-mobile/pull/5784#discussion_r3876588451).

This resyncs the Android copy and adds a CI gate so the two cannot silently diverge again.

## Linked Issue

Closes #5819

## Changes

- **Resync the Android copy** to the canonical schema (now byte-identical). This restores the `optional` step field and the `$defs`/props that had been dropped: `highlightSelector`, `highlightContainer`, `container`/`containerOf`/`selectionStrategy` on highlight, `getAppPermissions`/`setAppPermissions`, `getNotificationPolicy`/`setNotificationPolicy`, `getDeviceState`/`setDeviceState`, and the `doNotDisturbStateInput`/`biometricStateInput` inputs.
- **Add `scripts/check-schema-copy-drift.ts`** — a structural comparator that parses both copies and deep-compares them (object keys order-insensitive, arrays order-sensitive). It tolerates cosmetic formatting differences but fails on any real divergence: a missing field, a changed enum/const, or an added `$def`. On drift it prints the exact JSON paths that differ.
- **Wire the gate into CI** as the `schema-copy-drift` fast-validation check (`scripts/all_fast_validate_checks.sh`) and add it to the required **Fast Validation** job's `--only` list in `.github/workflows/pull_request.yml`.

## Acceptance criteria

- [x] The Android copy is resynced to the canonical schema (including the `optional` step field).
- [x] A CI gate fails when the two copies diverge — compared structurally, not byte-for-byte, so intentional formatting differences do not trip it.

## Validation

- [x] `bun test test/scripts/schemaCopyDrift.test.ts` — 11/11 green (comparator semantics, on-disk sync, `optional` field + `$def` restoration, CI wiring).
- [x] `scripts/all_fast_validate_checks.sh --only schema-copy-drift,yaml,shellcheck,shell-portability,shell-sete` passes.
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] `bun run format:check` clean; `oxlint` clean.
- [x] Full `bun test` suite: the only 2 failures are pre-existing environment artifacts unrelated to this diff (a worktree-local missing `oxlint` bin, and a bun-1.3.14 skip-output format mismatch in an untouched WebRTC meta-test).

## Testing

The comparator ships with unit tests that pin the "structural, not byte-for-byte" contract directly: key-order and array-formatting differences are treated as equal, while missing fields, changed scalars, and array-length/order differences are flagged. A repo-invariant test asserts the two on-disk copies are structurally identical, and workflow tests assert the gate is registered and included in the required Fast Validation `--only` list.