### PR TITLE
fix(observe): fence stale in-flight observe-cache writes with a per-device generation (#5884)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -318,6 +318,13 @@ export class RealObserveScreen implements ObserveScreen {
 
       const result = this.createBaseResult();
 
+      // Capture the device's cache generation before the hierarchy is captured so
+      // a concurrent invalidation (e.g. terminateApp force-stop) that lands while
+      // this observation is in flight fences out our late put() below, instead of
+      // repopulating the just-cleared cache with the terminated app's hierarchy
+      // (issue #5884).
+      const cacheGeneration = getObserveCacheStore().currentGeneration(this.device.deviceId);
+
       perf.serial("observe");
 
       // Ground-truth foreground app for the window-identity freshness check
@@ -429,7 +436,7 @@ export class RealObserveScreen implements ObserveScreen {
 
       // Cache the result for future use
       await perf.track("cacheResult", () =>
-        getObserveCacheStore().put(this.device.deviceId, result),
+        getObserveCacheStore().put(this.device.deviceId, result, cacheGeneration),
       );
 
       perf.end();

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -97,15 +97,29 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
     mkdirSync(this.cacheDir, { recursive: true });
   }
 
+  /**
+   * True when `generation` was supplied and no longer matches the device's
+   * current cache generation — i.e. the cache was invalidated for the device
+   * since `generation` was captured (issue #5884). Undefined `generation` is
+   * an unconditional write and is never stale.
+   */
+  private isStaleWrite(deviceId: string, generation: number | undefined): boolean {
+    if (generation === undefined || generation === this.currentGeneration(deviceId)) {
+      return false;
+    }
+    // Dropping the write keeps the just-cleared cache from being repopulated
+    // with a now-stale hierarchy.
+    logger.debug(
+      `[OBSERVE_CACHE] Dropping stale observe result for device ${deviceId} ` +
+        `(captured generation ${generation}, current ${this.currentGeneration(deviceId)})`,
+    );
+    return true;
+  }
+
   async put(deviceId: string, result: ObserveResult, generation?: number): Promise<void> {
-    if (generation !== undefined && generation !== this.currentGeneration(deviceId)) {
-      // The cache was invalidated for this device while the observation that
-      // produced `result` was in flight (issue #5884). Dropping the write keeps
-      // the just-cleared cache from being repopulated with a now-stale hierarchy.
-      logger.debug(
-        `[OBSERVE_CACHE] Dropping stale observe result for device ${deviceId} ` +
-          `(captured generation ${generation}, current ${this.currentGeneration(deviceId)})`,
-      );
+    // The cache was invalidated for this device while the observation that
+    // produced `result` was in flight (issue #5884).
+    if (this.isStaleWrite(deviceId, generation)) {
       return;
     }
     const timestamp = this.timer.now();
@@ -115,6 +129,13 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
         `[OBSERVE_CACHE] Caching observe result for device ${deviceId} with timestamp ${timestamp}`,
       );
       await this.pendingDiskCleanup;
+      // Re-check after the await: a clear() can advance the generation during
+      // that microtask hop, and its disk-deletion snapshot was taken before our
+      // file exists — so a write past this point would survive the very
+      // invalidation it raced, re-opening the #5884 hole in a narrower window.
+      if (this.isStaleWrite(deviceId, generation)) {
+        return;
+      }
       this.cache.set(cacheKey, { timestamp, deviceId, observeResult: result });
       await this.saveObserveResultToDisk(cacheKey, result);
       logger.debug(

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -74,6 +74,19 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
   private readonly timer: Timer;
   private pendingDiskCleanup: Promise<void> = Promise.resolve();
 
+  /**
+   * Per-device cache generation. `currentGeneration(deviceId)` is
+   * `globalGeneration + (deviceGeneration.get(deviceId) ?? 0)`, so a scoped
+   * `clear(deviceId)` advances only that device while a `clear()` (all) advances
+   * every device at once. Used to fence stale in-flight writes (issue #5884).
+   */
+  private globalGeneration: number = 0;
+  private readonly deviceGeneration: Map<string, number> = new Map();
+
+  currentGeneration(deviceId: string): number {
+    return this.globalGeneration + (this.deviceGeneration.get(deviceId) ?? 0);
+  }
+
   constructor(timer: Timer = defaultTimer, cacheDir?: string) {
     this.timer = timer;
     this.cacheDir = cacheDir ?? getTempDir(TEMP_SUBDIRS.OBSERVE_RESULTS);
@@ -84,7 +97,17 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
     mkdirSync(this.cacheDir, { recursive: true });
   }
 
-  async put(deviceId: string, result: ObserveResult): Promise<void> {
+  async put(deviceId: string, result: ObserveResult, generation?: number): Promise<void> {
+    if (generation !== undefined && generation !== this.currentGeneration(deviceId)) {
+      // The cache was invalidated for this device while the observation that
+      // produced `result` was in flight (issue #5884). Dropping the write keeps
+      // the just-cleared cache from being repopulated with a now-stale hierarchy.
+      logger.debug(
+        `[OBSERVE_CACHE] Dropping stale observe result for device ${deviceId} ` +
+          `(captured generation ${generation}, current ${this.currentGeneration(deviceId)})`,
+      );
+      return;
+    }
     const timestamp = this.timer.now();
     const cacheKey = `${deviceId}:${timestamp}`;
     try {
@@ -120,6 +143,9 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
 
   clear(deviceId?: string): void {
     if (deviceId) {
+      // Advance the device's generation before deleting so any in-flight
+      // observation that captured the prior generation is fenced out on put.
+      this.deviceGeneration.set(deviceId, (this.deviceGeneration.get(deviceId) ?? 0) + 1);
       for (const [key, entry] of this.cache.entries()) {
         if (entry.deviceId === deviceId) {
           this.cache.delete(key);
@@ -127,6 +153,8 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       }
       this.deleteDiskFilesForDevice(deviceId);
     } else {
+      // A clear-all advances every device's generation at once.
+      this.globalGeneration += 1;
       this.cache.clear();
       this.deleteAllDiskFiles();
     }

--- a/src/features/observe/cache/ObserveResultCacheStore.ts
+++ b/src/features/observe/cache/ObserveResultCacheStore.ts
@@ -9,8 +9,25 @@ import type { ObserveResult } from "../../../models";
  * so callers can pick the right tradeoff for their hot path.
  */
 export interface ObserveResultCacheStore {
-  /** Persist (memory + disk). Returns when both writes complete. */
-  put(deviceId: string, result: ObserveResult): Promise<void>;
+  /**
+   * Persist (memory + disk). Returns when both writes complete.
+   *
+   * `generation` is the device's cache generation captured at the *start* of the
+   * observation that produced `result` (see {@link currentGeneration}). When
+   * supplied and the device's generation has since advanced — i.e. the cache was
+   * invalidated for the device while this observation was in flight — the write
+   * is rejected so an in-flight observation cannot repopulate a just-cleared
+   * cache with a now-stale hierarchy (issue #5884). Omit it for unconditional
+   * writes (back-compat).
+   */
+  put(deviceId: string, result: ObserveResult, generation?: number): Promise<void>;
+
+  /**
+   * The device's current cache generation. Bumped by {@link clear} (per-device
+   * on a scoped clear; every device on a clear-all). Capture it at the start of
+   * an observation and pass it back to {@link put} to fence stale writes.
+   */
+  currentGeneration(deviceId: string): number;
 
   /** Async lookup: checks memory first, then disk; loads disk hits into memory. */
   getMostRecent(deviceId: string): Promise<ObserveResult | undefined>;

--- a/test/fakes/FakeObserveCacheStore.ts
+++ b/test/fakes/FakeObserveCacheStore.ts
@@ -23,18 +23,42 @@ interface FakeCacheEntry {
 export class FakeObserveCacheStore implements ObserveResultCacheStore {
   private readonly entries: Map<string, FakeCacheEntry> = new Map();
   private readonly timer: Timer;
+  private globalGeneration: number = 0;
+  private readonly deviceGeneration: Map<string, number> = new Map();
+
+  /**
+   * Test seam: invoked with `(deviceId, generation)` each time
+   * {@link currentGeneration} is read. Lets a test simulate a concurrent
+   * invalidation landing the instant an observation captures its generation
+   * (issue #5884). Defaults to a no-op.
+   */
+  onCurrentGeneration?: (deviceId: string, generation: number) => void;
 
   constructor(timer: Timer = defaultTimer) {
     this.timer = timer;
   }
 
-  async put(deviceId: string, result: ObserveResult): Promise<void> {
+  currentGeneration(deviceId: string): number {
+    const generation = this.globalGeneration + (this.deviceGeneration.get(deviceId) ?? 0);
+    this.onCurrentGeneration?.(deviceId, generation);
+    return generation;
+  }
+
+  async put(deviceId: string, result: ObserveResult, generation?: number): Promise<void> {
+    if (generation !== undefined && generation !== this.rawGeneration(deviceId)) {
+      return;
+    }
     const timestamp = this.timer.now();
     this.entries.set(`${deviceId}:${timestamp}`, {
       deviceId,
       timestamp,
       observeResult: result,
     });
+  }
+
+  /** Generation without firing {@link onCurrentGeneration} — used by put's fence. */
+  private rawGeneration(deviceId: string): number {
+    return this.globalGeneration + (this.deviceGeneration.get(deviceId) ?? 0);
   }
 
   async getMostRecent(deviceId: string): Promise<ObserveResult | undefined> {
@@ -51,9 +75,11 @@ export class FakeObserveCacheStore implements ObserveResultCacheStore {
 
   clear(deviceId?: string): void {
     if (!deviceId) {
+      this.globalGeneration += 1;
       this.entries.clear();
       return;
     }
+    this.deviceGeneration.set(deviceId, (this.deviceGeneration.get(deviceId) ?? 0) + 1);
     for (const [key, entry] of this.entries.entries()) {
       if (entry.deviceId === deviceId) {
         this.entries.delete(key);

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -130,6 +130,48 @@ describe("ObserveScreen", function () {
       }
     });
 
+    test("does not repopulate the observe cache when invalidated mid-observation (#5884)", async function () {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        updatedAt: 123,
+        screenWidth: 1080,
+        screenHeight: 1920,
+        systemInsets: { top: 24, right: 0, bottom: 48, left: 0 },
+        wakefulness: "Awake",
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 1920 },
+            node: [{ text: "Ready", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+          },
+        },
+      } as any);
+
+      const cacheStore = new FakeObserveCacheStore(new FakeTimer());
+      // Simulate a concurrent terminate invalidating the device cache the instant
+      // this observation captures its generation, before its own put() lands.
+      cacheStore.onCurrentGeneration = (deviceId) => {
+        cacheStore.clear(deviceId);
+      };
+
+      try {
+        const screen = new RealObserveScreen(mockDevice, new FakeAdbClientFactory(fakeAdb), {
+          viewHierarchy,
+          cacheStore,
+          performanceAuditor: { run: async () => undefined } as any,
+          accessibilityAuditor: { run: async () => undefined } as any,
+          accessibilityStateDetector: { run: async () => undefined } as any,
+        });
+
+        await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        // The in-flight observation's put must be rejected: the terminated app's
+        // hierarchy must not repopulate the cache for the device.
+        expect(cacheStore.getRecentInMemoryForDevice(mockDevice.deviceId)).toBeUndefined();
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
+
     test("should populate iOS heuristic screen identity from the view hierarchy", async function () {
       const viewHierarchy = new FakeViewHierarchy();
       viewHierarchy.configureHierarchy({

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -119,6 +119,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       getRecentInMemory: () => undefined,
       getRecentInMemoryForDevice: () => undefined,
       clear: () => undefined,
+      currentGeneration: () => 0,
     };
 
     const screen = new RealObserveScreen(

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -165,6 +165,20 @@ describe("FileSystemObserveCacheStore", function () {
     expect(readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length).toBe(0);
   });
 
+  test("put is rejected when clear() interleaves mid-write (in-flight put, not just pre-put)", async function () {
+    const capturedGen = store.currentGeneration("device-1");
+    // Start the put but do not await it: its body runs synchronously up to the
+    // internal `await this.pendingDiskCleanup`, then yields with the generation
+    // still current. A clear() landing in that hop must still fence the write.
+    const putPromise = store.put("device-1", makeResult("stale-mid-write"), capturedGen);
+    store.clear("device-1");
+    await putPromise;
+
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    expect(await store.getMostRecent("device-1")).toBeUndefined();
+    expect(readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length).toBe(0);
+  });
+
   test("put with a stale generation from clear-all is rejected", async function () {
     const capturedGen = store.currentGeneration("device-1");
     store.clear();

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -117,6 +117,61 @@ describe("FileSystemObserveCacheStore", function () {
     expect(store.getRecentInMemoryForDevice("device-2")).toBeUndefined();
   });
 
+  test("currentGeneration starts at 0 and is stable across reads", function () {
+    expect(store.currentGeneration("device-1")).toBe(0);
+    expect(store.currentGeneration("device-1")).toBe(0);
+    expect(store.currentGeneration("device-2")).toBe(0);
+  });
+
+  test("clear(deviceId) bumps only that device's generation", function () {
+    store.clear("device-1");
+    expect(store.currentGeneration("device-1")).toBe(1);
+    expect(store.currentGeneration("device-2")).toBe(0);
+    store.clear("device-1");
+    expect(store.currentGeneration("device-1")).toBe(2);
+  });
+
+  test("clear() (all devices) bumps every device's generation", function () {
+    expect(store.currentGeneration("device-1")).toBe(0);
+    expect(store.currentGeneration("device-2")).toBe(0);
+    store.clear();
+    expect(store.currentGeneration("device-1")).toBe(1);
+    expect(store.currentGeneration("device-2")).toBe(1);
+  });
+
+  test("put with the current generation stores normally", async function () {
+    const gen = store.currentGeneration("device-1");
+    await store.put("device-1", makeResult("fresh"), gen);
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeDefined();
+  });
+
+  test("put with no generation stores unconditionally (back-compat)", async function () {
+    store.clear("device-1"); // advance generation
+    await store.put("device-1", makeResult("no-gen"));
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeDefined();
+  });
+
+  test("put with a stale generation is rejected (race: invalidate then late put)", async function () {
+    // An observation captures the generation at its start...
+    const capturedGen = store.currentGeneration("device-1");
+    // ...a concurrent terminate invalidates the device cache mid-flight...
+    store.clear("device-1");
+    // ...and the in-flight observation's put lands afterwards with the stale gen.
+    await store.put("device-1", makeResult("stale-app-hierarchy"), capturedGen);
+
+    // The stale record must not repopulate the cache (memory and disk).
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    expect(await store.getMostRecent("device-1")).toBeUndefined();
+    expect(readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length).toBe(0);
+  });
+
+  test("put with a stale generation from clear-all is rejected", async function () {
+    const capturedGen = store.currentGeneration("device-1");
+    store.clear();
+    await store.put("device-1", makeResult("stale"), capturedGen);
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+  });
+
   test("put writes a JSON file with the sanitized device id in the name", async function () {
     await store.put("emulator-5554:abcd", makeResult("with-colon"));
     const files = readdirSync(cacheDir).filter((f) => f.endsWith(".json"));


### PR DESCRIPTION
## Summary

Closes a residual observe-cache race identified as a follow-up from [#5880](https://github.com/kaeawc/auto-mobile/pull/5880). Observe-result caching is not serialized across sessions per device, so a concurrent observation can capture the target app's hierarchy **before** a `terminateApp` force-stop, remain blocked in audits/prediction while the cache is invalidated, then run its `put()` **after** the clear — repopulating the observe cache with the terminated app's now-stale hierarchy. A later terminate-then-observe recovery could then still read the phantom record.

The fix is the issue's suggested per-device cache **generation**: `clear()` bumps the device's generation, and `put()` is given the generation captured at the **start** of the observation and drops the write if the generation advanced while it was in flight.

## Linked Issue

Closes #5884

## Bug / Regression Context

- **Prior attempts:** [#5880](https://github.com/kaeawc/auto-mobile/pull/5880) added a one-time cache clear on terminate; that clear can be undone by an in-flight observation's late write.
- **Observed symptom:** the observe cache is repopulated with a terminated app's hierarchy after invalidation, so a terminate-then-observe recovery can read a stale record.
- **Repro steps / conditions:** a concurrent observe captures the hierarchy, blocks in audits/prediction while `TerminateApp` runs `invalidate()`/`clear()`, then executes `getObserveCacheStore().put(...)` after the clear.

## Changes

- `ObserveResultCacheStore` gains `currentGeneration(deviceId)`; `put()` gains an optional `generation` token.
- `FileSystemObserveCacheStore` and `FakeObserveCacheStore`: `currentGeneration = globalGeneration + deviceGeneration[deviceId]`. `clear(deviceId)` bumps the device's generation; `clear()` (all) bumps a global generation covering every device. `put()` drops the write when the supplied generation no longer matches the current one.
- `ObserveScreen.execute` captures the generation before hierarchy capture and passes it to its caching `put()`. The generation-less `put()` path (`cacheObserveResult` back-compat shim) writes unconditionally.

## Validation

- [x] `bun run lint` + `bun test` — full suite green except two pre-existing, unrelated environmental flakes (`webrtcDeviceCaptureLatency` nested-`bun test` meta-test; a daemon-options test), both confirmed failing identically on the base tree without this change.
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] New code uses interfaces + fakes + FakeTimer; the new unit tests run in <100ms.
- [x] Reuses existing store/registry seams; no new dependencies.

## Acceptance Criteria

Inferred from the issue's "Suggested fix" (no explicit list in the body):

- [x] **AC1** Per-device cache generation; invalidation bumps it — pinned by `FileSystemObserveCacheStore` generation tests.
- [x] **AC2** `put()` with a start-of-observation generation is rejected if the generation advanced in flight — pinned by the "stale generation is rejected" race tests (scoped + clear-all).
- [x] **AC3** `ObserveScreen.execute` captures the generation before hierarchy capture and passes it to `put()` — pinned by the ObserveScreen mid-observation-invalidation test.
- [x] **AC4** Back-compat: generation-less `put()` writes unconditionally — pinned by the "no generation stores unconditionally" test; existing suite stays green.

## Device Verification

N/A for this change (cache-fencing logic; no on-device behavior change) — covered by deterministic unit tests that model the race.
