### PR TITLE
fix(observe): seal residual disk-only stale-write window and guard checkDisk re-warm by generation (#5892)

### DIFF
--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -60,6 +60,13 @@ export function normalizeCachedObserveResult(parsed: unknown): ObserveResult {
 export const OBSERVE_RESULT_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /**
+ * Narrow write seam so tests can drive the post-disk-write race deterministically
+ * (a `clear()` landing while `writeFileAsync` is in flight). Defaults to the real
+ * async file write.
+ */
+export type ObserveCacheFileWriter = (filePath: string, data: string) => Promise<void>;
+
+/**
  * File-system backed implementation of {@link ObserveResultCacheStore}.
  *
  * Behaviour parity with the previous `RealObserveScreen` static cache:
@@ -72,6 +79,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
   private readonly cache: Map<string, ObserveResultCacheEntry> = new Map();
   private readonly cacheDir: string;
   private readonly timer: Timer;
+  private readonly writeFile: ObserveCacheFileWriter;
   private pendingDiskCleanup: Promise<void> = Promise.resolve();
 
   /**
@@ -87,9 +95,14 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
     return this.globalGeneration + (this.deviceGeneration.get(deviceId) ?? 0);
   }
 
-  constructor(timer: Timer = defaultTimer, cacheDir?: string) {
+  constructor(
+    timer: Timer = defaultTimer,
+    cacheDir?: string,
+    writeFile: ObserveCacheFileWriter = writeFileAsync,
+  ) {
     this.timer = timer;
     this.cacheDir = cacheDir ?? getTempDir(TEMP_SUBDIRS.OBSERVE_RESULTS);
+    this.writeFile = writeFile;
     this.ensureCacheDirExists();
   }
 
@@ -136,8 +149,23 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       if (this.isStaleWrite(deviceId, generation)) {
         return;
       }
+      // Stamp the file with the generation it is written under so both the
+      // post-write re-check below and checkDisk can prove a file stale after a
+      // later clear() (issue #5892). A supplied `generation` equals the current
+      // one here (isStaleWrite passed); an unconditional write stamps current.
+      const stampGeneration = this.currentGeneration(deviceId);
+      const filename = this.diskFilename(cacheKey, stampGeneration);
       this.cache.set(cacheKey, { timestamp, deviceId, observeResult: result });
-      await this.saveObserveResultToDisk(cacheKey, result);
+      await this.saveObserveResultToDisk(filename, result);
+      // Residual 1: a clear() can land during the disk write above, and its
+      // deletion snapshot predates our file — so it survives on disk. Re-check
+      // and clean up ourselves rather than leaving a stale file for checkDisk to
+      // skip until TTL. Unconditional writes (no generation) are never stale.
+      if (this.isStaleWrite(deviceId, generation)) {
+        this.cache.delete(cacheKey);
+        await this.deleteDiskFile(filename);
+        return;
+      }
       logger.debug(
         `[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${this.cache.size}`,
       );
@@ -267,9 +295,23 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       }
 
       const now = this.timer.now();
+      const currentGeneration = this.currentGeneration(deviceId);
       let mostRecentFile: { path: string; mtime: number } | undefined;
 
       for (const file of jsonFiles) {
+        // Residual 2: never re-warm memory from a file whose stamped generation
+        // is older than the device's current generation — a clear() has advanced
+        // past it (issue #5892). Unstamped files can't be proven stale; serve
+        // them (back-compat, backstopped by the freshness check).
+        const fileGeneration = this.parseGenerationFromFilename(file);
+        if (fileGeneration !== undefined && fileGeneration < currentGeneration) {
+          logger.debug(
+            `[OBSERVE_CACHE] Skipping stale-generation disk file: ${file} ` +
+              `(file generation ${fileGeneration} < current ${currentGeneration})`,
+          );
+          continue;
+        }
+
         const filePath = path.join(this.cacheDir, file);
         const stats = await statAsync(filePath);
         const age = now - stats.mtime.getTime();
@@ -311,17 +353,44 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
     }
   }
 
+  /**
+   * Disk filename for a cache entry, stamped with the generation it is written
+   * under: `observe_<sanitizedDeviceId>_<timestamp>_g<generation>.json`. The
+   * `_g<generation>` suffix lets {@link checkDisk} and the post-write re-check
+   * prove a file stale after a later `clear()` (issue #5892).
+   */
+  private diskFilename(cacheKey: string, generation: number): string {
+    return `observe_${cacheKey.replace(/:/g, "_")}_g${generation}.json`;
+  }
+
+  /**
+   * Parse the `_g<generation>` stamp from a cache filename. Returns undefined for
+   * a legacy (pre-#5892) or cross-instance file with no stamp — such a file
+   * cannot be proven stale and is served, backstopped by the freshness check.
+   */
+  private parseGenerationFromFilename(filename: string): number | undefined {
+    const match = /_g(\d+)\.json$/.exec(filename);
+    return match ? Number(match[1]) : undefined;
+  }
+
   private async saveObserveResultToDisk(
-    cacheKey: string,
+    filename: string,
     observeResult: ObserveResult,
   ): Promise<void> {
     try {
-      const filename = `observe_${cacheKey.replace(/:/g, "_")}.json`;
       const filePath = path.join(this.cacheDir, filename);
-      await writeFileAsync(filePath, JSON.stringify(observeResult, null, 2));
+      await this.writeFile(filePath, JSON.stringify(observeResult, null, 2));
       logger.debug(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Failed to save observe result to disk: ${error}`);
+    }
+  }
+
+  private async deleteDiskFile(filename: string): Promise<void> {
+    try {
+      await unlinkAsync(path.join(this.cacheDir, filename));
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Failed to delete stale cache file ${filename}: ${error}`);
     }
   }
 

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import os from "os";
-import { mkdirSync, rmSync, readdirSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, readdirSync, existsSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
+import { writeFileAsync } from "../../../../src/utils/io";
 import {
   FileSystemObserveCacheStore,
   OBSERVE_RESULT_CACHE_TTL_MS,
@@ -197,6 +198,85 @@ describe("FileSystemObserveCacheStore", function () {
   test("getMostRecent returns undefined when nothing cached", async function () {
     const result = await store.getMostRecent("device-1");
     expect(result).toBeUndefined();
+  });
+
+  // --- Generation-stamped disk files (#5892) -------------------------------
+
+  test("put stamps the write generation into the disk filename", async function () {
+    await store.put("device-1", makeResult("g0"), store.currentGeneration("device-1"));
+    const files = readdirSync(cacheDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/_g0\.json$/);
+  });
+
+  test("put stamps the current generation even for an unconditional write", async function () {
+    store.clear("device-1"); // generation -> 1
+    await store.put("device-1", makeResult("no-gen")); // unconditional
+    const files = readdirSync(cacheDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/_g1\.json$/);
+  });
+
+  test("getMostRecent skips a disk file stamped with a stale generation and does not warm memory (Residual 2)", async function () {
+    // Advance the device generation so a g0-stamped file is provably stale.
+    store.clear("device-1"); // currentGeneration("device-1") === 1
+    // A stale file slipped onto disk (e.g. a clear() that landed mid disk-write,
+    // per Residual 1) stamped with the pre-clear generation 0.
+    const staleName = `observe_device-1_${timer.now()}_g0.json`;
+    writeFileSync(path.join(cacheDir, staleName), JSON.stringify(makeResult("stale-hierarchy")));
+
+    expect(await store.getMostRecent("device-1")).toBeUndefined();
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+  });
+
+  test("getMostRecent serves a disk file stamped with the current generation", async function () {
+    store.clear("device-1"); // generation -> 1
+    const currentName = `observe_device-1_${timer.now()}_g1.json`;
+    writeFileSync(path.join(cacheDir, currentName), JSON.stringify(makeResult("current")));
+
+    const restored = await store.getMostRecent("device-1");
+    expect(restored?.updatedAt).toBe("current");
+  });
+
+  test("getMostRecent still serves a legacy disk file with no generation stamp (cross-restart back-compat)", async function () {
+    store.clear("device-1"); // generation -> 1
+    // Pre-#5892 filename format (or a file from another process instance): no
+    // generation stamp. We cannot prove it stale, so it must still be served.
+    const legacyName = `observe_device-1_${timer.now()}.json`;
+    writeFileSync(path.join(cacheDir, legacyName), JSON.stringify(makeResult("legacy")));
+
+    const restored = await store.getMostRecent("device-1");
+    expect(restored?.updatedAt).toBe("legacy");
+  });
+
+  test("a clear() landing during the disk write cleans up the stale file (Residual 1)", async function () {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let writes = 0;
+    const gatedWriter = async (filePath: string, data: string): Promise<void> => {
+      writes += 1;
+      await gate;
+      await writeFileAsync(filePath, data);
+    };
+    const gatedStore = new FileSystemObserveCacheStore(timer, cacheDir, gatedWriter);
+
+    const gen = gatedStore.currentGeneration("device-1");
+    const putPromise = gatedStore.put("device-1", makeResult("mid-write"), gen);
+
+    // Let put() progress until it parks at the gated write.
+    while (writes === 0) {
+      await Promise.resolve();
+    }
+
+    // A concurrent terminate invalidates the device while the write is in flight.
+    gatedStore.clear("device-1");
+    release();
+    await putPromise;
+
+    expect(readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length).toBe(0);
+    expect(gatedStore.getRecentInMemoryForDevice("device-1")).toBeUndefined();
   });
 
   test("clear() followed immediately by put() does not delete the fresh file", async function () {


### PR DESCRIPTION
## Summary

Follow-up from [#5889](https://github.com/kaeawc/auto-mobile/pull/5889) (closed #5884), which fenced stale in-flight observe-cache writes with a per-device **generation**. Two residuals remained, both narrow and TTL-bounded but the same defect class:

- **Residual 1 (disk-only Scenario-B window):** a `clear(deviceId)` landing during `saveObserveResultToDisk`'s `writeFileAsync` — after the post-await generation re-check — leaves the just-written file on disk (the deletion snapshot predates it), surviving until TTL.
- **Residual 2 (`checkDisk` re-warm bypasses the fence):** `checkDisk` warmed memory via a direct `cache.set(...)` with no generation guard, so any surviving stale disk file (Residual 1, a swallowed unlink, or a cross-instance file) could be resurrected into the memory cache the fence had buried.

This makes the disk path **generation-aware**, per the issue's suggested fix: each cache file is stamped with the generation it was written under, and both the read path and the post-write path drop/skip files whose generation is stale relative to `currentGeneration(deviceId)`.

## Linked Issue

Closes #5892

## Bug / Regression Context

- **Prior attempts:** [#5889](https://github.com/kaeawc/auto-mobile/pull/5889) added the per-device generation fence; it closed the wide window and an in-`put` window but left the two disk residuals above.
- **Observed symptom:** a stale observe hierarchy survives on disk past a `clear()` and can be re-served (memory-miss → `checkDisk` re-warm) until the 5-minute TTL.
- **Repro steps / conditions:** a `clear(deviceId)` interleaves during the disk `writeFileAsync`, or a memory-miss `getMostRecent` hits a surviving stale disk file.

## Changes

- `FileSystemObserveCacheStore` disk files are now named `observe_<sanitizedDeviceId>_<timestamp>_g<generation>.json` — the `_g<generation>` stamp records the write's generation.
- `checkDisk` parses the stamp and **skips warming memory** from any file whose stamped generation is `< currentGeneration(deviceId)` (Residual 2). Unstamped legacy/cross-instance files can't be proven stale, so they are still served (back-compat, backstopped by the freshness check).
- `put()` re-checks staleness **after** the disk write and, if a `clear()` advanced the generation during the write, deletes the just-written file and drops the memory entry (Residual 1).
- Added a narrow, defaulted `ObserveCacheFileWriter` constructor seam so the post-write race is unit-testable deterministically.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` ratchet: no new violations; `bun test`: full suite green except two pre-existing, unrelated environmental flakes — the `webrtcDeviceCaptureLatency` nested-`bun test` meta-test and a daemon-options test, both confirmed failing identically on the base tree without this change)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; the new unit tests run in <100ms
- [x] Reuses existing store/io seams; no new dependencies

## Acceptance Criteria

Inferred from the issue's "Suggested fix" (no explicit list in the body):

- [x] **AC1** Each cache file is stamped with the generation it was written under — pinned by the "stamps the write generation into the disk filename" / "stamps the current generation even for an unconditional write" tests.
- [x] **AC2 (Residual 1)** A stale file that slips onto disk during the write is never served and is cleaned up on the post-write path — pinned by the "clear() landing during the disk write cleans up the stale file" test.
- [x] **AC3 (Residual 2)** `checkDisk` re-warm is generation-aware and skips stale-generation files — pinned by the "skips a disk file stamped with a stale generation and does not warm memory" + "serves a disk file stamped with the current generation" tests.
- [x] **AC4** Back-compat: legacy/unstamped files are still served, and unconditional `put()` still writes — pinned by the "still serves a legacy disk file with no generation stamp" test and the existing back-compat suite.

## Device Verification

N/A — cache-fencing logic; no on-device behavior change. Covered by deterministic unit tests that model the races.
