### PR TITLE
fix(daemon): bound existing-daemon reachability wait under client timeout (#5871)

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -99,6 +99,37 @@ export const DAEMON_STARTUP_TIMEOUT_MS =
     : 30000;
 
 /**
+ * Reachability budget for an already-live daemon during start (milliseconds).
+ *
+ * When a start request finds a live daemon process without a usable PID record,
+ * it waits for that daemon to become reachable before deciding what to do. This
+ * wait is nested INSIDE a client's `tools/list` request, and clients time that
+ * request out at ~30s (`DAEMON_STARTUP_TIMEOUT_MS`). If the wait itself consumed
+ * the full startup budget, the actionable "refusing to terminate a live daemon"
+ * error would be produced only as the client's own deadline expires — so the one
+ * useful diagnostic in the flow never reaches the client and AutoMobile appears
+ * connected with zero tools (issue #5871).
+ *
+ * Budgeting this wait well under the client request timeout guarantees the
+ * error is delivered rather than raced by the timeout it lives inside. This is
+ * only the reachability wait for an EXISTING daemon; cold-start bring-up still
+ * uses the full `DAEMON_STARTUP_TIMEOUT_MS`. The override is clamped to the
+ * startup timeout — a value at or above it would defeat the purpose.
+ */
+const existingDaemonReachabilityOverride =
+  process.env.AUTOMOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS ??
+  process.env.AUTO_MOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS;
+const parsedExistingDaemonReachability = existingDaemonReachabilityOverride
+  ? Number.parseInt(existingDaemonReachabilityOverride, 10)
+  : NaN;
+export const DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS = Math.min(
+  Number.isFinite(parsedExistingDaemonReachability) && parsedExistingDaemonReachability > 0
+    ? parsedExistingDaemonReachability
+    : 10000,
+  DAEMON_STARTUP_TIMEOUT_MS,
+);
+
+/**
  * Daemon shutdown timeout in milliseconds
  * How long to wait for graceful shutdown before SIGKILL
  */

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -113,8 +113,15 @@ export const DAEMON_STARTUP_TIMEOUT_MS =
  * Budgeting this wait well under the client request timeout guarantees the
  * error is delivered rather than raced by the timeout it lives inside. This is
  * only the reachability wait for an EXISTING daemon; cold-start bring-up still
- * uses the full `DAEMON_STARTUP_TIMEOUT_MS`. The override is clamped to the
- * startup timeout — a value at or above it would defeat the purpose.
+ * uses the full `DAEMON_STARTUP_TIMEOUT_MS`.
+ *
+ * The value is capped at two-thirds of the startup timeout, never at the full
+ * timeout: a budget EQUAL to `DAEMON_STARTUP_TIMEOUT_MS` (which the client uses
+ * as its request deadline) would produce the actionable error at the exact
+ * deadline it must beat, re-opening the zero-tools race for an override at or
+ * above the ceiling. Capping below the timeout reserves headroom so the error
+ * is always deliverable, and scaling with the timeout keeps that headroom
+ * meaningful when the startup budget is itself lowered.
  */
 const existingDaemonReachabilityOverride =
   process.env.AUTOMOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS ??
@@ -122,11 +129,15 @@ const existingDaemonReachabilityOverride =
 const parsedExistingDaemonReachability = existingDaemonReachabilityOverride
   ? Number.parseInt(existingDaemonReachabilityOverride, 10)
   : NaN;
+const maxExistingDaemonReachabilityMs = Math.max(
+  1,
+  Math.floor((DAEMON_STARTUP_TIMEOUT_MS * 2) / 3),
+);
 export const DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS = Math.min(
   Number.isFinite(parsedExistingDaemonReachability) && parsedExistingDaemonReachability > 0
     ? parsedExistingDaemonReachability
     : 10000,
-  DAEMON_STARTUP_TIMEOUT_MS,
+  maxExistingDaemonReachabilityMs,
 );
 
 /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -24,6 +24,7 @@ import {
   SOCKET_PATH,
   LOCK_FILE_PATH,
   DAEMON_STARTUP_TIMEOUT_MS,
+  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
   READINESS_PROBE_MAX_ATTEMPTS,
   READINESS_PROBE_BACKOFF_MS,
@@ -601,14 +602,22 @@ export class DaemonManager implements DaemonManagerLike {
       for (const pid of liveDaemons) {
         stderrLog(`  - PID ${pid}`);
       }
-      if (await this.waitForExistingDaemon(DAEMON_STARTUP_TIMEOUT_MS)) {
+      // Bound this reachability wait well under a client's request timeout. It is
+      // nested inside a `tools/list` that clients cut off at ~30s
+      // (DAEMON_STARTUP_TIMEOUT_MS); if it consumed the full startup budget the
+      // actionable error below would be produced only as the client's own
+      // deadline expired, so the client would see an AutoMobile server with zero
+      // tools and no error text instead (issue #5871). A daemon that has not
+      // become reachable within this shorter budget is one the client is better
+      // off hearing about now than waiting on.
+      if (await this.waitForExistingDaemon(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS)) {
         stderrLog("Reusing existing responsive daemon");
         return;
       }
 
       throw new ActionableError(
         `Found live AutoMobile daemon process(es) (${liveDaemons.join(", ")}) but none became reachable within ` +
-          `${DAEMON_STARTUP_TIMEOUT_MS}ms. Refusing to terminate a live daemon during start; ` +
+          `${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms. Refusing to terminate a live daemon during start; ` +
           `inspect it or run \`bunx ${resolveDaemonInstallSpecifier()} --daemon restart\` explicitly.`,
       );
     }

--- a/test/daemon/daemonExistingReachabilityTimeoutConfig.test.ts
+++ b/test/daemon/daemonExistingReachabilityTimeoutConfig.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const REACHABILITY_ENV = "AUTOMOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS";
+const LEGACY_REACHABILITY_ENV = "AUTO_MOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS";
+const STARTUP_TIMEOUT_ENV = "AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS";
+
+describe("daemon existing-daemon reachability timeout configuration", () => {
+  const trackedKeys = [REACHABILITY_ENV, LEGACY_REACHABILITY_ENV, STARTUP_TIMEOUT_ENV];
+  const originalEnvironment = new Map(trackedKeys.map((key) => [key, process.env[key]]));
+
+  function restoreEnvironment(): void {
+    for (const [key, value] of originalEnvironment) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  async function importFreshConstants() {
+    return import(`../../src/daemon/constants.ts?reachability=${Date.now()}-${Math.random()}`);
+  }
+
+  afterEach(restoreEnvironment);
+
+  test("defaults to 10s and stays well under the client startup/request timeout", async () => {
+    for (const key of trackedKeys) {
+      delete process.env[key];
+    }
+
+    const constants = await importFreshConstants();
+
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(10000);
+    // The whole point of #5871: the wait must finish before the client's 30s
+    // request timeout so the actionable error is deliverable.
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBeLessThan(
+      constants.DAEMON_STARTUP_TIMEOUT_MS,
+    );
+  });
+
+  test("honors a positive override", async () => {
+    process.env[REACHABILITY_ENV] = "5000";
+    delete process.env[LEGACY_REACHABILITY_ENV];
+
+    const constants = await importFreshConstants();
+
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(5000);
+  });
+
+  test("clamps an override at or above the startup timeout back to the startup timeout", async () => {
+    process.env[STARTUP_TIMEOUT_ENV] = "20000";
+    process.env[REACHABILITY_ENV] = "999999";
+    delete process.env[LEGACY_REACHABILITY_ENV];
+
+    const constants = await importFreshConstants();
+
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(20000);
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBeLessThanOrEqual(
+      constants.DAEMON_STARTUP_TIMEOUT_MS,
+    );
+  });
+});

--- a/test/daemon/daemonExistingReachabilityTimeoutConfig.test.ts
+++ b/test/daemon/daemonExistingReachabilityTimeoutConfig.test.ts
@@ -48,15 +48,33 @@ describe("daemon existing-daemon reachability timeout configuration", () => {
     expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(5000);
   });
 
-  test("clamps an override at or above the startup timeout back to the startup timeout", async () => {
-    process.env[STARTUP_TIMEOUT_ENV] = "20000";
+  test("caps an override at or above the startup timeout with headroom below the deadline", async () => {
+    process.env[STARTUP_TIMEOUT_ENV] = "30000";
     process.env[REACHABILITY_ENV] = "999999";
     delete process.env[LEGACY_REACHABILITY_ENV];
 
     const constants = await importFreshConstants();
 
+    // Two-thirds of the 30s startup timeout: never equal to the timeout, so the
+    // actionable error is produced with headroom before the client's request
+    // deadline rather than at it (issue #5871).
     expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(20000);
-    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBeLessThanOrEqual(
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBeLessThan(
+      constants.DAEMON_STARTUP_TIMEOUT_MS,
+    );
+  });
+
+  test("keeps headroom below a lowered startup timeout", async () => {
+    process.env[STARTUP_TIMEOUT_ENV] = "6000";
+    process.env[REACHABILITY_ENV] = "10000";
+    delete process.env[LEGACY_REACHABILITY_ENV];
+
+    const constants = await importFreshConstants();
+
+    // The default 10s candidate exceeds the lowered startup budget, so it is
+    // capped to two-thirds of it (4000ms), preserving headroom.
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBe(4000);
+    expect(constants.DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS).toBeLessThan(
       constants.DAEMON_STARTUP_TIMEOUT_MS,
     );
   });

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -29,6 +29,10 @@ import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { FakeTimer } from "../fakes/FakeTimer";
+import {
+  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
+  DAEMON_STARTUP_TIMEOUT_MS,
+} from "../../src/daemon/constants";
 
 describe("daemonBuildIdentityStatusLines", () => {
   const client: BuildIdentity = {
@@ -888,6 +892,92 @@ describe("Daemon manager process detection", () => {
       );
 
       expect(killCalls).toEqual([]);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds the wait for an unreachable live daemon to the reachability budget, not the full startup timeout (#5871)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-reachability-budget-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
+    const pidFilePath = join(dir, "daemon.pid");
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses() {
+        return [
+          {
+            pid: 86961,
+            ppid: 1,
+            command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+          },
+        ];
+      },
+      isProcessRunning(pid: number) {
+        return pid === 86961;
+      },
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn while a live daemon exists");
+      },
+    };
+    const killSpy = spyOn(process, "kill").mockImplementation(
+      ((_pid: number) => true) as typeof process.kill,
+    );
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        () => ({
+          // A live-but-useless daemon: every reachability probe is refused, so it
+          // never becomes reachable and the start must give up at the budget.
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        pidFilePath,
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      const error = await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      // The actionable error must be delivered within the reachability budget so
+      // it beats the client's ~30s tools/list timeout (issue #5871).
+      expect(error.message).toContain("Refusing to terminate a live daemon during start");
+      expect(error.message).toContain(`within ${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms`);
+      expect(error.message).not.toContain(`within ${DAEMON_STARTUP_TIMEOUT_MS}ms`);
+      expect(elapsed).toBeLessThanOrEqual(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
+      // Guard against a regression that reintroduces the full 30s wait.
+      expect(elapsed).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
     } finally {
       killSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Handshake with the AutoMobile MCP server succeeds and it advertises `hasTools: true`, but `tools/list` can block for the full 30 s daemon-readiness budget and then throw a good, actionable error — which the client never sees, because clients time `tools/list` out at ~30 s. The session ends up showing AutoMobile connected with **zero tools and no error text**.

The 30 s wait comes from the "found a live daemon process without a usable PID record" path in `DaemonManager.startUnlocked`: it waited `DAEMON_STARTUP_TIMEOUT_MS` (30 s) for that daemon to become reachable before refusing to terminate it. The one useful diagnostic in the whole flow lost the race with the timeout it was nested inside.

This bounds that reachability wait well under a client request timeout so the actionable error is deliverable. Cold-start bring-up (which legitimately needs the full budget for multi-simulator discovery) is untouched.

## Linked Issue

Closes #5871

## Bug / Regression Context

- **Observed symptom:** Client shows AutoMobile connected with zero tools; `tools/list` returns nothing and no error. Driven from a bare stdio harness the error arrives at 30.91 s: `Found live AutoMobile daemon process(es) (…) but none became reachable within 30000ms. Refusing to terminate a live daemon during start…`
- **Repro conditions:** A resident daemon that is alive by liveness check but never becomes reachable (e.g. half-initialized, 404s its own MCP path). The refuse-to-kill policy then makes it a hard block on every new client until a human runs `--daemon restart`.
- **Root cause:** The existing-daemon reachability wait used the 30 s startup budget — identical to the client's request timeout — so its error surfaced only as the client's deadline expired.

## Changes

- New `DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS` constant (default **10 000 ms**, overridable via `AUTOMOBILE_DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS` / legacy `AUTO_MOBILE_…`, clamped `<= DAEMON_STARTUP_TIMEOUT_MS`).
- `DaemonManager.startUnlocked` uses it for the `waitForExistingDaemon` wait and in the thrown `ActionableError` message.

Addresses the issue's item 1 ("the fix that matters"). The reachability probe (`verifyDaemonConnection`) already distinguishes *reachable* from *merely-alive*, so bounding its budget is what makes the error deliverable — item 2's usefulness distinction is largely subsumed. Item 3 (fail `tools/list` fast + lazy connect on first tool call) is a larger connection-model change and is deferred as a follow-up.

## Validation

- [x] `bun test` — full suite green except two known `.claude`-worktree/env artifacts unrelated to this change (`test/lint/oxlintConfigScoping` missing `node_modules/.bin/oxlint`; `test/integration/webrtcDeviceCaptureLatency`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100 ms
- [x] `oxfmt --check` and `oxlint` clean on touched files (no new ratchet violations)

### Tests
- `test/daemon/daemonExistingReachabilityTimeoutConfig.test.ts` — default 10 s, `< DAEMON_STARTUP_TIMEOUT_MS`, override honored + clamped.
- `test/daemon/manager.test.ts` — the refuse-to-terminate path bounds the wait to the reachability budget: error says `within 10000ms` (not `30000ms`) and FakeTimer elapsed `<= 10 000 ms` and `< DAEMON_STARTUP_TIMEOUT_MS`.

## Follow-ups

- [ ] Consider failing `tools/list` fast and lazily connecting to the daemon on first tool call (issue #5871, item 3) — a client that can see the tools and gets one clear error on first use beats one that can't see the server at all.
