### PR TITLE
fix(mcp): repair the device-acquisition workflow end-to-end (#5870)

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -91,7 +91,7 @@ the exact arguments supported by your connection.
 
 | Tool                                                                           | What it does                                                               |
 | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| 📋 <code>listDevices</code>                                                    | Provides guidance for listing devices through MCP resources.               |
+| 📋 <code>listDevices</code>                                                    | Lists booted devices; a note points to MCP resources for images and detail. |
 | 🖼️ <code>listDeviceImages</code>                                               | Lists available device images.                                             |
 | 🤖 <code>getAndroid</code> / 🍎 <code>getApple</code>                          | Finds or recovers an Android AVD or iOS Simulator for automation.          |
 | 🧱 <code>provisionDevice</code>                                                | Provisions an exact virtual-device identity.                               |

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -89,28 +89,28 @@ the exact arguments supported by your connection.
 
 ## Devices & system state
 
-| Tool                                                                           | What it does                                                               |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Tool                                                                           | What it does                                                                |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | 📋 <code>listDevices</code>                                                    | Lists booted devices; a note points to MCP resources for images and detail. |
-| 🖼️ <code>listDeviceImages</code>                                               | Lists available device images.                                             |
-| 🤖 <code>getAndroid</code> / 🍎 <code>getApple</code>                          | Finds or recovers an Android AVD or iOS Simulator for automation.          |
-| 🧱 <code>provisionDevice</code>                                                | Provisions an exact virtual-device identity.                               |
-| 🔧 <code>setActiveDevice</code>                                                | Sets the active device.                                                    |
-| ❌ <code>killDevice</code> / 🧹 <code>deleteDevice</code>                      | Stops a device, or stops and permanently deletes it.                       |
-| 📸 <code>deviceSnapshot</code>                                                 | Captures or restores a device snapshot.                                    |
-| 🔄 <code>rotate</code>                                                         | Changes device orientation.                                                |
-| 🌐 <code>openLink</code>                                                       | Opens web URLs or routes app and universal deep links.                     |
-| 🧰 <code>homeScreen</code> / <code>recentApps</code> / <code>systemTray</code> | Controls core system surfaces and notifications.                           |
-| 🔓 <code>wakeAndUnlock</code>                                                  | Wakes and unlocks the keyguard.                                            |
-| 🌍 <code>changeLocalization</code>                                             | Changes locale, time zone, text direction, time format, and calendar.      |
-| ⚙️ <code>getDeviceState</code> / ⚙️ <code>setDeviceState</code>                | Reads or changes Do Not Disturb and simulator biometric enrollment.        |
-| 🧬 <code>getIosSimulatorCapabilities</code>                                    | Discovers biometrics for a selected iOS Simulator device type and runtime. |
-| 🫆 <code>biometricAuth</code>                                                  | Simulates biometric authentication.                                        |
-| 📳 <code>shake</code>                                                          | Shakes an Android emulator or iOS Simulator.                               |
-| 📞 <code>phoneCall</code> / 💬 <code>sendSms</code>                            | Simulates an Android emulator phone call or incoming SMS.                  |
-| 🔔 <code>postNotification</code>                                               | Posts a notification through Android SDK hooks or iOS Simulator push.      |
-| 🔔 <code>getNotificationPolicy</code> / 🔔 <code>setNotificationPolicy</code>  | Reads or changes app notification and Do Not Disturb policy.               |
-| 🛂 <code>getAppPermissions</code> / 🛂 <code>setAppPermissions</code>          | Reads or changes app permissions.                                          |
+| 🖼️ <code>listDeviceImages</code>                                               | Lists available device images.                                              |
+| 🤖 <code>getAndroid</code> / 🍎 <code>getApple</code>                          | Finds or recovers an Android AVD or iOS Simulator for automation.           |
+| 🧱 <code>provisionDevice</code>                                                | Provisions an exact virtual-device identity.                                |
+| 🔧 <code>setActiveDevice</code>                                                | Sets the active device.                                                     |
+| ❌ <code>killDevice</code> / 🧹 <code>deleteDevice</code>                      | Stops a device, or stops and permanently deletes it.                        |
+| 📸 <code>deviceSnapshot</code>                                                 | Captures or restores a device snapshot.                                     |
+| 🔄 <code>rotate</code>                                                         | Changes device orientation.                                                 |
+| 🌐 <code>openLink</code>                                                       | Opens web URLs or routes app and universal deep links.                      |
+| 🧰 <code>homeScreen</code> / <code>recentApps</code> / <code>systemTray</code> | Controls core system surfaces and notifications.                            |
+| 🔓 <code>wakeAndUnlock</code>                                                  | Wakes and unlocks the keyguard.                                             |
+| 🌍 <code>changeLocalization</code>                                             | Changes locale, time zone, text direction, time format, and calendar.       |
+| ⚙️ <code>getDeviceState</code> / ⚙️ <code>setDeviceState</code>                | Reads or changes Do Not Disturb and simulator biometric enrollment.         |
+| 🧬 <code>getIosSimulatorCapabilities</code>                                    | Discovers biometrics for a selected iOS Simulator device type and runtime.  |
+| 🫆 <code>biometricAuth</code>                                                  | Simulates biometric authentication.                                         |
+| 📳 <code>shake</code>                                                          | Shakes an Android emulator or iOS Simulator.                                |
+| 📞 <code>phoneCall</code> / 💬 <code>sendSms</code>                            | Simulates an Android emulator phone call or incoming SMS.                   |
+| 🔔 <code>postNotification</code>                                               | Posts a notification through Android SDK hooks or iOS Simulator push.       |
+| 🔔 <code>getNotificationPolicy</code> / 🔔 <code>setNotificationPolicy</code>  | Reads or changes app notification and Do Not Disturb policy.                |
+| 🛂 <code>getAppPermissions</code> / 🛂 <code>setAppPermissions</code>          | Reads or changes app permissions.                                           |
 
 ## Network, plans & recording
 

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -29,7 +29,7 @@ The daemon accepts newline-delimited JSON on
 `~/.auto-mobile/webrtc-stream.sock`:
 
 ```bash
-SESSION_UUID="<sessionId returned by the MCP getAndroid or getApple tool>"
+SESSION_UUID="<sessionUuid returned by the MCP getAndroid or getApple tool>"
 DEVICE_ID="<device id returned by the same tool>"
 PLATFORM="android" # Use "ios" for an iOS Simulator.
 STREAM_ID="$CI_JOB_ID"
@@ -66,7 +66,7 @@ jq -nc \
 
 Acquire a fresh daemon session with the public MCP `getAndroid` or `getApple`
 tool before opening the socket; every request must carry that tool's
-`sessionId`. The example always includes `deviceId` and `platform` so the iOS
+`sessionUuid`. The example always includes `deviceId` and `platform` so the iOS
 path cannot silently fall back to Android. The stream reconnects after transient
 network failures; browser viewers may need to reconnect too.
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1175,13 +1175,7 @@
           "enum": ["summary", "full"]
         }
       },
-      "required": [
-        "planContent",
-        "startStep",
-        "platform",
-        "deviceAllocationTimeoutMs",
-        "abortStrategy"
-      ],
+      "required": ["planContent", "platform"],
       "additionalProperties": false
     },
     "outputSchema": {
@@ -1352,7 +1346,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -1428,12 +1421,16 @@
           "maximum": 120000
         },
         "avdName": {
-          "description": "Configured Android Virtual Device name",
+          "description": "Configured Android Virtual Device name (the `name` field of automobile:devices/images/android)",
+          "type": "string",
+          "minLength": 1
+        },
+        "deviceId": {
+          "description": "Booted device serial, e.g. emulator-5554 (the `deviceId` field of automobile:devices/booted/android)",
           "type": "string",
           "minLength": 1
         }
       },
-      "required": ["avdName"],
       "additionalProperties": false
     }
   },
@@ -1457,12 +1454,16 @@
           "maximum": 120000
         },
         "udid": {
-          "description": "iOS Simulator UDID",
+          "description": "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or `name` of automobile:devices/images/ios)",
+          "type": "string",
+          "minLength": 1
+        },
+        "deviceId": {
+          "description": "Booted device identifier (the `deviceId` field of automobile:devices/booted/ios); alias for udid",
           "type": "string",
           "minLength": 1
         }
       },
-      "required": ["udid"],
       "additionalProperties": false
     }
   },
@@ -1657,7 +1658,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -2735,7 +2735,7 @@
   },
   {
     "name": "listDevices",
-    "description": "List devices (resource guidance)",
+    "description": "List booted devices; resource pointers for images and detail in the note",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -2845,7 +2845,7 @@
           "type": "string"
         }
       },
-      "required": ["targetScreen", "platform"],
+      "required": ["targetScreen"],
       "additionalProperties": false
     }
   },
@@ -7660,7 +7660,7 @@
           "type": "boolean"
         }
       },
-      "required": ["deviceId", "platform"],
+      "required": ["deviceId"],
       "additionalProperties": false
     }
   },
@@ -8633,7 +8633,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -8806,7 +8806,7 @@
           "type": "string"
         }
       },
-      "required": ["selector", "action", "platform"],
+      "required": ["selector"],
       "additionalProperties": false,
       "if": {
         "anyOf": [

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1454,7 +1454,7 @@
           "maximum": 120000
         },
         "udid": {
-          "description": "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or `name` of automobile:devices/images/ios)",
+          "description": "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or automobile:devices/images/ios)",
           "type": "string",
           "minLength": 1
         },

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5854,9 +5854,9 @@ export class DevicePool {
       throw new ActionableError(
         `Device '${deviceId}' is locked to another session.\n` +
           `Autolock is enabled, so tool calls must either come from the same MCP session ` +
-          `that called 'getAndroid' or 'getApple', or include the sessionId returned for this device.\n\n` +
+          `that called 'getAndroid' or 'getApple', or include the sessionUuid returned for this device.\n\n` +
           `Options:\n` +
-          `  - Pass the sessionId from getAndroid or getApple that locked this device\n` +
+          `  - Pass the sessionUuid from getAndroid or getApple that locked this device\n` +
           `  - Use getAndroid or getApple to lock a different available device\n` +
           `  - Wait for the idle timeout to release this device`,
       );

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5591,7 +5591,7 @@ export class DevicePool {
           `The device may have been shut down or disconnected.\n\n` +
           `Options:\n` +
           `  - Use 'getAndroid' or 'getApple' with the target's stable identifier to prepare a device\n` +
-          `  - Use the returned sessionId to target this specific device\n` +
+          `  - Use the returned sessionUuid to target this specific device\n` +
           `  - Use 'listDevices' to see currently available devices`,
       );
     }
