### PR TITLE
fix(server): quiet observe union-error noise, log non-finite values, unify PlanExecutor validation (#5854)

### DIFF
--- a/src/server/formatToolParamError.ts
+++ b/src/server/formatToolParamError.ts
@@ -1,0 +1,128 @@
+import { ZodError, type ZodIssue } from "zod/v4";
+
+export function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
+  const flattened: ZodIssue[] = [];
+
+  const visit = (issue: ZodIssue) => {
+    if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
+      issue.errors.forEach((unionIssues) => {
+        unionIssues.forEach((unionIssue) => {
+          const normalizedIssue = issue.path.length
+            ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
+            : unionIssue;
+          visit(normalizedIssue as ZodIssue);
+        });
+      });
+      return;
+    }
+    flattened.push(issue);
+  };
+
+  issues.forEach(visit);
+  return flattened;
+}
+
+// A `z.union` reports every branch's failure, so a single bad field expands into
+// one issue per branch plus a "presence" artifact for every field the branch
+// required but the caller never passed (`<field> expected <type>, received
+// undefined`) or forbade (`expected never`). Rank issues so the caller's real
+// mistake leads and those branch artifacts sink to the end (issue #5854):
+//   0 — a concrete value error on a field the caller actually provided.
+//   1 — an enum `invalid_value`: usually a union discriminant that failed only
+//       because the caller selected a different branch; still shown, just not
+//       ahead of a concrete value error.
+//   2 — a missing/prohibited-field artifact of an unselected branch.
+// Ranking only reorders; a single-issue error is unaffected, so a genuine enum
+// or missing-field error still leads when it is the only thing wrong.
+function issuePriority(issue: ZodIssue): number {
+  if (issue.code === "invalid_type") {
+    if (issue.expected === "never") {
+      return 2;
+    }
+    const received = (issue as { received?: unknown }).received;
+    if (received === "undefined") {
+      return 2;
+    }
+  }
+  if (typeof issue.message === "string" && issue.message.endsWith("received undefined")) {
+    return 2;
+  }
+  if (issue.code === "invalid_value") {
+    return 1;
+  }
+  return 0;
+}
+
+function renderIssueMessage(issue: ZodIssue): string {
+  const path = issue.path.length ? issue.path.join(".") : "parameters";
+  if (issue.code === "invalid_type") {
+    // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
+    // `z.number()` check, so no `.finite()` refinement can carry a custom
+    // message. Those surface as an invalid_type whose value is still a number
+    // (`received` is "Infinity"/"NaN", or "number" from a typeof-based error
+    // map), collapsing the default text to the self-contradictory "expected
+    // number, received number". A finite number never trips invalid_type, so
+    // any of these markers means non-finite — name the real constraint (#5769).
+    const received = (issue as { received?: unknown }).received;
+    if (
+      issue.expected === "number" &&
+      (received === "Infinity" || received === "NaN" || received === "number")
+    ) {
+      return `${path} must be a finite number`;
+    }
+    // zod v4 issues otherwise carry a usable default message that already
+    // reads "Invalid input: expected X, received Y", so reuse it minus the
+    // prefix to keep the historical "<path> expected X" format.
+    return `${path} ${issue.message.replace(/^Invalid input: /, "")}`;
+  }
+  return `${path} ${issue.message}`;
+}
+
+// Exported for direct unit testing of the container-hint branch (issue #4181,
+// rank 7). The hint is only appended for tapOn/swipeOn container issues.
+export function formatToolParamError(toolName: string, error: unknown): string {
+  if (!(error instanceof ZodError)) {
+    return String(error);
+  }
+
+  const flattenedIssues = flattenZodIssues(error.issues);
+
+  // Stable-sort by priority (Array.prototype.sort is stable) so first-seen order
+  // is preserved within each tier, then dedup identical rendered fragments — a
+  // union surfaces the same real error from several branches.
+  const ordered = flattenedIssues
+    .slice()
+    .sort((a, b) => issuePriority(a) - issuePriority(b));
+
+  const seen = new Set<string>();
+  const issues: string[] = [];
+  for (const issue of ordered) {
+    const message = renderIssueMessage(issue);
+    if (seen.has(message)) {
+      continue;
+    }
+    seen.add(message);
+    issues.push(message);
+  }
+
+  const hints: string[] = [];
+  if (toolName === "swipeOn" || toolName === "tapOn") {
+    const containerIssue = flattenedIssues.find((issue) => issue.path[0] === "container");
+    if (containerIssue) {
+      hints.push(
+        'container must be an object like { "elementId": "<id>" } or { "text": "<text>" }',
+      );
+    }
+  }
+
+  const issueSummary = issues.join("; ");
+  const hintSummary = hints.length > 0 ? ` Hint: ${hints.join(" ")}` : "";
+  return `${issueSummary}${hintSummary}`;
+}
+
+// The single "Invalid parameters for tool <name>: <formatted>" rendering used at
+// the MCP call boundary (src/server/index.ts) and the plan-execution path
+// (PlanExecutor), so a validation failure reads identically on both (#5854 AC3).
+export function invalidParamsMessage(toolName: string, error: unknown): string {
+  return `Invalid parameters for tool ${toolName}: ${formatToolParamError(toolName, error)}`;
+}

