### PR TITLE
fix(keyboard): require a real IME window before close() sends Back (#5899)

### DIFF
--- a/src/features/action/Keyboard.ts
+++ b/src/features/action/Keyboard.ts
@@ -80,6 +80,12 @@ type KeyboardDetection = {
   open: boolean;
   bounds?: ElementBounds[];
   error?: string;
+  /** How `open` was decided: a real IME window vs. the content-desc fallback. */
+  source?: "window" | "heuristic";
+  /** True when the accessibility service reported window metadata for this sample. */
+  windowInfoAvailable?: boolean;
+  /** True when an IME window (type 2) is present, even without usable bounds. */
+  imeWindowPresent?: boolean;
 };
 
 export class Keyboard {
@@ -279,6 +285,22 @@ export class Keyboard {
       };
     }
 
+    // A heuristic-only "open" (a node whose content-desc matches
+    // delete/enter/emoji/keyboard/shift) is NOT sufficient to send Back: an app
+    // can expose such a control while the IME is genuinely closed, and Back would
+    // then navigate the app or discard a form (#5899). Only issue Back when a real
+    // IME window corroborates the open state, or when window info is genuinely
+    // unavailable — the deliberate fallback for IMEs that never surface an IME
+    // window (e.g. one that exposes a window without bounds, or none at all).
+    const corroborated = state.imeWindowPresent === true || state.windowInfoAvailable !== true;
+    if (!corroborated) {
+      return {
+        success: true,
+        open: false,
+        message: "Keyboard not open (no IME window); skipped Back",
+      };
+    }
+
     await this.adb.executeCommand(
       "shell input keyevent KEYCODE_BACK",
       undefined,
@@ -366,13 +388,25 @@ export class Keyboard {
       return { open: false, error: "No view hierarchy available" };
     }
 
+    const windows = viewHierarchy.windows ?? [];
+    const windowInfoAvailable = windows.length > 0;
+    const imeWindowPresent = windows.some(
+      (windowInfo) => windowInfo.type === Keyboard.INPUT_METHOD_WINDOW_TYPE,
+    );
+
     const windowBounds = this.findKeyboardWindowBounds(viewHierarchy);
     if (windowBounds) {
-      return { open: true, bounds: [windowBounds] };
+      return {
+        open: true,
+        bounds: [windowBounds],
+        source: "window",
+        windowInfoAvailable,
+        imeWindowPresent: true,
+      };
     }
 
     if (this.detectKeyboardInHierarchy(viewHierarchy)) {
-      return { open: true };
+      return { open: true, source: "heuristic", windowInfoAvailable, imeWindowPresent };
     }
 
     const hierarchyError = viewHierarchy.hierarchy?.error;

--- a/test/features/action/Keyboard.test.ts
+++ b/test/features/action/Keyboard.test.ts
@@ -53,6 +53,34 @@ describe("Keyboard", () => {
     },
   });
 
+  // The a11y service reports window metadata, but none of it is an IME window —
+  // yet an app control exposes a content-desc the heuristic matches ("Delete").
+  // The IME is genuinely closed; close() must not send Back (#5899).
+  const heuristicFalsePositiveHierarchy = (): ViewHierarchyResult => ({
+    hierarchy: {
+      node: {
+        $: {
+          "content-desc": "Delete",
+        },
+      },
+    },
+    windows: [{ type: 1, bounds: { left: 0, top: 0, right: 1080, bottom: 1920 } }],
+  });
+
+  // A real IME window is present (type 2) but exposes no usable bounds; the
+  // content-desc heuristic corroborates it. This is the "IME known not to expose
+  // window bounds" case — close() must still send Back.
+  const boundlessImeWindowHierarchy = (): ViewHierarchyResult => ({
+    hierarchy: {
+      node: {
+        $: {
+          "content-desc": "Delete",
+        },
+      },
+    },
+    windows: [{ type: 2 }],
+  });
+
   const focusedInputHierarchy = (): ViewHierarchyResult => ({
     hierarchy: {
       node: {
@@ -119,6 +147,46 @@ describe("Keyboard", () => {
 
   test("close sends back keyevent when keyboard is open", async () => {
     fakeHierarchy.setResults([keyboardWindowHierarchy(), baseHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(true);
+  });
+
+  test("close does not send Back when only the content-desc heuristic matches and window info is available", async () => {
+    // Windows are reported and none is an IME window, so a lone content-desc
+    // match is app content, not the keyboard. Sending Back here would navigate
+    // the app (#5899).
+    fakeHierarchy.setResults([heuristicFalsePositiveHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(false);
+    // No Back means no confirmation polling either.
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
+  test("close sends Back for a real IME window that exposes no bounds", async () => {
+    fakeHierarchy.setResults([boundlessImeWindowHierarchy(), baseHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(true);
+  });
+
+  test("close falls back to the heuristic and sends Back when window info is unavailable", async () => {
+    // keyboardNodeHierarchy exposes no window metadata at all — the deliberate
+    // fallback for IMEs that never surface an IME window.
+    fakeHierarchy.setResults([keyboardNodeHierarchy(), baseHierarchy()]);
     const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
 
     const result = await keyboard.execute("close");


### PR DESCRIPTION
## Summary

`detectKeyboardInHierarchy` (`src/features/action/Keyboard.ts`) classifies any node whose `content-desc` contains `delete`/`enter`/`emoji`/`keyboard`/`shift` as "keyboard open". This heuristic is a deliberate fallback for IMEs that don't expose an `INPUT_METHOD_WINDOW_TYPE` (type 2) window, but an app that exposes such a control while the IME is genuinely closed made `close()` send `KEYCODE_BACK` into the app — navigating away or discarding a form.

`close()` now only issues Back when the open verdict is **corroborated** by a real IME window (a type-2 window, with or without usable bounds), or when window info is **genuinely unavailable** (no windows reported at all) — the deliberate fallback path. A heuristic-only positive while windows *are* reported (and none is an IME window) is treated as closed and no Back is sent. `detect()`/`open()` keep their existing heuristic behavior.

## Linked Issue

Closes #5899

## Bug / Regression Context

- **Prior attempts:** PR #5895 fixed the stale-cache half (`close()` now forces a fresh read before deciding). This PR handles the orthogonal, still-open concern: a *fresh* heuristic false-positive on app content when no IME window is present.
- **Observed symptom:** `Keyboard.close()` sends `KEYCODE_BACK` into the foreground app when a non-IME control's `content-desc` matches the heuristic, navigating away.
- **Repro steps / conditions:** IME genuinely closed, app renders a control with `content-desc: "Delete"` (or enter/emoji/keyboard/shift), a11y service reports windows but no type-2 IME window → old code sent Back.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — lint: no new violations; full suite green apart from one unrelated pre-existing WebRTC subprocess-timeout flake (`webrtcDeviceCaptureLatency`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use interfaces + fakes + FakeTimer; run in <100ms
- [x] Reuses existing `resolveKeyboardState` seam and `ViewHierarchyResult.windows` metadata — no new dependencies

## Device Verification

- [ ] Not run here — logic is unit-pinned via `FakeKeyboardHierarchyProvider`. The "IME known not to expose window bounds" corroboration path (type-2 window without bounds) is covered by the `boundlessImeWindowHierarchy` test.

## Acceptance Criteria

- **Require a real IME window (or corroborated evidence) before Back; fall back to the heuristic only when window info is genuinely unavailable** — `close()` gate: `imeWindowPresent || !windowInfoAvailable`. Tests: `close does not send Back when only the content-desc heuristic matches and window info is available`; `close sends Back for a real IME window that exposes no bounds`; `close falls back to the heuristic and sends Back when window info is unavailable`.
- **Update `test/features/action/Keyboard.test.ts`** — added the three tests above plus `heuristicFalsePositiveHierarchy` / `boundlessImeWindowHierarchy` fixtures.
