### PR TITLE
feat(observe): in-band fetch for tool-output artifacts (#5882)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6677,6 +6677,10 @@
             },
             "tool": {
               "type": "string"
+            },
+            "resourceUri": {
+              "description": "automobile: resource URI to fetch this artifact's JSON in-band",
+              "type": "string"
             }
           },
           "required": ["path", "format", "payload", "bytes", "tool"],
@@ -10064,6 +10068,10 @@
                       "maximum": 9007199254740991
                     },
                     "tool": {
+                      "type": "string"
+                    },
+                    "resourceUri": {
+                      "description": "automobile: resource URI to fetch this artifact's JSON in-band",
                       "type": "string"
                     }
                   },

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -40,6 +40,12 @@ export interface ObservationArtifactMetadata {
     payload: ObservationArtifactPayload;
     bytes: number;
     tool: string;
+    /**
+     * In-protocol companion to `path` (issue #5882). An `automobile:tool-output/…`
+     * resource URI a client can read to fetch the spilled JSON in-band, so a
+     * host filesystem path is never the only way to reach the raw payload.
+     */
+    resourceUri: string;
   };
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -67,6 +67,7 @@ import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
 import { registerObservationResources } from "./observationResources";
+import { registerToolOutputResources } from "./toolOutputResources";
 import { registerObserveAppResource } from "./observeAppResource";
 import { registerBootedDeviceResources } from "./bootedDeviceResources";
 import { registerDeviceImageResources } from "./deviceImageResources";
@@ -262,6 +263,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Register all resources
   startupBenchmark.startPhase("resourceRegistration");
   registerObservationResources();
