### PR TITLE
ci(release): oxfmt-format generated files before the [skip ci] bump commit

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install Bun dependencies
+        run: bun install --frozen-lockfile
+
       - name: Install ripgrep
         run: |
           if ! command -v rg >/dev/null 2>&1; then
@@ -52,6 +55,16 @@ jobs:
           CURRENT_TAG: v${{ inputs.version }}
           GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
         run: scripts/changelog/update_changelog_from_issues.sh
+
+      # The bump and changelog steps write .claude-plugin/{marketplace,plugin}.json
+      # and CHANGELOG.md, and the commit below carries [skip ci] so the Check
+      # Formatting gate never runs on it. Format the tree here so those generated
+      # files land oxfmt-clean on main instead of reddening the next PR (#5817).
+      # Whole-tree format (oxfmt honours .oxfmtrc ignorePatterns) guarantees the
+      # commit passes format:check; the managed-path guard below fails closed if
+      # formatting ever touches an unexpected file.
+      - name: Format generated files
+        run: bun run format
 
       - name: Commit versioned release tree to staging ref
         id: commit

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -212,6 +212,50 @@
   [[ "$commit_step" == *'allowed_patterns+=("CHANGELOG.md")'* ]]
 }
 
+@test "prepare-release oxfmt-formats the generated files before committing them (#5817)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/prepare-release.yml"
+
+  # The version-bump and changelog steps write .claude-plugin/{marketplace,plugin}.json
+  # and CHANGELOG.md in a shape that must be oxfmt-clean, but the commit carries
+  # [skip ci] so the format gate never runs on it. The durable fix (#5817) runs
+  # oxfmt on the tree before committing so those files land clean on main.
+  local install_step format_step
+  install_step="$(yq -r '.jobs."prepare-version".steps[] | select(.name == "Install Bun dependencies") | .run' "$workflow")"
+  [ -n "$install_step" ]
+  [ "$install_step" != "null" ]
+  [[ "$install_step" == *"bun install --frozen-lockfile"* ]]
+
+  format_step="$(yq -r '.jobs."prepare-version".steps[] | select(.name == "Format generated files") | .run' "$workflow")"
+  [ -n "$format_step" ]
+  [ "$format_step" != "null" ]
+  [[ "$format_step" == *"bun run format"* ]]
+
+  # Ordering: the tree must be written (bump + changelog) and formatted BEFORE it
+  # is committed, otherwise the unformatted shape is what lands on main.
+  local names bump changelog format install commit
+  names="$(yq -r '.jobs."prepare-version".steps[].name // ""' "$workflow")"
+  bump="$(printf '%s\n' "$names" | grep -nxF 'Bump versions' | cut -d: -f1)"
+  changelog="$(printf '%s\n' "$names" | grep -nxF 'Update changelog' | cut -d: -f1)"
+  install="$(printf '%s\n' "$names" | grep -nxF 'Install Bun dependencies' | cut -d: -f1)"
+  format="$(printf '%s\n' "$names" | grep -nxF 'Format generated files' | cut -d: -f1)"
+  commit="$(printf '%s\n' "$names" | grep -nxF 'Commit versioned release tree to staging ref' | cut -d: -f1)"
+  [ -n "$bump" ] && [ -n "$changelog" ] && [ -n "$install" ] && [ -n "$format" ] && [ -n "$commit" ]
+  # oxfmt needs the toolchain installed before it can run.
+  [ "$install" -lt "$format" ]
+  # Format only after every generator has written its files.
+  [ "$bump" -lt "$format" ]
+  [ "$changelog" -lt "$format" ]
+  # And commit the already-formatted tree.
+  [ "$format" -lt "$commit" ]
+
+  # #5817 chose the run-oxfmt option, not the drop-[skip ci] option: the bump
+  # commit must still carry [skip ci] so the release pipeline is not double-run.
+  local commit_step
+  commit_step="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' "$workflow")"
+  [[ "$commit_step" == *"[skip ci]"* ]]
+}
+
 @test "bump script managed paths cover version-synchronized public docs" {
   local managed
   managed="$(bash scripts/versioning/bump-versions.sh --print-managed-paths)"


### PR DESCRIPTION
## Summary

The release pipeline's `prepare-version` job writes `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, and `CHANGELOG.md`, then commits them with `[skip ci]`. Because CI is skipped on that commit, the **Check Formatting** gate never runs on it — so whenever the generated shape drifts from `oxfmt`'s, the unformatted files land on `main` and redden the next contributor's PR. [PR #5744](https://github.com/kaeawc/auto-mobile/pull/5744) fixed one such recurrence by hand and deferred the durable fix to a separate maintenance change; this is that change.

## Linked Issue

Closes #5817

## Changes

- `.github/workflows/prepare-release.yml` (`prepare-version` job):
  - Add an **Install Bun dependencies** step (`bun install --frozen-lockfile`) so the formatter toolchain is available.
  - Add a **Format generated files** step (`bun run format`) after the bump + changelog steps and before the commit, so every generated file lands `oxfmt`-clean.
- `test/bats/release-workflow-wiring.bats`: new wiring test pinning that the format step exists, runs after both generators and before the commit, needs the install step, and that the bump commit still carries `[skip ci]` (documenting the run-`oxfmt` option was chosen over dropping `[skip ci]`).

### Why run `oxfmt` rather than drop `[skip ci]`

The issue offered both options. `[skip ci]` is load-bearing for the run-scoped staging-ref release pipeline (avoids double-running CI on the intermediate commits); dropping it would trigger a full CI pass on each bump. Running `oxfmt` on the written tree is the surgical fix. Whole-tree `bun run format` honours `.oxfmtrc` `ignorePatterns` and guarantees the commit passes `format:check`; the existing managed-path guard fails closed if formatting ever touches an unexpected file. `finalize-release` only rewrites `src/constants/release.ts` in place, so the three files stay clean through the rest of the pipeline.

## Acceptance criteria

- [x] **Version-bump step runs `oxfmt` on every file it writes** — `Format generated files` runs `bun run format` over the tree before the commit.
- [x] **The three generated files land already `oxfmt`-clean on `main`** — guaranteed by formatting the tree before the `[skip ci]` commit; continuously enforced thereafter by the `merge.yml` `oxfmt` job.

## Validation

- [x] `bats test/bats/release-workflow-wiring.bats` — 43/43 pass (new #5817 test included)
- [x] `bats test/bats/bump-versions.bats test/bats/update-changelog-from-issues.bats` — pass (no regression)
- [x] `scripts/all_fast_validate_checks.sh` — 34/34 pass (yaml, shellcheck, workflow-assertion-triggers, …)
- [x] No TypeScript/shell source changed, so lint/build/typecheck have no new surface.

## Follow-ups

- None. Scope kept to the three files named in #5817.