@@ -5630,7 +5630,7 @@ export class DevicePool {
         `The device may have been shut down or disconnected.\n\n` +
         `Options:\n` +
         `  - Use 'getAndroid' or 'getApple' with the target's stable identifier to prepare a device\n` +
-        `  - Use the returned sessionId to target this specific device\n` +
+        `  - Use the returned sessionUuid to target this specific device\n` +
         `  - Use 'listDevices' to see currently available devices`,
       readinessReservationOwners,
     );

--- a/src/server/deviceSessionResult.ts
+++ b/src/server/deviceSessionResult.ts
@@ -15,9 +15,11 @@ export function isDeviceSessionAcquisitionTool(name: string): boolean {
 }
 
 /**
- * Extract the `sessionId` a device-start tool minted, from its MCP tool result.
- * The id rides in the first `text` content item as JSON `{ "sessionId": "..." }`.
- * Returns undefined when the result is not a device-start envelope.
+ * Extract the session id a device-start tool minted, from its MCP tool result.
+ * The id rides in the first `text` content item as JSON `{ "sessionUuid": "..." }`
+ * (issue #5870 renamed the key from `sessionId`, which is still read as a
+ * fallback for any legacy envelope). Returns undefined when the result is not a
+ * device-start envelope.
  */
 export function getDeviceSessionIdFromResult(result: unknown): string | undefined {
   if (!result || typeof result !== "object" || !("content" in result)) {
@@ -40,10 +42,9 @@ export function getDeviceSessionIdFromResult(result: unknown): string | undefine
     return undefined;
   }
   try {
-    const payload = JSON.parse(text.text) as { sessionId?: unknown };
-    return typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
-      ? payload.sessionId
-      : undefined;
+    const payload = JSON.parse(text.text) as { sessionUuid?: unknown; sessionId?: unknown };
+    const minted = payload.sessionUuid ?? payload.sessionId;
+    return typeof minted === "string" && minted.trim().length > 0 ? minted : undefined;
   } catch (error) {
     logger.debug("[MCP] Device-start response did not contain JSON", { error });
     return undefined;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -275,8 +275,7 @@ export const getAppleSchema = devicePreparationTimeoutSchema
     if (!value.udid && !value.deviceId) {
       ctx.addIssue({
         code: "custom",
-        message:
-          "Provide udid or deviceId (the `deviceId` field of automobile:devices/booted/ios)",
+        message: "Provide udid or deviceId (the `deviceId` field of automobile:devices/booted/ios)",
         path: ["udid"],
       });
     }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -218,13 +218,65 @@ const devicePreparationTimeoutSchema = z
     }
   });
 
