### PR TITLE
fix(daemon): harden non-finite transport sentinel against collision and scope revival (#5863)

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -2,7 +2,7 @@ import { createConnection, Socket } from "node:net";
 import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { logger } from "../utils/logger";
-import { nonFiniteReplacer } from "../utils/nonFiniteJson";
+import { encodeNonFinite } from "../utils/nonFiniteJson";
 import { ActionableError } from "../models";
 import { DaemonRequest, DaemonResponse, DaemonNotification, isDaemonNotification } from "./types";
 import {
@@ -10,6 +10,7 @@ import {
   CONNECTION_TIMEOUT_MS,
   DAEMON_VERSION,
   DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
+  DAEMON_NON_FINITE_ENCODED_PARAM,
 } from "./constants";
 import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
@@ -137,6 +138,29 @@ export class DaemonClient {
       clientBuildId: this.clientIdentity.build.buildId,
       clientEntryScript: this.clientIdentity.build.entryScript,
     };
+  }
+
+  /**
+   * Serialize an outbound request as a newline-delimited frame, encoding any
+   * non-finite argument as a JSON-safe sentinel (#5854 §2). When — and only when —
+   * a tool call actually encoded a non-finite value, we stamp a transport-provenance
+   * flag inside `arguments` so the MCP handler knows this request is sentinel-encoded
+   * and must be revived (#5863); requests with no non-finite values carry no flag and
+   * the handler leaves them untouched.
+   */
+  private serializeRequestFrame(request: DaemonRequest): string {
+    const { value, encoded } = encodeNonFinite(request);
+    if (encoded && request.type === "mcp_request" && request.method === "tools/call") {
+      const params = (value as { params?: Record<string, unknown> }).params;
+      if (params && typeof params === "object") {
+        const existingArgs =
+          params.arguments && typeof params.arguments === "object" && !Array.isArray(params.arguments)
+            ? (params.arguments as Record<string, unknown>)
+            : {};
+        params.arguments = { ...existingArgs, [DAEMON_NON_FINITE_ENCODED_PARAM]: true };
+      }
+    }
+    return JSON.stringify(value) + "\n";
   }
 
   /**
@@ -496,7 +520,7 @@ export class DaemonClient {
         return;
       }
 
-      this.socket.write(JSON.stringify(request, nonFiniteReplacer) + "\n");
+      this.socket.write(this.serializeRequestFrame(request));
     });
   }
 
@@ -545,7 +569,7 @@ export class DaemonClient {
         return;
       }
 
-      this.socket.write(JSON.stringify(request, nonFiniteReplacer) + "\n");
+      this.socket.write(this.serializeRequestFrame(request));
     });
   }
 

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -154,7 +154,9 @@ export class DaemonClient {
       const params = (value as { params?: Record<string, unknown> }).params;
       if (params && typeof params === "object") {
         const existingArgs =
-          params.arguments && typeof params.arguments === "object" && !Array.isArray(params.arguments)
+          params.arguments &&
+          typeof params.arguments === "object" &&
+          !Array.isArray(params.arguments)
             ? (params.arguments as Record<string, unknown>)
             : {};
         params.arguments = { ...existingArgs, [DAEMON_NON_FINITE_ENCODED_PARAM]: true };

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -194,11 +194,12 @@ export const DAEMON_RELEASED_SESSION_PARAM = "__autoMobileReleasedSessionUuid";
 
 /**
  * Transport-provenance flag the daemon client sets inside a tool call's
- * `arguments` when — and only when — it actually sentinel-encoded a non-finite
- * argument on the wire (#5863). The MCP CallTool handler revives sentinels only
- * for requests carrying this flag, so direct in-memory / stdio clients (whose
- * requests were never encoded) skip the revival walk and its collision risk. It
- * is stripped before the tool runs (see `stripInternalToolParams`).
+ * `arguments` when — and only when — it transformed the payload on the wire
+ * (#5863): either sentinel-encoded a non-finite argument, or escaped a real object
+ * that collides with the sentinel shape. Both must be reversed by the receiver, so
+ * the MCP CallTool handler revives only requests carrying this flag; direct
+ * in-memory / stdio clients (whose requests were never encoded) skip the revival
+ * walk entirely. It is stripped before the tool runs (see `stripInternalToolParams`).
  */
 export const DAEMON_NON_FINITE_ENCODED_PARAM = "__autoMobileNonFiniteEncoded";
 

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -192,6 +192,16 @@ export const DAEMON_BOUND_SESSION_PARAM = "__autoMobileBoundSessionUuid";
 /** Socket RPC field identifying a released session used only for inactive resource reads. */
 export const DAEMON_RELEASED_SESSION_PARAM = "__autoMobileReleasedSessionUuid";
 
+/**
+ * Transport-provenance flag the daemon client sets inside a tool call's
+ * `arguments` when — and only when — it actually sentinel-encoded a non-finite
+ * argument on the wire (#5863). The MCP CallTool handler revives sentinels only
+ * for requests carrying this flag, so direct in-memory / stdio clients (whose
+ * requests were never encoded) skip the revival walk and its collision risk. It
+ * is stripped before the tool runs (see `stripInternalToolParams`).
+ */
+export const DAEMON_NON_FINITE_ENCODED_PARAM = "__autoMobileNonFiniteEncoded";
+
 /** Loopback-only header for a released session's inactive resource-read capability. */
 export const DAEMON_RELEASED_SESSION_HEADER = "x-auto-mobile-released-session-uuid";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ActionableError } from "../models";
 import { formatToolParamError } from "./toolParamError";
