### PR TITLE
fix(server): guard navigation appId decode against uncaught URIError (#5748)

### DIFF
--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -45,6 +45,29 @@ export interface NavigationAppsResourceContent {
 
 const GRAPH_RESOURCE_UPDATE_DEBOUNCE_MS = 1000;
 
+// Decode the `?appId={appId}` query param captured by these navigation templates.
+// The registry compiles the literal `?appId=` form to a RAW regex group (it only
+// URL-decodes params for RFC-6570 `{?appId}` templates like storageCapabilities),
+// so this single decodeURIComponent is the first-and-only decode — NOT the #5686
+// double-decode, and it must stay. Guard it so a malformed percent-sequence (a
+// bad-client `%`) falls back to the raw value instead of throwing an uncaught
+// URIError past each handler's try/catch and bypassing the JSON error envelope —
+// matching #5686's graceful handling of the same input (#5748).
+function decodeAppIdParam(raw: string | undefined): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(raw).trim();
+  } catch (error) {
+    // Malformed percent-encoding is bad client input, not a server fault: return
+    // the raw value so the handler emits its own JSON error envelope for a
+    // non-existent app rather than throwing. Safe to swallow after tracing.
+    logger.debug(`[NavigationResources] appId decode failed for '${raw}': ${error}`);
+    return raw.trim();
+  }
+}
+
 type NavigationGraphResourceProvider = NavigationGraphSummaryProvider &
   NavigationGraphNodeResourceProvider &
   NavigationGraphHistoryProvider &
@@ -396,7 +419,7 @@ export function registerNavigationResources(
     "High-level navigation graph filtered by app ID.",
     "application/json",
     async (params) => {
-      const appId = params.appId ? decodeURIComponent(params.appId).trim() : undefined;
+      const appId = decodeAppIdParam(params.appId);
       return getNavigationGraphResource(appId);
     },
   );