--- a/src/server/formatToolParamError.ts
+++ b/src/server/formatToolParamError.ts
@@ -1,6 +1,6 @@
 import { ZodError, type ZodIssue } from "zod/v4";
 
-export function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
+function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
   const flattened: ZodIssue[] = [];
 
   const visit = (issue: ZodIssue) => {
@@ -90,9 +90,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
   // Stable-sort by priority (Array.prototype.sort is stable) so first-seen order
   // is preserved within each tier, then dedup identical rendered fragments — a
   // union surfaces the same real error from several branches.
-  const ordered = flattenedIssues
-    .slice()
-    .sort((a, b) => issuePriority(a) - issuePriority(b));
+  const ordered = flattenedIssues.slice().sort((a, b) => issuePriority(a) - issuePriority(b));
 
   const seen = new Set<string>();
   const issues: string[] = [];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { ZodError, type ZodIssue } from "zod/v4";
+import { invalidParamsMessage } from "./formatToolParamError";
+// Re-exported so existing consumers/tests keep importing it from the server entry.
+export { formatToolParamError } from "./formatToolParamError";
 import { ActionableError } from "../models";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -184,75 +186,6 @@ function stripInternalToolParams(params: unknown): unknown {
   return rest;
 }
 
-function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
-  const flattened: ZodIssue[] = [];
-
-  const visit = (issue: ZodIssue) => {
-    if (issue.code === "invalid_union" && Array.isArray(issue.errors) && issue.errors.length) {
-      issue.errors.forEach((unionIssues) => {
-        unionIssues.forEach((unionIssue) => {
-          const normalizedIssue = issue.path.length
-            ? { ...unionIssue, path: [...issue.path, ...unionIssue.path] }
-            : unionIssue;
-          visit(normalizedIssue as ZodIssue);
-        });
-      });
-      return;
-    }
-    flattened.push(issue);
-  };
-
-  issues.forEach(visit);
-  return flattened;
-}
-
-// Exported for direct unit testing of the container-hint branch (issue #4181,
-// rank 7). The hint is only appended for tapOn/swipeOn container issues.
-export function formatToolParamError(toolName: string, error: unknown): string {
-  if (!(error instanceof ZodError)) {
-    return String(error);
-  }
-
-  const flattenedIssues = flattenZodIssues(error.issues);
-  const issues = flattenedIssues.map((issue) => {
-    const path = issue.path.length ? issue.path.join(".") : "parameters";
-    if (issue.code === "invalid_type") {
-      // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
-      // `z.number()` check, so no `.finite()` refinement can carry a custom
-      // message. Those surface as an invalid_type whose value is still a number
-      // (`received` is "Infinity"/"NaN", or "number" from a typeof-based error
-      // map), collapsing the default text to the self-contradictory "expected
-      // number, received number". A finite number never trips invalid_type, so
-      // any of these markers means non-finite — name the real constraint (#5769).
-      const received = (issue as { received?: unknown }).received;
-      if (
-        issue.expected === "number" &&
-        (received === "Infinity" || received === "NaN" || received === "number")
-      ) {
-        return `${path} must be a finite number`;
-      }
-      // zod v4 issues otherwise carry a usable default message that already
-      // reads "Invalid input: expected X, received Y", so reuse it minus the
-      // prefix to keep the historical "<path> expected X" format.
-      return `${path} ${issue.message.replace(/^Invalid input: /, "")}`;
-    }
-    return `${path} ${issue.message}`;
-  });
-
-  const hints: string[] = [];
-  if (toolName === "swipeOn" || toolName === "tapOn") {
-    const containerIssue = flattenedIssues.find((issue) => issue.path[0] === "container");
-    if (containerIssue) {
-      hints.push(
-        'container must be an object like { "elementId": "<id>" } or { "text": "<text>" }',
-      );
-    }
-  }
-
-  const issueSummary = issues.join("; ");
-  const hintSummary = hints.length > 0 ? ` Hint: ${hints.join(" ")}` : "";
-  return `${issueSummary}${hintSummary}`;
-}
 
 /**
  * Populate the canonical production registry and validate exact-tool startup
@@ -638,9 +571,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     try {
       parsedParams = tool.schema.parse(stripInternalToolParams(toolParams));
     } catch (error) {
-      throw new ActionableError(
-        `Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`,
-      );
+      throw new ActionableError(invalidParamsMessage(name, error));
     }
 
     const executionSessionUuid =

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -186,7 +186,6 @@ function stripInternalToolParams(params: unknown): unknown {
   return rest;
 }
 
-
 /**
  * Populate the canonical production registry and validate exact-tool startup
  * defaults. The process entrypoint calls this before opening daemon listeners;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -308,6 +308,13 @@ const safeStringify = (obj: any): string => {
   const ancestors: Array<{ holder: object; original: object }> = [];
   try {
     return JSON.stringify(obj, function (this: unknown, _key, value) {
+      // JSON can't represent non-finite numbers, so JSON.stringify coerces them
+      // to `null` — which hid the offending value in daemon request logs (a
+      // rejected `duration: Infinity` argument showed as `null`). Emit the marker
+      // instead so the trace shows what the caller actually sent (#5854).
+      if (typeof value === "number" && !Number.isFinite(value)) {
+        return Number.isNaN(value) ? "NaN" : value > 0 ? "Infinity" : "-Infinity";
+      }
       if (typeof value === "object" && value !== null) {
         // Unwind the path back to this value's holder before testing/pushing, so
         // siblings don't inherit each other's descendants as false ancestors.

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -24,6 +24,7 @@ import { Timer, defaultTimer } from "../SystemTimer";
 import type { FailureObservationSummary } from "../../models/FailureObservation";
 import { ScreenshotJobTracker } from "../ScreenshotJobTracker";
 import { isDeviceLostError } from "../../server/deviceLossOutcome";
+import { invalidParamsMessage } from "../../server/formatToolParamError";
 import { formatStructuredToolError } from "../formatStructuredToolError";
 import {
   summarizeObserveResultForFailure,
@@ -32,6 +33,16 @@ import {
 
 function formatToolError(error: unknown): string {
   return formatStructuredToolError(error) ?? String(error);
+}
+
+// A schema validation error is a plan-authoring mistake that must stay fatal even
+// for optional steps. `parseToolParams` now rewraps the ZodError as a formatted
+// ActionableError (keeping the ZodError as `cause`), so classify both forms.
+function isSchemaValidationError(error: unknown): boolean {
+  return (
+    error instanceof ZodError ||
+    (error instanceof ActionableError && error.cause instanceof ZodError)
+  );
 }
 
 type StepExecutionStatus = "completed" | "failed" | "skipped";
@@ -94,6 +105,30 @@ export class DefaultPlanExecutor implements PlanExecutor {
   constructor(timer: Timer = defaultTimer, loggerInstance: Logger = logger) {
     this.timer = timer;
     this.logger = loggerInstance;
+  }
+
+  /**
+   * Validate step params against a tool schema, routing any `ZodError` through
+   * the same `formatToolParamError` rendering the MCP call boundary uses so a
+   * non-finite/invalid value reads identically on the plan path instead of
+   * surfacing the raw, self-contradictory zod default (issue #5854 AC3).
+   */
+  private parseToolParams(
+    toolName: string,
+    schema: { parse: (value: unknown) => unknown },
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    try {
+      return schema.parse(params) as Record<string, unknown>;
+    } catch (error) {
+      if (error instanceof ZodError) {
+        // Keep the ZodError as `cause` so the optional-step guard still classifies
+        // this as a plan-authoring schema error (stays fatal) even though the
+        // thrown value is now the formatted ActionableError.
+        throw new ActionableError(invalidParamsMessage(toolName, error), { cause: error });
+      }
+      throw error;
+    }
   }
 
   /**
@@ -249,7 +284,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
       // (`observe` always resets it). This capture is for the plan's failure
       // summary, not shown to the agent. Parse against the tool schema first, then
       // pass the resolved tool to the seam so the timeout race stays local.
-      const parsedParams = observeTool.schema.parse(enhancedParams) as Record<string, unknown>;
+      const parsedParams = this.parseToolParams(observeTool.name, observeTool.schema, enhancedParams);
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const response = await Promise.race([
@@ -396,7 +431,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
       // below so finalize emits the full observation on the step envelope - never
       // a diff or a stripped payload - regardless of
       // `--actions-diff-observe`/`--actions-no-observe`.
-      const parsedParams = tool.schema.parse(enhancedParams) as Record<string, unknown>;
+      const parsedParams = this.parseToolParams(tool.name, tool.schema, enhancedParams);
 
       if (context.deviceId) {
         ScreenshotJobTracker.cancelJob(context.deviceId);
@@ -519,7 +554,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         throw error;
       }
       const errorMsg = `${error}`;
-      if (step.optional && !context.signal?.aborted && !(error instanceof ZodError)) {
+      if (step.optional && !context.signal?.aborted && !isSchemaValidationError(error)) {
         this.logger.warn(
           `${context.logPrefix} optional step ${step.tool} threw; returning skipped status`,
           error,

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -284,7 +284,11 @@ export class DefaultPlanExecutor implements PlanExecutor {
       // (`observe` always resets it). This capture is for the plan's failure
       // summary, not shown to the agent. Parse against the tool schema first, then
       // pass the resolved tool to the seam so the timeout race stays local.
-      const parsedParams = this.parseToolParams(observeTool.name, observeTool.schema, enhancedParams);
+      const parsedParams = this.parseToolParams(
+        observeTool.name,
+        observeTool.schema,
+        enhancedParams,
+      );
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const response = await Promise.race([

--- a/test/plan/planExecutorValidationFormatting.test.ts
+++ b/test/plan/planExecutorValidationFormatting.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerInteractionTools } from "../../src/server/interactionTools";
+import { z } from "zod/v4";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+
+// Issue #5854, AC3: PlanExecutor called `tool.schema.parse(...)` directly, so a
+// ZodError surfaced raw (the self-contradictory "expected number, received
+// number" for a non-finite value) instead of the MCP boundary's formatted
+// message. The plan path must render validation errors the same way.
+describe("PlanExecutor validation errors match the MCP boundary rendering", () => {
+  afterEach(() => {
+    registerInteractionTools();
+  });
+
+  test("a non-finite param yields the formatted finite-number message", async () => {
+    const schema = z.object({
+      value: z.number(),
+      platform: z.string().optional(),
+      deviceId: z.string().optional(),
+      sessionUuid: z.string().optional(),
+    });
+    const handler = mock(async () =>
+      createStructuredToolResponse({ success: true, message: "ok" }),
+    );
+    ToolRegistry.register("mockNum", "Mock numeric tool", schema, handler);
+
+    const plan: Plan = {
+      name: "validation-plan",
+      steps: [{ tool: "mockNum", params: { value: Infinity } }],
+    };
+
+    const planExecutor = new DefaultPlanExecutor();
+    const result = await planExecutor.executePlan(plan, 0, "android", "emulator-5554");
+
+    expect(result.success).toBe(false);
+    const serialized = JSON.stringify(result);
+    // Same "Invalid parameters for tool <name>: <formatted>" rendering the MCP
+    // boundary produces, and the finite-number constraint is named.
+    expect(serialized).toContain("Invalid parameters for tool mockNum");
+    expect(serialized).toContain("value must be a finite number");
+    // Never the raw, self-contradictory zod default.
+    expect(serialized).not.toContain("expected number, received number");
+    // The tool handler must never run when validation fails.
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
 import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
+import { observeSchema } from "../../src/server/observeTools";
 
 // Issue #4181, rank 7 (A6): the "container must be an object …" hint is
 // appended only for tapOn/swipeOn when a validation issue lands on the
@@ -133,5 +134,60 @@ describe("formatToolParamError non-finite numbers", () => {
     expect(formatToolParamError("tapOn", result.error)).toContain(
       "duration must be a finite number",
     );
+  });
+});
+
+// Issue #5854, AC1: `observe`'s `waitForSchema` is a `z.union`, so a single bad
+// field produces one issue per union branch — plus per-branch "presence"
+// artifacts (`<field> expected <type>, received undefined`) for every field the
+// caller never passed. The formatter must dedup repeated fragments and reorder so
+// the actionable message leads instead of being buried in the branch dump.
+describe("formatToolParamError union noise (observe waitFor)", () => {
+  test("non-finite waitFor.timeoutMs leads with the finite-number message", () => {
+    const result = observeSchema.safeParse({
+      platform: "android",
+      waitFor: { timeoutMs: Infinity },
+    });
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    const fragments = message.split("; ");
+
+    // The actionable message must be the first fragment, not buried.
+    expect(fragments[0]).toBe("waitFor.timeoutMs must be a finite number");
+
+    // Deduped: the finite-number fragment appears exactly once even though the
+    // union surfaces it in three branches.
+    const finiteCount = fragments.filter(
+      (f) => f === "waitFor.timeoutMs must be a finite number",
+    ).length;
+    expect(finiteCount).toBe(1);
+
+    // Branch-presence artifacts (missing fields) must not lead.
+    expect(fragments[0]).not.toContain("received undefined");
+  });
+
+  test("a genuinely bad enum value still leads with the enum message", () => {
+    const result = observeSchema.safeParse({
+      platform: "android",
+      waitFor: { for: "bogus" },
+    });
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    const fragments = message.split("; ");
+    expect(fragments[0]).toContain("waitFor.for");
+    expect(fragments[0]).toContain("Invalid option");
+  });
+
+  test("repeated branch artifacts are collapsed (no 5x activeWindow dump)", () => {
+    const result = observeSchema.safeParse({
+      platform: "android",
+      waitFor: { timeoutMs: Infinity },
+    });
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error);
+    const activeWindowCount = message
+      .split("; ")
+      .filter((f) => f === "waitFor.activeWindow expected object, received undefined").length;
+    expect(activeWindowCount).toBeLessThanOrEqual(1);
   });
 });

--- a/test/utils/logger-redaction.test.ts
+++ b/test/utils/logger-redaction.test.ts
@@ -90,6 +90,35 @@ describe("safeStringify redacts sensitive data", () => {
       '{"a":{"x":1},"b":{"child":{"x":1},"self":"[circular]"}}',
     );
   });
+
+  // Issue #5854, AC2: JSON.stringify renders non-finite numbers as `null`, so a
+  // request log for a rejected `duration: Infinity` argument showed `null` and
+  // hid what the caller actually sent. The replacer must preserve the marker.
+  test("renders a nested Infinity as the string marker instead of null", () => {
+    expect(safeStringify({ duration: Infinity })).toBe('{"duration":"Infinity"}');
+  });
+
+  test("renders a nested -Infinity as its signed marker", () => {
+    expect(safeStringify({ duration: -Infinity })).toBe('{"duration":"-Infinity"}');
+  });
+
+  test("renders a nested NaN as the string marker instead of null", () => {
+    expect(safeStringify({ returnSpeed: NaN })).toBe('{"returnSpeed":"NaN"}');
+  });
+
+  test("preserves the marker inside the request-log argument shape", () => {
+    const request = {
+      method: "tools/call",
+      params: { name: "tapOn", arguments: { duration: Infinity } },
+    };
+    expect(safeStringify(request)).toBe(
+      '{"method":"tools/call","params":{"name":"tapOn","arguments":{"duration":"Infinity"}}}',
+    );
+  });
+
+  test("leaves finite numbers untouched", () => {
+    expect(safeStringify({ a: 0, b: -3.5, c: 1000 })).toBe('{"a":0,"b":-3.5,"c":1000}');
+  });
 });
 
 describe("SENSITIVE_ENV_KEYS", () => {


### PR DESCRIPTION
## Summary

Follow-ups to [#5769](https://github.com/kaeawc/auto-mobile/issues/5769) / [#5852](https://github.com/kaeawc/auto-mobile/pull/5852) on the numeric-validation surface. All three are message-quality/diagnostic fixes about *how* validation failures are surfaced, not device-level correctness.

## Linked Issue

Closes #5854

## Changes

- **AC1 — quiet `observe` union noise.** `waitForSchema` is a `z.union`, so one bad field expanded into one issue per branch plus a presence artifact for every field the branch required (`… received undefined`) or forbade (`expected never`). `formatToolParamError` now (a) dedups identical rendered fragments and (b) stable-reorders by priority so the caller's real error leads, with branch-presence artifacts last and enum-discriminant mismatches below concrete value errors. Reordering only changes order — a single-issue error is untouched, so a genuine enum/missing-field error still leads when it is the only thing wrong. Extracted the formatter to `src/server/formatToolParamError.ts` (re-exported from `index.ts`) so it can be shared.
- **AC2 — log the actual non-finite value.** `safeStringify` (`src/utils/logger.ts`) now emits `"Infinity"` / `"-Infinity"` / `"NaN"` markers instead of letting `JSON.stringify` collapse them to `null`, so a rejected non-finite argument is visible in the daemon request log.
- **AC3 — unify PlanExecutor validation rendering.** Both `tool.schema.parse` sites in `PlanExecutor` route `ZodError`s through the shared `invalidParamsMessage`, matching the MCP call boundary exactly. The `ZodError` is preserved as `cause` so the optional-step guard still classifies a malformed step as a fatal plan-authoring error (invariant kept).

## Acceptance criteria

- [x] `observe` non-finite/invalid-field errors lead with the actionable message rather than a union-branch dump.
- [x] Daemon request log shows the actual non-finite value instead of `null`.
- [x] `PlanExecutor` validation errors use the same `formatToolParamError` rendering as the MCP boundary.

## Testing

- `test/server/toolParamErrorHint.test.ts` — observe `{waitFor:{timeoutMs:Infinity}}` leads with `waitFor.timeoutMs must be a finite number` and dedups; a genuinely bad enum still leads with the enum message; repeated branch artifacts collapse.
- `test/utils/logger-redaction.test.ts` — nested `Infinity`/`-Infinity`/`NaN` render as quoted markers; finite numbers untouched; request-log argument shape preserved.
- `test/plan/planExecutorValidationFormatting.test.ts` — a non-finite plan param yields the formatted `Invalid parameters for tool …: … must be a finite number`, never the raw zod default.

## Validation

- [x] `bun test` — full suite green except one pre-existing, unrelated environmental failure (`webrtcDeviceCaptureLatency` — a subprocess `bun test` skip-line format assertion; none of the changed modules are in its graph).
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] `bun run lint` + `bun run build` — clean; boundary-checks pass.
- [x] New code uses interfaces + fakes; unit tests run in <100ms.

## Follow-ups

- [ ] None — all three acceptance criteria addressed here.