### PR TITLE
fix(navigation): scope remaining telemetry screenshot URIs by appId (follow-up to #5600)

### DIFF
--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -14,6 +14,7 @@ import type { Database } from "../db/types";
 import type { Kysely } from "kysely";
 import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 import { truncateBodyText, boundStructuredField } from "../utils/truncateBodyText";
+import { buildNavigationNodeScreenshotUri } from "../utils/navigationResourceUri";
 import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
 
 /**
@@ -266,7 +267,10 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             .execute();
           for (const node of nodes) {
             const key = `${node.app_id}:${node.screen_name}`;
-            screenshotUris.set(key, `automobile:navigation/nodes/${node.id}/screenshot`);
+            // Scope by the node's app_id (already selected) so a telemetry client
+            // following this URI resolves the screenshot under the named app, not
+            // the daemon's current foreground app (#5851 / #5534).
+            screenshotUris.set(key, buildNavigationNodeScreenshotUri(node.id, node.app_id));
           }
         } catch {
           /* best-effort screenshot URI lookup */

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -20,6 +20,7 @@ import { serverConfig } from "../../../utils/ServerConfig";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import { getDbWriteBarrier } from "../../../db/dbWriteBarrier";
 import type { NavigationEvent } from "../../../utils/interfaces/NavigationGraph";
+import { buildNavigationNodeScreenshotUri } from "../../../utils/navigationResourceUri";
 import type { ViewHierarchyResult } from "../../../models";
 import type { SdkEvent, SdkEventIngestor } from "../interfaces/SdkEventIngestor";
 import type { CtrlProxyScreenshotResult } from "./types";
@@ -201,7 +202,10 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
                         .where("screen_name", "=", destination)
                         .executeTakeFirst();
                       if (node) {
-                        screenshotUri = `automobile:navigation/nodes/${node.id}/screenshot`;
+                        // Scope by applicationId (in scope) so a cross-app client
+                        // resolves this node's screenshot under the named app, not
+                        // the daemon's current foreground app (#5851 / #5534).
+                        screenshotUri = buildNavigationNodeScreenshotUri(node.id, applicationId);
                       }
                     } catch {
                       /* non-fatal */

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -742,3 +742,103 @@ describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
     });
   });
 });
