### PR TITLE
fix(validation): name the finite constraint and bound tapOn/tapAny duration (#5769)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8601,7 +8601,8 @@
         },
         "duration": {
           "description": "Long press duration (ms)",
-          "type": "number"
+          "type": "number",
+          "minimum": 0
         },
         "searchUntil": {
           "description": "Poll for clickable element before tapping",
@@ -8742,7 +8743,8 @@
         },
         "duration": {
           "description": "Long press duration (ms)",
-          "type": "number"
+          "type": "number",
+          "minimum": 0
         },
         "subtext": {
           "description": "Semantic link inside the selected element; fails if the platform does not expose that link",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -217,9 +217,23 @@ export function formatToolParamError(toolName: string, error: unknown): string {
   const issues = flattenedIssues.map((issue) => {
     const path = issue.path.length ? issue.path.join(".") : "parameters";
     if (issue.code === "invalid_type") {
-      // zod v4 issues carry no runtime `received` field; the default message
-      // already reads "Invalid input: expected X, received Y", so reuse it
-      // minus the prefix to keep the historical "<path> expected X" format.
+      // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
+      // `z.number()` check, so no `.finite()` refinement can carry a custom
+      // message. Those surface as an invalid_type whose value is still a number
+      // (`received` is "Infinity"/"NaN", or "number" from a typeof-based error
+      // map), collapsing the default text to the self-contradictory "expected
+      // number, received number". A finite number never trips invalid_type, so
+      // any of these markers means non-finite — name the real constraint (#5769).
+      const received = (issue as { received?: unknown }).received;
+      if (
+        issue.expected === "number" &&
+        (received === "Infinity" || received === "NaN" || received === "number")
+      ) {
+        return `${path} must be a finite number`;
+      }
+      // zod v4 issues otherwise carry a usable default message that already
+      // reads "Invalid input: expected X, received Y", so reuse it minus the
+      // prefix to keep the historical "<path> expected X" format.
       return `${path} ${issue.message.replace(/^Invalid input: /, "")}`;
     }
     return `${path} ${issue.message}`;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -209,7 +209,9 @@ export const tapOnSchema = withJsonSchemaOverride(
               "for a vertical list) instead of applying " +
               "selectionStrategy — for repeated controls with no unique text. Out of range → no match.",
           ),
-        duration: z.number().optional().describe("Long press duration (ms)"),
+        // A negative duration used to be accepted and silently degraded a
+        // longPress into a plain tap (#5769); bound it like the sibling params.
+        duration: z.number().min(0, "must be >= 0").optional().describe("Long press duration (ms)"),
         subtext: z
           .object({
             text: z
@@ -355,7 +357,9 @@ export const tapAnySchema = withJsonSchemaOverride(
           .enum(["tap", "doubleTap", "longPress"])
           .default("tap")
           .describe("Action type (default: tap)"),
-        duration: z.number().optional().describe("Long press duration (ms)"),
+        // Bounded like tapOn.duration so a negative longPress cannot silently
+        // become a plain tap (#5769).
+        duration: z.number().min(0, "must be >= 0").optional().describe("Long press duration (ms)"),
         searchUntil: z
           .object({
             duration: z

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
+import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
 
 // Issue #4181, rank 7 (A6): the "container must be an object …" hint is
 // appended only for tapOn/swipeOn when a validation issue lands on the
@@ -55,5 +56,82 @@ describe("formatToolParamError container hint", () => {
 
   test("non-Zod errors are stringified without a hint", () => {
     expect(formatToolParamError("tapOn", new Error("boom"))).toBe("Error: boom");
+  });
+});
+
+// Issue #5769: zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the
+// base `z.number()` check, so its default `invalid_type` text renders as the
+// self-contradictory "<param> expected number, received number" — which reads
+// like a bug in the validator. The formatter must name the real constraint.
+describe("formatToolParamError non-finite numbers", () => {
+  function nonFiniteIssue(path: string[], received: "Infinity" | "NaN" | "number"): z.ZodError {
+    // The exact shape zod v4 produces on a number field: `received` is the
+    // value-based marker "Infinity" (±Infinity) or "NaN", while the rendered
+    // message uses the typeof-based "number"/"NaN". Both markers appear in the
+    // wild, so the formatter must recognize each. typeof is still "number", so
+    // the default text collapses to "expected number, received number".
+    return new z.ZodError([
+      {
+        code: "invalid_type",
+        expected: "number",
+        received,
+        path,
+        message: `Invalid input: expected number, received ${received === "Infinity" ? "number" : received}`,
+      } as unknown as z.core.$ZodIssue,
+    ]);
+  }
+
+  test.each([
+    ["returnSpeed", ["returnSpeed"], "Infinity"],
+    ["apexPause", ["apexPause"], "NaN"],
+    ["nested waitFor.timeoutMs", ["waitFor", "timeoutMs"], "number"],
+  ] as const)("names the finite constraint for %s", (_label, path, received) => {
+    const message = formatToolParamError("swipeOn", nonFiniteIssue([...path], received));
+    expect(message).toBe(`${path.join(".")} must be a finite number`);
+    expect(message).not.toContain("expected number, received");
+  });
+
+  test("a genuine wrong-type mismatch still reports the type, not the finite constraint", () => {
+    // received "string" means the caller passed a string, not a non-finite
+    // number — that must keep the type-mismatch message.
+    const err = new z.ZodError([
+      {
+        code: "invalid_type",
+        expected: "number",
+        received: "string",
+        path: ["returnSpeed"],
+        message: "Invalid input: expected number, received string",
+      } as unknown as z.core.$ZodIssue,
+    ]);
+    const message = formatToolParamError("swipeOn", err);
+    expect(message).toBe("returnSpeed expected number, received string");
+    expect(message).not.toContain("finite");
+  });
+
+  test.each([Infinity, -Infinity, NaN])(
+    "end-to-end: swipeOn returnSpeed = %p is rejected as non-finite",
+    (value) => {
+      const result = swipeOnSchema.safeParse({
+        platform: "android",
+        direction: "up",
+        returnSpeed: value,
+      });
+      expect(result.success).toBe(false);
+      const message = formatToolParamError("swipeOn", result.error);
+      expect(message).toContain("returnSpeed must be a finite number");
+    },
+  );
+
+  test("end-to-end: tapOn duration = Infinity names the finite constraint", () => {
+    const result = tapOnSchema.safeParse({
+      platform: "android",
+      selector: { text: "Gmail" },
+      action: "longPress",
+      duration: Infinity,
+    });
+    expect(result.success).toBe(false);
+    expect(formatToolParamError("tapOn", result.error)).toContain(
+      "duration must be a finite number",
+    );
   });
 });

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -82,6 +82,17 @@ describe("MCP Tools Schema", () => {
     });
   });
 
+  // Issue #5769: the advertised JSON Schema for tapOn/tapAny duration must
+  // declare `minimum: 0`, matching the bounded sibling gesture params, so a
+  // negative long-press duration is rejected at the envelope.
+  test.each(["tapOn", "tapAny"])("%s advertises duration minimum 0", (toolName) => {
+    const tool = ToolRegistry.getToolDefinitions().find((t) => t.name === toolName);
+    expect(tool, `${toolName} should be advertised`).toBeDefined();
+    const duration = (tool!.inputSchema as any).properties?.duration;
+    expect(duration?.type).toBe("number");
+    expect(duration?.minimum).toBe(0);
+  });
+
   test("should not publish top-level schema combinators", () => {
     const toolDefinitions = ToolRegistry.getToolDefinitions();
 

--- a/test/server/tools/tapOnTapAnySchema.test.ts
+++ b/test/server/tools/tapOnTapAnySchema.test.ts
@@ -214,6 +214,28 @@ describe("tapOn schema", () => {
       key,
     );
   });
+
+  // Issue #5769: duration had no lower bound, so a negative longPress duration
+  // was accepted and silently degraded into an ordinary tap. It must be rejected
+  // with a too_small issue on ["duration"], matching the bounded sibling params.
+  test.each([-1, -100000])("rejects negative duration %p", (duration) => {
+    const tooSmall = zodIssues(() =>
+      tapOnSchema.parse({
+        platform: "android",
+        selector: { text: "Gmail" },
+        action: "longPress",
+        duration,
+      }),
+    ).find((issue) => issue.code === "too_small" && issue.path[0] === "duration");
+    expect(tooSmall, "expected a too_small issue on duration").toBeDefined();
+    expect(tooSmall!.message).toBe("must be >= 0");
+  });
+
+  test("accepts a zero duration (the lower bound is inclusive)", () => {
+    expect(
+      tapOnSchema.parse({ platform: "android", selector: { text: "Gmail" }, duration: 0 }),
+    ).toMatchObject({ duration: 0 });
+  });
 });
 
 describe("tapAny schema", () => {
@@ -278,5 +300,18 @@ describe("tapAny schema", () => {
     ["selector", "use tapOn instead", { text: "Login" }],
   ])("rejects removed field %s (%s) by name", (key, _reason, value) => {
     expectRejectedKey(tapAnySchema, { platform: "android", [key]: value }, key);
+  });
+
+  // Issue #5769: same missing lower bound as tapOn.duration.
+  test.each([-1, -100000])("rejects negative duration %p", (duration) => {
+    const tooSmall = zodIssues(() =>
+      tapAnySchema.parse({ platform: "android", action: "longPress", duration }),
+    ).find((issue) => issue.code === "too_small" && issue.path[0] === "duration");
+    expect(tooSmall, "expected a too_small issue on duration").toBeDefined();
+    expect(tooSmall!.message).toBe("must be >= 0");
+  });
+
+  test("accepts a zero duration (the lower bound is inclusive)", () => {
+    expect(tapAnySchema.parse({ platform: "android", duration: 0 })).toMatchObject({ duration: 0 });
   });
 });


### PR DESCRIPTION
## Summary

Closes two numeric-parameter validation gaps on the gesture/observe tools, found by the exploratory-tester routine (#5769). Neither reached the device with a bad value — this is about the validation *envelope* and a missing lower bound.

## Linked Issue

Closes #5769

## Changes

**1. Non-finite numbers no longer produce a self-contradictory message.**
Passing `1e999` (→ `Infinity`), `-Infinity`, or `NaN` was correctly rejected but with `"<param> expected number, received number"`, which reads as a bug in the validator. zod v4 rejects non-finite values at the base `z.number()` check *before* any refinement runs, so a per-field `.finite("…")` message is impossible — the constraint is now named centrally in `formatToolParamError` (`src/server/index.ts`):

```
swipeOn { direction: "up", returnSpeed: 1e999 }
-  returnSpeed expected number, received number
+  returnSpeed must be a finite number
```

This covers every numeric param on every tool at once (returnSpeed, apexPause, timeoutMs, logcatLines, duration, …). Genuine wrong-type mismatches (e.g. a string) keep their `expected number, received string` message.

**2. `tapOn.duration` / `tapAny.duration` now have a lower bound.**
They were bare `{ "type": "number" }` with no `minimum`, so a negative long-press duration was accepted and silently degraded into an ordinary tap (reported as success). Added `.min(0, "must be >= 0")`, matching the bounded sibling params (`swipeOn.apexPause` 0–3000, `swipeOn.returnSpeed` 0.1–3.0, `searchUntil.duration` 100–12000), and regenerated `schemas/tool-definitions.json` (`"minimum": 0`):

```
tapOn { selector: {text:"Gmail"}, action:"longPress", duration: -1 }
-  ok  { "message": "Tapped on element" }
+  Invalid parameters for tool tapOn: duration must be >= 0
```

## Bug / Regression Context

- **Observed symptom:** (1) non-finite input rejected with `expected number, received number`; (2) negative `longPress` duration silently performing a plain tap and reporting success, with no warning logged.
- **Repro conditions:** non-finite values arrive naturally from client-side arithmetic (`a / b` with `b === 0`); negative durations from unclamped user input.
- **Prior attempts:** #3615 closed the "±Infinity reaches the device" hole; this is the follow-on message-quality + missing-lower-bound gap in the same family (#4593).

## Testing

- `test/server/toolParamErrorHint.test.ts` — non-finite (`Infinity`/`-Infinity`/`NaN`) renders `"<param> must be a finite number"`; genuine wrong-type still names the type; end-to-end parses of `swipeOnSchema`/`tapOnSchema`.
- `test/server/tools/tapOnTapAnySchema.test.ts` — negative `duration` → `too_small` on `["duration"]` with message `"must be >= 0"`; zero accepted (inclusive bound).
- `test/server/tools/schema.test.ts` — advertised JSON Schema for `tapOn`/`tapAny` declares `duration.minimum === 0`.

## Validation

- [x] `bun run lint` + `bun test` (changed-area suites green; whole-suite green except two pre-existing worktree-env artifacts — `oxlintConfigScoping` needs a local `node_modules/.bin/oxlint`, and `#4343` webrtc subprocess — both fail identically with my diff reverted)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New generic code reuses the existing `formatToolParamError` helper and zod `.min()`; no new dependency

## Acceptance Criteria

- [x] Non-finite numeric input names the constraint (e.g. `returnSpeed must be a finite number`) instead of `expected number, received number`.
- [x] `tapOn.duration` / `tapAny.duration` reject negatives with `duration must be >= 0`; JSON schema declares `minimum: 0`, consistent with sibling gesture params.

## Follow-ups

The issue also noted, as *secondary* context (not part of its suggested fix): the daemon request log serializes the offending non-finite value as `null`, and `observe` emits cascading union-discrimination noise alongside the real error. Left out of scope to keep this PR focused; see follow-up note.