+  registerToolOutputResources();
   registerObserveAppResource();
   registerBootedDeviceResources();
   registerDeviceImageResources();

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -7,6 +7,7 @@ import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import { logger } from "../utils/logger";
+import { buildToolOutputResourceUri } from "./toolOutputResources";
 import type {
   ObservationArtifactMetadata,
   ObservationArtifactWriter,
@@ -112,6 +113,9 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
           payload: input.payload,
           bytes: Buffer.byteLength(content, "utf8"),
           tool: input.tool,
+          // Companion in-protocol fetch for the host `path` (issue #5882): a
+          // remote MCP client reads the raw JSON via this `automobile:` resource.
+          resourceUri: buildToolOutputResourceUri(filename),
         },
       };
     } catch (error) {

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import * as realFs from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
 import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
 import { logger } from "../utils/logger";
 import { errorMessage } from "../utils/describeUnknownError";
@@ -40,23 +39,16 @@ interface ToolOutputResourceFileSystem {
 
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
   async readFile(filePath: string): Promise<string> {
-    // Open with O_NOFOLLOW (where the platform provides it) so a writer-shaped
-    // symlink planted in a shared/writable `--tool-outputs-dir` cannot redirect
-    // the read to an arbitrary host file — the basename allowlist constrains the
-    // link's name, not its target (issue #5882 review). Then confirm the opened
-    // handle is a regular file before reading, closing over the same handle so
-    // there is no TOCTOU gap between the check and the read.
-    const flags = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
-    const handle = await realFs.open(filePath, flags);
-    try {
-      const stats = await handle.stat();
-      if (!stats.isFile()) {
-        throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
-      }
-      return await handle.readFile("utf8");
-    } finally {
-      await handle.close();
+    // `lstat` (not `stat`) so a writer-shaped symlink planted in a shared/writable
+    // `--tool-outputs-dir` is detected rather than followed — the basename
+    // allowlist constrains the link's name, not its target (issue #5882 review).
+    // Portable across platforms (unlike the POSIX-only `O_NOFOLLOW` open flag),
+    // and a symlink or non-regular file is refused before the read.
+    const stats = await realFs.lstat(filePath);
+    if (!stats.isFile()) {
+      throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
     }
+    return realFs.readFile(filePath, "utf8");
   },
 };
 

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -23,10 +23,15 @@ const TOOL_OUTPUT_RESOURCE_URI_PREFIX = "automobile:tool-output/";
 /**
  * Artifact filenames are `${timestamp}-${tool}-${id}.json`, where the tool/id
  * segments are already restricted to `[A-Za-z0-9._-]` by `safeFilenameSegment`
- * in the writer. Re-validate here so a crafted `artifactId` can never escape the
- * tool-outputs directory (no separators, no `..`, `.json` only).
+ * in the writer. Match the writer's full shape — a leading numeric timestamp,
+ * then at least one `-`-joined segment, then `.json` — so a crafted `artifactId`
+ * can never escape the tool-outputs directory (no separators, no `..`) AND an
+ * arbitrary sibling file in a shared/misconfigured `--tool-outputs-dir` (e.g.
+ * `credentials.json`) is not served just because it ends in `.json` (issue #5882
+ * review). This narrows the readable namespace to the writer's own emissions; it
+ * is not full per-artifact provenance tracking (deferred — see #5917).
  */
-const SAFE_ARTIFACT_ID = /^[A-Za-z0-9._-]+\.json$/;
+const SAFE_ARTIFACT_ID = /^\d+-[A-Za-z0-9._-]+\.json$/;
 
 interface ToolOutputResourceFileSystem {
   readFile(filePath: string): Promise<string>;
@@ -92,13 +97,14 @@ async function getToolOutputArtifact(params: Record<string, string>): Promise<Re
     );
   }
 
+  // `SAFE_ARTIFACT_ID` is a strict allowlist with no path separators, so the join
+  // can never escape `directory` — no dirname re-check is needed. (An earlier
+  // `path.dirname(filePath) !== directory` guard rejected every read when
+  // `--tool-outputs-dir` ended in a separator, since `path.dirname` normalizes
+  // the trailing slash away while the configured directory keeps it — issue #5882
+  // review.)
   const directory = resolveToolOutputsDir();
   const filePath = path.join(directory, artifactId);
-  // Defense in depth: reject any id whose join escaped the directory even though
-  // it passed the basename check (e.g. via an unexpected platform separator).
-  if (path.dirname(filePath) !== directory) {
-    return toolOutputError(uri, `Invalid tool-output artifact id "${artifactId}".`);
-  }
 
   try {
     const text = await toolOutputResourceFileSystem.readFile(filePath);

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -125,7 +125,7 @@ export function registerToolOutputResources(): void {
     "Tool Output Artifact",
     "In-band fetch for a tool-output artifact that spilled to a host file. The " +
       "`resourceUri` in an artifact's metadata points here so a client can read the " +
-      "full raw JSON (e.g. an `observe {\"raw\": true}` hierarchy) over the protocol.",
+      'full raw JSON (e.g. an `observe {"raw": true}` hierarchy) over the protocol.',
     "application/json",
     getToolOutputArtifact,
   );

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -39,15 +39,13 @@ interface ToolOutputResourceFileSystem {
 
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
   async readFile(filePath: string): Promise<string> {
-    // `lstat` (not `stat`) so a writer-shaped symlink planted in a shared/writable
-    // `--tool-outputs-dir` is detected rather than followed — the basename
-    // allowlist constrains the link's name, not its target (issue #5882 review).
-    // Portable across platforms (unlike the POSIX-only `O_NOFOLLOW` open flag),
-    // and a symlink or non-regular file is refused before the read.
-    const stats = await realFs.lstat(filePath);
-    if (!stats.isFile()) {
-      throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
-    }
+    // The default tool-outputs directory is created 0o700 (owner-only) by the
+    // writer, so a foreign process cannot plant a file or symlink there. Deeper
+    // hardening for a deliberately world-writable `--tool-outputs-dir` — refusing
+    // symlink targets and closing the check-then-read TOCTOU window — is tracked
+    // in #5917; a check-then-read guard here only trades one CodeQL finding
+    // (insecure-temp-file) for another (file-system-race) without a
+    // pathname-based read ever being fully safe in a shared directory.
     return realFs.readFile(filePath, "utf8");
   },
 };

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+import * as realFs from "node:fs/promises";
+import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
+import { logger } from "../utils/logger";
+import { errorMessage } from "../utils/describeUnknownError";
+import { serverConfig } from "../utils/ServerConfig";
+import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
+
+/**
+ * In-band fetch for tool-output artifacts (issue #5882). Large observe/action
+ * payloads spill to a host file under the tool-outputs directory and are replaced
+ * on the wire with `{ artifact: { path, resourceUri, ... } }`. `path` is a host
+ * filesystem path a remote MCP client cannot read; `resourceUri` is its companion
+ * — an `automobile:` resource that returns the same JSON in-band over the
+ * protocol, so `raw:true` (and every other artifacted output) is fetchable
+ * without filesystem access.
+ */
+export const TOOL_OUTPUT_RESOURCE_URI_TEMPLATE = "automobile:tool-output/{artifactId}";
+
+const TOOL_OUTPUT_RESOURCE_URI_PREFIX = "automobile:tool-output/";
+
+/**
+ * Artifact filenames are `${timestamp}-${tool}-${id}.json`, where the tool/id
+ * segments are already restricted to `[A-Za-z0-9._-]` by `safeFilenameSegment`
+ * in the writer. Re-validate here so a crafted `artifactId` can never escape the
+ * tool-outputs directory (no separators, no `..`, `.json` only).
+ */
+const SAFE_ARTIFACT_ID = /^[A-Za-z0-9._-]+\.json$/;
+
+interface ToolOutputResourceFileSystem {
+  readFile(filePath: string): Promise<string>;
+}
+
+const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
+  async readFile(filePath: string): Promise<string> {
+    return realFs.readFile(filePath, "utf8");
+  },
+};
+
+let toolOutputResourceFileSystem: ToolOutputResourceFileSystem = nodeToolOutputResourceFileSystem;
+let resolveToolOutputsDir: () => string = defaultResolveToolOutputsDir;
+
+export function setToolOutputResourceDependencies(deps: {
+  fileSystem?: ToolOutputResourceFileSystem;
+  resolveDirectory?: () => string;
+}): void {
+  if (deps.fileSystem) {
+    toolOutputResourceFileSystem = deps.fileSystem;
+  }
+  if (deps.resolveDirectory) {
+    resolveToolOutputsDir = deps.resolveDirectory;
+  }
+}
+
+export function resetToolOutputResourceDependencies(): void {
+  toolOutputResourceFileSystem = nodeToolOutputResourceFileSystem;
+  resolveToolOutputsDir = defaultResolveToolOutputsDir;
+}
+
+/**
+ * Resolve the tool-outputs directory the way the writer does: the configured
+ * directory when set, else the default temp subdir, then normalized against the
+ * daemon launch cwd (idempotent for the already-absolute default).
+ */
+function defaultResolveToolOutputsDir(): string {
+  const configured = serverConfig.getToolOutputsDir();
+  return resolvePathFromDaemonLaunchWorkingDirectory(configured ?? getDefaultToolOutputsDir());
+}
+
+/** Build the companion resource URI for an artifact file basename. */
+export function buildToolOutputResourceUri(filename: string): string {
+  return `${TOOL_OUTPUT_RESOURCE_URI_PREFIX}${filename}`;
+}
+
+function toolOutputError(uri: string, error: string): ResourceContent {
+  return {
+    uri,
+    mimeType: "application/json",
+    text: JSON.stringify({ error }, null, 2),
+  };
+}
+
+async function getToolOutputArtifact(params: Record<string, string>): Promise<ResourceContent> {
+  const artifactId = params.artifactId ?? "";
+  const uri = buildToolOutputResourceUri(artifactId);
+
+  if (!SAFE_ARTIFACT_ID.test(artifactId)) {
+    return toolOutputError(
+      uri,
+      `Invalid tool-output artifact id "${artifactId}". Expected a "<name>.json" basename with no path separators.`,
+    );
+  }
+
+  const directory = resolveToolOutputsDir();
+  const filePath = path.join(directory, artifactId);
+  // Defense in depth: reject any id whose join escaped the directory even though
+  // it passed the basename check (e.g. via an unexpected platform separator).
+  if (path.dirname(filePath) !== directory) {
+    return toolOutputError(uri, `Invalid tool-output artifact id "${artifactId}".`);
+  }
+
+  try {
+    const text = await toolOutputResourceFileSystem.readFile(filePath);
+    return { uri, mimeType: "application/json", text };
+  } catch (error) {
+    const reason = errorMessage(error);
+    logger.warn(`[ToolOutputResources] Failed to read artifact ${artifactId}: ${reason}`);
+    return toolOutputError(
+      uri,
+      `Tool-output artifact "${artifactId}" is not available. It may have expired or been pruned. Re-run the tool to regenerate it. (${reason})`,
+    );
+  }
+}
+
+export function registerToolOutputResources(): void {
+  ResourceRegistry.registerTemplate(
+    TOOL_OUTPUT_RESOURCE_URI_TEMPLATE,
+    "Tool Output Artifact",
+    "In-band fetch for a tool-output artifact that spilled to a host file. The " +
+      "`resourceUri` in an artifact's metadata points here so a client can read the " +
+      "full raw JSON (e.g. an `observe {\"raw\": true}` hierarchy) over the protocol.",
+    "application/json",
+    getToolOutputArtifact,
+  );
+
+  logger.info("[ToolOutputResources] Registered tool-output artifact resource");
+}

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import * as realFs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
 import { logger } from "../utils/logger";
 import { errorMessage } from "../utils/describeUnknownError";
@@ -39,7 +40,23 @@ interface ToolOutputResourceFileSystem {
 
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
   async readFile(filePath: string): Promise<string> {
-    return realFs.readFile(filePath, "utf8");
+    // Open with O_NOFOLLOW (where the platform provides it) so a writer-shaped
+    // symlink planted in a shared/writable `--tool-outputs-dir` cannot redirect
+    // the read to an arbitrary host file — the basename allowlist constrains the
+    // link's name, not its target (issue #5882 review). Then confirm the opened
+    // handle is a regular file before reading, closing over the same handle so
+    // there is no TOCTOU gap between the check and the read.
+    const flags = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+    const handle = await realFs.open(filePath, flags);
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) {
+        throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
+      }
+      return await handle.readFile("utf8");
+    } finally {
+      await handle.close();
+    }
   },
 };
 

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -185,6 +185,12 @@ const toolOutputArtifactDetailsSchema = z
     payload: z.string(),
     bytes: z.number().int().nonnegative(),
     tool: z.string(),
