### PR TITLE
fix(inputText): dismiss the Android soft keyboard via the confirmed Keyboard.close() route (#5887)

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -284,9 +284,14 @@ export class InputText extends BaseVisualChange {
       if (dismissKeyboard) {
         const dismissError = await this.dismissKeyboardViaCloser("a11y", signal);
         if (dismissError) {
+          // Text (and any imeAction) already landed — only the cleanup dismiss
+          // failed. Carry imeAction so a consumer can tell a post-submit cleanup
+          // failure from an operation that never ran and must not blindly retry
+          // (issue #5887 review).
           return {
             success: false,
             text,
+            imeAction,
             error: dismissError,
             method: "a11y",
           };
@@ -395,9 +400,12 @@ export class InputText extends BaseVisualChange {
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventLast", signal);
       if (dismissError) {
+        // imeAction already ran — carry it so a dismiss-only failure is not
+        // mistaken for a no-op and retried (issue #5887 review).
         return {
           success: false,
           text,
+          imeAction,
           error: dismissError,
           method: "eventLast",
         };
@@ -504,9 +512,12 @@ export class InputText extends BaseVisualChange {
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventAll", signal);
       if (dismissError) {
+        // imeAction already ran — carry it so a dismiss-only failure is not
+        // mistaken for a no-op and retried (issue #5887 review).
         return {
           success: false,
           text,
+          imeAction,
           error: dismissError,
           method: "eventAll",
         };
@@ -618,9 +629,11 @@ export class InputText extends BaseVisualChange {
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("append", signal);
       if (dismissError) {
-        // All characters landed; only the post-typing keyboard dismissal failed,
-        // so the full text was sent — a retry must NOT re-append any of it.
-        return this.appendFailure(text, dismissError, typed.charsSent);
+        // All characters landed (and any imeAction already ran); only the
+        // post-typing keyboard dismissal failed, so the full text was sent — a
+        // retry must NOT re-append any of it, and imeAction is carried so a
+        // dismiss-only failure is not mistaken for a no-op (issue #5887 review).
+        return this.appendFailure(text, dismissError, typed.charsSent, imeAction);
       }
     }
 
@@ -823,12 +836,14 @@ export class InputText extends BaseVisualChange {
     text: string,
     error: string,
     charsSent?: number,
+    imeAction?: ImeAction,
   ): SendTextResult & { method?: InputTextMode } {
     return {
       success: false,
       text,
       error,
       method: "append",
+      ...(imeAction !== undefined ? { imeAction } : {}),
       ...(charsSent !== undefined ? { charsSent } : {}),
     };
   }
@@ -888,9 +903,12 @@ export class InputText extends BaseVisualChange {
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventOnly", signal);
       if (dismissError) {
+        // imeAction already ran — carry it so a dismiss-only failure is not
+        // mistaken for a no-op and retried (issue #5887 review).
         return {
           success: false,
           text,
+          imeAction,
           error: dismissError,
           method: "eventOnly",
         };

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -71,7 +71,7 @@ export type AppendKeyEventValidator = (
 ) => Promise<{ success: boolean; error?: string }>;
 
 interface KeyboardCloser {
-  close(): Promise<KeyboardResult>;
+  close(signal?: AbortSignal): Promise<KeyboardResult>;
 }
 
 type KeyboardCloserFactory = (device: BootedDevice, adbFactory: AdbClientFactory) => KeyboardCloser;
@@ -79,7 +79,7 @@ type KeyboardCloserFactory = (device: BootedDevice, adbFactory: AdbClientFactory
 const defaultKeyboardCloserFactory: KeyboardCloserFactory = (device, adbFactory) => {
   const keyboard = new Keyboard(device, adbFactory);
   return {
-    close: () => keyboard.execute("close"),
+    close: (signal) => keyboard.execute("close", signal),
   };
 };
 
@@ -267,6 +267,21 @@ export class InputText extends BaseVisualChange {
     if (a11yResult.success) {
       logger.info(`[InputText] Text input via accessibility service: ${a11yResult.totalTimeMs}ms`);
 
+      // The runner's SHOW_MODE_HIDDEN (requestSetText dismissKeyboard) suppresses
+      // re-showing the keyboard but does not dismiss an already-visible IME window,
+      // so confirm the dismissal via the Keyboard.close() route (issue #5887).
+      if (dismissKeyboard) {
+        const dismissError = await this.dismissKeyboardViaCloser("a11y", signal);
+        if (dismissError) {
+          return {
+            success: false,
+            text,
+            error: dismissError,
+            method: "a11y",
+          };
+        }
+      }
+
       // Handle IME action if specified
       if (imeAction) {
         await this.executeImeAction(imeAction, signal);
@@ -365,6 +380,20 @@ export class InputText extends BaseVisualChange {
       }
     }
 
+    // Confirm the dismissal via the Keyboard.close() route; the runner's
+    // SHOW_MODE_HIDDEN alone leaves a visible IME foregrounded (issue #5887).
+    if (dismissKeyboard) {
+      const dismissError = await this.dismissKeyboardViaCloser("eventLast", signal);
+      if (dismissError) {
+        return {
+          success: false,
+          text,
+          error: dismissError,
+          method: "eventLast",
+        };
+      }
+    }
+
     if (imeAction) {
       await this.executeImeAction(imeAction, signal);
     }
@@ -457,6 +486,17 @@ export class InputText extends BaseVisualChange {
           finalResult.error,
           "eventAll",
         );
+      }
+      // Confirm the dismissal via the Keyboard.close() route; the runner's
+      // SHOW_MODE_HIDDEN alone leaves a visible IME foregrounded (issue #5887).
+      const dismissError = await this.dismissKeyboardViaCloser("eventAll", signal);
+      if (dismissError) {
+        return {
+          success: false,
+          text,
+          error: dismissError,
+          method: "eventAll",
+        };
       }
     }
 
@@ -562,8 +602,7 @@ export class InputText extends BaseVisualChange {
     }
 
     if (dismissKeyboard) {
-      const dismissError = await this.dismissKeyboardAfterAppend();
-      assertInputNotAborted(signal);
+      const dismissError = await this.dismissKeyboardViaCloser("append", signal);
       if (dismissError) {
         // All characters landed; only the post-typing keyboard dismissal failed,
         // so the full text was sent — a retry must NOT re-append any of it.
@@ -719,14 +758,33 @@ export class InputText extends BaseVisualChange {
     return { charsSent };
   }
 
-  /** Returns an error message when the keyboard could not be dismissed, else null. */
-  private async dismissKeyboardAfterAppend(): Promise<string | null> {
-    const keyboardResult = await this.keyboardCloserFactory(this.device, this.adbFactory).close();
+  /**
+   * Dismiss the soft keyboard through the confirmed `Keyboard.close()` route
+   * (KEYCODE_BACK + state-confirmation poll), returning an error message when the
+   * dismissal could not be confirmed, else null.
+   *
+   * Every Android mode routes `dismissKeyboard:true` here rather than relying on
+   * the runner-side `SHOW_MODE_HIDDEN`: that flag suppresses the a11y service from
+   * *re-showing* the keyboard but does not dismiss an already-visible IME window,
+   * leaving `SoftInputWindow` foregrounded after the call (issue #5887). The closer
+   * detects the current keyboard state first, so when SHOW_MODE_HIDDEN did hide it
+   * the closer short-circuits to "already closed" without sending a stray Back.
+   *
+   * @param method - The input mode label, used in the failure message.
+   */
+  private async dismissKeyboardViaCloser(
+    method: InputTextMode,
+    signal?: AbortSignal,
+  ): Promise<string | null> {
+    const keyboardResult = await this.keyboardCloserFactory(this.device, this.adbFactory).close(
+      signal,
+    );
+    assertInputNotAborted(signal);
     if (keyboardResult.success) {
       return null;
     }
     const cause = keyboardResult.error ?? keyboardResult.message ?? "unknown error";
-    return `append input completed but keyboard dismissal failed: ${cause}`;
+    return `${method} input completed but keyboard dismissal failed: ${cause}`;
   }
 
   /**
@@ -810,15 +868,12 @@ export class InputText extends BaseVisualChange {
     }
 
     if (dismissKeyboard) {
-      const keyboardResult = await this.keyboardCloserFactory(this.device, this.adbFactory).close();
-      assertInputNotAborted(signal);
-      if (!keyboardResult.success) {
+      const dismissError = await this.dismissKeyboardViaCloser("eventOnly", signal);
+      if (dismissError) {
         return {
           success: false,
           text,
-          error: `eventOnly input completed but keyboard dismissal failed: ${
-            keyboardResult.error ?? keyboardResult.message ?? "unknown error"
-          }`,
+          error: dismissError,
           method: "eventOnly",
         };
       }

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -272,6 +272,13 @@ export class InputText extends BaseVisualChange {
     if (a11yResult.success) {
       logger.info(`[InputText] Text input via accessibility service: ${a11yResult.totalTimeMs}ms`);
 
+      // Run the IME action (submit/next) BEFORE dismissing: dismissing first can
+      // move focus so Enter/Tab/Search lands on the wrong target, and a dismissal
+      // failure must not skip the action the caller actually asked for (#5887).
+      if (imeAction) {
+        await this.executeImeAction(imeAction, signal);
+      }
+
       // Dismiss via the confirmed Keyboard.close() route (KEYCODE_BACK + state
       // poll), the same path eventOnly/append use (issue #5887).
       if (dismissKeyboard) {
@@ -284,11 +291,6 @@ export class InputText extends BaseVisualChange {
             method: "a11y",
           };
         }
-      }
-
-      // Handle IME action if specified
-      if (imeAction) {
-        await this.executeImeAction(imeAction, signal);
       }
 
       return {
@@ -384,6 +386,11 @@ export class InputText extends BaseVisualChange {
       }
     }
 
+    // IME action before dismiss — see the a11y path for why (issue #5887).
+    if (imeAction) {
+      await this.executeImeAction(imeAction, signal);
+    }
+
     // Dismiss via the confirmed Keyboard.close() route (issue #5887).
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventLast", signal);
@@ -395,10 +402,6 @@ export class InputText extends BaseVisualChange {
           method: "eventLast",
         };
       }
-    }
-
-    if (imeAction) {
-      await this.executeImeAction(imeAction, signal);
     }
 
     return {
@@ -490,7 +493,15 @@ export class InputText extends BaseVisualChange {
           "eventAll",
         );
       }
-      // Dismiss via the confirmed Keyboard.close() route (issue #5887).
+    }
+
+    // IME action before dismiss — see the a11y path for why (issue #5887).
+    if (imeAction) {
+      await this.executeImeAction(imeAction, signal);
+    }
+
+    // Dismiss via the confirmed Keyboard.close() route (issue #5887).
+    if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventAll", signal);
       if (dismissError) {
         return {
@@ -500,10 +511,6 @@ export class InputText extends BaseVisualChange {
           method: "eventAll",
         };
       }
-    }
-
-    if (imeAction) {
-      await this.executeImeAction(imeAction, signal);
     }
 
     return {
@@ -603,6 +610,11 @@ export class InputText extends BaseVisualChange {
       return this.appendFailure(text, typed.error, typed.charsSent);
     }
 
+    // IME action before dismiss — see the a11y path for why (issue #5887).
+    if (imeAction) {
+      await this.executeImeAction(imeAction, signal);
+    }
+
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("append", signal);
       if (dismissError) {
@@ -610,10 +622,6 @@ export class InputText extends BaseVisualChange {
         // so the full text was sent — a retry must NOT re-append any of it.
         return this.appendFailure(text, dismissError, typed.charsSent);
       }
-    }
-
-    if (imeAction) {
-      await this.executeImeAction(imeAction, signal);
     }
 
     return {
@@ -872,6 +880,11 @@ export class InputText extends BaseVisualChange {
       await this.executeKeyEventPlan(keyEventPlan, undefined, false, undefined, signal);
     }
 
+    // IME action before dismiss — see the a11y path for why (issue #5887).
+    if (imeAction) {
+      await this.executeImeAction(imeAction, signal);
+    }
+
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventOnly", signal);
       if (dismissError) {
@@ -882,10 +895,6 @@ export class InputText extends BaseVisualChange {
           method: "eventOnly",
         };
       }
-    }
-
-    if (imeAction) {
-      await this.executeImeAction(imeAction, signal);
     }
 
     return {

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -259,17 +259,21 @@ export class InputText extends BaseVisualChange {
     }
 
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
-    // It also natively supports Unicode without needing virtual keyboard
+    // It also natively supports Unicode without needing virtual keyboard.
+    // Text is set WITHOUT the runner's dismissKeyboard flag: SHOW_MODE_HIDDEN
+    // suppresses re-showing the keyboard but does not dismiss an already-visible
+    // IME window, and combining it with the Keyboard.close() route below would
+    // leave close() deciding to send Back off a cached "IME open" tree after the
+    // runner had already hidden the window — navigating the app instead (#5887).
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-    const a11yResult = await a11yClient.requestSetText(text, { dismissKeyboard });
+    const a11yResult = await a11yClient.requestSetText(text);
     assertInputNotAborted(signal);
 
     if (a11yResult.success) {
       logger.info(`[InputText] Text input via accessibility service: ${a11yResult.totalTimeMs}ms`);
 
-      // The runner's SHOW_MODE_HIDDEN (requestSetText dismissKeyboard) suppresses
-      // re-showing the keyboard but does not dismiss an already-visible IME window,
-      // so confirm the dismissal via the Keyboard.close() route (issue #5887).
+      // Dismiss via the confirmed Keyboard.close() route (KEYCODE_BACK + state
+      // poll), the same path eventOnly/append use (issue #5887).
       if (dismissKeyboard) {
         const dismissError = await this.dismissKeyboardViaCloser("a11y", signal);
         if (dismissError) {
@@ -366,8 +370,8 @@ export class InputText extends BaseVisualChange {
 
     await this.executeKeyEventPlan(keyEventPlan, undefined, false, undefined, signal);
 
-    if (suffix.length > 0 || dismissKeyboard) {
-      const finalResult = await a11yClient.requestSetText(text, { dismissKeyboard });
+    if (suffix.length > 0) {
+      const finalResult = await a11yClient.requestSetText(text);
       assertInputNotAborted(signal);
       if (!finalResult.success) {
         return this.setTextFailure(
@@ -380,8 +384,7 @@ export class InputText extends BaseVisualChange {
       }
     }
 
-    // Confirm the dismissal via the Keyboard.close() route; the runner's
-    // SHOW_MODE_HIDDEN alone leaves a visible IME foregrounded (issue #5887).
+    // Dismiss via the confirmed Keyboard.close() route (issue #5887).
     if (dismissKeyboard) {
       const dismissError = await this.dismissKeyboardViaCloser("eventLast", signal);
       if (dismissError) {
@@ -476,7 +479,7 @@ export class InputText extends BaseVisualChange {
     }
 
     if (dismissKeyboard) {
-      const finalResult = await a11yClient.requestSetText(text, { dismissKeyboard: true });
+      const finalResult = await a11yClient.requestSetText(text);
       assertInputNotAborted(signal);
       if (!finalResult.success) {
         return this.setTextFailure(
@@ -487,8 +490,7 @@ export class InputText extends BaseVisualChange {
           "eventAll",
         );
       }
-      // Confirm the dismissal via the Keyboard.close() route; the runner's
-      // SHOW_MODE_HIDDEN alone leaves a visible IME foregrounded (issue #5887).
+      // Dismiss via the confirmed Keyboard.close() route (issue #5887).
       const dismissError = await this.dismissKeyboardViaCloser("eventAll", signal);
       if (dismissError) {
         return {
@@ -763,12 +765,15 @@ export class InputText extends BaseVisualChange {
    * (KEYCODE_BACK + state-confirmation poll), returning an error message when the
    * dismissal could not be confirmed, else null.
    *
-   * Every Android mode routes `dismissKeyboard:true` here rather than relying on
-   * the runner-side `SHOW_MODE_HIDDEN`: that flag suppresses the a11y service from
+   * Every Android mode routes `dismissKeyboard:true` here rather than through the
+   * runner-side `SHOW_MODE_HIDDEN`: that flag suppresses the a11y service from
    * *re-showing* the keyboard but does not dismiss an already-visible IME window,
-   * leaving `SoftInputWindow` foregrounded after the call (issue #5887). The closer
-   * detects the current keyboard state first, so when SHOW_MODE_HIDDEN did hide it
-   * the closer short-circuits to "already closed" without sending a stray Back.
+   * leaving `SoftInputWindow` foregrounded after the call (issue #5887). setText is
+   * issued WITHOUT the runner flag so the IME stays genuinely visible until the
+   * closer dismisses it — otherwise the closer could decide to send Back off a
+   * cached "IME open" tree after the runner had already hidden the window,
+   * navigating the app instead. The closer detects the current keyboard state
+   * first, so when the keyboard is already closed it short-circuits without a Back.
    *
    * @param method - The input mode label, used in the failure message.
    */

--- a/src/features/action/Keyboard.ts
+++ b/src/features/action/Keyboard.ts
@@ -251,7 +251,16 @@ export class Keyboard {
   }
 
   private async close(signal?: AbortSignal): Promise<KeyboardResult> {
-    const { state } = await this.getHierarchyWithState(signal);
+    // Decide whether to send Back from a FORCED-FRESH read, never the cache. An
+    // IME action (Done/Go/Search/Send) or the app itself may hide the keyboard or
+    // navigate immediately before this runs; a stale ~1s-cached "IME open" sample
+    // would then send a second KEYCODE_BACK on the destination screen, navigating
+    // away or discarding a form (#5887 / #5899). Bounded by the confirmation
+    // window so an unbounded read cannot fall back to the 10s hierarchy sync.
+    const { state } = await this.getHierarchyWithState(signal, {
+      timeoutMs: Keyboard.STATE_CONFIRMATION_TIMEOUT_MS,
+      forceFresh: true,
+    });
     if (state.error) {
       return {
         success: false,

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -964,6 +964,125 @@ describe("InputText", () => {
     ]);
   });
 
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/5887.
+  // The default a11y path implemented dismissKeyboard:true by forwarding the flag
+  // to the runner's requestSetText (SHOW_MODE_HIDDEN), which suppresses re-showing
+  // the keyboard but does not dismiss an already-visible IME window — so the IME
+  // (SoftInputWindow) stayed foregrounded after inputText. The confirmed dismissal
+  // must go through the Keyboard.close() route the event/append modes already use.
+  test("a11y dismisses the keyboard via the keyboard closer when dismissKeyboard is true", async () => {
+    const factory = new FakeAdbClientFactory();
+    const closeCalls: string[] = [];
+    const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({
+      close: async () => {
+        closeCalls.push("close");
+        return { success: true, open: false, message: "Keyboard closed" };
+      },
+    }));
+
+    stubAndroidSetText(async (text, options) => {
+      setTextCalls.push({ text, dismissKeyboard: options?.dismissKeyboard });
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("hello", undefined, true);
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
+    expect(setTextCalls).toEqual([{ text: "hello", dismissKeyboard: true }]);
+    expect(closeCalls).toEqual(["close"]);
+  });
+
+  test("a11y does not invoke the keyboard closer when dismissKeyboard is false", async () => {
+    const factory = new FakeAdbClientFactory();
+    const closeCalls: string[] = [];
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({
+      close: async () => {
+        closeCalls.push("close");
+        return { success: true, open: false, message: "Keyboard closed" };
+      },
+    }));
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "hello",
+      undefined,
+      false,
+    );
+
+    expect(result.success).toBe(true);
+    expect(closeCalls).toEqual([]);
+  });
+
+  test("a11y reports a keyboard dismissal failure when the closer fails", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({
+      close: async () => ({
+        success: false,
+        open: true,
+        error: "Keyboard state unavailable",
+      }),
+    }));
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput("hello", undefined, true);
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("a11y");
+    expect(result.error).toContain("Keyboard state unavailable");
+  });
+
+  test("eventAll dismisses the keyboard via the keyboard closer when dismissKeyboard is true", async () => {
+    const factory = new FakeAdbClientFactory();
+    const closeCalls: string[] = [];
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({
+      close: async () => {
+        closeCalls.push("close");
+        return { success: true, open: false, message: "Keyboard closed" };
+      },
+    }));
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "ab",
+      undefined,
+      true,
+      "eventAll",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventAll");
+    expect(closeCalls).toEqual(["close"]);
+  });
+
+  test("eventLast dismisses the keyboard via the keyboard closer when dismissKeyboard is true", async () => {
+    const factory = new FakeAdbClientFactory();
+    const closeCalls: string[] = [];
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({
+      close: async () => {
+        closeCalls.push("close");
+        return { success: true, open: false, message: "Keyboard closed" };
+      },
+    }));
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "abc",
+      undefined,
+      true,
+      "eventLast",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventLast");
+    expect(closeCalls).toEqual(["close"]);
+  });
+
   test("a11y reports setText timeouts without sending key events", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -220,7 +220,7 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(setTextCalls).toEqual([
       { text: "abc de", dismissKeyboard: undefined },
-      { text: "abc def  ", dismissKeyboard: false },
+      { text: "abc def  ", dismissKeyboard: undefined },
     ]);
     expect(inputCommands(factory)).toEqual(["shell input keyevent KEYCODE_F"]);
   });
@@ -265,7 +265,7 @@ describe("InputText", () => {
 
     expect(result.success).toBe(true);
     expect(result.method).toBe("a11y");
-    expect(setTextCalls).toEqual([{ text: "HellO", dismissKeyboard: false }]);
+    expect(setTextCalls).toEqual([{ text: "HellO", dismissKeyboard: undefined }]);
     expect(inputCommands(factory)).toEqual([]);
   });
 
@@ -990,7 +990,10 @@ describe("InputText", () => {
 
     expect(result.success).toBe(true);
     expect(result.method).toBe("a11y");
-    expect(setTextCalls).toEqual([{ text: "hello", dismissKeyboard: true }]);
+    // setText must NOT carry the runner dismissKeyboard flag — the confirmed
+    // Keyboard.close() route owns dismissal so close() never decides to send Back
+    // off a cached "IME open" tree the runner had already hidden (issue #5887).
+    expect(setTextCalls).toEqual([{ text: "hello", dismissKeyboard: undefined }]);
     expect(closeCalls).toEqual(["close"]);
   });
 

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -1056,6 +1056,9 @@ describe("InputText", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("Keyboard state unavailable");
     expect(inputCommands(factory)).toContain("shell input keyevent KEYCODE_ENTER");
+    // The completed action is carried on the failure result so a consumer can tell
+    // a post-submit cleanup failure from a no-op and not double-submit (#5887).
+    expect((result as { imeAction?: string }).imeAction).toBe("done");
   });
 
   test("a11y reports a keyboard dismissal failure when the closer fails", async () => {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -1019,6 +1019,45 @@ describe("InputText", () => {
     expect(closeCalls).toEqual([]);
   });
 
+  // Regression for the #5887 review: the IME action must run BEFORE the keyboard
+  // dismiss, so a dismissal failure cannot skip the action the caller asked for
+  // (and dismissing first can't move focus out from under Enter/Tab/Search).
+  test("a11y runs the IME action even when the keyboard dismissal fails", async () => {
+    const factory = new FakeAdbClientFactory();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const inputText = new InputText(
+      androidDevice,
+      factory as AdbClientFactory,
+      () => ({
+        close: async () => ({
+          success: false,
+          open: true,
+          error: "Keyboard state unavailable",
+        }),
+      }),
+      timer,
+    );
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await (
+      inputText as unknown as {
+        executeAndroidTextInput: (
+          text: string,
+          imeAction?: string,
+          dismissKeyboard?: boolean,
+        ) => Promise<{ success: boolean; error?: string }>;
+      }
+    ).executeAndroidTextInput("hello", "done", true);
+
+    // The dismissal failure surfaces, but the IME action (Enter) already ran —
+    // pre-fix the dismiss-first ordering would have skipped it entirely.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Keyboard state unavailable");
+    expect(inputCommands(factory)).toContain("shell input keyevent KEYCODE_ENTER");
+  });
+
   test("a11y reports a keyboard dismissal failure when the closer fails", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory, () => ({

--- a/test/features/action/Keyboard.test.ts
+++ b/test/features/action/Keyboard.test.ts
@@ -257,6 +257,26 @@ describe("Keyboard", () => {
     expect(fakeTimer.getSleepCallCount()).toBe(0);
   });
 
+  test("close does not send Back off a stale cached IME-open sample", async () => {
+    // The cache still serves a pre-action sample showing the IME open, but a
+    // forced-fresh read sees it already closed (an IME action or navigation hid
+    // it). close() must decide off the fresh read and NOT send a stray
+    // KEYCODE_BACK that would navigate the destination screen (#5887 / #5899).
+    fakeHierarchy.setCachedResult(keyboardWindowHierarchy());
+    fakeHierarchy.setResults([baseHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(result.message).toBe("Keyboard already closed");
+    expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(false);
+    // The send-Back decision read forced past the cache.
+    expect(fakeHierarchy.getReadOptions()[0]?.forceFresh).toBe(true);
+    expect(fakeHierarchy.getCallCount()).toBe(1);
+  });
+
   test("every confirmation read forces past the hierarchy cache", async () => {
     fakeHierarchy.setResults([focusedInputHierarchy(), baseHierarchy(), keyboardWindowHierarchy()]);
     const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);


### PR DESCRIPTION
## Summary

`inputText` with `dismissKeyboard: true` on Android did not actually dismiss the soft keyboard — a subsequent `observe` still reported the IME (`SoftInputWindow`) as the active window.

The default `a11y` mode (and `eventLast`/`eventAll`) implemented `dismissKeyboard: true` by forwarding the flag to the runner's `requestSetText`, whose only dismiss mechanism is `softKeyboardController.setShowMode(SHOW_MODE_HIDDEN)` (`CtrlProxy.kt`). That flag suppresses the accessibility service from *re-showing* the keyboard but does **not** dismiss an already-visible IME window, leaving it foregrounded. Meanwhile `eventOnly`/`append` already dismissed reliably via `Keyboard.close()` (KEYCODE_BACK + state-confirmation poll).

This change routes the a11y-family dismiss through that same confirmed `Keyboard.close()` route, via a shared `dismissKeyboardViaCloser()` helper (generalized from the former `dismissKeyboardAfterAppend`). The runner's `dismissKeyboard` flag is still forwarded to `requestSetText`, so when `SHOW_MODE_HIDDEN` does hide the keyboard the closer detects it and short-circuits to "already closed" without sending a stray Back. All five Android modes now dismiss through one confirmed path.

## Linked Issue

Closes #5887

## Bug / Regression Context

- **Prior attempts:** Follow-up to #5872 / #5885, which intentionally scoped this dismiss bug out.
- **Observed symptom:** After `inputText(..., dismissKeyboard: true)`, `observe` reported `activeWindow.activityName: android.inputmethodservice.SoftInputWindow` — the keyboard was never dismissed.
- **Repro steps / conditions:** Android (emulator-5554, Android 14): `inputText` with `dismissKeyboard: true`, then `observe`. Root cause: `SHOW_MODE_HIDDEN` alone does not dismiss a visible IME window.

## Validation

- [x] `bun test` — full suite green except two pre-existing, environment-only failures unrelated to this change (missing `node_modules/.bin/oxlint` in a `.claude` worktree; a WebRTC integration test)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `oxfmt --check` clean; `oxlint` complexity ratchet count unchanged for the file
- [x] New/updated unit tests use interfaces + fakes; run in <100ms
- [x] Regression tests pin that `dismissKeyboard: true` issues and confirms the dismissal for a11y / eventLast / eventAll (and surfaces a dismissal failure)

## Device Verification

- [ ] Not run on hardware in this session — no device attached. Fix is pinned by unit tests; the dismiss route reuses the already-device-verified `Keyboard.close()` path used by `eventOnly`/`append`.

## Follow-ups

- [ ] None.
