### PR TITLE
feat(tools): extend skeleton-default + raw/project opt-out to all observation-producing action tools (#5886)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -418,6 +418,15 @@
           "description": "SDK override TTL ms (default 5000)",
           "type": "number"
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
@@ -628,6 +637,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -1055,6 +1073,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -2373,6 +2400,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -2477,6 +2513,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -6898,6 +6943,15 @@
           "required": ["quietPeriodMs"],
           "additionalProperties": false
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -7050,6 +7104,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -7167,6 +7230,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -7467,6 +7539,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -7638,6 +7719,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -7664,6 +7754,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -8227,6 +8326,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -8557,6 +8665,15 @@
           "type": "string",
           "enum": ["android", "ios"]
         },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -8615,6 +8732,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -8698,6 +8824,15 @@
         "platform": {
           "type": "string",
           "enum": ["android", "ios"]
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -10645,6 +10780,15 @@
       "properties": {
         "appId": {
           "type": "string"
+        },
+        "raw": {
+          "description": "Return the raw view hierarchy instead of the compact skeleton",
+          "type": "boolean"
+        },
+        "project": {
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "type": "string",
+          "enum": ["full", "skeleton"]
         },
         "platform": {
           "type": "string",

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -98,6 +98,18 @@ export const packageNameSchema = withAppIdAliases(
   ),
 );
 
+// terminateApp embeds a post-action observation, so it carries the same
+// response-shape control as the other action tools (issue #5886): the embedded
+// observation defaults to the compact skeleton, opt-out-able via raw/project.
+export const terminateAppSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      ...responseShapeControlFields,
+    }),
+  ),
+);
+
 export const launchAppSchema = withAppIdAliases(
   addDeviceTargetingToSchema(
     z.object({
@@ -527,7 +539,7 @@ export function registerAppTools() {
   ToolRegistry.registerDeviceAware(
     "terminateApp",
     "Terminate app by package name",
-    packageNameSchema,
+    terminateAppSchema,
     terminateAppHandler,
     { defaultEnabled: true },
   );

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -3,7 +3,7 @@ import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { BiometricAuth, BiometricAuthOptions } from "../features/action/BiometricAuth";
 import { ActionableError, BootedDevice } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, responseShapeControlFields } from "./toolSchemaHelpers";
 import { computeIosSimulatorCapabilities } from "../features/utility/iosSimulatorCapabilities";
 import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
 import { DaemonState } from "../daemon/daemonState";
@@ -35,6 +35,7 @@ export const biometricAuthSchema = addDeviceTargetingToSchema(
         .describe("Fingerprint ID: default 1 for match/error, 2 for fail/cancel"),
       errorCode: z.number().optional().describe("BiometricPrompt error code; action=error only"),
       ttlMs: z.number().optional().describe("SDK override TTL ms (default 5000)"),
+      ...responseShapeControlFields,
     })
     .refine((data) => data.errorCode === undefined || data.action === "error", {
       message: "errorCode is only applicable when action is 'error'",

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -111,18 +111,37 @@ function classifyObservationAction(
 
 /**
  * Action tools that embed a post-action observation AND expose the `raw`/`project`
- * response-shape control (issue #5872). Their embedded observation defaults to the
- * compact skeleton, opt-out-able per call. The default is scoped to exactly the
- * tools that carry the opt-out so the two never diverge: a tool that skeletonizes
- * by default but cannot be asked for the raw tree would be a silent one-way door.
- * Extending both to every observation-producing action tool is tracked as a
- * follow-up. `observe` is not here — it owns the projection at the payload top
- * level, not under `.observation`.
+ * response-shape control (issues #5872, #5886). Their embedded observation defaults
+ * to the compact skeleton, opt-out-able per call. The default is scoped to exactly
+ * the tools that carry the opt-out so the two never diverge: a tool that
+ * skeletonizes by default but cannot be asked for the raw tree would be a silent
+ * one-way door. #5872 shipped the first three; #5886 extends both the default and
+ * the opt-out to every remaining observation-producing action tool, together.
+ * Membership is bound to the advertised opt-out by an anti-divergence test
+ * (test/server/tools/schema.test.ts) so the two can never diverge in CI.
+ * `observe` is not here — it owns the projection at the payload top level, not
+ * under `.observation`.
  */
-const SKELETON_DEFAULT_ACTION_TOOLS: ReadonlySet<string> = new Set([
+export const SKELETON_DEFAULT_ACTION_TOOLS: ReadonlySet<string> = new Set([
   "tapOn",
   "inputText",
   "launchApp",
+  "tapAny",
+  "dragAndDrop",
+  "clearText",
+  "selectAllText",
+  "pressButton",
+  "systemTray",
+  "swipeOn",
+  "pinchOn",
+  "openLink",
+  "shake",
+  "imeAction",
+  "recentApps",
+  "homeScreen",
+  "rotate",
+  "terminateApp",
+  "biometricAuth",
 ]);
 
 /**

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -144,6 +144,7 @@ export const shakeSchema = addDeviceTargetingToSchema(
     duration: z.number().optional().describe("Shake duration ms (default 1000)"),
     intensity: z.number().optional().describe("Shake intensity (Android; default 100)"),
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
@@ -374,6 +375,7 @@ export const tapAnySchema = withJsonSchemaOverride(
           .optional()
           .describe("Poll for clickable element before tapping"),
         platform: platformSchema,
+        ...responseShapeControlFields,
       })
       .strict(),
   ),
@@ -415,6 +417,7 @@ export const dragAndDropSchema = withJsonSchemaOverride(
         .optional()
         .describe("Hold duration ms (min: 100, max: 3000, default: 100)"),
       platform: platformSchema,
+      ...responseShapeControlFields,
     }),
   ),
   (js) => compactExclusiveSelectorProperties(js, ["source", "target"]),
@@ -453,6 +456,7 @@ export const swipeOnSchema = withJsonSchemaOverride(
         .describe("Speed multiplier for return swipe (0.1-3.0)"),
       speed: z.enum(["slow", "normal", "fast"]).optional().describe("Swipe speed preset"),
       platform: platformSchema,
+      ...responseShapeControlFields,
     }),
   ),
   (js) => compactExclusiveSelectorProperties(js, ["container", "lookFor"]),
@@ -479,6 +483,7 @@ export const pinchOnSchema = withJsonSchemaOverride(
       container: elementContainerSchema.optional().describe("Scope search to a container"),
       autoTarget: z.boolean().optional().describe("Auto-target pinchable containers"),
       platform: platformSchema,
+      ...responseShapeControlFields,
     }),
   ),
   (js) => compactExclusiveSelectorProperties(js, ["container"]),
@@ -487,12 +492,14 @@ export const pinchOnSchema = withJsonSchemaOverride(
 export const clearTextSchema = addDeviceTargetingToSchema(
   z.object({
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
 export const selectAllTextSchema = addDeviceTargetingToSchema(
   z.object({
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
@@ -500,6 +507,7 @@ export const pressButtonSchema = addDeviceTargetingToSchema(
   z.object({
     button: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"]),
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
@@ -520,6 +528,7 @@ const systemTraySchemaBase = z.object({
     .optional()
     .describe("Timeout in ms to wait for notification (default: 5000)"),
   platform: platformSchema,
+  ...responseShapeControlFields,
 });
 
 export const systemTraySchema = withAppIdAliases(
@@ -653,6 +662,7 @@ export const openLinkSchema = withAppIdAliases(
         settled: settledSchema
           .optional()
           .describe("After waitFor matches, wait for a quiet hierarchy period (requires waitFor)"),
+        ...responseShapeControlFields,
       }),
     ).superRefine(refineWaitForArgs),
     overrideWaitForJsonSchema,
@@ -700,18 +710,21 @@ export const imeActionSchema = addDeviceTargetingToSchema(
   z.object({
     action: z.enum(["done", "next", "search", "send", "go", "previous"]).describe("IME action"),
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
 export const recentAppsSchema = addDeviceTargetingToSchema(
   z.object({
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
 export const homeScreenSchema = addDeviceTargetingToSchema(
   z.object({
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 
@@ -719,6 +732,7 @@ export const rotateSchema = addDeviceTargetingToSchema(
   z.object({
     orientation: z.enum(["portrait", "landscape"]),
     platform: platformSchema,
+    ...responseShapeControlFields,
   }),
 );
 

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -236,16 +236,77 @@ describe("finalizeToolResponse", () => {
       expect(observation.skeleton).toBeUndefined();
     });
 
-    test("an action tool without the response-shape opt-out keeps the full hierarchy (no silent one-way skeleton)", () => {
-      // The skeleton default is scoped to the tools that also expose raw/project
-      // (tapOn/inputText/launchApp). A tool like swipeOn, which has no opt-out,
-      // must NOT be silently skeletonized — otherwise a client could never recover
-      // the raw tree from it. Broader coverage is a tracked follow-up.
+    // Issue #5886: the skeleton default + raw/project opt-out now extends to
+    // every observation-producing action tool, not just the original three.
+    // swipeOn is the representative extra tool named in the issue's test AC.
+    describe("extended to all observation-producing action tools (#5886)", () => {
+      test("swipeOn's observation defaults to the compact skeleton", () => {
+        const response = createStructuredToolResponse({
+          success: true,
+          observation: makeObserveResult(),
+        });
+        const finalized = finalizeToolResponse(response, { name: "swipeOn" });
+        const observation = (finalized.structuredContent as any).observation;
+        expect(Array.isArray(observation.skeleton)).toBe(true);
+        expect(observation.viewHierarchy).toBeUndefined();
+        expect(observation.elements).toBeUndefined();
+      });
+
+      test('swipeOn honors project:"full" back into the raw viewHierarchy', () => {
+        const response = createStructuredToolResponse({
+          success: true,
+          observation: makeObserveResult(),
+        });
+        const finalized = finalizeToolResponse(response, {
+          name: "swipeOn",
+          args: { project: "full" },
+        });
+        const observation = (finalized.structuredContent as any).observation;
+        expect(observation.viewHierarchy).toBeDefined();
+        expect(observation.skeleton).toBeUndefined();
+      });
+
+      test("swipeOn honors raw:true back into the raw viewHierarchy", () => {
+        const response = createStructuredToolResponse({
+          success: true,
+          observation: makeObserveResult(),
+        });
+        const finalized = finalizeToolResponse(response, {
+          name: "swipeOn",
+          args: { raw: true },
+        });
+        const observation = (finalized.structuredContent as any).observation;
+        expect(observation.viewHierarchy).toBeDefined();
+        expect(observation.skeleton).toBeUndefined();
+      });
+
+      // A representative sample of the newly-covered tools all skeletonize by
+      // default (the full roster is bound to the opt-out by the anti-divergence
+      // test in test/server/tools/schema.test.ts).
+      test.each(["dragAndDrop", "pressButton", "rotate", "homeScreen", "terminateApp"])(
+        "%s defaults its observation to the compact skeleton",
+        (toolName) => {
+          const response = createStructuredToolResponse({
+            success: true,
+            observation: makeObserveResult(),
+          });
+          const finalized = finalizeToolResponse(response, { name: toolName });
+          const observation = (finalized.structuredContent as any).observation;
+          expect(Array.isArray(observation.skeleton)).toBe(true);
+          expect(observation.viewHierarchy).toBeUndefined();
+        },
+      );
+    });
+
+    test("a tool NOT in the skeleton-default set keeps the full hierarchy", () => {
+      // The default remains scoped to the advertised set: a tool outside it (here
+      // a synthetic name that embeds an observation but never opts in) must NOT be
+      // silently skeletonized — the raw tree stays recoverable.
       const response = createStructuredToolResponse({
         success: true,
         observation: makeObserveResult(),
       });
-      const finalized = finalizeToolResponse(response, { name: "swipeOn" });
+      const finalized = finalizeToolResponse(response, { name: "someUncoveredTool" });
       const observation = (finalized.structuredContent as any).observation;
       expect(observation.viewHierarchy).toBeDefined();
       expect(observation.skeleton).toBeUndefined();

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -258,9 +258,8 @@ describe("MCP Tools Schema", () => {
   // one-way door (the footgun PR #5885 avoided). Every tool the finalize step
   // skeletonizes by default MUST therefore advertise the opt-out.
   test("every SKELETON_DEFAULT_ACTION_TOOLS member advertises the raw/project opt-out", async () => {
-    const { SKELETON_DEFAULT_ACTION_TOOLS } = await import(
-      "../../../src/server/finalizeToolResponse"
-    );
+    const { SKELETON_DEFAULT_ACTION_TOOLS } =
+      await import("../../../src/server/finalizeToolResponse");
     expect(SKELETON_DEFAULT_ACTION_TOOLS.size).toBeGreaterThan(0);
     for (const toolName of SKELETON_DEFAULT_ACTION_TOOLS) {
       const tool = ADVERTISED_TOOLS.find((t) => t.name === toolName);

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -220,18 +220,56 @@ describe("MCP Tools Schema", () => {
     expect(result.action).toBe("tap");
   });
 
-  // Issue #5872: the action tools gain observe's response-shape control so a
-  // client can opt out of the skeleton default back to the raw hierarchy.
-  test.each(["tapOn", "inputText", "launchApp"])(
-    "%s advertises the raw/project response-shape control",
-    async (toolName) => {
+  // Issue #5872 / #5886: every observation-producing action tool gains observe's
+  // response-shape control so a client can opt out of the skeleton default back
+  // to the raw hierarchy. #5872 shipped the first three; #5886 extends both the
+  // default and the opt-out to the full set (never one without the other).
+  test.each([
+    "tapOn",
+    "inputText",
+    "launchApp",
+    "tapAny",
+    "dragAndDrop",
+    "clearText",
+    "selectAllText",
+    "pressButton",
+    "systemTray",
+    "swipeOn",
+    "pinchOn",
+    "openLink",
+    "shake",
+    "imeAction",
+    "recentApps",
+    "homeScreen",
+    "rotate",
+    "terminateApp",
+    "biometricAuth",
+  ])("%s advertises the raw/project response-shape control", async (toolName) => {
+    const tool = ADVERTISED_TOOLS.find((t) => t.name === toolName);
+    expect(tool).toBeDefined();
+    const props = (tool!.inputSchema as any).properties ?? {};
+    expect(props.raw).toBeDefined();
+    expect(props.project).toBeDefined();
+  });
+
+  // Issue #5886: structural anti-divergence gate. The skeleton default and the
+  // raw/project opt-out must move together — a tool that skeletonizes its
+  // observation by default but cannot be asked for the raw tree is a silent
+  // one-way door (the footgun PR #5885 avoided). Every tool the finalize step
+  // skeletonizes by default MUST therefore advertise the opt-out.
+  test("every SKELETON_DEFAULT_ACTION_TOOLS member advertises the raw/project opt-out", async () => {
+    const { SKELETON_DEFAULT_ACTION_TOOLS } = await import(
+      "../../../src/server/finalizeToolResponse"
+    );
+    expect(SKELETON_DEFAULT_ACTION_TOOLS.size).toBeGreaterThan(0);
+    for (const toolName of SKELETON_DEFAULT_ACTION_TOOLS) {
       const tool = ADVERTISED_TOOLS.find((t) => t.name === toolName);
-      expect(tool).toBeDefined();
+      expect(tool, `${toolName} should be an advertised tool`).toBeDefined();
       const props = (tool!.inputSchema as any).properties ?? {};
-      expect(props.raw).toBeDefined();
-      expect(props.project).toBeDefined();
-    },
-  );
+      expect(props.raw, `${toolName} must advertise raw`).toBeDefined();
+      expect(props.project, `${toolName} must advertise project`).toBeDefined();
+    }
+  });
 
   test("inputText accepts a project override and a selector", async () => {
     const { inputTextSchema } = await import("../../../src/server/interactionTools");


### PR DESCRIPTION
## Summary

Follow-up to #5872 / #5885. #5872 made the embedded post-action `observation` default to the compact `skeleton` and added the `raw`/`project` opt-out, but PR #5885 deliberately scoped that to exactly three tools (`tapOn`, `inputText`, `launchApp`) so the default and its escape hatch could never diverge.

This PR extends **both** the skeleton default and the `raw`/`project` opt-out — together — to every remaining observation-producing action tool (16 of them): `tapAny`, `dragAndDrop`, `clearText`, `selectAllText`, `pressButton`, `systemTray`, `swipeOn`, `pinchOn`, `openLink`, `shake`, `imeAction`, `recentApps`, `homeScreen`, `rotate`, `terminateApp`, `biometricAuth`.

The one-way-door footgun #5885 warned about (a skeleton default with no way back to the raw tree) is now made *structurally* impossible by a CI-enforced anti-divergence test.

## Linked Issue

Closes #5886

## Changes

- **`src/server/toolSchemaHelpers.ts`** — unchanged; reuses the existing `responseShapeControlFields`.
- **`src/server/interactionTools.ts`, `appTools.ts`, `biometricTools.ts`** — spread `responseShapeControlFields` into each of the 16 tool schemas. `terminateApp` gets a dedicated `terminateAppSchema` (the shared `packageNameSchema` stays a plain package-name schema).
- **`src/server/finalizeToolResponse.ts`** — expand `SKELETON_DEFAULT_ACTION_TOOLS` to the full set and `export` it.
- **`schemas/tool-definitions.json`** — regenerated via `scripts/update-tool-definitions.sh`.

## Anti-divergence guarantee

`test/server/tools/schema.test.ts` asserts that **every** member of `SKELETON_DEFAULT_ACTION_TOOLS` advertises both `raw` and `project`. A tool that skeletonizes its observation by default but lacks the opt-out is therefore un-mergeable — the default and the escape hatch move together by construction.

## Validation

- [x] `bun test` on the touched surfaces (`finalizeToolResponse`, `tools/schema`, `toolSchemaHelpers`) — green
- [x] Full `bun test` suite — green except two pre-existing environment/worktree artifacts unrelated to this change: `test/lint/oxlintConfigScoping.test.ts` (missing `node_modules/.bin/oxlint` in a `.claude` worktree) and `test/integration/webrtcDeviceCaptureLatency.test.ts` (subprocess-spawn timing flake)
- [x] `bun run typecheck` — no new errors
- [x] `bun run lint` — no new ratchet violations
- [x] New tests run in <100ms; no new dependencies

## Acceptance criteria (from #5886)

- [x] Spread `responseShapeControlFields` into each observation-producing action tool schema
- [x] Add each tool name to `SKELETON_DEFAULT_ACTION_TOOLS` (kept the allowlist, bound it to the opt-out via a CI test rather than letting the two drift)
- [x] Regenerate `schemas/tool-definitions.json`
- [x] Test: a representative extra tool (`swipeOn`) defaults its `.observation` to `skeleton` and honors `project:"full"` / `raw:true`

## Device Verification

N/A — pure response-shaping/schema change at the serialization chokepoint; covered by unit tests against `finalizeToolResponse`.
