### PR TITLE
fix(tapOn): rebuild selectedElement metadata from the refreshed pre-tap-stability target (#5888)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -726,7 +726,13 @@ export class TapOnElement extends BaseVisualChange {
     requireResourceId: boolean,
     signal?: AbortSignal,
   ): Promise<
-    | { ok: true; viewHierarchy: ViewHierarchyResult; tapElement: Element; usedParent: boolean }
+    | {
+        ok: true;
+        viewHierarchy: ViewHierarchyResult;
+        tapElement: Element;
+        usedParent: boolean;
+        selection: ElementSelectionResult;
+      }
     | { ok: false; error: string }
   > {
     const stableMatchesRequired = androidPreTapConsecutiveStableMatchesRequired(options);
@@ -736,6 +742,7 @@ export class TapOnElement extends BaseVisualChange {
       viewHierarchy: ViewHierarchyResult;
       tapElement: Element;
       usedParent: boolean;
+      selection: ElementSelectionResult;
     } | null = null;
 
     const startTime = this.timer.now();
@@ -872,6 +879,10 @@ export class TapOnElement extends BaseVisualChange {
         viewHierarchy: freshHierarchy,
         tapElement: refreshed.element,
         usedParent: refreshed.usedParent,
+        // Carry the refreshed selection so the caller can rebuild selectedElement
+        // metadata (bounds/indexInMatches/totalMatches) from the node actually
+        // tapped, not the stale pre-refresh selection (#5888).
+        selection: refind.selection,
       };
 
       if (consecutiveStable >= stableMatchesRequired) {
@@ -1386,7 +1397,7 @@ export class TapOnElement extends BaseVisualChange {
           }
           const selection = searchOutcome.selection;
           const element = selection.element as Element;
-          const selectedElementMetadata = this.buildSelectedElementMetadata(selection);
+          let selectedElementMetadata = this.buildSelectedElementMetadata(selection);
           if (options.subtext) {
             const occurrence = options.subtext.occurrence ?? 0;
             const activation = await this.activateSemanticLink(
@@ -1468,6 +1479,11 @@ export class TapOnElement extends BaseVisualChange {
             viewHierarchy = stable.viewHierarchy;
             tapElement = stable.tapElement;
             usedParent = stable.usedParent;
+            // Rebuild from the refreshed selection so the reported selectedElement
+            // (bounds/indexInMatches/totalMatches) describes the node actually
+            // tapped after re-resolution, not the stale pre-refresh match (#5888).
+            selectedElementMetadata =
+              this.buildSelectedElementMetadata(stable.selection) ?? selectedElementMetadata;
           }
 
           this.logClickableParentSelection(usedParent);

--- a/test/features/action/TapOnElement.preTapStability.test.ts
+++ b/test/features/action/TapOnElement.preTapStability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Element, ViewHierarchyResult } from "../../../src/models";
+import type { Element, ElementSelectionResult, ViewHierarchyResult } from "../../../src/models";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -492,5 +492,77 @@ describe("resolveAndroidStableTapTargetAfterRefreshes", () => {
     );
 
     await expect(resultPromise).rejects.toThrow();
+  });
+
+  // Regression for #5888: on a dynamic/reordered hierarchy the stability path
+  // re-resolves the tap target against a REFRESHED hierarchy, so the reported
+  // selectedElement metadata (bounds, indexInMatches, totalMatches) must describe
+  // the refreshed node actually tapped — not the pre-refresh selection. The helper
+  // must carry the refreshed ElementSelectionResult out so execute can rebuild it.
+  describe("carries the refreshed ElementSelectionResult out (#5888)", () => {
+    // Reorders the matched row on the first refresh: the pre-refresh selection is
+    // index 0 of 5 at STALE_BOUNDS; the refreshed one is index 3 of 4 at FRESH_BOUNDS.
+    const STALE_SELECTION: ElementSelectionResult = {
+      element: makeElement(STABLE_BOUNDS),
+      indexInMatches: 0,
+      totalMatches: 5,
+      strategy: "first",
+    };
+    const FRESH_BOUNDS: Element["bounds"] = { left: 200, top: 400, right: 300, bottom: 450 };
+    const FRESH_SELECTION: ElementSelectionResult = {
+      element: makeElement(FRESH_BOUNDS),
+      indexInMatches: 3,
+      totalMatches: 4,
+      strategy: "first",
+    };
+
+    function stubRefreshedSelection(tap: TapOnElement, selection: ElementSelectionResult): void {
+      (tap as any).refreshViewHierarchy = async () => makeHierarchy();
+      (tap as any).findElementInHierarchy = () => ({ selection, containerFound: false });
+      (tap as any).resolveTapTargetElement = (el: Element) => ({ element: el, usedParent: false });
+    }
+
+    test("ok result exposes the refreshed selection, not the pre-refresh one", async () => {
+      const { tap } = createTapOnElement();
+      stubRefreshedSelection(tap, FRESH_SELECTION);
+
+      const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+        { text: "Contact Name", action: "tap" },
+        { screenSize: { width: 1080, height: 1920 } },
+        "tap",
+        false,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.selection).toBe(FRESH_SELECTION);
+      expect(result.selection.indexInMatches).toBe(3);
+      expect(result.selection.totalMatches).toBe(4);
+      expect(result.selection.element.bounds).toEqual(FRESH_BOUNDS);
+    });
+
+    test("metadata rebuilt from the refreshed selection reflects the tapped node, not stale positional fields", async () => {
+      const { tap } = createTapOnElement();
+      stubRefreshedSelection(tap, FRESH_SELECTION);
+
+      const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+        { text: "Contact Name", action: "tap" },
+        { screenSize: { width: 1080, height: 1920 } },
+        "tap",
+        false,
+      );
+
+      const stale = (tap as any).buildSelectedElementMetadata(STALE_SELECTION);
+      const rebuilt = (tap as any).buildSelectedElementMetadata(result.selection);
+
+      // The fix must yield the refreshed positional fields...
+      expect(rebuilt.indexInMatches).toBe(3);
+      expect(rebuilt.totalMatches).toBe(4);
+      expect(rebuilt.bounds.left).toBe(FRESH_BOUNDS.left);
+      expect(rebuilt.bounds.top).toBe(FRESH_BOUNDS.top);
+      // ...which must differ from the stale pre-refresh metadata it replaces.
+      expect(rebuilt.indexInMatches).not.toBe(stale.indexInMatches);
+      expect(rebuilt.totalMatches).not.toBe(stale.totalMatches);
+      expect(rebuilt.bounds.top).not.toBe(stale.bounds.top);
+    });
   });
 });


