### PR TITLE
fix(devices): direct-mode sessionUuid resolution + listDevices discovery marker (#5893)

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3798,15 +3798,36 @@ export function registerDeviceTools() {
     // switch to resources. The resource pointers (which also cover not-yet-booted
     // images and richer per-device detail) survive as a `note`.
     const platform: SomePlatform = args.platform ?? "either";
+    const requestedPlatforms: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
     const deviceManager = getDeviceToolsDependencies().deviceManagerFactory();
     let booted: BootedDevice[] = [];
+    // #5893 item 4: `getBootedDevices` collapses a failed per-platform probe to
+    // `[]`, so a transient tooling failure is indistinguishable from a genuinely
+    // empty inventory. Use the detailed contract, which reports which platforms
+    // completed, and surface an incomplete/error marker so the two are distinct.
+    let succeededPlatforms = new Set<Platform>(requestedPlatforms);
+    let discoveryErrors: BootedDeviceDiscovery["discoveryErrors"];
     try {
-      booted = await deviceManager.getBootedDevices(platform);
+      const discovery = await deviceManager.getBootedDevicesDetailed(platform);
+      booted = discovery.devices;
+      succeededPlatforms = discovery.succeededPlatforms;
+      discoveryErrors = discovery.discoveryErrors;
     } catch (error) {
       // Discovery is best-effort — a partial/failed probe still returns the
-      // resource guidance rather than failing the whole call.
+      // resource guidance rather than failing the whole call. A thrown error
+      // means no platform completed.
       logger.warn(`listDevices booted-device discovery failed: ${errorMessage(error)}`, error);
+      succeededPlatforms = new Set<Platform>();
     }
+
+    const failedPlatforms = requestedPlatforms.filter((p) => !succeededPlatforms.has(p));
+    const discovery = {
+      complete: failedPlatforms.length === 0,
+      failedPlatforms,
+      ...(discoveryErrors && Object.keys(discoveryErrors).length > 0
+        ? { errors: discoveryErrors }
+        : {}),
+    };
 
     const devices = booted.map((device) => ({
       deviceId: device.deviceId,
@@ -3821,6 +3842,7 @@ export function registerDeviceTools() {
       message: `Found ${devices.length} booted device${devices.length === 1 ? "" : "s"}${platformFilter}`,
       devices,
       count: devices.length,
+      discovery,
       note: {
         message:
           "Acquire a booted device with getAndroid { deviceId } or getApple { deviceId }. " +

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -501,18 +501,22 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       // (now optional) with both platforms connected falls through to
       // ensureDeviceReady("either", undefined) and hits an ambiguity error.
       const directSession = resolveDirectSessionDevice(sessionUuid);
-      if (directSession) {
-        if (!providedDeviceId) {
-          providedDeviceId = directSession.device.deviceId;
-          logger.info(
-            `[ToolRegistry] Resolved device from direct session ${sessionUuid}: ${providedDeviceId}`,
-          );
-        }
+      if (!directSession) {
+        logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
+      } else if (!providedDeviceId) {
+        providedDeviceId = directSession.device.deviceId;
+        logger.info(
+          `[ToolRegistry] Resolved device from direct session ${sessionUuid}: ${providedDeviceId}`,
+        );
+        // Adopt the session's platform only when we also adopted its device. An
+        // explicitly-provided deviceId names the target unambiguously, so leave
+        // platform as "either" and let ensureDeviceReady infer it from the id —
+        // narrowing to the session's platform here would send an explicit
+        // cross-platform deviceId to the wrong platform's search and fail
+        // (mirrors the #5870 deviceId-resolves-platform rule).
         if (platform === "either") {
           platform = directSession.device.platform;
         }
-      } else {
-        logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
       }
     } else if (sessionUuid) {
       logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -18,6 +18,7 @@ import { createToolExecutionContext } from "./ToolExecutionContext";
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
+import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import { isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
 import { isDebugModeEnabled } from "../utils/debug";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
@@ -491,6 +492,27 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       }
       if (platform === "either" && context.devicePlatform) {
         platform = context.devicePlatform;
+      }
+    } else if (shouldResolveDevice && sessionUuid) {
+      // Direct mode (--no-proxy): DaemonState is not initialized, so the
+      // session-based branch above never runs. Recover the acquired device and
+      // its platform from the direct-session registry (#5893) so a sessionUuid
+      // is sufficient on its own — without this, a client that omits `platform`
+      // (now optional) with both platforms connected falls through to
+      // ensureDeviceReady("either", undefined) and hits an ambiguity error.
+      const directSession = resolveDirectSessionDevice(sessionUuid);
+      if (directSession) {
+        if (!providedDeviceId) {
+          providedDeviceId = directSession.device.deviceId;
+          logger.info(
+            `[ToolRegistry] Resolved device from direct session ${sessionUuid}: ${providedDeviceId}`,
+          );
+        }
+        if (platform === "either") {
+          platform = directSession.device.platform;
+        }
+      } else {
+        logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
       }
     } else if (sessionUuid) {
       logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);

--- a/test/fakes/FakeDeviceSessionManager.ts
+++ b/test/fakes/FakeDeviceSessionManager.ts
@@ -27,6 +27,8 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
   private verificationAttempts: Map<string, number> = new Map();
   private deviceVerificationCalls: Map<string, Platform> = new Map();
   private lastOptions: DeviceReadyOptions | undefined;
+  private lastEnsureDeviceReadyPlatform: SomePlatform | undefined;
+  private lastEnsureDeviceReadyDeviceId: string | undefined;
 
   /**
    * Configure the list of connected devices
@@ -124,6 +126,23 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
   }
 
   /**
+   * The platform passed to the most recent ensureDeviceReady call. Lets a test
+   * prove ToolRegistry narrowed "either" to a concrete platform before
+   * resolving (e.g. direct-mode sessionUuid resolution, #5893).
+   */
+  getLastEnsureDeviceReadyPlatform(): SomePlatform | undefined {
+    return this.lastEnsureDeviceReadyPlatform;
+  }
+
+  /**
+   * The deviceId passed to the most recent ensureDeviceReady call, or undefined
+   * when none was provided.
+   */
+  getLastEnsureDeviceReadyDeviceId(): string | undefined {
+    return this.lastEnsureDeviceReadyDeviceId;
+  }
+
+  /**
    * Check if ensureDeviceReady was called at least once
    * @returns true if ensureDeviceReady was called
    */
@@ -190,6 +209,8 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
   ): Promise<BootedDevice> {
     this.ensureDeviceReadyCalls++;
     this.lastOptions = options;
+    this.lastEnsureDeviceReadyPlatform = platform;
+    this.lastEnsureDeviceReadyDeviceId = providedDeviceId;
 
     if (this.simulateDisconnection) {
       throw new ActionableError("Device disconnected during verification");

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -88,6 +88,7 @@ describe("listDevices tool (#5870)", () => {
 
   beforeEach(() => {
     fakeDeviceUtils.clearHistory();
+    fakeDeviceUtils.failedPlatforms.clear();
     fakeDeviceUtils.setBootedDevices("android", [android]);
     fakeDeviceUtils.setBootedDevices("ios", [ios]);
   });
@@ -129,6 +130,50 @@ describe("listDevices tool (#5870)", () => {
     const noteText = JSON.stringify(payload.note);
     expect(noteText).toContain("automobile:devices/booted");
     expect(noteText).toContain("automobile:devices/images");
+  });
+
+  test("marks discovery complete when every requested platform succeeds", async () => {
+    const payload = await callListDevices();
+
+    // #5893 item 4: a full sweep is explicitly complete, so an empty inventory
+    // is distinguishable from a failed scan.
+    expect(payload.discovery).toBeDefined();
+    expect(payload.discovery.complete).toBe(true);
+    expect(payload.discovery.failedPlatforms ?? []).toEqual([]);
+  });
+
+  test("surfaces an incomplete marker when a platform's discovery fails (#5893)", async () => {
+    // iOS discovery is unavailable this sweep; Android still succeeds.
+    fakeDeviceUtils.failedPlatforms.add("ios");
+
+    const payload = await callListDevices();
+
+    // Only the reachable platform's device is returned...
+    expect(payload.count).toBe(1);
+    expect(payload.devices).toEqual([
+      expect.objectContaining({ platform: "android", deviceId: "emulator-5554" }),
+    ]);
+
+    // ...but the response makes the failed scan distinguishable from empty.
+    expect(payload.discovery).toBeDefined();
+    expect(payload.discovery.complete).toBe(false);
+    expect(payload.discovery.failedPlatforms).toEqual(["ios"]);
+    expect(JSON.stringify(payload.discovery.errors)).toContain("iOS");
+    // The detailed contract is what gets consulted now.
+    expect(
+      fakeDeviceUtils.getExecutedOperations().some((op) => op.startsWith("getBootedDevices")),
+    ).toBe(true);
+  });
+
+  test("distinguishes a genuinely empty inventory from a failed scan", async () => {
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setBootedDevices("ios", []);
+
+    const payload = await callListDevices();
+
+    expect(payload.count).toBe(0);
+    expect(payload.discovery.complete).toBe(true);
+    expect(payload.discovery.failedPlatforms ?? []).toEqual([]);
   });
 
   test("filters by platform when provided", async () => {

--- a/test/server/toolRegistry.directSessionResolution.test.ts
+++ b/test/server/toolRegistry.directSessionResolution.test.ts
@@ -88,7 +88,12 @@ describe("ToolRegistry direct-mode sessionUuid resolution (#5893)", () => {
     expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("ios");
   });
 
-  test("does not override an explicitly provided deviceId", async () => {
+  test("does not override an explicitly provided cross-platform deviceId, and leaves platform for the id to resolve", async () => {
+    // Session is Android-bound, but the caller explicitly targets the iOS device
+    // and omits platform. The explicit id must win, and platform must stay
+    // "either" so the production ensureDeviceReady resolves the platform FROM the
+    // id — narrowing to the session's "android" here would search only Android
+    // devices and reject the iOS id (Codex #5906 P2).
     fakeDeviceSessionManager.setConnectedDevices([android, ios]);
     registerDirectSessionDevice("session-abc", android);
     const tool = registerTool();
@@ -97,6 +102,7 @@ describe("ToolRegistry direct-mode sessionUuid resolution (#5893)", () => {
     expect(response).toEqual({ success: true });
 
     expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBe(ios.deviceId);
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("either");
   });
 
   test("falls through unchanged when the sessionUuid has no direct-session device", async () => {

--- a/test/server/toolRegistry.directSessionResolution.test.ts
+++ b/test/server/toolRegistry.directSessionResolution.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { BootedDevice } from "../../src/models";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { z } from "zod/v4";
+
+// #5893 item 3: in direct mode (--no-proxy, DaemonState not initialized), a tool
+// call that carries only a sessionUuid must recover its device+platform from the
+// direct-session registry rather than falling through to
+// ensureDeviceReady("either", undefined) — which is ambiguous when both
+// platforms are connected.
+describe("ToolRegistry direct-mode sessionUuid resolution (#5893)", () => {
+  const android: BootedDevice = {
+    name: "Pixel_9_API_36",
+    deviceId: "emulator-5554",
+    platform: "android",
+  };
+  const ios: BootedDevice = {
+    name: "iPhone 17",
+    deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+    platform: "ios",
+  };
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+
+  beforeEach(() => {
+    // Direct mode: daemon must not be initialized.
+    expect(DaemonState.getInstance().isInitialized()).toBe(false);
+    ToolRegistry.clearTools();
+    clearDirectSessionDevices();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    clearDirectSessionDevices();
+  });
+
+  const registerTool = () => {
+    ToolRegistry.registerDeviceAware(
+      "directResolutionTool",
+      "Tool used to observe direct-mode device resolution",
+      z.object({
+        platform: z.enum(["ios", "android"]).optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      async () => ({ success: true }),
+    );
+    const tool = ToolRegistry.getTool("directResolutionTool");
+    expect(tool).toBeDefined();
+    return tool!;
+  };
+
+  test("resolves device and narrows platform from the direct-session registry", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([android, ios]);
+    registerDirectSessionDevice("session-abc", android);
+    const tool = registerTool();
+
+    // Only sessionUuid — no platform, no deviceId.
+    const response = await tool.handler({ sessionUuid: "session-abc" });
+    expect(response).toEqual({ success: true });
+
+    // Device was resolved from the direct session, and platform was narrowed
+    // away from "either".
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBe("emulator-5554");
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("android");
+  });
+
+  test("resolves an iOS direct session the same way", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([android, ios]);
+    registerDirectSessionDevice("session-ios", ios);
+    const tool = registerTool();
+
+    const response = await tool.handler({ sessionUuid: "session-ios" });
+    expect(response).toEqual({ success: true });
+
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBe(ios.deviceId);
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("ios");
+  });
+
+  test("does not override an explicitly provided deviceId", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([android, ios]);
+    registerDirectSessionDevice("session-abc", android);
+    const tool = registerTool();
+
+    const response = await tool.handler({ sessionUuid: "session-abc", deviceId: ios.deviceId });
+    expect(response).toEqual({ success: true });
+
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBe(ios.deviceId);
+  });
+
+  test("falls through unchanged when the sessionUuid has no direct-session device", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([android]);
+    const tool = registerTool();
+
+    const response = await tool.handler({ sessionUuid: "session-unknown" });
+    expect(response).toEqual({ success: true });
+
+    // No direct session registered: platform stays "either", no deviceId injected.
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("either");
+    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two items surfaced in [#5883](https://github.com/kaeawc/auto-mobile/pull/5883) review and folded here to keep that PR scoped (part of the systemic platform-optional work):

- **Direct-mode (`--no-proxy`) `sessionUuid` resolution.** `ToolRegistry`'s session-based device resolution only ran when `DaemonState` was initialized. In direct mode the branch was skipped entirely, so a `sessionUuid`-only call fell through to `ensureDeviceReady("either", undefined)`. Now that `platform` is optional on `tapOn` (etc.), a direct-mode client that omits `platform` with both platforms connected hit an ambiguity error instead of being able to rely on the session. The non-daemon branch now recovers the acquired device **and** platform from `resolveDirectSessionDevice(sessionUuid)`, narrowing `platform` away from `"either"`, so `sessionUuid` is sufficient on its own in direct mode too.
- **`listDevices` discovery-failure reporting.** `listDevices` called `getBootedDevices`, which collapses a per-platform ADB/simctl discovery failure to `[]` — so a failed scan was indistinguishable from an empty inventory (`Found 0 booted devices`). It now uses the `getBootedDevicesDetailed` contract (which reports `succeededPlatforms`) and surfaces a `discovery` marker (`complete` / `failedPlatforms` / `errors`) so the two cases are distinguishable.

## Linked Issue

Closes #5893

## Changes

- `src/server/toolRegistry.ts` — direct-mode `else if (sessionUuid)` branch resolves device + platform via `resolveDirectSessionDevice`; preserves the existing "not initialized" warn when no direct session exists; leaves an explicitly-provided `deviceId` untouched.
- `src/server/deviceTools.ts` — `listDevicesHandler` switched to `getBootedDevicesDetailed`; adds a `discovery` field to the response. A thrown discovery error means no platform completed (marker reflects that).
- `test/fakes/FakeDeviceSessionManager.ts` — records the last `ensureDeviceReady(platform, deviceId)` so a test can prove `"either"` was narrowed and the resolved deviceId was passed.

## Acceptance criteria (from #5893, `kaeawc`-authored)

| Criterion | Change | Test |
| --- | --- | --- |
| Item 3 — direct-mode `sessionUuid` resolves device + platform | `toolRegistry.ts` direct-session branch | `test/server/toolRegistry.directSessionResolution.test.ts` |
| Item 4 — `listDevices` distinguishes failed scan from empty | `deviceTools.ts` `getBootedDevicesDetailed` + `discovery` marker | `test/server/deviceTools.listDevices.test.ts` |

## Validation

- [x] `bun test` — full suite green except two **pre-existing, unrelated** failures also red on clean `main` (`toolRegistration.test.ts` committed tool-definitions drift; `webrtcDeviceCaptureLatency.test.ts` #4343). Neither surface is touched by this diff.
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — no new violations (ratchet gate)
- [x] `bun run build` + `bun run format:check` pass
- [x] New code uses interface + fake; new unit tests run in <100ms

## Notes

- No declared tool input/output schema changed (the `listDevices` `discovery` field is a runtime response payload), so `schemas/tool-definitions.json` is intentionally not regenerated here.

## Follow-ups

- [ ] The remaining #5893 items from the #5883 review (systemic platform-optional sweep, `provisionDevice`→`sessionUuid`) are tracked separately; this PR closes the two items in the issue body.
