### PR TITLE
chore(android): remove three unreferenced version-catalog keys (#5777)

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -25,9 +25,6 @@ bytedeco-javacpp = "1.5.14"
 # Java versions
 build-java-target = "21"                   # Used in root build.gradle.kts and playground
 
-# Gradle plugin versions (currently unused but available for future use)
-build-gradle-doctor = "0.10.0"
-build-gradle-sortDependencies = "0.14"
 detekt = "2.0.0-alpha.6"
 
 # AndroidX versions
@@ -49,7 +46,6 @@ junit-jupiter-api = "6.1.3"
 junit-vintage-engine = "6.1.3"
 koog-agents = "1.1.1"
 mockk = "1.14.11"
-mockk-android = "1.14.4"
 robolectric = "4.16.1"
 snakeyaml = "2.6"
 json-schema-validator = "3.0.7"


### PR DESCRIPTION
## Summary

Removes three dead `[versions]` entries in `android/gradle/libs.versions.toml`
that no library, plugin, or build script references — confirmed by the audit in
#5777 and re-verified against current `main`. Catalog-only, no behavior change.

Deleted keys:

| Key | Value | Why dead |
|-----|-------|----------|
| `build-gradle-doctor` | `0.10.0` | no `gradle-doctor`/osacky plugin applied anywhere |
| `build-gradle-sortDependencies` | `0.14` | no sort-dependencies plugin applied anywhere |
| `mockk-android` | `1.14.4` | only mockk library uses `version.ref = "mockk"` (1.14.11) |

Also drops the now-false `# Gradle plugin versions (currently unused but
available for future use)` comment: its only surviving member, `detekt`, is
actively applied (`libs.plugins.detekt`, `libs.versions.detekt.get()`).

## Linked Issue

Closes #5777

## Validation

- [x] Consumer grep across the Android tree (`*.kts`, `*.gradle`, `*.toml`,
  `*.properties`) for plugin ids and catalog accessor forms — zero references to
  the three keys outside their definitions.
- [x] Catalog structural consistency: all 73 `version.ref` entries still resolve
  to a defined `[versions]` key after removal.
- [x] `detekt` version key and plugin alias intact.
- [x] Single-file diff; worktree isolation verified.

No TS/Swift/shell surfaces touched, so the TS build/test/typecheck suites are
unaffected by this change.
