### PR TITLE
fix(validation): quiet observe union noise, log non-finite values, unify PlanExecutor errors (#5854)

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -2,6 +2,7 @@ import { createConnection, Socket } from "node:net";
 import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { logger } from "../utils/logger";
+import { nonFiniteReplacer } from "../utils/nonFiniteJson";
 import { ActionableError } from "../models";
 import { DaemonRequest, DaemonResponse, DaemonNotification, isDaemonNotification } from "./types";
 import {
@@ -495,7 +496,7 @@ export class DaemonClient {
         return;
       }
 
-      this.socket.write(JSON.stringify(request) + "\n");
+      this.socket.write(JSON.stringify(request, nonFiniteReplacer) + "\n");
     });
   }
 
@@ -544,7 +545,7 @@ export class DaemonClient {
         return;
       }
 
-      this.socket.write(JSON.stringify(request) + "\n");
+      this.socket.write(JSON.stringify(request, nonFiniteReplacer) + "\n");
     });
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { ZodError, type ZodIssue } from "zod/v4";
 import { ActionableError } from "../models";
+import { formatToolParamError } from "./toolParamError";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
@@ -184,75 +184,11 @@ function stripInternalToolParams(params: unknown): unknown {
   return rest;
 }
 
-function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
-  const flattened: ZodIssue[] = [];
-
-  const visit = (issue: ZodIssue) => {
-    if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
-      issue.errors.forEach((unionIssues) => {
-        unionIssues.forEach((unionIssue) => {
-          const normalizedIssue = issue.path.length
-            ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
-            : unionIssue;
-          visit(normalizedIssue as ZodIssue);
-        });
-      });
-      return;
-    }
-    flattened.push(issue);
-  };
-
-  issues.forEach(visit);
-  return flattened;
-}
-
-// Exported for direct unit testing of the container-hint branch (issue #4181,
-// rank 7). The hint is only appended for tapOn/swipeOn container issues.
-export function formatToolParamError(toolName: string, error: unknown): string {
-  if (!(error instanceof ZodError)) {
-    return String(error);
-  }
-
-  const flattenedIssues = flattenZodIssues(error.issues);
-  const issues = flattenedIssues.map((issue) => {
-    const path = issue.path.length ? issue.path.join(".") : "parameters";
-    if (issue.code === "invalid_type") {
-      // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
-      // `z.number()` check, so no `.finite()` refinement can carry a custom
-      // message. Those surface as an invalid_type whose value is still a number
-      // (`received` is "Infinity"/"NaN", or "number" from a typeof-based error
-      // map), collapsing the default text to the self-contradictory "expected
-      // number, received number". A finite number never trips invalid_type, so
-      // any of these markers means non-finite — name the real constraint (#5769).
-      const received = (issue as { received?: unknown }).received;
-      if (
-        issue.expected === "number" &&
-        (received === "Infinity" || received === "NaN" || received === "number")
-      ) {
-        return `${path} must be a finite number`;
-      }
-      // zod v4 issues otherwise carry a usable default message that already
-      // reads "Invalid input: expected X, received Y", so reuse it minus the
-      // prefix to keep the historical "<path> expected X" format.
-      return `${path} ${issue.message.replace(/^Invalid input: /, "")}`;
-    }
-    return `${path} ${issue.message}`;
-  });
-
-  const hints: string[] = [];
-  if (toolName === "swipeOn" || toolName === "tapOn") {
-    const containerIssue = flattenedIssues.find((issue) => issue.path[0] === "container");
-    if (containerIssue) {
-      hints.push(
-        'container must be an object like { "elementId": "<id>" } or { "text": "<text>" }',
-      );
-    }
-  }
-
-  const issueSummary = issues.join("; ");
-  const hintSummary = hints.length > 0 ? ` Hint: ${hints.join(" ")}` : "";
-  return `${issueSummary}${hintSummary}`;
-}
+// `formatToolParamError` lives in its own module so non-server callers (e.g.
+// PlanExecutor, #5854 §3) can share the exact MCP-boundary rendering without
+// importing the whole server entrypoint (which would be circular). Re-exported
+// here to preserve the historical import path used by existing tests.
+export { formatToolParamError };
 
 /**
  * Populate the canonical production registry and validate exact-tool startup

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ActionableError } from "../models";
 import { formatToolParamError } from "./toolParamError";
+import { reviveNonFiniteNumbers } from "../utils/nonFiniteJson";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
@@ -450,6 +451,16 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   });
 
   server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    // Revive non-finite arguments the daemon client encoded as sentinels so they
+    // survive the socket + loopback-HTTP hops (#5854 §2). Done BEFORE logging and
+    // validation so the request trace shows the real Infinity/-Infinity/NaN
+    // instead of `null`, and the schema rejects it with "must be a finite number".
+    if (request.params && request.params.arguments) {
+      request.params.arguments = reviveNonFiniteNumbers(request.params.arguments) as Record<
+        string,
+        unknown
+      >;
+    }
     logger.info("Request: ", request);
 
     // Extract tool name and arguments from the request

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -1,47 +1,55 @@
 import { ZodError, type ZodIssue } from "zod/v4";
 
+// Provenance of a flattened issue relative to the nearest `z.union` it came from.
+// A field that fails in EVERY branch of a union is a shared constraint the caller
+// must satisfy no matter which branch they meant (genuine); one that fails in only
+// SOME branches is branch-discrimination noise. `unionId` scopes the "every
+// branch" test to a specific union (nested unions get their own id); `branchCount`
+// is that union's arm count (#5854).
+interface UnionContext {
+  unionId: number;
+  branchIndex: number;
+  branchCount: number;
+}
+
 interface FlattenedIssue {
   issue: ZodIssue;
-  // True when this issue was produced by expanding a `z.union` branch. Only such
-  // issues can be branch-discrimination noise; a top-level sibling issue — e.g. a
-  // bad enum on a field that sits next to a union-typed field — is always the
-  // caller's real mistake and must never be suppressed (#5854).
-  fromUnion: boolean;
+  // null when the issue is not union-derived (a top-level sibling, e.g. a bad enum
+  // on a field beside a union-typed field) — those are always the caller's real
+  // mistake and are never suppressed.
+  union: UnionContext | null;
 }
 
 interface FlattenResult {
   issues: FlattenedIssue[];
-  // A `z.union` was expanded somewhere during flattening. Union expansion produces
-  // one issue per branch, so the same real problem repeats and every branch also
-  // reports its own discriminator/required fields as missing — noise that only
-  // exists because a union was tried (#5854).
   sawUnion: boolean;
 }
 
 function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
   const flattened: FlattenedIssue[] = [];
-  let sawUnion = false;
+  let unionCounter = 0;
 
-  const visit = (issue: ZodIssue, fromUnion: boolean) => {
+  const visit = (issue: ZodIssue, union: UnionContext | null) => {
     if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
-      sawUnion = true;
-      issue.errors.forEach((unionIssues) => {
+      const unionId = unionCounter++;
+      const branchCount = issue.errors.length;
+      issue.errors.forEach((unionIssues, branchIndex) => {
         unionIssues.forEach((unionIssue) => {
           const normalizedIssue = issue.path.length
             ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
             : unionIssue;
-          // Everything reached through a union branch is union-derived, so nested
-          // unions stay tagged too.
-          visit(normalizedIssue as ZodIssue, true);
+          // Re-tag with this union's context so the nearest enclosing union wins
+          // for nested unions.
+          visit(normalizedIssue as ZodIssue, { unionId, branchIndex, branchCount });
         });
       });
       return;
     }
-    flattened.push({ issue, fromUnion });
+    flattened.push({ issue, union });
   };
 
-  issues.forEach((issue) => visit(issue, false));
-  return { issues: flattened, sawUnion };
+  issues.forEach((issue) => visit(issue, null));
+  return { issues: flattened, sawUnion: unionCounter > 0 };
 }
 
 // zod v4 does not reliably populate `issue.received`: a non-finite number carries
@@ -57,21 +65,23 @@ function issueReportsMissingValue(issue: ZodIssue): boolean {
   return /received undefined$/.test(issue.message ?? "");
 }
 
-// A union branch reports fields it needs but the caller didn't supply, and fields
-// that are `never` on that branch — pure branch-discrimination artifacts, not the
-// caller's actual mistake. Recognizing them lets the formatter lead with the real
-// problem (a field the caller DID provide with a bad value) instead of a
-// per-branch dump (#5854). This is only consulted for union-derived errors; a
-// plain object schema's "missing required field" is genuine signal.
-function isBranchDiscriminationNoise(issue: ZodIssue): boolean {
-  if (issue.code === "invalid_type") {
-    // Field not valid on this branch (`never`), or a required field the caller
-    // omitted. A provided-but-bad value (e.g. a non-finite number or a wrong
-    // type) is the real problem and is kept.
-    return issue.expected === "never" || issueReportsMissingValue(issue);
+// A field the caller did not supply on this branch (`received undefined`) or one
+// that is `never` on this branch — pure branch-discrimination artifacts, never the
+// caller's real mistake, so always suppressible when union-derived. A provided-bad
+// value (a non-finite number, a wrong type, a bad enum) is NOT an artifact; whether
+// it is genuine is decided separately by the across-all-branches test (#5854).
+function isMissingOrNeverArtifact(issue: ZodIssue): boolean {
+  if (issue.code !== "invalid_type") {
+    return false;
   }
-  // A missing/misused literal-or-enum discriminator selecting the branch.
-  return issue.code === "invalid_value";
+  return issue.expected === "never" || issueReportsMissingValue(issue);
+}
+
+// Key for the (union, path) coverage map. `unionId` is a number and "#" cannot
+// appear in it, so the boundary with the joined path is unambiguous even when a
+// path segment contains digits.
+function coverageKey(unionId: number, path: ReadonlyArray<PropertyKey>): string {
+  return `${unionId}#${path.map(String).join(".")}`;
 }
 
 function formatIssue(issue: ZodIssue): string {
@@ -99,6 +109,52 @@ function formatIssue(issue: ZodIssue): string {
   return `${path} ${issue.message}`;
 }
 
+// Lead with the actionable message rather than a union-branch dump (#5854).
+// A union-derived issue is genuine only if its path fails in EVERY branch of its
+// union (a shared constraint the caller must fix regardless of intended branch);
+// an issue in only some branches is branch-discrimination noise. Non-union issues
+// (top-level siblings) are always kept. Returns the full list unchanged when no
+// union expanded, or when suppression would leave nothing — that fallback is
+// never worse than the raw dump this replaces.
+function selectGenuineIssues(
+  flattenedIssues: FlattenedIssue[],
+  sawUnion: boolean,
+): FlattenedIssue[] {
+  if (!sawUnion) {
+    return flattenedIssues;
+  }
+
+  // Per (union, path): which branches reported any issue there. A path covered by
+  // all `branchCount` branches is a shared constraint.
+  const branchCoverage = new Map<string, Set<number>>();
+  for (const entry of flattenedIssues) {
+    if (!entry.union) {
+      continue;
+    }
+    const key = coverageKey(entry.union.unionId, entry.issue.path);
+    let branches = branchCoverage.get(key);
+    if (!branches) {
+      branches = new Set<number>();
+      branchCoverage.set(key, branches);
+    }
+    branches.add(entry.union.branchIndex);
+  }
+
+  const isGenuine = (entry: FlattenedIssue): boolean => {
+    if (!entry.union) {
+      return true;
+    }
+    if (isMissingOrNeverArtifact(entry.issue)) {
+      return false;
+    }
+    const key = coverageKey(entry.union.unionId, entry.issue.path);
+    return (branchCoverage.get(key)?.size ?? 0) === entry.union.branchCount;
+  };
+
+  const primary = flattenedIssues.filter(isGenuine);
+  return primary.length > 0 ? primary : flattenedIssues;
+}
+
 // Exported for direct unit testing of the container-hint branch (issue #4181,
 // rank 7). The hint is only appended for tapOn/swipeOn container issues.
 export function formatToolParamError(toolName: string, error: unknown): string {
@@ -107,22 +163,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
   }
 
   const { issues: flattenedIssues, sawUnion } = flattenZodIssues(error.issues);
-
-  // Lead with the actionable message rather than a union-branch dump (#5854).
-  // Only union-derived issues can be branch-discrimination noise — top-level
-  // sibling issues (a bad enum next to a union-typed field) are the caller's real
-  // mistake and are always kept. Fall back to the full list if suppression would
-  // leave nothing (e.g. the caller supplied no bad value, only ambiguous/missing
-  // fields — then the per-branch requirements ARE the guidance to show).
-  let selectedIssues = flattenedIssues;
-  if (sawUnion) {
-    const primary = flattenedIssues.filter(
-      (entry) => !(entry.fromUnion && isBranchDiscriminationNoise(entry.issue)),
-    );
-    if (primary.length > 0) {
-      selectedIssues = primary;
-    }
-  }
+  const selectedIssues = selectGenuineIssues(flattenedIssues, sawUnion);
 
   // Dedupe formatted messages: union expansion repeats the same real issue once
   // per branch that carries the field.

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -1,0 +1,138 @@
+import { ZodError, type ZodIssue } from "zod/v4";
+
+interface FlattenResult {
+  issues: ZodIssue[];
+  // A `z.union` was expanded during flattening. Union expansion produces one
+  // issue per branch, so the same real problem repeats and every branch also
+  // reports its own discriminator/required fields as missing — noise that only
+  // exists because a union was tried (#5854).
+  sawUnion: boolean;
+}
+
+function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
+  const flattened: ZodIssue[] = [];
+  let sawUnion = false;
+
+  const visit = (issue: ZodIssue) => {
+    if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
+      sawUnion = true;
+      issue.errors.forEach((unionIssues) => {
+        unionIssues.forEach((unionIssue) => {
+          const normalizedIssue = issue.path.length
+            ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
+            : unionIssue;
+          visit(normalizedIssue as ZodIssue);
+        });
+      });
+      return;
+    }
+    flattened.push(issue);
+  };
+
+  issues.forEach(visit);
+  return { issues: flattened, sawUnion };
+}
+
+// zod v4 does not reliably populate `issue.received`: a non-finite number carries
+// `received: "Infinity"`, but a genuine wrong type (string→number) or an absent
+// field leaves it undefined and encodes the value only in the message text
+// ("… received string" / "… received undefined"). So "was this field actually
+// supplied?" must be read from the message, not the (often-missing) field.
+function issueReportsMissingValue(issue: ZodIssue): boolean {
+  const received = (issue as { received?: unknown }).received;
+  if (received !== undefined) {
+    return received === "undefined";
+  }
+  return /received undefined$/.test(issue.message ?? "");
+}
+
+// A union branch reports fields it needs but the caller didn't supply, and fields
+// that are `never` on that branch — pure branch-discrimination artifacts, not the
+// caller's actual mistake. Recognizing them lets the formatter lead with the real
+// problem (a field the caller DID provide with a bad value) instead of a
+// per-branch dump (#5854). This is only consulted for union-derived errors; a
+// plain object schema's "missing required field" is genuine signal.
+function isBranchDiscriminationNoise(issue: ZodIssue): boolean {
+  if (issue.code === "invalid_type") {
+    // Field not valid on this branch (`never`), or a required field the caller
+    // omitted. A provided-but-bad value (e.g. a non-finite number or a wrong
+    // type) is the real problem and is kept.
+    return issue.expected === "never" || issueReportsMissingValue(issue);
+  }
+  // A missing/misused literal-or-enum discriminator selecting the branch.
+  return issue.code === "invalid_value";
+}
+
+function formatIssue(issue: ZodIssue): string {
+  const path = issue.path.length ? issue.path.join(".") : "parameters";
+  if (issue.code === "invalid_type") {
+    // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
+    // `z.number()` check, so no `.finite()` refinement can carry a custom
+    // message. Those surface as an invalid_type whose value is still a number
+    // (`received` is "Infinity"/"NaN", or "number" from a typeof-based error
+    // map), collapsing the default text to the self-contradictory "expected
+    // number, received number". A finite number never trips invalid_type, so
+    // any of these markers means non-finite — name the real constraint (#5769).
+    const received = (issue as { received?: unknown }).received;
+    if (
+      issue.expected === "number" &&
+      (received === "Infinity" || received === "NaN" || received === "number")
+    ) {
+      return `${path} must be a finite number`;
+    }
+    // zod v4 issues otherwise carry a usable default message that already
+    // reads "Invalid input: expected X, received Y", so reuse it minus the
+    // prefix to keep the historical "<path> expected X" format.
+    return `${path} ${issue.message.replace(/^Invalid input: /, "")}`;
+  }
+  return `${path} ${issue.message}`;
+}
+
+// Exported for direct unit testing of the container-hint branch (issue #4181,
+// rank 7). The hint is only appended for tapOn/swipeOn container issues.
+export function formatToolParamError(toolName: string, error: unknown): string {
+  if (!(error instanceof ZodError)) {
+    return String(error);
+  }
+
+  const { issues: flattenedIssues, sawUnion } = flattenZodIssues(error.issues);
+
+  // Lead with the actionable message rather than a union-branch dump (#5854).
+  // When a union expanded, drop the per-branch discrimination noise so the real
+  // problem surfaces first; fall back to the full list if suppression would leave
+  // nothing (e.g. the caller supplied no bad value, only ambiguous/missing
+  // fields — then the per-branch requirements ARE the guidance to show).
+  let selectedIssues = flattenedIssues;
+  if (sawUnion) {
+    const primary = flattenedIssues.filter((issue) => !isBranchDiscriminationNoise(issue));
+    if (primary.length > 0) {
+      selectedIssues = primary;
+    }
+  }
+
+  // Dedupe formatted messages: union expansion repeats the same real issue once
+  // per branch that carries the field.
+  const seen = new Set<string>();
+  const issues: string[] = [];
+  for (const issue of selectedIssues) {
+    const formatted = formatIssue(issue);
+    if (!seen.has(formatted)) {
+      seen.add(formatted);
+      issues.push(formatted);
+    }
+  }
+
+  const hints: string[] = [];
+  if (toolName === "swipeOn" || toolName === "tapOn") {
+    const containerIssue = flattenedIssues.find((issue) => issue.path[0] === "container");
+    if (containerIssue) {
+      hints.push(
+        'container must be an object like { "elementId": "<id>" } or { "text": "<text>" }',
+      );
+    }
+  }
+
+  const issueSummary = issues.join("; ");
+  const hintSummary = hints.length > 0 ? ` Hint: ${hints.join(" ")}` : "";
+  return `${issueSummary}${hintSummary}`;
+}

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -1,11 +1,14 @@
 import { ZodError, type ZodIssue } from "zod/v4";
 
-// Provenance of a flattened issue relative to the nearest `z.union` it came from.
-// A field that fails in EVERY branch of a union is a shared constraint the caller
-// must satisfy no matter which branch they meant (genuine); one that fails in only
-// SOME branches is branch-discrimination noise. `unionId` scopes the "every
-// branch" test to a specific union (nested unions get their own id); `branchCount`
-// is that union's arm count (#5854).
+// Provenance of a flattened issue relative to the OUTERMOST `z.union` it came from
+// — the union that actually discriminates the caller's shape. A field that fails in
+// EVERY branch of that union is a shared constraint the caller must satisfy no
+// matter which branch they meant (genuine); one that fails in only SOME branches is
+// branch-discrimination noise. The outermost union is used deliberately: a missing
+// field whose value type is ITSELF a union would otherwise look "universal" inside
+// that inner type-union (every inner arm reports it missing) even though the field
+// is an optional predicate the caller simply omitted. `unionId` scopes the "every
+// branch" test; `branchCount` is that union's arm count (#5854).
 interface UnionContext {
   unionId: number;
   branchIndex: number;
@@ -31,16 +34,19 @@ function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
 
   const visit = (issue: ZodIssue, union: UnionContext | null) => {
     if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
-      const unionId = unionCounter++;
-      const branchCount = issue.errors.length;
+      // Establish a context only for the outermost union; a nested union keeps the
+      // outer branch's context so its issues stay attributed to the discriminating
+      // arm the caller actually took.
+      const outer = union;
+      const unionId = outer ? outer.unionId : unionCounter++;
+      const branchCount = outer ? outer.branchCount : issue.errors.length;
       issue.errors.forEach((unionIssues, branchIndex) => {
+        const branchContext: UnionContext = outer ?? { unionId, branchIndex, branchCount };
         unionIssues.forEach((unionIssue) => {
           const normalizedIssue = issue.path.length
             ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
             : unionIssue;
-          // Re-tag with this union's context so the nearest enclosing union wins
-          // for nested unions.
-          visit(normalizedIssue as ZodIssue, { unionId, branchIndex, branchCount });
+          visit(normalizedIssue as ZodIssue, branchContext);
         });
       });
       return;
@@ -52,29 +58,14 @@ function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
   return { issues: flattened, sawUnion: unionCounter > 0 };
 }
 
-// zod v4 does not reliably populate `issue.received`: a non-finite number carries
-// `received: "Infinity"`, but a genuine wrong type (string→number) or an absent
-// field leaves it undefined and encodes the value only in the message text
-// ("… received string" / "… received undefined"). So "was this field actually
-// supplied?" must be read from the message, not the (often-missing) field.
-function issueReportsMissingValue(issue: ZodIssue): boolean {
-  const received = (issue as { received?: unknown }).received;
-  if (received !== undefined) {
-    return received === "undefined";
-  }
-  return /received undefined$/.test(issue.message ?? "");
-}
-
-// A field the caller did not supply on this branch (`received undefined`) or one
-// that is `never` on this branch — pure branch-discrimination artifacts, never the
-// caller's real mistake, so always suppressible when union-derived. A provided-bad
-// value (a non-finite number, a wrong type, a bad enum) is NOT an artifact; whether
-// it is genuine is decided separately by the across-all-branches test (#5854).
-function isMissingOrNeverArtifact(issue: ZodIssue): boolean {
-  if (issue.code !== "invalid_type") {
-    return false;
-  }
-  return issue.expected === "never" || issueReportsMissingValue(issue);
+// A field declared `never` on this branch — a structural "this field is forbidden
+// here" marker that only ever fires because the union tried an inapplicable branch.
+// Always noise, so it is dropped before the across-all-branches test. Missing and
+// wrong-value issues are NOT pre-filtered: the coverage test keeps them when the
+// field fails in every branch (a genuinely-required field, or a shared constraint)
+// and drops them otherwise (a branch-specific discriminator) (#5854).
+function isNeverArtifact(issue: ZodIssue): boolean {
+  return issue.code === "invalid_type" && issue.expected === "never";
 }
 
 // Key for the (union, path) coverage map. `unionId` is a number and "#" cannot
@@ -144,7 +135,7 @@ function selectGenuineIssues(
     if (!entry.union) {
       return true;
     }
-    if (isMissingOrNeverArtifact(entry.issue)) {
+    if (isNeverArtifact(entry.issue)) {
       return false;
     }
     const key = coverageKey(entry.union.unionId, entry.issue.path);

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -1,19 +1,28 @@
 import { ZodError, type ZodIssue } from "zod/v4";
 
+interface FlattenedIssue {
+  issue: ZodIssue;
+  // True when this issue was produced by expanding a `z.union` branch. Only such
+  // issues can be branch-discrimination noise; a top-level sibling issue — e.g. a
+  // bad enum on a field that sits next to a union-typed field — is always the
+  // caller's real mistake and must never be suppressed (#5854).
+  fromUnion: boolean;
+}
+
 interface FlattenResult {
-  issues: ZodIssue[];
-  // A `z.union` was expanded during flattening. Union expansion produces one
-  // issue per branch, so the same real problem repeats and every branch also
+  issues: FlattenedIssue[];
+  // A `z.union` was expanded somewhere during flattening. Union expansion produces
+  // one issue per branch, so the same real problem repeats and every branch also
   // reports its own discriminator/required fields as missing — noise that only
   // exists because a union was tried (#5854).
   sawUnion: boolean;
 }
 
 function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
-  const flattened: ZodIssue[] = [];
+  const flattened: FlattenedIssue[] = [];
   let sawUnion = false;
 
-  const visit = (issue: ZodIssue) => {
+  const visit = (issue: ZodIssue, fromUnion: boolean) => {
     if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
       sawUnion = true;
       issue.errors.forEach((unionIssues) => {
@@ -21,15 +30,17 @@ function flattenZodIssues(issues: ZodIssue[]): FlattenResult {
           const normalizedIssue = issue.path.length
             ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
             : unionIssue;
-          visit(normalizedIssue as ZodIssue);
+          // Everything reached through a union branch is union-derived, so nested
+          // unions stay tagged too.
+          visit(normalizedIssue as ZodIssue, true);
         });
       });
       return;
     }
-    flattened.push(issue);
+    flattened.push({ issue, fromUnion });
   };
 
-  issues.forEach(visit);
+  issues.forEach((issue) => visit(issue, false));
   return { issues: flattened, sawUnion };
 }
 
@@ -98,13 +109,16 @@ export function formatToolParamError(toolName: string, error: unknown): string {
   const { issues: flattenedIssues, sawUnion } = flattenZodIssues(error.issues);
 
   // Lead with the actionable message rather than a union-branch dump (#5854).
-  // When a union expanded, drop the per-branch discrimination noise so the real
-  // problem surfaces first; fall back to the full list if suppression would leave
-  // nothing (e.g. the caller supplied no bad value, only ambiguous/missing
+  // Only union-derived issues can be branch-discrimination noise — top-level
+  // sibling issues (a bad enum next to a union-typed field) are the caller's real
+  // mistake and are always kept. Fall back to the full list if suppression would
+  // leave nothing (e.g. the caller supplied no bad value, only ambiguous/missing
   // fields — then the per-branch requirements ARE the guidance to show).
   let selectedIssues = flattenedIssues;
   if (sawUnion) {
-    const primary = flattenedIssues.filter((issue) => !isBranchDiscriminationNoise(issue));
+    const primary = flattenedIssues.filter(
+      (entry) => !(entry.fromUnion && isBranchDiscriminationNoise(entry.issue)),
+    );
     if (primary.length > 0) {
       selectedIssues = primary;
     }
@@ -114,7 +128,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
   // per branch that carries the field.
   const seen = new Set<string>();
   const issues: string[] = [];
-  for (const issue of selectedIssues) {
+  for (const { issue } of selectedIssues) {
     const formatted = formatIssue(issue);
     if (!seen.has(formatted)) {
       seen.add(formatted);
@@ -124,7 +138,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
 
   const hints: string[] = [];
   if (toolName === "swipeOn" || toolName === "tapOn") {
-    const containerIssue = flattenedIssues.find((issue) => issue.path[0] === "container");
+    const containerIssue = flattenedIssues.find((entry) => entry.issue.path[0] === "container");
     if (containerIssue) {
       hints.push(
         'container must be an object like { "elementId": "<id>" } or { "text": "<text>" }',

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -327,6 +327,13 @@ const safeStringify = (obj: any): string => {
         ancestors.push({ holder: filtered, original: value });
         return filtered;
       }
+      // JSON has no representation for non-finite numbers, so JSON.stringify would
+      // emit them as `null` — masking what a caller actually sent (e.g. the daemon
+      // request log showing a rejected `Infinity`/`NaN` argument as `null`, #5854).
+      // Render the literal marker instead so the trace is faithful.
+      if (typeof value === "number" && !Number.isFinite(value)) {
+        return String(value);
+      }
       return value;
     });
   } catch (error) {

--- a/src/utils/nonFiniteJson.ts
+++ b/src/utils/nonFiniteJson.ts
@@ -73,9 +73,10 @@ export function reviveNonFiniteNumbers(value: unknown): unknown {
   if (marker) {
     return numberFor(marker);
   }
-  const out: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    out[key] = reviveNonFiniteNumbers(child);
-  }
-  return out;
+  // Build with Object.fromEntries so an own "__proto__" key (valid JSON, e.g. a
+  // header map) is set as an own data property rather than invoking the prototype
+  // setter — plain `out[key] = …` would drop it and could pollute the prototype.
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, reviveNonFiniteNumbers(child)]),
+  );
 }

--- a/src/utils/nonFiniteJson.ts
+++ b/src/utils/nonFiniteJson.ts
@@ -1,0 +1,81 @@
+// JSON-RPC (and JSON generally) cannot represent non-finite numbers — `JSON.stringify`
+// coerces Infinity/-Infinity/NaN to `null`. The daemon carries tool-call requests
+// over a socket AND a loopback StreamableHTTP hop, so a non-finite argument a caller
+// produced (e.g. `a / b` with `b === 0`) is silently flattened to `null` before the
+// daemon request log or the tool schema ever sees it (#5854 §2).
+//
+// To keep the value faithful across those hops, the daemon client encodes each
+// non-finite number as a JSON-safe SENTINEL object on the wire, and the receiving
+// MCP request handler decodes it back to the real number before logging and
+// validation. The sentinel is a plain `{ [TAG]: "Infinity" }` object, so it passes
+// through every intermediate JSON.parse/stringify (including the MCP SDK's HTTP
+// transport, which this code cannot hook) untouched.
+
+// Deliberately unlikely to collide with a real payload key.
+const NON_FINITE_TAG = "__autoMobileNonFinite__";
+
+type NonFiniteMarker = "Infinity" | "-Infinity" | "NaN";
+
+function markerFor(value: number): NonFiniteMarker | null {
+  if (Number.isNaN(value)) {
+    return "NaN";
+  }
+  if (value === Infinity) {
+    return "Infinity";
+  }
+  if (value === -Infinity) {
+    return "-Infinity";
+  }
+  return null;
+}
+
+function numberFor(marker: NonFiniteMarker): number {
+  if (marker === "NaN") {
+    return NaN;
+  }
+  return marker === "Infinity" ? Infinity : -Infinity;
+}
+
+// A `JSON.stringify` replacer that rewrites non-finite numbers as sentinel objects.
+// `JSON.stringify` invokes the replacer with the live value BEFORE its own
+// null-coercion, so returning an object here is what actually reaches the wire.
+export function nonFiniteReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "number") {
+    const marker = markerFor(value);
+    if (marker) {
+      return { [NON_FINITE_TAG]: marker };
+    }
+  }
+  return value;
+}
+
+function sentinelMarker(value: object): NonFiniteMarker | null {
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== NON_FINITE_TAG) {
+    return null;
+  }
+  const marker = (value as Record<string, unknown>)[NON_FINITE_TAG];
+  return marker === "Infinity" || marker === "-Infinity" || marker === "NaN" ? marker : null;
+}
+
+// Recursively convert sentinel objects produced by {@link nonFiniteReplacer} back
+// into their non-finite numbers. Returns a decoded copy; the input is not mutated.
+// Anything that is not a sentinel is passed through unchanged, so calling this on a
+// payload with no sentinels (the common case) is a cheap structural walk.
+export function reviveNonFiniteNumbers(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(reviveNonFiniteNumbers);
+  }
+  const marker = sentinelMarker(value);
+  if (marker) {
+    return numberFor(marker);
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = reviveNonFiniteNumbers(child);
+  }
+  return out;
+}

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -24,6 +24,7 @@ import { Timer, defaultTimer } from "../SystemTimer";
 import type { FailureObservationSummary } from "../../models/FailureObservation";
 import { ScreenshotJobTracker } from "../ScreenshotJobTracker";
 import { isDeviceLostError } from "../../server/deviceLossOutcome";
+import { formatToolParamError } from "../../server/toolParamError";
 import { formatStructuredToolError } from "../formatStructuredToolError";
 import {
   summarizeObserveResultForFailure,
@@ -32,6 +33,19 @@ import {
 
 function formatToolError(error: unknown): string {
   return formatStructuredToolError(error) ?? String(error);
+}
+
+// The MCP boundary (`src/server/index.ts`) renders a schema `ZodError` through
+// `formatToolParamError` as "Invalid parameters for tool <name>: …". PlanExecutor
+// parses against the same tool schemas, so a validation failure on the plan path
+// must read identically instead of leaking the raw zod issue dump (#5854 §3).
+// Non-Zod errors fall through unchanged; the `instanceof ZodError` shape is left
+// intact for callers that branch on it (e.g. optional-step handling below).
+function formatStepError(toolName: string, error: unknown): string {
+  if (error instanceof ZodError) {
+    return `Invalid parameters for tool ${toolName}: ${formatToolParamError(toolName, error)}`;
+  }
+  return `${error}`;
 }
 
 type StepExecutionStatus = "completed" | "failed" | "skipped";
@@ -270,9 +284,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
       }
       return summarizeObserveResultForFailure(raw);
     } catch (error) {
+      // The observe schema parse above can throw a ZodError; render it the same
+      // way the MCP boundary does rather than leaking the raw issue dump (#5854).
       return {
         capturedAtMs: Date.now(),
-        observeError: errorMessage(error),
+        observeError:
+          error instanceof ZodError ? formatStepError("observe", error) : errorMessage(error),
       };
     }
   }
@@ -518,7 +535,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
       if (isDeviceLostError(error)) {
         throw error;
       }
-      const errorMsg = `${error}`;
+      const errorMsg = formatStepError(step.tool, error);
       if (step.optional && !context.signal?.aborted && !(error instanceof ZodError)) {
         this.logger.warn(
           `${context.logPrefix} optional step ${step.tool} threw; returning skipped status`,

--- a/test/daemon/clientNonFiniteEncoding.test.ts
+++ b/test/daemon/clientNonFiniteEncoding.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Duplex } from "node:stream";
+import { DaemonClient } from "../../src/daemon/client";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+// Issue #5854 §2: a non-finite tool-call argument must reach the daemon as a
+// JSON-safe sentinel, not `null`, so the request log and schema see the real
+// value. This pins the wire encoding at the client boundary.
+
+function createCapturingSocket(writes: string[]): Duplex {
+  return new Duplex({
+    read() {},
+    write(chunk, _encoding, callback) {
+      writes.push(chunk.toString());
+      callback();
+    },
+  });
+}
+
+function createConnectedClient(fakeTimer: FakeTimer, writes: string[]): DaemonClient {
+  const client = new DaemonClient(
+    "/fake/socket",
+    1000,
+    fakeTimer,
+    {},
+    null,
+    new CountingIdGenerator("req"),
+  );
+  (client as unknown as { connected: boolean }).connected = true;
+  (client as unknown as { socket: Duplex }).socket = createCapturingSocket(writes);
+  return client;
+}
+
+function firstFrame(writes: string[]): Record<string, unknown> {
+  const line = writes
+    .join("")
+    .split("\n")
+    .find((candidate) => candidate.trim().length > 0);
+  return JSON.parse(line!);
+}
+
+describe("DaemonClient encodes non-finite tool arguments on the wire", () => {
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+  });
+
+  test("Infinity/-Infinity/NaN are written as sentinels, not null", async () => {
+    const writes: string[] = [];
+    const client = createConnectedClient(fakeTimer, writes);
+
+    const pending = client
+      .callTool("tapOn", { duration: Infinity, back: -Infinity, ratio: NaN, ok: 3 })
+      .catch(() => {});
+
+    const frame = firstFrame(writes) as {
+      params: { arguments: Record<string, unknown> };
+    };
+    const args = frame.params.arguments;
+    expect(args.duration).toEqual({ __autoMobileNonFinite__: "Infinity" });
+    expect(args.back).toEqual({ __autoMobileNonFinite__: "-Infinity" });
+    expect(args.ratio).toEqual({ __autoMobileNonFinite__: "NaN" });
+    // A finite sibling is untouched, and nothing became null.
+    expect(args.ok).toBe(3);
+    expect(JSON.stringify(args)).not.toContain("null");
+
+    await client.close();
+    await pending;
+  });
+});

--- a/test/plan/planExecutorValidationError.test.ts
+++ b/test/plan/planExecutorValidationError.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod/v4";
+import { Plan } from "../../src/models/Plan";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerObserveTools } from "../../src/server/observeTools";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+
+// Issue #5854 §3: PlanExecutor called `tool.schema.parse(...)` directly, so a
+// ZodError surfaced unformatted (raw "expected number, received number") instead
+// of the same `formatToolParamError` rendering the MCP boundary produces. This
+// pins that the plan path now names the constraint the same way.
+describe("PlanExecutor validation error rendering (#5854)", () => {
+  let planExecutor: DefaultPlanExecutor;
+  const TOOL = "validationErrorTool5854";
+
+  beforeEach(() => {
+    planExecutor = new DefaultPlanExecutor();
+
+    ToolRegistry.register(
+      TOOL,
+      "requires a finite duration",
+      z.object({
+        platform: z.string().optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+        duration: z.number(),
+      }),
+      mock(async () => createStructuredToolResponse({ success: true })),
+    );
+    (ToolRegistry.getTool(TOOL) as { requiresDevice: boolean }).requiresDevice = true;
+
+    // The failure-observation `observe` capture also parses against a schema; stub
+    // it so it does not interfere with the assertion under test.
+    ToolRegistry.register(
+      "observe",
+      "failure observation",
+      z.object({
+        platform: z.string().optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      mock(async () =>
+        createStructuredToolResponse({ updatedAt: 0, activeWindow: { appId: "com.example" } }),
+      ),
+    );
+    (ToolRegistry.getTool("observe") as { requiresDevice: boolean }).requiresDevice = true;
+  });
+
+  afterEach(() => {
+    registerObserveTools();
+  });
+
+  test("a non-finite step param names the finite constraint with the MCP wording", async () => {
+    const plan: Plan = {
+      name: "non-finite-duration",
+      steps: [{ tool: TOOL, params: { duration: Infinity } }],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "android", "emulator-5554");
+
+    expect(result.success).toBe(false);
+    const error = result.failedStep?.error ?? "";
+    expect(error).toContain(`Invalid parameters for tool ${TOOL}`);
+    expect(error).toContain("duration must be a finite number");
+    expect(error).not.toContain("expected number, received number");
+  });
+});

--- a/test/server/nonFiniteReviveHandler.test.ts
+++ b/test/server/nonFiniteReviveHandler.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+
+// Issue #5854 §2: the daemon client encodes non-finite arguments as sentinels so
+// they survive the wire. The CallTool handler must revive them BEFORE schema
+// validation, so a sentinel-encoded Infinity is rejected as a real non-finite
+// number ("must be a finite number") rather than as a stray object.
+describe("CallTool handler revives non-finite sentinels before validation", () => {
+  let fixture: McpTestFixture;
+
+  beforeAll(async () => {
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+  });
+
+  test("a sentinel-encoded duration is rejected as a non-finite number", async () => {
+    const { client } = fixture.getContext();
+
+    const call = client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "tapOn",
+          arguments: {
+            platform: "android",
+            selector: { text: "Gmail" },
+            action: "longPress",
+            // The exact shape the daemon client puts on the wire for `Infinity`.
+            duration: { __autoMobileNonFinite__: "Infinity" },
+          },
+        },
+      },
+      z.object({}).passthrough(),
+    );
+
+    // The handler revives the sentinel to Infinity, so validation names the
+    // finite constraint instead of complaining about an object-typed duration.
+    await expect(call).rejects.toThrow(/duration must be a finite number/);
+  });
+});

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
 import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
+import { waitForSchema } from "../../src/server/observeTools";
 
 // Issue #4181, rank 7 (A6): the "container must be an object …" hint is
 // appended only for tapOn/swipeOn when a validation issue lands on the
@@ -133,5 +134,44 @@ describe("formatToolParamError non-finite numbers", () => {
     expect(formatToolParamError("tapOn", result.error)).toContain(
       "duration must be a finite number",
     );
+  });
+});
+
+// Issue #5854 §1: `waitForSchema` is a `z.union`, so a single bad field fails
+// every branch and `flattenZodIssues` surfaces one fragment per branch — the real
+// problem (`timeoutMs must be a finite number`) is buried among ~15
+// `expected <T>, received undefined` / `expected never, received …` fragments for
+// fields the caller never passed. The formatter must lead with the actionable
+// message and drop the union-branch discrimination noise.
+describe("formatToolParamError observe union noise (#5854)", () => {
+  test("a non-finite waitFor field leads with the finite constraint, no branch dump", () => {
+    const result = waitForSchema.safeParse({ timeoutMs: 1e999 } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    expect(message).toBe("timeoutMs must be a finite number");
+    expect(message).not.toContain("expected never");
+    expect(message).not.toContain("received undefined");
+  });
+
+  test("a wrong-type waitFor field leads with the type mismatch, deduplicated", () => {
+    const result = waitForSchema.safeParse({ timeoutMs: "abc" } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    expect(message).toBe("timeoutMs expected number, received string");
+  });
+
+  test("the actionable message is never repeated once per union branch", () => {
+    const result = waitForSchema.safeParse({ timeoutMs: 1e999 } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    const occurrences = message.split("must be a finite number").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("with no actionable field, falls back to the full guidance instead of an empty message", () => {
+    const result = waitForSchema.safeParse({} as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    expect(message.length).toBeGreaterThan(0);
   });
 });

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
 import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
 import { waitForSchema } from "../../src/server/observeTools";
+import { setPreferenceSchema } from "../../src/server/preferenceTools";
 
 // Issue #4181, rank 7 (A6): the "container must be an object …" hint is
 // appended only for tapOn/swipeOn when a validation issue lands on the
@@ -173,5 +174,50 @@ describe("formatToolParamError observe union noise (#5854)", () => {
     expect(result.success).toBe(false);
     const message = formatToolParamError("observe", result.error);
     expect(message.length).toBeGreaterThan(0);
+  });
+
+  // Regression (#5854, PR review): noise suppression must be scoped to issues that
+  // actually came from a union branch. `setPreferenceSchema` has top-level enums
+  // (`scope`, `type`) beside a union-typed `value`; the union failure must not
+  // suppress the sibling enum errors — those are the caller's real mistakes.
+  test("a union-typed field does not suppress genuine enum errors on sibling fields", () => {
+    const result = setPreferenceSchema.safeParse({
+      scope: "bogus",
+      key: "k",
+      type: "bogus",
+      value: {},
+    } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("setPreference", result.error);
+    // Both top-level enum failures survive alongside the union-valued failures.
+    expect(message).toContain("scope Invalid option");
+    expect(message).toContain("type Invalid option");
+    expect(message).toContain("value expected string");
+  });
+});
+
+// The union-noise classifier keys off zod v4's default issue shape: a missing
+// field leaves `received` unset and ends the message with "received undefined",
+// while a genuine wrong type ends with "received <type>". This pins that contract
+// so a future zod bump that changes the message shape fails loudly here rather
+// than silently regressing the suppression in `issueReportsMissingValue` (#5854).
+describe("zod v4 issue-shape contract the classifier depends on", () => {
+  const schema = z.object({ n: z.number() });
+
+  test("a missing field's message ends with 'received undefined'", () => {
+    const result = schema.safeParse({});
+    expect(result.success).toBe(false);
+    const issue = result.error!.issues[0];
+    expect(issue.code).toBe("invalid_type");
+    expect(issue.message).toMatch(/received undefined$/);
+  });
+
+  test("a genuine wrong type reports the type, not 'received undefined'", () => {
+    const result = schema.safeParse({ n: "x" });
+    expect(result.success).toBe(false);
+    const issue = result.error!.issues[0];
+    expect(issue.code).toBe("invalid_type");
+    expect(issue.message).toMatch(/received string$/);
+    expect(issue.message).not.toMatch(/received undefined$/);
   });
 });

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -194,6 +194,39 @@ describe("formatToolParamError observe union noise (#5854)", () => {
     expect(message).toContain("type Invalid option");
     expect(message).toContain("value expected string");
   });
+
+  // Regression (#5854, PR review): when the whole schema is a `z.union` and a
+  // required enum fails in EVERY branch (a shared constraint), it is the caller's
+  // real mistake and must survive — the fact that a sibling field also failed
+  // must not suppress it via the missing-branch fallback being unavailable.
+  test("an enum that fails in every branch of a top-level union is kept", () => {
+    const schema = z.union([
+      z.object({ id: z.string(), name: z.string(), kind: z.enum(["a", "b"]) }),
+      z.object({ id: z.string(), label: z.string(), kind: z.enum(["a", "b"]) }),
+    ]);
+    // `id` is wrong-typed and `kind` is a bad enum; both are required in both
+    // branches, so both are genuine and must appear.
+    const result = schema.safeParse({ id: 42, name: "n", kind: "BOGUS" } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("setKeyValue", result.error);
+    expect(message).toContain("id expected string, received number");
+    expect(message).toContain("kind Invalid option");
+  });
+
+  // The complement of the above: an enum that is only required on ONE branch (a
+  // discriminator the caller didn't supply) is branch noise and must NOT lead.
+  test("a discriminator required on only one branch is suppressed when a real error exists", () => {
+    const schema = z.union([
+      z.object({ mode: z.enum(["x", "y"]), shared: z.number() }),
+      z.object({ shared: z.number() }),
+    ]);
+    // `shared` is bad in both branches (genuine); `mode` is missing but required
+    // only on branch 0 (discrimination noise).
+    const result = schema.safeParse({ shared: 1e999 } as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    expect(message).toBe("shared must be a finite number");
+  });
 });
 
 // The union-noise classifier keys off zod v4's default issue shape: a missing

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -227,30 +227,34 @@ describe("formatToolParamError observe union noise (#5854)", () => {
     const message = formatToolParamError("observe", result.error);
     expect(message).toBe("shared must be a finite number");
   });
-});
 
-// The union-noise classifier keys off zod v4's default issue shape: a missing
-// field leaves `received` unset and ends the message with "received undefined",
-// while a genuine wrong type ends with "received <type>". This pins that contract
-// so a future zod bump that changes the message shape fails loudly here rather
-// than silently regressing the suppression in `issueReportsMissingValue` (#5854).
-describe("zod v4 issue-shape contract the classifier depends on", () => {
-  const schema = z.object({ n: z.number() });
-
-  test("a missing field's message ends with 'received undefined'", () => {
-    const result = schema.safeParse({});
+  // Regression (#5854, PR review): a required field MISSING from every branch of a
+  // top-level union is a genuine "you forgot a required field", not branch noise —
+  // it must survive alongside another provided-bad field, not be dropped.
+  test("a required field missing from every branch is kept", () => {
+    const schema = z.union([
+      z.object({ id: z.string(), key: z.string(), name: z.string() }),
+      z.object({ id: z.string(), key: z.string(), fileName: z.string() }),
+    ]);
+    // `id` is wrong-typed and `key` is missing; both branches require `key`, so the
+    // missing-`key` error is genuine and must appear next to the `id` error.
+    const result = schema.safeParse({ id: 42, name: "n" } as unknown as object);
     expect(result.success).toBe(false);
-    const issue = result.error!.issues[0];
-    expect(issue.code).toBe("invalid_type");
-    expect(issue.message).toMatch(/received undefined$/);
+    const message = formatToolParamError("setKeyValue", result.error);
+    expect(message).toContain("id expected string, received number");
+    expect(message).toContain("key expected string, received undefined");
   });
 
-  test("a genuine wrong type reports the type, not 'received undefined'", () => {
-    const result = schema.safeParse({ n: "x" });
+  // A missing field whose value type is ITSELF a union must not be mistaken for a
+  // shared constraint: every arm of the inner type-union reports it missing, which
+  // would look "universal" if coverage were measured at the nearest union instead
+  // of the outermost discriminating one. `observe`'s `waitFor.activeWindow` is such
+  // a field, so a bad `timeoutMs` must still lead alone (#5854).
+  test("a missing union-typed predicate is not resurrected as a shared constraint", () => {
+    const result = waitForSchema.safeParse({ timeoutMs: 1e999 } as unknown as object);
     expect(result.success).toBe(false);
-    const issue = result.error!.issues[0];
-    expect(issue.code).toBe("invalid_type");
-    expect(issue.message).toMatch(/received string$/);
-    expect(issue.message).not.toMatch(/received undefined$/);
+    const message = formatToolParamError("observe", result.error);
+    expect(message).toBe("timeoutMs must be a finite number");
+    expect(message).not.toContain("activeWindow");
   });
 });

--- a/test/utils/logger-redaction.test.ts
+++ b/test/utils/logger-redaction.test.ts
@@ -92,6 +92,35 @@ describe("safeStringify redacts sensitive data", () => {
   });
 });
 
+// Issue #5854 §2: the daemon request log serializes non-finite arguments
+// (Infinity/-Infinity/NaN) as `null`, because JSON has no representation for
+// them, so a caller debugging a rejected non-finite value sees `null` in the
+// trace and can't tell what was actually sent. safeStringify must render the
+// literal marker instead.
+describe("safeStringify preserves non-finite numbers (#5854)", () => {
+  test('renders a nested Infinity as the string "Infinity" instead of null', () => {
+    expect(safeStringify({ arguments: { duration: Infinity } })).toBe(
+      '{"arguments":{"duration":"Infinity"}}',
+    );
+  });
+
+  test('renders -Infinity as the string "-Infinity"', () => {
+    expect(safeStringify({ v: -Infinity })).toBe('{"v":"-Infinity"}');
+  });
+
+  test('renders NaN as the string "NaN"', () => {
+    expect(safeStringify({ v: NaN })).toBe('{"v":"NaN"}');
+  });
+
+  test("leaves finite numbers untouched", () => {
+    expect(safeStringify({ a: 0, b: -3.5, c: 1000 })).toBe('{"a":0,"b":-3.5,"c":1000}');
+  });
+
+  test("renders a top-level non-finite primitive via String() (unchanged)", () => {
+    expect(safeStringify(Infinity)).toBe("Infinity");
+  });
+});
+
 describe("SENSITIVE_ENV_KEYS", () => {
   test("includes the common secret-bearing environment key names", () => {
     expect(SENSITIVE_ENV_KEYS.has("PASSWORD")).toBe(true);

--- a/test/utils/nonFiniteJson.test.ts
+++ b/test/utils/nonFiniteJson.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { nonFiniteReplacer, reviveNonFiniteNumbers } from "../../src/utils/nonFiniteJson";
+
+// Issue #5854 §2: JSON has no representation for non-finite numbers, so a
+// tool-call argument that is Infinity/-Infinity/NaN is flattened to `null` before
+// the daemon can log or validate it. The client encodes them as JSON-safe
+// sentinels that survive the wire; the MCP handler revives them.
+
+const TAG = "__autoMobileNonFinite__";
+
+describe("nonFiniteReplacer encodes non-finite numbers as sentinels", () => {
+  test("Infinity/-Infinity/NaN become tagged objects on the wire", () => {
+    const wire = JSON.stringify(
+      { duration: Infinity, back: -Infinity, ratio: NaN, ok: 3, label: "hi" },
+      nonFiniteReplacer,
+    );
+    expect(JSON.parse(wire)).toEqual({
+      duration: { [TAG]: "Infinity" },
+      back: { [TAG]: "-Infinity" },
+      ratio: { [TAG]: "NaN" },
+      ok: 3,
+      label: "hi",
+    });
+  });
+
+  test("finite numbers (including -0 and large values) are left untouched", () => {
+    const wire = JSON.stringify({ a: 0, b: -0, c: -3.5, d: 1e308 }, nonFiniteReplacer);
+    // -0 serializes as 0 (unchanged from default JSON behavior).
+    expect(JSON.parse(wire)).toEqual({ a: 0, b: 0, c: -3.5, d: 1e308 });
+  });
+
+  test("non-finite values nested in arrays and objects are encoded", () => {
+    const wire = JSON.stringify({ xs: [1, Infinity], inner: { n: NaN } }, nonFiniteReplacer);
+    expect(JSON.parse(wire)).toEqual({
+      xs: [1, { [TAG]: "Infinity" }],
+      inner: { n: { [TAG]: "NaN" } },
+    });
+  });
+});
+
+describe("reviveNonFiniteNumbers restores the real numbers", () => {
+  test("round-trips through multiple JSON hops (socket + loopback HTTP)", () => {
+    const original = { params: { arguments: { duration: Infinity, x: -Infinity, y: NaN } } };
+    const wire = JSON.stringify(original, nonFiniteReplacer);
+    // Two further plain JSON hops model the daemon parse and the SDK HTTP transport.
+    const afterHops = JSON.parse(JSON.stringify(JSON.parse(wire)));
+    const revived = reviveNonFiniteNumbers(afterHops.params.arguments) as Record<string, number>;
+    expect(revived.duration).toBe(Infinity);
+    expect(revived.x).toBe(-Infinity);
+    expect(Number.isNaN(revived.y)).toBe(true);
+  });
+
+  test("a revived non-finite fails Number.isFinite, so the schema rejects it", () => {
+    const revived = reviveNonFiniteNumbers({ [TAG]: "Infinity" });
+    expect(typeof revived).toBe("number");
+    expect(Number.isFinite(revived as number)).toBe(false);
+  });
+
+  test("a payload with no sentinels is returned structurally unchanged", () => {
+    const input = { a: 1, b: "x", c: [1, 2, { d: true }], e: null };
+    expect(reviveNonFiniteNumbers(input)).toEqual(input);
+  });
+
+  test("an object that merely resembles a sentinel is not misdecoded", () => {
+    // Extra key → not a sentinel; unknown marker → not a sentinel.
+    expect(reviveNonFiniteNumbers({ [TAG]: "Infinity", extra: 1 })).toEqual({
+      [TAG]: "Infinity",
+      extra: 1,
+    });
+    expect(reviveNonFiniteNumbers({ [TAG]: "nope" })).toEqual({ [TAG]: "nope" });
+  });
+
+  test("primitives pass through", () => {
+    expect(reviveNonFiniteNumbers(5)).toBe(5);
+    expect(reviveNonFiniteNumbers("s")).toBe("s");
+    expect(reviveNonFiniteNumbers(null)).toBe(null);
+  });
+});

--- a/test/utils/nonFiniteJson.test.ts
+++ b/test/utils/nonFiniteJson.test.ts
@@ -75,4 +75,19 @@ describe("reviveNonFiniteNumbers restores the real numbers", () => {
     expect(reviveNonFiniteNumbers("s")).toBe("s");
     expect(reviveNonFiniteNumbers(null)).toBe(null);
   });
+
+  // Every tool request passes through this walk, so an own "__proto__" key in a
+  // valid payload (e.g. a header map) must be preserved as data, not routed to the
+  // prototype setter (which would drop it and could pollute the prototype).
+  test("an own __proto__ key is preserved as a data property, not the prototype", () => {
+    const parsed = JSON.parse('{"headers":{"__proto__":"keep","X-Ok":"1"}}') as {
+      headers: Record<string, unknown>;
+    };
+    const revived = reviveNonFiniteNumbers(parsed) as { headers: Record<string, unknown> };
+    expect(Object.prototype.hasOwnProperty.call(revived.headers, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(revived.headers, "__proto__")?.value).toBe("keep");
+    expect(revived.headers["X-Ok"]).toBe("1");
+    // The reconstructed object keeps a normal prototype (no pollution).
+    expect(Object.getPrototypeOf(revived.headers)).toBe(Object.prototype);
+  });
 });


### PR DESCRIPTION
## Summary

Three diagnostics/message-quality fixes on the numeric-validation surface,
follow-ups to [#5769](https://github.com/kaeawc/auto-mobile/issues/5769) /
[#5852](https://github.com/kaeawc/auto-mobile/pull/5852).

**1. `observe` no longer buries the real error in a union-branch dump.**
`waitForSchema` is a `z.union`, so one bad field failed every branch and the
actionable message was buried among ~15 branch-discrimination fragments.
`formatToolParamError` (moved to `src/server/toolParamError.ts`) now leads with
the genuine problem and drops the noise, using a principled rule: a union-derived
issue is genuine **iff its path fails in every branch of the outermost
(discriminating) union** — a shared constraint the caller must fix regardless of
intended branch. Branch-specific issues (a discriminator or a field the caller
omitted on one arm) are dropped; only structural `never` fields are pre-filtered.
Non-union sibling fields (e.g. a bad enum beside a union-typed field) are always
kept, and suppression falls back to the full list when it would leave nothing —
never worse than the raw dump it replaces.

```
observe { waitFor: { timeoutMs: 1e999 } }
-  for Invalid option: …; timeoutMs must be a finite number; textAny …; (×15 more)
+  timeoutMs must be a finite number
```

**2. The daemon request log now shows the actual non-finite value, not `null`.**
Two parts, both required:
- `safeStringify` (`src/utils/logger.ts`) renders in-memory non-finite numbers as
  `"Infinity"`/`"-Infinity"`/`"NaN"` instead of JSON's `null`.
- Transport preservation (`src/utils/nonFiniteJson.ts`): JSON-RPC cannot carry
  non-finite numbers, so a non-finite argument was flattened to `null` at the
  client→daemon socket (and again at the loopback StreamableHTTP hop) *before* the
  request log or the schema saw it. `DaemonClient` now encodes them as a JSON-safe
  sentinel `{ __autoMobileNonFinite__: "<marker>" }` that survives every
  intermediate `JSON.parse`/`stringify` (including the MCP SDK transport we can't
  hook), and the CallTool handler revives them before logging and validation — so
  the trace shows the real value and the schema names the finite constraint.

**3. `PlanExecutor` validation errors use the MCP-boundary rendering.**
The two `tool.schema.parse(...)` catch sites render a `ZodError` through the same
`formatToolParamError` as the MCP boundary (`Invalid parameters for tool <name>: …`),
preserving the `instanceof ZodError` shape so optional-step handling is unchanged.

## Linked Issue

Closes #5854

## Acceptance Criteria

- [x] `observe` non-finite/invalid-field errors lead with the actionable message rather than a union-branch dump.
- [x] Daemon request log shows the actual non-finite value instead of `null`.
- [x] `PlanExecutor` validation errors use the same `formatToolParamError` rendering as the MCP boundary.

## Validation

- [x] `bun test` — whole suite green except two pre-existing worktree-env artifacts (`oxlintConfigScoping` needs a local `node_modules/.bin/oxlint`; `#4343` webrtc subprocess), both unrelated to this diff
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — oxlint ratchet: no new violations; boundary checks pass
- [x] `bun run format:check` clean

## Testing

- `test/server/toolParamErrorHint.test.ts` — union noise leads with the actionable message; shared-constraint enums, universally-required missing fields, and non-union sibling enums are preserved; discriminators/nested-union-typed predicates are suppressed.
- `test/utils/logger-redaction.test.ts` — non-finite numbers render as string markers.
- `test/utils/nonFiniteJson.test.ts`, `test/daemon/clientNonFiniteEncoding.test.ts`, `test/server/nonFiniteReviveHandler.test.ts` — sentinel encode/revive round-trip across hops; client wire-encoding; handler revives a sentinel to a non-finite before validation.
- `test/plan/planExecutorValidationError.test.ts` — a non-finite plan-step param yields `Invalid parameters for tool <name>: duration must be a finite number`.

## Follow-ups

- [#5862](https://github.com/kaeawc/auto-mobile/issues/5862) — a narrower union-suppression edge: a provided-value error on a nested field valid only in the input's *viable* arms (where another arm rejects the field's parent as `never`) is still dropped. Message-quality only; never worse than the pre-existing dump.
