### PR TITLE
fix(ci): invalidate boundary bindings when a receiver method is replaced

### DIFF
--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -117,6 +117,11 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
   type InvocationExpression = ts.CallExpression | ts.NewExpression;
   const calls: ts.CallExpression[] = [];
   const invocations: InvocationExpression[] = [];
+  // Receiver method properties written or deleted somewhere (`config.configure = ...` or
+  // `delete config.configure`), keyed by receiver name and method name, scope-insensitively.
+  // A single such mutation is enough to stop trusting the class body for that receiver method:
+  // the call site may resolve to the replacement rather than the declared instance method.
+  const mutatedReceiverMethods = new Set<string>();
   const launcherAliases = new Set(PROCESS_LAUNCHERS);
   const executionSeamAliases = new Set(["executeCommand", "runExecSeam", "execute"]);
   const runExecSeamAliases = new Set(["runExecSeam"]);
@@ -435,6 +440,28 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
         });
       }
     }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      (ts.isPropertyAccessExpression(node.left) || ts.isElementAccessExpression(node.left)) &&
+      ts.isIdentifier(node.left.expression)
+    ) {
+      const method = propertyName(node.left);
+      if (method) {
+        mutatedReceiverMethods.add(`${node.left.expression.text}\u0000${method}`);
+      }
+    }
+    if (
+      ts.isDeleteExpression(node) &&
+      (ts.isPropertyAccessExpression(node.expression) ||
+        ts.isElementAccessExpression(node.expression)) &&
+      ts.isIdentifier(node.expression.expression)
+    ) {
+      const method = propertyName(node.expression);
+      if (method) {
+        mutatedReceiverMethods.add(`${node.expression.expression.text}\u0000${method}`);
+      }
+    }
     if (ts.isCallExpression(node)) {
       calls.push(node);
       invocations.push(node);
@@ -493,7 +520,12 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
       continue;
     }
     for (const method of classInstanceMethods) {
-      if (method.classDeclaration === classDeclaration) {
+      if (
+        method.classDeclaration === classDeclaration &&
+        // A `config.configure = ...` write (or delete) anywhere can replace the declared body,
+        // so the call site is no longer guaranteed to run it. Stay conservative and do not bind.
+        !mutatedReceiverMethods.has(`${binding.name}\u0000${method.name}`)
+      ) {
         functionBindings.push({
           name: method.name,
           node: method.node,

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -239,6 +239,30 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(
       findViolationsInSource(
         "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } const config=new Config(); config.configure=()=>{}; config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } const config=new Config(); config["configure"]=()=>{}; config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } const config=new Config(); delete config.configure; config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
+        'let runner=executor; class Config { configure(){runner=/x/;} } const config=new Config(); config.other=()=>{}; config.configure(); runner.exec("kill");',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findViolationsInSource(
+        "fixture.ts",
         'let runner = /x/; function configure(){ runner = executor; } unrelated(); runner.exec("kill");',
       ),
     ).toHaveLength(0);


### PR DESCRIPTION
## Summary

Follow-up to the review on [#5845](https://github.com/kaeawc/auto-mobile/pull/5845) (now merged). Closes a false-negative in the shared execution-boundary analyzer (`scripts/lib/executionBoundaryAst.ts`) surfaced by an automated reviewer.

#5845 taught the analyzer to follow directly-invoked instance methods, so an assignment inside a method body could prove a launcher receiver had been rebound to a harmless regex before a guarded `.exec(...)` call. That binding, however, survived a later replacement of the method property. For:

```ts
let runner = executor;
class Config { configure(){ runner = /x/; } }
const config = new Config();
config.configure = () => {};   // real body replaced with a no-op
config.configure();
runner.exec("kill");           // runner is still `executor` — a real launcher
```

the analyzer still attributed `config.configure()` to the declared `Config.configure` and silently suppressed the violation. The plain-function analog (`configure = () => {}; configure()`) was already handled; instance method-property writes were not.

## What changed

- Track `config.configure = ...` writes (property- and element-access) and `delete config.configure`, keyed by receiver name + method name, scope-insensitively.
- When binding class instance methods to a `new`-constructed receiver, skip any method whose property has been mutated anywhere. This mirrors the existing whole-receiver reassignment guard and keeps the analyzer on the conservative side of its contract ("cannot silently let an injected seam hide a prohibited launcher call").

## Tests

Added regressions to `test/lint/iosCtrlProxyProcessBoundary.test.ts`:
- property-access replacement, element-access replacement, and `delete` each now flag (1 violation);
- a control confirming an unrelated method mutation (`config.other = ...`) does **not** over-suppress the real call.

## Reviewer notes

- The two other reviewer comments on #5845 (conditionally-invoked calls, and `Promise.all` rejection under `try/catch`) were investigated and intentionally **not** changed here: both are pre-existing manifestations of the analyzer's documented scope-insensitive / try-catch-resumption behavior that apply equally to plain functions and plain `await` (not net-new from #5845), and the completion-inference is used symmetrically — a naive guard there would flip a launcher-*creating* case and hide a real launcher. A sound fix requires reworking the single-effective-binding model and is out of scope for this follow-up.

## Validation

- `bun test test/lint/iosCtrlProxyProcessBoundary.test.ts` (5 pass / 64 expects)
- `bun run format:check`
- `bun run lint` (no new ratchet violations; 13/13 boundary-checks pass)
- `bun run typecheck` gate passes