### PR DESCRIPTION
## Summary

When Android pre-tap stability runs (`preTapStability`, or implicitly via `ensureTap`), `TapOnElement.execute` built `selectedElement` from the **initial** selection, then `resolveAndroidStableTapTargetAfterRefreshes` re-resolved the tap target against a **refreshed** hierarchy and tapped that node. `selectedElement` was not rebuilt, so on a dynamic/reordered hierarchy the reported `bounds`, `indexInMatches`, and `totalMatches` could describe the pre-refresh node while the tap actually hit the refreshed one.

This makes the metadata contract from [#5877](https://github.com/kaeawc/auto-mobile/pull/5877) honest for the pre-tap-stability path: the helper now carries the refreshed `ElementSelectionResult` out, and `execute` rebuilds `selectedElement` from it when the stability path ran.

## Linked Issue

Closes #5888

## Bug / Regression Context

- **Prior attempts:** [#5877](https://github.com/kaeawc/auto-mobile/pull/5877) made `selectedElement` load-bearing (naming matched identity/count/index) but deliberately deferred the pre-tap-stability staleness, flagged by a reviewer.
- **Observed symptom:** reported `bounds`/`indexInMatches`/`totalMatches` drift from the node actually tapped on a reordered/dynamic hierarchy; the matched identity stayed correct (same selector re-finds the node), only positional fields drifted.
- **Repro conditions:** `tapOn` with `preTapStability`/`ensureTap` on Android against a list that reorders between the initial observe and the stability re-resolution.

## Changes

- `resolveAndroidStableTapTargetAfterRefreshes` return shape gains `selection: ElementSelectionResult` (the refreshed find), stored alongside `tapElement`/`viewHierarchy`/`usedParent`.
- `execute` rebuilds `selectedElementMetadata` from `stable.selection` after the stability block (falls back to the initial metadata if the refreshed selection has no element).

## Validation

- [x] `bun test` — full suite green except two pre-existing, unrelated env failures (`webrtcDeviceCaptureLatency` integration test; `oxlintConfigScoping` missing `node_modules/.bin/oxlint` in the worktree)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use interfaces + fakes + FakeTimer; run in <100ms
- [x] oxlint: no new ratchet violations (file counts unchanged)

## Acceptance criteria

- [x] The refreshed `ElementSelectionResult` is carried out of `resolveAndroidStableTapTargetAfterRefreshes` — pinned by `TapOnElement.preTapStability.test.ts` ("ok result exposes the refreshed selection").
- [x] `selectedElement` metadata is rebuilt from the refreshed selection so positional fields match the tapped node — pinned by the drift-correction test in the same file.

## Device Verification

- [ ] Not run — behavior is metadata accuracy on a dynamic hierarchy; unit tests pin the data-flow. Real-device confirmation is a reasonable follow-up during manual-test.