@@ -458,7 +481,7 @@ export function registerNavigationResources(
     "application/json",
     async (params) => {
       const nodeId = Number(params.nodeId);
-      const appId = params.appId ? decodeURIComponent(params.appId).trim() : undefined;
+      const appId = decodeAppIdParam(params.appId);
       if (!Number.isFinite(nodeId)) {
         return buildNavigationNodeError(
           `automobile:navigation/nodes/${params.nodeId}`,
@@ -513,7 +536,7 @@ export function registerNavigationResources(
     "image/webp",
     async (params) => {
       const nodeId = Number(params.nodeId);
-      const appId = params.appId ? decodeURIComponent(params.appId).trim() : undefined;
+      const appId = decodeAppIdParam(params.appId);
       if (!Number.isFinite(nodeId)) {
         return {
           uri: `automobile:navigation/nodes/${params.nodeId}/screenshot`,

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -561,9 +561,7 @@ describe("MCP Navigation Graph Resource", () => {
       // URI value %2541: a double-decode path (storageCapabilities' `{?appId}`)
       // would hand the handler "%41"; navigation's literal `?appId=` template
       // captures it raw, so the single handler decode is the first-and-only one.
-      const match = ResourceRegistry.matchTemplate(
-        "automobile:navigation/graph?appId=%2541",
-      );
+      const match = ResourceRegistry.matchTemplate("automobile:navigation/graph?appId=%2541");
       expect(match?.template.uriTemplate).toBe(NAVIGATION_RESOURCE_URIS.GRAPH_WITH_APP_ID);
       expect(match?.params.appId).toBe("%2541");
     });

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -636,8 +636,16 @@ describe("MCP Navigation Graph Resource", () => {
 
       const content = result.contents[0];
       expect(content.mimeType).toBe("application/json");
-      // Parseable JSON envelope — the read completed instead of throwing.
-      expect(() => JSON.parse(content.text!)).not.toThrow();
+      // Deliberate contract: a malformed `%` appId degrades to a normal graph
+      // envelope (its fields present, no `error`), NOT an uncaught URIError and
+      // NOT a bespoke malformed-input rejection. This mirrors #5686, which treats
+      // a `%`-bearing id as an ordinary (here, unknown) app id rather than
+      // rejecting it — decoding is best-effort, so an unresolvable id degrades the
+      // same way any unknown id does. Asserting the shape (not just "some JSON
+      // parses") pins that intended degradation.
+      const body = JSON.parse(content.text!);
+      expect(body.error).toBeUndefined();
+      expect(Array.isArray(body.nodes)).toBe(true);
     });
   });
 });

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -9,6 +9,7 @@ import {
   setNavigationScreenshotProvider,
 } from "../../../src/server/navigationResources";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
+import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { z } from "zod/v4";
 
 describe("MCP Navigation Graph Resource", () => {
@@ -545,5 +546,98 @@ describe("MCP Navigation Graph Resource", () => {
     expect(content.mimeType).toBe("application/json");
     const payload = JSON.parse(content.text!);
     expect(payload.error).toContain("No screenshot available");
+  });
+
+  // #5748: sibling of #5686. storageCapabilities double-decoded appId because its
+  // RFC-6570 `{?appId}` template makes the registry URL-decode the query param, so
+  // the handler's second decodeURIComponent was redundant. These navigation
+  // templates use the literal `?appId={appId}` form instead, which the registry
+  // captures as a RAW regex group (no URLSearchParams) — so navigation's single
+  // decodeURIComponent is correct and must NOT be removed. What navigation still
+  // needed was to stop that decode throwing an uncaught URIError past the
+  // handler's try/catch on a malformed `%` (the other harm #5686 flagged).
+  describe("appId query param is single-decoded, not double-decoded (#5748)", () => {
+    test("registry hands the handler the RAW query param (not URLSearchParams-decoded)", () => {
+      // URI value %2541: a double-decode path (storageCapabilities' `{?appId}`)
+      // would hand the handler "%41"; navigation's literal `?appId=` template
+      // captures it raw, so the single handler decode is the first-and-only one.
+      const match = ResourceRegistry.matchTemplate(
+        "automobile:navigation/graph?appId=%2541",
+      );
+      expect(match?.template.uriTemplate).toBe(NAVIGATION_RESOURCE_URIS.GRAPH_WITH_APP_ID);
+      expect(match?.params.appId).toBe("%2541");
+    });
+
+    test("a %-bearing appId round-trips through the resource (identity contract)", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+      fakeGraph.addNode({
+        screenName: "Home",
+        firstSeenAt: 100,
+        lastSeenAt: 200,
+        visitCount: 1,
+      });
+
+      const { client } = fixture.getContext();
+      const readResourceResponseSchema = z.object({
+        contents: z.array(
+          z.object({
+            uri: z.string(),
+            mimeType: z.string().optional(),
+            text: z.string().optional(),
+          }),
+        ),
+      });
+
+      // URI value 100%25 → single decode → "100%". Same external contract as
+      // #5686 (100%25 → "100%"), reached via regex capture + one decode here.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/nodes/1?appId=100%25" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      const nodeResource: NavigationNodeResourceContent = JSON.parse(content.text!);
+      expect(nodeResource.appId).toBe("100%");
+    });
+
+    test("a literal-% appId returns a graceful JSON envelope, not an uncaught URIError", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+      fakeGraph.addNode({
+        screenName: "Home",
+        firstSeenAt: 100,
+        lastSeenAt: 200,
+        visitCount: 1,
+      });
+
+      const { client } = fixture.getContext();
+      const readResourceResponseSchema = z.object({
+        contents: z.array(
+          z.object({
+            uri: z.string(),
+            mimeType: z.string().optional(),
+            text: z.string().optional(),
+          }),
+        ),
+      });
+
+      // Raw "100%" is not a valid percent-sequence: decodeURIComponent throws.
+      // The decode runs outside the handler's try/catch, so before the fix this
+      // URIError escaped the JSON error envelope and failed the read.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/graph?appId=100%" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      // Parseable JSON envelope — the read completed instead of throwing.
+      expect(() => JSON.parse(content.text!)).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Resolves the [#5748](https://github.com/kaeawc/auto-mobile/issues/5748) verification: does `src/server/navigationResources.ts` double-decode its `{?appId}` query param like the confirmed [#5686](https://github.com/kaeawc/auto-mobile/issues/5686) regression?

**No — it does not double-decode.** storageCapabilities used the RFC-6570 `{?appId}` template form, which makes the resource registry URL-decode the query param via `URLSearchParams`, so its handler's second `decodeURIComponent` was redundant. navigation's templates use the *literal* `?appId={appId}` form, which the registry compiles to a **raw regex capture group** (no `URLSearchParams` — `queryParamNames` is empty). So navigation's single `decodeURIComponent` is the first-and-only decode and **must stay** — removing it would leave percent-encoded app ids undecoded (a regression).

What navigation *did* still have was the **other half** of #5686's defect class that the issue flagged: that decode ran **outside** each handler's `try/catch`, so a malformed `%` threw an uncaught `URIError` past the JSON error envelope. This PR closes that gap and pins the correct single-decode behavior.

## Linked Issue

Closes #5748

## Bug / Regression Context

- **Prior attempts:** [#5709](https://github.com/kaeawc/auto-mobile/pull/5709) fixed the storageCapabilities double-decode (#5686) and left this navigation sibling as a deferred note, harvested into #5748.
- **Observed symptom:** `resources/read` on `automobile:navigation/graph?appId=100%` (a literal, un-encoded `%`) threw `URIError` (`MCP error -32603`) instead of returning the resource's `application/json` error envelope. Same for the node-by-id and screenshot `?appId=` variants.
- **Root cause:** `decodeURIComponent(params.appId)` was evaluated in the template lambda, before the handler's `try/catch`, so it could not be caught.
- **Not a double-decode:** verified empirically — the registry hands navigation handlers the raw value (`%2541`, not `%41`), unlike storageCapabilities' URLSearchParams-decoded path.

## Changes

- Route the three `?appId=` decode sites (graph, node-by-id, screenshot) through a new `decodeAppIdParam` helper that decodes once and, on a malformed percent-sequence, falls back to the raw value (matching #5686's graceful handling of the same input) instead of throwing.
- Document at the decode site why the single decode is correct here and structurally distinct from #5686, so it is not "fixed" into a regression later.
- Regression tests mirroring #5686's shape: registry hands the handler a raw param (mechanism / proves single-decode), a `%`-bearing appId round-trips through the resource (identity: `100%25` → `100%`, same external contract as #5686), and a literal-`%` appId returns a JSON envelope rather than an uncaught throw.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalents: `bun run lint` (no new ratchet violations), `bun test` full suite green except two pre-existing, unrelated failures (`webrtcDeviceCaptureLatency`, `oxlintConfigScoping`) confirmed failing on the clean tree without this change.
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] `bun run build` succeeds.
- [x] New tests use interfaces + fakes (`FakeNavigationGraphManager`); the touched suite runs in <400ms.
- [x] No new dependency; reuses existing helpers and the standard library.

## Device Verification

N/A — pure server-side resource-handler change, exercised end-to-end through the in-memory MCP fixture.

## Follow-ups

- The same "decode outside the handler's try/catch" shape exists for the `screen=` param (`NODE_BY_SCREEN`) and the `cursor`/`limit` params (`parseHistoryParams`). Out of scope for this `{?appId}`-scoped issue; noted here rather than filed unless it recurs.
