### PR TITLE
fix(server): guard navigation screen/cursor/limit decode against uncaught URIError (#5853)

### DIFF
--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -46,15 +46,16 @@ export interface NavigationAppsResourceContent {
 
 const GRAPH_RESOURCE_UPDATE_DEBOUNCE_MS = 1000;
 
-// Decode the `?appId={appId}` query param captured by these navigation templates.
-// The registry compiles the literal `?appId=` form to a RAW regex group (it only
-// URL-decodes params for RFC-6570 `{?appId}` templates like storageCapabilities),
-// so this single decodeURIComponent is the first-and-only decode — NOT the #5686
-// double-decode, and it must stay. Guard it so a malformed percent-sequence (a
-// bad-client `%`) falls back to the raw value instead of throwing an uncaught
-// URIError past each handler's try/catch and bypassing the JSON error envelope —
-// matching #5686's graceful handling of the same input (#5748).
-function decodeAppIdParam(raw: string | undefined): string | undefined {
+// Decode a query param captured by these navigation templates (`appId`,
+// `screenName`, `cursor`, `limit`). The registry compiles the literal `?name=`
+// form to a RAW regex group (it only URL-decodes params for RFC-6570 `{?name}`
+// templates like storageCapabilities), so this single decodeURIComponent is the
+// first-and-only decode — NOT the #5686 double-decode, and it must stay. Guard it
+// so a malformed percent-sequence (a bad-client `%`) falls back to the raw value
+// instead of throwing an uncaught URIError past each handler's try/catch and
+// bypassing the JSON error envelope — matching #5686's graceful handling of the
+// same input (#5748 for `{?appId}`; #5853 extended it to the sibling params).
+function decodeUriParam(raw: string | undefined): string | undefined {
   if (!raw) {
     return undefined;
   }
@@ -62,9 +63,10 @@ function decodeAppIdParam(raw: string | undefined): string | undefined {
     return decodeURIComponent(raw).trim();
   } catch (error) {
     // Malformed percent-encoding is bad client input, not a server fault: return
-    // the raw value so the handler emits its own JSON error envelope for a
-    // non-existent app rather than throwing. Safe to swallow after tracing.
-    logger.debug(`[NavigationResources] appId decode failed for '${raw}': ${error}`);
+    // the raw value so the handler emits its own JSON error envelope (unresolvable
+    // app / screen / cursor / limit) rather than throwing. Safe to swallow after
+    // tracing.
+    logger.debug(`[NavigationResources] param decode failed for '${raw}': ${error}`);
     return raw.trim();
   }
 }
@@ -287,8 +289,8 @@ function parseHistoryParams(params: Record<string, string>): {
   cursor?: string;
   limit?: number;
 } {
-  const cursorRaw = params.cursor ? decodeURIComponent(params.cursor).trim() : "";
-  const limitRaw = params.limit ? decodeURIComponent(params.limit).trim() : "";
+  const cursorRaw = decodeUriParam(params.cursor) ?? "";
+  const limitRaw = decodeUriParam(params.limit) ?? "";
 
   const cursor = cursorRaw || undefined;
   if (!limitRaw) {
@@ -418,7 +420,7 @@ export function registerNavigationResources(
     "High-level navigation graph filtered by app ID.",
     "application/json",
     async (params) => {
-      const appId = decodeAppIdParam(params.appId);
+      const appId = decodeUriParam(params.appId);
       return getNavigationGraphResource(appId);
     },
   );
@@ -432,19 +434,38 @@ export function registerNavigationResources(
   );
 
   const historyHandler = async (params: Record<string, string>) => {
-    const { cursor, limit } = parseHistoryParams(params);
-    const query = new URLSearchParams();
-    if (cursor) {
-      query.set("cursor", cursor);
+    try {
+      const { cursor, limit } = parseHistoryParams(params);
+      const query = new URLSearchParams();
+      if (cursor) {
+        query.set("cursor", cursor);
+      }
+      if (limit) {
+        query.set("limit", limit.toString());
+      }
+      const queryString = query.toString();
+      const uri = queryString
+        ? `${NAVIGATION_RESOURCE_URIS.HISTORY}?${queryString}`
+        : NAVIGATION_RESOURCE_URIS.HISTORY;
+      return getNavigationGraphHistoryResource(uri, { cursor, limit });
+    } catch (error) {
+      // parseHistoryParams throws a plain Error on an invalid `limit`. That throw
+      // runs outside getNavigationGraphHistoryResource's try/catch, so without this
+      // it would escape past the JSON error envelope as a JSON-RPC -32603 (#5853).
+      // Log and return the resource's own error envelope instead.
+      logger.error(`[NavigationResources] Failed to parse navigation history params: ${error}`);
+      return {
+        uri: NAVIGATION_RESOURCE_URIS.HISTORY,
+        mimeType: "application/json",
+        text: JSON.stringify(
+          {
+            error: `Failed to retrieve navigation history: ${error}`,
+          },
+          null,
+          2,
+        ),
+      };
     }
-    if (limit) {
-      query.set("limit", limit.toString());
-    }
-    const queryString = query.toString();
-    const uri = queryString
-      ? `${NAVIGATION_RESOURCE_URIS.HISTORY}?${queryString}`
-      : NAVIGATION_RESOURCE_URIS.HISTORY;
-    return getNavigationGraphHistoryResource(uri, { cursor, limit });
   };
 
   ResourceRegistry.registerTemplate(
@@ -480,7 +501,7 @@ export function registerNavigationResources(
     "application/json",
     async (params) => {
       const nodeId = Number(params.nodeId);
-      const appId = decodeAppIdParam(params.appId);
+      const appId = decodeUriParam(params.appId);
       if (!Number.isFinite(nodeId)) {
         return buildNavigationNodeError(
           `automobile:navigation/nodes/${params.nodeId}`,
@@ -514,7 +535,7 @@ export function registerNavigationResources(
     "Detailed navigation graph node by screen name, including relationships.",
     "application/json",
     async (params) => {
-      const screenName = decodeURIComponent(params.screenName ?? "").trim();
+      const screenName = decodeUriParam(params.screenName) ?? "";
       if (!screenName) {
         return buildNavigationNodeError(
           "automobile:navigation/nodes?screen=",
@@ -535,7 +556,7 @@ export function registerNavigationResources(
     "image/webp",
     async (params) => {
       const nodeId = Number(params.nodeId);
-      const appId = decodeAppIdParam(params.appId);
+      const appId = decodeUriParam(params.appId);
       if (!Number.isFinite(nodeId)) {
         return {
           uri: `automobile:navigation/nodes/${params.nodeId}/screenshot`,

--- a/test/fakes/FakeNavigationGraphManager.ts
+++ b/test/fakes/FakeNavigationGraphManager.ts
@@ -18,6 +18,8 @@ import {
   NavigationGraphNodeResourceProvider,
   NavigationAppSummary,
   NavigationAppListProvider,
+  NavigationGraphHistoryProvider,
+  NavigationGraphHistoryPage,
 } from "../../src/utils/interfaces/NavigationGraph";
 
 /**
@@ -29,7 +31,8 @@ export class FakeNavigationGraphManager
     NavigationGraph,
     NavigationGraphSummaryProvider,
     NavigationGraphNodeResourceProvider,
-    NavigationAppListProvider
+    NavigationAppListProvider,
+    NavigationGraphHistoryProvider
 {
   private currentAppId: string | null = null;
   private currentScreen: string | null = null;
@@ -48,6 +51,7 @@ export class FakeNavigationGraphManager
 
   // Configurable responses
   private pathResult: PathResult | null = null;
+  private historyPage: NavigationGraphHistoryPage | null = null;
 
   // ==================== Configuration Methods ====================
 
@@ -463,5 +467,33 @@ export class FakeNavigationGraphManager
     this.nodeSummaryIds.set(screenName, nodeId);
 
     return this.buildNodeResource(node, nodeId, this.currentAppId);
+  }
+
+  /**
+   * Configure the page returned by exportGraphHistory. Defaults to an empty page
+   * scoped to the current app when unset.
+   */
+  setHistoryPage(page: NavigationGraphHistoryPage | null): void {
+    this.historyPage = page;
+  }
+
+  async exportGraphHistory(options?: {
+    cursor?: string;
+    limit?: number;
+  }): Promise<NavigationGraphHistoryPage> {
+    this.trackCall("exportGraphHistory", [options]);
+
+    if (this.historyPage) {
+      return this.historyPage;
+    }
+
+    return {
+      appId: this.currentAppId,
+      currentScreen: this.currentScreen,
+      cursor: options?.cursor ?? null,
+      nextCursor: null,
+      nodes: [],
+      edges: [],
+    };
   }
 }

--- a/test/fakes/FakeNavigationGraphManager.ts
+++ b/test/fakes/FakeNavigationGraphManager.ts
@@ -487,6 +487,17 @@ export class FakeNavigationGraphManager
       return this.historyPage;
     }
 
+    // Mirror NavigationGraphManager.parseHistoryCursor: with an active app, a
+    // cursor is only valid as a numeric `timestamp:id`. Real production rejects a
+    // malformed cursor rather than echoing it, so replicate that here to keep the
+    // malformed-cursor regression test faithful to the shipped behavior.
+    if (this.currentAppId && options?.cursor) {
+      const [timestampRaw, idRaw] = options.cursor.split(":");
+      if (!Number.isFinite(Number(timestampRaw)) || !Number.isFinite(Number(idRaw))) {
+        throw new Error(`Invalid history cursor: ${options.cursor}`);
+      }
+    }
+
     return {
       appId: this.currentAppId,
       currentScreen: this.currentScreen,

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -646,4 +646,120 @@ describe("MCP Navigation Graph Resource", () => {
       expect(Array.isArray(body.nodes)).toBe(true);
     });
   });
+
+  // #5853: siblings of #5748. The `screenName`, `cursor`, and `limit` params were
+  // decoded (and `limit` validated) OUTSIDE each handler's try/catch, so a
+  // malformed percent-sequence (or an invalid `limit`) threw past the JSON error
+  // envelope and surfaced as JSON-RPC -32603 instead. Same guarded-decode contract
+  // as the `{?appId}` fix: a bad param degrades to the resource's own JSON envelope.
+  describe("screen/cursor/limit params are guarded against uncaught URIError (#5853)", () => {
+    const readResourceResponseSchema = z.object({
+      contents: z.array(
+        z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+        }),
+      ),
+    });
+
+    test("a literal-% screen name returns a graceful JSON envelope, not an uncaught URIError", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+      fakeGraph.addNode({
+        screenName: "Home",
+        firstSeenAt: 100,
+        lastSeenAt: 200,
+        visitCount: 1,
+      });
+
+      const { client } = fixture.getContext();
+
+      // Raw "100%" is not a valid percent-sequence: decodeURIComponent throws.
+      // Before the fix, that URIError escaped the handler's try/catch and failed
+      // the read with -32603. Now the guarded decode degrades to the raw value,
+      // which resolves to no node → the resource's normal not-found JSON envelope.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/nodes?screen=100%" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text!);
+      expect(typeof body.error).toBe("string");
+      expect(body.error).toContain("not found");
+    });
+
+    test("a literal-% cursor returns a graceful JSON envelope, not an uncaught URIError", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+
+      const { client } = fixture.getContext();
+
+      // "100%" is a malformed cursor; the guarded decode degrades to the raw value
+      // and the history export proceeds, returning its normal JSON page instead of
+      // throwing a URIError past the handler.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/history?cursor=100%" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text!);
+      expect(body.error).toBeUndefined();
+      expect(Array.isArray(body.nodes)).toBe(true);
+    });
+
+    test("a literal-% limit returns a graceful JSON error envelope, not an uncaught URIError", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+
+      const { client } = fixture.getContext();
+
+      // "100%" decodes (guarded) to the raw value, which is not a finite positive
+      // number, so parseHistoryParams throws a plain Error. Before the fix that
+      // throw was uncaught (-32603); now historyHandler catches it and returns the
+      // resource's JSON error envelope.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/history?limit=100%" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text!);
+      expect(typeof body.error).toBe("string");
+      expect(body.error).toContain("limit");
+    });
+
+    test("a non-numeric limit returns a graceful JSON error envelope, not an uncaught throw", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+
+      const { client } = fixture.getContext();
+
+      // Well-formed but invalid limit: parseHistoryParams throws a plain Error that
+      // is likewise uncaught before the fix. historyHandler must catch it too.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/history?limit=abc" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text!);
+      expect(typeof body.error).toBe("string");
+      expect(body.error).toContain("limit");
+    });
+  });
 });

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -693,18 +693,45 @@ describe("MCP Navigation Graph Resource", () => {
       expect(body.error).toContain("not found");
     });
 
-    test("a literal-% cursor returns a graceful JSON envelope, not an uncaught URIError", async () => {
+    test("a literal-% cursor returns a graceful JSON error envelope, not an uncaught URIError", async () => {
       fakeGraph.setCurrentAppId("com.example.a");
 
       const { client } = fixture.getContext();
 
-      // "100%" is a malformed cursor; the guarded decode degrades to the raw value
-      // and the history export proceeds, returning its normal JSON page instead of
-      // throwing a URIError past the handler.
+      // "100%" is a malformed cursor. The bug was the decode itself: before the fix
+      // decodeURIComponent("100%") threw a URIError past the handler (-32603). Now
+      // the guarded decode degrades to the raw value, which the history export then
+      // rejects as an invalid `timestamp:id` cursor (mirroring the real
+      // NavigationGraphManager.parseHistoryCursor) — surfacing the resource's JSON
+      // error envelope instead of a URIError. Pre-fix this request rejected with
+      // -32603; post-fix it resolves with an error body.
       const result = await client.request(
         {
           method: "resources/read",
           params: { uri: "automobile:navigation/history?cursor=100%" },
+        },
+        readResourceResponseSchema,
+      );
+
+      const content = result.contents[0];
+      expect(content.mimeType).toBe("application/json");
+      const body = JSON.parse(content.text!);
+      expect(typeof body.error).toBe("string");
+      expect(body.error).toContain("cursor");
+    });
+
+    test("a well-formed cursor returns a normal (non-error) JSON page", async () => {
+      fakeGraph.setCurrentAppId("com.example.a");
+
+      const { client } = fixture.getContext();
+
+      // Guards against over-broad rejection: a valid `timestamp:id` cursor must
+      // still produce a normal history page, so the fix does not turn every cursor
+      // into an error envelope.
+      const result = await client.request(
+        {
+          method: "resources/read",
+          params: { uri: "automobile:navigation/history?cursor=123:45" },
         },
         readResourceResponseSchema,
       );


### PR DESCRIPTION
## Summary

`src/server/navigationResources.ts` decoded three URI-template query params —
`screenName`, `cursor`, and `limit` — with `decodeURIComponent` **outside** each
handler's `try/catch`. A malformed percent-sequence (e.g. a bad-client `%`) threw
an uncaught `URIError` that bypassed the resource's JSON error envelope and
surfaced as a JSON-RPC `-32603` internal error. `parseHistoryParams` also `throw`s
a plain `Error` for an invalid `limit`, likewise outside any catch, with the same
envelope-bypass.

This extends the guarded-decode pattern established for `{?appId}` in
[#5748](https://github.com/kaeawc/auto-mobile/issues/5748) /
PR [#5849](https://github.com/kaeawc/auto-mobile/pull/5849) to the sibling params:

- Generalizes `decodeAppIdParam` → a shared `decodeUriParam` used at every
  literal-`?name=` site (`appId` ×3, `screenName`, `cursor`, `limit`). A malformed
  `%` degrades to the raw value instead of throwing.
- Wraps `historyHandler` in a `try/catch` so the invalid-`limit` throw returns the
  resource's JSON error envelope instead of escaping past it.

## Linked Issue

Closes #5853

## Bug / Regression Context

- **Prior attempts:** PR [#5849](https://github.com/kaeawc/auto-mobile/pull/5849)
  fixed exactly this class for `{?appId}` only, deliberately scoped per #5748.
- **Observed symptom:** `resources/read` on
  `automobile:navigation/nodes?screen=100%`,
  `automobile:navigation/history?cursor=100%`, or `.../history?limit=100%`
  returned `MCP error -32603: URI error` (or `Invalid history limit`) instead of an
  `application/json` `{error}` envelope.
- **Repro steps / conditions:** a client passes a param with a malformed percent-
  sequence (or an invalid `limit`) to one of the navigation resources.

## Validation

- [x] `bun test test/server/resources/navigationGraph.test.ts` — 19 pass
- [x] `bun run lint` + `bun run build` — no new violations
- [x] `bun test` (full suite) — only 2 pre-existing, unrelated flakes fail
      (`webrtcDeviceCaptureLatency` bun-reporter self-assertion; confirmed failing
      on a clean tree without this change)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use interfaces + fakes; unit tests run in <100ms

## Acceptance Criteria (from #5853)

- [x] `screen=100%` → graceful `application/json` `{error}` envelope, not `-32603`
- [x] `cursor=100%` → graceful JSON envelope, not `-32603`
- [x] `limit=100%` (and invalid-`limit` throw) → JSON error envelope, not `-32603`
- [x] Regression tests added mirroring the `{?appId}` graceful-envelope test in
      `test/server/resources/navigationGraph.test.ts`

## Follow-ups

- [ ] None. The three sibling sites named in #5853 are all covered.
