### PR TITLE
fix(observe): scope skeleton hoisting/suppression to same-window ancestry (#5881)

### DIFF
--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -4,6 +4,7 @@ import { isClickableElementProperties } from "../../utils/elementProperties";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { FlattenedElementEntry, IdentifyMediaViews } from "./IdentifyMediaViews";
+import { ElementProvenance, setElementProvenance } from "./output/elementProvenance";
 
 export interface ObserveElementCollector {
   collect(
@@ -27,19 +28,31 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
     const flattenedEntries: FlattenedElementEntry[] = [];
     let currentIndex = 0;
 
-    const rootNodes = [
-      ...this.parser.extractRootNodes(viewHierarchy),
-      ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first"),
+    // Each root/window becomes its own ancestry group so downstream skeleton
+    // hoisting/suppression can tell a genuine descendant from an unrelated node
+    // in another window (issue #5881). `mainRootCount` keeps every main-hierarchy
+    // root in a single group while each window root gets its own.
+    const mainRoots = this.parser.extractRootNodes(viewHierarchy);
+    const windowRoots = this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first");
+    const rootGroups: { root: ViewHierarchyNode; group: number }[] = [
+      ...mainRoots.map((root) => ({ root, group: 0 })),
+      ...windowRoots.map((root, index) => ({ root, group: index + 1 })),
     ];
 
-    for (const rootNode of rootNodes) {
-      this.collectFromRoot(rootNode, {
+    // Shared pre-order counter + parent records so ancestry intervals are
+    // computed once after every root is walked.
+    const provenanceState: ProvenanceState = { enter: 0, records: [] };
+
+    for (const { root, group } of rootGroups) {
+      this.collectFromRoot(root, group, provenanceState, {
         clickable,
         scrollable,
         flattenedEntries,
         nextIndex: () => currentIndex++,
       });
     }
+
+    finalizeProvenanceExits(provenanceState.records);
 
     const text = flattenedEntries
       .filter((entry) => typeof entry.text === "string" && entry.text.trim().length > 0)
@@ -51,6 +64,8 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
 
   private collectFromRoot(
     rootNode: ViewHierarchyNode,
+    group: number,
+    provenanceState: ProvenanceState,
     collections: {
       clickable: Element[];
       scrollable: Element[];
@@ -58,11 +73,26 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
       nextIndex: () => number;
     },
   ): void {
+    // Stack of enclosing parsed nodes (by tree depth) so each parsed node links
+    // to its nearest parsed ancestor — bounds-less nodes are skipped in the
+    // arrays but must not break ancestry between the nodes that survive.
+    const ancestors: { depth: number; provenance: ElementProvenance }[] = [];
+
     this.parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
       const parsedNode = this.parser.parseNodeBounds(node);
       if (!parsedNode) {
         return;
       }
+
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1].depth >= depth) {
+        ancestors.pop();
+      }
+      const parent = ancestors.length > 0 ? ancestors[ancestors.length - 1].provenance : undefined;
+      const enter = provenanceState.enter++;
+      const provenance: ElementProvenance = { group, enter, exit: enter };
+      setElementProvenance(parsedNode, provenance);
+      provenanceState.records.push({ provenance, parent });
+      ancestors.push({ depth, provenance });
 
       const nodeProperties = this.parser.extractNodeProperties(node);
       if (isClickableElementProperties(nodeProperties)) {
@@ -80,5 +110,28 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
         text: accessibilityText,
       });
     });
+  }
+}
+
+/** Shared pre-order counter and parent records accumulated across all roots. */
+interface ProvenanceState {
+  enter: number;
+  records: { provenance: ElementProvenance; parent?: ElementProvenance }[];
+}
+
+/**
+ * Compute each node's `exit` (the maximum `enter` in its parsed subtree) by
+ * propagating child intervals up to parents. Processing in descending `enter`
+ * order guarantees every descendant is folded into a node before that node
+ * propagates to its own parent, since a parent always has a smaller `enter`.
+ */
+function finalizeProvenanceExits(
+  records: { provenance: ElementProvenance; parent?: ElementProvenance }[],
+): void {
+  const ordered = [...records].sort((a, b) => b.provenance.enter - a.provenance.enter);
+  for (const { provenance, parent } of ordered) {
+    if (parent && provenance.exit > parent.exit) {
+      parent.exit = provenance.exit;
+    }
   }
 }

--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -79,14 +79,20 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
     const ancestors: { depth: number; provenance: ElementProvenance }[] = [];
 
     this.parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
+      // Pop stale same-or-deeper entries for EVERY visited node, before the
+      // bounds-less early return — otherwise a skipped wrapper never terminates a
+      // preceding parsed sibling's ancestry, and the wrapper's parsed descendants
+      // would inherit that sibling as their parent, mislabelling it with disjoint
+      // text (issue #5881).
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1].depth >= depth) {
+        ancestors.pop();
+      }
+
       const parsedNode = this.parser.parseNodeBounds(node);
       if (!parsedNode) {
         return;
       }
 
