### PR TITLE
fix(mcp): surface provided-value errors from viable union arms (#5862)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -582,11 +582,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
     // Parse and validate the parameters
     let parsedParams;
+    const strippedToolParams = stripInternalToolParams(toolParams);
     try {
-      parsedParams = tool.schema.parse(stripInternalToolParams(toolParams));
+      parsedParams = tool.schema.parse(strippedToolParams);
     } catch (error) {
       throw new ActionableError(
-        `Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`,
+        `Invalid parameters for tool ${name}: ${formatToolParamError(name, error, strippedToolParams)}`,
       );
     }
 

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -100,24 +100,53 @@ function formatIssue(issue: ZodIssue): string {
   return `${path} ${issue.message}`;
 }
 
+// Walk `rawInput` along `path`; true only when every segment resolves through an
+// object and the terminal value is not `undefined`. A value the caller actually
+// SUPPLIED that is wrong (e.g. a number where a string is required) is a genuine
+// mistake we must surface even when only the input's *viable* union arms flag it;
+// a field the caller OMITTED is judged by branch coverage instead, so inner-union
+// discriminators the caller never provided stay suppressed (#5862).
+function isProvidedInput(rawInput: unknown, path: ReadonlyArray<PropertyKey>): boolean {
+  let current = rawInput;
+  for (const segment of path) {
+    if (current === null || typeof current !== "object") {
+      return false;
+    }
+    current = (current as Record<PropertyKey, unknown>)[segment];
+    if (current === undefined) {
+      return false;
+    }
+  }
+  return current !== undefined;
+}
+
 // Lead with the actionable message rather than a union-branch dump (#5854).
-// A union-derived issue is genuine only if its path fails in EVERY branch of its
-// union (a shared constraint the caller must fix regardless of intended branch);
-// an issue in only some branches is branch-discrimination noise. Non-union issues
+// A union-derived issue on a field the caller OMITTED is genuine only if its path
+// fails in EVERY branch of its union (a shared constraint the caller must fix
+// regardless of intended branch); an issue in only some branches is
+// branch-discrimination noise. A field the caller PROVIDED is genuine when every
+// arm that could apply to it flags it — arms that rejected a strict ancestor of
+// the path as `never` are inapplicable (they forbid the whole subtree and never
+// evaluate the field), so they are excluded from the denominator instead of
+// counting the field as failing in "only some" arms (#5862). Non-union issues
 // (top-level siblings) are always kept. Returns the full list unchanged when no
 // union expanded, or when suppression would leave nothing — that fallback is
 // never worse than the raw dump this replaces.
 function selectGenuineIssues(
   flattenedIssues: FlattenedIssue[],
   sawUnion: boolean,
+  rawInput: unknown,
 ): FlattenedIssue[] {
   if (!sawUnion) {
     return flattenedIssues;
   }
 
   // Per (union, path): which branches reported any issue there. A path covered by
-  // all `branchCount` branches is a shared constraint.
+  // all `branchCount` branches is a shared constraint. Alongside, per union, the
+  // paths each branch rejected as `never` — used to discount inapplicable arms
+  // from a provided field's viable-arm denominator.
   const branchCoverage = new Map<string, Set<number>>();
+  const neverPathsByUnion = new Map<number, Array<{ branchIndex: number; path: string }>>();
   for (const entry of flattenedIssues) {
     if (!entry.union) {
       continue;
@@ -129,7 +158,41 @@ function selectGenuineIssues(
       branchCoverage.set(key, branches);
     }
     branches.add(entry.union.branchIndex);
+
+    if (isNeverArtifact(entry.issue)) {
+      const nevers = neverPathsByUnion.get(entry.union.unionId) ?? [];
+      nevers.push({
+        branchIndex: entry.union.branchIndex,
+        path: entry.issue.path.map(String).join("."),
+      });
+      neverPathsByUnion.set(entry.union.unionId, nevers);
+    }
   }
+
+  // Arms viable for `path`: `branchCount` minus the arms that rejected a STRICT
+  // ancestor of `path` as `never` (those arms forbid the subtree, so they never
+  // evaluate the field and must not count against its coverage).
+  const viableBranchCount = (union: UnionContext, path: ReadonlyArray<PropertyKey>): number => {
+    const nevers = neverPathsByUnion.get(union.unionId);
+    if (!nevers || nevers.length === 0) {
+      return union.branchCount;
+    }
+    const segs = path.map(String);
+    const strictAncestors = new Set<string>();
+    for (let i = 1; i < segs.length; i++) {
+      strictAncestors.add(segs.slice(0, i).join("."));
+    }
+    if (strictAncestors.size === 0) {
+      return union.branchCount;
+    }
+    const excluded = new Set<number>();
+    for (const never of nevers) {
+      if (strictAncestors.has(never.path)) {
+        excluded.add(never.branchIndex);
+      }
+    }
+    return union.branchCount - excluded.size;
+  };
 
   const isGenuine = (entry: FlattenedIssue): boolean => {
     if (!entry.union) {
@@ -139,7 +202,11 @@ function selectGenuineIssues(
       return false;
     }
     const key = coverageKey(entry.union.unionId, entry.issue.path);
-    return (branchCoverage.get(key)?.size ?? 0) === entry.union.branchCount;
+    const coverage = branchCoverage.get(key)?.size ?? 0;
+    if (isProvidedInput(rawInput, entry.issue.path)) {
+      return coverage === viableBranchCount(entry.union, entry.issue.path);
+    }
+    return coverage === entry.union.branchCount;
   };
 
   const primary = flattenedIssues.filter(isGenuine);
@@ -148,13 +215,18 @@ function selectGenuineIssues(
 
 // Exported for direct unit testing of the container-hint branch (issue #4181,
 // rank 7). The hint is only appended for tapOn/swipeOn container issues.
-export function formatToolParamError(toolName: string, error: unknown): string {
+// `rawInput` is the object handed to `schema.parse` (undefined when a caller has
+// no access to it — the message is then computed from branch coverage alone,
+// identical to pre-#5862 behavior). Threading it lets a provided-value error on a
+// nested field survive even when an inapplicable union arm rejects its parent as
+// `never` (#5862).
+export function formatToolParamError(toolName: string, error: unknown, rawInput?: unknown): string {
   if (!(error instanceof ZodError)) {
     return String(error);
   }
 
   const { issues: flattenedIssues, sawUnion } = flattenZodIssues(error.issues);
-  const selectedIssues = selectGenuineIssues(flattenedIssues, sawUnion);
+  const selectedIssues = selectGenuineIssues(flattenedIssues, sawUnion, rawInput);
 
   // Dedupe formatted messages: union expansion repeats the same real issue once
   // per branch that carries the field.

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -41,9 +41,9 @@ function formatToolError(error: unknown): string {
 // must read identically instead of leaking the raw zod issue dump (#5854 §3).
 // Non-Zod errors fall through unchanged; the `instanceof ZodError` shape is left
 // intact for callers that branch on it (e.g. optional-step handling below).
-function formatStepError(toolName: string, error: unknown): string {
+function formatStepError(toolName: string, error: unknown, rawInput?: unknown): string {
   if (error instanceof ZodError) {
-    return `Invalid parameters for tool ${toolName}: ${formatToolParamError(toolName, error)}`;
+    return `Invalid parameters for tool ${toolName}: ${formatToolParamError(toolName, error, rawInput)}`;
   }
   return `${error}`;
 }
@@ -535,7 +535,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
       if (isDeviceLostError(error)) {
         throw error;
       }
-      const errorMsg = formatStepError(step.tool, error);
+      const errorMsg = formatStepError(step.tool, error, step.params);
       if (step.optional && !context.signal?.aborted && !(error instanceof ZodError)) {
         this.logger.warn(
           `${context.logPrefix} optional step ${step.tool} threw; returning skipped status`,

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
 import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
-import { waitForSchema } from "../../src/server/observeTools";
+import { observeSchema, waitForSchema } from "../../src/server/observeTools";
 import { setPreferenceSchema } from "../../src/server/preferenceTools";
 
 // Issue #4181, rank 7 (A6): the "container must be an object …" hint is
@@ -323,5 +323,39 @@ describe("formatToolParamError viable-arm provided value (#5862)", () => {
     const message = formatToolParamError("observe", result.error, input);
     expect(message).toBe("shared must be a finite number");
     expect(message).not.toContain("mode");
+  });
+
+  // End-to-end through the real `observeSchema` (the tool the issue's repro names),
+  // not `waitForSchema` directly: the path carries the `waitFor.` prefix and the
+  // union nesting is a level deeper, so this pins acceptance criterion 1 exactly as
+  // written and guards against regressions a shallower `waitForSchema`-only test
+  // could miss. This mirrors how the MCP boundary calls `formatToolParamError` with
+  // the same object it handed to `schema.parse`.
+  test("criterion 1 end-to-end: the observe repro surfaces the nested provided-value error", () => {
+    const input = {
+      platform: "android",
+      waitFor: { timeoutMs: Infinity, activeWindow: { activityName: 123 } },
+    };
+    const result = observeSchema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error, input);
+    expect(message).toContain("waitFor.activeWindow.activityName expected string, received number");
+    expect(message.startsWith("waitFor.timeoutMs must be a finite number")).toBe(true);
+    expect(message).not.toContain("received undefined");
+    expect(message).not.toContain("expected never");
+  });
+
+  // Criterion 2 on the production path: the real call sites now always thread
+  // rawInput, so exercise `setPreferenceSchema` (top-level enums beside a union-typed
+  // `value`) WITH rawInput to prove the new code path preserves the genuine enum
+  // errors rather than only the two-arg path the #5854 tests cover.
+  test("criterion 2: setPreference enum errors survive with rawInput threaded", () => {
+    const input = { scope: "bogus", key: "k", type: "bogus", value: {} };
+    const result = setPreferenceSchema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("setPreference", result.error, input);
+    expect(message).toContain("scope Invalid option");
+    expect(message).toContain("type Invalid option");
+    expect(message).toContain("value expected string");
   });
 });

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -258,3 +258,70 @@ describe("formatToolParamError observe union noise (#5854)", () => {
     expect(message).not.toContain("activeWindow");
   });
 });
+
+// Issue #5862 (follow-up to #5854): a genuine PROVIDED-value error on a nested
+// field that is valid in the input's *viable* union arms was dropped when another
+// (inapplicable) arm rejected the field's parent as `never`. Threading the raw
+// input into `formatToolParamError` lets it tell "the caller supplied this value"
+// (genuine — judge by coverage across viable arms only) from "the caller omitted
+// this field" (branch-discrimination noise — keep the across-all-branches test).
+describe("formatToolParamError viable-arm provided value (#5862)", () => {
+  test("a provided-value error surfaces despite a never-parent inapplicable arm", () => {
+    // `waitForSchema` is a 3-arm union. `activeWindow.activityName` is a real
+    // wrong-type error in the textAny and element arms, but the DSL arm declares
+    // `activeWindow` as `z.never()`, so it never evaluates `activityName`. The
+    // across-all-branches test counted the inapplicable DSL arm and suppressed it.
+    const input = { timeoutMs: 1e999, activeWindow: { activityName: 123 } };
+    const result = waitForSchema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error, input);
+    expect(message).toContain("activeWindow.activityName expected string, received number");
+    // Criterion 2: the finite-number error still leads.
+    expect(message.startsWith("timeoutMs must be a finite number")).toBe(true);
+    // Inner-union discriminators the caller never supplied stay suppressed: the
+    // caller passed activityName, not appId/packageName/bundleId, so their
+    // "received undefined" fragments must not leak back in.
+    expect(message).not.toContain("appId");
+    expect(message).not.toContain("received undefined");
+    expect(message).not.toContain("expected never");
+  });
+
+  test("criterion 2: a lone non-finite waitFor field still leads exactly, with rawInput", () => {
+    const input = { timeoutMs: 1e999 };
+    const result = waitForSchema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error, input);
+    expect(message).toBe("timeoutMs must be a finite number");
+  });
+
+  test("criterion 2: threading rawInput keeps genuine enum + universally-missing errors", () => {
+    const schema = z.union([
+      z.object({ id: z.string(), key: z.string(), name: z.string() }),
+      z.object({ id: z.string(), key: z.string(), fileName: z.string() }),
+    ]);
+    // `id` is provided but wrong-typed (genuine); `key` is missing from both
+    // branches (universally required — genuine); both must survive.
+    const input = { id: 42, name: "n" };
+    const result = schema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("setKeyValue", result.error, input);
+    expect(message).toContain("id expected string, received number");
+    expect(message).toContain("key expected string, received undefined");
+  });
+
+  test("criterion 2: a provided discriminator wrong only in the non-viable arm is not surfaced", () => {
+    // `shared` is bad in both arms (genuine); `mode` is provided but is a valid
+    // discriminator that only branch 0 constrains — its error there is arm-local
+    // noise, so coverage-across-viable-arms must still suppress it.
+    const schema = z.union([
+      z.object({ mode: z.enum(["x", "y"]), shared: z.number() }),
+      z.object({ shared: z.number() }),
+    ]);
+    const input = { shared: 1e999, mode: "z" };
+    const result = schema.safeParse(input as unknown as object);
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error, input);
+    expect(message).toBe("shared must be a finite number");
+    expect(message).not.toContain("mode");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to [#5854](https://github.com/kaeawc/auto-mobile/issues/5854) / PR [#5860](https://github.com/kaeawc/auto-mobile/pull/5860). `formatToolParamError` (`src/server/toolParamError.ts`) dropped a genuine **provided-value** error on a nested field when an *inapplicable* union arm rejected the field's parent as `z.never()`. The "fails in every branch" coverage test can't distinguish a viable arm from an inapplicable one, so it counted the inapplicable arm against the field's coverage and suppressed the error.

This threads the raw parse input into `formatToolParamError` (issue's option B — the robust general fix). A field the caller **actually supplied** is judged genuine by coverage across the input's *viable* arms only — arms that rejected a strict ancestor of the path as `never` forbid the whole subtree and never evaluate the field, so they are excluded from the denominator. A field the caller **omitted** keeps the existing across-all-branches test, so inner-union discriminators the caller never provided (e.g. `appId`/`packageName` "received undefined") stay suppressed. When `rawInput` is absent, behavior is byte-identical to before #5862.

## Linked Issue

Closes #5862

## Bug / Regression Context

- **Prior attempts:** #5860 fixed the main union-noise cases and deliberately deferred this narrower edge.
- **Observed symptom:** `observe { platform: "android", waitFor: { timeoutMs: Infinity, activeWindow: { activityName: 123 } } }` reported only `timeoutMs must be a finite number`; the real `activeWindow.activityName expected string, received number` was suppressed because the `for`-DSL arm rejects `activeWindow` as `never`. The caller fixed `timeoutMs`, resubmitted, and only then discovered the second error.
- **Repro steps / conditions:** a provided-value error on a nested field valid in only *some* arms of the outer union, where another arm rejects the field's parent as `never`.

## Changes

- `src/server/toolParamError.ts`: `formatToolParamError` gains an optional `rawInput` param. New `isProvidedInput` (walk the raw input along the issue path) and `viableBranchCount` (discount arms that reject a strict ancestor as `never`) drive the genuine-issue selection for provided fields.
- `src/server/index.ts` and `src/utils/plan/PlanExecutor.ts`: the two call sites now pass the parsed input so the fix applies end-to-end.

## Validation

- [x] `bun run lint` — oxlint ratchet gate: no new violations
- [x] `bun test` — full suite; the only failure is a pre-existing, unrelated bun-1.3.14 skip-label formatting flake in `webrtcDeviceCaptureLatency.test.ts` (imports none of the changed modules)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] New tests run in <100ms; no DB/FakeTimer surface touched

## Acceptance Criteria

- [x] A provided-value error on a nested field valid in the input's *viable* union arms surfaces even when another (inapplicable) arm rejects the field's parent as `never` — the `observe` repro now includes `activeWindow.activityName expected string, received number`.
- [x] #5860 behavior preserved: `observe { waitFor: { timeoutMs: 1e999 } }` still leads with exactly `timeoutMs must be a finite number`; `setKeyValue`/`setPreference` still keep genuine enum and universally-required-missing errors.
