### PR TITLE
fix(server): gate non-finite sentinel revival on daemonMode (#5919)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -462,10 +462,17 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // survive the socket + loopback-HTTP hops (#5854 §2). Done BEFORE logging and
     // validation so the request trace shows the real Infinity/-Infinity/NaN
     // instead of `null`, and the schema rejects it with "must be a finite number".
-    // Scoped by transport provenance (#5863): revival runs only for requests the
-    // daemon client actually sentinel-encoded (flagged inside `arguments`); direct
-    // in-memory / stdio clients are left untouched. The flag is stripped here.
-    if (request.params && request.params.arguments) {
+    // Scoped by transport provenance (#5863, hardened #5919): revival runs only for
+    // daemon-forwarded requests. `daemonMode` is a server-CONSTRUCTION boundary the
+    // tool caller cannot influence, so a direct in-memory / stdio client
+    // (`daemonMode: false`) can never assert daemon transport provenance by forging
+    // the in-arguments flag — its arguments are left untouched regardless. Sentinel
+    // encoding is only ever performed by the daemon client (`daemon/client.ts`),
+    // whose requests always terminate at this `daemonMode: true` loopback server, so
+    // gating reverts nothing legitimate. `reviveNonFiniteArguments` still strips the
+    // flag when present; a forged flag on a direct server is stripped instead by
+    // `stripInternalToolParams` before the tool runs.
+    if (daemonMode && request.params && request.params.arguments) {
       request.params.arguments = reviveNonFiniteArguments(request.params.arguments) as Record<
         string,
         unknown

--- a/test/server/nonFiniteReviveHandler.test.ts
+++ b/test/server/nonFiniteReviveHandler.test.ts
@@ -6,22 +6,40 @@ import { McpTestFixture } from "../fixtures/mcpTestFixture";
 // they survive the wire. The CallTool handler must revive them BEFORE schema
 // validation, so a sentinel-encoded Infinity is rejected as a real non-finite
 // number ("must be a finite number") rather than as a stray object.
-describe("CallTool handler revives non-finite sentinels before validation", () => {
-  let fixture: McpTestFixture;
+//
+// Issue #5919 hardens the provenance gate: revival is scoped to `daemonMode`, a
+// server-CONSTRUCTION boundary the tool caller cannot influence, so only the
+// daemon's own loopback MCP server (created with `daemonMode: true`) ever revives.
+// The daemon client is the only producer of sentinel-encoded requests, and its
+// requests always terminate at that server — so a direct in-memory / stdio client
+// (`daemonMode: false`) can never assert daemon transport provenance by forging the
+// in-arguments flag.
+describe("CallTool handler revives non-finite sentinels only for daemon-forwarded requests", () => {
+  // The daemon's loopback MCP server is created with `daemonMode: true`
+  // (`daemon.ts` StreamableHTTP transport setup). Revival is scoped to it.
+  let daemonFixture: McpTestFixture;
+  // A direct in-memory / stdio client's server is `daemonMode: false` (the default
+  // in the stdio entrypoint and every embedded consumer).
+  let directFixture: McpTestFixture;
 
   beforeAll(async () => {
-    fixture = new McpTestFixture();
-    await fixture.setup();
+    daemonFixture = new McpTestFixture({ daemonMode: true });
+    await daemonFixture.setup();
+    directFixture = new McpTestFixture({ daemonMode: false });
+    await directFixture.setup();
   });
 
   afterAll(async () => {
-    if (fixture) {
-      await fixture.teardown();
+    if (daemonFixture) {
+      await daemonFixture.teardown();
+    }
+    if (directFixture) {
+      await directFixture.teardown();
     }
   });
 
-  test("a sentinel-encoded duration is rejected as a non-finite number", async () => {
-    const { client } = fixture.getContext();
+  test("a daemon-forwarded sentinel-encoded duration is revived and rejected as a non-finite number", async () => {
+    const { client } = daemonFixture.getContext();
 
     const call = client.request(
       {
@@ -52,7 +70,7 @@ describe("CallTool handler revives non-finite sentinels before validation", () =
   // sentinel-shaped object stays an object and is NOT reported as a non-finite
   // number — proving revival is scoped by provenance, not applied blindly.
   test("an unflagged sentinel-shaped duration is not revived to a non-finite number", async () => {
-    const { client } = fixture.getContext();
+    const { client } = daemonFixture.getContext();
 
     const call = client.request(
       {
@@ -72,6 +90,41 @@ describe("CallTool handler revives non-finite sentinels before validation", () =
 
     // No provenance flag → the object is left as-is and rejected as a type
     // mismatch, never as "must be a finite number".
+    await expect(call).rejects.toThrow();
+    await expect(call).rejects.not.toThrow(/duration must be a finite number/);
+  });
+
+  // #5919: a DIRECT (non-daemon) client that forges the in-arguments provenance
+  // flag must NOT get revival applied. The flag lives in the caller-controllable
+  // `arguments` namespace, so a direct client can set it — but revival is gated on
+  // `daemonMode`, which the tool caller cannot influence. So a literal sentinel-
+  // shaped object it passes stays an object and is rejected as a type mismatch,
+  // never decoded to Infinity, restoring #5863's direct-client-isolation intent.
+  test("a direct client's FORGED provenance flag does not trigger revival", async () => {
+    const { client } = directFixture.getContext();
+
+    const call = client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "tapOn",
+          arguments: {
+            platform: "android",
+            selector: { text: "Gmail" },
+            action: "longPress",
+            // A direct client forges BOTH the reserved sentinel shape and the
+            // provenance flag — exactly the spoof #5919 hardens against.
+            duration: { __autoMobileNonFinite__: "Infinity" },
+            __autoMobileNonFiniteEncoded: true,
+          },
+        },
+      },
+      z.object({}).passthrough(),
+    );
+
+    // daemonMode is false → revival is skipped despite the forged flag, so the
+    // object is left untouched and rejected as a type mismatch, NOT as a
+    // non-finite number.
     await expect(call).rejects.toThrow();
     await expect(call).rejects.not.toThrow(/duration must be a finite number/);
   });


### PR DESCRIPTION
## Summary

Hardens non-finite transport-provenance so a **direct** in-memory / stdio MCP client can no longer forge daemon transport provenance. The `__autoMobileNonFiniteEncoded` flag lives in the caller-controllable `arguments` namespace, so a direct client that set it — alongside a literal `{ "__autoMobileNonFinite__": "<marker>" }` object — would have that object revived to a real `Infinity`/`-Infinity`/`NaN`, even though its transport never sentinel-encoded anything. This contradicts [#5863](https://github.com/kaeawc/auto-mobile/issues/5863)'s direct-client-isolation intent (AC2).

The fix gates `reviveNonFiniteArguments` on **`daemonMode`** — a `createMcpServer` *construction-time* boundary the tool caller cannot influence. Sentinel encoding is only ever performed by the daemon client (`src/daemon/client.ts`), whose requests always terminate at the daemon's `daemonMode: true` loopback MCP server (`src/daemon/daemon.ts`), so gating reverts nothing legitimate while making a direct (`daemonMode: false`) client's forged flag inert.

### Why not the literal "DaemonRequest → loopback header" proposal

The issue proposed carrying provenance as a `DaemonRequest`-level field the socket server translates into a loopback-only header. That does not fit the current architecture: the MCP SDK's `StreamableHTTPClientTransport` fixes headers at **construction**, the daemon pools loopback clients **per-session** (`socketServer.ts`), and non-finite encoding is **per-request** — so a per-request header would need materially new plumbing (the issue itself flags this as "heavier and out of scope"). The `daemonMode` gate delivers the same security property ("a direct client can never assert daemon transport provenance") minimally, at a boundary the caller cannot forge.

## Linked Issue

Closes #5919

## Bug / Regression Context

- **Prior attempts:** [#5863](https://github.com/kaeawc/auto-mobile/issues/5863) scoped revival by an in-`arguments` provenance flag; [#5854](https://github.com/kaeawc/auto-mobile/issues/5854) / #5860 introduced the sentinel encoding.
- **Observed symptom:** a direct client forging `__autoMobileNonFiniteEncoded: true` gets a sentinel-shaped object decoded to a non-finite number (fails safe — schema then rejects it — but violates direct-client isolation).
- **Repro conditions:** a `daemonMode: false` MCP server (stdio entrypoint / embedded / in-memory) receiving both the forged flag and a bare sentinel object in one tool call.

## Changes

- `src/server/index.ts`: gate the `CallTool` handler's `reviveNonFiniteArguments` call on `daemonMode`.
- `test/server/nonFiniteReviveHandler.test.ts`: restructure into a daemon-mode fixture (revival on) and a direct-mode fixture (revival off); add a test asserting a direct client's forged flag does **not** trigger revival.

## Validation

- [x] `bun test` — full suite green except one **pre-existing, unrelated** flake (`webrtcDeviceCaptureLatency.test.ts`, a bun `(skip)`-label output-format assertion; confirmed failing on the unmodified base).
- [x] `bun run typecheck` — no new errors (baseline gate).
- [x] `bun run lint` — no new violations; `bun run build` — success.
- [x] New tests use the in-memory MCP fixture; run in <100ms.

## Acceptance criteria (inferred from the issue)

- [x] **AC1** A direct (non-daemon) client's forged provenance flag + sentinel is NOT revived — the object is rejected as a type mismatch, never decoded to a non-finite number.
- [x] **AC2** Legitimate daemon-forwarded requests still revive sentinels correctly (no #5854/#5860/#5863 regression).
- [x] **AC3** The trust decision is made on a boundary the tool caller cannot influence (`daemonMode` construction option), not solely the in-`arguments` flag.