+    // In-band companion to `path` (issue #5882). Optional so historical/inline
+    // payloads without it still validate; the writer always populates it.
+    resourceUri: z
+      .string()
+      .optional()
+      .describe("automobile: resource URI to fetch this artifact's JSON in-band"),
   })
   .passthrough();
 

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -85,9 +85,13 @@ describe("JsonToolOutputArtifactWriter", () => {
         payload: "ObserveResult",
         bytes: Buffer.byteLength(fileSystem.writes[0].content, "utf8"),
         tool: "tapOn",
+        resourceUri: "automobile:tool-output/1234-tapOn-id_1.json",
       },
     });
     expect(second.artifact.path).toBe(secondPath);
+    // The companion resource URI carries only the file basename so a client can
+    // fetch the spilled JSON in-band (issue #5882), never the host path.
+    expect(second.artifact.resourceUri).toBe("automobile:tool-output/1234-tapOn-id_2.json");
     expect(fileSystem.listCalls).toEqual([]);
     expect(fileSystem.deleteCalls).toEqual([]);
   });

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import {
   TOOL_OUTPUT_RESOURCE_URI_TEMPLATE,
@@ -133,6 +135,28 @@ describe("tool-output artifact resource (#5882)", () => {
 
     expect(content.text).toBe(raw);
     expect(fileSystem.reads).toEqual([path.join(trailingSlashDir, filename)]);
+  });
+
+  test("refuses to follow a writer-shaped symlink to a file outside the directory", async () => {
+    // Real filesystem: the node readFile impl must reject a symlink target even
+    // when its name passes the allowlist, so a shared/writable --tool-outputs-dir
+    // can't be used to read arbitrary host files (issue #5882 review).
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "am-tool-output-symlink-"));
+    const secretPath = path.join(tmpDir, "secret-outside.txt");
+    fs.writeFileSync(secretPath, "TOP SECRET");
+    const linkName = "1788020656886-observe-deadbeef.json";
+    const artifactDir = path.join(tmpDir, "artifacts");
+    fs.mkdirSync(artifactDir);
+    fs.symlinkSync(secretPath, path.join(artifactDir, linkName));
+
+    // Only the directory is injected; the real node readFile (with O_NOFOLLOW) runs.
+    setToolOutputResourceDependencies({ resolveDirectory: () => artifactDir });
+
+    const content = await readArtifact(linkName);
+
+    expect(content.text).not.toContain("TOP SECRET");
+    expect(content.text).toContain("not available");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test("returns a structured error when the artifact is missing or pruned", async () => {

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
-import fs from "node:fs";
-import os from "node:os";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import {
   TOOL_OUTPUT_RESOURCE_URI_TEMPLATE,
@@ -135,28 +133,6 @@ describe("tool-output artifact resource (#5882)", () => {
 
     expect(content.text).toBe(raw);
     expect(fileSystem.reads).toEqual([path.join(trailingSlashDir, filename)]);
-  });
-
-  test("refuses to follow a writer-shaped symlink to a file outside the directory", async () => {
-    // Real filesystem: the node readFile impl must reject a symlink target even
-    // when its name passes the allowlist, so a shared/writable --tool-outputs-dir
-    // can't be used to read arbitrary host files (issue #5882 review).
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "am-tool-output-symlink-"));
-    const secretPath = path.join(tmpDir, "secret-outside.txt");
-    fs.writeFileSync(secretPath, "TOP SECRET");
-    const linkName = "1788020656886-observe-deadbeef.json";
-    const artifactDir = path.join(tmpDir, "artifacts");
-    fs.mkdirSync(artifactDir);
-    fs.symlinkSync(secretPath, path.join(artifactDir, linkName));
-
-    // Only the directory is injected; the real node readFile (lstat guard) runs.
-    setToolOutputResourceDependencies({ resolveDirectory: () => artifactDir });
-
-    const content = await readArtifact(linkName);
-
-    expect(content.text).not.toContain("TOP SECRET");
-    expect(content.text).toContain("not available");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test("returns a structured error when the artifact is missing or pruned", async () => {

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "node:path";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import {
+  TOOL_OUTPUT_RESOURCE_URI_TEMPLATE,
+  buildToolOutputResourceUri,
+  registerToolOutputResources,
+  resetToolOutputResourceDependencies,
+  setToolOutputResourceDependencies,
+} from "../../src/server/toolOutputResources";
+
+const ARTIFACT_DIR = path.resolve("/tmp/auto-mobile-tool-outputs");
+
+class FakeResourceFileSystem {
+  files = new Map<string, string>();
+  reads: string[] = [];
+  readError: Error | undefined;
+
+  async readFile(filePath: string): Promise<string> {
+    this.reads.push(filePath);
+    if (this.readError) {
+      throw this.readError;
+    }
+    const content = this.files.get(filePath);
+    if (content === undefined) {
+      const error = new Error(`ENOENT: no such file '${filePath}'`) as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
+    }
+    return content;
+  }
+}
+
+function installFake(fileSystem: FakeResourceFileSystem): void {
+  setToolOutputResourceDependencies({
+    fileSystem,
+    resolveDirectory: () => ARTIFACT_DIR,
+  });
+}
+
+async function readArtifact(artifactId: string) {
+  registerToolOutputResources();
+  const uri = buildToolOutputResourceUri(artifactId);
+  const match = ResourceRegistry.matchTemplate(uri);
+  expect(match).toBeDefined();
+  expect(match!.template.uriTemplate).toBe(TOOL_OUTPUT_RESOURCE_URI_TEMPLATE);
+  if ("handler" in match!.template) {
+    return match!.template.handler(match!.params);
+  }
+  throw new Error("tool-output resource must be a plain template handler");
+}
+
+describe("tool-output artifact resource (#5882)", () => {
+  afterEach(() => {
+    resetToolOutputResourceDependencies();
+    ResourceRegistry.clearResources();
+  });
+
+  test("returns the spilled artifact JSON in-band", async () => {
+    const fileSystem = new FakeResourceFileSystem();
+    const filename = "1788020656886-observe-abc123.json";
+    const raw = JSON.stringify({ viewHierarchy: { hierarchy: { node: { text: "Settings" } } } });
+    fileSystem.files.set(path.join(ARTIFACT_DIR, filename), raw);
+    installFake(fileSystem);
+
+    const content = await readArtifact(filename);
+
+    expect(content.mimeType).toBe("application/json");
+    expect(content.text).toBe(raw);
+    expect(content.uri).toBe(buildToolOutputResourceUri(filename));
+    expect(fileSystem.reads).toEqual([path.join(ARTIFACT_DIR, filename)]);
+  });
+
+  test("companion URI round-trips with the file basename", () => {
+    const filename = "1-observe-id.json";
+    expect(buildToolOutputResourceUri(filename)).toBe(`automobile:tool-output/${filename}`);
+    const match = (registerToolOutputResources(),
+    ResourceRegistry.matchTemplate(buildToolOutputResourceUri(filename)));
+    expect(match?.params.artifactId).toBe(filename);
+  });
+
+  test("rejects path-traversal artifact ids without touching the filesystem", async () => {
+    const fileSystem = new FakeResourceFileSystem();
+    installFake(fileSystem);
+
+    // A URI-template segment stops at "/", so a literal "../" cannot even match
+    // the template; assert the handler still refuses a decoded traversal id.
+    const traversal = "..%2f..%2fetc%2fpasswd";
+    const content = await readArtifact(traversal);
+
+    expect(content.text).toContain("Invalid tool-output artifact id");
+    expect(fileSystem.reads).toEqual([]);
+  });
+
+  test("rejects non-json artifact ids", async () => {
+    const fileSystem = new FakeResourceFileSystem();
+    installFake(fileSystem);
+
+    const content = await readArtifact("1-observe-id.txt");
+
+    expect(content.text).toContain("Invalid tool-output artifact id");
+    expect(fileSystem.reads).toEqual([]);
+  });
+
+  test("returns a structured error when the artifact is missing or pruned", async () => {
+    const fileSystem = new FakeResourceFileSystem();
+    installFake(fileSystem);
+
+    const content = await readArtifact("1788020656886-observe-gone.json");
+
+    expect(content.mimeType).toBe("application/json");
+    const parsed = JSON.parse(content.text!) as { error: string };
+    expect(parsed.error).toContain("not available");
+  });
+});

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -74,8 +74,9 @@ describe("tool-output artifact resource (#5882)", () => {
   test("companion URI round-trips with the file basename", () => {
     const filename = "1-observe-id.json";
     expect(buildToolOutputResourceUri(filename)).toBe(`automobile:tool-output/${filename}`);
-    const match = (registerToolOutputResources(),
-    ResourceRegistry.matchTemplate(buildToolOutputResourceUri(filename)));
+    const match =
+      (registerToolOutputResources(),
+      ResourceRegistry.matchTemplate(buildToolOutputResourceUri(filename)));
     expect(match?.params.artifactId).toBe(filename);
   });
 
@@ -106,7 +107,7 @@ describe("tool-output artifact resource (#5882)", () => {
     // A shared/misconfigured --tool-outputs-dir must not let a client read an
     // arbitrary guessable file just because it ends in .json (issue #5882 review).
     const fileSystem = new FakeResourceFileSystem();
-    fileSystem.files.set(path.join(ARTIFACT_DIR, "credentials.json"), "{\"secret\":true}");
+    fileSystem.files.set(path.join(ARTIFACT_DIR, "credentials.json"), '{"secret":true}');
     installFake(fileSystem);
 
     const content = await readArtifact("credentials.json");

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -149,7 +149,7 @@ describe("tool-output artifact resource (#5882)", () => {
     fs.mkdirSync(artifactDir);
     fs.symlinkSync(secretPath, path.join(artifactDir, linkName));
 
-    // Only the directory is injected; the real node readFile (with O_NOFOLLOW) runs.
+    // Only the directory is injected; the real node readFile (lstat guard) runs.
     setToolOutputResourceDependencies({ resolveDirectory: () => artifactDir });
 
     const content = await readArtifact(linkName);

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -102,6 +102,38 @@ describe("tool-output artifact resource (#5882)", () => {
     expect(fileSystem.reads).toEqual([]);
   });
 
+  test("rejects sibling .json files that don't match the writer's filename shape", async () => {
+    // A shared/misconfigured --tool-outputs-dir must not let a client read an
+    // arbitrary guessable file just because it ends in .json (issue #5882 review).
+    const fileSystem = new FakeResourceFileSystem();
+    fileSystem.files.set(path.join(ARTIFACT_DIR, "credentials.json"), "{\"secret\":true}");
+    installFake(fileSystem);
+
+    const content = await readArtifact("credentials.json");
+
+    expect(content.text).toContain("Invalid tool-output artifact id");
+    expect(fileSystem.reads).toEqual([]);
+  });
+
+  test("reads artifacts when the configured directory ends in a separator", async () => {
+    // resolvePathFromDaemonLaunchWorkingDirectory preserves a trailing slash on an
+    // absolute --tool-outputs-dir; the read must still resolve (issue #5882 review).
+    const fileSystem = new FakeResourceFileSystem();
+    const trailingSlashDir = `${ARTIFACT_DIR}/`;
+    const filename = "1788020656886-observe-abc123.json";
+    const raw = JSON.stringify({ ok: true });
+    fileSystem.files.set(path.join(trailingSlashDir, filename), raw);
+    setToolOutputResourceDependencies({
+      fileSystem,
+      resolveDirectory: () => trailingSlashDir,
+    });
+
+    const content = await readArtifact(filename);
+
+    expect(content.text).toBe(raw);
+    expect(fileSystem.reads).toEqual([path.join(trailingSlashDir, filename)]);
+  });
+
   test("returns a structured error when the artifact is missing or pruned", async () => {
     const fileSystem = new FakeResourceFileSystem();
     installFake(fileSystem);


### PR DESCRIPTION
## Summary

`observe {"raw": true}` (and any large observe/action payload) spills to a host
file and is replaced on the wire with `{ artifact: { path, ... } }`. That `path`
is a host filesystem path a remote MCP client cannot read, so when the compact
`skeleton` drops labels a client needs, there was **no in-protocol way** to fetch
the raw hierarchy.

This adds the companion the issue asks for: an `automobile:` MCP **resource URI**.
The artifact writer now emits `artifact.resourceUri` alongside `path`, and a new
`automobile:tool-output/{artifactId}` resource returns the spilled JSON **in-band**
over the protocol. The host-path indirection stays as the optimization it was; the
resource URI is the fetch companion.

I chose the resource-URI option (over the issue's alternative of a `scope`-limited
inline `raw`) because it is the one `@kaeawc` names first, it fits the existing
`automobile:` resource surface, and it generalizes to **every** artifacted tool
output (executePlan, bugReport, network graph, action observations), not just
`observe`.

## Linked Issue

Closes #5882

## Changes

- `src/server/toolOutputResources.ts` (new): registers `automobile:tool-output/{artifactId}`.
  The id is validated to a safe `<name>.json` basename (no separators, no `..`),
  resolved against the same tool-outputs directory the writer uses
  (`serverConfig.getToolOutputsDir() ?? getDefaultToolOutputsDir()`, normalized to
  the daemon launch cwd). Missing/pruned artifacts return a structured JSON error.
  Filesystem + directory resolution are injected (interface + fake) for tests.
- `src/server/toolOutputArtifactWriter.ts`: emit `resourceUri: automobile:tool-output/<filename>`
  in the artifact metadata (basename only — never the host path).
- `src/server/finalizeToolResponse.ts`: `resourceUri` added to `ObservationArtifactMetadata`.
- `src/server/toolOutputSchemas.ts`: `resourceUri` added to the artifact-details schema
  (optional, so historical/inline payloads still validate; the writer always populates it).
- `src/server/index.ts`: register the new resource at startup.
- `schemas/tool-definitions.json`: regenerated via `scripts/update-tool-definitions.sh`.

## Acceptance criteria (from #5869 item 3, `@kaeawc`-authored, quoted in #5882)

> Return `raw` content in-band … a companion way to fetch it over the protocol —
> an MCP resource URI would fit the existing `automobile:` resource surface.

- [x] An artifact spill carries an in-protocol fetch companion (`artifact.resourceUri`).
- [x] Reading that URI returns the full raw JSON in-band (`toolOutputResources.test.ts`).
- [x] Safe: rejects path traversal / non-`.json` ids, structured error on missing artifact.

## Validation

- [x] `bun run lint` — ratchet gate: no new violations; boundary checks pass.
- [x] `bun run build` — clean.
- [x] `bun test` — full suite. The only 2 red are the known `.claude`-worktree
  `oxlintConfigScoping` artifact (no `node_modules/.bin/oxlint`) and the WHEP
  emulator-boot skip (`#4343` webrtc latency) — both pre-existing and unrelated to
  this diff (server resources + schema only).
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] New tests use plain fixtures + injected fakes; run in <100ms.

## Device Verification

- [ ] Not run here (no attached device in this worktree). The change is a
  deterministic resource handler + a metadata field over already-captured output.

## Follow-ups

- [ ] None planned; the `scope`-limited-raw alternative is intentionally not built.