-      while (ancestors.length > 0 && ancestors[ancestors.length - 1].depth >= depth) {
-        ancestors.pop();
-      }
       const parent = ancestors.length > 0 ? ancestors[ancestors.length - 1].provenance : undefined;
       const enter = provenanceState.enter++;
       const provenance: ElementProvenance = { group, enter, exit: enter };

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -132,8 +132,12 @@ export function sanitizeObserveResult(
   // Skeleton projection (issue #4388): runs before `compact`/`dropElements` so it
   // reads object-shaped element bounds. It emits its own compact tuple bounds and
   // removes the tree + elements, so the later steps become no-ops on those fields.
+  // It projects from the pre-clone `obs`, not `out`: the collector's ancestry
+  // provenance (issue #5881) is a non-enumerable Symbol property that the line-119
+  // JSON round-trip strips, so reading `out.elements` would silently lose it and
+  // revert hoisting/suppression to the pre-#5881 geometry fallback.
   if (cfg.project === "skeleton") {
-    projectSkeleton(out);
+    projectSkeleton(out, obs);
   }
 
   if (cfg.compact) {
@@ -155,12 +159,17 @@ export function sanitizeObserveResult(
 
 /**
  * Replace the full tree with the actionable-only skeleton (issue #4388): set
- * `out.skeleton` from the already-computed `elements`, then drop `viewHierarchy`
- * and `elements`. A hierarchy-less observation (capture failure) yields an empty
- * skeleton — still a valid, if empty, projection. Operates on the cloned copy.
+ * `out.skeleton` from the collector's `elements`, then drop `viewHierarchy` and
+ * `elements` from the emitted copy. A hierarchy-less observation (capture
+ * failure) yields an empty skeleton — still a valid, if empty, projection.
+ *
+ * `source` is the pre-clone `obs`: its elements still carry the non-enumerable
+ * ancestry provenance (issue #5881) that the `sanitizeObserveResult` JSON clone
+ * strips from `out`. The projection reads but never mutates them, so the "input
+ * is never mutated" contract holds; only `out` (the clone) is edited.
  */
-function projectSkeleton(out: ObserveResult): void {
-  out.skeleton = out.elements ? toSkeleton(out.elements) : [];
+function projectSkeleton(out: ObserveResult, source: ObserveResult): void {
+  out.skeleton = source.elements ? toSkeleton(source.elements) : [];
   delete out.viewHierarchy;
   delete out.elements;
 }

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -2,6 +2,11 @@ import type { Element } from "../../../models/Element";
 import { isTruthy } from "../../../models/Element";
 import { hasAccessibilityAction } from "../../../utils/elementProperties";
 import type { Affordance, ObserveResult, SkeletonElement } from "../../../models/ObserveResult";
+import {
+  ElementProvenance,
+  getElementProvenance,
+  isStrictAncestor,
+} from "./elementProvenance";
 
 /**
  * Interactable Skeleton Projection (issue #4388).
@@ -122,6 +127,12 @@ interface SkeletonAccumulator {
   bounds: SkeletonElement["bounds"];
   affordances: Set<Affordance>;
   checked?: boolean;
+  /**
+   * Root/window ancestry, when the collector supplied it (issue #5881). Present
+   * on real captures; absent on hand-built fixtures and non-provenance producers,
+   * where hoisting/suppression fall back to geometric containment.
+   */
+  provenance?: ElementProvenance;
 }
 
 /** NUL-joined identity so `(id, label, bounds)` triples dedup without straddling. */
@@ -175,6 +186,9 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
       acc = { id, label, bounds, affordances: new Set<Affordance>() };
       byIdentity.set(key, acc);
     }
+    if (acc.provenance === undefined) {
+      acc.provenance = getElementProvenance(el);
+    }
     for (const affordance of affordances) {
       acc.affordances.add(affordance);
     }
@@ -192,15 +206,35 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
 }
 
 /**
+ * Whether `container` encloses `inner` for hoisting/suppression. When both
+ * carry collector provenance (issue #5881) this is true tree ancestry — same
+ * window/root and an enclosing Euler interval — so cross-window geometry never
+ * matches and an exact-fill (equal-bounds) descendant still does. Without
+ * provenance (hand-built fixtures, non-provenance producers) it falls back to
+ * strict geometric containment, preserving the pre-#5881 behavior.
+ */
+function containerEnclosesText(
+  container: SkeletonAccumulator,
+  inner: SkeletonAccumulator,
+): boolean {
+  if (container.provenance && inner.provenance) {
+    return isStrictAncestor(container.provenance, inner.provenance);
+  }
+  return strictlyContains(container.bounds, inner.bounds);
+}
+
+/**
  * Keep rule (issue #4388): a row is kept if it has ≥1 affordance, carries
  * semantic links, OR carries a non-empty label with no clickable ancestor.
  * Semantic links remain independently discoverable even when the linked text is
  * inside a generic tappable card that would otherwise suppress its text row.
+ *
+ * The clickable-ancestor test is scoped to same-window/same-root descendants
+ * when provenance is present (issue #5881), so a labelled overlay in a topmost
+ * window is no longer dropped by a geometrically-overlapping clickable in a
+ * lower window.
  */
-function shouldKeep(
-  acc: SkeletonAccumulator,
-  clickableBounds: SkeletonElement["bounds"][],
-): boolean {
+function shouldKeep(acc: SkeletonAccumulator, clickable: SkeletonAccumulator[]): boolean {
   if (acc.affordances.size > 0) {
     return true;
   }
@@ -210,7 +244,7 @@ function shouldKeep(
   if (acc.label === undefined) {
     return false;
   }
-  return !clickableBounds.some((bounds) => strictlyContains(bounds, acc.bounds));
+  return !clickable.some((container) => containerEnclosesText(container, acc));
 }
 
 /**
@@ -260,7 +294,7 @@ function groupTextByContainer(
     if (acc.affordances.size > 0 || acc.label === undefined) {
       continue;
     }
-    const container = smallestClickableAncestor(acc.bounds, clickable);
+    const container = smallestClickableAncestor(acc, clickable);
     if (!container) {
       continue;
     }
@@ -314,24 +348,41 @@ function byReadingOrder(a: SkeletonAccumulator, b: SkeletonAccumulator): number 
 }
 
 /**
- * The smallest-area clickable accumulator that strictly encloses `bounds`, or
- * `undefined` when none does. Smallest-area so text folds into its immediate row
- * rather than an outer clickable card or list that also encloses it.
+ * The innermost clickable accumulator that encloses `text`, or `undefined` when
+ * none does. With provenance (issue #5881) "innermost" is the deepest true tree
+ * ancestor (greatest `enter`), so an exact-fill descendant folds into its proven
+ * parent; without it, the smallest-area geometric container, so text folds into
+ * its immediate row rather than an outer clickable card or list.
  */
 function smallestClickableAncestor(
-  bounds: SkeletonElement["bounds"],
+  text: SkeletonAccumulator,
   clickable: SkeletonAccumulator[],
 ): SkeletonAccumulator | undefined {
   let best: SkeletonAccumulator | undefined;
   for (const candidate of clickable) {
-    if (!strictlyContains(candidate.bounds, bounds)) {
+    if (!containerEnclosesText(candidate, text)) {
       continue;
     }
-    if (!best || area(candidate.bounds) < area(best.bounds)) {
+    if (!best || isTighterContainer(candidate, best)) {
       best = candidate;
     }
   }
   return best;
+}
+
+/**
+ * Whether `candidate` is a tighter (more immediate) container than the current
+ * `best`. With provenance, the deeper tree ancestor wins (greater `enter`);
+ * otherwise the smaller-area geometric container.
+ */
+function isTighterContainer(
+  candidate: SkeletonAccumulator,
+  best: SkeletonAccumulator,
+): boolean {
+  if (candidate.provenance && best.provenance) {
+    return candidate.provenance.enter > best.provenance.enter;
+  }
+  return area(candidate.bounds) < area(best.bounds);
 }
 
 /** Materialize one accumulator into an emitted skeleton row (omitting absent optionals). */
@@ -372,8 +423,6 @@ export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
   // Hoist descendant text onto labelless/underlabelled clickable rows (issue
   // #5869) before the keep filter suppresses the now-folded text accumulators.
   hoistContainerLabels(accumulators, clickable);
-  // Bounds of every tappable row, for the clickable-ancestor suppression test.
-  const clickableBounds = clickable.map((acc) => acc.bounds);
 
-  return accumulators.filter((acc) => shouldKeep(acc, clickableBounds)).map(toSkeletonEntry);
+  return accumulators.filter((acc) => shouldKeep(acc, clickable)).map(toSkeletonEntry);
 }

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -2,11 +2,7 @@ import type { Element } from "../../../models/Element";
 import { isTruthy } from "../../../models/Element";
 import { hasAccessibilityAction } from "../../../utils/elementProperties";
 import type { Affordance, ObserveResult, SkeletonElement } from "../../../models/ObserveResult";
-import {
-  ElementProvenance,
-  getElementProvenance,
-  isStrictAncestor,
-} from "./elementProvenance";
+import { ElementProvenance, getElementProvenance, isStrictAncestor } from "./elementProvenance";
 
 /**
  * Interactable Skeleton Projection (issue #4388).
@@ -375,10 +371,7 @@ function smallestClickableAncestor(
  * `best`. With provenance, the deeper tree ancestor wins (greater `enter`);
  * otherwise the smaller-area geometric container.
  */
-function isTighterContainer(
-  candidate: SkeletonAccumulator,
-  best: SkeletonAccumulator,
-): boolean {
+function isTighterContainer(candidate: SkeletonAccumulator, best: SkeletonAccumulator): boolean {
   if (candidate.provenance && best.provenance) {
     return candidate.provenance.enter > best.provenance.enter;
   }

--- a/src/features/observe/output/elementProvenance.ts
+++ b/src/features/observe/output/elementProvenance.ts
@@ -1,0 +1,70 @@
+import type { Element } from "../../../models/Element";
+
+/**
+ * Root/window ancestry provenance for a collected element (issue #5881).
+ *
+ * The `observe` skeleton projection folds descendant text onto clickable
+ * containers, but `ObserveResult.elements` is a flat `{ clickable, text, … }`
+ * model that merges the main hierarchy **and every window root** with no
+ * window/root provenance. Geometry-only containment then crosses window
+ * boundaries: text from a topmost dialog/toast/IME window can be strictly
+ * contained by an unrelated clickable in a lower window and get hoisted onto it
+ * (mislabel) or dropped by the clickable-ancestor suppression.
+ *
+ * This carries the missing ancestry as a nested-set (Euler-interval) encoding
+ * over the *parsed* nodes of one root/window:
+ * - `group` — which root/window the node came from; ancestry only exists within
+ *   one group, so a different `group` is never an ancestor.
+ * - `enter` — the node's pre-order position (monotonic across groups; distinct
+ *   per node).
+ * - `exit` — the maximum `enter` in this node's parsed subtree (inclusive), so a
+ *   parent's `[enter, exit]` interval encloses every descendant's.
+ *
+ * `outer` is a strict tree ancestor of `inner` iff they share a `group` and
+ * `outer.enter < inner.enter <= inner.exit <= outer.exit`. Because it is tree
+ * ancestry rather than geometry, an exact-fill descendant (identical bounds to
+ * its clickable parent — a `match_parent` child) is still recognized as a
+ * descendant without relaxing geometric containment to unrelated equal-bounds
+ * overlays.
+ */
+export interface ElementProvenance {
+  /** Root/window group index; ancestry only holds within one group. */
+  group: number;
+  /** Pre-order enter position over parsed nodes (distinct, monotonic across groups). */
+  enter: number;
+  /** Maximum `enter` within this node's parsed subtree (inclusive interval end). */
+  exit: number;
+}
+
+/**
+ * Symbol key for the provenance side-channel. A `Symbol`-keyed, non-enumerable
+ * property never appears in `Object.keys` / `JSON.stringify` / structural
+ * `toEqual`, so it neither leaks into the emitted `elements` output nor churns
+ * fixture comparisons — it exists only for the in-process skeleton projection.
+ */
+const PROVENANCE = Symbol("auto-mobile.elementProvenance");
+
+/** Attach ancestry provenance to a parsed element (non-enumerable; see {@link PROVENANCE}). */
+export function setElementProvenance(el: Element, provenance: ElementProvenance): void {
+  Object.defineProperty(el, PROVENANCE, {
+    value: provenance,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** Read ancestry provenance from an element, or `undefined` when it was never tagged. */
+export function getElementProvenance(el: Element): ElementProvenance | undefined {
+  return (el as { [PROVENANCE]?: ElementProvenance })[PROVENANCE];
+}
+
+/**
+ * Whether `outer` is a strict tree ancestor of `inner`: same group and
+ * `outer`'s Euler interval strictly encloses `inner`'s. Distinct nodes have
+ * distinct `enter` values, so `outer.enter < inner.enter` already excludes the
+ * `outer === inner` case.
+ */
+export function isStrictAncestor(outer: ElementProvenance, inner: ElementProvenance): boolean {
+  return outer.group === inner.group && outer.enter < inner.enter && inner.exit <= outer.exit;
+}

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -12,6 +12,8 @@ import {
   loadIosRemindersNoiseObservePair,
   measureValue,
 } from "../../../fixtures/observe/observeFixture";
+import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
+import scrollBeforeFixture from "../../../fixtures/observe/diff/scroll-before.json";
 
 /**
  * Unit tests for `sanitizeObserveResult` — the output-only transform for issue
@@ -943,6 +945,30 @@ describe("sanitizeObserveResult", () => {
       const before = JSON.stringify(observe);
       sanitizeObserveResult(observe, { dropElements: false, project: "skeleton" });
       expect(JSON.stringify(observe)).toBe(before);
+    });
+
+    test("hoists the exact-fill descendant through the JSON-clone boundary (#5881)", () => {
+      // The collector tags each element with non-enumerable Symbol ancestry
+      // provenance (#5881). `sanitizeObserveResult` JSON-clones its input before
+      // projecting, which strips that Symbol — so the projection must read the
+      // pre-clone elements. This drives the real collector on the checked-in
+      // `long_press_card` fixture (an exact-fill content-desc descendant) through
+      // the full sanitize path: if provenance is lost, the exact-fill child is
+      // dropped and the card comes back label:"Long press me" (geometry fallback).
+      const observe: ObserveResult = {
+        ...(scrollBeforeFixture as unknown as ObserveResult),
+        elements: new DefaultObserveElementCollector().collect(
+          scrollBeforeFixture.viewHierarchy as NonNullable<ObserveResult["viewHierarchy"]>,
+          "android",
+        ),
+      };
+
+      const out = sanitizeObserveResult(observe, { dropElements: true, project: "skeleton" });
+
+      const card = out.skeleton?.find((entry) => entry.id === "long_press_card");
+      expect(card).toBeDefined();
+      expect(card?.label).toBe("Basic long press card");
+      expect(card?.sublabel).toContain("Long press me");
     });
   });
 

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -495,9 +495,7 @@ describe("toSkeleton — acceptance criteria", () => {
         1,
       );
 
-      const skeleton = toSkeleton(
-        makeElements({ clickable: [underlying], text: [overlayText] }),
-      );
+      const skeleton = toSkeleton(makeElements({ clickable: [underlying], text: [overlayText] }));
 
       // The underlying action keeps its own (absent) label — not relabelled from
       // the unrelated overlay text in another window.
@@ -518,9 +516,7 @@ describe("toSkeleton — acceptance criteria", () => {
         1,
       );
 
-      const skeleton = toSkeleton(
-        makeElements({ clickable: [underlying], text: [overlayText] }),
-      );
+      const skeleton = toSkeleton(makeElements({ clickable: [underlying], text: [overlayText] }));
 
       // The overlay text survives as its own affordance-less row — the
       // clickable-ancestor suppression no longer crosses the window boundary.

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { toSkeleton } from "../../../../src/features/observe/output/SkeletonProjection";
+import { setElementProvenance } from "../../../../src/features/observe/output/elementProvenance";
+import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
 import type { Element } from "../../../../src/models/Element";
 import type { ObserveResult } from "../../../../src/models/ObserveResult";
 import type { SkeletonElement } from "../../../../src/models/ObserveResult";
+import scrollBeforeFixture from "../../../fixtures/observe/diff/scroll-before.json";
 
 type ObserveElements = NonNullable<ObserveResult["elements"]>;
 
@@ -464,6 +467,154 @@ describe("toSkeleton — acceptance criteria", () => {
       const parent = findById(skeleton, "s-parent");
       expect(parent?.label).toBeUndefined();
       expect("sublabel" in (parent as SkeletonElement)).toBe(false);
+    });
+  });
+
+  describe("#5881: window/root provenance gates hoisting and suppression", () => {
+    // Tag an element with a root/window group and its Euler interval so the
+    // projection can restrict hoisting/suppression to true tree ancestry.
+    const withProvenance = (el: Element, group: number, enter: number, exit: number): Element => {
+      setElementProvenance(el, { group, enter, exit });
+      return el;
+    };
+
+    test("cross-window text is NOT hoisted onto a clickable in a lower window (mislabel fixed)", () => {
+      // An underlying clickable in the base window (group 0) with no own text.
+      const underlying = withProvenance(
+        { bounds: bounds(0, 0, 300, 100), "view-id": "s-underlying", clickable: "true" },
+        0,
+        0,
+        0,
+      );
+      // Overlay text in a topmost dialog window (group 1) that geometrically —
+      // but not by ancestry — sits inside the underlying clickable.
+      const overlayText = withProvenance(
+        { bounds: bounds(20, 20, 280, 80), text: "Permission required" },
+        1,
+        1,
+        1,
+      );
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [underlying], text: [overlayText] }),
+      );
+
+      // The underlying action keeps its own (absent) label — not relabelled from
+      // the unrelated overlay text in another window.
+      expect(findById(skeleton, "s-underlying")?.label).toBeUndefined();
+    });
+
+    test("cross-window text is NOT suppressed by a clickable in a lower window", () => {
+      const underlying = withProvenance(
+        { bounds: bounds(0, 0, 300, 100), "view-id": "s-underlying", clickable: "true" },
+        0,
+        0,
+        0,
+      );
+      const overlayText = withProvenance(
+        { bounds: bounds(20, 20, 280, 80), text: "Permission required" },
+        1,
+        1,
+        1,
+      );
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [underlying], text: [overlayText] }),
+      );
+
+      // The overlay text survives as its own affordance-less row — the
+      // clickable-ancestor suppression no longer crosses the window boundary.
+      const overlay = skeleton.find((entry) => entry.label === "Permission required");
+      expect(overlay).toBeDefined();
+      expect(overlay?.affordances).toEqual([]);
+    });
+
+    test("same-window descendant text IS still hoisted (geometry gate is ancestry, not window count)", () => {
+      // Identical geometry to the cross-window case, but now a genuine descendant
+      // in the same group — proving it is ancestry, not bounds, that gates.
+      const container = withProvenance(
+        { bounds: bounds(0, 0, 300, 100), "view-id": "s-row", clickable: "true" },
+        0,
+        0,
+        1,
+      );
+      const innerText = withProvenance(
+        { bounds: bounds(20, 20, 280, 80), text: "Permission required" },
+        0,
+        1,
+        1,
+      );
+
+      const skeleton = toSkeleton(makeElements({ clickable: [container], text: [innerText] }));
+
+      expect(findById(skeleton, "s-row")?.label).toBe("Permission required");
+      // Folded in, not emitted as a separate row.
+      expect(skeleton).toHaveLength(1);
+    });
+
+    test("exact-fill descendant is hoisted onto its proven parent (no geometry >= relaxation)", () => {
+      // A clickable card whose genuine descendant fills it exactly (identical
+      // bounds — a match_parent child). Strict geometric containment (`>`) rejects
+      // it; true tree ancestry hoists it. Mirrors the checked-in scroll-before
+      // fixture's `long_press_card`.
+      const card = withProvenance(
+        {
+          bounds: bounds(42, 1404, 1038, 1635),
+          "resource-id": "long_press_card",
+          clickable: "true",
+          "long-clickable": "true",
+        },
+        0,
+        0,
+        3,
+      );
+      const exactFill = withProvenance(
+        { bounds: bounds(42, 1404, 1038, 1635), "content-desc": "Basic long press card" },
+        0,
+        1,
+        1,
+      );
+      const inner1 = withProvenance(
+        { bounds: bounds(84, 1446, 381, 1509), text: "Long press me" },
+        0,
+        2,
+        2,
+      );
+      const inner2 = withProvenance(
+        { bounds: bounds(84, 1530, 334, 1593), text: "Hold to trigger" },
+        0,
+        3,
+        3,
+      );
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [card], text: [exactFill, inner1, inner2] }),
+      );
+
+      const entry = findById(skeleton, "long_press_card");
+      expect(entry?.affordances).toEqual(["tap", "long-press"]);
+      // The exact-fill child becomes the label (top-most by reading order).
+      expect(entry?.label).toBe("Basic long press card");
+      expect(entry?.sublabel).toBe("Long press me, Hold to trigger");
+      // The exact-fill descendant is not emitted as its own affordance-less row.
+      expect(skeleton).toHaveLength(1);
+    });
+
+    test("end-to-end: the real collector emits provenance that hoists the exact-fill descendant", () => {
+      const elements = new DefaultObserveElementCollector().collect(
+        scrollBeforeFixture.viewHierarchy as NonNullable<ObserveResult["viewHierarchy"]>,
+        "android",
+      );
+      expect(elements).toBeDefined();
+
+      const skeleton = toSkeleton(elements!);
+      const card = skeleton.find((entry) => entry.id === "long_press_card");
+      expect(card).toBeDefined();
+      // Without ancestry provenance the exact-fill child is dropped and the card
+      // stays label:null; with it, the label lands on the tappable row.
+      expect(card?.label).toBe("Basic long press card");
+      expect(card?.sublabel).toContain("Long press me");
+      expect(card?.sublabel).toContain("Hold to trigger");
     });
   });
 

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -600,6 +600,44 @@ describe("toSkeleton — acceptance criteria", () => {
       expect(skeleton).toHaveLength(1);
     });
 
+    test("a bounds-less wrapper does not leak a preceding sibling's ancestry to its descendants", () => {
+      // Regression for the ancestor-stack skipped-sibling bug (Codex P1): a
+      // clickable sibling followed by a bounds-less wrapper whose descendant text
+      // sits at disjoint bounds. The text is NOT a tree descendant of the
+      // clickable, and geometry does not contain it either — so it must not be
+      // hoisted onto the clickable.
+      const viewHierarchy = {
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 1080 },
+            node: [
+              {
+                "resource-id": "clickable-a",
+                clickable: "true",
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+              },
+              {
+                // Bounds-less wrapper (skipped by parseNodeBounds) — its child
+                // must reparent to the root, not to `clickable-a`.
+                node: {
+                  text: "Faraway",
+                  bounds: { left: 200, top: 200, right: 250, bottom: 250 },
+                },
+              },
+            ],
+          },
+        },
+      } as unknown as NonNullable<ObserveResult["viewHierarchy"]>;
+
+      const elements = new DefaultObserveElementCollector().collect(viewHierarchy, "android");
+      const skeleton = toSkeleton(elements!);
+
+      // The clickable is not mislabelled from the disjoint faraway text...
+      expect(findById(skeleton, "clickable-a")?.label).toBeUndefined();
+      // ...and the faraway text survives as its own row.
+      expect(skeleton.some((entry) => entry.label === "Faraway")).toBe(true);
+    });
+
     test("end-to-end: the real collector emits provenance that hoists the exact-fill descendant", () => {
       const elements = new DefaultObserveElementCollector().collect(
         scrollBeforeFixture.viewHierarchy as NonNullable<ObserveResult["viewHierarchy"]>,


### PR DESCRIPTION
## Summary

`observe`'s compact `skeleton` folded descendant text onto clickable rows purely by **geometry** over the flattened `elements` model, which merges the main hierarchy **and every window root** into shared `clickable`/`text` arrays with no window/root provenance. Because containment is geometric, text from a topmost dialog/toast/IME window can be strictly contained by an unrelated clickable in a lower window and get **hoisted onto it** (mislabelling the underlying action) or **dropped** by the clickable-ancestor suppression — a pre-existing cross-window bug that #5875 turned from a silent drop into a visible mislabel.

The fix threads **true tree ancestry** as element provenance: a `Symbol`-keyed, non-enumerable `{ group, enter, exit }` Euler interval per parsed node (symbol keys never appear in `Object.keys`/`JSON.stringify`/`toEqual`, so nothing leaks into the emitted `elements` output). The collector assigns a `group` per root/window and a pre-order interval per node; `SkeletonProjection` scopes **both** hoisting and suppression to same-window/same-root descendants, falling back to the prior geometric containment when provenance is absent (hand-built fixtures, non-provenance producers). Interval ancestry also fixes the equal-bounds case: an **exact-fill** descendant (identical bounds to its clickable parent) is hoisted onto its proven parent **without** relaxing geometric matching to `>=` (the P1 broad-false-hoist risk).

## Linked Issue

Closes #5881

## Bug / Regression Context

- **Prior attempts:** [#5875](https://github.com/kaeawc/auto-mobile/pull/5875) added geometric label-hoisting; the Codex reviewer raised the cross-window (P1) and exact-fill (P2) cases there and they were deferred to keep that PR scoped to #5869.
- **Observed symptom:** (P1) an underlying clickable `[0,0,300,100]` relabelled from a layer-100 overlay text `[20,20,280,80]` in another window; (P2) an exact-fill descendant (`long_press_card` / `"Basic long press card"` sharing `[42,1404,1038,1635]`) left off the tappable row, which stayed `label:null`.
- **Repro steps / conditions:** `observe` when overlapping windows exist (dialog/toast/IME), or any `clickable container > match_parent child` layout.

## Changes

- `src/features/observe/output/elementProvenance.ts` (new): `ElementProvenance` Euler-interval model + `setElementProvenance` / `getElementProvenance` / `isStrictAncestor`.
- `ObserveElementCollector.ts`: assign a group per root/window and a pre-order `enter`/`exit` interval per parsed node (parented to the nearest **parsed** ancestor so bounds-less nodes don't break ancestry).
- `SkeletonProjection.ts`: `smallestClickableAncestor` and the `shouldKeep` suppression use tree ancestry (`containerEnclosesText`) when provenance is present, geometry otherwise; deepest ancestor wins for hoist targeting.
- `skeletonProjection.test.ts`: cross-window no-hoist, cross-window no-suppression, same-window control, exact-fill hoist, and an end-to-end pass through the real `DefaultObserveElementCollector` on the checked-in `scroll-before` fixture.

## Acceptance criteria (from the issue, `kaeawc`-authored)

- [x] Cross-window text is **not hoisted** onto a clickable in a different window/root.
- [x] The clickable-ancestor **suppression** no longer crosses window/root boundaries.
- [x] An exact-fill (equal-bounds) genuine descendant **is hoisted** onto its proven parent via true ancestry — not a geometry `>=` relaxation.

## Validation

- [x] `bun run lint` (ratchet gate: no new violations) + `bun test` (full suite; the only 2 red are the known `.claude`-worktree `oxlintConfigScoping` artifact and the WHEP/device-capture worktree flake, both pre-existing and unrelated)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] New code is a pure projection over already-captured `elements`; no new dependency; unit tests run in <100ms

## Device Verification

- [ ] Not run here (no attached device in this worktree); the change is a deterministic, unit-tested projection, guarded end-to-end through the real collector on a checked-in fixture.

## Follow-ups

- The #5869 item 3 (in-band `raw` fetch via an MCP resource) remains a separate deferred item, called out in the issue; verifying/filing tracked in the ship summary.