-export const getAndroidSchema = devicePreparationTimeoutSchema.extend({
-  avdName: z.string().min(1).describe("Configured Android Virtual Device name"),
-});
+// #5870: `deviceId` — the identifier every device resource leads with — is
+// accepted alongside the platform-native identifier. Either is sufficient; the
+// refine names both sources when neither is given so the caller is never left
+// guessing which field of which resource to read.
+export const getAndroidSchema = devicePreparationTimeoutSchema
+  .extend({
+    avdName: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Configured Android Virtual Device name (the `name` field of automobile:devices/images/android)",
+      ),
+    deviceId: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Booted device serial, e.g. emulator-5554 (the `deviceId` field of automobile:devices/booted/android)",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.avdName && !value.deviceId) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Provide avdName (the `name` field of automobile:devices/images/android) or deviceId (the `deviceId` field of automobile:devices/booted/android)",
+        path: ["avdName"],
+      });
+    }
+  });
 
-export const getAppleSchema = devicePreparationTimeoutSchema.extend({
-  udid: z.string().min(1).describe("iOS Simulator UDID"),
-});
+export const getAppleSchema = devicePreparationTimeoutSchema
+  .extend({
+    udid: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or `name` of automobile:devices/images/ios)",
+      ),
+    deviceId: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Booted device identifier (the `deviceId` field of automobile:devices/booted/ios); alias for udid",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.udid && !value.deviceId) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Provide udid or deviceId (the `deviceId` field of automobile:devices/booted/ios)",
+        path: ["udid"],
+      });
+    }
+  });
 
 const MODERN_PLAY_IMAGE_MIN_API_LEVEL = 30;
 
@@ -470,13 +522,15 @@ export interface StartDeviceArgs {
 }
 
 export interface GetAndroidArgs {
-  avdName: string;
+  avdName?: string;
+  deviceId?: string;
   bootTimeoutMs?: number;
   automationReadyTimeoutMs?: number;
 }
 
 export interface GetAppleArgs {
-  udid: string;
+  udid?: string;
+  deviceId?: string;
   bootTimeoutMs?: number;
   automationReadyTimeoutMs?: number;
 }
@@ -3736,32 +3790,49 @@ export function registerDeviceTools() {
   };
 
   const listDevicesHandler = async (args: ListDevicesArgs) => {
+    // #5870: a tool named `listDevices` returns the devices. The data is right
+    // here — enumerate booted devices directly instead of forcing a modality
+    // switch to resources. The resource pointers (which also cover not-yet-booted
+    // images and richer per-device detail) survive as a `note`.
+    const platform: SomePlatform = args.platform ?? "either";
+    const deviceManager = getDeviceToolsDependencies().deviceManagerFactory();
+    let booted: BootedDevice[] = [];
+    try {
+      booted = await deviceManager.getBootedDevices(platform);
+    } catch (error) {
+      // Discovery is best-effort — a partial/failed probe still returns the
+      // resource guidance rather than failing the whole call.
+      logger.warn(`listDevices booted-device discovery failed: ${errorMessage(error)}`, error);
+    }
+
+    const devices = booted.map((device) => ({
+      deviceId: device.deviceId,
+      name: device.name,
+      platform: device.platform,
+      osVersion: device.osVersion ?? device.iosVersion,
+      formFactor: device.formFactor,
+    }));
     const platformFilter = args.platform ? ` (${args.platform} only)` : "";
 
     return createJSONToolResponse({
-      message:
-        `To list devices${platformFilter}, use these MCP resources:\n\n` +
-        "RUNNING DEVICES (booted/active):\n" +
-        `  - automobile:devices/booted - All running devices\n` +
-        `  - automobile:devices/booted/android - Android devices only\n` +
-        `  - automobile:devices/booted/ios - Booted iOS simulators and connected physical iOS devices\n\n` +
-        "AVAILABLE DEVICE IMAGES (can be started):\n" +
-        `  - automobile:devices/images - All available images\n` +
-        `  - automobile:devices/images/android - Android AVDs\n` +
-        `  - automobile:devices/images/ios - iOS simulator runtimes\n\n` +
-        "WORKFLOW:\n" +
-        "  1. Read 'automobile:devices/images/android' to select an Android AVD by name\n" +
-        "  2. Read 'automobile:devices/images/ios' to select an iOS simulator by UDID\n" +
-        "  3. Call getAndroid or getApple, then use its returned sessionId for automation",
-      resources: [
-        BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
-        `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
-        `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/ios`,
-        DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
-        `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
-        `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`,
-      ],
-      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported.",
+      message: `Found ${devices.length} booted device${devices.length === 1 ? "" : "s"}${platformFilter}`,
+      devices,
+      count: devices.length,
+      note: {
+        message:
+          "Acquire a booted device with getAndroid { deviceId } or getApple { deviceId }. " +
+          "For available (not-yet-booted) images and richer per-device detail, read these MCP resources:",
+        resources: [
+          BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
+          `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
+          `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/ios`,
+          DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
+          `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
+          `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`,
+        ],
+        uriPrefix:
+          "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported.",
+      },
     });
   };
 
