### PR TITLE
feat(desktop): pause pane video streams when the window is unfocused (#5219)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -413,6 +414,13 @@ fun AutoMobileDesktopApp(
             )
           else ->
             Box(Modifier.fillMaxSize()) {
+              // Pause every pane's live video when this window is unfocused or minimized (#5219):
+              // the grid thumbnails are one-shot screenshots, so the panes are the only standing
+              // decode/encode cost. Focus is read once here and threaded into both pane surfaces
+              // (stream + inspect), so an unfocused window disconnects all pane sources and a
+              // refocus reconnects them via the existing auto-reconnect machinery.
+              val streamingEnabled = LocalWindowInfo.current.isWindowFocused
+
               // Roll live connection health up into the top-bar status dot. The daemon signal is
               // polled here; per-device stream health is not yet fed in — device streams are
               // facet-owned and carry screenshots, so opening extra status-only streams would be
@@ -440,6 +448,7 @@ fun AutoMobileDesktopApp(
                   LayoutFacet(
                     column,
                     sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
+                    streamingEnabled = streamingEnabled,
                   )
                 },
                 // Live device mirror in each pane's stream area, fed by the daemon's video-stream
@@ -479,6 +488,7 @@ fun AutoMobileDesktopApp(
                     // Wires the per-pane quality overlay (manual Low/Medium/High + live FPS +
                     // auto-adjust) and persists the choice across sessions.
                     settings = settings,
+                    streamingEnabled = streamingEnabled,
                   )
                 },
               )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -352,7 +352,13 @@ internal fun rememberLiveVideoFrame(
       return@LaunchedEffect
     if (stallReconnectMs == null && firstFrameTimeoutMs == null) return@LaunchedEffect
     var noProgressSinceMs = nowMs()
-    var lastSeenSequence = -1L
+    // Seed from the frame already on screen so a RETAINED frame is not mistaken for fresh progress.
+    // On a streamingEnabled resume this watchdog restarts while liveFrame still holds the pre-pause
+    // frame; keyed at -1 the first tick would adopt that frame's ancient receivedAtMs as the
+    // baseline and, for a pause longer than stallReconnectMs, reconnect immediately (issue #5219).
+    // frameSequence is a monotonic per-source counter, so the next real frame always outranks the
+    // retained one and still registers as progress.
+    var lastSeenSequence = liveFrame?.sequence ?: -1L
     fun reconnect(reason: String) {
       LOG.info("Live mirror for $deviceId reconnecting: $reason")
       noProgressSinceMs = nowMs()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -249,12 +249,22 @@ internal const val LIVE_FIRST_FRAME_TIMEOUT_MS = 15_000L
  * torn down and rebuilt. This rechecks Screen Recording after the user returns from System
  * Settings. Off (the default) preserves the original clear-and-stop behavior for the IDE-plugin/
  * `AutoMobileContent` path, which blends in screenshot updates instead.
+ *
+ * [streamingEnabled] gates the live subscription without tearing the composition down
+ * (issue #5219): the desktop workspace passes window focus here, so an unfocused/minimized window
+ * disconnects every pane's source — the daemon can then drop the device-side encode once no
+ * subscriber remains — and a refocus reconnects the same source. Disconnect (not
+ * [VideoStreamSource.dispose]) is used so the source is reusable on refocus; dispose stays reserved
+ * for composition teardown. All connect-driving loops below (the Unavailable retry and the progress
+ * watchdog) are gated on this flag so a paused pane cannot silently reconnect itself. Default
+ * `true` leaves the IDE-plugin/`AutoMobileContent` path always-on and unchanged.
  */
 @Composable
 internal fun rememberLiveVideoFrame(
   source: VideoStreamSource?,
   deviceId: String?,
   autoReconnect: Boolean = false,
+  streamingEnabled: Boolean = true,
   reconnectInitialMs: Long = LIVE_RECONNECT_INITIAL_MS,
   nowMs: () -> Long = MONOTONIC_NOW_MS,
   // Null disables the Streaming-stall reconnect; iOS (idle-frame-dropping) callers pass null.
@@ -265,12 +275,24 @@ internal fun rememberLiveVideoFrame(
 ): LiveVideoFrame? {
   var liveFrame by remember(source, deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
 
+  // Dispose the source when the composition leaves. Keyed on source/deviceId only — NOT on
+  // streamingEnabled — so a focus toggle never disposes: dispose is terminal (the source cannot
+  // reconnect), whereas a pause must resume on the same source.
   DisposableEffect(source, deviceId) {
-    if (source != null && deviceId != null) source.connect(deviceId)
     onDispose {
       liveFrame = null
       source?.dispose()
     }
+  }
+
+  // Connect while focused, disconnect while not. Re-running on streamingEnabled flips the pane
+  // between a live subscription and none; connect() no-ops while a reader is already active, so a
+  // redundant enable cannot double-subscribe.
+  DisposableEffect(source, deviceId, streamingEnabled) {
+    if (source != null && deviceId != null) {
+      if (streamingEnabled) source.connect(deviceId) else source.disconnect()
+    }
+    onDispose {}
   }
 
   LaunchedEffect(source) {
@@ -281,8 +303,9 @@ internal fun rememberLiveVideoFrame(
     }
   }
 
-  LaunchedEffect(source, deviceId, autoReconnect) {
-    if (source == null) return@LaunchedEffect
+  LaunchedEffect(source, deviceId, autoReconnect, streamingEnabled) {
+    // A paused pane (window unfocused) owns no subscription, so it must not retry a reconnect.
+    if (source == null || !streamingEnabled) return@LaunchedEffect
     // collectLatest (not collect) is load-bearing for the retry: when the socket is absent,
     // connect() re-assigns the SAME Unavailable value, which MutableStateFlow suppresses — so a
     // plain collector would receive no further event and retry only once. Under collectLatest the
@@ -321,8 +344,12 @@ internal fun rememberLiveVideoFrame(
   // keeps rendering across it. Idle static screens are handled correctly: on iOS stallReconnectMs
   // is null so an idle `Streaming` stream is left alone, and the first-frame deadline only applies
   // BEFORE the first frame, where a static screen is irrelevant.
-  LaunchedEffect(source, deviceId, autoReconnect) {
-    if (source == null || deviceId == null || !autoReconnect) return@LaunchedEffect
+  LaunchedEffect(source, deviceId, autoReconnect, streamingEnabled) {
+    // Gate on streamingEnabled too: while paused the source sits Idle after disconnect, and the
+    // Connecting/Idle branch below would otherwise treat that as a never-first-frame wedge and
+    // reconnect — silently defeating the pause.
+    if (source == null || deviceId == null || !autoReconnect || !streamingEnabled)
+      return@LaunchedEffect
     if (stallReconnectMs == null && firstFrameTimeoutMs == null) return@LaunchedEffect
     var noProgressSinceMs = nowMs()
     var lastSeenSequence = -1L

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -89,6 +89,11 @@ fun DeviceStreamView(
   // an auto-adjust toggle) whose choice persists here across sessions. Null keeps today's fixed
   // per-mode preset with no overlay, so existing embeddings are unchanged.
   settings: SettingsProvider? = null,
+  // Window-focus gate (#5219): the desktop host passes `false` when its window is unfocused or
+  // minimized, which disconnects this pane's live subscription (so the daemon can drop the
+  // device-side encode) and reconnects on refocus. Default `true` keeps every other embedding
+  // always-streaming and unchanged.
+  streamingEnabled: Boolean = true,
   // Hoisted so a host or test can pass a different quality/rate or a fake source entirely. The
   // quality is passed in (rather than baked in) so the pane can re-subscribe when the selector or
   // auto-adjust changes it.
@@ -157,6 +162,7 @@ fun DeviceStreamView(
       source,
       column.deviceId,
       autoReconnect = true,
+      streamingEnabled = streamingEnabled,
       // The Streaming-stall reconnect is only valid for idle-heartbeat sources (Android). The iOS
       // capture drops idle buffers, so a healthy static screen makes no frame progress and must
       // NOT be reconnected; the first-frame deadline still catches a never-first-frame wedge.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
@@ -48,6 +48,10 @@ fun LayoutFacet(
   backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
   socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
   sessionUuidProvider: () -> String? = { null },
+  // Window-focus gate (#5219): the desktop host passes `false` when its window is unfocused or
+  // minimized, pausing the inspector's live mirror the same way the stream pane pauses. Default
+  // `true` keeps other embeddings always-streaming.
+  streamingEnabled: Boolean = true,
   videoSourceFactory: (deviceId: String) -> VideoStreamSource = {
     VideoStreamClient(
       quality = VideoStreamQuality.High,
@@ -69,6 +73,7 @@ fun LayoutFacet(
       videoSource,
       column.deviceId,
       autoReconnect = true,
+      streamingEnabled = streamingEnabled,
       // Streaming-stall reconnect only for idle-heartbeat sources (Android); the iOS capture drops
       // idle buffers, so a static inspected screen legitimately makes no frame progress.
       stallReconnectMs = if (column.platform == Platform.Android) LIVE_STALL_RECONNECT_MS else null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -236,5 +237,55 @@ class LiveVideoStreamTest {
     source.emitFrame(width = 1, height = 1)
     waitForIdle()
     assertNull(observedFrame)
+  }
+
+  @Test
+  fun `resuming after a long pause does not reconnect off the retained frame`() = runComposeUiTest {
+    // #5219 regression: a streamingEnabled resume restarts the stall watchdog while liveFrame still
+    // holds the pre-pause frame. It must not adopt that stale frame's ancient receivedAtMs as the
+    // progress baseline — otherwise a pause longer than stallReconnectMs makes the first tick judge
+    // the freshly-resumed stream stalled and reconnect immediately. The logical clock (nowMs) is
+    // frozen at the resume instant so the assertion is deterministic: with the fix the watchdog
+    // sees
+    // zero elapsed no-progress time and never reconnects.
+    val clock = java.util.concurrent.atomic.AtomicLong(0L)
+    val nowMs = { clock.get() }
+    val source = FakeVideoStreamSource(nowMs = nowMs)
+    val streaming = mutableStateOf(true)
+    setContent {
+      rememberLiveVideoFrame(
+        source,
+        "emulator-5554",
+        autoReconnect = true,
+        streamingEnabled = streaming.value,
+        reconnectInitialMs = 10,
+        nowMs = nowMs,
+        stallReconnectMs = 100,
+        stallCheckIntervalMs = 20,
+      )
+    }
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+    source.emitFrame(width = 1, height = 1) // retained frame, receivedAtMs = 0
+    waitUntil { source.state.value is VideoStreamState.Streaming }
+
+    runOnUiThread { streaming.value = false } // window unfocused → pause/disconnect
+    waitUntil { source.connectedDeviceId == null }
+    clock.set(10_000) // 10s elapse while unfocused, far exceeding stallReconnectMs
+
+    runOnUiThread { streaming.value = true } // refocus → a single reconnect
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+    val connectsAtResume = source.connectCalls
+
+    // waitUntil pumps the test clock, firing the watchdog's stallCheck ticks (Thread.sleep would
+    // not advance it). No fresh frame arrives, so with the stale baseline the watchdog reconnects
+    // within a tick or two; with the fix the frozen nowMs yields zero no-progress time forever, so
+    // the wait times out with connectCalls unchanged.
+    var reconnected = true
+    try {
+      waitUntil(timeoutMillis = 1_000) { source.connectCalls > connectsAtResume }
+    } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
+      reconnected = false
+    }
+    assertFalse(reconnected, "watchdog must not reconnect off the retained pre-pause frame")
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -8,7 +8,6 @@ import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -276,16 +275,19 @@ class LiveVideoStreamTest {
     waitUntil { source.connectedDeviceId == "emulator-5554" }
     val connectsAtResume = source.connectCalls
 
-    // waitUntil pumps the test clock, firing the watchdog's stallCheck ticks (Thread.sleep would
-    // not advance it). No fresh frame arrives, so with the stale baseline the watchdog reconnects
-    // within a tick or two; with the fix the frozen nowMs yields zero no-progress time forever, so
-    // the wait times out with connectCalls unchanged.
-    var reconnected = true
-    try {
-      waitUntil(timeoutMillis = 1_000) { source.connectCalls > connectsAtResume }
-    } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
-      reconnected = false
-    }
-    assertFalse(reconnected, "watchdog must not reconnect off the retained pre-pause frame")
+    // Freeze auto-advance and step the test clock deterministically through a bounded run of the
+    // watchdog's stallCheck ticks (stallCheckIntervalMs = 20, so 500 ms = 25 ticks, well past the
+    // 100 ms stallReconnectMs window). No fresh frame arrives: with the stale baseline the watchdog
+    // would reconnect within the first tick, but with the fix the frozen nowMs yields zero
+    // no-progress time forever, so connectCalls stays put. Advancing the clock ourselves keeps the
+    // passing path off the wall clock (the old waitUntil timeout burned a full second per run).
+    mainClock.autoAdvance = false
+    mainClock.advanceTimeBy(500L)
+    waitForIdle()
+    assertEquals(
+      connectsAtResume,
+      source.connectCalls,
+      "watchdog must not reconnect off the retained pre-pause frame",
+    )
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -44,6 +44,44 @@ class DeviceStreamViewTest {
   }
 
   @Test
+  fun `disconnects when the window loses focus and reconnects on refocus`() = runComposeUiTest {
+    // #5219: an unfocused/minimized desktop window pauses the pane's live stream so the daemon can
+    // drop the device-side encode; refocus resumes it on the same source.
+    val source = FakeVideoStreamSource()
+    val focused = mutableStateOf(true)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          sourceFactory = { _, _ -> source },
+          streamingEnabled = focused.value,
+        )
+      }
+    }
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+
+    runOnUiThread { focused.value = false }
+    waitUntil { source.connectedDeviceId == null }
+
+    runOnUiThread { focused.value = true }
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+  }
+
+  @Test
+  fun `never connects while the window starts unfocused`() = runComposeUiTest {
+    // Mounting a pane while the window is already unfocused must not open a subscription at all.
+    val source = FakeVideoStreamSource()
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(col(), sourceFactory = { _, _ -> source }, streamingEnabled = false)
+      }
+    }
+    waitForIdle()
+    assertNull(source.connectedDeviceId)
+    assertEquals(0, source.connectCalls)
+  }
+
+  @Test
   fun `draws the newest decoded frame as the live mirror`() = runComposeUiTest {
     val source = FakeVideoStreamSource()
     setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }


### PR DESCRIPTION
## Summary

Closes #5219.

Live H.264 pane mirrors kept decoding — and kept the device encoding — even when the desktop window was unfocused or minimized, which is pure wasted CPU/battery and on-device encode load. This gates the workspace panes' live subscriptions on window focus so an unfocused/minimized window does no decode/encode.

Note on scope: the issue's background describes the **device grid** streaming live H.264 too, but the grid was since changed to one-shot screenshot thumbnails (`DeviceThumbnail` — "DELIBERATELY not live video"), so the grid has no standing stream to pause. The workspace **panes** (stream mirror + Inspect-mode Layout mirror) are now the only continuous decode/encode cost, and are what this PR gates.

## Changes

- `rememberLiveVideoFrame` gains a `streamingEnabled` flag (default `true`, so the IDE-plugin / `AutoMobileContent` path is unchanged). While disabled it `disconnect()`s the source — reusable, unlike `dispose()`, which stays reserved for composition teardown — and **both** connect-driving loops (the Unavailable-driven retry and the progress/first-frame watchdog) short-circuit, so a paused pane cannot silently reconnect itself. A refocus reconnects the same source via the existing auto-reconnect machinery.
- `DeviceStreamView` and `LayoutFacet` thread the flag through.
- `AutoMobileDesktopApp` reads `LocalWindowInfo.current.isWindowFocused` once at the workspace and feeds both pane surfaces.

## Acceptance criteria

- ✅ Unfocused/minimized window → pane streams disconnect (daemon stops the device-side encode once no subscriber remains). Grid has no live stream to pause (screenshots).
- ✅ On refocus, live video resumes via `rememberLiveVideoFrame(autoReconnect = true)`.
- ✅ The retained last frame / status placeholders keep rendering while paused (no error wall).
- ✅ Covered by a test that drives a focus flag through `FakeVideoStreamSource` and asserts connect/disconnect, plus a test that a pane mounted while unfocused never subscribes.

## Validation

- `:desktop-core:test --tests DeviceStreamViewTest` (18 passed, incl. the two new focus tests)
- `:desktop-core:test` full module — green except `VideoStreamClientTest > a rapid reconnect is not wedged…`, a **pre-existing real-IO timing flake** in a file this PR does not touch (passes 3/3 in isolation).
- `:desktop-app:compileKotlin`, `:desktop-core:compileKotlin`
- `scripts/ktfmt/validate_ktfmt.sh` (clean tree-wide)

Labeled `needs-human` and auto-merge left off: the diff changes runtime behavior in `android/`.