### PR TITLE
fix(observe): retract freshness on wrong-window capture and invalidate window cache on terminate (#5867)

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -176,6 +176,11 @@ export class TerminateApp extends BaseVisualChange {
       });
 
       if (!isRunning) {
+        // The process is already gone — the exact dead-process state that
+        // terminate-then-observe is meant to recover from (issue #5867). Any
+        // cached window/hierarchy record for it is stale, so invalidate here too,
+        // not only on the force-stop path below.
+        this.cacheInvalidator.invalidate(this.device);
         return {
           success: true,
           packageName,

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -14,6 +14,32 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
 import { getIosInstalledAppBundleId } from "../../utils/ios-cmdline-tools/iosInstalledApp";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import { RealObserveScreen } from "../observe/ObserveScreen";
+
+/**
+ * Invalidates the host-side cached window/hierarchy record for a device after
+ * its foreground process is force-stopped (issue #5867). Without this, a client
+ * that terminates a stuck app and re-observes to recover is re-served the same
+ * stale wrong-window hierarchy from cache. Injected so the invalidation is
+ * exercised in tests without a real CtrlProxy connection.
+ */
+export interface DeviceWindowCacheInvalidator {
+  invalidate(device: BootedDevice): void;
+}
+
+/**
+ * Default invalidator: drops the Android CtrlProxy hierarchy cache (an existing
+ * instance only — never bootstraps a connection just to clear it) and the
+ * observe-result cache for the device, so the next observe re-syncs fresh.
+ */
+export class DefaultDeviceWindowCacheInvalidator implements DeviceWindowCacheInvalidator {
+  invalidate(device: BootedDevice): void {
+    if (device.platform === "android") {
+      AndroidCtrlProxyClient.getExistingInstance(device.deviceId)?.invalidateCache();
+    }
+    RealObserveScreen.clearCache(device.deviceId);
+  }
+}
 
 /**
  * Physical-device app terminator. `DeviceAppManager` satisfies this
@@ -31,6 +57,7 @@ export interface DeviceAppTerminator {
 export class TerminateApp extends BaseVisualChange {
   private simctl: SimCtlClient;
   private deviceTerminator: DeviceAppTerminator;
+  private cacheInvalidator: DeviceWindowCacheInvalidator;
 
   /**
    * Create an TerminateApp instance
@@ -46,11 +73,13 @@ export class TerminateApp extends BaseVisualChange {
     simctl: SimCtlClient | null = null,
     timer: Timer = defaultTimer,
     deviceTerminator: DeviceAppTerminator | null = null,
+    cacheInvalidator: DeviceWindowCacheInvalidator | null = null,
   ) {
     super(device, adb, timer);
     this.device = device;
     this.simctl = simctl || new SimCtlClient(device);
     this.deviceTerminator = deviceTerminator || new DeviceAppManager();
+    this.cacheInvalidator = cacheInvalidator || new DefaultDeviceWindowCacheInvalidator();
   }
 
   /**
@@ -170,6 +199,11 @@ export class TerminateApp extends BaseVisualChange {
       await perf.track("forceStop", async () => {
         await this.adb.executeCommand(`shell am force-stop --user ${targetUserId} ${packageName}`);
       });
+
+      // The process is now gone, so any cached window/hierarchy record for it is
+      // stale. Invalidate it so a client re-observing to recover gets a fresh
+      // sync instead of the same phantom window (issue #5867).
+      this.cacheInvalidator.invalidate(this.device);
 
       return {
         success: true,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -391,13 +391,6 @@ export class RealObserveScreen implements ObserveScreen {
         }
       }
 
-      // Cache the result for future use
-      await perf.track("cacheResult", () =>
-        getObserveCacheStore().put(this.device.deviceId, result),
-      );
-
-      perf.end();
-
       // Freshness diagnostics.
       //
       // This used to read `isFresh = requestedAfter === undefined ? true : …`,
@@ -407,6 +400,13 @@ export class RealObserveScreen implements ObserveScreen {
       // property in question measured nothing. It is now always a measurement:
       // capture age, plus whether the delegate verified the tree against the
       // device on this call. See ./observationFreshness.ts.
+      //
+      // Computed BEFORE caching so the persisted result carries the verdict: the
+      // observe cache serializes the result at `put` time (the filesystem store),
+      // so a verdict attached afterward would be lost on a daemon-restart cache
+      // reload within the TTL, and a consumer reading the cached tree directly
+      // (e.g. `SwipeOn.getScrollableContext`, nav/registry embeds) would accept a
+      // phantom hierarchy without its `isFresh: false` signal (issue #5867).
       result.freshness = computeFreshness({
         requestedAfter: minTimestamp > 0 ? minTimestamp : undefined,
         actualTimestamp: this.resolveObservationTimestampMs(result),
@@ -426,6 +426,13 @@ export class RealObserveScreen implements ObserveScreen {
           signal,
         ),
       });
+
+      // Cache the result for future use
+      await perf.track("cacheResult", () =>
+        getObserveCacheStore().put(this.device.deviceId, result),
+      );
+
+      perf.end();
 
       // Attach the windowed performance snapshot when opted in (independent of --debug-perf).
       await this.attachPerfSnapshot(result);

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -420,7 +420,11 @@ export class RealObserveScreen implements ObserveScreen {
           !hierarchyPlatformValid ||
           result.viewHierarchy?.hierarchy === undefined ||
           result.viewHierarchy?.hierarchy?.error !== undefined,
-        windowIdentityMismatch: await this.resolveWindowIdentityMismatch(result, foregroundIdentity),
+        windowIdentityMismatch: await this.resolveWindowIdentityMismatch(
+          result,
+          foregroundIdentity,
+          signal,
+        ),
       });
 
       // Attach the windowed performance snapshot when opted in (independent of --debug-perf).
@@ -783,10 +787,18 @@ export class RealObserveScreen implements ObserveScreen {
    * not a stale capture. Excluding it keeps first-class shade workflows (the
    * `systemTray` tool) from misfiring while still catching the app-vs-app case
    * the issue reported.
+   *
+   * The parallel sample is taken before hierarchy capture, so during an A→B app
+   * transition it can lag the (valid, newer) captured window and read a spurious
+   * mismatch. A detected mismatch is therefore confirmed against a second read
+   * taken now — after capture: freshness is retracted only when the device is
+   * *stably* on a different app (both samples agree, and still differ from the
+   * observed window). The extra dumpsys runs only on the rare mismatch path.
    */
   private async resolveWindowIdentityMismatch(
     result: ObserveResult,
     foregroundIdentity: Promise<string | undefined>,
+    signal?: AbortSignal,
   ): Promise<{ observed: string; foreground: string } | undefined> {
     const foreground = await foregroundIdentity;
     const observed = result.activeWindow?.appId;
@@ -797,6 +809,11 @@ export class RealObserveScreen implements ObserveScreen {
       SYSTEM_UI_WINDOW_PACKAGES.has(observed) ||
       SYSTEM_UI_WINDOW_PACKAGES.has(foreground)
     ) {
+      return undefined;
+    }
+    // Confirm the mismatch is steady-state, not a transient transition (see above).
+    const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
+    if (!confirmed || confirmed !== foreground || confirmed === observed) {
       return undefined;
     }
     return { observed, foreground };

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -80,6 +80,16 @@ function boundCachedLayoutWarnings(result: ObserveResult | undefined): ObserveRe
   return capped === result.layoutWarnings ? result : { ...result, layoutWarnings: capped };
 }
 
+/**
+ * Packages that legitimately present as the accessibility active window without
+ * being the device's resumed activity — a system-UI panel (notification shade,
+ * quick settings, volume, power dialog, keyguard) is a window, not an
+ * ActivityRecord, so it never appears as the resumed activity behind it. The
+ * window-identity freshness check (issue #5867) excludes these to avoid
+ * misreporting an expanded shade as a stale wrong-window capture.
+ */
+const SYSTEM_UI_WINDOW_PACKAGES = new Set<string>(["com.android.systemui"]);
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -312,7 +322,8 @@ export class RealObserveScreen implements ObserveScreen {
 
       // Ground-truth foreground app for the window-identity freshness check
       // (issue #5867). Started here so it overlaps hierarchy collection and adds
-      // no serial latency; Android only (dumpsys `topResumedActivity`), best-effort.
+      // no serial latency; Android only (dumpsys resumed/focused activity),
+      // best-effort.
       const foregroundIdentity: Promise<string | undefined> =
         this.device.platform === "android"
           ? this.deviceStateCollector.collectForegroundIdentity(signal)
@@ -758,12 +769,20 @@ export class RealObserveScreen implements ObserveScreen {
 
   /**
    * Compare the app the observed hierarchy was captured from against the
-   * device's ground-truth top resumed activity (issue #5867). Returns a mismatch
+   * device's ground-truth resumed activity (issue #5867). Returns a mismatch
    * descriptor only when both are known and their package names differ — the
    * cross-app stale-window case. A same-package activity change, an unknown
    * ground truth, or an unknown observed window all yield `undefined` (no
    * comparison, no false alarm). iOS never supplies a ground truth and so is
    * always `undefined`.
+   *
+   * A system-UI window (`com.android.systemui`) on either side is excluded: when
+   * the notification shade, quick settings, volume, or power dialog takes
+   * accessibility focus, the a11y active window is systemui while the resumed
+   * activity behind the panel is the underlying app — a legitimate divergence,
+   * not a stale capture. Excluding it keeps first-class shade workflows (the
+   * `systemTray` tool) from misfiring while still catching the app-vs-app case
+   * the issue reported.
    */
   private async resolveWindowIdentityMismatch(
     result: ObserveResult,
@@ -772,6 +791,12 @@ export class RealObserveScreen implements ObserveScreen {
     const foreground = await foregroundIdentity;
     const observed = result.activeWindow?.appId;
     if (!foreground || !observed || observed === foreground) {
+      return undefined;
+    }
+    if (
+      SYSTEM_UI_WINDOW_PACKAGES.has(observed) ||
+      SYSTEM_UI_WINDOW_PACKAGES.has(foreground)
+    ) {
       return undefined;
     }
     return { observed, foreground };

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -821,10 +821,7 @@ export class RealObserveScreen implements ObserveScreen {
     if (!foreground || !observed || observed === foreground) {
       return undefined;
     }
-    if (
-      SYSTEM_UI_WINDOW_PACKAGES.has(observed) ||
-      SYSTEM_UI_WINDOW_PACKAGES.has(foreground)
-    ) {
+    if (SYSTEM_UI_WINDOW_PACKAGES.has(observed) || SYSTEM_UI_WINDOW_PACKAGES.has(foreground)) {
       return undefined;
     }
     // Confirm the mismatch is steady-state, not a transient transition (see above).

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -801,6 +801,15 @@ export class RealObserveScreen implements ObserveScreen {
    * taken now — after capture: freshness is retracted only when the device is
    * *stably* on a different app (both samples agree, and still differ from the
    * observed window). The extra dumpsys runs only on the rare mismatch path.
+   *
+   * The observed package is `viewHierarchy.packageName` — the package of the
+   * tree actually being validated — in preference to `activeWindow.appId`. The
+   * latter is derived from the accessibility `foregroundActivity`, which with an
+   * active soft keyboard can be the IME root's package while the captured
+   * hierarchy is the underlying app; comparing the IME package would falsely
+   * retract a valid application hierarchy. Falls back to `activeWindow.appId`
+   * only when the hierarchy carries no package (e.g. the bootstrap path, whose
+   * appId is itself a resumed-activity read in the same domain as the ground truth).
    */
   private async resolveWindowIdentityMismatch(
     result: ObserveResult,
@@ -808,7 +817,7 @@ export class RealObserveScreen implements ObserveScreen {
     signal?: AbortSignal,
   ): Promise<{ observed: string; foreground: string } | undefined> {
     const foreground = await foregroundIdentity;
-    const observed = result.activeWindow?.appId;
+    const observed = result.viewHierarchy?.packageName ?? result.activeWindow?.appId;
     if (!foreground || !observed || observed === foreground) {
       return undefined;
     }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -310,6 +310,14 @@ export class RealObserveScreen implements ObserveScreen {
 
       perf.serial("observe");
 
+      // Ground-truth foreground app for the window-identity freshness check
+      // (issue #5867). Started here so it overlaps hierarchy collection and adds
+      // no serial latency; Android only (dumpsys `topResumedActivity`), best-effort.
+      const foregroundIdentity: Promise<string | undefined> =
+        this.device.platform === "android"
+          ? this.deviceStateCollector.collectForegroundIdentity(signal)
+          : Promise.resolve(undefined);
+
       // Phase 1+2: hierarchy + derived device state (platform-specific orchestration).
       await this.collectAllData(
         result,
@@ -401,6 +409,7 @@ export class RealObserveScreen implements ObserveScreen {
           !hierarchyPlatformValid ||
           result.viewHierarchy?.hierarchy === undefined ||
           result.viewHierarchy?.hierarchy?.error !== undefined,
+        windowIdentityMismatch: await this.resolveWindowIdentityMismatch(result, foregroundIdentity),
       });
 
       // Attach the windowed performance snapshot when opted in (independent of --debug-perf).
@@ -746,6 +755,27 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   // ---------- Helpers ----------
+
+  /**
+   * Compare the app the observed hierarchy was captured from against the
+   * device's ground-truth top resumed activity (issue #5867). Returns a mismatch
+   * descriptor only when both are known and their package names differ — the
+   * cross-app stale-window case. A same-package activity change, an unknown
+   * ground truth, or an unknown observed window all yield `undefined` (no
+   * comparison, no false alarm). iOS never supplies a ground truth and so is
+   * always `undefined`.
+   */
+  private async resolveWindowIdentityMismatch(
+    result: ObserveResult,
+    foregroundIdentity: Promise<string | undefined>,
+  ): Promise<{ observed: string; foreground: string } | undefined> {
+    const foreground = await foregroundIdentity;
+    const observed = result.activeWindow?.appId;
+    if (!foreground || !observed || observed === foreground) {
+      return undefined;
+    }
+    return { observed, foreground };
+  }
 
   private resolveObservationTimestampMs(result: ObserveResult): number | undefined {
     const candidate = result.viewHierarchy?.updatedAt ?? result.updatedAt;

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -72,11 +72,13 @@ export class DeviceStateCollector {
   }
 
   /**
-   * Ground-truth foreground app package from dumpsys `topResumedActivity`
-   * (issue #5867), used to validate that the observed hierarchy actually belongs
-   * to the app currently resumed on the device. Best-effort: a failed or absent
-   * read returns `undefined`, which the caller treats as "cannot compare" (no
-   * false alarm) rather than a mismatch.
+   * Ground-truth foreground app package from dumpsys (the resumed/focused
+   * activity — `adb.getForegroundApp` reads `mResumedActivity` /
+   * `mFocusedActivity` / `topResumedActivity`), used to validate that the
+   * observed hierarchy actually belongs to the app currently resumed on the
+   * device (issue #5867). Best-effort: a failed or absent read returns
+   * `undefined`, which the caller treats as "cannot compare" (no false alarm)
+   * rather than a mismatch.
    */
   async collectForegroundIdentity(signal?: AbortSignal): Promise<string | undefined> {
     const { adb } = this.opts;

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -71,6 +71,26 @@ export class DeviceStateCollector {
     }
   }
 
+  /**
+   * Ground-truth foreground app package from dumpsys `topResumedActivity`
+   * (issue #5867), used to validate that the observed hierarchy actually belongs
+   * to the app currently resumed on the device. Best-effort: a failed or absent
+   * read returns `undefined`, which the caller treats as "cannot compare" (no
+   * false alarm) rather than a mismatch.
+   */
+  async collectForegroundIdentity(signal?: AbortSignal): Promise<string | undefined> {
+    const { adb } = this.opts;
+    try {
+      const foreground = await adb.getForegroundApp(signal);
+      return foreground?.packageName ?? undefined;
+    } catch (error) {
+      // Best-effort window-identity check: a failed foreground read must not fail
+      // the observation, only skip the comparison.
+      logger.debug("Failed to get ground-truth foreground app:", error);
+      return undefined;
+    }
+  }
+
   async collectActiveWindow(result: ObserveResult): Promise<void> {
     const { window, timer } = this.opts;
     try {

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -67,6 +67,16 @@ export interface FreshnessInputs {
   verified?: boolean;
   /** The hierarchy could not be retrieved, so no freshness verdict is possible. */
   unavailable?: boolean;
+  /**
+   * The observed hierarchy's window identity does not match the device's current
+   * top resumed activity — the tree is a stale wrong-window capture (issue
+   * #5867). `observed` is the app the hierarchy was captured from; `foreground`
+   * is the app actually resumed on the device. When set, freshness is retracted
+   * unconditionally: `verified: false`, `isFresh: false`, regardless of age or
+   * the delegate's own `verified` signal — a tree from the wrong window was
+   * never verified against the foreground app no matter how recently captured.
+   */
+  windowIdentityMismatch?: { observed: string; foreground: string };
   /** Age budget; defaults to {@link maxObservationAgeMs}. */
   maxAgeMs?: number;
 }
@@ -152,6 +162,7 @@ function resolveAgeMs(
  */
 export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
   const { requestedAfter, actualTimestamp, hostAgeBasisMs, now, verified, unavailable } = inputs;
+  const windowIdentityMismatch = inputs.windowIdentityMismatch;
   const maxAgeMs = inputs.maxAgeMs ?? maxObservationAgeMs();
 
   const ageMs = resolveAgeMs(hostAgeBasisMs, actualTimestamp, now);
@@ -164,6 +175,21 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       verified,
       isFresh: false,
       warning: "View hierarchy could not be retrieved, so its freshness cannot be established.",
+    };
+  }
+
+  // The tree belongs to a different app than the one currently resumed on the
+  // device (issue #5867). This dominates every other signal — a wrong-window
+  // capture is unfresh at any age, and `verified` is retracted to false so a
+  // consumer reading that field alone is not green-lit onto a phantom.
+  if (windowIdentityMismatch) {
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app.`,
     };
   }
 

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -303,6 +303,69 @@ describe("TerminateApp (Android)", () => {
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(true);
   });
 
+  test("invalidates the cached window record after a successful force-stop (issue #5867)", async () => {
+    fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "1",
+    );
+    fakeAdb.setCommandResult("shell dumpsys activity processes", "3220:com.example.app/u0a123");
+    fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
+
+    const invalidated: BootedDevice[] = [];
+    const cacheInvalidator = {
+      invalidate: (device: BootedDevice) => {
+        invalidated.push(device);
+      },
+    };
+
+    const terminateApp = new TerminateApp(
+      androidDevice,
+      fakeAdb as any,
+      null,
+      fakeTimer,
+      null,
+      cacheInvalidator,
+    );
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(true);
+    expect(invalidated).toHaveLength(1);
+    expect(invalidated[0].deviceId).toBe("emulator-5554");
+  });
+
+  test("does not invalidate the cache when the app was not running (issue #5867)", async () => {
+    fakeAdb.setForegroundApp(null);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "1",
+    );
+    fakeAdb.setCommandResult("shell dumpsys activity processes", "3271:com.example.other/u0a123");
+
+    const invalidated: BootedDevice[] = [];
+    const cacheInvalidator = {
+      invalidate: (device: BootedDevice) => {
+        invalidated.push(device);
+      },
+    };
+
+    const terminateApp = new TerminateApp(
+      androidDevice,
+      fakeAdb as any,
+      null,
+      fakeTimer,
+      null,
+      cacheInvalidator,
+    );
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.wasRunning).toBe(false);
+    expect(invalidated).toHaveLength(0);
+  });
+
   test("returns not installed when package is missing", async () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -336,7 +336,10 @@ describe("TerminateApp (Android)", () => {
     expect(invalidated[0].deviceId).toBe("emulator-5554");
   });
 
-  test("does not invalidate the cache when the app was not running (issue #5867)", async () => {
+  test("invalidates the cache when an installed app's process is already gone (issue #5867)", async () => {
+    // The dead-process state is exactly what terminate-then-observe recovers
+    // from, so the already-stopped path must invalidate the stale window record
+    // too — not only the force-stop path.
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     fakeAdb.setCommandResult(
@@ -363,6 +366,37 @@ describe("TerminateApp (Android)", () => {
     const result = await terminateApp.execute("com.example.app", { skipObservation: true });
 
     expect(result.wasRunning).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
+    expect(invalidated).toHaveLength(1);
+    expect(invalidated[0].deviceId).toBe("emulator-5554");
+  });
+
+  test("does not invalidate the cache when the package is not installed (issue #5867)", async () => {
+    fakeAdb.setForegroundApp(null);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "0",
+    );
+
+    const invalidated: BootedDevice[] = [];
+    const cacheInvalidator = {
+      invalidate: (device: BootedDevice) => {
+        invalidated.push(device);
+      },
+    };
+
+    const terminateApp = new TerminateApp(
+      androidDevice,
+      fakeAdb as any,
+      null,
+      fakeTimer,
+      null,
+      cacheInvalidator,
+    );
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.wasInstalled).toBe(false);
     expect(invalidated).toHaveLength(0);
   });
 

--- a/test/features/observe/ObserveScreenPerfSnapshot.test.ts
+++ b/test/features/observe/ObserveScreenPerfSnapshot.test.ts
@@ -50,8 +50,15 @@ class FakeHierarchyCollector implements Pick<
 
 class FakeDeviceStateCollector implements Pick<
   DeviceStateCollector,
-  "collectBackStack" | "collectWakefulness" | "collectDeviceLock" | "collectActiveWindow"
+  | "collectBackStack"
+  | "collectWakefulness"
+  | "collectDeviceLock"
+  | "collectActiveWindow"
+  | "collectForegroundIdentity"
 > {
+  async collectForegroundIdentity(): Promise<string | undefined> {
+    return undefined;
+  }
   async collectBackStack(result: ObserveResult): Promise<void> {
     result.backStack = [{ activity: "com.example/.MainActivity", taskId: 1 }] as any;
   }

--- a/test/features/observe/ObserveScreenSkipOptions.test.ts
+++ b/test/features/observe/ObserveScreenSkipOptions.test.ts
@@ -54,11 +54,19 @@ class FakeHierarchyCollector implements Pick<
 
 class FakeDeviceStateCollector implements Pick<
   DeviceStateCollector,
-  "collectBackStack" | "collectWakefulness" | "collectDeviceLock" | "collectActiveWindow"
+  | "collectBackStack"
+  | "collectWakefulness"
+  | "collectDeviceLock"
+  | "collectActiveWindow"
+  | "collectForegroundIdentity"
 > {
   backStackCalls = 0;
   activeWindowCalls = 0;
   deviceLockCalls = 0;
+
+  async collectForegroundIdentity(_signal?: AbortSignal): Promise<string | undefined> {
+    return undefined;
+  }
 
   async collectBackStack(
     result: ObserveResult,

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -123,6 +123,55 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("an expanded system-UI shade is not flagged as a wrong-window capture", async () => {
+    // When the notification shade / quick settings takes accessibility focus,
+    // the observed window is com.android.systemui while the resumed activity
+    // behind it is the underlying app. That legitimate divergence must NOT be
+    // reported as a stale wrong-window capture (the systemTray workflow relies
+    // on observing the expanded shade).
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      foregroundActivity: "com.android.systemui/.shade.NotificationPanelView",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Silent", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("no ground-truth foreground app leaves freshness unchanged (no false alarm)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -92,6 +92,55 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toContain("com.android.settings");
   });
 
+  test("the freshness verdict is present when the result is cached (survives serialization)", async () => {
+    // The filesystem observe cache serializes the result at put() time, so the
+    // verdict must be attached BEFORE caching — otherwise a daemon-restart cache
+    // reload loses the isFresh:false signal (issue #5867). Snapshot the result as
+    // the real store would (deep clone at put) and assert the verdict is there.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(calendarHierarchy(now));
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    let putSnapshot: any;
+    const snapshotStore = {
+      async put(_deviceId: string, result: any): Promise<void> {
+        putSnapshot = JSON.parse(JSON.stringify(result));
+      },
+      async getMostRecent(): Promise<any> {
+        return undefined;
+      },
+      getRecentInMemory: () => undefined,
+      getRecentInMemoryForDevice: () => undefined,
+      clear: () => undefined,
+    };
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: snapshotStore as any,
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(putSnapshot).toBeDefined();
+    expect(putSnapshot.freshness?.verified).toBe(false);
+    expect(putSnapshot.freshness?.isFresh).toBe(false);
+    expect(putSnapshot.freshness?.warning).toContain("wrong-window");
+  });
+
   test("does not retract freshness when the observed window matches the top resumed activity", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -43,6 +43,7 @@ function calendarHierarchy(now: number): any {
     fresh: true,
     screenWidth: 1080,
     screenHeight: 2400,
+    packageName: "com.google.android.calendar",
     foregroundActivity: "com.google.android.calendar/.MainActivity",
     hierarchy: {
       node: {
@@ -189,6 +190,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       fresh: true,
       screenWidth: 1080,
       screenHeight: 2400,
+      packageName: "com.android.systemui",
       foregroundActivity: "com.android.systemui/.shade.NotificationPanelView",
       hierarchy: {
         node: {
@@ -245,6 +247,55 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       }
     }
     const fakeAdb = new SequencedForegroundAdb();
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("an active IME is not flagged: the check uses the captured hierarchy's package", async () => {
+    // With a soft keyboard active, the a11y foregroundActivity (→ activeWindow.appId)
+    // can be the IME root's package while the captured hierarchy is the underlying
+    // app. The window-identity check must compare the hierarchy's own package
+    // (viewHierarchy.packageName), so a valid app hierarchy is not retracted.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.google.android.calendar", // the captured tree is the app
+      foregroundActivity: "com.google.android.inputmethod.latin/.LatinIME", // IME root
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Note", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    // Ground truth: the app is the resumed activity (the IME is not an activity).
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
 
     const screen = new RealObserveScreen(
       androidDevice,

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -172,6 +172,50 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("a transient app transition is not flagged: the confirming read settles onto the observed app", async () => {
+    // The parallel foreground sample lags the newer captured hierarchy during an
+    // A→B transition: sample1 = the old app, observed hierarchy = the new app.
+    // The confirming read (taken after capture) sees the device settled on the
+    // new app, so freshness must NOT be retracted.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(calendarHierarchy(now)); // observed = calendar
+
+    // First getForegroundApp read lags (still reports settings); the confirming
+    // read reports calendar, matching the observed window.
+    const sequence = [
+      { packageName: "com.android.settings", userId: 0 },
+      { packageName: "com.google.android.calendar", userId: 0 },
+    ];
+    class SequencedForegroundAdb extends FakeAdbExecutor {
+      async getForegroundApp(): Promise<{ packageName: string; userId: number } | null> {
+        return sequence.shift() ?? { packageName: "com.google.android.calendar", userId: 0 };
+      }
+    }
+    const fakeAdb = new SequencedForegroundAdb();
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("no ground-truth foreground app leaves freshness unchanged (no false alarm)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Issue #5867: `observe` could return a stale wrong-window hierarchy (e.g. a
+ * status-bar-only Calendar tree) while the device's top resumed activity was a
+ * different app entirely, and still report `freshness.verified: true`.
+ *
+ * These tests drive the real `RealObserveScreen` Android path through fakes.
+ * They pin the fix: when the app the hierarchy was captured from does not match
+ * the device's current top resumed activity (`adb getForegroundApp`, i.e.
+ * dumpsys `topResumedActivity`), freshness is retracted — `verified: false`,
+ * `isFresh: false`, with a warning naming both apps.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeViewHierarchy } from "../../fakes/FakeViewHierarchy";
+import { FakeObserveCacheStore } from "../../fakes/FakeObserveCacheStore";
+import { resetObserveCacheStore } from "../../../src/features/observe/cache/ObserveCacheRegistry";
+import type { BootedDevice } from "../../../src/models";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 7",
+  platform: "android",
+};
+
+function makeScreen(viewHierarchy: FakeViewHierarchy, fakeAdb: FakeAdbExecutor): RealObserveScreen {
+  return new RealObserveScreen(androidDevice, new FakeAdbClientFactory(fakeAdb), {
+    viewHierarchy,
+    cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+    performanceAuditor: { run: async () => undefined } as any,
+    accessibilityAuditor: { run: async () => undefined } as any,
+    accessibilityStateDetector: { run: async () => undefined } as any,
+  });
+}
+
+function calendarHierarchy(now: number): any {
+  return {
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    foregroundActivity: "com.google.android.calendar/.MainActivity",
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [{ text: "12:34", bounds: { left: 0, top: 0, right: 200, bottom: 60 } }],
+      },
+    },
+  };
+}
+
+describe("ObserveScreen window-identity freshness (issue #5867)", () => {
+  afterEach(() => {
+    resetObserveCacheStore();
+  });
+
+  test("retracts freshness when the observed window is not the top resumed activity", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(calendarHierarchy(now));
+
+    const fakeAdb = new FakeAdbExecutor();
+    // Ground truth: Settings is the resumed activity, not Calendar.
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.google.android.calendar");
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("com.google.android.calendar");
+    expect(result.freshness?.warning).toContain("com.android.settings");
+  });
+
+  test("does not retract freshness when the observed window matches the top resumed activity", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(calendarHierarchy(now));
+
+    const fakeAdb = new FakeAdbExecutor();
+    // Ground truth agrees with the observed window.
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("no ground-truth foreground app leaves freshness unchanged (no false alarm)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(calendarHierarchy(now));
+
+    const fakeAdb = new FakeAdbExecutor();
+    // getForegroundApp returns null (default) — cannot compare, must not flag.
+    const screen = makeScreen(viewHierarchy, fakeAdb);
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+});

--- a/test/features/observe/freshnessRegressionRepro.test.ts
+++ b/test/features/observe/freshnessRegressionRepro.test.ts
@@ -76,7 +76,11 @@ class NoOpAuditor implements Pick<
 
 class FakeDeviceStateCollector implements Pick<
   DeviceStateCollector,
-  "collectBackStack" | "collectWakefulness" | "collectDeviceLock" | "collectActiveWindow"
+  | "collectBackStack"
+  | "collectWakefulness"
+  | "collectDeviceLock"
+  | "collectActiveWindow"
+  | "collectForegroundIdentity"
 > {
   async collectBackStack(): Promise<void> {}
   async collectWakefulness(result: ObserveResult): Promise<void> {
@@ -84,6 +88,9 @@ class FakeDeviceStateCollector implements Pick<
   }
   async collectDeviceLock(): Promise<void> {}
   async collectActiveWindow(): Promise<void> {}
+  async collectForegroundIdentity(): Promise<string | undefined> {
+    return undefined;
+  }
 }
 
 /** Hands `execute()` a caller-controlled `result.viewHierarchy` directly. */

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -185,6 +185,58 @@ describe("computeFreshness", () => {
     });
   });
 
+  // --- issue #5867: window-identity mismatch retracts freshness ---
+  describe("window-identity mismatch (issue #5867)", () => {
+    test("a wrong-window capture is NOT verified and NOT fresh, even when device-verified and recent", () => {
+      // The delegate said the tree was verified (`verified: true`) and it is
+      // brand new, but it belongs to a different app than the one currently
+      // resumed on the device. That is the stale wrong-window bug: it must not
+      // read as fresh, and `verified` must be retracted to false.
+      const v = computeFreshness({
+        actualTimestamp: NOW - 100,
+        now: NOW,
+        verified: true,
+        windowIdentityMismatch: {
+          observed: "com.google.android.calendar",
+          foreground: "com.android.settings",
+        },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("com.google.android.calendar");
+      expect(v.warning).toContain("com.android.settings");
+    });
+
+    test("the mismatch dominates a requested-minimum poll too", () => {
+      const v = computeFreshness({
+        requestedAfter: NOW - 1_000,
+        actualTimestamp: NOW,
+        now: NOW,
+        windowIdentityMismatch: {
+          observed: "com.google.android.calendar",
+          foreground: "com.android.settings",
+        },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+    });
+
+    test("a hierarchy that could not be retrieved still reports unavailable, not a mismatch", () => {
+      // No hierarchy means no window to compare — unavailable dominates.
+      const v = computeFreshness({
+        actualTimestamp: NOW,
+        now: NOW,
+        unavailable: true,
+        windowIdentityMismatch: {
+          observed: "com.google.android.calendar",
+          foreground: "com.android.settings",
+        },
+      });
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("could not be retrieved");
+    });
+  });
+
   test("every `isFresh: false` names its cause", () => {
     const falseCases = [
       computeFreshness({ actualTimestamp: NOW - 999_999, now: NOW }),


### PR DESCRIPTION
## Summary

`observe` could latch onto a stale wrong-window hierarchy — reporting one app's
`activeWindow` (e.g. Calendar, a 6-node status-bar-only tree) while the device's
top resumed activity was actually a different app (Settings) — and still report
`freshness.verified: true` / `isFresh: true`. The failure was silent: every
downstream `tapOn` matched against the phantom view and reported success, and a
client could not recover in-protocol.

This adds two client-facing guarantees, both scoped to Android:

1. **Window-identity freshness check.** `observe` now fetches the ground-truth
   foreground app (`dumpsys topResumedActivity`, via `adb.getForegroundApp()`)
   in parallel with hierarchy collection and compares its package to the app the
   observed hierarchy was captured from. On a cross-app mismatch, `computeFreshness`
   retracts the verdict: `verified: false`, `isFresh: false`, with a `warning`
   naming both apps. This turns a silent phantom into one legible signal — the
   issue's own "smallest change I'd want as a client (1) alone".
2. **Cache invalidation on terminate.** A successful Android force-stop in
   `TerminateApp` now invalidates the CtrlProxy hierarchy cache and the
   observe-result cache for the device (via an injectable
   `DeviceWindowCacheInvalidator` seam), so the recovery a client naturally
   reaches for — terminate then re-observe — returns a fresh sync instead of the
   same stale record.

The comparison is conservative (package-level, only when both the observed and
ground-truth apps are known and differ), so a same-app activity change or an
unknown ground truth never raises a false alarm. The extra `getForegroundApp`
call is started in parallel with hierarchy collection, adding ~0 serial latency.

## Linked Issue

Closes #5867

## Bug / Regression Context

- **Observed symptom:** `observe.activeWindow.appId = com.google.android.calendar`
  (6-node status-bar-only tree, `layoutSeqSum` frozen at 7092) while
  `dumpsys ... topResumedActivity` = `com.android.settings/.SubSettings`;
  `freshness.verified: true` on every wrong response.
- **Repro:** launch `com.android.settings` → tap `Network & internet` → tap the
  Internet row (`AndroidWifi`) → `observe` reports Calendar.
- **Recovery before this change:** `terminateApp com.google.android.calendar`
  returned success but the next `observe` still reported Calendar for a dead
  process; only `homeScreen` cleared it.

## Validation

- [x] `bun run lint` (ratchet: no new violations) + `bun test` (14794 pass; the
  one unrelated failure is the pre-existing `#4343` WHEP subprocess-marker
  integration flake, which this diff does not touch)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses existing helpers (`adb.getForegroundApp`,
  `AndroidCtrlProxyClient.invalidateCache`, `RealObserveScreen.clearCache`)

## Device Verification

- [ ] Not run on hardware in this change — logic is covered by unit tests driving
  the real `RealObserveScreen` / `computeFreshness` / `TerminateApp` classes
  through fakes (`FakeViewHierarchy`, `FakeAdbExecutor.setForegroundApp`,
  injected `DeviceWindowCacheInvalidator`).

## Follow-ups

- [ ] The window-identity check is Android-only; iOS has no `topResumedActivity`
  equivalent wired here. If the package-level compare proves noisy on
  overlay/dialog windows in practice, a suppression list may be warranted.