+
+/**
+ * Regression (#5851, follow-up to #5600/#5534/#4933): the navigation backfill
+ * push must carry the app-SCOPED screenshot URI (`?appId=<app>`), built via
+ * `buildNavigationNodeScreenshotUri(node.id, node.app_id)`. An unscoped URI
+ * resolves against the daemon's current foreground app — a telemetry-dashboard
+ * client following it while a different app is foregrounded gets the wrong
+ * app's screenshot or "No current app set". The `app_id` is already SELECTed at
+ * the node lookup, so scoping is free.
+ */
+describe("TelemetryPushSocketServer navigation screenshot URI scoping (#5851)", () => {
+  it("backfills a navigation event with an app-scoped screenshot URI", async () => {
+    await withInMemorySingletonDatabase(async () => {
+      const db = getDatabase() as unknown as Kysely<Database>;
+      await runMigrations(db as unknown as Kysely<unknown>);
+
+      const APP_B = "com.example.b";
+      await db
+        .insertInto("navigation_apps")
+        .values([{ app_id: "com.example.a" }, { app_id: APP_B }])
+        .execute();
+
+      // Colliding "Home" node under app A (a different app) — the same
+      // cross-app collision #5534 fixed in the resolver but left in this emitter.
+      await db
+        .insertInto("navigation_nodes")
+        .values({
+          app_id: "com.example.a",
+          screen_name: "Home",
+          first_seen_at: 1000,
+          last_seen_at: 1000,
+          visit_count: 1,
+          back_stack_depth: null,
+          task_id: null,
+          screenshot_path: "/screens/com.example.a/Home.webp",
+        })
+        .execute();
+      const homeB = await db
+        .insertInto("navigation_nodes")
+        .values({
+          app_id: APP_B,
+          screen_name: "Home",
+          first_seen_at: 1000,
+          last_seen_at: 1000,
+          visit_count: 1,
+          back_stack_depth: null,
+          task_id: null,
+          screenshot_path: "/screens/com.example.b/Home.webp",
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+
+      await db
+        .insertInto("navigation_events")
+        .values({
+          device_id: "emulator-5554",
+          timestamp: 2000,
+          application_id: APP_B,
+          session_id: "session-b",
+          destination: "Home",
+          source: null,
+          arguments_json: null,
+          metadata_json: null,
+        })
+        .execute();
+
+      const server = new TestableTelemetryPushSocketServer(new FakeTimer());
+      const socket = new FakeSocket();
+      const filter = {
+        category: "navigation",
+        deviceSessionUuid: null,
+        deviceId: "emulator-5554",
+        sessionId: null,
+      };
+      (server as any).subscribers.set("nav-scope", {
+        socket: socket as unknown as Socket,
+        subscriptionId: "nav-scope",
+        lastActivity: 0,
+        filter,
+        backfilling: true,
+        drainPending: false,
+      });
+
+      await (server as any).backfillRecentEvents(
+        "nav-scope",
+        filter,
+        socket as unknown as Socket,
+      );
+
+      const messages = socket.getWrittenMessages<{
+        data: TelemetryEvent & { data: { screenshotUri: string | null } };
+      }>();
+      const nav = messages.find((m) => m.data.category === "navigation");
+      expect(nav).toBeDefined();
+      expect(nav!.data.data.screenshotUri).toBe(
+        `automobile:navigation/nodes/${homeB.id}/screenshot?appId=com.example.b`,
+      );
+    });
+  });
+});

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -825,11 +825,7 @@ describe("TelemetryPushSocketServer navigation screenshot URI scoping (#5851)", 
         drainPending: false,
       });
 
-      await (server as any).backfillRecentEvents(
-        "nav-scope",
-        filter,
-        socket as unknown as Socket,
-      );
+      await (server as any).backfillRecentEvents("nav-scope", filter, socket as unknown as Socket);
 
       const messages = socket.getWrittenMessages<{
         data: TelemetryEvent & { data: { screenshotUri: string | null } };

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -10,6 +10,12 @@ import type { CtrlProxyScreenshotResult } from "../../../../src/features/observe
 import type { ViewHierarchyResult } from "../../../../src/models";
 import type { NavigationEvent } from "../../../../src/utils/interfaces/NavigationGraph";
 import { FakeFailureRecorder } from "../../../fakes/FakeFailureRecorder";
+import { NavigationScreenshotManager } from "../../../../src/features/navigation/NavigationScreenshotManager";
+import { withInMemorySingletonDatabase } from "../../../db/inMemorySingletonDatabase";
+import { getDatabase } from "../../../../src/db/database";
+import { runMigrations } from "../../../../src/db/migrator";
+import type { Database } from "../../../../src/db/types";
+import type { Kysely } from "kysely";
 
 const DEVICE_ID = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890";
 
@@ -490,6 +496,85 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect(
       (recorder.navigation[0].event as { screenshotUri: string | null }).screenshotUri,
     ).toBeNull();
+  });
+
+  /**
+   * Regression (#5851, follow-up to #5600/#5534/#4933): when a screenshot is
+   * captured and stored, the telemetry event's screenshotUri must be the
+   * app-SCOPED resource URI (`?appId=<applicationId>`), built via
+   * buildNavigationNodeScreenshotUri(node.id, applicationId). An unscoped URI
+   * resolves against the daemon's current foreground app, so a client following
+   * it while another app is foregrounded gets the wrong app's screenshot.
+   */
+  test("navigation screenshot URI is scoped by applicationId (#5851)", async () => {
+    await withInMemorySingletonDatabase(async () => {
+      const db = getDatabase() as unknown as Kysely<Database>;
+      await runMigrations(db as unknown as Kysely<unknown>);
+
+      await db
+        .insertInto("navigation_apps")
+        .values([{ app_id: "com.other" }, { app_id: "com.app" }])
+        .execute();
+
+      // Colliding "Home" node under a different app to make scoping meaningful.
+      await db
+        .insertInto("navigation_nodes")
+        .values({
+          app_id: "com.other",
+          screen_name: "Home",
+          first_seen_at: 1000,
+          last_seen_at: 1000,
+          visit_count: 1,
+          back_stack_depth: null,
+          task_id: null,
+          screenshot_path: "/screens/com.other/Home.webp",
+        })
+        .execute();
+      const node = await db
+        .insertInto("navigation_nodes")
+        .values({
+          app_id: "com.app",
+          screen_name: "Home",
+          first_seen_at: 1000,
+          last_seen_at: 1000,
+          visit_count: 1,
+          back_stack_depth: null,
+          task_id: null,
+          screenshot_path: "/screens/com.app/Home.webp",
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+
+      const screenshotManagerSpy = spyOn(NavigationScreenshotManager, "getInstance").mockReturnValue(
+        {
+          storeScreenshot: async () => "/screens/com.app/Home.webp",
+        } as unknown as NavigationScreenshotManager,
+      );
+
+      try {
+        const withScreenshots = new DefaultIosSdkEventIngestor({
+          deviceId: DEVICE_ID,
+          getNavigationGraphManager: () => navSink,
+          captureScreenshot: async (): Promise<CtrlProxyScreenshotResult> => ({
+            success: true,
+            data: "AAAA",
+            format: "png",
+          }),
+          telemetryRecorder: recorder as unknown as IosTelemetryRecorder,
+          failureRecorder,
+          navigationScreenshotsEnabled: () => true,
+        });
+
+        await withScreenshots.recordSdkEvent(event("navigation", { destination: "Home" }), "com.app");
+
+        expect(recorder.navigation).toHaveLength(1);
+        expect(
+          (recorder.navigation[0].event as { screenshotUri: string | null }).screenshotUri,
+        ).toBe(`automobile:navigation/nodes/${node.id}/screenshot?appId=com.app`);
+      } finally {
+        screenshotManagerSpy.mockRestore();
+      }
+    });
   });
 
   test("handled_exception routes to failure recorder as non-fatal", async () => {

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -545,11 +545,12 @@ describe("DefaultIosSdkEventIngestor", () => {
         .returning("id")
         .executeTakeFirstOrThrow();
 
-      const screenshotManagerSpy = spyOn(NavigationScreenshotManager, "getInstance").mockReturnValue(
-        {
-          storeScreenshot: async () => "/screens/com.app/Home.webp",
-        } as unknown as NavigationScreenshotManager,
-      );
+      const screenshotManagerSpy = spyOn(
+        NavigationScreenshotManager,
+        "getInstance",
+      ).mockReturnValue({
+        storeScreenshot: async () => "/screens/com.app/Home.webp",
+      } as unknown as NavigationScreenshotManager);
 
       try {
         const withScreenshots = new DefaultIosSdkEventIngestor({
@@ -565,7 +566,10 @@ describe("DefaultIosSdkEventIngestor", () => {
           navigationScreenshotsEnabled: () => true,
         });
 
-        await withScreenshots.recordSdkEvent(event("navigation", { destination: "Home" }), "com.app");
+        await withScreenshots.recordSdkEvent(
+          event("navigation", { destination: "Home" }),
+          "com.app",
+        );
 
         expect(recorder.navigation).toHaveLength(1);
         expect(


### PR DESCRIPTION
## Summary

Follow-up to [#5600](https://github.com/kaeawc/auto-mobile/issues/5600) / [PR #5847](https://github.com/kaeawc/auto-mobile/pull/5847). Two telemetry emitters still built the legacy **unscoped** node-screenshot URI even though the `appId`/`applicationId` was already in scope. This routes both through the existing `buildNavigationNodeScreenshotUri(node.id, appId)` helper so every emitter produces the identical app-scoped shape.

## Linked Issue

Closes #5851

## Bug / Regression Context

- **Prior attempts:** [#5600](https://github.com/kaeawc/auto-mobile/issues/5600) / [PR #5847](https://github.com/kaeawc/auto-mobile/pull/5847) centralized the URI in `buildNavigationNodeScreenshotUri` and scoped the exported graph summary + `recordNavigationEvent` emitter, but explicitly left these two out of its named scope.
- **Observed symptom:** a telemetry-dashboard client that follows one of these URIs while a different app is foregrounded resolves against `getCurrentAppId()` → the wrong app's screenshot or `No current app set` (same cross-app failure as #5534/#4933).
- **Repro conditions:** two apps sharing a screen name; browse app B's telemetry while app A is foregrounded.

## Changes

- `src/features/observe/ios/IosSdkEventIngestor.ts` — pass `applicationId` (in scope) at the nav-screenshot node lookup.
- `src/daemon/telemetryPushSocketServer.ts` — pass `node.app_id` (already SELECTed) at the backfill push.

## Validation

- [x] `bun test` for both touched suites green; full suite green except one **pre-existing, unrelated** flake in `test/integration/webrtcDeviceCaptureLatency.test.ts` (it greps a child `bun test`'s stdout for a `(skip) ...` line that bun 1.3.14 no longer emits — touches no navigation code).
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] `bun run lint` — no new ratchet violations.
- [x] New tests use in-memory singleton DB + fakes; run in <100ms.

## Acceptance criteria

- [x] Route `IosSdkEventIngestor.ts` emitter through `buildNavigationNodeScreenshotUri(node.id, applicationId)`.
- [x] Route `telemetryPushSocketServer.ts` emitter through `buildNavigationNodeScreenshotUri(node.id, app_id)`.
- [x] Regression assertion for each path (cross-app collision → correct `?appId=` scope).
- [x] Confirmed no consumer relies on the bare form — remaining bare literals are only the resolver's own URI templates (the resolution targets) and the helper itself.
