### PR TITLE
fix(daemon): make the two residual tools/list error-waits deliverable (#5878)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -10,7 +10,6 @@ import { logger } from "../utils/logger";
 import {
   SOCKET_PATH,
   DAEMON_STARTUP_TIMEOUT_MS,
-  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   CONNECTION_TIMEOUT_MS,
   DAEMON_VERSION,
   DAEMON_VERSION_RESTART_COOLDOWN_MS,
@@ -1236,23 +1235,25 @@ export class DaemonMcpProxy {
     // genuinely wedged daemon that never publishes still fails promptly at the
     // deadline with an actionable error.
     //
-    // Bound this reachability wait to DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS
-    // rather than the full startup budget. This branch is nested inside a
-    // `tools/list` request that clients cut off at ~30s (DAEMON_STARTUP_TIMEOUT_MS);
-    // if it consumed the full budget the actionable error below would be produced
-    // only as the client's own deadline expired, so the client would see an
-    // AutoMobile server with zero tools and no error text (issue #5878, residual of
-    // #5871/#5874). The daemon here already reports running — it is an EXISTING
-    // daemon whose socket has not published, the same "already-live daemon must
-    // become reachable" class #5874 bounded — not one we spawned in this call
-    // (that path keeps the full budget above). A daemon that has not published its
-    // socket within this shorter budget is one the client is better off hearing
-    // about now than waiting on.
-    const ready = await this.daemonManager.waitForReady(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
+    // This wait is nested inside a `tools/list` request that clients cut off at
+    // ~30s (DAEMON_STARTUP_TIMEOUT_MS); if the error it can throw is produced only
+    // as that deadline expires, the client sees an AutoMobile server with zero
+    // tools and no error text (issue #5878, residual of #5871/#5874). So keep the
+    // full startup budget while a live process is actively bringing the daemon up
+    // — a legitimate concurrent cold start writes its early-owner PID (making
+    // status.running true) seconds before it publishes the socket, and abandoning
+    // it early would reject a start that was about to succeed — but exit the moment
+    // no live startup-lock holder remains. A genuinely wedged or orphaned daemon
+    // (early-owner record present, socket unreachable, no live holder finishing the
+    // start) is then reported now instead of at the client's deadline, while the
+    // concurrent-cold-start case keeps the budget it needs.
+    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
+      this.daemonManager.isStartupLockHeldByLiveProcess(),
+    );
     if (!ready) {
       throw new DaemonUnavailableError(
-        `Daemon reported running but its socket did not become reachable within ` +
-          `${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms`,
+        `Daemon reported running but its socket did not become reachable, and no live ` +
+          `process is completing its startup`,
       );
     }
     logger.info("[DaemonMcpProxy] Daemon reported running; socket became ready");

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -10,6 +10,7 @@ import { logger } from "../utils/logger";
 import {
   SOCKET_PATH,
   DAEMON_STARTUP_TIMEOUT_MS,
+  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   CONNECTION_TIMEOUT_MS,
   DAEMON_VERSION,
   DAEMON_VERSION_RESTART_COOLDOWN_MS,
@@ -1234,10 +1235,24 @@ export class DaemonMcpProxy {
     // the "do not replace a live daemon's socket" contract are preserved. A
     // genuinely wedged daemon that never publishes still fails promptly at the
     // deadline with an actionable error.
-    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+    //
+    // Bound this reachability wait to DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS
+    // rather than the full startup budget. This branch is nested inside a
+    // `tools/list` request that clients cut off at ~30s (DAEMON_STARTUP_TIMEOUT_MS);
+    // if it consumed the full budget the actionable error below would be produced
+    // only as the client's own deadline expired, so the client would see an
+    // AutoMobile server with zero tools and no error text (issue #5878, residual of
+    // #5871/#5874). The daemon here already reports running — it is an EXISTING
+    // daemon whose socket has not published, the same "already-live daemon must
+    // become reachable" class #5874 bounded — not one we spawned in this call
+    // (that path keeps the full budget above). A daemon that has not published its
+    // socket within this shorter budget is one the client is better off hearing
+    // about now than waiting on.
+    const ready = await this.daemonManager.waitForReady(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
     if (!ready) {
       throw new DaemonUnavailableError(
-        `Daemon failed to start within ${DAEMON_STARTUP_TIMEOUT_MS}ms`,
+        `Daemon reported running but its socket did not become reachable within ` +
+          `${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms`,
       );
     }
     logger.info("[DaemonMcpProxy] Daemon reported running; socket became ready");

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,7 +1,7 @@
 import { errorMessage } from "../utils/describeUnknownError";
 import { execSync, type ChildProcess } from "node:child_process";
 import { open, readFile, rm, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync } from "node:fs";
+import { existsSync, openSync, closeSync, readFileSync } from "node:fs";
 import { basename, isAbsolute, join, resolve, sep } from "node:path";
 import { devNull, tmpdir } from "node:os";
 import { isStructuredLoggingEnabled, logger, resolveAutomobileLogSink } from "../utils/logger";
@@ -370,7 +370,11 @@ export interface DaemonManagerLike {
   status(): Promise<DaemonStatus>;
   start(options?: DaemonOptions): Promise<void>;
   restart(options?: DaemonOptions): Promise<void>;
-  waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean>;
+  waitForReady(
+    timeout: number,
+    signal?: AbortSignal,
+    shouldContinueWaiting?: () => boolean,
+  ): Promise<boolean>;
 }
 
 /**
@@ -543,9 +547,17 @@ export class DaemonManager implements DaemonManagerLike {
   async start(options: DaemonOptions = {}): Promise<void> {
     const acquired = this.acquireLock();
     if (!acquired) {
-      // Another process is starting the daemon — wait for it to become ready
+      // Another process is starting the daemon — wait for it to become ready.
+      // Keep the full DAEMON_STARTUP_TIMEOUT_MS while that holder is alive (a
+      // legitimate cold start by another process — multi-simulator discovery —
+      // needs the full budget), but stop the moment the holder is gone. Without
+      // that early exit a crashed holder makes this wait run the full budget with
+      // nothing left to become ready, and the actionable failure below is produced
+      // only as the client's ~30s `tools/list` deadline expires (issue #5878).
       stderrLog("Another process is starting the daemon, waiting...");
-      const ready = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+      const ready = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
+        this.isStartupLockHeldByLiveProcess(),
+      );
       if (ready) {
         stderrLog("Daemon started by another process");
         return;
@@ -561,10 +573,14 @@ export class DaemonManager implements DaemonManagerLike {
         }
         return;
       }
-      // Another process won the retry race — wait for it to finish
+      // Another process won the retry race — wait for it to finish, again only as
+      // long as that retry holder is alive so the double-race failure stays
+      // deliverable before the client's request timeout (issue #5878).
       stderrLog("Another process is retrying daemon start, waiting...");
       const retryHolderLogPath = await this.getLockHolderStartupLogPath();
-      const retryReady = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+      const retryReady = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
+        this.isStartupLockHeldByLiveProcess(),
+      );
       if (retryReady) {
         stderrLog("Daemon started by another process (retry)");
         return;
@@ -880,6 +896,46 @@ export class DaemonManager implements DaemonManagerLike {
       );
     }
     return new ActionableError(await this.formatDaemonStartupFailure(summary, logPath));
+  }
+
+  /**
+   * Whether the daemon startup lock is currently held by a still-live process.
+   *
+   * Early-exit predicate for the two lock-contention waits in {@link start}. When
+   * another process holds the startup lock and is bringing up the daemon, this
+   * process waits for the socket to publish. If the holder crashes — or fails and
+   * releases the lock — the plain readiness wait would keep polling for the full
+   * DAEMON_STARTUP_TIMEOUT_MS even though nothing will ever become ready, so the
+   * actionable lock-holder-startup-failure error is produced only as the client's
+   * own `tools/list` deadline expires (issue #5878). Giving up the instant the
+   * holder is gone makes that error deliverable, while a holder that is still alive
+   * keeps the full budget so a legitimate slow cold start by another process is not
+   * abandoned. Reuses the injected liveness checker and the shared lock format so
+   * there is one canonical primitive per concern rather than a second PID reader.
+   */
+  private isStartupLockHeldByLiveProcess(): boolean {
+    let content: string;
+    try {
+      content = readFileSync(this.lockFilePath, "utf-8").trim();
+    } catch (error) {
+      // Lock file is gone: the holder released it (finished or crashed). Nothing
+      // left to wait on — stop so start() can re-acquire or surface its failure.
+      logger.debug(
+        `[DaemonManager] Startup lock unreadable while waiting for holder: ${this.describeError(error)}`,
+      );
+      return false;
+    }
+    if (content.length === 0) {
+      // A holder created the lock but has not written its PID yet (mirrors the
+      // fileLock mid-write window); treat as still held so we do not abandon it.
+      return true;
+    }
+    const { pid } = parseLockContent(content);
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      // Unreadable PID — a holder may still be filling it in; keep waiting.
+      return true;
+    }
+    return this.isProcessRunning(pid);
   }
 
   private async getLockHolderStartupLogPath(): Promise<string | null> {
@@ -1200,7 +1256,14 @@ export class DaemonManager implements DaemonManagerLike {
   /**
    * Wait for daemon to be ready (socket listening)
    */
-  async waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean> {
+  async waitForReady(
+    timeout: number,
+    signal?: AbortSignal,
+    // Defaults to "always keep waiting" so the common no-predicate call stays
+    // synchronous through to the poll sleep (a caller that inspects pending timers
+    // right after invocation relies on that); a predicate is consulted each poll.
+    shouldContinueWaiting: () => boolean = () => true,
+  ): Promise<boolean> {
     const startTime = this.timer.now();
     const deadline = startTime + timeout;
     const pollInterval = 100; // Poll every 100ms
@@ -1214,23 +1277,31 @@ export class DaemonManager implements DaemonManagerLike {
       pollCount++;
       if (existsSync(this.socketPath)) {
         socketObserved = true;
-        // A daemon started from another checkout can own this namespace's socket
-        // without writing this namespace's PID record. The socket connection is
-        // authoritative readiness in that case; status() cannot prove ownership.
-        if (await this.verifyDaemonConnection(this.remainingTime(deadline), signal)) {
+        const outcome = await this.probeObservedSocket(deadline, signal);
+        if (outcome === "ready") {
           stderrLog(
             `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
               `(${pollCount} polls; socket observed)`,
           );
           return true;
         }
-        if (signal?.aborted) {
+        if (outcome === "aborted") {
           return false;
         }
-        const status = await this.status();
-        if (status.running) {
-          await this.removeInvalidSocketPath();
-        }
+      }
+
+      // Give up early when the caller's precondition for waiting no longer holds —
+      // e.g. the process that was bringing up the daemon has died. Readiness is
+      // checked first (a daemon that just became reachable wins), so this only
+      // short-circuits a wait that would otherwise run the full budget with nothing
+      // left to become ready, producing the caller's actionable error only as the
+      // client's request times out (issue #5878).
+      if (!shouldContinueWaiting()) {
+        stderrLog(
+          `Daemon readiness wait abandoned after ${this.timer.now() - startTime}ms ` +
+            `(${pollCount} polls); the process it was waiting on is no longer running`,
+        );
+        return false;
       }
 
       const remainingPollTimeMs = this.remainingTime(deadline);
@@ -1245,6 +1316,33 @@ export class DaemonManager implements DaemonManagerLike {
         `(${pollCount} polls; socket ${socketObserved ? "observed" : "not observed"})`,
     );
     return false;
+  }
+
+  /**
+   * Probe an observed socket for readiness within a single {@link waitForReady}
+   * poll. Returns `"ready"` when the daemon is connectable, `"aborted"` when the
+   * caller's signal fired mid-probe, or `"unready"` otherwise. A daemon started
+   * from another checkout can own this namespace's socket without writing this
+   * namespace's PID record, so a successful socket connection is authoritative
+   * readiness even when `status()` cannot prove ownership; an unready socket for a
+   * daemon that nonetheless reports running has its stale path unlinked as a side
+   * effect, mirroring the pre-extraction behavior.
+   */
+  private async probeObservedSocket(
+    deadline: number,
+    signal?: AbortSignal,
+  ): Promise<"ready" | "aborted" | "unready"> {
+    if (await this.verifyDaemonConnection(this.remainingTime(deadline), signal)) {
+      return "ready";
+    }
+    if (signal?.aborted) {
+      return "aborted";
+    }
+    const status = await this.status();
+    if (status.running) {
+      await this.removeInvalidSocketPath();
+    }
+    return "unready";
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -375,16 +375,6 @@ const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 
 /**
- * Upper bound on how many successive live startup-lock holders `start()` will wait
- * on before reporting failure (issue #5878). Each distinct live holder that
- * reclaims the lock is a process actively bringing the daemon up, so waiting for it
- * is correct; the cap only stops a pathological churn of holders that die and are
- * replaced from looping without end. A stuck same holder or a dead lock ends the
- * loop immediately regardless of this cap.
- */
-const MAX_PEER_STARTUP_WAITS = 3;
-
-/**
  * Surface of DaemonManager used by clients (e.g. DaemonMcpProxy).
  * Allows injecting fakes in tests without subclassing the concrete class.
  */
@@ -604,18 +594,22 @@ export class DaemonManager implements DaemonManagerLike {
     let holderLogPath: string | null = null;
     let waitedOnPid = this.readStartupLockHolder().livePid;
 
-    // ONE arbitration deadline across every holder, replacements included. Each
-    // wait gets only the remaining time, so a chain of holders (A replaced by B
-    // near A's deadline) cannot reset the budget and push the failure past the
-    // client's ~30s `tools/list` deadline — which would hide the very error this
-    // change exists to deliver (issue #5878).
+    // ONE arbitration deadline across every holder, replacements included, and the
+    // final confirm bounded by whatever time is left under it — so a chain of
+    // holders (A replaced by B near A's deadline) plus the confirm cannot push the
+    // failure past the client's ~30s `tools/list` deadline, which would hide the
+    // very error this change exists to deliver (issue #5878). The loop is bounded by
+    // this deadline rather than a fixed iteration count, so a legitimate replacement
+    // that reclaims the lock with time still on the clock is not cut off prematurely.
     const arbitrationDeadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
 
-    for (let attempt = 1; attempt <= MAX_PEER_STARTUP_WAITS; attempt++) {
+    // A wait on a live holder polls on an interval and so consumes real time, and
+    // a dead holder is either taken over or ends the loop — so the arbitration
+    // deadline bounds the number of iterations; no separate count cap is needed
+    // (and a count cap would wrongly cut off a legitimate replacement that reclaims
+    // the lock with time still on the clock).
+    while (this.remainingTime(arbitrationDeadline) > 0) {
       const remaining = this.remainingTime(arbitrationDeadline);
-      if (remaining === 0) {
-        break;
-      }
       stderrLog("Another process is starting the daemon, waiting...");
       // Capture diagnostics while the current holder still holds the lock, so they
       // survive into the failure message if the holder later releases on failure.
@@ -654,11 +648,18 @@ export class DaemonManager implements DaemonManagerLike {
     // between a poll's socket check and its liveness check, so confirm reachability
     // directly before reporting failure. Use verifyDaemonConnection rather than
     // waitForReady: it is a bounded, NON-destructive probe that never unlinks a
-    // socket, so a healthy-but-slow daemon that just came up is not torn down
-    // (issue #5878).
+    // socket, so a healthy-but-slow daemon that just came up is not torn down. Cap
+    // it to whatever time is left under the arbitration deadline so it cannot push
+    // total elapsed past the client deadline (issue #5878); when the loop already
+    // consumed the whole budget there is no release-race window to catch anyway.
+    const confirmBudget = Math.min(
+      ABANDONED_WAIT_CONFIRM_TIMEOUT_MS,
+      this.remainingTime(arbitrationDeadline),
+    );
     if (
+      confirmBudget > 0 &&
       existsSync(this.socketPath) &&
-      (await this.verifyDaemonConnection(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS))
+      (await this.verifyDaemonConnection(confirmBudget))
     ) {
       stderrLog("Daemon became ready before reporting startup failure");
       return;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -604,12 +604,23 @@ export class DaemonManager implements DaemonManagerLike {
     let holderLogPath: string | null = null;
     let waitedOnPid = this.readStartupLockHolder().livePid;
 
+    // ONE arbitration deadline across every holder, replacements included. Each
+    // wait gets only the remaining time, so a chain of holders (A replaced by B
+    // near A's deadline) cannot reset the budget and push the failure past the
+    // client's ~30s `tools/list` deadline — which would hide the very error this
+    // change exists to deliver (issue #5878).
+    const arbitrationDeadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
+
     for (let attempt = 1; attempt <= MAX_PEER_STARTUP_WAITS; attempt++) {
+      const remaining = this.remainingTime(arbitrationDeadline);
+      if (remaining === 0) {
+        break;
+      }
       stderrLog("Another process is starting the daemon, waiting...");
       // Capture diagnostics while the current holder still holds the lock, so they
       // survive into the failure message if the holder later releases on failure.
       holderLogPath = (await this.getLockHolderStartupLogPath()) ?? holderLogPath;
-      const ready = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
+      const ready = await this.waitForReady(remaining, undefined, () =>
         this.isStartupLockHeldByLiveProcess(),
       );
       if (ready) {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -363,6 +363,18 @@ function hasProcessLivenessChecker(value: unknown): value is DaemonProcessLivene
 const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 
 /**
+ * Budget for the confirming socket probe once the process a readiness wait was
+ * waiting on has died (issue #5878). A daemon that genuinely published its socket
+ * answers a probe near-instantly, so this only needs to cover the readiness
+ * probe's own retry/backoff — not a real cold start. Capping it here keeps a
+ * stale or stalling socket from consuming the client's whole `tools/list`
+ * deadline before the wait abandons: without the cap, the per-poll probe is
+ * handed the full remaining startup budget and runs before the liveness check
+ * gets another turn.
+ */
+const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
+
+/**
  * Surface of DaemonManager used by clients (e.g. DaemonMcpProxy).
  * Allows injecting fakes in tests without subclassing the concrete class.
  */
@@ -583,6 +595,16 @@ export class DaemonManager implements DaemonManagerLike {
       );
       if (retryReady) {
         stderrLog("Daemon started by another process (retry)");
+        return;
+      }
+      // The retry holder could publish its socket and release its lock in the
+      // narrow window between a poll's socket check and its liveness check, so the
+      // wait above can observe the lock gone the instant startup actually
+      // succeeded. Unlike the first contention pass, this path throws without a
+      // reacquire, so confirm the daemon really is not up — bounded so a genuine
+      // failure is still reported fast — before reporting failure (issue #5878).
+      if (await this.waitForReady(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS)) {
+        stderrLog("Daemon became ready before reporting retry-holder failure");
         return;
       }
       throw await this.createLockHolderStartupFailure(retryHolderLogPath);
@@ -1275,9 +1297,19 @@ export class DaemonManager implements DaemonManagerLike {
         return false;
       }
       pollCount++;
+      // Evaluated before the socket probe so a probe against a stale/stalling
+      // socket cannot be handed the full remaining budget while the thing we are
+      // waiting on is already gone. Readiness still wins (the probe runs first),
+      // but when the holder is gone the probe is capped so it merely confirms an
+      // already-connectable daemon rather than absorbing the client's deadline
+      // (issue #5878).
+      const keepWaiting = shouldContinueWaiting();
       if (existsSync(this.socketPath)) {
         socketObserved = true;
-        const outcome = await this.probeObservedSocket(deadline, signal);
+        const probeDeadline = keepWaiting
+          ? deadline
+          : Math.min(deadline, this.timer.now() + ABANDONED_WAIT_CONFIRM_TIMEOUT_MS);
+        const outcome = await this.probeObservedSocket(probeDeadline, signal);
         if (outcome === "ready") {
           stderrLog(
             `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
@@ -1296,7 +1328,7 @@ export class DaemonManager implements DaemonManagerLike {
       // short-circuits a wait that would otherwise run the full budget with nothing
       // left to become ready, producing the caller's actionable error only as the
       // client's request times out (issue #5878).
-      if (!shouldContinueWaiting()) {
+      if (!keepWaiting) {
         stderrLog(
           `Daemon readiness wait abandoned after ${this.timer.now() - startTime}ms ` +
             `(${pollCount} polls); the process it was waiting on is no longer running`,

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -375,6 +375,16 @@ const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 
 /**
+ * Upper bound on how many successive live startup-lock holders `start()` will wait
+ * on before reporting failure (issue #5878). Each distinct live holder that
+ * reclaims the lock is a process actively bringing the daemon up, so waiting for it
+ * is correct; the cap only stops a pathological churn of holders that die and are
+ * replaced from looping without end. A stuck same holder or a dead lock ends the
+ * loop immediately regardless of this cap.
+ */
+const MAX_PEER_STARTUP_WAITS = 3;
+
+/**
  * Surface of DaemonManager used by clients (e.g. DaemonMcpProxy).
  * Allows injecting fakes in tests without subclassing the concrete class.
  */
@@ -387,6 +397,13 @@ export interface DaemonManagerLike {
     signal?: AbortSignal,
     shouldContinueWaiting?: () => boolean,
   ): Promise<boolean>;
+  /**
+   * Whether the daemon startup lock is held by a still-live process — used as the
+   * early-exit predicate for readiness waits that block on another process bringing
+   * up the daemon, so a crashed holder is not waited on for the full budget while a
+   * live one keeps it (issue #5878).
+   */
+  isStartupLockHeldByLiveProcess(): boolean;
 }
 
 /**
@@ -557,16 +574,41 @@ export class DaemonManager implements DaemonManagerLike {
    * proxy processes try to start the daemon simultaneously.
    */
   async start(options: DaemonOptions = {}): Promise<void> {
-    const acquired = this.acquireLock();
-    if (!acquired) {
-      // Another process is starting the daemon — wait for it to become ready.
-      // Keep the full DAEMON_STARTUP_TIMEOUT_MS while that holder is alive (a
-      // legitimate cold start by another process — multi-simulator discovery —
-      // needs the full budget), but stop the moment the holder is gone. Without
-      // that early exit a crashed holder makes this wait run the full budget with
-      // nothing left to become ready, and the actionable failure below is produced
-      // only as the client's ~30s `tools/list` deadline expires (issue #5878).
+    if (!this.acquireLock()) {
+      await this.startByAwaitingLockHolder(options);
+      return;
+    }
+
+    try {
+      await this.startUnlocked(options);
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Resolve a start where another process already holds the startup lock.
+   *
+   * Loops: wait for the current holder to publish the socket — exiting the wait the
+   * instant that holder dies, so a crashed holder cannot burn the client's ~30s
+   * `tools/list` deadline (issue #5878) — then, if it died, take over the lock, or
+   * if a *different* live process reclaimed it, wait on that replacement. A holder
+   * that stays alive keeps the full DAEMON_STARTUP_TIMEOUT_MS so a legitimate slow
+   * cold start by another process is not abandoned. Only once no live holder remains
+   * and a bounded readiness confirm still fails do we report the lock-holder startup
+   * failure — that confirm closes the race where a holder publishes its socket and
+   * releases its lock in the window between a poll's socket check and its liveness
+   * check.
+   */
+  private async startByAwaitingLockHolder(options: DaemonOptions): Promise<void> {
+    let holderLogPath: string | null = null;
+    let waitedOnPid = this.readStartupLockHolder().livePid;
+
+    for (let attempt = 1; attempt <= MAX_PEER_STARTUP_WAITS; attempt++) {
       stderrLog("Another process is starting the daemon, waiting...");
+      // Capture diagnostics while the current holder still holds the lock, so they
+      // survive into the failure message if the holder later releases on failure.
+      holderLogPath = (await this.getLockHolderStartupLogPath()) ?? holderLogPath;
       const ready = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
         this.isStartupLockHeldByLiveProcess(),
       );
@@ -574,9 +616,9 @@ export class DaemonManager implements DaemonManagerLike {
         stderrLog("Daemon started by another process");
         return;
       }
-      // Lock holder may have crashed — retry lock acquisition once
-      const retryAcquired = this.acquireLock();
-      if (retryAcquired) {
+
+      // The holder we waited on is gone — take over its start.
+      if (this.acquireLock()) {
         stderrLog("Previous lock holder failed, taking over daemon start...");
         try {
           await this.startUnlocked(options);
@@ -585,36 +627,23 @@ export class DaemonManager implements DaemonManagerLike {
         }
         return;
       }
-      // Another process won the retry race — wait for it to finish, again only as
-      // long as that retry holder is alive so the double-race failure stays
-      // deliverable before the client's request timeout (issue #5878).
-      stderrLog("Another process is retrying daemon start, waiting...");
-      const retryHolderLogPath = await this.getLockHolderStartupLogPath();
-      const retryReady = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
-        this.isStartupLockHeldByLiveProcess(),
-      );
-      if (retryReady) {
-        stderrLog("Daemon started by another process (retry)");
-        return;
+
+      // We could not take over, so the lock is still held. Keep waiting only for a
+      // genuinely different live holder (a replacement that reclaimed the lock while
+      // the prior one died); a stuck same holder or a now-dead lock ends the loop.
+      const current = this.readStartupLockHolder().livePid;
+      if (current === undefined || current === waitedOnPid) {
+        break;
       }
-      // The retry holder could publish its socket and release its lock in the
-      // narrow window between a poll's socket check and its liveness check, so the
-      // wait above can observe the lock gone the instant startup actually
-      // succeeded. Unlike the first contention pass, this path throws without a
-      // reacquire, so confirm the daemon really is not up — bounded so a genuine
-      // failure is still reported fast — before reporting failure (issue #5878).
-      if (await this.waitForReady(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS)) {
-        stderrLog("Daemon became ready before reporting retry-holder failure");
-        return;
-      }
-      throw await this.createLockHolderStartupFailure(retryHolderLogPath);
+      waitedOnPid = current;
+      stderrLog("Startup lock reclaimed by another process, waiting again...");
     }
 
-    try {
-      await this.startUnlocked(options);
-    } finally {
-      this.releaseLock();
+    if (await this.waitForReady(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS)) {
+      stderrLog("Daemon became ready before reporting startup failure");
+      return;
     }
+    throw await this.createLockHolderStartupFailure(holderLogPath);
   }
 
   /**
@@ -921,21 +950,18 @@ export class DaemonManager implements DaemonManagerLike {
   }
 
   /**
-   * Whether the daemon startup lock is currently held by a still-live process.
+   * Read the current owner of the daemon startup lock.
    *
-   * Early-exit predicate for the two lock-contention waits in {@link start}. When
-   * another process holds the startup lock and is bringing up the daemon, this
-   * process waits for the socket to publish. If the holder crashes — or fails and
-   * releases the lock — the plain readiness wait would keep polling for the full
-   * DAEMON_STARTUP_TIMEOUT_MS even though nothing will ever become ready, so the
-   * actionable lock-holder-startup-failure error is produced only as the client's
-   * own `tools/list` deadline expires (issue #5878). Giving up the instant the
-   * holder is gone makes that error deliverable, while a holder that is still alive
-   * keeps the full budget so a legitimate slow cold start by another process is not
-   * abandoned. Reuses the injected liveness checker and the shared lock format so
-   * there is one canonical primitive per concern rather than a second PID reader.
+   * `present` is true while there is a holder worth waiting for — a live PID, or a
+   * lock file mid-write whose PID is not yet readable; it is false once the lock is
+   * gone or its holder has died. `livePid` is that holder's PID when it is both
+   * readable and alive, else `undefined`, so a caller can tell a *replacement*
+   * holder (a different live PID) from the same one it was already waiting on.
+   *
+   * Reuses the injected liveness checker and the shared lock format so there is one
+   * canonical primitive per concern rather than a second PID reader (issue #5878).
    */
-  private isStartupLockHeldByLiveProcess(): boolean {
+  private readStartupLockHolder(): { present: boolean; livePid: number | undefined } {
     let content: string;
     try {
       content = readFileSync(this.lockFilePath, "utf-8").trim();
@@ -945,19 +971,40 @@ export class DaemonManager implements DaemonManagerLike {
       logger.debug(
         `[DaemonManager] Startup lock unreadable while waiting for holder: ${this.describeError(error)}`,
       );
-      return false;
+      return { present: false, livePid: undefined };
     }
     if (content.length === 0) {
       // A holder created the lock but has not written its PID yet (mirrors the
-      // fileLock mid-write window); treat as still held so we do not abandon it.
-      return true;
+      // fileLock mid-write window); treat as still held so we do not abandon it,
+      // but with no comparable identity yet.
+      return { present: true, livePid: undefined };
     }
     const { pid } = parseLockContent(content);
     if (!Number.isSafeInteger(pid) || pid <= 0) {
       // Unreadable PID — a holder may still be filling it in; keep waiting.
-      return true;
+      return { present: true, livePid: undefined };
     }
-    return this.isProcessRunning(pid);
+    return this.isProcessRunning(pid)
+      ? { present: true, livePid: pid }
+      : { present: false, livePid: undefined };
+  }
+
+  /**
+   * Whether the daemon startup lock is currently held by a still-live process.
+   *
+   * Early-exit predicate for the readiness waits that block on another process
+   * bringing up the daemon (in {@link start} and in `DaemonMcpProxy.startDaemon`'s
+   * "reports running but socket not yet published" branch). A plain readiness wait
+   * polls only the socket, so when the holder crashes — or fails and releases the
+   * lock — it keeps polling for the full DAEMON_STARTUP_TIMEOUT_MS even though
+   * nothing will ever become ready, and the actionable failure is produced only as
+   * the client's own `tools/list` deadline expires (issue #5878). Giving up the
+   * instant the holder is gone makes that error deliverable, while a holder that is
+   * still alive keeps the full budget so a legitimate slow cold start by another
+   * process is not abandoned.
+   */
+  isStartupLockHeldByLiveProcess(): boolean {
+    return this.readStartupLockHolder().present;
   }
 
   private async getLockHolderStartupLogPath(): Promise<string | null> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -639,7 +639,16 @@ export class DaemonManager implements DaemonManagerLike {
       stderrLog("Startup lock reclaimed by another process, waiting again...");
     }
 
-    if (await this.waitForReady(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS)) {
+    // The holder may have published its socket and released its lock in the window
+    // between a poll's socket check and its liveness check, so confirm reachability
+    // directly before reporting failure. Use verifyDaemonConnection rather than
+    // waitForReady: it is a bounded, NON-destructive probe that never unlinks a
+    // socket, so a healthy-but-slow daemon that just came up is not torn down
+    // (issue #5878).
+    if (
+      existsSync(this.socketPath) &&
+      (await this.verifyDaemonConnection(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS))
+    ) {
       stderrLog("Daemon became ready before reporting startup failure");
       return;
     }
@@ -1356,7 +1365,10 @@ export class DaemonManager implements DaemonManagerLike {
         const probeDeadline = keepWaiting
           ? deadline
           : Math.min(deadline, this.timer.now() + ABANDONED_WAIT_CONFIRM_TIMEOUT_MS);
-        const outcome = await this.probeObservedSocket(probeDeadline, signal);
+        // Only the full-budget wait (holder still live) is authoritative enough to
+        // unlink a stale socket; a capped probe must not, or it could remove a
+        // healthy-but-slow daemon's socket (issue #5878).
+        const outcome = await this.probeObservedSocket(probeDeadline, signal, keepWaiting);
         if (outcome === "ready") {
           stderrLog(
             `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
@@ -1403,13 +1415,21 @@ export class DaemonManager implements DaemonManagerLike {
    * caller's signal fired mid-probe, or `"unready"` otherwise. A daemon started
    * from another checkout can own this namespace's socket without writing this
    * namespace's PID record, so a successful socket connection is authoritative
-   * readiness even when `status()` cannot prove ownership; an unready socket for a
-   * daemon that nonetheless reports running has its stale path unlinked as a side
-   * effect, mirroring the pre-extraction behavior.
+   * readiness even when `status()` cannot prove ownership.
+   *
+   * `allowSocketRemoval` gates the stale-socket cleanup on the unready path.
+   * Unlinking a socket whose daemon still reports running is only safe after an
+   * authoritative full-budget probe; a probe capped to a short confirm budget can
+   * fail merely because a healthy daemon was slow to accept (backlog / first accept
+   * after restart), so cleaning up there would unlink a LIVE daemon's socket and
+   * break every later client (issue #5878, guarded by
+   * `daemonManagerReadiness.test.ts` "recovers on a later retry without removing a
+   * live daemon's socket"). Callers running a capped probe pass `false`.
    */
   private async probeObservedSocket(
     deadline: number,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    allowSocketRemoval: boolean,
   ): Promise<"ready" | "aborted" | "unready"> {
     if (await this.verifyDaemonConnection(this.remainingTime(deadline), signal)) {
       return "ready";
@@ -1417,9 +1437,11 @@ export class DaemonManager implements DaemonManagerLike {
     if (signal?.aborted) {
       return "aborted";
     }
-    const status = await this.status();
-    if (status.running) {
-      await this.removeInvalidSocketPath();
+    if (allowSocketRemoval) {
+      const status = await this.status();
+      if (status.running) {
+        await this.removeInvalidSocketPath();
+      }
     }
     return "unready";
   }

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -194,7 +194,11 @@ describe("DaemonManager file lock", () => {
       await expect(manager.start()).rejects.toThrow(
         /Another process is starting the daemon but it failed to become ready[\s\S]*holder-logs[\s\S]*SIMULATOR-B/,
       );
-      expect(timeouts).toEqual([30_000, 30_000]);
+      // Both contention waits run the full cold-start budget; a bounded readiness
+      // confirm then runs before the failure is reported (#5878).
+      expect(timeouts.slice(0, 2)).toEqual([30_000, 30_000]);
+      expect(timeouts).toHaveLength(3);
+      expect(timeouts[2]).toBeLessThan(30_000);
 
       holder.releaseLock();
     });
@@ -238,7 +242,10 @@ describe("DaemonManager file lock", () => {
       await expect(manager.start()).rejects.toThrow(
         /Another process is starting the daemon but it failed to become ready[\s\S]*retry-holder-logs[\s\S]*Retry holder failed/,
       );
-      expect(waitCount).toBe(2);
+      // Two contention waits plus the bounded readiness confirm before the failure
+      // is reported (#5878); diagnostics are captured before the retry holder
+      // releases, so they survive into the thrown error.
+      expect(waitCount).toBe(3);
     });
 
     test("releases lock after successful start", async () => {

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -194,11 +194,12 @@ describe("DaemonManager file lock", () => {
       await expect(manager.start()).rejects.toThrow(
         /Another process is starting the daemon but it failed to become ready[\s\S]*holder-logs[\s\S]*SIMULATOR-B/,
       );
-      // Both contention waits run the full cold-start budget; a bounded readiness
-      // confirm then runs before the failure is reported (#5878).
-      expect(timeouts.slice(0, 2)).toEqual([30_000, 30_000]);
-      expect(timeouts).toHaveLength(3);
-      expect(timeouts[2]).toBeLessThan(30_000);
+      // The live holder is waited on once at the full cold-start budget; because it
+      // stays the same live holder (not a replacement) the loop then stops and a
+      // bounded readiness confirm runs before the failure is reported (#5878).
+      expect(timeouts[0]).toBe(30_000);
+      expect(timeouts).toHaveLength(2);
+      expect(timeouts[1]).toBeLessThan(30_000);
 
       holder.releaseLock();
     });

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -195,11 +195,10 @@ describe("DaemonManager file lock", () => {
         /Another process is starting the daemon but it failed to become ready[\s\S]*holder-logs[\s\S]*SIMULATOR-B/,
       );
       // The live holder is waited on once at the full cold-start budget; because it
-      // stays the same live holder (not a replacement) the loop then stops and a
-      // bounded readiness confirm runs before the failure is reported (#5878).
-      expect(timeouts[0]).toBe(30_000);
-      expect(timeouts).toHaveLength(2);
-      expect(timeouts[1]).toBeLessThan(30_000);
+      // stays the same live holder (not a replacement) the loop then stops. The
+      // pre-failure readiness confirm is a direct non-destructive probe, not a
+      // waitForReady call, so only the one budgeted wait is recorded (#5878).
+      expect(timeouts).toEqual([30_000]);
 
       holder.releaseLock();
     });
@@ -243,10 +242,11 @@ describe("DaemonManager file lock", () => {
       await expect(manager.start()).rejects.toThrow(
         /Another process is starting the daemon but it failed to become ready[\s\S]*retry-holder-logs[\s\S]*Retry holder failed/,
       );
-      // Two contention waits plus the bounded readiness confirm before the failure
-      // is reported (#5878); diagnostics are captured before the retry holder
-      // releases, so they survive into the thrown error.
-      expect(waitCount).toBe(3);
+      // The initial holder wait plus one wait on the replacement retry holder; the
+      // pre-failure confirm is a direct probe, not a waitForReady call (#5878).
+      // Diagnostics are captured before the retry holder releases, so they survive
+      // into the thrown error.
+      expect(waitCount).toBe(2);
     });
 
     test("releases lock after successful start", async () => {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -17,7 +17,6 @@ import {
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_STARTUP_TIMEOUT_MS,
-  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
 } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -480,13 +479,19 @@ describe("DaemonMcpProxy", () => {
         waitForReadyCalls = 0;
         publishOnWaitForReady = true;
         lastWaitForReadyTimeout: number | undefined;
+        lastShouldContinueWaiting: (() => boolean) | undefined;
 
-        override async waitForReady(timeout: number): Promise<boolean> {
+        override async waitForReady(
+          timeout: number,
+          _signal?: AbortSignal,
+          shouldContinueWaiting?: () => boolean,
+        ): Promise<boolean> {
           this.waitForReadyCalls++;
           this.lastWaitForReadyTimeout = timeout;
+          this.lastShouldContinueWaiting = shouldContinueWaiting;
           if (this.publishOnWaitForReady) {
-            // Model the bounded readiness path observing the socket become
-            // connectable once the starting daemon finishes publishing it.
+            // Model the readiness path observing the socket become connectable once
+            // the starting daemon finishes publishing it.
             this.socketPublished = true;
             return true;
           }
@@ -576,7 +581,7 @@ describe("DaemonMcpProxy", () => {
           // The unreachable-running-daemon branch surfaces an actionable error
           // rather than the client seeing zero tools with no text (issue #5878).
           await expect(proxy.listTools()).rejects.toThrow(
-            /socket did not become reachable within \d+ms/,
+            /socket did not become reachable, and no live process is completing its startup/,
           );
           // The readiness deadline gates the connect: the client is never asked to
           // connect against a socket that was never published.
@@ -588,9 +593,10 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("bounds the unreachable-running-daemon wait to the reachability budget so the error beats the client timeout (#5878)", async () => {
+      test("keeps the full startup budget and exits on holder liveness rather than a shorter bound (#5878)", async () => {
         const fakeManager = new StartingDaemonManager();
         fakeManager.publishOnWaitForReady = false;
+        fakeManager.startupLockHeldByLiveProcess = true;
         fakeManager.statusResult = {
           running: true,
           pid: 1234,
@@ -609,16 +615,20 @@ describe("DaemonMcpProxy", () => {
 
         try {
           await expect(proxy.listTools()).rejects.toThrow(
-            new RegExp(`within ${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms`),
+            /socket did not become reachable, and no live process is completing its startup/,
           );
-          // The wait for an already-running daemon's socket must use the bounded
-          // reachability budget, NOT the full 30s startup budget — otherwise the
-          // actionable error is produced only as the client's own ~30s tools/list
-          // deadline expires and the client sees zero tools (issue #5878). This is
-          // the existing-daemon branch; a daemon we spawn ourselves keeps the full
-          // budget.
-          expect(fakeManager.lastWaitForReadyTimeout).toBe(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
-          expect(fakeManager.lastWaitForReadyTimeout).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+          // A concurrent cold start writes its early-owner PID (status.running) well
+          // before it publishes the socket, so this wait must keep the FULL startup
+          // budget — not a shorter bound that would reject a start about to succeed —
+          // and instead exit early via the startup-lock liveness predicate (#5878).
+          expect(fakeManager.lastWaitForReadyTimeout).toBe(DAEMON_STARTUP_TIMEOUT_MS);
+          expect(fakeManager.lastShouldContinueWaiting).toBeDefined();
+          // The predicate delegates to the manager's live-holder check: flipping the
+          // manager flips what the predicate reports.
+          fakeManager.startupLockHeldByLiveProcess = true;
+          expect(fakeManager.lastShouldContinueWaiting?.()).toBe(true);
+          fakeManager.startupLockHeldByLiveProcess = false;
+          expect(fakeManager.lastShouldContinueWaiting?.()).toBe(false);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -16,6 +16,8 @@ import {
   DAEMON_VERSION_RESTART_COOLDOWN_MS,
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
+  DAEMON_STARTUP_TIMEOUT_MS,
+  DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
 } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -477,9 +479,11 @@ describe("DaemonMcpProxy", () => {
         socketPublished = false;
         waitForReadyCalls = 0;
         publishOnWaitForReady = true;
+        lastWaitForReadyTimeout: number | undefined;
 
-        override async waitForReady(_timeout: number): Promise<boolean> {
+        override async waitForReady(timeout: number): Promise<boolean> {
           this.waitForReadyCalls++;
+          this.lastWaitForReadyTimeout = timeout;
           if (this.publishOnWaitForReady) {
             // Model the bounded readiness path observing the socket become
             // connectable once the starting daemon finishes publishing it.
@@ -569,11 +573,52 @@ describe("DaemonMcpProxy", () => {
         });
 
         try {
-          await expect(proxy.listTools()).rejects.toThrow(/failed to start within \d+ms/);
+          // The unreachable-running-daemon branch surfaces an actionable error
+          // rather than the client seeing zero tools with no text (issue #5878).
+          await expect(proxy.listTools()).rejects.toThrow(
+            /socket did not become reachable within \d+ms/,
+          );
           // The readiness deadline gates the connect: the client is never asked to
           // connect against a socket that was never published.
           expect(fakeManager.waitForReadyCalls).toBeGreaterThanOrEqual(1);
           expect(client.connectCallCount).toBe(0);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("bounds the unreachable-running-daemon wait to the reachability budget so the error beats the client timeout (#5878)", async () => {
+        const fakeManager = new StartingDaemonManager();
+        fakeManager.publishOnWaitForReady = false;
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+        };
+        const client = new SocketGatedClient(fakeManager);
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
+
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => client,
+          daemonManager: fakeManager,
+          autoStartDaemon: true,
+        });
+
+        try {
+          await expect(proxy.listTools()).rejects.toThrow(
+            new RegExp(`within ${DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}ms`),
+          );
+          // The wait for an already-running daemon's socket must use the bounded
+          // reachability budget, NOT the full 30s startup budget — otherwise the
+          // actionable error is produced only as the client's own ~30s tools/list
+          // deadline expires and the client sees zero tools (issue #5878). This is
+          // the existing-daemon branch; a daemon we spawn ourselves keeps the full
+          // budget.
+          expect(fakeManager.lastWaitForReadyTimeout).toBe(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
+          expect(fakeManager.lastWaitForReadyTimeout).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -95,6 +95,9 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       async waitForReady() {
         return tracker.waitForReadyResult;
       },
+      isStartupLockHeldByLiveProcess() {
+        return false;
+      },
     };
     return tracker;
   }

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -29,6 +29,7 @@ import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { formatLockContent } from "../../src/utils/fileLock";
 import {
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_STARTUP_TIMEOUT_MS,
@@ -980,6 +981,160 @@ describe("Daemon manager process detection", () => {
       expect(elapsed).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
     } finally {
       killSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("double lock-contention delivers its failure fast when the startup-lock holder is dead, not at the full startup timeout (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-lock-contention-dead-holder-"));
+    const lockPath = join(dir, "daemon.lock");
+    const holderPid = 55555;
+    // Another process holds the startup lock but its PID is no longer alive — a
+    // crashed cold-start holder. The lock file was never released.
+    writeFileSync(lockPath, formatLockContent(holderPid));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => pid !== holderPid,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn on the double-contention path");
+      },
+    };
+
+    // Perpetual lock contention: this process can never acquire the lock, so
+    // start() runs both wait-for-holder paths and then throws the lock-holder
+    // startup failure. Before #5878 each wait consumed the full 30s budget, so the
+    // error arrived at ~60s — long past the client's ~30s tools/list deadline.
+    class ContentionDaemonManager extends DaemonManager {
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+    }
+
+    try {
+      const manager = new ContentionDaemonManager(
+        () => ({
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      const error = await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      expect(error.message).toContain(
+        "Another process is starting the daemon but it failed to become ready",
+      );
+      // A dead holder is detected on the first poll, so both waits bail out well
+      // under the reachability budget — and nowhere near the full startup timeout
+      // the pre-#5878 code would have burned twice over.
+      expect(elapsed).toBeLessThanOrEqual(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
+      expect(elapsed).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps waiting the full startup budget while the lock holder is still alive (no premature bound) (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-lock-contention-live-holder-"));
+    const lockPath = join(dir, "daemon.lock");
+    const holderPid = 55556;
+    // The holder is alive and legitimately cold-starting the daemon (multi-simulator
+    // discovery can take longer than the reachability budget), so this process must
+    // NOT abandon the wait early.
+    writeFileSync(lockPath, formatLockContent(holderPid));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => pid === holderPid,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn while the holder is alive");
+      },
+    };
+
+    class ContentionDaemonManager extends DaemonManager {
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+    }
+
+    try {
+      const manager = new ContentionDaemonManager(
+        () => ({
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      // A live holder keeps the FULL DAEMON_STARTUP_TIMEOUT_MS: had #5878 blindly
+      // bounded these waits to the reachability budget instead, elapsed would be a
+      // couple of reachability budgets (~20s) and this assertion would fail — the
+      // guard that a legitimate slow cold start by another process is not abandoned.
+      expect(elapsed).toBeGreaterThanOrEqual(DAEMON_STARTUP_TIMEOUT_MS);
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1416,6 +1416,94 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("a replacement lock holder shares one arbitration deadline, not a fresh budget each (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-replacement-deadline-"));
+    const lockPath = join(dir, "daemon.lock");
+    const pidA = 60001;
+    const pidB = 60002;
+    // Holder A initially owns the lock; part-way through A's wait it dies and B
+    // reclaims the lock. Both are "alive" by liveness — the handoff is the lock
+    // file's PID changing.
+    writeFileSync(lockPath, formatLockContent(pidA));
+    const fakeTimer = new FakeTimer();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => pid === pidA || pid === pidB,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn during the replacement-holder handoff");
+      },
+    };
+
+    class HandoffDaemonManager extends DaemonManager {
+      readonly grantedTimeouts: number[] = [];
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+      override async waitForReady(timeout: number): Promise<boolean> {
+        this.grantedTimeouts.push(timeout);
+        // First wait: A runs part-way then dies and B reclaims the lock. Later
+        // waits consume whatever budget they were granted.
+        const consumed = this.grantedTimeouts.length === 1 ? 20_000 : timeout;
+        fakeTimer.advanceTime(consumed);
+        if (this.grantedTimeouts.length === 1) {
+          writeFileSync(lockPath, formatLockContent(pidB));
+        }
+        return false;
+      }
+    }
+
+    try {
+      const manager = new HandoffDaemonManager(
+        () => ({
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      // The replacement (B) is granted only the REMAINING time, not a fresh full
+      // budget — so the total stays within one DAEMON_STARTUP_TIMEOUT_MS and the
+      // failure is delivered before the client's ~30s deadline (#5878). A per-holder
+      // reset would grant [30000, 30000] and take ~60s.
+      expect(manager.grantedTimeouts[0]).toBe(DAEMON_STARTUP_TIMEOUT_MS);
+      expect(manager.grantedTimeouts[1]).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+      expect(elapsed).toBeLessThanOrEqual(DAEMON_STARTUP_TIMEOUT_MS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("explicit restart force-stops an unreachable daemon without the default namespace PID record", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1139,6 +1139,169 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("a dead holder plus a stalling stale socket still abandons fast — the probe cannot absorb the full budget (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-lock-contention-stalling-socket-"));
+    const lockPath = join(dir, "daemon.lock");
+    const socketPath = join(dir, "daemon.sock");
+    const holderPid = 55557;
+    // Dead holder, but a stale socket file is present and every connect probe
+    // stalls until aborted — the case Codex flagged, where the per-poll probe was
+    // handed the full remaining budget and ran before the liveness check.
+    writeFileSync(lockPath, formatLockContent(holderPid));
+    writeFileSync(socketPath, "stale socket placeholder");
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => pid !== holderPid,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn on the stalling-socket contention path");
+      },
+    };
+
+    class ContentionDaemonManager extends DaemonManager {
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+    }
+
+    try {
+      const manager = new ContentionDaemonManager(
+        () => ({
+          async connect(_timeoutMs?: number, signal?: AbortSignal) {
+            // Never resolves; only the probe's own abort ends it — modelling a
+            // socket that accepts but never completes the handshake.
+            await new Promise<void>((_resolve, reject) => {
+              if (signal?.aborted) {
+                reject(new Error("probe aborted"));
+                return;
+              }
+              signal?.addEventListener("abort", () => reject(new Error("probe aborted")), {
+                once: true,
+              });
+            });
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        socketPath,
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      const error = await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      expect(error.message).toContain(
+        "Another process is starting the daemon but it failed to become ready",
+      );
+      // Each stalling probe is capped to the confirm budget (two contention waits
+      // plus the final confirm), so the failure is delivered in a few seconds —
+      // far under the full startup timeout the uncapped probe would have burned.
+      expect(elapsed).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the retry-holder failure path confirms readiness before throwing, reusing a daemon that just became ready (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-retry-confirm-"));
+    const lockPath = join(dir, "daemon.lock");
+    writeFileSync(lockPath, formatLockContent(55558));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: () => false,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn on the retry-confirm path");
+      },
+    };
+
+    // Both predicate-driven contention waits abandon (holder dead); the FINAL
+    // no-predicate confirm finds the daemon ready — the race window where the
+    // retry holder published its socket and released its lock just as the wait
+    // observed the lock gone. start() must reuse, not throw (Codex P2, #5878).
+    class RetryConfirmDaemonManager extends DaemonManager {
+      confirmCalls = 0;
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+      override async waitForReady(
+        _timeout: number,
+        _signal?: AbortSignal,
+        shouldContinueWaiting?: () => boolean,
+      ): Promise<boolean> {
+        if (shouldContinueWaiting) {
+          // The two contention waits abandon on the dead holder.
+          return false;
+        }
+        // The final bounded confirm observes the now-ready daemon.
+        this.confirmCalls++;
+        return true;
+      }
+    }
+
+    try {
+      const manager = new RetryConfirmDaemonManager(
+        () => ({
+          async connect() {},
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      // Resolves (reuse) rather than throwing the lock-holder startup failure.
+      await manager.start();
+      expect(manager.confirmCalls).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("explicit restart force-stops an unreachable daemon without the default namespace PID record", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1504,6 +1504,92 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("the contention loop is bounded by the arbitration deadline, not a fixed holder count (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-replacement-churn-"));
+    const lockPath = join(dir, "daemon.lock");
+    const livePids = new Set<number>([60001]);
+    writeFileSync(lockPath, formatLockContent(60001));
+    const fakeTimer = new FakeTimer();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => livePids.has(pid),
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn during replacement churn");
+      },
+    };
+
+    // Each wait consumes part of the budget, then the holder is replaced by a new
+    // live contender — more than three handoffs, all within one deadline.
+    class ChurnDaemonManager extends DaemonManager {
+      readonly grantedTimeouts: number[] = [];
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+      override async waitForReady(timeout: number): Promise<boolean> {
+        this.grantedTimeouts.push(timeout);
+        fakeTimer.advanceTime(Math.min(timeout, 5000));
+        const nextPid = 60001 + this.grantedTimeouts.length;
+        livePids.add(nextPid);
+        writeFileSync(lockPath, formatLockContent(nextPid));
+        return false;
+      }
+    }
+
+    try {
+      const manager = new ChurnDaemonManager(
+        () => ({
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      await manager.start().then(
+        () => {
+          throw new Error("expected start to reject");
+        },
+        (rejection: unknown) => rejection as Error,
+      );
+      const elapsed = fakeTimer.now() - startedAt;
+
+      // The loop waits on more than three successive live replacement holders — an
+      // earlier fixed count cap would have stopped at three and reported failure
+      // with time still on the clock (#5878) — while the shared deadline still
+      // bounds the total.
+      expect(manager.grantedTimeouts.length).toBeGreaterThan(3);
+      expect(elapsed).toBeLessThanOrEqual(DAEMON_STARTUP_TIMEOUT_MS);
+      // Each successive wait is granted only the shrinking remaining time.
+      for (let i = 1; i < manager.grantedTimeouts.length; i++) {
+        expect(manager.grantedTimeouts[i]).toBeLessThan(manager.grantedTimeouts[i - 1]);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("explicit restart force-stops an unreachable daemon without the default namespace PID record", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1139,6 +1139,81 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("a live holder that publishes its socket between the reachability and startup budgets still succeeds (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-lock-contention-slow-publish-"));
+    const lockPath = join(dir, "daemon.lock");
+    const socketPath = join(dir, "daemon.sock");
+    const holderPid = 55559;
+    // The holder is alive and legitimately cold-starting; its socket only becomes
+    // connectable at ~15s — past the 10s reachability budget a blind bound would
+    // have used, but well within the 30s startup budget. The liveness pivot must
+    // keep waiting and reuse the daemon rather than reject the start (#5878).
+    const publishAtMs = 15_000;
+    writeFileSync(lockPath, formatLockContent(holderPid));
+    writeFileSync(socketPath, "socket placeholder");
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: (pid: number) => pid === holderPid,
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        throw new Error("should not spawn while the holder is alive");
+      },
+    };
+
+    class ContentionDaemonManager extends DaemonManager {
+      override acquireLock(): boolean {
+        return false;
+      }
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+    }
+
+    try {
+      const manager = new ContentionDaemonManager(
+        () => ({
+          async connect() {
+            // The socket is not connectable until the holder finishes publishing it.
+            if (fakeTimer.now() < publishAtMs) {
+              throw new Error("socket not published yet");
+            }
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        lockPath,
+        join(dir, "daemon.pid"),
+        socketPath,
+        processFinder,
+        processSpawner,
+      );
+
+      const startedAt = fakeTimer.now();
+      // Resolves (reuse) rather than rejecting — the slow-but-alive cold start is
+      // not abandoned at the reachability budget.
+      await manager.start();
+      const elapsed = fakeTimer.now() - startedAt;
+
+      expect(elapsed).toBeGreaterThanOrEqual(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS);
+      expect(elapsed).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("a dead holder plus a stalling stale socket still abandons fast — the probe cannot absorb the full budget (#5878)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-lock-contention-stalling-socket-"));
     const lockPath = join(dir, "daemon.lock");

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1302,10 +1302,14 @@ describe("Daemon manager process detection", () => {
     }
   });
 
-  test("the retry-holder failure path confirms readiness before throwing, reusing a daemon that just became ready (#5878)", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-retry-confirm-"));
+  test("the contention path reuses a reachable daemon even when the startup-lock holder is dead (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-contention-reuse-"));
     const lockPath = join(dir, "daemon.lock");
+    const socketPath = join(dir, "daemon.sock");
+    // Dead holder, but the daemon it started has already published a connectable
+    // socket. start() must reuse it rather than throw the lock-holder failure.
     writeFileSync(lockPath, formatLockContent(55558));
+    writeFileSync(socketPath, "socket placeholder");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
@@ -1314,41 +1318,23 @@ describe("Daemon manager process detection", () => {
     };
     const processSpawner: DaemonProcessSpawner = {
       spawn: () => {
-        throw new Error("should not spawn on the retry-confirm path");
+        throw new Error("should not spawn when the daemon is already reachable");
       },
     };
 
-    // Both predicate-driven contention waits abandon (holder dead); the FINAL
-    // no-predicate confirm finds the daemon ready — the race window where the
-    // retry holder published its socket and released its lock just as the wait
-    // observed the lock gone. start() must reuse, not throw (Codex P2, #5878).
-    class RetryConfirmDaemonManager extends DaemonManager {
-      confirmCalls = 0;
+    class ContentionDaemonManager extends DaemonManager {
       override acquireLock(): boolean {
         return false;
       }
       override async status(): Promise<any> {
-        return { running: false };
-      }
-      override async waitForReady(
-        _timeout: number,
-        _signal?: AbortSignal,
-        shouldContinueWaiting?: () => boolean,
-      ): Promise<boolean> {
-        if (shouldContinueWaiting) {
-          // The two contention waits abandon on the dead holder.
-          return false;
-        }
-        // The final bounded confirm observes the now-ready daemon.
-        this.confirmCalls++;
-        return true;
+        return { running: true, pid: 4242 };
       }
     }
 
     try {
-      const manager = new RetryConfirmDaemonManager(
+      const manager = new ContentionDaemonManager(
         () => ({
-          async connect() {},
+          async connect() {}, // reachable
           async close() {},
           async callTool() {
             return {};
@@ -1364,14 +1350,67 @@ describe("Daemon manager process detection", () => {
         fakeTimer,
         lockPath,
         join(dir, "daemon.pid"),
-        join(dir, "daemon.sock"),
+        socketPath,
         processFinder,
         processSpawner,
       );
 
       // Resolves (reuse) rather than throwing the lock-holder startup failure.
       await manager.start();
-      expect(manager.confirmCalls).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a capped confirmation probe does not unlink a live but slow daemon's socket (#5878)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-capped-probe-nondestructive-"));
+    const socketPath = join(dir, "daemon.sock");
+    // The daemon reports running and its socket exists, but the connect probe is
+    // slow to be accepted (backlog / first accept after restart). A capped probe
+    // that fails must NOT tear down this healthy socket (issue #5878).
+    writeFileSync(socketPath, "socket placeholder");
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    class RunningDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: true, pid: 9191 };
+      }
+    }
+
+    try {
+      const manager = new RunningDaemonManager(
+        () => ({
+          async connect() {
+            // Never accepts within the probe budget — models a slow first accept.
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        socketPath,
+      );
+
+      // A liveness predicate that reports the holder gone forces the capped probe.
+      const ready = await manager.waitForReady(5000, undefined, () => false);
+
+      expect(ready).toBe(false);
+      // The healthy daemon's socket must survive the capped probe; unlinking it
+      // here is the regression this guards (a full-budget probe would still clean
+      // a genuinely stale socket).
+      expect(existsSync(socketPath)).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/fakes/FakeDaemonManager.ts
+++ b/test/fakes/FakeDaemonManager.ts
@@ -21,6 +21,7 @@ export class FakeDaemonManager implements DaemonManagerLike {
   restartOptions: DaemonOptions | undefined;
   waitForReadyResult = true;
   waitForReadyCallCount = 0;
+  startupLockHeldByLiveProcess = false;
 
   async status(): Promise<DaemonStatus> {
     const nextStatus = this.statusResults.shift();
@@ -45,5 +46,9 @@ export class FakeDaemonManager implements DaemonManagerLike {
   async waitForReady(_timeout: number): Promise<boolean> {
     this.waitForReadyCallCount++;
     return this.waitForReadyResult;
+  }
+
+  isStartupLockHeldByLiveProcess(): boolean {
+    return this.startupLockHeldByLiveProcess;
   }
 }


### PR DESCRIPTION
## Summary

Two daemon start-waits could produce a good, actionable error only as the client's own ~30s `tools/list` deadline expired — leaving the client showing AutoMobile connected with zero tools and no error text. Both were called out as out-of-scope residuals in [#5871](https://github.com/kaeawc/auto-mobile/issues/5871) / PR [#5874](https://github.com/kaeawc/auto-mobile/pull/5874). This makes both deliverable while keeping the full `DAEMON_STARTUP_TIMEOUT_MS` for legitimate cold-start bring-up, per the issue: only the branches that end in a client-visible *error* need to beat the request timeout.

## Linked Issue

Closes #5878

## Approach

Both waits now key their early-exit on the **startup-lock holder's liveness** (`DaemonManager.isStartupLockHeldByLiveProcess()`), a single mechanism across both paths: keep the full budget while a live process is actively bringing the daemon up (a legitimate cold start writes its early-owner PID — making `status.running` true — seconds before it publishes the socket, so it must not be abandoned), and give up the instant no live holder remains (an orphaned/wedged daemon), so the actionable error is delivered rather than raced.

## Changes

1. **`DaemonMcpProxy.startDaemon` #5664 branch** (daemon reports running, socket not yet connectable) — keeps the full `DAEMON_STARTUP_TIMEOUT_MS` but passes the liveness predicate, so a concurrent cold start is waited out while an orphaned/wedged daemon is reported now.
2. **`DaemonManager.start` contention** — extracted to `startByAwaitingLockHolder`, a bounded loop: wait for the current live holder, take over when it dies, and wait on a genuinely *different* replacement holder that reclaims the lock (keyed on holder PID identity, so a stuck same holder or a dead lock ends the loop). A bounded, **non-destructive** `verifyDaemonConnection` confirm before the failure closes the race where a holder publishes its socket and releases its lock between a poll's socket check and its liveness check.
3. **`waitForReady`** gains an optional synchronous `shouldContinueWaiting` predicate (defaulted so the common no-predicate call stays synchronous through to the poll sleep). The observed-socket probe is extracted to `probeObservedSocket`; when the holder is gone the probe is capped so a stale/stalling socket can't absorb the whole deadline, and the capped probe is made **non-destructive** (`allowSocketRemoval`) so it never unlinks a healthy-but-slow daemon's socket — only a full-budget wait is authoritative enough to clean a stale socket.

## Bug / Regression Context

- **Observed symptom:** `tools/list` blocks the full budget then throws a good error the client never sees; AutoMobile shows connected with zero tools.
- **Repro conditions:** (1) a daemon that reports running but whose socket never publishes (#5664 window / half-initialized); (2) two other processes both lose the startup race and fail to bring the daemon up (double lock-contention).

## Validation

- [x] `scripts/all_fast_validate_checks.sh` (`bun run lint` + `bun test`) — full suite green except two known `.claude`-worktree/env artifacts unrelated to this change (`test/lint/oxlintConfigScoping` missing `node_modules/.bin/oxlint`; `test/integration/webrtcDeviceCaptureLatency`)
- [x] `bun run typecheck` — no new errors (baseline gate; baseline untouched)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] `oxfmt --check` and the oxlint ratchet clean (no new violations)

### Tests (all in `test/daemon/`)

- Proxy keeps the full startup budget and delegates the liveness predicate (not a shorter bound).
- A live holder that publishes its socket **between** the reachability and startup budgets (~15s) still succeeds — the concurrent-cold-start case a blind bound would have rejected.
- Double lock-contention with a **dead** holder delivers its failure well under the startup timeout; with a **live** holder it keeps the full budget; a **stalling stale socket** still abandons fast; a **capped probe leaves a live-but-slow daemon's socket intact**; the contention path reuses a reachable daemon even when the lock holder is dead.

## Follow-ups

- [ ] #5904 — reconcile startup-lock-holder liveness with the detached daemon **child's** liveness. The lock identifies the launcher, not the `unref()`'d child; if the launcher dies after the child writes its early-owner PID but before the child publishes its socket, a second client's predicate abandons the wait early. Fixing it fully needs a *bounded* child-liveness grace (keying on the child alone would reopen this issue's wedged-alive hazard), so it is deferred as a narrow, self-recovering edge.
