### PR TITLE
fix(observe): hoist descendant text onto clickable skeleton rows (#5869)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4400,6 +4400,9 @@
               "label": {
                 "type": "string"
               },
+              "sublabel": {
+                "type": "string"
+              },
               "testTag": {
                 "type": "string"
               },

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -15,6 +15,13 @@ import type { Affordance, ObserveResult, SkeletonElement } from "../../../models
  * walk. The output is what an agent needs to decide "what can I do here, and
  * what does it say?", at a fraction of the token cost of the full hierarchy.
  *
+ * A clickable container commonly carries no text of its own — the label lives on
+ * descendant `TextView`s (the standard Android `clickable container > TextView`
+ * preference-row layout). `hoistContainerLabels` (issue #5869) folds that
+ * descendant text back onto the container's `label` / `sublabel` using the
+ * already-flattened `text` category's geometry, so those rows are no longer
+ * `label: null` and non-clickable state text is not lost.
+ *
  * `id` / `label` map directly onto the `tapOn` selector union (`elementId` /
  * `text`), so a skeleton row is issued as `tapOn({ elementId })` with no new
  * selector semantics (issue #4388 acceptance criterion 2).
@@ -109,6 +116,7 @@ function boundsTuple(el: Element): SkeletonElement["bounds"] | undefined {
 interface SkeletonAccumulator {
   id?: string;
   label?: string;
+  sublabel?: string;
   testTag?: string;
   semanticLinks?: SkeletonElement["semanticLinks"];
   bounds: SkeletonElement["bounds"];
@@ -205,6 +213,127 @@ function shouldKeep(
   return !clickableBounds.some((bounds) => strictlyContains(bounds, acc.bounds));
 }
 
+/**
+ * Hoist descendant text onto clickable containers (issue #5869). The standard
+ * Android `clickable container > TextView` preference-row layout puts the visible
+ * label on descendant `TextView`s, not on the clickable node itself — so the
+ * container's own `label` is `null` and, without this, every such row (most of
+ * Settings and most well-built apps) is `label: null`.
+ *
+ * This mirrors what an accessibility service does: for each pure-text accumulator
+ * (a labelled row with no affordances) that is strictly enclosed by a clickable
+ * container, fold its text into that container's **smallest** enclosing clickable
+ * ancestor. Texts are ordered top-to-bottom, left-to-right; the first becomes the
+ * container's `label` when it has none, and the remainder join into `sublabel`
+ * (so a preference summary line or an alarm's day-of-week schedule survives in the
+ * compact form). Text equal to the container's own label is not duplicated.
+ *
+ * The folded text accumulators are left in place — {@link shouldKeep} already
+ * suppresses labelled text that has a clickable ancestor, so they drop out and
+ * are not re-emitted as separate rows (semantic-link rows are the deliberate
+ * exception and stay discoverable).
+ */
+function hoistContainerLabels(
+  accumulators: SkeletonAccumulator[],
+  clickable: SkeletonAccumulator[],
+): void {
+  if (clickable.length === 0) {
+    return;
+  }
+  for (const [container, texts] of groupTextByContainer(accumulators, clickable)) {
+    texts.sort(byReadingOrder);
+    applyHoistedLabels(container, distinctHoistParts(container, texts));
+  }
+}
+
+/**
+ * Bucket each pure-text accumulator (a label, no affordance of its own) under
+ * its smallest enclosing clickable container. Nested clickable/toggle rows keep
+ * their own identity and are never folded.
+ */
+function groupTextByContainer(
+  accumulators: SkeletonAccumulator[],
+  clickable: SkeletonAccumulator[],
+): Map<SkeletonAccumulator, SkeletonAccumulator[]> {
+  const byContainer = new Map<SkeletonAccumulator, SkeletonAccumulator[]>();
+  for (const acc of accumulators) {
+    if (acc.affordances.size > 0 || acc.label === undefined) {
+      continue;
+    }
+    const container = smallestClickableAncestor(acc.bounds, clickable);
+    if (!container) {
+      continue;
+    }
+    const bucket = byContainer.get(container);
+    if (bucket) {
+      bucket.push(acc);
+    } else {
+      byContainer.set(container, [acc]);
+    }
+  }
+  return byContainer;
+}
+
+/** Distinct descendant labels, excluding any equal to the container's own label. */
+function distinctHoistParts(
+  container: SkeletonAccumulator,
+  texts: SkeletonAccumulator[],
+): string[] {
+  const parts: string[] = [];
+  for (const text of texts) {
+    const label = text.label;
+    if (label !== undefined && label !== container.label && !parts.includes(label)) {
+      parts.push(label);
+    }
+  }
+  return parts;
+}
+
+/**
+ * Fold `parts` onto the container: the first becomes `label` when it has none,
+ * and the remainder join into `sublabel`. A container with an own label keeps it
+ * and takes every part as `sublabel`.
+ */
+function applyHoistedLabels(container: SkeletonAccumulator, parts: string[]): void {
+  if (parts.length === 0) {
+    return;
+  }
+  if (container.label === undefined) {
+    container.label = parts[0];
+    if (parts.length > 1) {
+      container.sublabel = parts.slice(1).join(", ");
+    }
+  } else {
+    container.sublabel = parts.join(", ");
+  }
+}
+
+/** Order two rows top-to-bottom, then left-to-right, by their bounds tuple. */
+function byReadingOrder(a: SkeletonAccumulator, b: SkeletonAccumulator): number {
+  return a.bounds[1] - b.bounds[1] || a.bounds[0] - b.bounds[0];
+}
+
+/**
+ * The smallest-area clickable accumulator that strictly encloses `bounds`, or
+ * `undefined` when none does. Smallest-area so text folds into its immediate row
+ * rather than an outer clickable card or list that also encloses it.
+ */
+function smallestClickableAncestor(
+  bounds: SkeletonElement["bounds"],
+  clickable: SkeletonAccumulator[],
+): SkeletonAccumulator | undefined {
+  let best: SkeletonAccumulator | undefined;
+  for (const candidate of clickable) {
+    if (!strictlyContains(candidate.bounds, bounds)) {
+      continue;
+    }
+    if (!best || area(candidate.bounds) < area(best.bounds)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
 /** Materialize one accumulator into an emitted skeleton row (omitting absent optionals). */
 function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
   const entry: SkeletonElement = {
@@ -216,6 +345,9 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
   }
   if (acc.label !== undefined) {
     entry.label = acc.label;
+  }
+  if (acc.sublabel !== undefined) {
+    entry.sublabel = acc.sublabel;
   }
   if (acc.testTag !== undefined) {
     entry.testTag = acc.testTag;
@@ -236,10 +368,12 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
  */
 export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
   const accumulators = accumulateByIdentity(elements);
+  const clickable = accumulators.filter((acc) => acc.affordances.has("tap"));
+  // Hoist descendant text onto labelless/underlabelled clickable rows (issue
+  // #5869) before the keep filter suppresses the now-folded text accumulators.
+  hoistContainerLabels(accumulators, clickable);
   // Bounds of every tappable row, for the clickable-ancestor suppression test.
-  const clickableBounds = accumulators
-    .filter((acc) => acc.affordances.has("tap"))
-    .map((acc) => acc.bounds);
+  const clickableBounds = clickable.map((acc) => acc.bounds);
 
   return accumulators.filter((acc) => shouldKeep(acc, clickableBounds)).map(toSkeletonEntry);
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -77,8 +77,22 @@ export type Affordance = "tap" | "long-press" | "input" | "scroll" | "toggle";
 export interface SkeletonElement {
   /** `resource-id ?? view-id` (the stable content-hash id from #3228). */
   id?: string;
-  /** `text ?? content-desc`. */
+  /**
+   * `text ?? content-desc`, else the hoisted primary text of descendants (issue
+   * #5869). A clickable container whose own node carries no text/content-desc
+   * (the standard Android `clickable container > TextView` preference-row layout)
+   * takes the top-most descendant text as its label, so the row is no longer
+   * `label: null`.
+   */
   label?: string;
+  /**
+   * Secondary descendant text hoisted onto a clickable row (issue #5869): the
+   * remaining descendant text after `label`, joined with `", "`. Present only
+   * when a clickable container encloses text beyond its primary label — e.g. a
+   * preference row's summary line or an alarm's day-of-week schedule — so compact
+   * state text is not lost. Omitted when there is no secondary text.
+   */
+  sublabel?: string;
   /** Compose test tag, when supplied by the app; usable as the stable owner key for `subtext`. */
   testTag?: string;
   /** Embedded accessibility links, omitted unless this element exposes one. */

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -541,6 +541,7 @@ export const skeletonElementSchema = z
   .object({
     id: z.string().optional(),
     label: z.string().optional(),
+    sublabel: z.string().optional(),
     testTag: z.string().optional(),
     semanticLinks: z.array(semanticLinkSchema).optional(),
     bounds: compactBoundsTupleSchema.describe(

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -435,6 +435,36 @@ describe("toSkeleton — acceptance criteria", () => {
       expect(findById(skeleton, "s-inner")?.label).toBe("Inner label");
       expect(findById(skeleton, "s-outer")?.label).toBeUndefined();
     });
+
+    test("a nested clickable child's own text is not swallowed into the parent", () => {
+      // A clickable parent with no own text, enclosing a clickable child that
+      // carries its own text. The child owns a `tap` affordance, so it is not a
+      // hoist candidate — its label stays on the child, and the parent is not
+      // relabelled from it.
+      const parentCard: Element = {
+        bounds: bounds(0, 0, 1080, 300),
+        "view-id": "s-parent",
+        clickable: "true",
+      };
+      const childButton: Element = {
+        bounds: bounds(800, 40, 1040, 160),
+        "resource-id": "child-btn",
+        text: "OK",
+        clickable: "true",
+      };
+
+      const skeleton = toSkeleton(
+        // The child, carrying text, appears in both categories on a real capture.
+        makeElements({ clickable: [parentCard, childButton], text: [childButton] }),
+      );
+
+      expect(findById(skeleton, "child-btn")?.label).toBe("OK");
+      expect(findById(skeleton, "child-btn")?.affordances).toEqual(["tap"]);
+      // The parent keeps no label hoisted from the child's own text.
+      const parent = findById(skeleton, "s-parent");
+      expect(parent?.label).toBeUndefined();
+      expect("sublabel" in (parent as SkeletonElement)).toBe(false);
+    });
   });
 
   describe("empty input", () => {

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -311,6 +311,136 @@ describe("toSkeleton — acceptance criteria", () => {
     });
   });
 
+  describe("AC1 (#5869): hoist descendant text onto a labelless clickable container", () => {
+    test("a clickable row with no own text takes its descendant text as label + sublabel", () => {
+      // The standard Android `clickable container > TextView` preference row:
+      // the container is clickable but carries no text of its own; the visible
+      // title/summary live on descendant TextViews strictly inside it.
+      const row: Element = {
+        bounds: bounds(0, 200, 1080, 400),
+        "view-id": "s-53a78106563f5449",
+        clickable: "true",
+      };
+      const title: Element = {
+        bounds: bounds(72, 240, 600, 300),
+        text: "Network & internet",
+      };
+      const summary: Element = {
+        bounds: bounds(72, 310, 600, 360),
+        text: "Mobile, Wi-Fi, hotspot",
+      };
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [row], text: [title, summary] }),
+      );
+
+      // Only the container row survives; its inner labels are folded in.
+      const entry = findById(skeleton, "s-53a78106563f5449");
+      expect(entry).toBeDefined();
+      expect(entry?.affordances).toEqual(["tap"]);
+      expect(entry?.label).toBe("Network & internet");
+      expect(entry?.sublabel).toBe("Mobile, Wi-Fi, hotspot");
+      // The two inner text nodes are not emitted as separate rows.
+      expect(skeleton).toHaveLength(1);
+    });
+
+    test("primary label is the top-most descendant; remaining texts join into sublabel", () => {
+      const row: Element = {
+        bounds: bounds(0, 0, 1080, 300),
+        "view-id": "s-multi",
+        clickable: "true",
+      };
+      // Deliberately out of document order to prove positional (top,left) sort.
+      const third: Element = { bounds: bounds(72, 200, 600, 260), text: "Third" };
+      const first: Element = { bounds: bounds(72, 20, 600, 80), text: "First" };
+      const second: Element = { bounds: bounds(72, 110, 600, 170), text: "Second" };
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [row], text: [third, first, second] }),
+      );
+
+      const entry = findById(skeleton, "s-multi");
+      expect(entry?.label).toBe("First");
+      expect(entry?.sublabel).toBe("Second, Third");
+    });
+  });
+
+  describe("AC2 (#5869): descendant state text is preserved, not dropped", () => {
+    test("a clickable row with its own label folds descendant state text into sublabel", () => {
+      // Clock alarm row: the row is clickable and labelled (the time), and the
+      // schedule lives on a non-clickable descendant TextView. Previously the
+      // schedule was dropped from the skeleton entirely.
+      const alarmRow: Element = {
+        bounds: bounds(0, 0, 1080, 240),
+        "resource-id": "com.android.deskclock:id/alarm_item",
+        text: "7:00 AM",
+        clickable: "true",
+      };
+      const daysOfWeek: Element = {
+        bounds: bounds(72, 140, 600, 200),
+        "resource-id": "com.android.deskclock:id/days_of_week",
+        text: "Mon, Tue, Wed, Thu, Fri",
+      };
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [alarmRow], text: [alarmRow, daysOfWeek] }),
+      );
+
+      const entry = findById(skeleton, "com.android.deskclock:id/alarm_item");
+      expect(entry?.label).toBe("7:00 AM");
+      expect(entry?.sublabel).toBe("Mon, Tue, Wed, Thu, Fri");
+      // The schedule text is not lost, and not emitted as a separate row.
+      expect(skeleton).toHaveLength(1);
+    });
+
+    test("descendant text equal to the container's own label is not duplicated into sublabel", () => {
+      const row: Element = {
+        bounds: bounds(0, 0, 300, 80),
+        "resource-id": "row",
+        text: "Settings",
+        clickable: "true",
+      };
+      const innerLabel: Element = {
+        bounds: bounds(20, 20, 120, 60),
+        text: "Settings",
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [row], text: [row, innerLabel] }));
+
+      const entry = findById(skeleton, "row");
+      expect(entry?.label).toBe("Settings");
+      expect("sublabel" in (entry as SkeletonElement)).toBe(false);
+      expect(skeleton).toHaveLength(1);
+    });
+  });
+
+  describe("AC1 (#5869): hoist targets the smallest clickable ancestor", () => {
+    test("descendant text is hoisted onto the innermost clickable container", () => {
+      const outerCard: Element = {
+        bounds: bounds(0, 0, 1080, 500),
+        "view-id": "s-outer",
+        clickable: "true",
+      };
+      const innerRow: Element = {
+        bounds: bounds(20, 20, 1060, 240),
+        "view-id": "s-inner",
+        clickable: "true",
+      };
+      const label: Element = {
+        bounds: bounds(72, 60, 600, 120),
+        text: "Inner label",
+      };
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [outerCard, innerRow], text: [label] }),
+      );
+
+      // The text belongs to the innermost enclosing clickable, not the outer card.
+      expect(findById(skeleton, "s-inner")?.label).toBe("Inner label");
+      expect(findById(skeleton, "s-outer")?.label).toBeUndefined();
+    });
+  });
+
   describe("empty input", () => {
     test("no elements yields an empty skeleton", () => {
       expect(toSkeleton(makeElements({}))).toEqual([]);

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -330,9 +330,7 @@ describe("toSkeleton — acceptance criteria", () => {
         text: "Mobile, Wi-Fi, hotspot",
       };
 
-      const skeleton = toSkeleton(
-        makeElements({ clickable: [row], text: [title, summary] }),
-      );
+      const skeleton = toSkeleton(makeElements({ clickable: [row], text: [title, summary] }));
 
       // Only the container row survives; its inner labels are folded in.
       const entry = findById(skeleton, "s-53a78106563f5449");
@@ -355,9 +353,7 @@ describe("toSkeleton — acceptance criteria", () => {
       const first: Element = { bounds: bounds(72, 20, 600, 80), text: "First" };
       const second: Element = { bounds: bounds(72, 110, 600, 170), text: "Second" };
 
-      const skeleton = toSkeleton(
-        makeElements({ clickable: [row], text: [third, first, second] }),
-      );
+      const skeleton = toSkeleton(makeElements({ clickable: [row], text: [third, first, second] }));
 
       const entry = findById(skeleton, "s-multi");
       expect(entry?.label).toBe("First");

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -602,6 +602,8 @@ describe("observe tool registration advertises the schema (#3025)", () => {
       expect(json).toContain('"affordances"');
       expect(json).toContain('"semanticLinks"');
       expect(json).toContain('"testTag"');
+      // Hoisted secondary state text (#5869) is advertised like its siblings.
+      expect(json).toContain('"sublabel"');
     });
   });
 });


### PR DESCRIPTION
## Summary

`observe`'s compact `skeleton` derived each row's `label` only from the clickable node's own `text`/`content-desc`. On the standard Android `clickable container > TextView` preference-row layout — most of Settings, and most well-built apps — the visible label lives on descendant `TextView`s, not the clickable node, so every such row came back `label: null` and the compact form was unusable there.

`hoistContainerLabels` folds the already-flattened `text` category back onto the **smallest** enclosing clickable container by geometry (reusing the existing `strictlyContains` machinery — no tree walk, no device I/O). The top-most descendant text becomes the row's `label` when it has none, and the remaining descendant text joins into a new `sublabel`. This also preserves non-clickable state text that was previously dropped (e.g. a Clock alarm's day-of-week schedule), keeping primary and secondary lines separate as the issue requested.

## Linked Issue

Closes #5869

## Bug / Regression Context

- **Observed symptom:** on every Settings list screen, all eight+ tappable rows returned `label: null`; the real labels lived on descendant `TextView`s that the skeleton dropped.
- **Repro steps / conditions:** `observe` on any `clickable container > TextView` list (Settings homepage, Network & internet, etc.).

## Changes

- `SkeletonProjection.ts`: add `hoistContainerLabels` (+ `groupTextByContainer` / `distinctHoistParts` / `applyHoistedLabels` / `smallestClickableAncestor` / `byReadingOrder` helpers); run it before the keep filter so folded text accumulators are suppressed rather than re-emitted.
- `ObserveResult.ts`: document the new hoist semantics on `label`; add the optional `sublabel` field.
- `skeletonProjection.test.ts`: cover the Settings-row hoist, positional label/sublabel ordering, the Clock-alarm state-text case, own-label de-duplication, and smallest-ancestor targeting.

## Acceptance criteria (from the issue, `kaeawc`-authored)

- [x] **(1)** A clickable node with no own text/content-desc hoists concatenated descendant text into `label`, keeping primary/secondary separately as `label` + `sublabel`.
- [x] **(2)** Non-clickable descendant state text is no longer lost — it is folded into the enclosing row's `sublabel` (a cleaner, compact-form-preserving realization of "don't drop the text" than a separate empty-affordance row).
- [ ] **(3)** In-band `raw` fetch (MCP resource for the artifact spill path) — **deferred to a follow-up**: it is a distinct, larger surface (artifact writer + MCP resource registry + public tool schemas) that the issue frames as an optimization companion. Tracked separately; see Follow-ups.

## Validation

- [x] `bun run lint` (ratchet gate: no new violations) + `bun test` (full suite; the only 2 red are the known `.claude`-worktree `oxlintConfigScoping` artifact and the WHEP emulator-boot flake, both unrelated)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] New tests use plain fixtures; run in <100ms
- [x] Pure output projection — no new dependency, reuses existing `strictlyContains` geometry

## Device Verification

- [ ] Not run here (no attached device in this worktree); the change is a deterministic, unit-tested projection over already-captured `elements`.

## Follow-ups

- [ ] In-band `raw` fetch for the artifact spill path (issue #5869 item 3) — to be filed.
