### PR TITLE
fix(mcp): verify launchApp/tapOn postconditions in tool responses (#5868)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4633,6 +4633,9 @@
               "resourceId": {
                 "type": "string"
               },
+              "testTag": {
+                "type": "string"
+              },
               "contentDesc": {
                 "type": "string"
               },
@@ -9159,6 +9162,9 @@
                       "resourceId": {
                         "type": "string"
                       },
+                      "testTag": {
+                        "type": "string"
+                      },
                       "contentDesc": {
                         "type": "string"
                       },
@@ -10048,6 +10054,9 @@
             "resourceId": {
               "type": "string"
             },
+            "testTag": {
+              "type": "string"
+            },
             "contentDesc": {
               "type": "string"
             },
@@ -10157,6 +10166,9 @@
                 "type": "string"
               },
               "resourceId": {
+                "type": "string"
+              },
+              "testTag": {
                 "type": "string"
               },
               "contentDesc": {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1016,10 +1016,13 @@ export class TapOnElement extends BaseVisualChange {
             : "";
     const resourceId =
       typeof selection.element["resource-id"] === "string" ? selection.element["resource-id"] : "";
+    const testTag =
+      typeof selection.element["test-tag"] === "string" ? selection.element["test-tag"] : undefined;
 
     return {
       text,
       resourceId,
+      ...(testTag ? { testTag } : {}),
       bounds: {
         left: bounds.left,
         top: bounds.top,

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -13,6 +13,8 @@ export interface TapOnSelectedElementBounds extends ElementBounds {
 export interface TapOnSelectedElement {
   text: string;
   resourceId: string;
+  /** Compose test tag, when the node exposes one (may be the only stable identity). */
+  testTag?: string;
   bounds: TapOnSelectedElementBounds;
   indexInMatches: number;
   totalMatches: number;

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -115,7 +115,13 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
   }
 
   const observedAppId = result.observation?.activeWindow?.appId;
-  const verified = observedAppId !== undefined ? observedAppId === appId : undefined;
+  // Only assert verification on an exact foreground match. `LaunchApp.execute`
+  // returns `success:true` only when the foreground reconciles with the request —
+  // an exact match, an accepted surface (e.g. a notification-permission dialog
+  // whose foreground is the permission controller), or no observation at all — so
+  // a non-matching `observedAppId` here is such an accepted surface, not a failed
+  // launch. Emit `verified` as true-or-undefined; never a misleading `false`.
+  const verified = observedAppId === appId ? true : undefined;
 
   return {
     message: verified

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -124,9 +124,7 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
   const verified = observedAppId === appId ? true : undefined;
 
   return {
-    message: verified
-      ? `Launched app ${appId} (foreground verified)`
-      : `Launched app ${appId}`,
+    message: verified ? `Launched app ${appId} (foreground verified)` : `Launched app ${appId}`,
     verified,
     observedAppId,
     observation: result.observation,

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -1,6 +1,11 @@
 import { z } from "zod/v4";
 import { ToolRegistry } from "./toolRegistry";
-import { ActionableError, BootedDevice, type TerminateAppResult } from "../models";
+import {
+  ActionableError,
+  BootedDevice,
+  type LaunchAppResult,
+  type TerminateAppResult,
+} from "../models";
 import { LaunchApp } from "../features/action/LaunchApp";
 import { TerminateApp } from "../features/action/TerminateApp";
 import { InstallApp } from "../features/action/InstallApp";
@@ -86,6 +91,41 @@ export function setTerminateAppToolDependencies(deps: Partial<TerminateAppToolDe
 
 export function resetTerminateAppToolDependencies(): void {
   terminateAppToolDependencies = null;
+}
+
+/**
+ * Build the launchApp tool response from a {@link LaunchAppResult}, enforcing the
+ * launch postcondition instead of reporting a flat "Launched app X" success
+ * regardless of what actually happened (#5868).
+ *
+ * `LaunchApp.execute` already resolves the package (returning `success:false`
+ * with "App is not installed" for an uninstalled package) and reconciles the
+ * launch observation against the requested app (returning `success:false` when
+ * the foreground app never matches). This surfaces those typed failures as a
+ * real error — mirroring the terminate handler (#5621) — rather than swallowing
+ * them behind a success message. On success it additionally reports the observed
+ * foreground appId and whether it matched, so a client can skip a confirming
+ * `observe` round-trip.
+ */
+export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
+  if (!result.success) {
+    // `||` not `??`: an empty-string error must still yield the non-empty
+    // fallback rather than surfacing a blank message.
+    throw new ActionableError(result.error || `Failed to launch app ${appId}`);
+  }
+
+  const observedAppId = result.observation?.activeWindow?.appId;
+  const verified = observedAppId !== undefined ? observedAppId === appId : undefined;
+
+  return {
+    message: verified
+      ? `Launched app ${appId} (foreground verified)`
+      : `Launched app ${appId}`,
+    verified,
+    observedAppId,
+    observation: result.observation,
+    ...result,
+  };
 }
 
 // Schema definitions
@@ -332,13 +372,15 @@ export function registerAppTools() {
       );
       signal?.throwIfAborted();
 
-      return createJSONToolResponse({
-        message: `Launched app ${args.appId}`,
-        observation: result.observation,
-        ...result,
-      });
+      return createJSONToolResponse(buildLaunchAppResponse(args.appId, result));
     } catch (error) {
       if (isDeviceLostError(error)) {
+        throw error;
+      }
+      // A typed launch failure (uninstalled package, foreground mismatch) is
+      // already an actionable error — surface it verbatim rather than re-wrapping
+      // it as "Failed to launch app: Error: ..." (#5868).
+      if (error instanceof ActionableError) {
         throw error;
       }
       throw new ActionableError(`Failed to launch app: ${error}`);

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -114,7 +114,11 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
     throw new ActionableError(result.error || `Failed to launch app ${appId}`);
   }
 
-  const observedAppId = result.observation?.activeWindow?.appId;
+  // Mirror `LaunchApp`'s own reconciliation, which accepts either the active
+  // window's appId or the view hierarchy's packageName — so a launch verified via
+  // the hierarchy (active window absent) still reports the observed app.
+  const observedAppId =
+    result.observation?.activeWindow?.appId ?? result.observation?.viewHierarchy?.packageName;
   // Only assert verification on an exact foreground match. `LaunchApp.execute`
   // returns `success:true` only when the foreground reconciles with the request —
   // an exact match, an accepted surface (e.g. a notification-permission dialog

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -782,6 +782,7 @@ export function formatSwipeOnMessage(
 export function buildTapOnResultMessage(
   selectedElement: TapOnSelectedElement | undefined,
   searchSummary: string | undefined,
+  activatedSubtext?: { text: string; occurrence: number },
 ): string {
   const details: string[] = [];
   if (selectedElement) {
@@ -792,6 +793,13 @@ export function buildTapOnResultMessage(
         : "element";
     const count = selectedElement.totalMatches;
     details.push(`matched ${identity}`, `${count} ${count === 1 ? "match" : "matches"}`);
+  } else if (activatedSubtext) {
+    // The accessibilityLink selector activates a semantic link without resolving a
+    // selectedElement, so name the activated link (and occurrence, when it
+    // disambiguates) — otherwise taps on different links stay byte-identical.
+    const occurrence =
+      activatedSubtext.occurrence > 0 ? ` [occurrence ${activatedSubtext.occurrence}]` : "";
+    details.push(`activated link ${JSON.stringify(activatedSubtext.text)}${occurrence}`);
   }
   if (searchSummary) {
     details.push(searchSummary);
@@ -852,7 +860,11 @@ export function registerInteractionTools() {
         : undefined;
 
     return createStructuredToolResponse({
-      message: buildTapOnResultMessage(result.selectedElement, searchSummary),
+      message: buildTapOnResultMessage(
+        result.selectedElement,
+        searchSummary,
+        result.activatedSubtext,
+      ),
       observation: result.observation,
       ...result,
     });

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -793,6 +793,9 @@ export function buildTapOnResultMessage(
     if (selectedElement.resourceId) {
       identity.push(`id=${selectedElement.resourceId}`);
     }
+    if (selectedElement.testTag) {
+      identity.push(`testTag=${selectedElement.testTag}`);
+    }
     if (selectedElement.text) {
       identity.push(`text=${JSON.stringify(selectedElement.text)}`);
     }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -26,6 +26,7 @@ import {
   ClipboardResult,
   OpenURLResult,
   SwipeOnToolPayload,
+  type TapOnSelectedElement,
 } from "../models";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -769,6 +770,35 @@ export function formatSwipeOnMessage(
     : `Swiped ${direction}`;
 }
 
+/**
+ * Build the tapOn success message so it says *what* it matched, not just
+ * "Tapped on element" (#5868). A correct tap and a wrong tap were byte-identical;
+ * now the message carries the resolved match identity and match count (so an
+ * ambiguous selector is distinguishable from a precise one) alongside the
+ * existing hierarchy-changed search summary. The structured `selectedElement`
+ * (resourceId/text/bounds/totalMatches) still rides on the result for clients
+ * that read the payload.
+ */
+export function buildTapOnResultMessage(
+  selectedElement: TapOnSelectedElement | undefined,
+  searchSummary: string | undefined,
+): string {
+  const details: string[] = [];
+  if (selectedElement) {
+    const identity = selectedElement.resourceId
+      ? `id=${selectedElement.resourceId}`
+      : selectedElement.text
+        ? `text=${JSON.stringify(selectedElement.text)}`
+        : "element";
+    const count = selectedElement.totalMatches;
+    details.push(`matched ${identity}`, `${count} ${count === 1 ? "match" : "matches"}`);
+  }
+  if (searchSummary) {
+    details.push(searchSummary);
+  }
+  return details.length > 0 ? `Tapped on element (${details.join("; ")})` : "Tapped on element";
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
@@ -822,7 +852,7 @@ export function registerInteractionTools() {
         : undefined;
 
     return createStructuredToolResponse({
-      message: searchSummary ? `Tapped on element (${searchSummary})` : "Tapped on element",
+      message: buildTapOnResultMessage(result.selectedElement, searchSummary),
       observation: result.observation,
       ...result,
     });

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -786,17 +786,29 @@ export function buildTapOnResultMessage(
 ): string {
   const details: string[] = [];
   if (selectedElement) {
-    const identity = selectedElement.resourceId
-      ? `id=${selectedElement.resourceId}`
-      : selectedElement.text
-        ? `text=${JSON.stringify(selectedElement.text)}`
-        : "element";
+    // Include every available identity field, not just the resource id: Android
+    // list rows commonly reuse an id such as `...:id/title`, so the id alone can't
+    // tell "Internet" from "Calendar" — the text can.
+    const identity: string[] = [];
+    if (selectedElement.resourceId) {
+      identity.push(`id=${selectedElement.resourceId}`);
+    }
+    if (selectedElement.text) {
+      identity.push(`text=${JSON.stringify(selectedElement.text)}`);
+    }
+    details.push(`matched ${identity.length > 0 ? identity.join(" ") : "element"}`);
     const count = selectedElement.totalMatches;
-    details.push(`matched ${identity}`, `${count} ${count === 1 ? "match" : "matches"}`);
-  } else if (activatedSubtext) {
-    // The accessibilityLink selector activates a semantic link without resolving a
-    // selectedElement, so name the activated link (and occurrence, when it
-    // disambiguates) — otherwise taps on different links stay byte-identical.
+    // For an ambiguous selector, name which occurrence was tapped so index 0 vs 2
+    // (or a random pick) among identical rows is distinguishable.
+    const index = count > 1 ? ` (index ${selectedElement.indexInMatches})` : "";
+    details.push(`${count} ${count === 1 ? "match" : "matches"}${index}`);
+  }
+  // Append the activated semantic link whenever present, additively: an
+  // owner-scoped subtext tap resolves BOTH an owner (selectedElement) and the
+  // activated link, and the accessibilityLink selector resolves only the link —
+  // either way, naming the link keeps taps on different links from being
+  // byte-identical.
+  if (activatedSubtext) {
     const occurrence =
       activatedSubtext.occurrence > 0 ? ` [occurrence ${activatedSubtext.occurrence}]` : "";
     details.push(`activated link ${JSON.stringify(activatedSubtext.text)}${occurrence}`);

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -98,6 +98,7 @@ export const selectedElementSchema = z
   .object({
     text: z.string().optional(),
     resourceId: z.string().optional(),
+    testTag: z.string().optional(),
     contentDesc: z.string().optional(),
     bounds: elementBoundsSchema.optional(),
     indexInMatches: z.number().int().optional(),

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -238,6 +238,29 @@ describe("TapOnElement selectedElement metadata", () => {
     });
   });
 
+  // A Compose node selected by testTag may carry only a test tag (no text, no
+  // resource-id); the metadata must retain it so the tap message can name it.
+  test("retains the Compose test tag as selected-element identity", () => {
+    const tapOnElement = createTapOnElement();
+    const element: Element = {
+      "test-tag": "message_row_42",
+      class: "android.view.View",
+      bounds: { left: 0, top: 0, right: 100, bottom: 40 },
+    } as Element;
+    const selection: ElementSelectionResult = {
+      element,
+      indexInMatches: 0,
+      totalMatches: 1,
+      strategy: "first",
+    };
+
+    const selectedElement = (tapOnElement as any).buildSelectedElementMetadata(selection);
+
+    expect(selectedElement.testTag).toBe("message_row_42");
+    expect(selectedElement.text).toBe("");
+    expect(selectedElement.resourceId).toBe("");
+  });
+
   test("handles text, button, and list item element types", () => {
     const tapOnElement = createTapOnElement();
     const cases: Array<{ label: string; element: Element }> = [

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -4,9 +4,7 @@ import { ActionableError, type LaunchAppResult, type ObserveResult } from "../..
 
 const observationForApp = (appId: string | undefined): ObserveResult =>
   ({
-    activeWindow: appId
-      ? { appId, activityName: "MainActivity", layoutSeqSum: 1 }
-      : undefined,
+    activeWindow: appId ? { appId, activityName: "MainActivity", layoutSeqSum: 1 } : undefined,
   }) as ObserveResult;
 
 describe("buildLaunchAppResponse", () => {

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -84,6 +84,25 @@ describe("buildLaunchAppResponse", () => {
     expect(payload.message).toBe("Launched app com.android.settings");
   });
 
+  // LaunchApp reconciles a launch via viewHierarchy.packageName when the active
+  // window is absent; the response must report that verified app rather than
+  // dropping the signal and forcing the client to re-observe.
+  test("falls back to viewHierarchy.packageName when the active window is absent", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        viewHierarchy: { packageName: "com.android.settings" },
+      } as ObserveResult,
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.observedAppId).toBe("com.android.settings");
+    expect(payload.verified).toBe(true);
+    expect(payload.message).toBe("Launched app com.android.settings (foreground verified)");
+  });
+
   test("omits verification when no observation is available", () => {
     const result: LaunchAppResult = {
       success: true,

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { buildLaunchAppResponse } from "../../src/server/appTools";
+import { ActionableError, type LaunchAppResult, type ObserveResult } from "../../src/models";
+
+const observationForApp = (appId: string | undefined): ObserveResult =>
+  ({
+    activeWindow: appId
+      ? { appId, activityName: "MainActivity", layoutSeqSum: 1 }
+      : undefined,
+  }) as ObserveResult;
+
+describe("buildLaunchAppResponse", () => {
+  // AC1: launchApp must return a real error when the package is not installed,
+  // instead of a flat "Launched app X" success string (#5868).
+  test("throws the underlying error when the app is not installed", () => {
+    const result: LaunchAppResult = {
+      success: false,
+      packageName: "com.android.contacts",
+      error: "App is not installed",
+    };
+
+    expect(() => buildLaunchAppResponse("com.android.contacts", result)).toThrow(ActionableError);
+    expect(() => buildLaunchAppResponse("com.android.contacts", result)).toThrow(
+      "App is not installed",
+    );
+  });
+
+  // AC2: when the launch observation reports a different foreground app, execute()
+  // returns success:false with a descriptive error; the handler must surface it.
+  test("throws the foreground-mismatch error rather than reporting success", () => {
+    const result: LaunchAppResult = {
+      success: false,
+      packageName: "com.android.settings",
+      error:
+        "Timed out waiting for launch observation to show com.android.settings; last observation reported com.google.android.calendar",
+    };
+
+    expect(() => buildLaunchAppResponse("com.android.settings", result)).toThrow(
+      "com.google.android.calendar",
+    );
+  });
+
+  test("falls back to a generic error message when success is false without an error", () => {
+    const result: LaunchAppResult = {
+      success: false,
+      packageName: "com.example.app",
+    };
+
+    expect(() => buildLaunchAppResponse("com.example.app", result)).toThrow(
+      "Failed to launch app com.example.app",
+    );
+  });
+
+  // AC2: on success, surface the verified foreground appId so the client does not
+  // have to burn a round-trip on observe to confirm the launch.
+  test("reports verified foreground when the observation matches the requested app", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: observationForApp("com.android.settings"),
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.verified).toBe(true);
+    expect(payload.observedAppId).toBe("com.android.settings");
+    expect(payload.message).toBe("Launched app com.android.settings (foreground verified)");
+    expect(payload.success).toBe(true);
+  });
+
+  test("omits verification when no observation is available", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.verified).toBeUndefined();
+    expect(payload.observedAppId).toBeUndefined();
+    expect(payload.message).toBe("Launched app com.android.settings");
+  });
+});

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -68,6 +68,24 @@ describe("buildLaunchAppResponse", () => {
     expect(payload.success).toBe(true);
   });
 
+  // A successful launch that lands on an accepted surface (e.g. a notification
+  // permission dialog, whose foreground is the permission controller) must not
+  // emit a misleading verified:false — execute already returns success:false for a
+  // genuine wrong-app landing. It still reports the observed appId.
+  test("omits verification (never false) on a successful launch with a differing foreground", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: observationForApp("com.google.android.permissioncontroller"),
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.verified).toBeUndefined();
+    expect(payload.observedAppId).toBe("com.google.android.permissioncontroller");
+    expect(payload.message).toBe("Launched app com.android.settings");
+  });
+
   test("omits verification when no observation is available", () => {
     const result: LaunchAppResult = {
       success: true,

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -70,6 +70,20 @@ describe("buildTapOnResultMessage", () => {
     expect(first).not.toBe(third);
   });
 
+  // A testTag-selected Compose node may expose only a test tag (no text, no id);
+  // the message must name it so tapping message_row_42 vs another tag is not
+  // byte-identical.
+  test("names the test tag when it is the only stable identity", () => {
+    const message = buildTapOnResultMessage(selected({ testTag: "message_row_42" }), undefined);
+    expect(message).toBe("Tapped on element (matched testTag=message_row_42; 1 match)");
+  });
+
+  test("two uniquely-tagged nodes stay distinguishable via their test tag", () => {
+    const a = buildTapOnResultMessage(selected({ testTag: "message_row_42" }), undefined);
+    const b = buildTapOnResultMessage(selected({ testTag: "message_row_7" }), undefined);
+    expect(a).not.toBe(b);
+  });
+
   test("omits the index for a precise single match", () => {
     const message = buildTapOnResultMessage(selected({ text: "Internet" }), undefined);
     expect(message).toContain("1 match");

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -31,12 +31,49 @@ describe("buildTapOnResultMessage", () => {
     expect(message).toContain("3 matches");
   });
 
-  test("prefers the resource id as the match identity when present", () => {
+  // Both identity fields must appear: Android rows commonly share a resource id
+  // like ...:id/title, so id alone leaves "Internet" and "Calendar" byte-identical.
+  test("includes both the resource id and the text as the match identity", () => {
     const message = buildTapOnResultMessage(
       selected({ text: "Internet", resourceId: "com.android.settings:id/title" }),
       undefined,
     );
     expect(message).toContain("matched id=com.android.settings:id/title");
+    expect(message).toContain('text="Internet"');
+  });
+
+  test("two rows sharing a resource id stay distinguishable via their text", () => {
+    const internet = buildTapOnResultMessage(
+      selected({ text: "Internet", resourceId: "android:id/title" }),
+      undefined,
+    );
+    const calendar = buildTapOnResultMessage(
+      selected({ text: "Calendar", resourceId: "android:id/title" }),
+      undefined,
+    );
+    expect(internet).not.toBe(calendar);
+  });
+
+  // For an ambiguous selector the chosen occurrence must be named — index 0 vs 2
+  // (or a random pick) among identical rows is otherwise indistinguishable.
+  test("names the chosen index when the selector is ambiguous", () => {
+    const first = buildTapOnResultMessage(
+      selected({ text: "Row", totalMatches: 3, indexInMatches: 0 }),
+      undefined,
+    );
+    const third = buildTapOnResultMessage(
+      selected({ text: "Row", totalMatches: 3, indexInMatches: 2 }),
+      undefined,
+    );
+    expect(first).toContain("3 matches (index 0)");
+    expect(third).toContain("3 matches (index 2)");
+    expect(first).not.toBe(third);
+  });
+
+  test("omits the index for a precise single match", () => {
+    const message = buildTapOnResultMessage(selected({ text: "Internet" }), undefined);
+    expect(message).toContain("1 match");
+    expect(message).not.toContain("index");
   });
 
   test("a different matched text yields a different message", () => {
@@ -80,13 +117,21 @@ describe("buildTapOnResultMessage", () => {
     expect(terms).not.toBe(privacy);
   });
 
-  test("prefers the matched element over the activated link when both are present", () => {
-    const message = buildTapOnResultMessage(selected({ text: "Internet" }), undefined, {
+  // Owner-scoped subtext taps resolve BOTH an owner and an activated link, so the
+  // message must carry both — the owner identity and which link was activated —
+  // otherwise activating "Terms" vs "Privacy" on the same owner is byte-identical.
+  test("includes both the owner identity and the activated link when both are present", () => {
+    const terms = buildTapOnResultMessage(selected({ text: "Legal" }), undefined, {
       text: "Terms",
       occurrence: 0,
     });
-    expect(message).toContain('matched text="Internet"');
-    expect(message).not.toContain("activated link");
+    const privacy = buildTapOnResultMessage(selected({ text: "Legal" }), undefined, {
+      text: "Privacy",
+      occurrence: 0,
+    });
+    expect(terms).toContain('matched text="Legal"');
+    expect(terms).toContain('activated link "Terms"');
+    expect(terms).not.toBe(privacy);
   });
 
   test("keeps the plain message when nothing was resolved", () => {

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { buildTapOnResultMessage } from "../../src/server/interactionTools";
+import type { TapOnSelectedElement } from "../../src/models";
+
+const selected = (overrides: Partial<TapOnSelectedElement>): TapOnSelectedElement => ({
+  text: "",
+  resourceId: "",
+  bounds: { left: 0, top: 0, right: 10, bottom: 10, centerX: 5, centerY: 5 },
+  indexInMatches: 0,
+  totalMatches: 1,
+  selectionStrategy: "first",
+  ...overrides,
+});
+
+describe("buildTapOnResultMessage", () => {
+  // AC3: a precise selector must be distinguishable from an ambiguous one, and the
+  // message must say what it matched — a correct tap and a wrong tap must not be
+  // byte-identical (#5868).
+  test("names the matched text and a single match count", () => {
+    const message = buildTapOnResultMessage(selected({ text: "Internet" }), undefined);
+    expect(message).toContain('matched text="Internet"');
+    expect(message).toContain("1 match");
+    expect(message).not.toContain("matches");
+  });
+
+  test("reports an ambiguous selector via the match count", () => {
+    const message = buildTapOnResultMessage(selected({ text: "Internet", totalMatches: 3 }), undefined);
+    expect(message).toContain("3 matches");
+  });
+
+  test("prefers the resource id as the match identity when present", () => {
+    const message = buildTapOnResultMessage(
+      selected({ text: "Internet", resourceId: "com.android.settings:id/title" }),
+      undefined,
+    );
+    expect(message).toContain("matched id=com.android.settings:id/title");
+  });
+
+  test("a different matched text yields a different message", () => {
+    const right = buildTapOnResultMessage(selected({ text: "Internet" }), undefined);
+    const wrong = buildTapOnResultMessage(selected({ text: "Calendar" }), undefined);
+    expect(right).not.toBe(wrong);
+  });
+
+  test("appends the hierarchy-changed search summary when provided", () => {
+    const summary = "0 view hierarchy changes over 28 requests within 1523ms";
+    const message = buildTapOnResultMessage(selected({ text: "Internet" }), summary);
+    expect(message).toContain('matched text="Internet"');
+    expect(message).toContain(summary);
+  });
+
+  test("keeps the plain message when nothing was resolved", () => {
+    expect(buildTapOnResultMessage(undefined, undefined)).toBe("Tapped on element");
+  });
+
+  test("uses only the search summary when there is no selected element", () => {
+    const summary = "2 view hierarchy changes over 5 requests within 300ms";
+    expect(buildTapOnResultMessage(undefined, summary)).toBe(`Tapped on element (${summary})`);
+  });
+});

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -49,6 +49,37 @@ describe("buildTapOnResultMessage", () => {
     expect(message).toContain(summary);
   });
 
+  // The accessibilityLink selector resolves no selectedElement; the message must
+  // still say which semantic link was activated so different links are not
+  // byte-identical.
+  test("names the activated semantic link when there is no selected element", () => {
+    const message = buildTapOnResultMessage(undefined, undefined, {
+      text: "Terms and privacy",
+      occurrence: 0,
+    });
+    expect(message).toBe('Tapped on element (activated link "Terms and privacy")');
+  });
+
+  test("includes the occurrence when it disambiguates repeated link text", () => {
+    const message = buildTapOnResultMessage(undefined, undefined, { text: "Learn more", occurrence: 2 });
+    expect(message).toContain('activated link "Learn more" [occurrence 2]');
+  });
+
+  test("different activated links yield different messages", () => {
+    const terms = buildTapOnResultMessage(undefined, undefined, { text: "Terms", occurrence: 0 });
+    const privacy = buildTapOnResultMessage(undefined, undefined, { text: "Privacy", occurrence: 0 });
+    expect(terms).not.toBe(privacy);
+  });
+
+  test("prefers the matched element over the activated link when both are present", () => {
+    const message = buildTapOnResultMessage(selected({ text: "Internet" }), undefined, {
+      text: "Terms",
+      occurrence: 0,
+    });
+    expect(message).toContain('matched text="Internet"');
+    expect(message).not.toContain("activated link");
+  });
+
   test("keeps the plain message when nothing was resolved", () => {
     expect(buildTapOnResultMessage(undefined, undefined)).toBe("Tapped on element");
   });

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -24,7 +24,10 @@ describe("buildTapOnResultMessage", () => {
   });
 
   test("reports an ambiguous selector via the match count", () => {
-    const message = buildTapOnResultMessage(selected({ text: "Internet", totalMatches: 3 }), undefined);
+    const message = buildTapOnResultMessage(
+      selected({ text: "Internet", totalMatches: 3 }),
+      undefined,
+    );
     expect(message).toContain("3 matches");
   });
 
@@ -61,13 +64,19 @@ describe("buildTapOnResultMessage", () => {
   });
 
   test("includes the occurrence when it disambiguates repeated link text", () => {
-    const message = buildTapOnResultMessage(undefined, undefined, { text: "Learn more", occurrence: 2 });
+    const message = buildTapOnResultMessage(undefined, undefined, {
+      text: "Learn more",
+      occurrence: 2,
+    });
     expect(message).toContain('activated link "Learn more" [occurrence 2]');
   });
 
   test("different activated links yield different messages", () => {
     const terms = buildTapOnResultMessage(undefined, undefined, { text: "Terms", occurrence: 0 });
-    const privacy = buildTapOnResultMessage(undefined, undefined, { text: "Privacy", occurrence: 0 });
+    const privacy = buildTapOnResultMessage(undefined, undefined, {
+      text: "Privacy",
+      occurrence: 0,
+    });
     expect(terms).not.toBe(privacy);
   });
 


### PR DESCRIPTION
## Summary

Action tools reported success without checking their postcondition. `launchApp`
returned a flat `Launched app X` even when the package was not installed or the
launched app never reached the foreground, and `tapOn` returned a byte-identical
`Tapped on element` whether it matched the right node or the wrong one — so an
MCP client had no way to tell "it worked" from "it silently didn't" without a
follow-up `observe`.

The verification data already existed; the handlers just weren't surfacing it:

- `LaunchApp.execute` already resolves the package (returns `success:false` /
  `App is not installed`) and reconciles the launch observation against the
  requested `appId` (returns `success:false` with a descriptive error when the
  foreground app never matches). `launchAppHandler` ignored `result.success` and
  always reported success.
- `TapOnElement` already resolves the match into `selectedElement`
  (`resourceId`/`text`/`bounds`/`totalMatches`) and `searchUntil`, but the
  message never named any of it.

## Changes

- **`launchApp`** (`src/server/appTools.ts`): new pure `buildLaunchAppResponse`
  throws the typed failure as a real `ActionableError` instead of a success
  message — mirroring the terminate handler (#5621). The handler's catch no
  longer re-wraps an `ActionableError`. On success it reports the observed
  foreground `appId` and `verified` (whether it matched the requested app), so a
  client can skip a confirming `observe`.
- **`tapOn`** (`src/server/interactionTools.ts`): new pure
  `buildTapOnResultMessage` names the resolved match identity and match count
  (e.g. `Tapped on element (matched text="Internet"; 1 match; 0 view hierarchy
  changes over 28 requests within 1523ms)`), so an ambiguous selector is
  distinguishable from a precise one and a wrong tap is no longer byte-identical
  to a correct one. The structured `selectedElement`/`searchUntil` still ride on
  the result.

## Linked Issue

Closes #5868

## Bug / Regression Context

- **Observed symptom:** `launchApp` on an uninstalled package and on an app that
  never foregrounded both returned `{"message":"Launched app X"}`; `tapOn`
  returned `{"message":"Tapped on element"}` regardless of what (if anything) it
  matched.
- **Repro conditions:** driving AutoMobile as an MCP client; documented in the
  issue against local build `0.0.66+ga99f379ce400`.

## Acceptance criteria

- [x] `launchApp` returns a real error when the package isn't installed —
  `test/server/appTools.launchAppResponse.test.ts`
- [x] `launchApp` surfaces the foreground-mismatch failure (and reports the
  observed foreground `appId` + `verified` on success) — same test
- [x] `tapOn` result says what it matched (identity + match count) and is no
  longer byte-identical for a right vs wrong match —
  `test/server/interactionTools.tapOnMessage.test.ts`

## Validation

- [x] `bun test` (full suite): the only 2 failures are pre-existing worktree/env
  artifacts (`node_modules/.bin/oxlint` ENOENT in the `.claude` worktree; a
  WebRTC latency test's subprocess `bun test` skip-line format) — neither imports
  the changed files.
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` + `bun run lint` ratchet gate: no new violations
- [x] New code uses pure helpers with fast unit tests (<100ms); no new deps