@@ -4943,22 +5014,39 @@ export function registerDeviceTools() {
     const automationReadyTimeoutMs =
       args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
     const startedAtMs = getDeviceToolsDependencies().timer.now();
+    const mcpSessionId = typeof __mcpSessionId === "string" ? __mcpSessionId : undefined;
+    // Prefer the AVD name (exact virtual-device identity); otherwise target the
+    // booted serial by deviceId (#5870). The AVD path also coordinates lifecycle
+    // by the stable AVD name, which the deviceId path cannot infer.
+    const target: StartDeviceArgs = args.avdName
+      ? {
+          platform: "android",
+          name: args.avdName,
+          matchExactName: true,
+          preferRunning: true,
+          createIfMissing: false,
+          __mcpSessionId: mcpSessionId,
+        }
+      : {
+          platform: "android",
+          deviceId: args.deviceId,
+          preferRunning: true,
+          createIfMissing: false,
+          __mcpSessionId: mcpSessionId,
+        };
     return await prepareDevice(
-      {
-        platform: "android",
-        name: args.avdName,
-        matchExactName: true,
-        preferRunning: true,
-        createIfMissing: false,
-        __mcpSessionId: typeof __mcpSessionId === "string" ? __mcpSessionId : undefined,
-      },
+      target,
       {
         bootTimeoutMs,
         automationReadyTimeoutMs,
         automationDeadlineMs: startedAtMs + bootTimeoutMs + automationReadyTimeoutMs,
         operationName: "getAndroid",
-        androidAvdName: args.avdName,
-        stableTarget: { platform: "android", stableId: args.avdName },
+        ...(args.avdName
+          ? {
+              androidAvdName: args.avdName,
+              stableTarget: { platform: "android", stableId: args.avdName },
+            }
+          : {}),
       },
       progress,
       signal,
@@ -4976,6 +5064,8 @@ export function registerDeviceTools() {
     delete externalArgs.__executionId;
     delete externalArgs.__executionStartTime;
     const args = getAppleSchema.parse(externalArgs);
+    // #5870: `deviceId` is an accepted alias for `udid` on iOS.
+    const udid = args.udid ?? args.deviceId!;
     const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
     const automationReadyTimeoutMs =
       args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
@@ -4983,7 +5073,7 @@ export function registerDeviceTools() {
     return await prepareDevice(
       {
         platform: "ios",
-        deviceId: args.udid,
+        deviceId: udid,
         preferRunning: true,
         createIfMissing: false,
         __mcpSessionId: typeof __mcpSessionId === "string" ? __mcpSessionId : undefined,
@@ -4993,7 +5083,7 @@ export function registerDeviceTools() {
         automationReadyTimeoutMs,
         automationDeadlineMs: startedAtMs + bootTimeoutMs + automationReadyTimeoutMs,
         operationName: "getApple",
-        stableTarget: { platform: "ios", stableId: args.udid },
+        stableTarget: { platform: "ios", stableId: udid },
       },
       progress,
       signal,
@@ -5090,9 +5180,13 @@ export function registerDeviceTools() {
       timing: (timing ?? {}) as unknown as Record<string, number>,
     };
 
+    // #5870: emit the session handle as `sessionUuid` — the key every consumer
+    // tool's schema declares — so the obvious copy-paste is correct.
+    const { sessionId: sessionUuid, ...resultWithoutSessionId } = result;
     return createJSONToolResponse({
       message: `${device.platform} '${device.name}' is ready (${source})`,
-      ...result,
+      ...resultWithoutSessionId,
+      sessionUuid,
       deviceIdentity: deviceIdentityPayload(device, sourceImage),
     });
   }
@@ -5302,7 +5396,7 @@ export function registerDeviceTools() {
 
   ToolRegistry.register(
     "listDevices",
-    "List devices (resource guidance)",
+    "List booted devices; resource pointers for images and detail in the note",
     listDevicesSchema,
     listDevicesHandler,
     { defaultEnabled: true },

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -222,6 +222,10 @@ const devicePreparationTimeoutSchema = z
 // accepted alongside the platform-native identifier. Either is sufficient; the
 // refine names both sources when neither is given so the caller is never left
 // guessing which field of which resource to read.
+// The at-least-one rule lives in `.superRefine()` + a sourced error message, not
+// in the advertised JSON Schema: a top-level `anyOf`/`oneOf` is exactly what
+// `TopLevelUnionFlattener` strips (the Anthropic API rejects top-level
+// combinators), so it cannot be advertised in the flat object schema.
 export const getAndroidSchema = devicePreparationTimeoutSchema
   .extend({
     avdName: z
@@ -257,7 +261,7 @@ export const getAppleSchema = devicePreparationTimeoutSchema
       .min(1)
       .optional()
       .describe(
-        "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or `name` of automobile:devices/images/ios)",
+        "iOS Simulator UDID (the `deviceId` field of automobile:devices/booted/ios or automobile:devices/images/ios)",
       ),
     deviceId: z
       .string()

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -251,7 +251,9 @@ export const tapOnSchema = withJsonSchemaOverride(
           .optional()
           .describe("Retry once if the view hierarchy is unchanged after tap"),
         ensureTap: z.boolean().optional().describe("Enable preTapStability and retryIfNoChange"),
-        platform: platformSchema,
+        // #5870: a `sessionUuid` resolves the platform, so `platform` is not
+        // required — a device handle from getAndroid is sufficient on its own.
+        platform: platformSchema.optional(),
       })
       .strict(),
   ).superRefine((value, ctx) => {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -654,7 +654,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
 
     throw new ActionableError(
       "Device pool autolock is enabled and multiple devices are available. " +
-        "Call getAndroid or getApple first from this MCP session, or provide the returned sessionId (or a deviceId) to target a specific device.",
+        "Call getAndroid or getApple first from this MCP session, or provide the returned sessionUuid (or a deviceId) to target a specific device.",
     );
   }
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -57,11 +57,39 @@ import { executionTracker } from "./executionTracker";
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
 export { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 
+/**
+ * A field with a default is never truly required — the default supplies it when
+ * the caller omits it. zod v4's `toJSONSchema` nonetheless lists defaulted keys
+ * in `required`, which reads to a client as "you must send `action` on every
+ * tap" (issue #5870). Drop any `required` entry whose property carries a
+ * `default`; runtime validation is unaffected (the default still applies).
+ */
+function dropDefaultedKeysFromRequired(jsonSchema: Record<string, unknown>): void {
+  const required = jsonSchema.required;
+  const properties = jsonSchema.properties as Record<string, unknown> | undefined;
+  if (!Array.isArray(required) || !properties) {
+    return;
+  }
+  const pruned = required.filter((key) => {
+    const prop = properties[key as string];
+    return !(prop && typeof prop === "object" && "default" in (prop as Record<string, unknown>));
+  });
+  if (pruned.length === required.length) {
+    return;
+  }
+  if (pruned.length === 0) {
+    delete jsonSchema.required;
+  } else {
+    jsonSchema.required = pruned;
+  }
+}
+
 function toAdvertisedJsonSchema(schema: any): Record<string, unknown> {
   return flattenTopLevelUnion(
     toJSONSchema(schema, {
       override: ({ zodSchema, jsonSchema }) => {
         applyJsonSchemaOverride(zodSchema, jsonSchema);
+        dropDefaultedKeysFromRequired(jsonSchema);
         if (isInjectedDeviceIdSchema(zodSchema)) {
           const properties = jsonSchema.properties as Record<string, unknown> | undefined;
           if (properties) {

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -30,7 +30,9 @@ import {
 export const setActiveDeviceSchema = addSessionUuidToSchema(
   z.object({
     deviceId: z.string(),
-    platform: platformSchema,
+    // #5870: the platform is inferred from the resolved device (or the session),
+    // so callers targeting a concrete `deviceId` need not also send `platform`.
+    platform: platformSchema.optional(),
   }),
 );
 
@@ -146,7 +148,7 @@ export const setDeviceStateSchema = addDeviceTargetingToSchema(
 // Export interfaces for type safety
 export interface SetActiveDeviceArgs {
   deviceId: string;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface ChangeLocalizationArgs {
@@ -227,10 +229,12 @@ export function registerUtilityTools() {
         // one, so a failed write leaves the caller's existing session intact.
         const existing = sessionManager.getSession(args.sessionUuid);
         if (!existing || existing.assignedDevice !== args.deviceId) {
+          // #5870: infer the platform from the resolved pool device when the
+          // caller did not send one.
           const boundSession = await devicePool.bindOrReuseDeviceSession(
             args.sessionUuid,
             args.deviceId,
-            args.platform,
+            args.platform ?? pooledDevice.platform,
             undefined,
             undefined,
             undefined,
@@ -251,13 +255,19 @@ export function registerUtilityTools() {
         const previousDevice = sessionManager.getCurrentDevice();
         const previousPlatform = sessionManager.getCurrentPlatform();
 
-        await sessionManager.ensureDeviceReady(args.platform, args.deviceId);
+        // #5870: with no explicit platform, "either" lets the deviceId
+        // disambiguate; the resolved device carries the effective platform.
+        const readyDevice = await sessionManager.ensureDeviceReady(
+          args.platform ?? "either",
+          args.deviceId,
+        );
+        const resolvedPlatform = args.platform ?? readyDevice.platform;
 
         // When switching platforms, clear observation caches to prevent stale
         // data from the previous platform contaminating subsequent observe calls.
-        if (previousPlatform && previousPlatform !== args.platform && previousDevice) {
+        if (previousPlatform && previousPlatform !== resolvedPlatform && previousDevice) {
           logger.info(
-            `[setActiveDevice] Platform switch detected (${previousPlatform} -> ${args.platform}), ` +
+            `[setActiveDevice] Platform switch detected (${previousPlatform} -> ${resolvedPlatform}), ` +
               `clearing observation cache for previous device ${previousDevice.deviceId}`,
           );
           RealObserveScreen.clearCache(previousDevice.deviceId);

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -442,13 +442,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
       default:
         // Only check for mixed platforms when auto-detecting (not explicitly specified)
         if (androidDevices.length > 0 && iosDevices.length > 0) {
-          // If setActiveDevice was called, use that platform to resolve ambiguity
-          if (this.currentDevice && this.currentPlatform) {
-            platformDevices = this.currentPlatform === "android" ? androidDevices : iosDevices;
-            resolvedPlatform = this.currentPlatform;
-            break;
-          }
-          // If a specific deviceId was provided, find which platform it belongs to
+          // An explicit deviceId names the target unambiguously, so it resolves
+          // the platform ahead of the ambient one — otherwise switching to a
+          // device on the other platform by id would be pinned to whatever
+          // setActiveDevice last selected and fail (issue #5870).
           if (providedDeviceId) {
             const allDevices = [...androidDevices, ...iosDevices];
             const match = allDevices.find((d) => d.deviceId === providedDeviceId);
@@ -457,6 +454,12 @@ export class DeviceSessionManager implements DeviceSessionManager {
               resolvedPlatform = match.platform;
               break;
             }
+          }
+          // With no matching deviceId, fall back to the platform setActiveDevice selected.
+          if (this.currentDevice && this.currentPlatform) {
+            platformDevices = this.currentPlatform === "android" ? androidDevices : iosDevices;
+            resolvedPlatform = this.currentPlatform;
+            break;
           }
           throw new ActionableError(
             "Both Android and iOS devices are connected. Please disconnect devices from one platform or call setActiveDevice to select a platform.",

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -39,7 +39,9 @@ function matchingDaemonManager(): FakeDaemonManager {
   return manager;
 }
 
-function deviceStartResult(sessionUuid: string): { content: Array<{ type: string; text: string }> } {
+function deviceStartResult(sessionUuid: string): {
+  content: Array<{ type: string; text: string }>;
+} {
   // Acquisition tools emit `sessionUuid` (#5870); mirror the production shape so
   // this exercises the primary read, not the legacy `sessionId` fallback.
   return { content: [{ type: "text", text: JSON.stringify({ sessionUuid }) }] };

--- a/test/daemon/proxyResultMintedSession.test.ts
+++ b/test/daemon/proxyResultMintedSession.test.ts
@@ -39,8 +39,10 @@ function matchingDaemonManager(): FakeDaemonManager {
   return manager;
 }
 
-function deviceStartResult(sessionId: string): { content: Array<{ type: string; text: string }> } {
-  return { content: [{ type: "text", text: JSON.stringify({ sessionId }) }] };
+function deviceStartResult(sessionUuid: string): { content: Array<{ type: string; text: string }> } {
+  // Acquisition tools emit `sessionUuid` (#5870); mirror the production shape so
+  // this exercises the primary read, not the legacy `sessionId` fallback.
+  return { content: [{ type: "text", text: JSON.stringify({ sessionUuid }) }] };
 }
 
 // A FakeDaemonClient standing in for a daemon that mints a fresh device session

--- a/test/server/deviceAcquisitionErgonomics.test.ts
+++ b/test/server/deviceAcquisitionErgonomics.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerInteractionTools } from "../../src/server/interactionTools";
+import { registerUtilityTools } from "../../src/server/utilityTools";
+import { getDeviceSessionIdFromResult } from "../../src/server/deviceSessionResult";
+
+/**
+ * Ergonomics fixes for the device-acquisition workflow (issue #5870).
+ *
+ * These pin the advertised-schema shape a client sees in `tools/list`:
+ * a field with a default is never advertised as required, and `platform`
+ * drops out of `required` on tools that also accept a `sessionUuid`
+ * (the session resolves the platform). Also pins the acquisition tools'
+ * result session key (`sessionUuid`) that consumer tools' params declare.
+ */
+describe("device acquisition ergonomics (#5870)", () => {
+  function advertisedInputSchema(name: string): {
+    required?: string[];
+    properties?: Record<string, unknown>;
+  } {
+    const def = ToolRegistry.getToolDefinitions().find((tool) => tool.name === name);
+    if (!def) {
+      throw new Error(`${name} is not registered`);
+    }
+    return def.inputSchema as { required?: string[]; properties?: Record<string, unknown> };
+  }
+
+  describe("advertised schema required-field ergonomics", () => {
+    beforeEach(() => {
+      ToolRegistry.clearTools();
+      registerInteractionTools();
+      registerUtilityTools();
+    });
+
+    afterEach(() => {
+      ToolRegistry.clearTools();
+    });
+
+    test("tapOn does not advertise `action` as required (it has a default)", () => {
+      const schema = advertisedInputSchema("tapOn");
+      expect(schema.properties).toHaveProperty("action");
+      expect(schema.required ?? []).not.toContain("action");
+    });
+
+    test("tapOn does not advertise `platform` as required (sessionUuid resolves it)", () => {
+      const schema = advertisedInputSchema("tapOn");
+      expect(schema.required ?? []).not.toContain("platform");
+    });
+
+    test("setActiveDevice does not advertise `platform` as required", () => {
+      const schema = advertisedInputSchema("setActiveDevice");
+      expect(schema.required ?? []).not.toContain("platform");
+    });
+  });
+
+  describe("getDeviceSessionIdFromResult reads the renamed key", () => {
+    const envelope = (payload: Record<string, unknown>) => ({
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+    });
+
+    test("reads `sessionUuid` from an acquisition result", () => {
+      expect(getDeviceSessionIdFromResult(envelope({ sessionUuid: "abc-123" }))).toBe("abc-123");
+    });
+
+    test("still tolerates the legacy `sessionId` key", () => {
+      expect(getDeviceSessionIdFromResult(envelope({ sessionId: "legacy-9" }))).toBe("legacy-9");
+    });
+  });
+});

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -117,9 +117,9 @@ describe("listDevices tool (#5870)", () => {
     );
 
     // The device manager is actually consulted now.
-    expect(fakeDeviceUtils.getExecutedOperations().some((op) => op.startsWith("getBootedDevices"))).toBe(
-      true,
-    );
+    expect(
+      fakeDeviceUtils.getExecutedOperations().some((op) => op.startsWith("getBootedDevices")),
+    ).toBe(true);
   });
 
   test("keeps the resource pointers as a note", async () => {

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -5,6 +5,7 @@ import {
   setDeviceToolsDependencies,
 } from "../../src/server/deviceTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice } from "../../src/models";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -50,8 +51,29 @@ const resolveWithFakeTimer = async <T>(
   return result as T;
 };
 
-describe("listDevices tool", () => {
+describe("listDevices tool (#5870)", () => {
   let fakeDeviceUtils: FakeDeviceUtils;
+
+  const android: BootedDevice = {
+    platform: "android",
+    name: "Pixel_9_API_36",
+    deviceId: "emulator-5554",
+  };
+  const ios: BootedDevice = {
+    platform: "ios",
+    name: "iPhone 17",
+    deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+    iosVersion: "18.0",
+  };
+
+  const callListDevices = async (args: Record<string, unknown> = {}) => {
+    const tool = ToolRegistry.getTool("listDevices");
+    expect(tool).toBeDefined();
+    const fakeTimer = new FakeTimer();
+    const response = await resolveWithFakeTimer(tool!.handler(args), fakeTimer);
+    expect(response.content?.[0]?.type).toBe("text");
+    return JSON.parse(response.content?.[0]?.text ?? "{}");
+  };
 
   beforeAll(() => {
     fakeDeviceUtils = new FakeDeviceUtils();
@@ -66,73 +88,55 @@ describe("listDevices tool", () => {
 
   beforeEach(() => {
     fakeDeviceUtils.clearHistory();
+    fakeDeviceUtils.setBootedDevices("android", [android]);
+    fakeDeviceUtils.setBootedDevices("ios", [ios]);
   });
 
   afterAll(() => {
     resetDeviceToolsDependencies();
   });
 
-  test("returns resource guidance without calling device manager", async () => {
-    const tool = ToolRegistry.getTool("listDevices");
-    expect(tool).toBeDefined();
+  test("returns the actual booted devices instead of prose", async () => {
+    const payload = await callListDevices();
 
-    const fakeTimer = new FakeTimer();
+    expect(payload.count).toBe(2);
+    expect(Array.isArray(payload.devices)).toBe(true);
+    expect(payload.devices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "android",
+          deviceId: "emulator-5554",
+          name: "Pixel_9_API_36",
+        }),
+        expect.objectContaining({
+          platform: "ios",
+          deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+          name: "iPhone 17",
+        }),
+      ]),
+    );
 
-    const response = await resolveWithFakeTimer(tool!.handler({}), fakeTimer);
-
-    expect(response.content?.[0]?.type).toBe("text");
-    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
-
-    // Verify resources include all platform-specific URIs
-    expect(payload.resources).toEqual([
-      "automobile:devices/booted",
-      "automobile:devices/booted/android",
-      "automobile:devices/booted/ios",
-      "automobile:devices/images",
-      "automobile:devices/images/android",
-      "automobile:devices/images/ios",
-    ]);
-
-    // Verify the message contains workflow guidance
-    expect(payload.message).toContain("RUNNING DEVICES");
-    expect(payload.message).toContain("AVAILABLE DEVICE IMAGES");
-    expect(payload.message).toContain("WORKFLOW");
-    expect(payload.message).toContain("automobile:devices/booted");
-    expect(payload.message).toContain("automobile:devices/images");
-
-    // Verify note about URI prefix
-    expect(payload.note).toContain("automobile:");
-    expect(payload.note).toContain("android://devices");
-
-    expect(fakeDeviceUtils.getExecutedOperations()).toHaveLength(0);
+    // The device manager is actually consulted now.
+    expect(fakeDeviceUtils.getExecutedOperations().some((op) => op.startsWith("getBootedDevices"))).toBe(
+      true,
+    );
   });
 
-  test("returns platform-specific resource guidance when platform is provided", async () => {
-    const tool = ToolRegistry.getTool("listDevices");
-    expect(tool).toBeDefined();
+  test("keeps the resource pointers as a note", async () => {
+    const payload = await callListDevices();
 
-    const fakeTimer = new FakeTimer();
+    expect(payload.note).toBeDefined();
+    const noteText = JSON.stringify(payload.note);
+    expect(noteText).toContain("automobile:devices/booted");
+    expect(noteText).toContain("automobile:devices/images");
+  });
 
-    const response = await resolveWithFakeTimer(tool!.handler({ platform: "android" }), fakeTimer);
+  test("filters by platform when provided", async () => {
+    const payload = await callListDevices({ platform: "android" });
 
-    expect(response.content?.[0]?.type).toBe("text");
-    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
-
-    // Same resources regardless of platform filter (guidance tool shows all options)
-    expect(payload.resources).toEqual([
-      "automobile:devices/booted",
-      "automobile:devices/booted/android",
-      "automobile:devices/booted/ios",
-      "automobile:devices/images",
-      "automobile:devices/images/android",
-      "automobile:devices/images/ios",
+    expect(payload.count).toBe(1);
+    expect(payload.devices).toEqual([
+      expect.objectContaining({ platform: "android", deviceId: "emulator-5554" }),
     ]);
-
-    // Message should include platform filter indicator
-    expect(payload.message).toContain("android only");
-    expect(payload.message).toContain("automobile:devices/booted/android");
-    expect(payload.message).toContain("automobile:devices/images/android");
-
-    expect(fakeDeviceUtils.getExecutedOperations()).toHaveLength(0);
   });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -70,7 +70,10 @@ describe("platform device preparation tools", () => {
 
     const result = await callTool("getAndroid", { avdName: "Pixel_9_API_36" });
 
-    expect(result.sessionId).toBeDefined();
+    // #5870: acquisition tools return `sessionUuid` (the key every consumer
+    // tool's schema declares), not `sessionId`.
+    expect(result.sessionUuid).toBeDefined();
+    expect(result.sessionId).toBeUndefined();
     expect(result.deviceIdentity).toEqual({
       platform: "android",
       avdName: "Pixel_9_API_36",
@@ -127,10 +130,50 @@ describe("platform device preparation tools", () => {
       readinessTimeoutMs: 20_000,
       totalDeadlineMs: 60_000,
     });
+    // #5870: `deviceId` — the identifier every device resource leads with — is
+    // now an accepted target on getAndroid alongside `avdName`.
     expect(() =>
       getAndroidSchema.parse({ avdName: image.name, deviceId: "emulator-5554" }),
-    ).toThrow();
+    ).not.toThrow();
+    // `platform` remains an unrecognized key on getApple (strict schema).
     expect(() => getAppleSchema.parse({ udid: "sim-udid", platform: "ios" })).toThrow();
+  });
+
+  test("getAndroid accepts a deviceId target and prepares that serial (#5870)", async () => {
+    const emulator: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5554",
+    };
+    deviceUtils.setBootedDevices("android", [emulator]);
+    matcher.setBootedResult(emulator);
+
+    const result = await callTool("getAndroid", { deviceId: "emulator-5554" });
+
+    expect(result.sessionUuid).toBeDefined();
+    expect(result.deviceIdentity).toMatchObject({ adbSerial: "emulator-5554" });
+  });
+
+  test("getApple accepts a deviceId target alongside udid (#5870)", async () => {
+    const simulator: DeviceInfo = {
+      platform: "ios",
+      name: "iPhone 17",
+      deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+      isRunning: false,
+    };
+    deviceUtils.setDeviceImages("ios", [simulator]);
+
+    const result = await callTool("getApple", { deviceId: simulator.deviceId });
+
+    expect(result.deviceIdentity).toMatchObject({ simulatorUdid: simulator.deviceId });
+  });
+
+  test("getAndroid rejects a call with neither avdName nor deviceId, naming the source (#5870)", () => {
+    expect(() => getAndroidSchema.parse({})).toThrow(/avdName.*deviceId|deviceId.*avdName/i);
+  });
+
+  test("getApple rejects a call with neither udid nor deviceId (#5870)", () => {
+    expect(() => getAppleSchema.parse({})).toThrow(/udid.*deviceId|deviceId.*udid/i);
   });
 
   test("matches the requested Android AVD name exactly", async () => {
@@ -174,7 +217,7 @@ describe("platform device preparation tools", () => {
     const first = await callTool("getAndroid", { avdName: emulator.name });
     const second = await callTool("getAndroid", { avdName: emulator.name });
 
-    expect(second.sessionId).toBe(first.sessionId);
+    expect(second.sessionUuid).toBe(first.sessionUuid);
     expect(pool.getDevice(emulator.deviceId)).toMatchObject({ avdName: emulator.name });
   });
 

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -144,8 +144,8 @@ describe("startDevice handler", () => {
     expect(result.isReady).toBe(true);
     expect(result.source).toBe("booted");
     expect(result.osVersion).toBe("14");
-    expect(result.sessionId).toBeDefined();
-    expect(typeof result.sessionId).toBe("string");
+    expect(result.sessionUuid).toBeDefined();
+    expect(typeof result.sessionUuid).toBe("string");
   });
 
   it("does not reach runner readiness or session binding after an externally cancelled boot", async () => {
@@ -273,7 +273,7 @@ describe("startDevice handler", () => {
 
     const result = await callStartDevice({ platform: "android" });
 
-    expect(result.sessionId).toBe("session-1");
+    expect(result.sessionUuid).toBe("session-1");
     expect(resolveDirectSessionDevice("session-1")).toEqual({
       sessionUuid: "session-1",
       device: androidDevice,
@@ -367,10 +367,10 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "android" });
 
     expect(result.source).toBe("cold-boot");
-    expect(result.sessionId).toBeDefined();
+    expect(result.sessionUuid).toBeDefined();
     expect(pool.getDevice(androidDevice.deviceId)).toMatchObject({
       transportId: "23",
-      sessionId: result.sessionId,
+      sessionId: result.sessionUuid,
     });
     expect(childProcess.killed).toBe(false);
   });
@@ -408,13 +408,13 @@ describe("startDevice handler", () => {
 
     try {
       const result = await callStartDevice({ platform: "android" });
-      expect(daemonSessionManager.getSession(result.sessionId as string)).not.toBeNull();
+      expect(daemonSessionManager.getSession(result.sessionUuid as string)).not.toBeNull();
 
       childProcess.emit("exit", 1, null);
       await new Promise((resolve) => setImmediate(resolve));
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(daemonSessionManager.getSession(result.sessionId as string)).toBeNull();
+      expect(daemonSessionManager.getSession(result.sessionUuid as string)).toBeNull();
       expect(pool.getDevice(androidDevice.deviceId)).toBeNull();
     } finally {
       for (const key of recoveryKeys) {
@@ -477,7 +477,7 @@ describe("startDevice handler", () => {
     } finally {
       releaseResources();
       const result = await start;
-      expect(result.sessionId).toBe("session-1");
+      expect(result.sessionUuid).toBe("session-1");
     }
   });
 
@@ -526,7 +526,7 @@ describe("startDevice handler", () => {
 
     releaseReadiness();
     const result = await start;
-    expect(result.sessionId).toBe("session-1");
+    expect(result.sessionUuid).toBe("session-1");
     expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe("session-1");
   });
 
@@ -608,7 +608,7 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "android" });
 
     expect(result.deviceId).toBe("emulator-5556");
-    expect(result.sessionId).toBe("owner-session");
+    expect(result.sessionUuid).toBe("owner-session");
     expect(fakeDeviceUtils.getExecutedOperations()).toContain("killDevice:Unknown (emulator-5554)");
     expect(fakeDeviceUtils.getExecutedOperations()).toContain("startDevice:Pixel_7_API_34:120000");
     expect(pool.getDevice("emulator-5556")).toMatchObject({
@@ -666,7 +666,7 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "android" });
 
     expect(result.deviceId).toBe("emulator-5556");
-    expect(result.sessionId).toBe("session-1");
+    expect(result.sessionUuid).toBe("session-1");
     expect(pool.getDevice("emulator-5556")).toMatchObject({
       sessionId: "session-1",
       status: "busy",
@@ -1285,9 +1285,9 @@ describe("startDevice handler", () => {
     const ownerResult = await ownerStart;
     await expect(adopterStart).rejects.toThrow(/Freshly started device .* assigned to session/);
 
-    expect(ownerResult.sessionId).toBeDefined();
+    expect(ownerResult.sessionUuid).toBeDefined();
     expect(childProcess.killed).toBe(false);
-    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(ownerResult.sessionId);
+    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(ownerResult.sessionUuid);
   });
 
   it("does not kill a shared cold boot when autolock rejects the later caller", async () => {
@@ -1355,9 +1355,9 @@ describe("startDevice handler", () => {
     const ownerResult = await ownerStart;
     await expect(adopterStart).rejects.toThrow(/Freshly started device .* assigned to session/);
 
-    expect(ownerResult.sessionId).toBeDefined();
+    expect(ownerResult.sessionUuid).toBeDefined();
     expect(childProcess.killed).toBe(false);
-    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(ownerResult.sessionId);
+    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(ownerResult.sessionUuid);
   });
 
   it("passes timeout to the cold boot start operation", async () => {
@@ -1803,9 +1803,9 @@ describe("startDevice handler", () => {
       __mcpSessionId: "mcp-session-1",
     });
 
-    expect(typeof result.sessionId).toBe("string");
+    expect(typeof result.sessionUuid).toBe("string");
     expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(
-      result.sessionId,
+      result.sessionUuid,
     );
   });
 
@@ -1967,13 +1967,13 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "ios" });
     const repeated = await callStartDevice({ platform: "ios" });
 
-    expect(typeof result.sessionId).toBe("string");
-    expect(repeated.sessionId).toBe(result.sessionId);
-    const session = daemonSessionManager.getSession(result.sessionId as string);
+    expect(typeof result.sessionUuid).toBe("string");
+    expect(repeated.sessionUuid).toBe(result.sessionUuid);
+    const session = daemonSessionManager.getSession(result.sessionUuid as string);
     expect(session).not.toBeNull();
     expect(session!.assignedDevice).toBe(iosDevice.deviceId);
     expect(session!.platform).toBe("ios");
-    expect(pool.getDevice(iosDevice.deviceId)?.sessionId).toBe(result.sessionId);
+    expect(pool.getDevice(iosDevice.deviceId)?.sessionId).toBe(result.sessionUuid);
     expect(pool.getDevice(iosDevice.deviceId)?.status).toBe("busy");
   });
 });

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -963,6 +963,19 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     expect(result.deviceId).toBe("ios-sim-1");
   });
 
+  test("resolves the other platform by providedDeviceId even when setActiveDevice selected a different one (#5870)", async () => {
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
+
+    // Ambient platform is Android (a prior setActiveDevice), but the caller now
+    // targets the iOS device by id with no explicit platform — switching must
+    // honor the named device over the ambient platform, not throw.
+    manager.setCurrentDevice(androidDevice, "android");
+
+    const result = await manager.ensureDeviceReady("either", iosDevice.deviceId);
+    expect(result.platform).toBe("ios");
+    expect(result.deviceId).toBe("ios-sim-1");
+  });
+
   test("should resolve to active platform without deviceId when setActiveDevice was called", async () => {
     const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 


### PR DESCRIPTION
## Summary

The very first thing an MCP client does — acquire a usable device handle —
was broken end to end, taking five failed calls (per [#5870](https://github.com/kaeawc/auto-mobile/issues/5870)).
This fixes each step of that trail, following the issue's own "smallest change
I'd want as a client" list:

1. **`listDevices` returns the devices.** It enumerated nothing and returned a
   prose blob pointing at MCP resources; it now lists the booted devices
   directly and keeps the resource pointers (which also cover not-yet-booted
   images and richer per-device detail) as a `note`.
2. **`getAndroid`/`getApple` accept `deviceId`** — the identifier every device
   resource leads with — alongside `avdName`/`udid`. When neither is given, the
   error names both sources (which field of which resource to read).
3. **Acquisition tools return `sessionUuid`, not `sessionId`.** `getAndroid`,
   `getApple`, and `startDevice` now emit `sessionUuid` — the key every consumer
   tool's schema declares — so the obvious copy-paste is correct. The internal
   result reader accepts it (with a `sessionId` fallback).
4. **`sessionUuid` resolves the platform.** A handle from `getAndroid` is
   sufficient on its own (the registry already promotes the session's platform),
   so `platform` drops out of `required` on `tapOn` and `setActiveDevice`
   (which now infers the platform from the resolved device / session).
5. **A defaulted field is never advertised as required.** zod v4 lists keys with
   a `.default()` in `required`; the advertised-schema converter now strips them,
   so `action` leaves `tapOn`'s required list (and every other defaulted field,
   consistently — e.g. defaulted `platform` on `explore`/`navigateTo`).

Regenerated `schemas/tool-definitions.json`.

**Scope note:** item 4's "`platform` drops out of `required`" is applied to the
tools the issue explicitly named (`tapOn`, `setActiveDevice`); a systemic sweep
of the remaining ~30 tools that declare a required `platform` beside `sessionUuid`
is deferred as a follow-up to keep this change focused and low-risk.

## Linked Issue

Closes #5870

## Bug / Regression Context

- **Observed symptom:** `listDevices` lists no devices; `getAndroid` rejects
  `deviceId`; it returns `sessionId` but every tool takes `sessionUuid`; and the
  session did not resolve the platform, so `launchApp` demanded `setActiveDevice`,
  which itself failed on a missing-but-reported-as-invalid `platform`.
- **Repro steps / conditions:** the dogfood trail in the issue — `listDevices` →
  `getAndroid {deviceId}` → copy `sessionId` into a consumer tool.

## Validation

- [x] `bun test` — the changed-area suites pass (`deviceTools.*`,
  `deviceAcquisitionErgonomics`, `startDevice`, session-binding); the full suite's
  only reds are two pre-existing worktree artifacts (no `node_modules` in the
  `.claude` worktree): `oxlintConfigScoping` and the `webrtc…Latency` subprocess
  skip-marker grep — both green in CI.
- [x] `bun run typecheck` — no new errors (changed files clean; baseline untouched).
- [x] `bun build.ts` — succeeds.
- [x] oxlint on the changed files — no new ratchet violations (counts match baseline).
- [x] New tests use interfaces + fakes + FakeTimer; unit tests run in <100ms.

## Device Verification

- [ ] Not run on hardware in this change — the fixes are schema/handler-level and
  covered by fakes; a manual-test pass against a real emulator/simulator would
  confirm the full acquisition trail.

## Follow-ups

- [ ] Systemic `platform`-optional sweep for the remaining tools that pair a
  required `platform` with `sessionUuid` (this PR does the two named tools).
