### PR TITLE
feat(tools): default action-tool observations to the compact skeleton; add inputText selector (#5872)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2505,6 +2505,63 @@
           "type": "string",
           "minLength": 1
         },
+        "selector": {
+          "description": "Focus this field before typing, collapsing the mandatory focus-then-type pair into one call. Without it, text goes to whatever is currently focused.",
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "elementId": {
+                  "description": "Resource ID, e.g. com.app:id/field",
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["elementId"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "testTag": {
+                  "description": "Android accessibility test tag",
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["testTag"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "description": "Text, content-desc, or placeholder of the field",
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["text"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "textAny": {
+                  "description": "Ordered text variants; first visible match wins",
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "required": ["textAny"],
+              "additionalProperties": false
+            }
+          ]
+        },
         "mode": {
           "description": "Android text mode: a11y default; eventLast and eventAll start with accessibility setText; eventOnly clears and types supported ASCII with key events only",
           "type": "string",
@@ -2522,6 +2579,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -2652,6 +2718,15 @@
         "coldBoot": {
           "description": "Cold boot app (default false)",
           "type": "boolean"
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "platform": {
           "type": "string",
@@ -8793,6 +8868,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -27,8 +27,42 @@ import {
   type KeyEventPlan,
 } from "./asciiKeyEvents";
 import { Keyboard } from "./Keyboard";
+import { TapOnElement } from "./TapOnElement";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll" | "eventOnly" | "append";
+
+/** Selector variants that identify a field to focus before typing (issue #5872). */
+export interface TextInputTargetSelector {
+  elementId?: string;
+  testTag?: string;
+  text?: string;
+  textAny?: string[];
+}
+
+/**
+ * Focuses the field a `selector` names before {@link InputText} types into it,
+ * collapsing the mandatory focus-then-type pair into one call (issue #5872 AC3).
+ * Interface + fake so the focus step is unit-testable without a real tap.
+ */
+export interface TextInputTargetFocuser {
+  focus(
+    selector: TextInputTargetSelector,
+    signal?: AbortSignal,
+  ): Promise<{ success: boolean; error?: string }>;
+}
+
+type TextInputTargetFocuserFactory = (device: BootedDevice) => TextInputTargetFocuser;
+
+const defaultTargetFocuserFactory: TextInputTargetFocuserFactory = (device) => ({
+  focus: async (selector, signal) => {
+    const result = await new TapOnElement(device).execute(
+      { ...selector, action: "focus" },
+      undefined,
+      signal,
+    );
+    return { success: result.success, error: result.error };
+  },
+});
 
 const DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS = 1000;
 
@@ -55,15 +89,18 @@ function assertInputNotAborted(signal?: AbortSignal): void {
 
 export class InputText extends BaseVisualChange {
   private androidInputKeyCombinationSupported: boolean | undefined;
+  private targetFocuser: TextInputTargetFocuser;
 
   constructor(
     device: BootedDevice,
     adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null,
     private readonly keyboardCloserFactory: KeyboardCloserFactory = defaultKeyboardCloserFactory,
     timer: Timer = defaultTimer,
+    targetFocuserFactory: TextInputTargetFocuserFactory = defaultTargetFocuserFactory,
   ) {
     super(device, adbFactoryOrExecutor, timer);
     this.device = device;
+    this.targetFocuser = targetFocuserFactory(device);
   }
 
   async execute(
@@ -72,6 +109,7 @@ export class InputText extends BaseVisualChange {
     dismissKeyboard: boolean = false,
     mode?: InputTextMode,
     signal?: AbortSignal,
+    selector?: TextInputTargetSelector,
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("inputText");
@@ -99,6 +137,25 @@ export class InputText extends BaseVisualChange {
         logger.debug(
           "[InputText] auto-promoted a11y -> eventAll (text matched a configured event-all marker)",
         );
+      }
+    }
+
+    // A selector focuses the target field first (issue #5872 AC3), so the text
+    // lands where the caller means rather than in whatever happened to be focused.
+    // Focus before the observedInteraction captures its baseline, so the "before"
+    // snapshot already reflects the focused field. A focus failure short-circuits —
+    // typing into an unknown field would be worse than reporting the miss.
+    if (selector) {
+      assertInputNotAborted(signal);
+      const focusResult = await this.targetFocuser.focus(selector, signal);
+      if (!focusResult.success) {
+        perf.end();
+        return {
+          success: false,
+          text,
+          error: focusResult.error ?? "Failed to focus the target element before typing",
+          method: this.device.platform === "android" ? resolvedMode : "a11y",
+        };
       }
     }
 

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1025,12 +1025,21 @@ export class LaunchApp extends BaseVisualChange {
     expectedPackageName: string,
     staleObservation: ObserveResult,
   ): LaunchAppResult {
+    const reportedPackages = this.describeLaunchObservationPackages(staleObservation);
     logger.warn(
       `[LaunchApp] Omitting stale launch observation for ${expectedPackageName}; ` +
-        `last observation reported ${this.describeLaunchObservationPackages(staleObservation)}`,
+        `last observation reported ${reportedPackages}`,
     );
     const resultWithoutObservation = { ...result };
     delete resultWithoutObservation.observation;
+    // Explain the omission (issue #5872) so the payload shape is deterministic:
+    // a launch either carries `observation` or carries `observationOmitted`
+    // naming why, never a silently-vanishing observation.
+    resultWithoutObservation.observationOmitted = {
+      reason: "stale_launch_observation",
+      expectedPackage: expectedPackageName,
+      reportedPackages,
+    };
     return resultWithoutObservation;
   }
 

--- a/src/models/LaunchAppResult.ts
+++ b/src/models/LaunchAppResult.ts
@@ -10,4 +10,15 @@ export interface LaunchAppResult extends BaseActionResult {
   userId?: number;
   /** Process ID (iOS only) */
   pid?: number;
+  /**
+   * Explains a deliberately-omitted `observation` (issue #5872) so the launch
+   * payload has a deterministic, self-describing shape: rather than silently
+   * dropping the observation when it still reports the previous app, the response
+   * carries this marker naming why and what the stale observation actually showed.
+   */
+  observationOmitted?: {
+    reason: "stale_launch_observation";
+    expectedPackage: string;
+    reportedPackages: string;
+  };
 }

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -14,6 +14,7 @@ import {
 } from "../utils/toolUtils";
 import {
   addDeviceTargetingToSchema,
+  responseShapeControlFields,
   withAppIdAliases,
   withJsonSchemaOverride,
 } from "./toolSchemaHelpers";
@@ -103,6 +104,7 @@ export const launchAppSchema = withAppIdAliases(
       appId: z.string(),
       clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
       coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
+      ...responseShapeControlFields,
     }),
   ),
 );
@@ -268,6 +270,8 @@ export interface LaunchAppActionArgs {
   appId: string;
   clearAppData?: boolean;
   coldBoot?: boolean;
+  raw?: boolean;
+  project?: "full" | "skeleton";
 }
 
 export interface InstallAppArgs {

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -110,6 +110,22 @@ function classifyObservationAction(
 }
 
 /**
+ * Action tools that embed a post-action observation AND expose the `raw`/`project`
+ * response-shape control (issue #5872). Their embedded observation defaults to the
+ * compact skeleton, opt-out-able per call. The default is scoped to exactly the
+ * tools that carry the opt-out so the two never diverge: a tool that skeletonizes
+ * by default but cannot be asked for the raw tree would be a silent one-way door.
+ * Extending both to every observation-producing action tool is tracked as a
+ * follow-up. `observe` is not here — it owns the projection at the payload top
+ * level, not under `.observation`.
+ */
+const SKELETON_DEFAULT_ACTION_TOOLS: ReadonlySet<string> = new Set([
+  "tapOn",
+  "inputText",
+  "launchApp",
+]);
+
+/**
  * Resolve the observe output projection (issue #4388). An explicit per-call
  * `project` arg always wins; otherwise `raw: true` forces `"full"` (the raw tree
  * is the documented disambiguation escape hatch). The skeleton projection is now
@@ -348,14 +364,19 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
       const sanitized = sanitizeObserveResult(payload.observation as ObserveResult, cfg);
       // Action observations default to the compact skeleton (issue #5872) — the
       // same response-shape control `observe` already has — so a client no longer
-      // pays the full raw hierarchy on every tapOn/inputText/launchApp. The compact
+      // pays the full raw hierarchy on every tapOn/inputText/launchApp. Scoped to
+      // SKELETON_DEFAULT_ACTION_TOOLS (the tools that also expose the `raw`/`project`
+      // opt-out), so the default and the escape hatch never diverge. The compact
       // form lands under the same `skeleton` key `observe` uses; `raw:true` /
       // `project:"full"` opts back into the raw `viewHierarchy`. Two paths always
       // keep the full tree: internal tool-to-tool consumers read
       // `.observation.viewHierarchy`, and the opt-in `--actions-diff-observe`
       // pipeline diffs against (and emits) the full hierarchy.
       const servedObservation =
-        !ctx.internal && !diffActive && resolveObserveProjection(ctx.args) === "skeleton"
+        !ctx.internal &&
+        !diffActive &&
+        SKELETON_DEFAULT_ACTION_TOOLS.has(ctx.name) &&
+        resolveObserveProjection(ctx.args) === "skeleton"
           ? sanitizeObserveResult(payload.observation as ObserveResult, {
               ...cfg,
               project: "skeleton",

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -346,7 +346,22 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
       sanitizedPayload = stripped;
     } else if (isObserveResult(payload.observation)) {
       const sanitized = sanitizeObserveResult(payload.observation as ObserveResult, cfg);
-      let observationOut: unknown = sanitized;
+      // Action observations default to the compact skeleton (issue #5872) — the
+      // same response-shape control `observe` already has — so a client no longer
+      // pays the full raw hierarchy on every tapOn/inputText/launchApp. The compact
+      // form lands under the same `skeleton` key `observe` uses; `raw:true` /
+      // `project:"full"` opts back into the raw `viewHierarchy`. Two paths always
+      // keep the full tree: internal tool-to-tool consumers read
+      // `.observation.viewHierarchy`, and the opt-in `--actions-diff-observe`
+      // pipeline diffs against (and emits) the full hierarchy.
+      const servedObservation =
+        !ctx.internal && !diffActive && resolveObserveProjection(ctx.args) === "skeleton"
+          ? sanitizeObserveResult(payload.observation as ObserveResult, {
+              ...cfg,
+              project: "skeleton",
+            })
+          : sanitized;
+      let observationOut: unknown = servedObservation;
       let observationDiff: ObservationDiffMetadata | undefined;
       if (ctx.internal) {
         // Internal envelopes are consumed by in-process tool callers, not agents.

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -36,12 +36,23 @@ export interface SystemTrayArgs {
   platform: Platform;
 }
 
+/** Selector variants that focus an input field before typing (issue #5872). */
+export interface InputTextSelector {
+  elementId?: string;
+  testTag?: string;
+  text?: string;
+  textAny?: string[];
+}
+
 export interface InputTextArgs {
   text: string;
+  selector?: InputTextSelector;
   mode?: "a11y" | "eventLast" | "eventAll" | "eventOnly";
   imeAction?: ImeAction;
   dismissKeyboard?: boolean;
   platform: Platform;
+  raw?: boolean;
+  project?: "full" | "skeleton";
 }
 
 export interface WakeAndUnlockArgs {
@@ -84,6 +95,8 @@ export interface TapOnArgs {
     text: string;
     occurrence?: number;
   };
+  raw?: boolean;
+  project?: "full" | "skeleton";
 }
 
 export interface TapAnyArgs {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -51,6 +51,7 @@ import {
   withAppIdAliases,
   withJsonSchemaOverride,
   compactExclusiveSelectorProperties,
+  responseShapeControlFields,
 } from "./toolSchemaHelpers";
 import { serverConfig } from "../utils/ServerConfig";
 import {
@@ -252,6 +253,7 @@ export const tapOnSchema = withJsonSchemaOverride(
           .describe("Retry once if the view hierarchy is unchanged after tap"),
         ensureTap: z.boolean().optional().describe("Enable preTapStability and retryIfNoChange"),
         platform: platformSchema,
+        ...responseShapeControlFields,
       })
       .strict(),
   ).superRefine((value, ctx) => {
@@ -571,9 +573,43 @@ export const clearStateSchema = withAppIdAliases(
   ),
 );
 
+// A selector focuses the target field before typing (issue #5872 AC3), so a
+// form field no longer costs a mandatory tapOn-then-inputText pair. Kept to the
+// selector variants that identify an input; semantic-link activation is a tapOn
+// concern, not a field to type into.
+const inputTextSelectorSchema = z
+  .union([
+    z
+      .object({ elementId: z.string().min(1).describe("Resource ID, e.g. com.app:id/field") })
+      .strict(),
+    z.object({ testTag: z.string().min(1).describe("Android accessibility test tag") }).strict(),
+    z
+      .object({
+        text: z.string().min(1).describe("Text, content-desc, or placeholder of the field"),
+      })
+      .strict(),
+    z
+      .object({
+        textAny: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe("Ordered text variants; first visible match wins"),
+      })
+      .strict(),
+  ])
+  .describe(
+    "Field to focus before typing: elementId, Android testTag, text, or ordered text variants",
+  );
+
 export const inputTextSchema = addDeviceTargetingToSchema(
   z.object({
     text: z.string().min(1),
+    selector: inputTextSelectorSchema
+      .optional()
+      .describe(
+        "Focus this field before typing, collapsing the mandatory focus-then-type pair into " +
+          "one call. Without it, text goes to whatever is currently focused.",
+      ),
     mode: z
       .enum(["a11y", "eventLast", "eventAll", "eventOnly"])
       .optional()
@@ -586,6 +622,7 @@ export const inputTextSchema = addDeviceTargetingToSchema(
       .describe("IME action after input"),
     dismissKeyboard: z.boolean().optional().describe("Android: dismiss keyboard after input"),
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
@@ -1249,6 +1286,7 @@ export function registerInteractionTools() {
       dismissKeyboard,
       mode,
       signal,
+      args.selector,
     );
     return createJSONToolResponse({
       message: `Input text`,

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -138,6 +138,10 @@ const screenIdentitySchema = z
   })
   .passthrough();
 
+// `.passthrough()` — action tools default their embedded observation to the
+// compact `skeleton` (issue #5872) and carry the raw `viewHierarchy` under
+// raw/project:"full"; both flow through without an explicit field here (the
+// schemas they'd reference are declared later in this module).
 export const observationSummarySchema = z
   .object({
     selectedElements: z.array(selectedElementSchema).optional(),

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -5,6 +5,30 @@ export const platformSchema = z.enum(["android", "ios"]);
 
 export const DEVICE_LABEL_DESCRIPTION = "Device label";
 
+/**
+ * Response-shape control for tools that embed a post-action observation (issue
+ * #5872). Spread into an action tool's `z.object` shape to give it the same
+ * projection control `observe` already has: the embedded observation defaults to
+ * the compact skeleton, and these two fields opt back into the raw hierarchy.
+ * The compact form always lands under `skeleton`, the raw form under
+ * `viewHierarchy`, regardless of which tool produced it.
+ */
+export const responseShapeControlFields = {
+  raw: z
+    .boolean()
+    .optional()
+    .describe("Return the raw view hierarchy instead of the compact skeleton"),
+  project: z
+    .enum(["full", "skeleton"])
+    .optional()
+    .describe(
+      "Observation projection. 'skeleton' (default) returns a flat, actionable-only list " +
+        "(id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' " +
+        "returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is " +
+        "directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+    ),
+} as const;
+
 export const appIdFieldAliases = [
   "packageId",
   "package",

--- a/test/features/action/InputText.execute.test.ts
+++ b/test/features/action/InputText.execute.test.ts
@@ -148,4 +148,54 @@ describe("InputText.execute", () => {
     ]);
     expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
+
+  // A `selector` focuses the field first, collapsing the mandatory focus-then-type
+  // pair into a single call (issue #5872 AC3).
+  describe("selector focuses the target before typing (#5872)", () => {
+    test("focuses the selected element, then types into it", async () => {
+      serverConfig.setEventAllMarkers([]);
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+        fakeA11yService as unknown as AndroidCtrlProxyClient,
+      );
+
+      const focusCalls: unknown[] = [];
+      const inputText = new InputText(androidDevice, fakeAdb as any);
+      wireFakes(inputText);
+      (inputText as any).targetFocuser = {
+        focus: async (selector: unknown) => {
+          focusCalls.push(selector);
+          return { success: true };
+        },
+      };
+
+      const result = await inputText.execute("Ada", undefined, false, undefined, undefined, {
+        text: "First name",
+      });
+
+      expect(result.success).toBe(true);
+      // The field was focused with the caller's selector before any text landed.
+      expect(focusCalls).toEqual([{ text: "First name" }]);
+      expect(fakeA11yService.getTextInputHistory()).toEqual([
+        { text: "Ada", resourceId: undefined },
+      ]);
+    });
+
+    test("returns the focus failure without typing when the selector cannot be focused", async () => {
+      const inputText = new InputText(androidDevice, fakeAdb as any);
+      wireFakes(inputText);
+      (inputText as any).targetFocuser = {
+        focus: async () => ({ success: false, error: "no element matches text=Missing" }),
+      };
+
+      const result = await inputText.execute("Ada", undefined, false, undefined, undefined, {
+        text: "Missing",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("no element matches");
+      // Focus failed, so nothing was ever typed.
+      expect(fakeA11yService.getTextInputHistory()).toEqual([]);
+      expect(fakeAdb.getExecutedCommands().some((cmd) => cmd.includes("keyevent"))).toBe(false);
+    });
+  });
 });

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -610,6 +610,29 @@ describe("LaunchApp", () => {
     expect(result.observation).toBeUndefined();
   });
 
+  // Deterministic launch payload shape (issue #5872 AC2): when the observation is
+  // dropped because it is stale, the response must EXPLAIN which shape it is rather
+  // than silently omitting the observation with nothing distinguishing it.
+  test("explains the omitted observation with observationOmitted when the launch is stale", async () => {
+    fakeTimer.enableAutoAdvance();
+    const previousPackageName = "com.example.previous";
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
+    fakeObserveScreen.setObserveResult(() => createObserveResult(previousPackageName));
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.observation).toBeUndefined();
+    expect(result.observationOmitted).toBeDefined();
+    expect(result.observationOmitted!.reason).toBe("stale_launch_observation");
+    expect(result.observationOmitted!.expectedPackage).toBe(packageName);
+    expect(result.observationOmitted!.reportedPackages).toContain(previousPackageName);
+  });
+
   test("runs target user detection and install check in parallel", async () => {
     const targetUserDetector = new FakeTargetUserDetector(fakeTimer, {
       delayMs: 50,

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -145,7 +145,13 @@ describe("finalizeToolResponse", () => {
     const actionPayload = { success: true, observation: obs };
     const response = createStructuredToolResponse(actionPayload);
 
-    const finalized = finalizeToolResponse(response, { name: "tapOn", sessionUuid: "s1" });
+    // project:"full" keeps the raw hierarchy under test; the skeleton default is
+    // covered separately in "action-tool skeleton default (#5872)".
+    const finalized = finalizeToolResponse(response, {
+      name: "tapOn",
+      sessionUuid: "s1",
+      args: { project: "full" },
+    });
 
     const obsSc = (finalized.structuredContent as any).observation as ObserveResult;
     const rootSc = obsSc.viewHierarchy!.hierarchy.node as any;
@@ -156,6 +162,79 @@ describe("finalizeToolResponse", () => {
     const parsed = JSON.parse(finalized.content[0].text);
     expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
     expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  // Action tools default their embedded observation to the compact skeleton
+  // (issue #5872): the same response-shape control `observe` already has, so a
+  // client no longer pays the full raw hierarchy on every tapOn/inputText/launchApp.
+  describe("action-tool skeleton default (#5872)", () => {
+    test("an action observation defaults to the compact skeleton (no viewHierarchy)", () => {
+      const response = createStructuredToolResponse({
+        success: true,
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, { name: "tapOn" });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(Array.isArray(observation.skeleton)).toBe(true);
+      expect(observation.viewHierarchy).toBeUndefined();
+      expect(observation.elements).toBeUndefined();
+      // The compact form is under the SAME `skeleton` key `observe` uses (#5872 AC2).
+      const parsed = JSON.parse(finalized.content[0].text);
+      expect(Array.isArray(parsed.observation.skeleton)).toBe(true);
+      expect(parsed.observation.viewHierarchy).toBeUndefined();
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test('project:"full" opts an action observation back into the raw viewHierarchy', () => {
+      const response = createStructuredToolResponse({
+        success: true,
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, {
+        name: "tapOn",
+        args: { project: "full" },
+      });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.viewHierarchy).toBeDefined();
+      expect(observation.skeleton).toBeUndefined();
+    });
+
+    test("raw:true opts an action observation back into the raw viewHierarchy", () => {
+      const response = createStructuredToolResponse({
+        success: true,
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, {
+        name: "inputText",
+        args: { raw: true },
+      });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.viewHierarchy).toBeDefined();
+      expect(observation.skeleton).toBeUndefined();
+    });
+
+    test("launchApp's observation also defaults to the compact skeleton", () => {
+      const response = createStructuredToolResponse({
+        success: true,
+        packageName: "com.example",
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, { name: "launchApp" });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(Array.isArray(observation.skeleton)).toBe(true);
+      expect(observation.viewHierarchy).toBeUndefined();
+    });
+
+    test("internal tool-to-tool calls keep the full viewHierarchy for in-process consumers", () => {
+      const response = createStructuredToolResponse({
+        success: true,
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, { name: "tapOn", internal: true });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.viewHierarchy).toBeDefined();
+      expect(observation.skeleton).toBeUndefined();
+    });
   });
 
   test("EC4: elements are kept only when the include-elements gate is enabled", () => {
@@ -351,7 +430,11 @@ describe("finalizeToolResponse", () => {
       success: true,
       observation: makeObserveResultWithBounds(),
     });
-    const finalized = finalizeToolResponse(response, { name: "tapOn", sessionUuid: "s1" });
+    const finalized = finalizeToolResponse(response, {
+      name: "tapOn",
+      sessionUuid: "s1",
+      args: { project: "full" },
+    });
 
     const obsSc = (finalized.structuredContent as any).observation;
     expect(obsSc.viewHierarchy.hierarchy.node.bounds).toEqual([0, 0, 1080, 1920]);
@@ -624,6 +707,10 @@ describe("finalizeToolResponse", () => {
         name: "tapOn",
         sessionUuid: "s1",
         baselineStore: store,
+        // project:"full" opts out of the #5872 skeleton default so the "full, not a
+        // diff" path under test keeps its raw hierarchy; the diff/store behavior is
+        // the actual subject here.
+        args: { project: "full" },
       });
 
       const obsSc = (finalized.structuredContent as any).observation;
@@ -1307,7 +1394,15 @@ describe("finalizeToolResponse", () => {
       const writer = new FakeObservationArtifactWriter();
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({ success: true, observation: makeObserveResult() }),
-        { name: "tapOn", sessionUuid: "s1", artifactWriter: writer } as any,
+        // project:"full" keeps the raw hierarchy under test; the assertions below
+        // check that the FULL observation (not the #5872 skeleton default) is the
+        // payload handed to the artifact writer.
+        {
+          name: "tapOn",
+          sessionUuid: "s1",
+          args: { project: "full" },
+          artifactWriter: writer,
+        } as any,
       );
 
       expect((finalized.structuredContent as any).success).toBe(true);
@@ -1470,7 +1565,9 @@ describe("finalizeToolResponse", () => {
           65536,
         );
         expect(writer.writes).toHaveLength(0);
-        expect((finalized.structuredContent as any).observation.viewHierarchy).toBeDefined();
+        // Inline (not artifacted): the observation is present as the #5872 skeleton
+        // default, not replaced by artifact metadata.
+        expect((finalized.structuredContent as any).observation.skeleton).toBeDefined();
         expect((finalized.structuredContent as any).observation.artifact).toBeUndefined();
       });
 
@@ -2073,7 +2170,7 @@ describe("finalizeToolResponse", () => {
       expect(sc.viewHierarchy?.hierarchy).toBeDefined();
     });
 
-    test("embedded action observations are never skeletonized (scoped to observe)", () => {
+    test("embedded action observations now skeletonize by default too (#5872 superseded #4388's scoping)", () => {
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({
           success: true,
@@ -2082,8 +2179,10 @@ describe("finalizeToolResponse", () => {
         { name: "tapOn", sessionUuid: "s1" },
       );
       const obsSc = (finalized.structuredContent as any).observation as ObserveResult;
-      expect(obsSc.skeleton).toBeUndefined();
-      expect(obsSc.viewHierarchy?.hierarchy).toBeDefined();
+      // Issue #5872: the skeleton default extended to the action tools' embedded
+      // observation, using the same `skeleton` key `observe` uses.
+      expect(obsSc.skeleton).toBeDefined();
+      expect(obsSc.viewHierarchy).toBeUndefined();
     });
   });
 });

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -235,6 +235,21 @@ describe("finalizeToolResponse", () => {
       expect(observation.viewHierarchy).toBeDefined();
       expect(observation.skeleton).toBeUndefined();
     });
+
+    test("an action tool without the response-shape opt-out keeps the full hierarchy (no silent one-way skeleton)", () => {
+      // The skeleton default is scoped to the tools that also expose raw/project
+      // (tapOn/inputText/launchApp). A tool like swipeOn, which has no opt-out,
+      // must NOT be silently skeletonized — otherwise a client could never recover
+      // the raw tree from it. Broader coverage is a tracked follow-up.
+      const response = createStructuredToolResponse({
+        success: true,
+        observation: makeObserveResult(),
+      });
+      const finalized = finalizeToolResponse(response, { name: "swipeOn" });
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.viewHierarchy).toBeDefined();
+      expect(observation.skeleton).toBeUndefined();
+    });
   });
 
   test("EC4: elements are kept only when the include-elements gate is enabled", () => {

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -160,6 +160,9 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
 
     const response = await tool.handler({
       platform: "android",
+      // project:"full" opts out of the #5872 skeleton default so this test can
+      // assert the raw hierarchy is sanitized end-to-end through the chokepoint.
+      project: "full",
       __mcpSessionId: "mcp-session-1",
     });
 

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -220,6 +220,41 @@ describe("MCP Tools Schema", () => {
     expect(result.action).toBe("tap");
   });
 
+  // Issue #5872: the action tools gain observe's response-shape control so a
+  // client can opt out of the skeleton default back to the raw hierarchy.
+  test.each(["tapOn", "inputText", "launchApp"])(
+    "%s advertises the raw/project response-shape control",
+    async (toolName) => {
+      const tool = ADVERTISED_TOOLS.find((t) => t.name === toolName);
+      expect(tool).toBeDefined();
+      const props = (tool!.inputSchema as any).properties ?? {};
+      expect(props.raw).toBeDefined();
+      expect(props.project).toBeDefined();
+    },
+  );
+
+  test("inputText accepts a project override and a selector", async () => {
+    const { inputTextSchema } = await import("../../../src/server/interactionTools");
+    const parsed = inputTextSchema.parse({
+      platform: "android",
+      text: "Ada",
+      project: "full",
+      selector: { text: "First name" },
+    });
+    expect(parsed.project).toBe("full");
+    expect(parsed.selector).toEqual({ text: "First name" });
+  });
+
+  test("launchApp accepts raw:true to opt back into the full hierarchy", async () => {
+    const { launchAppSchema } = await import("../../../src/server/appTools");
+    const parsed = launchAppSchema.parse({
+      platform: "android",
+      appId: "com.example",
+      raw: true,
+    });
+    expect(parsed.raw).toBe(true);
+  });
+
   test("an unknown tool name is rejected with an Unknown tool error", async function () {
     const { client } = fixture.getContext();
 


### PR DESCRIPTION
## Summary

`tapOn`, `inputText`, and `launchApp` returned the **full raw view hierarchy on every call with no opt-out** — the dogfood loop spent 392 KB of tool output to type three short strings into three contact fields — while `observe` already had a compact, affordance-tagged `skeleton` form. This PR makes the cheap representation the default everywhere the bytes actually are.

- **Response-shape control + skeleton default.** `tapOn`/`inputText`/`launchApp` gain the same `raw`/`project` control `observe` has, and their embedded observation now defaults to the compact `skeleton`. The compact form lands under the same `skeleton` key `observe` uses; the raw tree stays reachable via `raw:true` / `project:"full"`. This applies on the standard (non-diff) path — internal tool-to-tool consumers (which read `.observation.viewHierarchy`) and the opt-in `--actions-diff-observe` pipeline still receive the full hierarchy.
- **One key per concept.** Compact form → `skeleton`, raw form → `viewHierarchy`, in the same place regardless of which tool produced it.
- **`inputText` selector.** A new optional `selector` focuses the target field before typing, collapsing the previously-mandatory focus-then-type (`tapOn` + `inputText`) pair into a single call. A focus miss short-circuits rather than typing into the wrong field.
- **Deterministic `launchApp` payload.** When a stale post-launch observation is dropped (it still reports the previous app), the response now carries an explicit `observationOmitted: { reason, expectedPackage, reportedPackages }` marker naming why — instead of the observation silently vanishing, which made the identical call return 28 KB one time and 336 bytes the next with nothing explaining the difference.

## Linked Issue

Closes #5872

## Acceptance Criteria (from the issue)

1. ✅ `tapOn`/`inputText`/`launchApp` get observe's response-shape control and **default to `skeleton`**; a client can opt back into the full tree with `raw`/`project:"full"`.
2. ✅ One key name per concept (`skeleton` = compact, `viewHierarchy` = raw), same place regardless of producer; `launchApp`'s payload shape is now deterministic and self-describing.
3. ✅ `selector` added to `inputText`.

## Validation

- [x] `bun test` — full suite green except a **pre-existing, unrelated** flake in `test/integration/webrtcDeviceCaptureLatency.test.ts` (an isolated `bun test` subprocess whose stdout lacks the expected `(skip)` label under bun 1.3.14; touches no code in this PR).
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] `bun run lint` — no new ratchet violations; `bun run format:check` clean.
- [x] `schemas/tool-definitions.json` regenerated for the new params.
- [x] New tests use interfaces + fakes; unit tests run in <100ms. `inputText`'s focus step is injected behind a `TextInputTargetFocuser` interface for deterministic unit testing.

## Device Verification

- [ ] Not run on hardware — change is at the MCP serialization/schema layer, fully covered by unit tests through the `finalizeToolResponse` chokepoint. The compact/raw representations are produced by the existing, already-device-verified `toSkeleton` projection.

## Follow-ups

- [ ] `dismissKeyboard: true` not dismissing the Android soft keyboard (noted as minor in the issue) — separate bug, tracked as a follow-up; not part of these three changes.
- Note: related skeleton label-attribution bug #5869 is a separate issue and out of scope here.
