### PR TITLE
fix(devices): derive listDevices discovery completeness from succeededSources (#5918)

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -10,6 +10,7 @@ import {
   MultiPlatformDeviceManager,
   PlatformDeviceManager,
 } from "../utils/deviceUtils";
+import { type DiscoverySource, sourcesForPlatform } from "../utils/discoverySource";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, Platform, SomePlatform } from "../models";
 import type {
@@ -3806,24 +3807,39 @@ export function registerDeviceTools() {
     // empty inventory. Use the detailed contract, which reports which platforms
     // completed, and surface an incomplete/error marker so the two are distinct.
     let succeededPlatforms = new Set<Platform>(requestedPlatforms);
+    // #5918: iOS is discovered by two independent sources (simctl + devicectl).
+    // `succeededPlatforms.ios` tracks only the simulator source, so a devicectl
+    // failure leaves the platform "succeeded" while physical-iOS discovery is
+    // actually incomplete. Derive completeness from the finer per-source set,
+    // falling back to the platform aggregate for producers that predate #5683
+    // (which return no `succeededSources`).
+    let succeededSources: Set<DiscoverySource> | undefined;
     let discoveryErrors: BootedDeviceDiscovery["discoveryErrors"];
     try {
       const discovery = await deviceManager.getBootedDevicesDetailed(platform);
       booted = discovery.devices;
       succeededPlatforms = discovery.succeededPlatforms;
+      succeededSources = discovery.succeededSources;
       discoveryErrors = discovery.discoveryErrors;
     } catch (error) {
       // Discovery is best-effort — a partial/failed probe still returns the
       // resource guidance rather than failing the whole call. A thrown error
-      // means no platform completed.
+      // means no platform (and thus no source) completed.
       logger.warn(`listDevices booted-device discovery failed: ${errorMessage(error)}`, error);
       succeededPlatforms = new Set<Platform>();
+      succeededSources = new Set<DiscoverySource>();
     }
 
     const failedPlatforms = requestedPlatforms.filter((p) => !succeededPlatforms.has(p));
+    const failedSources = succeededSources
+      ? requestedPlatforms
+          .flatMap((p) => sourcesForPlatform(p))
+          .filter((source) => !succeededSources!.has(source))
+      : undefined;
     const discovery = {
-      complete: failedPlatforms.length === 0,
+      complete: failedSources ? failedSources.length === 0 : failedPlatforms.length === 0,
       failedPlatforms,
+      ...(failedSources && failedSources.length > 0 ? { failedSources } : {}),
       ...(discoveryErrors && Object.keys(discoveryErrors).length > 0
         ? { errors: discoveryErrors }
         : {}),

--- a/src/utils/discoverySource.ts
+++ b/src/utils/discoverySource.ts
@@ -36,6 +36,18 @@ export function discoverySourceFor(
   return deviceId !== undefined && isIosPhysicalUdid(deviceId) ? "ios-physical" : "ios-simulator";
 }
 
+/**
+ * The discovery sources that make up a platform's sweep.
+ *
+ * Android has one; iOS has two independent sources (`simctl` and `devicectl`),
+ * so a per-platform completeness flag cannot express which half of a mixed
+ * outcome is authoritative (#5683). A consumer that reports completeness per
+ * source enumerates a platform's sources through this.
+ */
+export function sourcesForPlatform(platform: Platform): DiscoverySource[] {
+  return platform === "android" ? ["android"] : ["ios-simulator", "ios-physical"];
+}
+
 /** The completeness half of a discovery result, per platform and per source. */
 export interface DiscoveryCompleteness {
   succeededPlatforms: ReadonlySet<Platform>;

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -6,6 +6,7 @@ import {
   DeviceImageDiscovery,
   PlatformDeviceManager,
 } from "../../src/utils/deviceUtils";
+import { type DiscoverySource, sourcesForPlatform } from "../../src/utils/discoverySource";
 
 /**
  * Fake implementation of PlatformDeviceManager for testing
@@ -169,13 +170,37 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
    */
   failedPlatforms: Set<Platform> = new Set();
 
+  /**
+   * Individual discovery sources to report as failed, one level finer than
+   * `failedPlatforms` (#5683). Failing `ios-physical` alone models the macOS
+   * case where simctl completed but devicectl did not: the iOS platform still
+   * aggregates as succeeded (it tracks the simulator source) while the physical
+   * source is absent from `succeededSources`.
+   */
+  failedSources: Set<DiscoverySource> = new Set();
+
+  /**
+   * Omit `succeededSources` from the result to model a producer that predates
+   * per-source reporting, exercising the consumer's platform-aggregate fallback.
+   */
+  omitSucceededSources: boolean = false;
+
   async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
     const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const succeededSources = new Set<DiscoverySource>();
     const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
     for (const p of requested) {
-      if (this.failedPlatforms.has(p)) {
+      for (const source of sourcesForPlatform(p)) {
+        if (!this.failedPlatforms.has(p) && !this.failedSources.has(source)) {
+          succeededSources.add(source);
+        }
+      }
+      // The platform aggregate mirrors production: iOS tracks the simulator
+      // source, so a devicectl-only failure keeps the platform succeeded.
+      const platformSource: DiscoverySource = p === "android" ? "android" : "ios-simulator";
+      if (this.failedPlatforms.has(p) || this.failedSources.has(platformSource)) {
         discoveryErrors[p] = {
           code: "unavailable",
           message: `${p === "ios" ? "iOS" : "Android"} booted-device discovery is unavailable.`,
@@ -186,7 +211,12 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
       devices.push(...(await this.getBootedDevices(p)));
       succeededPlatforms.add(p);
     }
-    return { devices, succeededPlatforms, discoveryErrors };
+    return {
+      devices,
+      succeededPlatforms,
+      discoveryErrors,
+      ...(this.omitSucceededSources ? {} : { succeededSources }),
+    };
   }
 
   async getDeviceImagesDetailed(platform: SomePlatform): Promise<DeviceImageDiscovery> {

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -6,7 +6,11 @@ import {
   DeviceImageDiscovery,
   PlatformDeviceManager,
 } from "../../src/utils/deviceUtils";
-import { type DiscoverySource, sourcesForPlatform } from "../../src/utils/discoverySource";
+import {
+  type DiscoverySource,
+  discoverySourceFor,
+  sourcesForPlatform,
+} from "../../src/utils/discoverySource";
 
 /**
  * Fake implementation of PlatformDeviceManager for testing
@@ -192,10 +196,19 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     const succeededSources = new Set<DiscoverySource>();
     const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
     for (const p of requested) {
+      // Delegate to getBootedDevices so operation tracking stays consistent,
+      // then assemble per source: iOS's two sources fail independently, so a
+      // failed simctl must not drop the physical devices devicectl still
+      // returns (and vice versa), matching FakeDeviceManager and production.
+      const platformDevices = await this.getBootedDevices(p);
       for (const source of sourcesForPlatform(p)) {
-        if (!this.failedPlatforms.has(p) && !this.failedSources.has(source)) {
-          succeededSources.add(source);
+        if (this.failedPlatforms.has(p) || this.failedSources.has(source)) {
+          continue;
         }
+        succeededSources.add(source);
+        devices.push(
+          ...platformDevices.filter((device) => discoverySourceFor(p, device.deviceId) === source),
+        );
       }
       // The platform aggregate mirrors production: iOS tracks the simulator
       // source, so a devicectl-only failure keeps the platform succeeded.
@@ -207,8 +220,6 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
         };
         continue;
       }
-      // Delegate to getBootedDevices so operation tracking stays consistent.
-      devices.push(...(await this.getBootedDevices(p)));
       succeededPlatforms.add(p);
     }
     return {

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -89,6 +89,8 @@ describe("listDevices tool (#5870)", () => {
   beforeEach(() => {
     fakeDeviceUtils.clearHistory();
     fakeDeviceUtils.failedPlatforms.clear();
+    fakeDeviceUtils.failedSources.clear();
+    fakeDeviceUtils.omitSucceededSources = false;
     fakeDeviceUtils.setBootedDevices("android", [android]);
     fakeDeviceUtils.setBootedDevices("ios", [ios]);
   });
@@ -163,6 +165,49 @@ describe("listDevices tool (#5870)", () => {
     expect(
       fakeDeviceUtils.getExecutedOperations().some((op) => op.startsWith("getBootedDevices")),
     ).toBe(true);
+  });
+
+  test("marks discovery incomplete when only physical-iOS (devicectl) discovery fails (#5918)", async () => {
+    // macOS mixed outcome: simctl completed but devicectl did not. The iOS
+    // platform still aggregates as succeeded (it tracks the simulator source),
+    // so a platform-level marker would wrongly report `complete: true`.
+    fakeDeviceUtils.failedSources.add("ios-physical");
+
+    const payload = await callListDevices();
+
+    // Source-level completeness catches the incomplete physical source...
+    expect(payload.discovery.complete).toBe(false);
+    // ...and surfaces exactly which source failed, not the whole platform.
+    expect(payload.discovery.failedSources).toEqual(["ios-physical"]);
+    // The simulator source completed, so the platform aggregate is unaffected.
+    expect(payload.discovery.failedPlatforms).toEqual([]);
+  });
+
+  test("reports every source when a whole iOS platform fails (#5918)", async () => {
+    fakeDeviceUtils.failedPlatforms.add("ios");
+
+    const payload = await callListDevices();
+
+    expect(payload.discovery.complete).toBe(false);
+    expect(payload.discovery.failedPlatforms).toEqual(["ios"]);
+    expect(payload.discovery.failedSources).toEqual(
+      expect.arrayContaining(["ios-simulator", "ios-physical"]),
+    );
+    expect(payload.discovery.failedSources).toHaveLength(2);
+  });
+
+  test("omits failedSources and falls back to platforms for pre-#5683 producers (#5918)", async () => {
+    // A producer that predates per-source reporting returns no `succeededSources`.
+    fakeDeviceUtils.omitSucceededSources = true;
+    fakeDeviceUtils.failedPlatforms.add("ios");
+
+    const payload = await callListDevices();
+
+    // Completeness still resolves through the platform aggregate.
+    expect(payload.discovery.complete).toBe(false);
+    expect(payload.discovery.failedPlatforms).toEqual(["ios"]);
+    // No source detail is fabricated when the producer did not report it.
+    expect(payload.discovery.failedSources).toBeUndefined();
   });
 
   test("distinguishes a genuinely empty inventory from a failed scan", async () => {

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -183,6 +183,39 @@ describe("listDevices tool (#5870)", () => {
     expect(payload.discovery.failedPlatforms).toEqual([]);
   });
 
+  test("returns physical devices when only simulator (simctl) discovery fails (#5918)", async () => {
+    // Reciprocal mixed outcome: simctl is down but devicectl still reports a
+    // connected iPhone. The physical device must survive even though the iOS
+    // platform aggregate (which tracks the simulator source) reports failed.
+    const iphone: BootedDevice = {
+      platform: "ios",
+      name: "Jason's iPhone",
+      deviceId: "00008120-001A2D3E4F5B6A2E",
+      iosVersion: "18.0",
+    };
+    fakeDeviceUtils.setBootedDevices("ios", [ios, iphone]);
+    fakeDeviceUtils.failedSources.add("ios-simulator");
+
+    const payload = await callListDevices();
+
+    // The physical device is still returned; the simulator's is not.
+    expect(payload.devices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ platform: "android", deviceId: "emulator-5554" }),
+        expect.objectContaining({ platform: "ios", deviceId: "00008120-001A2D3E4F5B6A2E" }),
+      ]),
+    );
+    expect(payload.devices.some((d: { deviceId: string }) => d.deviceId === ios.deviceId)).toBe(
+      false,
+    );
+
+    // Completeness reflects the incomplete simulator source.
+    expect(payload.discovery.complete).toBe(false);
+    expect(payload.discovery.failedSources).toEqual(["ios-simulator"]);
+    // The platform aggregate tracks the simulator source, so it reports failed.
+    expect(payload.discovery.failedPlatforms).toEqual(["ios"]);
+  });
+
   test("reports every source when a whole iOS platform fails (#5918)", async () => {
     fakeDeviceUtils.failedPlatforms.add("ios");
 


### PR DESCRIPTION
## Summary

`listDevices` computed its `discovery.complete` marker from the platform-level
`succeededPlatforms` set. On macOS, `getBootedDevicesDetailed` adds `ios` to
that set whenever **simctl** succeeds — even when **devicectl** (physical)
discovery failed (see the `#5683` per-source design in
`src/utils/discoverySource.ts`). So when simulator discovery succeeded but
physical-device discovery was incomplete, `listDevices` reported
`discovery.complete: true` while `ios-physical` was actually incomplete and any
returned physical devices could be retained/stale — re-introducing, for the
physical-iOS source specifically, the ambiguity the marker exists to remove.

This PR derives iOS completeness from the finer per-source result and surfaces
which source failed. Production `getBootedDevicesDetailed` already returns
`succeededSources`; only the `listDevices` consumer and one test fake needed
changes.

## Linked Issue

Closes #5918

## Bug / Regression Context

- **Prior attempts:** [#5906](https://github.com/kaeawc/auto-mobile/pull/5906) added the platform-level marker (the criterion #5893 stated verbatim); this is the deferred precision refinement, not a regression — the marker is still strictly better than the pre-#5906 no-marker behavior.
- **Observed symptom:** `discovery.complete: true` on macOS when devicectl (physical iOS) discovery was incomplete but simctl succeeded.
- **Repro conditions:** `platform: "either"` or `"ios"` on macOS with a simctl-success / devicectl-failure sweep.

## Changes

- **`src/server/deviceTools.ts`** — `listDevicesHandler` derives `discovery.complete` and a new `discovery.failedSources` from `succeededSources` (`ios-simulator` + `ios-physical`), falling back to `succeededPlatforms` when `succeededSources` is absent (producers/fakes that predate #5683).
- **`src/utils/discoverySource.ts`** — new `sourcesForPlatform(platform)` helper enumerating a platform's discovery sources.
- **`test/fakes/FakeDeviceUtils.ts`** — `getBootedDevicesDetailed` now models `succeededSources`, with a `failedSources` per-source failure seam and an `omitSucceededSources` flag to exercise the pre-#5683 fallback.

## Acceptance criteria (from #5918)

- [x] Derive iOS completeness from source-level `succeededSources`, falling back to `succeededPlatforms` when absent.
- [x] Expose the incomplete source in the `discovery` marker (`failedSources`).
- [x] Extend `FakeDeviceUtils.getBootedDevicesDetailed` to model `succeededSources` so the physical-iOS-incomplete case is testable.

## Validation

- [x] `bun test` — full suite green except two pre-existing, environment-sensitive WebRTC integration tests in `test/integration/webrtcDeviceCaptureLatency.test.ts` (skipped on the PR lane; untouched by this diff).
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] `bun run lint` — no new ratchet violations; `oxfmt --check` clean.
- [x] New tests use interfaces + fakes + FakeTimer; run in <100ms.
- [x] New code reuses the existing `discoverySource` module (added one small helper).

## Testing

Added to `test/server/deviceTools.listDevices.test.ts`:
- physical-iOS (devicectl) fails while simctl succeeds → `complete: false`, `failedSources: ["ios-physical"]`, `failedPlatforms: []`
- whole iOS platform fails → both sources in `failedSources`, `failedPlatforms: ["ios"]`
- pre-#5683 producer (no `succeededSources`) → completeness falls back to platforms, `failedSources` omitted

## Device Verification

N/A — pure discovery-marker refinement, covered by unit tests through the fake seam.