-import { reviveNonFiniteNumbers } from "../utils/nonFiniteJson";
+import { reviveNonFiniteArguments } from "../utils/nonFiniteJson";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
@@ -11,7 +11,10 @@ import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanEx
 import { SessionToolBinding } from "./SessionToolBinding";
 import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
 import { TerminalSessionError } from "../daemon/sessionManager";
-import { INTERNAL_MCP_REQUEST_TIMEOUT_PARAM } from "../daemon/constants";
+import {
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  DAEMON_NON_FINITE_ENCODED_PARAM,
+} from "../daemon/constants";
 import {
   deviceLostErrorFromAbortSignal,
   deviceLossOutcomeFromError,
@@ -172,7 +175,8 @@ function stripInternalToolParams(params: unknown): unknown {
   if (
     !(INTERNAL_MCP_SESSION_PARAM in params) &&
     !(INTERNAL_EXECUTION_ID_PARAM in params) &&
-    !(INTERNAL_EXECUTION_START_TIME_PARAM in params)
+    !(INTERNAL_EXECUTION_START_TIME_PARAM in params) &&
+    !(DAEMON_NON_FINITE_ENCODED_PARAM in params)
   ) {
     return params;
   }
@@ -182,6 +186,9 @@ function stripInternalToolParams(params: unknown): unknown {
   delete rest[INTERNAL_EXECUTION_ID_PARAM];
   delete rest[INTERNAL_EXECUTION_START_TIME_PARAM];
   delete rest[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+  // Safety net: revival already strips this transport-provenance flag (#5863), but
+  // guard the tool boundary against any future path that sets it without reviving.
+  delete rest[DAEMON_NON_FINITE_ENCODED_PARAM];
   return rest;
 }
 
@@ -455,8 +462,11 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // survive the socket + loopback-HTTP hops (#5854 §2). Done BEFORE logging and
     // validation so the request trace shows the real Infinity/-Infinity/NaN
     // instead of `null`, and the schema rejects it with "must be a finite number".
+    // Scoped by transport provenance (#5863): revival runs only for requests the
+    // daemon client actually sentinel-encoded (flagged inside `arguments`); direct
+    // in-memory / stdio clients are left untouched. The flag is stripped here.
     if (request.params && request.params.arguments) {
-      request.params.arguments = reviveNonFiniteNumbers(request.params.arguments) as Record<
+      request.params.arguments = reviveNonFiniteArguments(request.params.arguments) as Record<
         string,
         unknown
       >;

--- a/src/utils/nonFiniteJson.ts
+++ b/src/utils/nonFiniteJson.ts
@@ -10,9 +10,25 @@
 // validation. The sentinel is a plain `{ [TAG]: "Infinity" }` object, so it passes
 // through every intermediate JSON.parse/stringify (including the MCP SDK's HTTP
 // transport, which this code cannot hook) untouched.
+//
+// #5863 hardens two robustness gaps left open by #5860:
+//   1. Collision — a real payload object that literally has the shape
+//      `{ [TAG]: "Infinity" }` would decode to the number Infinity. {@link encodeNonFinite}
+//      ESCAPES any real object that carries the reserved TAG key, so on the wire a
+//      bare sentinel shape can only ever come from our own encoder, and every real
+//      payload round-trips unchanged.
+//   2. Provenance — {@link reviveNonFiniteArguments} decodes only requests the client
+//      actually encoded (flagged via `DAEMON_NON_FINITE_ENCODED_PARAM`), so direct
+//      in-memory / stdio clients skip the walk entirely.
+
+import { DAEMON_NON_FINITE_ENCODED_PARAM } from "../daemon/constants";
 
 // Deliberately unlikely to collide with a real payload key.
 const NON_FINITE_TAG = "__autoMobileNonFinite__";
+
+// Key of the escape wrapper's single field. Only ever appears nested under
+// NON_FINITE_TAG in an escaped-object sentinel, never at a payload's top level.
+const ESCAPE_KEY = "__esc__";
 
 type NonFiniteMarker = "Infinity" | "-Infinity" | "NaN";
 
@@ -36,47 +52,126 @@ function numberFor(marker: NonFiniteMarker): number {
   return marker === "Infinity" ? Infinity : -Infinity;
 }
 
-// A `JSON.stringify` replacer that rewrites non-finite numbers as sentinel objects.
-// `JSON.stringify` invokes the replacer with the live value BEFORE its own
-// null-coercion, so returning an object here is what actually reaches the wire.
-export function nonFiniteReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "number") {
-    const marker = markerFor(value);
-    if (marker) {
-      return { [NON_FINITE_TAG]: marker };
-    }
-  }
-  return value;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function sentinelMarker(value: object): NonFiniteMarker | null {
+// Rebuild an object from decoded/encoded entries with Object.fromEntries so an own
+// "__proto__" key (valid JSON, e.g. a header map) is set as an own data property
+// rather than invoking the prototype setter — plain `out[key] = …` would drop it and
+// could pollute the prototype.
+function fromEntries(entries: Array<[string, unknown]>): Record<string, unknown> {
+  return Object.fromEntries(entries);
+}
+
+// A number-sentinel: single key TAG whose value is a recognized marker string.
+function numberSentinelMarker(value: Record<string, unknown>): NonFiniteMarker | null {
   const keys = Object.keys(value);
   if (keys.length !== 1 || keys[0] !== NON_FINITE_TAG) {
     return null;
   }
-  const marker = (value as Record<string, unknown>)[NON_FINITE_TAG];
+  const marker = value[NON_FINITE_TAG];
   return marker === "Infinity" || marker === "-Infinity" || marker === "NaN" ? marker : null;
 }
 
-// Recursively convert sentinel objects produced by {@link nonFiniteReplacer} back
-// into their non-finite numbers. Returns a decoded copy; the input is not mutated.
-// Anything that is not a sentinel is passed through unchanged, so calling this on a
-// payload with no sentinels (the common case) is a cheap structural walk.
-export function reviveNonFiniteNumbers(value: unknown): unknown {
-  if (value === null || typeof value !== "object") {
+// An escaped-object sentinel: single key TAG whose value is `{ [ESCAPE_KEY]: entries }`
+// where `entries` is an array of the original object's [key, encodedValue] pairs.
+function escapedEntries(value: Record<string, unknown>): Array<[string, unknown]> | null {
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== NON_FINITE_TAG) {
+    return null;
+  }
+  const inner = value[NON_FINITE_TAG];
+  if (!isPlainObject(inner)) {
+    return null;
+  }
+  const innerKeys = Object.keys(inner);
+  if (innerKeys.length !== 1 || innerKeys[0] !== ESCAPE_KEY) {
+    return null;
+  }
+  const entries = inner[ESCAPE_KEY];
+  return Array.isArray(entries) ? (entries as Array<[string, unknown]>) : null;
+}
+
+function encodeInto(value: unknown, state: { encoded: boolean }): unknown {
+  if (typeof value === "number") {
+    const marker = markerFor(value);
+    if (marker) {
+      state.encoded = true;
+      return { [NON_FINITE_TAG]: marker };
+    }
     return value;
   }
   if (Array.isArray(value)) {
-    return value.map(reviveNonFiniteNumbers);
+    return value.map((child) => encodeInto(child, state));
   }
-  const marker = sentinelMarker(value);
+  if (isPlainObject(value)) {
+    const encodedEntries = Object.entries(value).map(
+      ([key, child]) => [key, encodeInto(child, state)] as [string, unknown],
+    );
+    // If the (encoded) object carries the reserved TAG key, its bare shape could be
+    // misread as a sentinel on decode. Escape it: stash the entries under
+    // `{ [TAG]: { [ESCAPE_KEY]: entries } }`, which decode reverses. This makes a
+    // raw sentinel shape on the wire provably our own.
+    if (Object.prototype.hasOwnProperty.call(value, NON_FINITE_TAG)) {
+      return { [NON_FINITE_TAG]: { [ESCAPE_KEY]: encodedEntries } };
+    }
+    return fromEntries(encodedEntries);
+  }
+  return value;
+}
+
+/**
+ * Encode non-finite numbers as JSON-safe sentinels and escape any real object that
+ * collides with the sentinel shape. Returns a decoded-safe copy plus whether any
+ * non-finite number was actually encoded (transport provenance — the client only
+ * flags requests where this is true). The input is not mutated.
+ */
+export function encodeNonFinite(value: unknown): { value: unknown; encoded: boolean } {
+  const state = { encoded: false };
+  const encoded = encodeInto(value, state);
+  return { value: encoded, encoded: state.encoded };
+}
+
+/**
+ * Reverse {@link encodeNonFinite}: restore non-finite numbers and un-escape real
+ * objects that used the reserved TAG key. Returns a decoded copy; the input is not
+ * mutated. A payload with no sentinels is a cheap structural walk.
+ */
+export function decodeNonFinite(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(decodeNonFinite);
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const marker = numberSentinelMarker(value);
   if (marker) {
     return numberFor(marker);
   }
-  // Build with Object.fromEntries so an own "__proto__" key (valid JSON, e.g. a
-  // header map) is set as an own data property rather than invoking the prototype
-  // setter — plain `out[key] = …` would drop it and could pollute the prototype.
-  return Object.fromEntries(
-    Object.entries(value).map(([key, child]) => [key, reviveNonFiniteNumbers(child)]),
+  const escaped = escapedEntries(value);
+  if (escaped) {
+    return fromEntries(escaped.map(([key, child]) => [key, decodeNonFinite(child)]));
+  }
+  return fromEntries(
+    Object.entries(value).map(([key, child]) => [key, decodeNonFinite(child)]),
   );
+}
+
+/**
+ * Provenance-scoped revival for a tool call's `arguments` (#5863). Decodes sentinels
+ * ONLY when the arguments carry the encoded flag the daemon client sets, then strips
+ * the flag. Arguments without the flag — direct in-memory / stdio clients that never
+ * encoded — are returned untouched, so no valid payload is walked or misread.
+ */
+export function reviveNonFiniteArguments(args: unknown): unknown {
+  if (!isPlainObject(args)) {
+    return args;
+  }
+  if (args[DAEMON_NON_FINITE_ENCODED_PARAM] !== true) {
+    return args;
+  }
+  const rest = { ...args };
+  delete rest[DAEMON_NON_FINITE_ENCODED_PARAM];
+  return decodeNonFinite(rest);
 }

--- a/src/utils/nonFiniteJson.ts
+++ b/src/utils/nonFiniteJson.ts
@@ -112,8 +112,13 @@ function encodeInto(value: unknown, state: { encoded: boolean }): unknown {
     // If the (encoded) object carries the reserved TAG key, its bare shape could be
     // misread as a sentinel on decode. Escape it: stash the entries under
     // `{ [TAG]: { [ESCAPE_KEY]: entries } }`, which decode reverses. This makes a
-    // raw sentinel shape on the wire provably our own.
+    // raw sentinel shape on the wire provably our own. Escaping needs its inverse
+    // (decode) to run, and decode is provenance-gated on `encoded`, so an escape
+    // must flip `encoded` too — otherwise a collision-shaped object with no
+    // co-occurring non-finite number would be escaped on the wire but never
+    // un-escaped by the receiver, corrupting a payload #5863 promises to preserve.
     if (Object.prototype.hasOwnProperty.call(value, NON_FINITE_TAG)) {
+      state.encoded = true;
       return { [NON_FINITE_TAG]: { [ESCAPE_KEY]: encodedEntries } };
     }
     return fromEntries(encodedEntries);
@@ -123,9 +128,11 @@ function encodeInto(value: unknown, state: { encoded: boolean }): unknown {
 
 /**
  * Encode non-finite numbers as JSON-safe sentinels and escape any real object that
- * collides with the sentinel shape. Returns a decoded-safe copy plus whether any
- * non-finite number was actually encoded (transport provenance — the client only
- * flags requests where this is true). The input is not mutated.
+ * collides with the sentinel shape. Returns a decoded-safe copy plus whether the
+ * payload was transformed at all — a non-finite encoded OR a collision escaped.
+ * Both need {@link decodeNonFinite} to run to be reversed, so the client flags a
+ * request (transport provenance) exactly when `encoded` is true. The input is not
+ * mutated.
  */
 export function encodeNonFinite(value: unknown): { value: unknown; encoded: boolean } {
   const state = { encoded: false };
@@ -153,9 +160,7 @@ export function decodeNonFinite(value: unknown): unknown {
   if (escaped) {
     return fromEntries(escaped.map(([key, child]) => [key, decodeNonFinite(child)]));
   }
-  return fromEntries(
-    Object.entries(value).map(([key, child]) => [key, decodeNonFinite(child)]),
-  );
+  return fromEntries(Object.entries(value).map(([key, child]) => [key, decodeNonFinite(child)]));
 }
 
 /**

--- a/test/daemon/clientNonFiniteEncoding.test.ts
+++ b/test/daemon/clientNonFiniteEncoding.test.ts
@@ -65,6 +65,28 @@ describe("DaemonClient encodes non-finite tool arguments on the wire", () => {
     // A finite sibling is untouched, and nothing became null.
     expect(args.ok).toBe(3);
     expect(JSON.stringify(args)).not.toContain("null");
+    // #5863: because a non-finite was actually encoded, the client stamps the
+    // transport-provenance flag so the handler knows to revive this request.
+    expect(args.__autoMobileNonFiniteEncoded).toBe(true);
+
+    await client.close();
+    await pending;
+  });
+
+  test("a request with only finite arguments carries no provenance flag", async () => {
+    const writes: string[] = [];
+    const client = createConnectedClient(fakeTimer, writes);
+
+    const pending = client.callTool("tapOn", { x: 10, y: 20 }).catch(() => {});
+
+    const frame = firstFrame(writes) as {
+      params: { arguments: Record<string, unknown> };
+    };
+    const args = frame.params.arguments;
+    expect(args.x).toBe(10);
+    expect(args.y).toBe(20);
+    // No non-finite encoded → no flag → the handler skips revival for this request.
+    expect("__autoMobileNonFiniteEncoded" in args).toBe(false);
 
     await client.close();
     await pending;

--- a/test/server/nonFiniteReviveHandler.test.ts
+++ b/test/server/nonFiniteReviveHandler.test.ts
@@ -32,8 +32,10 @@ describe("CallTool handler revives non-finite sentinels before validation", () =
             platform: "android",
             selector: { text: "Gmail" },
             action: "longPress",
-            // The exact shape the daemon client puts on the wire for `Infinity`.
+            // The exact shape the daemon client puts on the wire for `Infinity`,
+            // plus the transport-provenance flag it stamps alongside it (#5863).
             duration: { __autoMobileNonFinite__: "Infinity" },
+            __autoMobileNonFiniteEncoded: true,
           },
         },
       },
@@ -43,5 +45,34 @@ describe("CallTool handler revives non-finite sentinels before validation", () =
     // The handler revives the sentinel to Infinity, so validation names the
     // finite constraint instead of complaining about an object-typed duration.
     await expect(call).rejects.toThrow(/duration must be a finite number/);
+  });
+
+  // #5863 AC2: a request WITHOUT the provenance flag (e.g. a direct in-memory /
+  // stdio client that never sentinel-encoded) is not revived, so a bare
+  // sentinel-shaped object stays an object and is NOT reported as a non-finite
+  // number — proving revival is scoped by provenance, not applied blindly.
+  test("an unflagged sentinel-shaped duration is not revived to a non-finite number", async () => {
+    const { client } = fixture.getContext();
+
+    const call = client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "tapOn",
+          arguments: {
+            platform: "android",
+            selector: { text: "Gmail" },
+            action: "longPress",
+            duration: { __autoMobileNonFinite__: "Infinity" },
+          },
+        },
+      },
+      z.object({}).passthrough(),
+    );
+
+    // No provenance flag → the object is left as-is and rejected as a type
+    // mismatch, never as "must be a finite number".
+    await expect(call).rejects.toThrow();
+    await expect(call).rejects.not.toThrow(/duration must be a finite number/);
   });
 });

--- a/test/utils/nonFiniteJson.test.ts
+++ b/test/utils/nonFiniteJson.test.ts
@@ -23,6 +23,20 @@ function throughWire(value: unknown): unknown {
   return decodeNonFinite(afterHops);
 }
 
+// Model the FULL client→server path, including the provenance gate: the client
+// stamps the flag only when `encodeNonFinite` reports it transformed the payload,
+// and the server (`reviveNonFiniteArguments`) decodes only flagged requests. This
+// is the path an argument actually travels — decode does not run unconditionally.
+function throughDaemon(args: unknown): unknown {
+  const { value, encoded } = encodeNonFinite(args);
+  const wire =
+    encoded && value !== null && typeof value === "object" && !Array.isArray(value)
+      ? { ...(value as Record<string, unknown>), [DAEMON_NON_FINITE_ENCODED_PARAM]: true }
+      : value;
+  const afterHops = JSON.parse(JSON.stringify(JSON.parse(JSON.stringify(wire))));
+  return reviveNonFiniteArguments(afterHops);
+}
+
 describe("encodeNonFinite encodes non-finite numbers as sentinels", () => {
   test("Infinity/-Infinity/NaN become tagged objects on the wire", () => {
     const { value, encoded } = encodeNonFinite({
@@ -167,5 +181,31 @@ describe("reviveNonFiniteArguments applies revival only by transport provenance"
   test("non-object arguments pass through", () => {
     expect(reviveNonFiniteArguments(undefined)).toBe(undefined);
     expect(reviveNonFiniteArguments("x")).toBe("x");
+  });
+
+  // Regression (#5863): escaping is applied whenever a real object collides with
+  // the sentinel shape, but un-escaping (decode) is provenance-gated. If a request
+  // whose ONLY special feature is a collision-shaped object — no co-occurring
+  // non-finite number — did not set the flag, the escaped wrapper would reach the
+  // tool uncorrected. The client must flag escape-only requests too.
+  test("a collision-shaped argument with NO non-finite still round-trips end-to-end", () => {
+    const bare = { __autoMobileNonFinite__: "NaN" };
+    expect(throughDaemon(bare)).toEqual(bare);
+
+    const nested = { responseHeaders: { __autoMobileNonFinite__: "Infinity" }, ok: 1 };
+    expect(throughDaemon(nested)).toEqual(nested);
+  });
+
+  test("encodeNonFinite reports encoded=true when it only escaped a collision", () => {
+    // No non-finite number anywhere, but the payload is transformed (escaped), so
+    // the flag must fire — otherwise decode never runs to reverse the escape.
+    const { encoded } = encodeNonFinite({ __autoMobileNonFinite__: "Infinity" });
+    expect(encoded).toBe(true);
+  });
+
+  test("a non-finite argument still round-trips end-to-end through the gate", () => {
+    const revived = throughDaemon({ duration: Infinity, ok: 3 }) as Record<string, unknown>;
+    expect(revived.duration).toBe(Infinity);
+    expect(revived.ok).toBe(3);
   });
 });

--- a/test/utils/nonFiniteJson.test.ts
+++ b/test/utils/nonFiniteJson.test.ts
@@ -1,20 +1,39 @@
 import { describe, expect, test } from "bun:test";
-import { nonFiniteReplacer, reviveNonFiniteNumbers } from "../../src/utils/nonFiniteJson";
+import {
+  decodeNonFinite,
+  encodeNonFinite,
+  reviveNonFiniteArguments,
+} from "../../src/utils/nonFiniteJson";
+import { DAEMON_NON_FINITE_ENCODED_PARAM } from "../../src/daemon/constants";
 
 // Issue #5854 §2: JSON has no representation for non-finite numbers, so a
 // tool-call argument that is Infinity/-Infinity/NaN is flattened to `null` before
 // the daemon can log or validate it. The client encodes them as JSON-safe
 // sentinels that survive the wire; the MCP handler revives them.
+//
+// Issue #5863 hardens two gaps: literal-collision escaping and provenance scoping.
 
 const TAG = "__autoMobileNonFinite__";
 
-describe("nonFiniteReplacer encodes non-finite numbers as sentinels", () => {
+// Model the real wire path: encode → JSON stringify → parse (socket) → stringify →
+// parse (loopback HTTP) → decode.
+function throughWire(value: unknown): unknown {
+  const { value: encoded } = encodeNonFinite(value);
+  const afterHops = JSON.parse(JSON.stringify(JSON.parse(JSON.stringify(encoded))));
+  return decodeNonFinite(afterHops);
+}
+
+describe("encodeNonFinite encodes non-finite numbers as sentinels", () => {
   test("Infinity/-Infinity/NaN become tagged objects on the wire", () => {
-    const wire = JSON.stringify(
-      { duration: Infinity, back: -Infinity, ratio: NaN, ok: 3, label: "hi" },
-      nonFiniteReplacer,
-    );
-    expect(JSON.parse(wire)).toEqual({
+    const { value, encoded } = encodeNonFinite({
+      duration: Infinity,
+      back: -Infinity,
+      ratio: NaN,
+      ok: 3,
+      label: "hi",
+    });
+    expect(encoded).toBe(true);
+    expect(JSON.parse(JSON.stringify(value))).toEqual({
       duration: { [TAG]: "Infinity" },
       back: { [TAG]: "-Infinity" },
       ratio: { [TAG]: "NaN" },
@@ -23,57 +42,49 @@ describe("nonFiniteReplacer encodes non-finite numbers as sentinels", () => {
     });
   });
 
-  test("finite numbers (including -0 and large values) are left untouched", () => {
-    const wire = JSON.stringify({ a: 0, b: -0, c: -3.5, d: 1e308 }, nonFiniteReplacer);
+  test("finite numbers (including -0 and large values) are left untouched, encoded=false", () => {
+    const { value, encoded } = encodeNonFinite({ a: 0, b: -0, c: -3.5, d: 1e308 });
+    expect(encoded).toBe(false);
     // -0 serializes as 0 (unchanged from default JSON behavior).
-    expect(JSON.parse(wire)).toEqual({ a: 0, b: 0, c: -3.5, d: 1e308 });
+    expect(JSON.parse(JSON.stringify(value))).toEqual({ a: 0, b: 0, c: -3.5, d: 1e308 });
   });
 
   test("non-finite values nested in arrays and objects are encoded", () => {
-    const wire = JSON.stringify({ xs: [1, Infinity], inner: { n: NaN } }, nonFiniteReplacer);
-    expect(JSON.parse(wire)).toEqual({
+    const { value, encoded } = encodeNonFinite({ xs: [1, Infinity], inner: { n: NaN } });
+    expect(encoded).toBe(true);
+    expect(JSON.parse(JSON.stringify(value))).toEqual({
       xs: [1, { [TAG]: "Infinity" }],
       inner: { n: { [TAG]: "NaN" } },
     });
   });
 });
 
-describe("reviveNonFiniteNumbers restores the real numbers", () => {
-  test("round-trips through multiple JSON hops (socket + loopback HTTP)", () => {
-    const original = { params: { arguments: { duration: Infinity, x: -Infinity, y: NaN } } };
-    const wire = JSON.stringify(original, nonFiniteReplacer);
-    // Two further plain JSON hops model the daemon parse and the SDK HTTP transport.
-    const afterHops = JSON.parse(JSON.stringify(JSON.parse(wire)));
-    const revived = reviveNonFiniteNumbers(afterHops.params.arguments) as Record<string, number>;
-    expect(revived.duration).toBe(Infinity);
-    expect(revived.x).toBe(-Infinity);
-    expect(Number.isNaN(revived.y)).toBe(true);
+describe("decodeNonFinite restores the real numbers", () => {
+  test("round-trips non-finite numbers through multiple JSON hops", () => {
+    const revived = throughWire({
+      params: { arguments: { duration: Infinity, x: -Infinity, y: NaN } },
+    }) as { params: { arguments: Record<string, number> } };
+    const args = revived.params.arguments;
+    expect(args.duration).toBe(Infinity);
+    expect(args.x).toBe(-Infinity);
+    expect(Number.isNaN(args.y)).toBe(true);
   });
 
   test("a revived non-finite fails Number.isFinite, so the schema rejects it", () => {
-    const revived = reviveNonFiniteNumbers({ [TAG]: "Infinity" });
+    const revived = decodeNonFinite({ [TAG]: "Infinity" });
     expect(typeof revived).toBe("number");
     expect(Number.isFinite(revived as number)).toBe(false);
   });
 
-  test("a payload with no sentinels is returned structurally unchanged", () => {
+  test("a payload with no sentinels round-trips structurally unchanged", () => {
     const input = { a: 1, b: "x", c: [1, 2, { d: true }], e: null };
-    expect(reviveNonFiniteNumbers(input)).toEqual(input);
-  });
-
-  test("an object that merely resembles a sentinel is not misdecoded", () => {
-    // Extra key → not a sentinel; unknown marker → not a sentinel.
-    expect(reviveNonFiniteNumbers({ [TAG]: "Infinity", extra: 1 })).toEqual({
-      [TAG]: "Infinity",
-      extra: 1,
-    });
-    expect(reviveNonFiniteNumbers({ [TAG]: "nope" })).toEqual({ [TAG]: "nope" });
+    expect(throughWire(input)).toEqual(input);
   });
 
   test("primitives pass through", () => {
-    expect(reviveNonFiniteNumbers(5)).toBe(5);
-    expect(reviveNonFiniteNumbers("s")).toBe("s");
-    expect(reviveNonFiniteNumbers(null)).toBe(null);
+    expect(decodeNonFinite(5)).toBe(5);
+    expect(decodeNonFinite("s")).toBe("s");
+    expect(decodeNonFinite(null)).toBe(null);
   });
 
   // Every tool request passes through this walk, so an own "__proto__" key in a
@@ -83,11 +94,78 @@ describe("reviveNonFiniteNumbers restores the real numbers", () => {
     const parsed = JSON.parse('{"headers":{"__proto__":"keep","X-Ok":"1"}}') as {
       headers: Record<string, unknown>;
     };
-    const revived = reviveNonFiniteNumbers(parsed) as { headers: Record<string, unknown> };
+    const revived = decodeNonFinite(parsed) as { headers: Record<string, unknown> };
     expect(Object.prototype.hasOwnProperty.call(revived.headers, "__proto__")).toBe(true);
     expect(Object.getOwnPropertyDescriptor(revived.headers, "__proto__")?.value).toBe("keep");
     expect(revived.headers["X-Ok"]).toBe("1");
     // The reconstructed object keeps a normal prototype (no pollution).
     expect(Object.getPrototypeOf(revived.headers)).toBe(Object.prototype);
+  });
+});
+
+// Issue #5863 AC1: a literal user object shaped exactly like the sentinel must
+// round-trip unchanged rather than being misdecoded as a non-finite number.
+describe("encodeNonFinite escapes literal objects that collide with the sentinel", () => {
+  test("a bare sentinel-shaped object round-trips as an object, not a number", () => {
+    const literal = { [TAG]: "Infinity" };
+    const result = throughWire(literal);
+    expect(result).toEqual(literal);
+    expect(typeof result).toBe("object");
+  });
+
+  test("each marker value round-trips as a literal object", () => {
+    for (const marker of ["Infinity", "-Infinity", "NaN"]) {
+      expect(throughWire({ [TAG]: marker })).toEqual({ [TAG]: marker });
+    }
+  });
+
+  test("a sentinel-shaped object nested inside a real payload round-trips", () => {
+    const input = {
+      responseHeaders: { [TAG]: "NaN" },
+      other: { list: [{ [TAG]: "-Infinity" }, 7] },
+    };
+    expect(throughWire(input)).toEqual(input);
+  });
+
+  test("a real object whose TAG value is itself a non-finite number round-trips both facets", () => {
+    const input = { [TAG]: Infinity };
+    const result = throughWire(input) as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual([TAG]);
+    expect(result[TAG]).toBe(Infinity);
+  });
+
+  test("a TAG-keyed object with sibling keys round-trips unchanged", () => {
+    const input = { [TAG]: "Infinity", extra: 1, nested: { ok: true } };
+    expect(throughWire(input)).toEqual(input);
+  });
+
+  test("a non-marker TAG value still round-trips unchanged", () => {
+    expect(throughWire({ [TAG]: "nope" })).toEqual({ [TAG]: "nope" });
+  });
+});
+
+// Issue #5863 AC2: revival must be scoped to requests the client actually encoded.
+describe("reviveNonFiniteArguments applies revival only by transport provenance", () => {
+  test("with the encoded flag it revives sentinels and strips the flag", () => {
+    const { value } = encodeNonFinite({ duration: Infinity, ok: 3 });
+    const args = { ...(value as Record<string, unknown>), [DAEMON_NON_FINITE_ENCODED_PARAM]: true };
+    const revived = reviveNonFiniteArguments(args) as Record<string, unknown>;
+    expect(revived.duration).toBe(Infinity);
+    expect(revived.ok).toBe(3);
+    expect(DAEMON_NON_FINITE_ENCODED_PARAM in revived).toBe(false);
+  });
+
+  test("without the flag, a sentinel-shaped argument is returned untouched", () => {
+    // A direct in-memory / stdio client never encodes, so its request carries no
+    // flag. Even an argument that literally looks like a sentinel is left alone.
+    const args = { duration: { [TAG]: "Infinity" }, ok: 3 };
+    const result = reviveNonFiniteArguments(args);
+    expect(result).toBe(args);
+    expect((result as Record<string, unknown>).duration).toEqual({ [TAG]: "Infinity" });
+  });
+
+  test("non-object arguments pass through", () => {
+    expect(reviveNonFiniteArguments(undefined)).toBe(undefined);
+    expect(reviveNonFiniteArguments("x")).toBe("x");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to [#5854](https://github.com/kaeawc/auto-mobile/issues/5854) / PR [#5860](https://github.com/kaeawc/auto-mobile/pull/5860). Closes the two robustness gaps that #5860 deliberately deferred on the JSON-safe non-finite argument sentinel (`src/utils/nonFiniteJson.ts`).

## Linked Issue

Closes #5863

## Changes

- **Collision-proof escaping.** Replaced the `nonFiniteReplacer` / `reviveNonFiniteNumbers` pair with a custom serializer, `encodeNonFinite` / `decodeNonFinite`. During encode, any real payload object that carries the reserved `__autoMobileNonFinite__` key is escaped (wrapped as `{ [TAG]: { __esc__: entries } }`), so a bare sentinel shape on the wire can only ever come from our own encoder. A literal user object shaped exactly like the sentinel now round-trips unchanged instead of being revived to `Infinity`/`-Infinity`/`NaN`. `__proto__`-safe reconstruction (via `Object.fromEntries`) is preserved.
- **Provenance scoping.** The daemon client (`DaemonClient.serializeRequestFrame`) stamps an internal `__autoMobileNonFiniteEncoded` flag inside a tool call's `arguments` **only when** it actually sentinel-encoded a non-finite value. The MCP CallTool handler revives (via `reviveNonFiniteArguments`) and strips that flag **only** for flagged requests. Direct in-memory / stdio clients — which never encode — skip the revival walk and its collision risk entirely. The flag is also registered in `stripInternalToolParams` as a tool-boundary safety net.

## Acceptance criteria

- [x] A literal user object shaped like the sentinel round-trips unchanged (escaping) — `test/utils/nonFiniteJson.test.ts` "escapes literal objects that collide with the sentinel".
- [x] Revival is applied only to requests that were actually sentinel-encoded (transport provenance) — `reviveNonFiniteArguments` unit tests + `test/server/nonFiniteReviveHandler.test.ts` unflagged negative case.
- [x] The #5860 behavior is preserved: a non-finite argument through the daemon still reaches the request log as its real value and is rejected with "must be a finite number" — `test/server/nonFiniteReviveHandler.test.ts` + `test/daemon/clientNonFiniteEncoding.test.ts`.

## Validation

- [x] `bun run lint` (oxlint + ratchet + boundaries) passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bunx turbo run build` succeeds
- [x] Full `bun test` suite green except one pre-existing, unrelated flake (`webrtcDeviceCaptureLatency` — a subprocess reporter-format assertion for bun 1.3.14, imports nothing this PR touches)
- [x] New code uses no new dependencies; unit tests run in <100ms

## Follow-ups

None required; scope matches the issue exactly.