### PR TITLE
feat(daemon): serve tools/list from the static registry, connect lazily on first tool call (#5879)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -693,6 +693,12 @@ export class DaemonMcpProxy {
   // connection. On the next successful connect the proxy emits a tools
   // list_changed so the client re-fetches the accurate (session-scoped) list.
   private servedStaticToolList = false;
+  // Set when listAdvertisedResources()/listAdvertisedResourceTemplates() served
+  // a cold (empty/cached) roster without a live connection. On the next connect
+  // the proxy emits a resources list_changed so the client re-fetches the real
+  // resources (issue #5879 review — a host that enumerates resources on init
+  // must not block on a wedged daemon before the first tool call).
+  private servedStaticResourceList = false;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -738,16 +744,8 @@ export class DaemonMcpProxy {
       this.initialSessionBindingConfigured = true;
       this.ownedDeviceSessions.add(this.boundSessionUuid);
     }
-    // The default provider derives outputSchema suppression from the daemon
-    // options this proxy is configured with (the flag the connected daemon will
-    // enforce) — NOT from this process's serverConfig, which proxy-mode startup
-    // never sets for this flag (issue #5879 review).
     this.staticToolDefinitionsProvider =
-      config.staticToolDefinitionsProvider ??
-      (() =>
-        getStaticToolDefinitions({
-          suppressOutputSchema: this.config.daemonOptions?.toolResultsNoStructuredContent === true,
-        }));
+      config.staticToolDefinitionsProvider ?? getStaticToolDefinitions;
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
     this.clientAssetVersion = isExplicitPin() ? resolveAssetVersion(resolvePinnedVersion()) : null;
@@ -888,23 +886,32 @@ export class DaemonMcpProxy {
     // profile filters the live list.
     if (this.servedStaticToolList) {
       this.servedStaticToolList = false;
-      this.notifyToolListChanged();
+      this.notifyListChanged("tools");
+    }
+    if (this.servedStaticResourceList) {
+      this.servedStaticResourceList = false;
+      this.notifyListChanged("resources");
     }
   }
 
-  // Invalidate the tool cache and re-emit a tools list_changed to listeners,
+  // Invalidate the matching cache and re-emit a list_changed to listeners,
   // mirroring the daemon-pushed invalidation path (see handleDaemonNotification)
   // so a re-fetch is never stale.
-  private notifyToolListChanged(): void {
+  private notifyListChanged(kind: ListChangedKind): void {
     this.discoveryEpoch += 1;
-    this.cachedTools = null;
+    if (kind === "tools") {
+      this.cachedTools = null;
+    } else {
+      this.cachedResources = null;
+      this.cachedResourceTemplates = null;
+    }
     for (const listener of this.listChangedListeners) {
       try {
-        listener("tools");
+        listener(kind);
       } catch (error) {
         // Best-effort re-emit: a dead/mid-teardown client transport must not
         // break sibling listeners.
-        logger.warn(`[DaemonMcpProxy] list_changed listener failed for tools: ${error}`);
+        logger.warn(`[DaemonMcpProxy] list_changed listener failed for ${kind}: ${error}`);
       }
     }
   }
@@ -1421,6 +1428,37 @@ export class DaemonMcpProxy {
     }
     this.servedStaticToolList = true;
     return this.staticToolDefinitionsProvider();
+  }
+
+  /**
+   * Serve a client `resources/list` request without connecting when no daemon
+   * connection exists yet (issue #5879 review). AutoMobile resources are dynamic
+   * and daemon-owned (device-session screenshots, per-app navigation graphs), so
+   * there is no static cold surface — the cold roster is whatever a prior
+   * connection cached, else empty. Deferring the connect keeps a host that
+   * enumerates resources during initialization from blocking on a wedged daemon
+   * before the first tool call. The first successful connect after a cold serve
+   * emits a resources `list_changed` (see {@link doConnect}) so the client
+   * re-fetches the real resources.
+   */
+  async listAdvertisedResources(): Promise<ProxiedResourceDefinition[]> {
+    if (this.connected && this.client) {
+      return this.listResources();
+    }
+    this.servedStaticResourceList = true;
+    return this.cachedResources ?? [];
+  }
+
+  /**
+   * Serve a client `resources/templates/list` request without connecting when no
+   * daemon connection exists yet. See {@link listAdvertisedResources}.
+   */
+  async listAdvertisedResourceTemplates(): Promise<ProxiedResourceTemplate[]> {
+    if (this.connected && this.client) {
+      return this.listResourceTemplates();
+    }
+    this.servedStaticResourceList = true;
+    return this.cachedResourceTemplates ?? [];
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -44,6 +44,7 @@ import {
   getCurrentBuildIdentity,
 } from "./buildIdentity";
 import { DeviceControlTransportError } from "./deviceControlTransportFailure";
+import { getStaticToolDefinitions } from "./staticToolDefinitions";
 
 export type VersionMismatchReason =
   | "autoStartDisabled"
@@ -279,6 +280,12 @@ export interface DaemonMcpProxyConfig {
   clientVersion?: string;
   /** Existing device-pool session bound before the first discovery request. */
   initialSessionUuid?: string;
+  /**
+   * Supplies the static tool surface served by `listAdvertisedTools()` before a
+   * daemon connection exists (issue #5879). Defaults to the committed
+   * `schemas/tool-definitions.json`; injectable for testing.
+   */
+  staticToolDefinitionsProvider?: () => ProxiedToolDefinition[];
 }
 
 /**
@@ -288,6 +295,7 @@ export interface ProxiedToolDefinition {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
 }
 
 /**
@@ -674,6 +682,14 @@ export class DaemonMcpProxy {
   // discovery refetches under the current scope (issue #4655).
   private discoveryEpoch: number = 0;
 
+  // Supplies the static tool surface for listAdvertisedTools() before a daemon
+  // connection exists (issue #5879).
+  private readonly staticToolDefinitionsProvider: () => ProxiedToolDefinition[];
+  // Set when listAdvertisedTools() served the static surface without a live
+  // connection. On the next successful connect the proxy emits a tools
+  // list_changed so the client re-fetches the accurate (session-scoped) list.
+  private servedStaticToolList = false;
+
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
   private cachedResources: ProxiedResourceDefinition[] | null = null;
@@ -718,6 +734,8 @@ export class DaemonMcpProxy {
       this.initialSessionBindingConfigured = true;
       this.ownedDeviceSessions.add(this.boundSessionUuid);
     }
+    this.staticToolDefinitionsProvider =
+      config.staticToolDefinitionsProvider ?? getStaticToolDefinitions;
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
     this.clientAssetVersion = isExplicitPin() ? resolveAssetVersion(resolvePinnedVersion()) : null;
@@ -848,6 +866,33 @@ export class DaemonMcpProxy {
         // cached behavior instead of failing the connection. Unexpected against
         // a same-version daemon (the handshake gate pins versions), so warn.
         logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
+      }
+    }
+
+    // If a client `tools/list` was served statically before this connection
+    // existed (issue #5879), prompt it to re-fetch now that the daemon can
+    // return the accurate (session-scoped) list. A no-op in the common case
+    // where the static and live lists match; correct when a tool-selection
+    // profile filters the live list.
+    if (this.servedStaticToolList) {
+      this.servedStaticToolList = false;
+      this.notifyToolListChanged();
+    }
+  }
+
+  // Invalidate the tool cache and re-emit a tools list_changed to listeners,
+  // mirroring the daemon-pushed invalidation path (see handleDaemonNotification)
+  // so a re-fetch is never stale.
+  private notifyToolListChanged(): void {
+    this.discoveryEpoch += 1;
+    this.cachedTools = null;
+    for (const listener of this.listChangedListeners) {
+      try {
+        listener("tools");
+      } catch (error) {
+        // Best-effort re-emit: a dead/mid-teardown client transport must not
+        // break sibling listeners.
+        logger.warn(`[DaemonMcpProxy] list_changed listener failed for tools: ${error}`);
       }
     }
   }
@@ -1336,6 +1381,28 @@ export class DaemonMcpProxy {
     } catch (error) {
       logger.warn(`[DaemonMcpProxy] Failed to close stale daemon client: ${error}`);
     }
+  }
+
+  /**
+   * Serve the tool surface for a client `tools/list` request.
+   *
+   * When no daemon connection exists yet, this returns the static tool surface
+   * (`schemas/tool-definitions.json`) WITHOUT connecting or starting the daemon,
+   * and defers the daemon connect/start to the first actual tool call (issue
+   * #5879). A wedged or absent daemon therefore never hides the tool surface at
+   * `tools/list` time; the client still gets one clear error on first use.
+   *
+   * Once a connection is established, it delegates to {@link listTools} so the
+   * accurate (session-scoped) list is served. The first successful connect after
+   * a static serve emits a tools `list_changed` (see {@link doConnect}) so the
+   * client re-fetches and reconciles any difference.
+   */
+  async listAdvertisedTools(): Promise<ProxiedToolDefinition[]> {
+    if (this.connected && this.client) {
+      return this.listTools();
+    }
+    this.servedStaticToolList = true;
+    return this.staticToolDefinitionsProvider();
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -738,8 +738,16 @@ export class DaemonMcpProxy {
       this.initialSessionBindingConfigured = true;
       this.ownedDeviceSessions.add(this.boundSessionUuid);
     }
+    // The default provider derives outputSchema suppression from the daemon
+    // options this proxy is configured with (the flag the connected daemon will
+    // enforce) — NOT from this process's serverConfig, which proxy-mode startup
+    // never sets for this flag (issue #5879 review).
     this.staticToolDefinitionsProvider =
-      config.staticToolDefinitionsProvider ?? getStaticToolDefinitions;
+      config.staticToolDefinitionsProvider ??
+      (() =>
+        getStaticToolDefinitions({
+          suppressOutputSchema: this.config.daemonOptions?.toolResultsNoStructuredContent === true,
+        }));
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
     this.clientAssetVersion = isExplicitPin() ? resolveAssetVersion(resolvePinnedVersion()) : null;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1445,7 +1445,7 @@ export class DaemonMcpProxy {
     if (this.connected && this.client) {
       return this.listResources();
     }
-    this.servedStaticResourceList = true;
+    this.serveResourcesColdAndConnectInBackground();
     return this.cachedResources ?? [];
   }
 
@@ -1457,8 +1457,31 @@ export class DaemonMcpProxy {
     if (this.connected && this.client) {
       return this.listResourceTemplates();
     }
-    this.servedStaticResourceList = true;
+    this.serveResourcesColdAndConnectInBackground();
     return this.cachedResourceTemplates ?? [];
+  }
+
+  // Resource discovery has no "first use that connects" equivalent — a
+  // resource-only client may list resources and never call a tool, so nothing
+  // would ever establish the connection that populates its daemon-owned
+  // resources (e.g. `automobile:devices/booted`). Kick off a NON-BLOCKING
+  // background connect so the daemon connects and the reconciliation
+  // `resources/list_changed` fires, WITHOUT blocking this cold discovery
+  // response (issue #5879 review). The `connecting` guard in ensureConnected()
+  // dedupes concurrent/polled calls, so at most one attempt is in flight.
+  private serveResourcesColdAndConnectInBackground(): void {
+    this.servedStaticResourceList = true;
+    if (this.connecting || this.closing) {
+      return;
+    }
+    void this.ensureConnected().catch((error) => {
+      // Best-effort: the cold roster already returned, and the tool surface is
+      // visible via tools/list. A wedged/absent daemon must not surface here; the
+      // next actual request still reports the failure to the client.
+      logger.debug(
+        `[DaemonMcpProxy] background connect after cold resource discovery failed: ${error}`,
+      );
+    });
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1396,6 +1396,12 @@ export class DaemonMcpProxy {
    * accurate (session-scoped) list is served. The first successful connect after
    * a static serve emits a tools `list_changed` (see {@link doConnect}) so the
    * client re-fetches and reconciles any difference.
+   *
+   * The static path deliberately does NOT call `throwIfBoundSessionUnavailable()`
+   * (unlike {@link listTools}): re-coupling `tools/list` to daemon/session state
+   * is exactly what issue #5879 removes. A fenced/expired bound session still
+   * surfaces its ownership-lost error on the next actual tool call, which routes
+   * through {@link callTool}'s gate.
    */
   async listAdvertisedTools(): Promise<ProxiedToolDefinition[]> {
     if (this.connected && this.client) {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -296,6 +296,10 @@ export interface ProxiedToolDefinition {
   description?: string;
   inputSchema: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
+  // Passed through verbatim from the daemon (live path) or the committed static
+  // surface (cold path) — e.g. the MCP Apps UI pointer `_meta.ui.resourceUri`
+  // (issue #4669). Non-Apps hosts ignore it.
+  _meta?: Record<string, unknown>;
 }
 
 /**

--- a/src/daemon/staticToolDefinitions.ts
+++ b/src/daemon/staticToolDefinitions.ts
@@ -1,4 +1,5 @@
 import toolDefinitionsJson from "../../schemas/tool-definitions.json";
+import { serverConfig } from "../utils/ServerConfig";
 import type { ProxiedToolDefinition } from "./daemonMcpProxy";
 
 /**
@@ -7,35 +8,51 @@ import type { ProxiedToolDefinition } from "./daemonMcpProxy";
  * `schemas/tool-definitions.json` is generated from the live {@link
  * ToolRegistry} (`scripts/generate-tool-definitions.ts`) and kept byte-for-byte
  * in sync with it by `test/server/toolRegistration.test.ts` ("committed
- * tool-definitions.json matches the live schemas in both directions"). It is the
- * full advertised surface — including plan/daemon-only tools (`barrier`,
- * `criticalSection`) that a stdio proxy process does not itself register — so it
- * is the correct source for advertising tools before any daemon connection
- * exists (issue #5879).
+ * tool-definitions.json matches the live schemas in both directions").
+ *
+ * It is generated with `includeUnavailable: true`, so it is a strict SUPERSET of
+ * the runtime `tools/list` surface: it never omits a tool the daemon would serve
+ * (feature-flag state lives in the daemon's DB, which this proxy process cannot
+ * read, so a subset would risk hiding a live tool — the exact failure #5879
+ * fixes). It over-advertises plan-only tools (`barrier`, `criticalSection`) and
+ * flag-gated tools that a given daemon may not serve; calling one before connect
+ * yields a clean actionable error, and the reconciliation `tools/list_changed`
+ * (see `DaemonMcpProxy.doConnect`) narrows the client to the accurate list once
+ * connected. This matches the issue's "show the tools, one clear error on first
+ * use" intent.
  */
 interface RawToolDefinition {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
 }
 
-// Map once at module load. Callers treat the result as read-only (the proxy
-// hands it straight to the MCP `tools/list` response), so a single array is
-// shared across every proxy instance and request rather than re-mapped per call.
-const STATIC_TOOL_DEFINITIONS: ProxiedToolDefinition[] = (
-  toolDefinitionsJson as RawToolDefinition[]
-).map((tool) => ({
-  name: tool.name,
-  ...(tool.description !== undefined ? { description: tool.description } : {}),
-  inputSchema: tool.inputSchema,
-  ...(tool.outputSchema !== undefined ? { outputSchema: tool.outputSchema } : {}),
-}));
+// Parse once at module load; the per-call mapping below is cheap (tools/list is
+// not a hot path) and must re-read the structured-content flag each call.
+const RAW_DEFINITIONS: RawToolDefinition[] = toolDefinitionsJson as RawToolDefinition[];
 
 /**
  * The static tool surface served by `tools/list` before a daemon connection is
- * established. Returns the shared array; callers must not mutate it.
+ * established.
+ *
+ * `outputSchema` is dropped when `toolResultsNoStructuredContent` is enabled,
+ * mirroring `ToolRegistry.getToolDefinitions()`: a server that advertises an
+ * output schema is expected to return matching `structuredContent`, which that
+ * flag strips (issue #2899). The flag is reuse-critical, so the proxy's value
+ * matches the daemon it will connect to. `_meta` (e.g. the MCP Apps UI pointer,
+ * issue #4669) is preserved verbatim.
  */
 export function getStaticToolDefinitions(): ProxiedToolDefinition[] {
-  return STATIC_TOOL_DEFINITIONS;
+  const suppressOutputSchema = serverConfig.isToolResultsNoStructuredContentEnabled();
+  return RAW_DEFINITIONS.map((tool) => ({
+    name: tool.name,
+    ...(tool.description !== undefined ? { description: tool.description } : {}),
+    inputSchema: tool.inputSchema,
+    ...(tool.outputSchema !== undefined && !suppressOutputSchema
+      ? { outputSchema: tool.outputSchema }
+      : {}),
+    ...(tool._meta !== undefined ? { _meta: tool._meta } : {}),
+  }));
 }

--- a/src/daemon/staticToolDefinitions.ts
+++ b/src/daemon/staticToolDefinitions.ts
@@ -1,5 +1,4 @@
 import toolDefinitionsJson from "../../schemas/tool-definitions.json";
-import { serverConfig } from "../utils/ServerConfig";
 import type { ProxiedToolDefinition } from "./daemonMcpProxy";
 
 /**
@@ -30,29 +29,52 @@ interface RawToolDefinition {
 }
 
 // Parse once at module load; the per-call mapping below is cheap (tools/list is
-// not a hot path) and must re-read the structured-content flag each call.
+// not a hot path) and must re-read the runtime inputs (suppression flag, env)
+// each call.
 const RAW_DEFINITIONS: RawToolDefinition[] = toolDefinitionsJson as RawToolDefinition[];
+
+export interface StaticToolDefinitionsOptions {
+  /**
+   * Drop `outputSchema` from the advertised surface, mirroring
+   * `ToolRegistry.getToolDefinitions()` when `toolResultsNoStructuredContent` is
+   * enabled: a server advertising an output schema is expected to return matching
+   * `structuredContent`, which that flag strips (issue #2899). The proxy derives
+   * this from the daemon options it is configured with — NOT from its own
+   * `serverConfig`, which proxy-mode startup never populates for this flag.
+   */
+  suppressOutputSchema?: boolean;
+}
 
 /**
  * The static tool surface served by `tools/list` before a daemon connection is
- * established.
- *
- * `outputSchema` is dropped when `toolResultsNoStructuredContent` is enabled,
- * mirroring `ToolRegistry.getToolDefinitions()`: a server that advertises an
- * output schema is expected to return matching `structuredContent`, which that
- * flag strips (issue #2899). The flag is reuse-critical, so the proxy's value
- * matches the daemon it will connect to. `_meta` (e.g. the MCP Apps UI pointer,
- * issue #4669) is preserved verbatim.
+ * established. `_meta` (e.g. the MCP Apps UI pointer, issue #4669) is preserved
+ * verbatim, and `_meta["anthropic/alwaysLoad"]` is synthesized when
+ * `AUTOMOBILE_ALWAYS_LOAD_TOOLS=true`, both matching
+ * `ToolRegistry.getToolDefinitions()`.
  */
-export function getStaticToolDefinitions(): ProxiedToolDefinition[] {
-  const suppressOutputSchema = serverConfig.isToolResultsNoStructuredContentEnabled();
-  return RAW_DEFINITIONS.map((tool) => ({
-    name: tool.name,
-    ...(tool.description !== undefined ? { description: tool.description } : {}),
-    inputSchema: tool.inputSchema,
-    ...(tool.outputSchema !== undefined && !suppressOutputSchema
-      ? { outputSchema: tool.outputSchema }
-      : {}),
-    ...(tool._meta !== undefined ? { _meta: tool._meta } : {}),
-  }));
+export function getStaticToolDefinitions(
+  options: StaticToolDefinitionsOptions = {},
+): ProxiedToolDefinition[] {
+  const suppressOutputSchema = options.suppressOutputSchema ?? false;
+  const alwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true";
+  return RAW_DEFINITIONS.map((tool) => {
+    const meta: Record<string, unknown> = {
+      ...(tool._meta ?? {}),
+      ...(alwaysLoad ? { "anthropic/alwaysLoad": true } : {}),
+    };
+    const definition: ProxiedToolDefinition = {
+      name: tool.name,
+      inputSchema: tool.inputSchema,
+    };
+    if (tool.description !== undefined) {
+      definition.description = tool.description;
+    }
+    if (tool.outputSchema !== undefined && !suppressOutputSchema) {
+      definition.outputSchema = tool.outputSchema;
+    }
+    if (Object.keys(meta).length > 0) {
+      definition._meta = meta;
+    }
+    return definition;
+  });
 }

--- a/src/daemon/staticToolDefinitions.ts
+++ b/src/daemon/staticToolDefinitions.ts
@@ -1,0 +1,41 @@
+import toolDefinitionsJson from "../../schemas/tool-definitions.json";
+import type { ProxiedToolDefinition } from "./daemonMcpProxy";
+
+/**
+ * The committed, static MCP tool surface.
+ *
+ * `schemas/tool-definitions.json` is generated from the live {@link
+ * ToolRegistry} (`scripts/generate-tool-definitions.ts`) and kept byte-for-byte
+ * in sync with it by `test/server/toolRegistration.test.ts` ("committed
+ * tool-definitions.json matches the live schemas in both directions"). It is the
+ * full advertised surface — including plan/daemon-only tools (`barrier`,
+ * `criticalSection`) that a stdio proxy process does not itself register — so it
+ * is the correct source for advertising tools before any daemon connection
+ * exists (issue #5879).
+ */
+interface RawToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+// Map once at module load. Callers treat the result as read-only (the proxy
+// hands it straight to the MCP `tools/list` response), so a single array is
+// shared across every proxy instance and request rather than re-mapped per call.
+const STATIC_TOOL_DEFINITIONS: ProxiedToolDefinition[] = (
+  toolDefinitionsJson as RawToolDefinition[]
+).map((tool) => ({
+  name: tool.name,
+  ...(tool.description !== undefined ? { description: tool.description } : {}),
+  inputSchema: tool.inputSchema,
+  ...(tool.outputSchema !== undefined ? { outputSchema: tool.outputSchema } : {}),
+}));
+
+/**
+ * The static tool surface served by `tools/list` before a daemon connection is
+ * established. Returns the shared array; callers must not mutate it.
+ */
+export function getStaticToolDefinitions(): ProxiedToolDefinition[] {
+  return STATIC_TOOL_DEFINITIONS;
+}

--- a/src/daemon/staticToolDefinitions.ts
+++ b/src/daemon/staticToolDefinitions.ts
@@ -19,43 +19,37 @@ import type { ProxiedToolDefinition } from "./daemonMcpProxy";
  * (see `DaemonMcpProxy.doConnect`) narrows the client to the accurate list once
  * connected. This matches the issue's "show the tools, one clear error on first
  * use" intent.
+ *
+ * `outputSchema` is deliberately NOT advertised cold. Whether the daemon
+ * suppresses it depends on `toolResultsNoStructuredContent`, which can be set by
+ * CLI, by persisted feature-flag DB state, or by a runtime toggle — none of
+ * which this proxy can read without connecting. Advertising an output schema the
+ * daemon may then strip from results would violate the MCP contract before the
+ * client can call anything. The cold list therefore carries only the
+ * flag-independent shape (name, description, inputSchema, `_meta`); the
+ * post-connect reconciliation delivers the accurate list, `outputSchema`
+ * included when the daemon advertises it (issue #5879 review).
  */
 interface RawToolDefinition {
   name: string;
   description?: string;
   inputSchema: Record<string, unknown>;
-  outputSchema?: Record<string, unknown>;
   _meta?: Record<string, unknown>;
 }
 
 // Parse once at module load; the per-call mapping below is cheap (tools/list is
-// not a hot path) and must re-read the runtime inputs (suppression flag, env)
-// each call.
+// not a hot path) and must re-read the always-load env each call.
 const RAW_DEFINITIONS: RawToolDefinition[] = toolDefinitionsJson as RawToolDefinition[];
-
-export interface StaticToolDefinitionsOptions {
-  /**
-   * Drop `outputSchema` from the advertised surface, mirroring
-   * `ToolRegistry.getToolDefinitions()` when `toolResultsNoStructuredContent` is
-   * enabled: a server advertising an output schema is expected to return matching
-   * `structuredContent`, which that flag strips (issue #2899). The proxy derives
-   * this from the daemon options it is configured with — NOT from its own
-   * `serverConfig`, which proxy-mode startup never populates for this flag.
-   */
-  suppressOutputSchema?: boolean;
-}
 
 /**
  * The static tool surface served by `tools/list` before a daemon connection is
  * established. `_meta` (e.g. the MCP Apps UI pointer, issue #4669) is preserved
  * verbatim, and `_meta["anthropic/alwaysLoad"]` is synthesized when
  * `AUTOMOBILE_ALWAYS_LOAD_TOOLS=true`, both matching
- * `ToolRegistry.getToolDefinitions()`.
+ * `ToolRegistry.getToolDefinitions()`. `outputSchema` is intentionally omitted
+ * (see the file docstring).
  */
-export function getStaticToolDefinitions(
-  options: StaticToolDefinitionsOptions = {},
-): ProxiedToolDefinition[] {
-  const suppressOutputSchema = options.suppressOutputSchema ?? false;
+export function getStaticToolDefinitions(): ProxiedToolDefinition[] {
   const alwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true";
   return RAW_DEFINITIONS.map((tool) => {
     const meta: Record<string, unknown> = {
@@ -68,9 +62,6 @@ export function getStaticToolDefinitions(
     };
     if (tool.description !== undefined) {
       definition.description = tool.description;
-    }
-    if (tool.outputSchema !== undefined && !suppressOutputSchema) {
-      definition.outputSchema = tool.outputSchema;
     }
     if (Object.keys(meta).length > 0) {
       definition._meta = meta;

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -141,8 +141,14 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     },
     {
       capabilities: {
-        resources: {},
-        tools: {},
+        // Declare listChanged: this proxy is the boundary external MCP clients
+        // connect to, and it emits notifications/{tools,resources}/list_changed —
+        // both the daemon-forwarded invalidations (issue #3223) and the
+        // post-lazy-connect tools reconciliation (issue #5879). Without the
+        // capability a spec-strict client may ignore those notifications and keep
+        // a stale (cold, over-broad) tool list for the session.
+        resources: { listChanged: true },
+        tools: { listChanged: true },
         prompts: {},
       },
     },

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -182,10 +182,13 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     };
   });
 
-  // Register tools/list handler - forward to daemon
+  // Register tools/list handler. Serves the static tool surface without
+  // connecting to the daemon when no connection exists yet, deferring the daemon
+  // connect/start to the first actual tool call (issue #5879). Once connected,
+  // the accurate session-scoped list is served.
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {
     try {
-      const tools = await proxy.listTools();
+      const tools = await proxy.listAdvertisedTools();
       return { tools };
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -253,10 +253,13 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     }
   });
 
-  // Register resources/list handler - forward to daemon
+  // Register resources/list handler. Serves a cold (empty/cached) roster without
+  // connecting when no connection exists yet, deferring the daemon connect to the
+  // first tool call (issue #5879) so a host that enumerates resources on init
+  // never blocks on a wedged daemon. Once connected, the live list is served.
   server.server.setRequestHandler(ListResourcesRequestSchema, async () => {
     try {
-      const resources = await proxy.listResources();
+      const resources = await proxy.listAdvertisedResources();
       return { resources };
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {
@@ -270,10 +273,11 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     }
   });
 
-  // Register resources/templates/list handler - forward to daemon
+  // Register resources/templates/list handler. Cold-serves without connecting
+  // (see resources/list above); defers the daemon connect to the first tool call.
   server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
     try {
-      const resourceTemplates = await proxy.listResourceTemplates();
+      const resourceTemplates = await proxy.listAdvertisedResourceTemplates();
       return { resourceTemplates };
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -175,7 +175,10 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
     }
   });
 
-  test("serves an empty resource roster without connecting, then reconciles (AC #5879 review)", async () => {
+  test("serves an empty resource roster immediately, then reconciles for a resource-only client (AC #5879 review)", async () => {
+    // A resource-only client never calls a tool, so the reconciliation must be
+    // driven by a non-blocking background connect kicked off from cold resource
+    // discovery — not by a tool call.
     const fakeClient = new FakeDaemonClient({
       daemonMethodResults: new Map<string, any>([
         ["tools/list", { tools: [] }],
@@ -193,17 +196,16 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
     proxy.onListChanged((kind) => kinds.push(kind));
 
     try {
-      // Cold: empty roster, no connection, no socket probe.
+      // Cold discovery returns an empty roster immediately (non-blocking).
       expect(await proxy.listAdvertisedResources()).toEqual([]);
       expect(await proxy.listAdvertisedResourceTemplates()).toEqual([]);
-      expect(proxy.isConnected()).toBe(false);
-      expect(isAvailableSpy).not.toHaveBeenCalled();
-      expect(kinds).toEqual([]);
 
-      // First tool call connects; the cold resource serve is reconciled.
-      await proxy.callTool("observe", {});
+      // A background connect was kicked off — WITHOUT any tool call. Await it to
+      // settle (ensureConnected returns the in-flight connecting promise).
+      await proxy.ensureConnected();
       expect(proxy.isConnected()).toBe(true);
       expect(kinds).toContain("resources");
+      expect(fakeClient.callToolCalls).toHaveLength(0);
 
       // Once connected, the live resource roster is served.
       const resources = await proxy.listAdvertisedResources();

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -165,6 +165,29 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
     }
   });
 
+  test("derives outputSchema suppression from daemon options, not serverConfig (AC #5879 review)", async () => {
+    // The default provider must drop outputSchema when the daemon the proxy will
+    // connect to runs with toolResultsNoStructuredContent — read from the proxy's
+    // daemonOptions, since proxy-mode startup never sets this on serverConfig.
+    const suppressed = new DaemonMcpProxy({
+      autoStartDaemon: false,
+      daemonOptions: { toolResultsNoStructuredContent: true },
+    });
+    const advertised = new DaemonMcpProxy({
+      autoStartDaemon: false,
+      daemonOptions: { toolResultsNoStructuredContent: false },
+    });
+    try {
+      const suppressedTools = await suppressed.listAdvertisedTools();
+      const advertisedTools = await advertised.listAdvertisedTools();
+      expect(suppressedTools.some((tool) => tool.outputSchema !== undefined)).toBe(false);
+      expect(advertisedTools.some((tool) => tool.outputSchema !== undefined)).toBe(true);
+    } finally {
+      await suppressed.close();
+      await advertised.close();
+    }
+  });
+
   test("honors an injected static tool definitions provider", async () => {
     const proxy = new DaemonMcpProxy({
       autoStartDaemon: false,

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test, spyOn } from "bun:test";
+import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import type { ListChangedKind } from "../../src/server/listChangedBroadcast";
+
+// A FakeDaemonManager reporting a running daemon whose version matches this
+// client's stamped DAEMON_VERSION, so the version gate does not fire when a
+// lazy tool call actually connects.
+function matchingDaemonManager(): FakeDaemonManager {
+  const manager = new FakeDaemonManager();
+  manager.statusResult = { ...manager.statusResult, version: DAEMON_VERSION };
+  return manager;
+}
+
+describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)", () => {
+  test("serves the full static tool surface without connecting to the daemon", async () => {
+    // No isAvailable spy and autoStartDaemon:false: any connection attempt would
+    // throw "Daemon is not running and auto-start is disabled". A wedged/absent
+    // daemon must NOT hide the tool surface (AC1/AC3).
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable");
+    const fakeClient = new FakeDaemonClient();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: new FakeDaemonManager(),
+      autoStartDaemon: false,
+    });
+
+    try {
+      const tools = await proxy.listAdvertisedTools();
+
+      const staticNames = getStaticToolDefinitions().map((tool) => tool.name);
+      expect(tools.map((tool) => tool.name).sort()).toEqual([...staticNames].sort());
+      // Includes daemon/plan-only tools the proxy process never registers itself.
+      expect(tools.map((tool) => tool.name)).toContain("barrier");
+      expect(tools.map((tool) => tool.name)).toContain("criticalSection");
+      // Never connected, never even probed the socket.
+      expect(proxy.isConnected()).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
+      expect(isAvailableSpy).not.toHaveBeenCalled();
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("every advertised tool carries a name and an input schema", async () => {
+    const proxy = new DaemonMcpProxy({ autoStartDaemon: false });
+    try {
+      const tools = await proxy.listAdvertisedTools();
+      expect(tools.length).toBeGreaterThan(0);
+      for (const tool of tools) {
+        expect(typeof tool.name).toBe("string");
+        expect(tool.name.length).toBeGreaterThan(0);
+        expect(tool.inputSchema).toBeDefined();
+        expect(typeof tool.inputSchema).toBe("object");
+      }
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("the FIRST tool call — not tools/list — connects to the daemon (AC2)", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([
+        ["tools/list", { tools: [{ name: "liveTool", inputSchema: {} }] }],
+      ]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+    });
+
+    try {
+      await proxy.listAdvertisedTools();
+      expect(proxy.isConnected()).toBe(false);
+      expect(fakeClient.callToolCalls).toHaveLength(0);
+
+      await proxy.callTool("observe", {});
+      expect(proxy.isConnected()).toBe(true);
+      expect(fakeClient.callToolCalls.map((call) => call.toolName)).toContain("observe");
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("once connected, serves the live daemon tool list, not the static surface (AC4)", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([
+        ["tools/list", { tools: [{ name: "liveOnlyTool", inputSchema: {} }] }],
+      ]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+    });
+
+    try {
+      // Force a connection via a tool call.
+      await proxy.callTool("observe", {});
+      expect(proxy.isConnected()).toBe(true);
+
+      const tools = await proxy.listAdvertisedTools();
+      expect(tools.map((tool) => tool.name)).toEqual(["liveOnlyTool"]);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("prompts a tools/list re-fetch once the deferred connection is established (AC5)", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+    });
+    const kinds: ListChangedKind[] = [];
+    proxy.onListChanged((kind) => kinds.push(kind));
+
+    try {
+      // Serve static first (no connection), then connect via a tool call.
+      await proxy.listAdvertisedTools();
+      expect(kinds).toEqual([]);
+
+      await proxy.callTool("observe", {});
+      expect(kinds).toContain("tools");
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("does not emit a reconciliation tools/list_changed when no static list was served", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+    });
+    const kinds: ListChangedKind[] = [];
+    proxy.onListChanged((kind) => kinds.push(kind));
+
+    try {
+      // Connect directly, without ever serving the static advertisement.
+      await proxy.callTool("observe", {});
+      expect(kinds).not.toContain("tools");
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("honors an injected static tool definitions provider", async () => {
+    const proxy = new DaemonMcpProxy({
+      autoStartDaemon: false,
+      staticToolDefinitionsProvider: () => [
+        { name: "injectedTool", description: "d", inputSchema: { type: "object" } },
+      ],
+    });
+    try {
+      const tools = await proxy.listAdvertisedTools();
+      expect(tools).toEqual([
+        { name: "injectedTool", description: "d", inputSchema: { type: "object" } },
+      ]);
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -165,26 +165,52 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
     }
   });
 
-  test("derives outputSchema suppression from daemon options, not serverConfig (AC #5879 review)", async () => {
-    // The default provider must drop outputSchema when the daemon the proxy will
-    // connect to runs with toolResultsNoStructuredContent — read from the proxy's
-    // daemonOptions, since proxy-mode startup never sets this on serverConfig.
-    const suppressed = new DaemonMcpProxy({
-      autoStartDaemon: false,
-      daemonOptions: { toolResultsNoStructuredContent: true },
-    });
-    const advertised = new DaemonMcpProxy({
-      autoStartDaemon: false,
-      daemonOptions: { toolResultsNoStructuredContent: false },
-    });
+  test("never advertises outputSchema cold (reconciliation delivers it post-connect)", async () => {
+    const proxy = new DaemonMcpProxy({ autoStartDaemon: false });
     try {
-      const suppressedTools = await suppressed.listAdvertisedTools();
-      const advertisedTools = await advertised.listAdvertisedTools();
-      expect(suppressedTools.some((tool) => tool.outputSchema !== undefined)).toBe(false);
-      expect(advertisedTools.some((tool) => tool.outputSchema !== undefined)).toBe(true);
+      const tools = await proxy.listAdvertisedTools();
+      expect(tools.some((tool) => tool.outputSchema !== undefined)).toBe(false);
     } finally {
-      await suppressed.close();
-      await advertised.close();
+      await proxy.close();
+    }
+  });
+
+  test("serves an empty resource roster without connecting, then reconciles (AC #5879 review)", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map<string, any>([
+        ["tools/list", { tools: [] }],
+        ["resources/list", { resources: [{ uri: "automobile:live", name: "live" }] }],
+        ["resources/list-templates", { resourceTemplates: [] }],
+      ]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+    });
+    const kinds: ListChangedKind[] = [];
+    proxy.onListChanged((kind) => kinds.push(kind));
+
+    try {
+      // Cold: empty roster, no connection, no socket probe.
+      expect(await proxy.listAdvertisedResources()).toEqual([]);
+      expect(await proxy.listAdvertisedResourceTemplates()).toEqual([]);
+      expect(proxy.isConnected()).toBe(false);
+      expect(isAvailableSpy).not.toHaveBeenCalled();
+      expect(kinds).toEqual([]);
+
+      // First tool call connects; the cold resource serve is reconciled.
+      await proxy.callTool("observe", {});
+      expect(proxy.isConnected()).toBe(true);
+      expect(kinds).toContain("resources");
+
+      // Once connected, the live resource roster is served.
+      const resources = await proxy.listAdvertisedResources();
+      expect(resources.map((resource) => resource.uri)).toEqual(["automobile:live"]);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
     }
   });
 

--- a/test/daemon/staticToolDefinitions.test.ts
+++ b/test/daemon/staticToolDefinitions.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
+import { serverConfig } from "../../src/utils/ServerConfig";
+
+// Issue #5879 / Codex review: the static cold-start surface must mirror the
+// runtime `ToolRegistry.getToolDefinitions()` shape, not just carry names.
+
+describe("getStaticToolDefinitions", () => {
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  test("preserves _meta (the MCP Apps UI pointer) for tools that carry it", () => {
+    const observe = getStaticToolDefinitions().find((tool) => tool.name === "observe");
+    expect(observe).toBeDefined();
+    expect(observe!._meta).toEqual({ ui: { resourceUri: "ui://automobile/observe" } });
+  });
+
+  test("advertises outputSchema by default", () => {
+    const withOutput = getStaticToolDefinitions().filter((tool) => tool.outputSchema !== undefined);
+    expect(withOutput.length).toBeGreaterThan(0);
+  });
+
+  test("drops outputSchema when toolResultsNoStructuredContent is enabled", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const anyOutputSchema = getStaticToolDefinitions().some(
+      (tool) => tool.outputSchema !== undefined,
+    );
+    expect(anyOutputSchema).toBe(false);
+    // _meta and names are unaffected by the flag.
+    const observe = getStaticToolDefinitions().find((tool) => tool.name === "observe");
+    expect(observe!._meta).toEqual({ ui: { resourceUri: "ui://automobile/observe" } });
+  });
+
+  test("every definition carries a name and an input schema", () => {
+    const tools = getStaticToolDefinitions();
+    expect(tools.length).toBeGreaterThan(0);
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe("string");
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.inputSchema).toBe("object");
+    }
+  });
+});

--- a/test/daemon/staticToolDefinitions.test.ts
+++ b/test/daemon/staticToolDefinitions.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
 
-// Issue #5879 / Codex review: the static cold-start surface must mirror the
-// runtime `ToolRegistry.getToolDefinitions()` shape, not just carry names.
+// Issue #5879 / review: the static cold-start surface mirrors the runtime
+// `ToolRegistry.getToolDefinitions()` shape for the flag-independent fields
+// (name, description, inputSchema, _meta) and deliberately omits outputSchema,
+// which depends on daemon flag state the proxy cannot read cold.
 
 describe("getStaticToolDefinitions", () => {
   const originalAlwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS;
@@ -15,26 +17,16 @@ describe("getStaticToolDefinitions", () => {
     }
   });
 
-  test("preserves _meta (the MCP Apps UI pointer) for tools that carry it", () => {
-    const observe = getStaticToolDefinitions().find((tool) => tool.name === "observe");
-    expect(observe).toBeDefined();
-    expect(observe!._meta).toEqual({ ui: { resourceUri: "ui://automobile/observe" } });
-  });
-
-  test("advertises outputSchema by default", () => {
-    const withOutput = getStaticToolDefinitions().filter((tool) => tool.outputSchema !== undefined);
-    expect(withOutput.length).toBeGreaterThan(0);
-  });
-
-  test("drops outputSchema when suppressOutputSchema is set", () => {
-    const anyOutputSchema = getStaticToolDefinitions({ suppressOutputSchema: true }).some(
+  test("never advertises outputSchema cold (reconciliation delivers it post-connect)", () => {
+    const anyOutputSchema = getStaticToolDefinitions().some(
       (tool) => tool.outputSchema !== undefined,
     );
     expect(anyOutputSchema).toBe(false);
-    // _meta and names are unaffected by suppression.
-    const observe = getStaticToolDefinitions({ suppressOutputSchema: true }).find(
-      (tool) => tool.name === "observe",
-    );
+  });
+
+  test("preserves _meta (the MCP Apps UI pointer) for tools that carry it", () => {
+    const observe = getStaticToolDefinitions().find((tool) => tool.name === "observe");
+    expect(observe).toBeDefined();
     expect(observe!._meta).toEqual({ ui: { resourceUri: "ui://automobile/observe" } });
   });
 

--- a/test/daemon/staticToolDefinitions.test.ts
+++ b/test/daemon/staticToolDefinitions.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
-import { serverConfig } from "../../src/utils/ServerConfig";
 
 // Issue #5879 / Codex review: the static cold-start surface must mirror the
 // runtime `ToolRegistry.getToolDefinitions()` shape, not just carry names.
 
 describe("getStaticToolDefinitions", () => {
+  const originalAlwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS;
+
   afterEach(() => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    if (originalAlwaysLoad === undefined) {
+      delete process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS;
+    } else {
+      process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS = originalAlwaysLoad;
+    }
   });
 
   test("preserves _meta (the MCP Apps UI pointer) for tools that carry it", () => {
@@ -21,15 +26,39 @@ describe("getStaticToolDefinitions", () => {
     expect(withOutput.length).toBeGreaterThan(0);
   });
 
-  test("drops outputSchema when toolResultsNoStructuredContent is enabled", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    const anyOutputSchema = getStaticToolDefinitions().some(
+  test("drops outputSchema when suppressOutputSchema is set", () => {
+    const anyOutputSchema = getStaticToolDefinitions({ suppressOutputSchema: true }).some(
       (tool) => tool.outputSchema !== undefined,
     );
     expect(anyOutputSchema).toBe(false);
-    // _meta and names are unaffected by the flag.
-    const observe = getStaticToolDefinitions().find((tool) => tool.name === "observe");
+    // _meta and names are unaffected by suppression.
+    const observe = getStaticToolDefinitions({ suppressOutputSchema: true }).find(
+      (tool) => tool.name === "observe",
+    );
     expect(observe!._meta).toEqual({ ui: { resourceUri: "ui://automobile/observe" } });
+  });
+
+  test("synthesizes _meta.anthropic/alwaysLoad when AUTOMOBILE_ALWAYS_LOAD_TOOLS=true", () => {
+    process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS = "true";
+    const tools = getStaticToolDefinitions();
+    for (const tool of tools) {
+      expect(tool._meta?.["anthropic/alwaysLoad"]).toBe(true);
+    }
+    // Existing _meta is merged, not overwritten.
+    const observe = tools.find((tool) => tool.name === "observe");
+    expect(observe!._meta).toEqual({
+      ui: { resourceUri: "ui://automobile/observe" },
+      "anthropic/alwaysLoad": true,
+    });
+  });
+
+  test("omits alwaysLoad meta when the env is unset", () => {
+    delete process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS;
+    const tools = getStaticToolDefinitions();
+    expect(tools.some((tool) => tool._meta?.["anthropic/alwaysLoad"] !== undefined)).toBe(false);
+    // A tool with no other _meta carries none at all.
+    const accessibility = tools.find((tool) => tool.name === "accessibility");
+    expect(accessibility!._meta).toBeUndefined();
   });
 
   test("every definition carries a name and an input schema", () => {

--- a/test/server/proxyServerLazyToolList.test.ts
+++ b/test/server/proxyServerLazyToolList.test.ts
@@ -55,6 +55,38 @@ describe("proxy server lazy tools/list", () => {
     }
   });
 
+  test("resources/list returns an empty roster without connecting to the daemon", async () => {
+    const isAvailableProbe = spyOn(DaemonClient, "isAvailable");
+    isAvailableSpy = isAvailableProbe;
+    const fakeClient = new FakeDaemonClient();
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => fakeClient,
+        daemonManager: new FakeDaemonManager(),
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "lazy-resources-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const resources = await client.listResources();
+      const templates = await client.listResourceTemplates();
+
+      expect(resources.resources).toEqual([]);
+      expect(templates.resourceTemplates).toEqual([]);
+      expect(proxy.isConnected()).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
+      expect(isAvailableProbe).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
+
   test("advertises tools.listChanged so clients honor the reconciliation notification", async () => {
     isAvailableSpy = spyOn(DaemonClient, "isAvailable");
     const { server, proxy } = createProxyMcpServer({

--- a/test/server/proxyServerLazyToolList.test.ts
+++ b/test/server/proxyServerLazyToolList.test.ts
@@ -54,4 +54,29 @@ describe("proxy server lazy tools/list", () => {
       await proxy.close();
     }
   });
+
+  test("advertises tools.listChanged so clients honor the reconciliation notification", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable");
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => new FakeDaemonClient(),
+        daemonManager: new FakeDaemonManager(),
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "cap-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const capabilities = client.getServerCapabilities();
+      expect(capabilities?.tools).toEqual({ listChanged: true });
+      expect(capabilities?.resources).toEqual({ listChanged: true });
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
 });

--- a/test/server/proxyServerLazyToolList.test.ts
+++ b/test/server/proxyServerLazyToolList.test.ts
@@ -55,8 +55,11 @@ describe("proxy server lazy tools/list", () => {
     }
   });
 
-  test("resources/list returns an empty roster without connecting to the daemon", async () => {
-    const isAvailableProbe = spyOn(DaemonClient, "isAvailable");
+  test("resources/list returns an immediate empty roster without blocking (daemon absent)", async () => {
+    // With no daemon available and auto-start disabled, the background connect
+    // kicked off by cold resource discovery fails silently; the client still gets
+    // an immediate empty roster rather than a blocked/errored request.
+    const isAvailableProbe = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
     isAvailableSpy = isAvailableProbe;
     const fakeClient = new FakeDaemonClient();
     const { server, proxy } = createProxyMcpServer({
@@ -78,9 +81,10 @@ describe("proxy server lazy tools/list", () => {
 
       expect(resources.resources).toEqual([]);
       expect(templates.resourceTemplates).toEqual([]);
+      // Auto-start is disabled and the daemon is absent, so the best-effort
+      // background connect cannot establish a connection.
       expect(proxy.isConnected()).toBe(false);
       expect(fakeClient.isConnected()).toBe(false);
-      expect(isAvailableProbe).not.toHaveBeenCalled();
     } finally {
       await client.close();
       await proxy.close();

--- a/test/server/proxyServerLazyToolList.test.ts
+++ b/test/server/proxyServerLazyToolList.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { DaemonClient } from "../../src/daemon/client";
+import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+
+// Issue #5879: the proxy MCP server serves tools/list from the static tool
+// registry without connecting to the daemon, so a wedged/absent daemon never
+// hides the tool surface. The daemon connect/start is deferred to the first
+// tool call.
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+describe("proxy server lazy tools/list", () => {
+  test("tools/list returns the full static surface with no daemon available", async () => {
+    // isAvailable is NOT stubbed and autoStartDaemon is false: a connection
+    // attempt would throw. tools/list must still resolve the whole surface.
+    const isAvailableProbe = spyOn(DaemonClient, "isAvailable");
+    isAvailableSpy = isAvailableProbe;
+    const fakeClient = new FakeDaemonClient();
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => fakeClient,
+        daemonManager: new FakeDaemonManager(),
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "lazy-tools-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const result = await client.listTools();
+
+      const staticNames = getStaticToolDefinitions()
+        .map((tool) => tool.name)
+        .sort();
+      expect(result.tools.map((tool) => tool.name).sort()).toEqual(staticNames);
+      expect(proxy.isConnected()).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
+      expect(isAvailableProbe).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The proxy MCP server forwarded `tools/list` straight to the daemon, so a wedged or absent daemon blocked — and ultimately hid — the entire tool surface at discovery time (clients time `tools/list` out at ~30s, leaving AutoMobile "connected with zero tools and no error text", [#5871](https://github.com/kaeawc/auto-mobile/issues/5871)).

This implements [#5871](https://github.com/kaeawc/auto-mobile/issues/5871) item 3: serve discovery from the static registry **without connecting**, and defer the daemon connect/start to the first actual **tool call**. A wedged daemon can no longer hide the tool surface; the client sees every tool and gets one clear, actionable error on first use.

## Changes

- **`DaemonMcpProxy.listAdvertisedTools()`** — serves the static tool surface (`src/daemon/staticToolDefinitions.ts`, backed by the committed `schemas/tool-definitions.json`) without connecting when no connection exists; delegates to the live session-scoped `listTools()` once connected. `proxyServer.ts` calls it.
- **Static surface fidelity** — the committed JSON is a strict SUPERSET of the runtime `tools/list` surface, so cold discovery never *hides* a live tool (daemon feature-flag state lives in a DB the proxy can't read). `_meta` (MCP Apps UI pointer, `_meta["anthropic/alwaysLoad"]`) is reproduced from `getToolDefinitions()`; `outputSchema` is deliberately **omitted cold** (its suppression depends on daemon flag state the proxy can't know pre-connect) and delivered by reconciliation.
- **Reconciliation** — after the first connect following a cold serve, the proxy emits a `tools/list_changed` (and `resources/list_changed`) so the client re-fetches the accurate, session-scoped list. The proxy now declares `capabilities.{tools,resources}.listChanged`.
- **Resources** — `resources/list` / `resources/templates/list` also serve a cold (empty/cached) roster without blocking, and kick off a **non-blocking background connect** so resource-only clients (that never call a tool) still connect and reconcile.
- First tool call still connects via the existing `callTool → ensureConnected` path, where [#5874](https://github.com/kaeawc/auto-mobile/pull/5874)'s bounded actionable error surfaces.

## Linked Issue

Closes #5879

## Acceptance criteria (inferred from the issue body)

- [x] `tools/list` serves from the static registry without connecting to the daemon.
- [x] Daemon connect/start deferred to the first actual tool call.
- [x] A wedged/absent daemon does not hide the tool surface.
- [x] Once connected, `tools/list` serves the live (session-scoped) list.
- [x] After the deferred connection, the client is prompted to re-fetch (`tools/list_changed`).

## Validation

- [x] `bun run lint` (oxlint ratchet clean, oxfmt clean), `bun run typecheck` (no new errors)
- [x] `bun test` — daemon + server suites green (3810 pass); full CI green
- [x] New code uses interfaces + fakes; unit tests run <100ms
- [x] Worktree isolation verified — only the six intended files changed

### Tests
- `test/daemon/daemonMcpProxyLazyToolList.test.ts` — cold static serve without connecting; first tool call connects; live list once connected; cold `outputSchema` omission; resource-only background-connect reconciliation; injected provider.
- `test/daemon/staticToolDefinitions.test.ts` — `_meta` preservation, always-load synthesis, no cold `outputSchema`.
- `test/server/proxyServerLazyToolList.test.ts` — end-to-end via a linked MCP client: full static surface with no daemon; `listChanged` capability; immediate empty resource roster.

## Follow-ups

- [ ] #5900 — serve static tools/list after an idle daemon death (stale `connected` state).
- [ ] #5920 — retry the background connect after a transient failure (resource-only cold discovery hardening).
