### PR TITLE
test(tapOn): pin the execute() selectedElement rebuild via a pure seam (#5897)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1048,6 +1048,23 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
+  /**
+   * Rebuild `selectedElement` metadata after the Android pre-tap-stability path
+   * re-resolved the tap target against a refreshed hierarchy (#5888). Returns the
+   * metadata rebuilt from the refreshed `selection`; when the refreshed selection
+   * carries no element (nothing new to describe), falls back to the pre-refresh
+   * `previous` metadata so the reported node still matches something real.
+   *
+   * This is the seam #5897 pins directly: the decision lived inline in `execute`
+   * as a single line that no test exercised, so a refactor could silently drop it.
+   */
+  private rebuildSelectedElementMetadataAfterStability(
+    previous: TapOnSelectedElement | undefined,
+    selection: ElementSelectionResult,
+  ): TapOnSelectedElement | undefined {
+    return this.buildSelectedElementMetadata(selection) ?? previous;
+  }
+
   private async handleElementNotFound(
     options: TapOnElementOptions,
     observeResult?: ObserveResult,
@@ -1485,8 +1502,11 @@ export class TapOnElement extends BaseVisualChange {
             // Rebuild from the refreshed selection so the reported selectedElement
             // (bounds/indexInMatches/totalMatches) describes the node actually
             // tapped after re-resolution, not the stale pre-refresh match (#5888).
-            selectedElementMetadata =
-              this.buildSelectedElementMetadata(stable.selection) ?? selectedElementMetadata;
+            // The decision lives in a pure seam so it can be unit-tested (#5897).
+            selectedElementMetadata = this.rebuildSelectedElementMetadataAfterStability(
+              selectedElementMetadata,
+              stable.selection,
+            );
           }
 
           this.logClickableParentSelection(usedParent);

--- a/test/features/action/TapOnElement.preTapStability.test.ts
+++ b/test/features/action/TapOnElement.preTapStability.test.ts
@@ -564,5 +564,51 @@ describe("resolveAndroidStableTapTargetAfterRefreshes", () => {
       expect(rebuilt.totalMatches).not.toBe(stale.totalMatches);
       expect(rebuilt.bounds.top).not.toBe(stale.bounds.top);
     });
+
+    // Regression for #5897: the `execute()`-level rebuild decision that consumes
+    // the refreshed `stable.selection` is a single production line that no test
+    // exercised — deleting it left every test green. Rather than drive the full
+    // `execute` path (the repo deliberately avoids the `observedInteraction`
+    // harness), the decision is extracted into the pure
+    // `rebuildSelectedElementMetadataAfterStability` seam and pinned here.
+    describe("rebuildSelectedElementMetadataAfterStability seam (#5897)", () => {
+      test("rebuilds from the refreshed selection when it has an element", () => {
+        const { tap } = createTapOnElement();
+        const previous = (tap as any).buildSelectedElementMetadata(STALE_SELECTION);
+
+        const rebuilt = (tap as any).rebuildSelectedElementMetadataAfterStability(
+          previous,
+          FRESH_SELECTION,
+        );
+
+        // The refreshed selection's positional fields win over the stale previous.
+        expect(rebuilt.indexInMatches).toBe(3);
+        expect(rebuilt.totalMatches).toBe(4);
+        expect(rebuilt.bounds.left).toBe(FRESH_BOUNDS.left);
+        expect(rebuilt.bounds.top).toBe(FRESH_BOUNDS.top);
+        expect(rebuilt).not.toBe(previous);
+      });
+
+      test("falls back to the previous metadata when the refreshed selection has no element", () => {
+        const { tap } = createTapOnElement();
+        const previous = (tap as any).buildSelectedElementMetadata(STALE_SELECTION);
+        const emptySelection: ElementSelectionResult = {
+          element: null,
+          indexInMatches: 0,
+          totalMatches: 0,
+          strategy: "first",
+        } as unknown as ElementSelectionResult;
+
+        const rebuilt = (tap as any).rebuildSelectedElementMetadataAfterStability(
+          previous,
+          emptySelection,
+        );
+
+        // No refreshed element to describe: keep the pre-refresh metadata intact.
+        expect(rebuilt).toBe(previous);
+        expect(rebuilt.indexInMatches).toBe(STALE_SELECTION.indexInMatches);
+        expect(rebuilt.totalMatches).toBe(STALE_SELECTION.totalMatches);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #5888 / #5894. That PR made `TapOnElement.execute` rebuild `selectedElement` from the refreshed pre-tap-stability selection, but the one production line that consumes `stable.selection` was never exercised — the #5894 tests pin the building blocks (`resolveAndroidStableTapTargetAfterRefreshes` carrying the refreshed selection out, and `buildSelectedElementMetadata` applied to it), so deleting that line left every test green.

This takes the issue's preferred "Option B": extract the rebuild decision into a tiny pure helper, `rebuildSelectedElementMetadataAfterStability(previous, selection)`, and unit-test that seam directly. `execute` now calls the helper instead of inlining `buildSelectedElementMetadata(stable.selection) ?? selectedElementMetadata`. Behavior is unchanged; the fallback semantics (keep the pre-refresh metadata when the refreshed selection has no element) are now pinned.

This stays within the repo convention of not driving `execute()` end-to-end (the `observedInteraction` harness is why that path is avoided in unit tests).

## Linked Issue

Closes #5897

## Changes

- `src/features/action/TapOnElement.ts`: add the pure `rebuildSelectedElementMetadataAfterStability` helper; `execute` consumes it in the pre-tap-stability block.
- `test/features/action/TapOnElement.preTapStability.test.ts`: add a `rebuildSelectedElementMetadataAfterStability seam (#5897)` block pinning (a) rebuild-from-refreshed when the selection has an element, and (b) fallback-to-previous when it does not.

## Validation

- [x] `bun test` — full suite green except the two pre-existing worktree/env failures unrelated to this diff (`webrtcDeviceCaptureLatency` integration; `oxlintConfigScoping` missing `node_modules/.bin/oxlint` in the `.claude` worktree)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] New tests use the existing interface + fake + FakeTimer harness; run in <100ms
- [ ] oxlint not runnable in this worktree (no `node_modules/.bin/oxlint`); CI covers it. The added helper is trivial — no new complexity/catch-convention surface.

## Acceptance criteria

Inferred from the issue body (no explicit criteria stated):

- [x] The `execute()`-level rebuild decision is extracted into a small pure helper — `rebuildSelectedElementMetadataAfterStability`.
- [x] The seam is unit-tested: refreshed-with-element yields refreshed metadata; refreshed-without-element falls back to the previous metadata.
- [x] `execute` consumes the helper (wiring preserved, behavior unchanged).

## Device Verification

- [ ] N/A — test-only refactor of a private seam; no on-device behavior change.
