### PR TITLE
harden(tool-output): provenance ledger + O_NOFOLLOW read + fence exemption (#5917)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -61,6 +61,17 @@ function isFreshSessionScreenshotUri(uri: string, sessionUuid: string): boolean 
   return uri === `automobile:device-session/${sessionUuid}/screenshot`;
 }
 
+// A tool-output artifact read (`automobile:tool-output/<id>`) is a plain host
+// file read routed through the session-independent resource registry — no device
+// access and no session data. So unlike the fresh-screenshot exemption it is not
+// scoped to any session, and it must stay retrievable after a terminal release
+// (e.g. executePlan auto-releases its bound session, then emits an artifact
+// resourceUri that would otherwise be fenced). Kept in lockstep with the
+// `automobile:tool-output/` prefix in src/server/toolOutputResources.ts.
+function isToolOutputResourceUri(uri: string): boolean {
+  return uri.startsWith("automobile:tool-output/");
+}
+
 // The session UUID embedded in a fresh-session-screenshot resource URI
 // (`automobile:device-session/<uuid>/screenshot`), or undefined for any other
 // URI. Kept in lockstep with {@link isFreshSessionScreenshotUri}.
@@ -2260,15 +2271,23 @@ export class DaemonMcpProxy {
    */
   async readResource(uri: string): Promise<any> {
     const terminalSessionUuid = this.terminalBoundSession?.sessionUuid;
+    // A tool-output artifact read is session-independent, so it survives a
+    // terminal release without any session params at all (issue #5917). The
+    // fresh-screenshot exemption, by contrast, must still target the released
+    // session it belongs to.
+    const isToolOutput = isToolOutputResourceUri(uri);
     const allowReleasedSession =
-      terminalSessionUuid !== undefined && isFreshSessionScreenshotUri(uri, terminalSessionUuid);
-    const forwardedParams = allowReleasedSession
-      ? {
-          sessionUuid: terminalSessionUuid,
-          [DAEMON_BOUND_SESSION_PARAM]: terminalSessionUuid,
-          [DAEMON_RELEASED_SESSION_PARAM]: terminalSessionUuid,
-        }
-      : (this.freshScreenshotOwnerForwardParams(uri) ?? this.withBoundSessionUuid({}));
+      isToolOutput ||
+      (terminalSessionUuid !== undefined && isFreshSessionScreenshotUri(uri, terminalSessionUuid));
+    const forwardedParams = isToolOutput
+      ? {}
+      : allowReleasedSession
+        ? {
+            sessionUuid: terminalSessionUuid,
+            [DAEMON_BOUND_SESSION_PARAM]: terminalSessionUuid,
+            [DAEMON_RELEASED_SESSION_PARAM]: terminalSessionUuid,
+          }
+        : (this.freshScreenshotOwnerForwardParams(uri) ?? this.withBoundSessionUuid({}));
     return await this.withRecoverableReconnect(
       () => this.client!.readResource(uri, forwardedParams),
       this.sessionUuidFromArgs(forwardedParams),

--- a/src/server/toolOutputArtifactLedger.ts
+++ b/src/server/toolOutputArtifactLedger.ts
@@ -19,25 +19,20 @@ import path from "node:path";
  * are pruned by retention, and a lost ledger entry (eviction, daemon restart)
  * degrades to the existing "expired or pruned" response — never an unsafe read.
  */
-/** Filesystem identity of an issued artifact, captured at creation. */
-export interface ArtifactFileIdentity {
-  dev: number;
-  ino: number;
-}
-
-/** A file the writer issued: its path plus the identity to verify at read time. */
+/** A file the writer issued: its path plus the content hash to verify at read time. */
 export interface IssuedArtifact {
   /** Absolute path the writer wrote. */
   path: string;
   /**
-   * dev/ino captured when the writer exclusively created the file. The read
-   * fstat's the open handle and rejects any mismatch, so a foreign process that
-   * replaces the recorded path with a *different regular file* in a world-writable
-   * `--tool-outputs-dir` cannot get its bytes served — O_NOFOLLOW alone accepts a
-   * regular-file swap; identity binding is what closes it (issue #5917 review).
-   * Undefined only for entries recorded without identity (test seams).
+   * SHA-256 (hex) of the exact bytes the writer wrote. The read hashes the bytes
+   * it is about to return and rejects any mismatch, so a foreign process that
+   * replaces the recorded path in a world-writable `--tool-outputs-dir` cannot
+   * get its bytes served — not via a symlink (O_NOFOLLOW), a regular-file swap,
+   * *or* an inode-reuse alias, all of which a path/dev-ino check misses but a
+   * content hash catches (issue #5917 review). Undefined only for entries
+   * recorded without a hash (test seams).
    */
-  identity?: ArtifactFileIdentity;
+  sha256?: string;
 }
 
 export class ToolOutputArtifactLedger {
@@ -51,10 +46,10 @@ export class ToolOutputArtifactLedger {
   }
 
   /** Record an artifact the writer just created, keyed by its basename. */
-  record(absolutePath: string, identity?: ArtifactFileIdentity): void {
+  record(absolutePath: string, sha256?: string): void {
     const filename = path.basename(absolutePath);
     this.issued.delete(filename);
-    this.issued.set(filename, { path: absolutePath, identity });
+    this.issued.set(filename, { path: absolutePath, sha256 });
     while (this.issued.size > this.maxEntries) {
       const oldest = this.issued.keys().next().value;
       if (oldest === undefined) {

--- a/src/server/toolOutputArtifactLedger.ts
+++ b/src/server/toolOutputArtifactLedger.ts
@@ -19,10 +19,31 @@ import path from "node:path";
  * are pruned by retention, and a lost ledger entry (eviction, daemon restart)
  * degrades to the existing "expired or pruned" response — never an unsafe read.
  */
+/** Filesystem identity of an issued artifact, captured at creation. */
+export interface ArtifactFileIdentity {
+  dev: number;
+  ino: number;
+}
+
+/** A file the writer issued: its path plus the identity to verify at read time. */
+export interface IssuedArtifact {
+  /** Absolute path the writer wrote. */
+  path: string;
+  /**
+   * dev/ino captured when the writer exclusively created the file. The read
+   * fstat's the open handle and rejects any mismatch, so a foreign process that
+   * replaces the recorded path with a *different regular file* in a world-writable
+   * `--tool-outputs-dir` cannot get its bytes served — O_NOFOLLOW alone accepts a
+   * regular-file swap; identity binding is what closes it (issue #5917 review).
+   * Undefined only for entries recorded without identity (test seams).
+   */
+  identity?: ArtifactFileIdentity;
+}
+
 export class ToolOutputArtifactLedger {
-  // basename -> absolute path the writer wrote. Insertion order is recency order
-  // (a re-record deletes then re-sets), so eviction drops the least-recent.
-  private readonly issued = new Map<string, string>();
+  // basename -> issued artifact. Insertion order is recency order (a re-record
+  // deletes then re-sets), so eviction drops the least-recent.
+  private readonly issued = new Map<string, IssuedArtifact>();
   private readonly maxEntries: number;
 
   constructor(maxEntries = 1024) {
@@ -30,10 +51,10 @@ export class ToolOutputArtifactLedger {
   }
 
   /** Record an artifact the writer just created, keyed by its basename. */
-  record(absolutePath: string): void {
+  record(absolutePath: string, identity?: ArtifactFileIdentity): void {
     const filename = path.basename(absolutePath);
     this.issued.delete(filename);
-    this.issued.set(filename, absolutePath);
+    this.issued.set(filename, { path: absolutePath, identity });
     while (this.issued.size > this.maxEntries) {
       const oldest = this.issued.keys().next().value;
       if (oldest === undefined) {
@@ -43,8 +64,8 @@ export class ToolOutputArtifactLedger {
     }
   }
 
-  /** The absolute path the writer issued for this basename, or undefined. */
-  resolve(filename: string): string | undefined {
+  /** The artifact the writer issued for this basename, or undefined. */
+  resolve(filename: string): IssuedArtifact | undefined {
     return this.issued.get(filename);
   }
 

--- a/src/server/toolOutputArtifactLedger.ts
+++ b/src/server/toolOutputArtifactLedger.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+
+/**
+ * Provenance ledger for tool-output artifacts (issue #5917).
+ *
+ * The `automobile:tool-output/{artifactId}` resource must serve ONLY files the
+ * {@link JsonToolOutputArtifactWriter} actually created. A filename-shape
+ * allowlist alone (`SAFE_ARTIFACT_ID`) still serves a hostile, writer-shaped
+ * sibling planted in a shared/misconfigured `--tool-outputs-dir`. The writer
+ * records every artifact it issues here; the resource resolves the read path
+ * from this ledger instead of re-deriving it from the client-supplied id.
+ *
+ * Because the opened path is a value the writer constructed — never the request
+ * parameter — this also breaks the request→filesystem-sink dataflow that
+ * CodeQL's temp-dir heuristics flag, so the O_NOFOLLOW handle read on top of it
+ * is satisfied rather than ping-ponged (issue #5917 review).
+ *
+ * In-memory and bounded: the daemon is a single long-lived process, artifacts
+ * are pruned by retention, and a lost ledger entry (eviction, daemon restart)
+ * degrades to the existing "expired or pruned" response — never an unsafe read.
+ */
+export class ToolOutputArtifactLedger {
+  // basename -> absolute path the writer wrote. Insertion order is recency order
+  // (a re-record deletes then re-sets), so eviction drops the least-recent.
+  private readonly issued = new Map<string, string>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = 1024) {
+    this.maxEntries = Math.max(1, maxEntries);
+  }
+
+  /** Record an artifact the writer just created, keyed by its basename. */
+  record(absolutePath: string): void {
+    const filename = path.basename(absolutePath);
+    this.issued.delete(filename);
+    this.issued.set(filename, absolutePath);
+    while (this.issued.size > this.maxEntries) {
+      const oldest = this.issued.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.issued.delete(oldest);
+    }
+  }
+
+  /** The absolute path the writer issued for this basename, or undefined. */
+  resolve(filename: string): string | undefined {
+    return this.issued.get(filename);
+  }
+
+  /** Drop an artifact (e.g. after retention prunes its file). */
+  forget(absolutePath: string): void {
+    this.issued.delete(path.basename(absolutePath));
+  }
+
+  clear(): void {
+    this.issued.clear();
+  }
+
+  get size(): number {
+    return this.issued.size;
+  }
+}
+
+/**
+ * Process-wide ledger shared between the writer (which records) and the
+ * tool-output resource handler (which resolves). Both run in the same daemon
+ * process, so a single module singleton is the shared provenance record.
+ */
+export const toolOutputArtifactLedger = new ToolOutputArtifactLedger();

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import { toActionableError } from "../models/ActionableError";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
@@ -10,7 +11,6 @@ import { logger } from "../utils/logger";
 import { buildToolOutputResourceUri } from "./toolOutputResources";
 import {
   toolOutputArtifactLedger,
-  type ArtifactFileIdentity,
   type ToolOutputArtifactLedger,
 } from "./toolOutputArtifactLedger";
 import type {
@@ -24,9 +24,7 @@ const SECURE_TOOL_OUTPUT_DIR_MODE = 0o700;
 export interface ToolOutputArtifactFileSystem {
   ensureDirectory(dirPath: string): void;
   assertWritableDirectory(dirPath: string): void;
-  // Returns the created file's dev/ino so provenance can bind to filesystem
-  // identity, not just the pathname (issue #5917).
-  writeFileExclusive(filePath: string, content: string, mode: number): ArtifactFileIdentity;
+  writeFileExclusive(filePath: string, content: string, mode: number): void;
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[];
   deleteFile(filePath: string): void;
 }
@@ -51,18 +49,8 @@ export class NodeToolOutputArtifactFileSystem implements ToolOutputArtifactFileS
     fs.accessSync(dirPath, fsConstants.W_OK);
   }
 
-  writeFileExclusive(filePath: string, content: string, mode: number): ArtifactFileIdentity {
-    // Create + open exclusively ("wx" = O_CREAT|O_EXCL), then capture identity by
-    // fstat'ing the very fd we created — race-free, unlike a path stat after the
-    // write, which a foreign process could win in a world-writable dir (#5917).
-    const fd = fs.openSync(filePath, "wx", mode);
-    try {
-      fs.writeFileSync(fd, content, { encoding: "utf8" });
-      const stats = fs.fstatSync(fd);
-      return { dev: stats.dev, ino: stats.ino };
-    } finally {
-      fs.closeSync(fd);
-    }
+  writeFileExclusive(filePath: string, content: string, mode: number): void {
+    fs.writeFileSync(filePath, content, { encoding: "utf8", flag: "wx", mode });
   }
 
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
@@ -126,10 +114,13 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
       const content = stringifyToolResponse(input.data);
       const filename = `${Math.trunc(this.timer.now())}-${safeFilenameSegment(input.tool)}-${safeFilenameSegment(this.idGenerator.next())}.json`;
       const artifactPath = path.join(this.outputDirectory, filename);
-      const identity = this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
-      // Record provenance (path + filesystem identity) so the resource serves only
-      // files we actually wrote and rejects a later replacement at that path (#5917).
-      this.ledger.record(artifactPath, identity);
+      this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
+      // Record provenance (path + content hash) so the resource serves only the
+      // exact bytes we wrote: it re-hashes what it reads and rejects any later
+      // replacement at that path — symlink, regular-file swap, or inode-reuse
+      // alias — in a world-writable --tool-outputs-dir (#5917).
+      const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
+      this.ledger.record(artifactPath, sha256);
 
       return {
         artifact: {

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -8,6 +8,10 @@ import { stringifyToolResponse } from "../utils/toolUtils";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import { logger } from "../utils/logger";
 import { buildToolOutputResourceUri } from "./toolOutputResources";
+import {
+  toolOutputArtifactLedger,
+  type ToolOutputArtifactLedger,
+} from "./toolOutputArtifactLedger";
 import type {
   ObservationArtifactMetadata,
   ObservationArtifactWriter,
@@ -78,6 +82,7 @@ export interface JsonToolOutputArtifactWriterOptions {
   idGenerator?: IdGenerator;
   timer?: Timer;
   retention?: ToolOutputArtifactRetention;
+  ledger?: ToolOutputArtifactLedger;
 }
 
 export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
@@ -86,6 +91,7 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
   private readonly idGenerator: IdGenerator;
   private readonly timer: Timer;
   private readonly retention: ToolOutputArtifactRetention | undefined;
+  private readonly ledger: ToolOutputArtifactLedger;
 
   constructor(options: JsonToolOutputArtifactWriterOptions) {
     this.outputDirectory = resolvePathFromDaemonLaunchWorkingDirectory(options.outputDirectory);
@@ -93,6 +99,9 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
     this.idGenerator = options.idGenerator ?? defaultIdGenerator;
     this.timer = options.timer ?? defaultTimer;
     this.retention = options.retention;
+    // Default to the process-wide ledger the tool-output resource reads from, so
+    // an artifact this writer creates is fetchable in-band (issue #5917).
+    this.ledger = options.ledger ?? toolOutputArtifactLedger;
   }
 
   writeJsonArtifact(input: ObservationArtifactWriteInput): ObservationArtifactMetadata {
@@ -105,6 +114,9 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
       const filename = `${Math.trunc(this.timer.now())}-${safeFilenameSegment(input.tool)}-${safeFilenameSegment(this.idGenerator.next())}.json`;
       const artifactPath = path.join(this.outputDirectory, filename);
       this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
+      // Record provenance so the resource serves only files we actually wrote,
+      // and reads them back by this writer-constructed path (issue #5917).
+      this.ledger.record(artifactPath);
 
       return {
         artifact: {
@@ -147,6 +159,8 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
 
       for (const filePath of filesToDelete) {
         this.fileSystem.deleteFile(filePath);
+        // Keep provenance in lockstep so a pruned file stops resolving (#5917).
+        this.ledger.forget(filePath);
       }
     } catch (error) {
       logger.warn(`Failed to prune old tool output artifacts: ${error}`, error);

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -10,6 +10,7 @@ import { logger } from "../utils/logger";
 import { buildToolOutputResourceUri } from "./toolOutputResources";
 import {
   toolOutputArtifactLedger,
+  type ArtifactFileIdentity,
   type ToolOutputArtifactLedger,
 } from "./toolOutputArtifactLedger";
 import type {
@@ -23,7 +24,9 @@ const SECURE_TOOL_OUTPUT_DIR_MODE = 0o700;
 export interface ToolOutputArtifactFileSystem {
   ensureDirectory(dirPath: string): void;
   assertWritableDirectory(dirPath: string): void;
-  writeFileExclusive(filePath: string, content: string, mode: number): void;
+  // Returns the created file's dev/ino so provenance can bind to filesystem
+  // identity, not just the pathname (issue #5917).
+  writeFileExclusive(filePath: string, content: string, mode: number): ArtifactFileIdentity;
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[];
   deleteFile(filePath: string): void;
 }
@@ -48,8 +51,18 @@ export class NodeToolOutputArtifactFileSystem implements ToolOutputArtifactFileS
     fs.accessSync(dirPath, fsConstants.W_OK);
   }
 
-  writeFileExclusive(filePath: string, content: string, mode: number): void {
-    fs.writeFileSync(filePath, content, { encoding: "utf8", flag: "wx", mode });
+  writeFileExclusive(filePath: string, content: string, mode: number): ArtifactFileIdentity {
+    // Create + open exclusively ("wx" = O_CREAT|O_EXCL), then capture identity by
+    // fstat'ing the very fd we created — race-free, unlike a path stat after the
+    // write, which a foreign process could win in a world-writable dir (#5917).
+    const fd = fs.openSync(filePath, "wx", mode);
+    try {
+      fs.writeFileSync(fd, content, { encoding: "utf8" });
+      const stats = fs.fstatSync(fd);
+      return { dev: stats.dev, ino: stats.ino };
+    } finally {
+      fs.closeSync(fd);
+    }
   }
 
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
@@ -113,10 +126,10 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
       const content = stringifyToolResponse(input.data);
       const filename = `${Math.trunc(this.timer.now())}-${safeFilenameSegment(input.tool)}-${safeFilenameSegment(this.idGenerator.next())}.json`;
       const artifactPath = path.join(this.outputDirectory, filename);
-      this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
-      // Record provenance so the resource serves only files we actually wrote,
-      // and reads them back by this writer-constructed path (issue #5917).
-      this.ledger.record(artifactPath);
+      const identity = this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
+      // Record provenance (path + filesystem identity) so the resource serves only
+      // files we actually wrote and rejects a later replacement at that path (#5917).
+      this.ledger.record(artifactPath, identity);
 
       return {
         artifact: {

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -5,6 +5,7 @@ import { logger } from "../utils/logger";
 import { errorMessage } from "../utils/describeUnknownError";
 import {
   toolOutputArtifactLedger,
+  type ArtifactFileIdentity,
   type ToolOutputArtifactLedger,
 } from "./toolOutputArtifactLedger";
 
@@ -33,7 +34,7 @@ const TOOL_OUTPUT_RESOURCE_URI_PREFIX = "automobile:tool-output/";
 const SAFE_ARTIFACT_ID = /^\d+-[A-Za-z0-9._-]+\.json$/;
 
 interface ToolOutputResourceFileSystem {
-  readFile(filePath: string): Promise<string>;
+  readFile(filePath: string, identity?: ArtifactFileIdentity): Promise<string>;
 }
 
 // O_NOFOLLOW is POSIX-only; on platforms without it (Windows) the flag is
@@ -41,7 +42,7 @@ interface ToolOutputResourceFileSystem {
 const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
 
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
-  async readFile(filePath: string): Promise<string> {
+  async readFile(filePath: string, identity?: ArtifactFileIdentity): Promise<string> {
     // `filePath` comes from the provenance ledger — a value the writer itself
     // constructed, never the client-supplied id — so a shared/misconfigured
     // `--tool-outputs-dir` cannot steer this read to an arbitrary sibling.
@@ -53,6 +54,12 @@ const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
       const stats = await handle.stat();
       if (!stats.isFile()) {
         throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
+      }
+      // Bind to the identity captured at creation: O_NOFOLLOW accepts a *regular
+      // file* swapped over the recorded path, so verify dev/ino on the open fd to
+      // reject a replacement a foreign process planted in a world-writable dir.
+      if (identity && (stats.dev !== identity.dev || stats.ino !== identity.ino)) {
+        throw new Error(`tool-output artifact identity mismatch: ${filePath}`);
       }
       return await handle.readFile("utf8");
     } finally {
@@ -118,13 +125,13 @@ async function getToolOutputArtifact(params: Record<string, string>): Promise<Re
   // path the writer recorded rather than one re-derived from the client id. A
   // shape-valid sibling planted in a shared `--tool-outputs-dir` has no ledger
   // entry, so it is refused before any filesystem access (issue #5917).
-  const issuedPath = issuedArtifactLedger.resolve(artifactId);
-  if (issuedPath === undefined) {
+  const issued = issuedArtifactLedger.resolve(artifactId);
+  if (issued === undefined) {
     return notAvailable(uri, artifactId);
   }
 
   try {
-    const text = await toolOutputResourceFileSystem.readFile(issuedPath);
+    const text = await toolOutputResourceFileSystem.readFile(issued.path, issued.identity);
     return { uri, mimeType: "application/json", text };
   } catch (error) {
     const reason = errorMessage(error);

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -1,11 +1,11 @@
 import * as realFs from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
+import { createHash } from "node:crypto";
 import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
 import { logger } from "../utils/logger";
 import { errorMessage } from "../utils/describeUnknownError";
 import {
   toolOutputArtifactLedger,
-  type ArtifactFileIdentity,
   type ToolOutputArtifactLedger,
 } from "./toolOutputArtifactLedger";
 
@@ -34,7 +34,7 @@ const TOOL_OUTPUT_RESOURCE_URI_PREFIX = "automobile:tool-output/";
 const SAFE_ARTIFACT_ID = /^\d+-[A-Za-z0-9._-]+\.json$/;
 
 interface ToolOutputResourceFileSystem {
-  readFile(filePath: string, identity?: ArtifactFileIdentity): Promise<string>;
+  readFile(filePath: string, sha256?: string): Promise<string>;
 }
 
 // O_NOFOLLOW is POSIX-only; on platforms without it (Windows) the flag is
@@ -42,29 +42,35 @@ interface ToolOutputResourceFileSystem {
 const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
 
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
-  async readFile(filePath: string, identity?: ArtifactFileIdentity): Promise<string> {
+  async readFile(filePath: string, sha256?: string): Promise<string> {
     // `filePath` comes from the provenance ledger — a value the writer itself
     // constructed, never the client-supplied id — so a shared/misconfigured
     // `--tool-outputs-dir` cannot steer this read to an arbitrary sibling.
-    // Opening with O_NOFOLLOW additionally refuses a planted symlink, and reading
-    // through the single returned handle (fstat + read on the same fd) closes the
-    // check-then-read TOCTOU window (issue #5917).
+    // Opening with O_NOFOLLOW refuses a planted symlink, and reading through the
+    // single returned handle (stat + read on the same fd) closes the check-then
+    // -read TOCTOU window (issue #5917).
     const handle = await realFs.open(filePath, fsConstants.O_RDONLY | O_NOFOLLOW);
+    let text: string;
     try {
       const stats = await handle.stat();
       if (!stats.isFile()) {
         throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
       }
-      // Bind to the identity captured at creation: O_NOFOLLOW accepts a *regular
-      // file* swapped over the recorded path, so verify dev/ino on the open fd to
-      // reject a replacement a foreign process planted in a world-writable dir.
-      if (identity && (stats.dev !== identity.dev || stats.ino !== identity.ino)) {
-        throw new Error(`tool-output artifact identity mismatch: ${filePath}`);
-      }
-      return await handle.readFile("utf8");
+      text = await handle.readFile("utf8");
     } finally {
       await handle.close();
     }
+    // Authorize by the content hash captured at creation: verify the exact bytes
+    // we are about to return, so no replacement at the recorded path — regular-
+    // file swap or inode-reuse alias, both of which a path/dev-ino check misses —
+    // can get its bytes served (issue #5917 review).
+    if (sha256 !== undefined) {
+      const actual = createHash("sha256").update(text, "utf8").digest("hex");
+      if (actual !== sha256) {
+        throw new Error(`tool-output artifact content hash mismatch: ${filePath}`);
+      }
+    }
+    return text;
   },
 };
 
@@ -131,7 +137,7 @@ async function getToolOutputArtifact(params: Record<string, string>): Promise<Re
   }
 
   try {
-    const text = await toolOutputResourceFileSystem.readFile(issued.path, issued.identity);
+    const text = await toolOutputResourceFileSystem.readFile(issued.path, issued.sha256);
     return { uri, mimeType: "application/json", text };
   } catch (error) {
     const reason = errorMessage(error);

--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -1,11 +1,12 @@
-import path from "node:path";
 import * as realFs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
 import { logger } from "../utils/logger";
 import { errorMessage } from "../utils/describeUnknownError";
-import { serverConfig } from "../utils/ServerConfig";
-import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
-import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
+import {
+  toolOutputArtifactLedger,
+  type ToolOutputArtifactLedger,
+} from "./toolOutputArtifactLedger";
 
 /**
  * In-band fetch for tool-output artifacts (issue #5882). Large observe/action
@@ -24,12 +25,10 @@ const TOOL_OUTPUT_RESOURCE_URI_PREFIX = "automobile:tool-output/";
  * Artifact filenames are `${timestamp}-${tool}-${id}.json`, where the tool/id
  * segments are already restricted to `[A-Za-z0-9._-]` by `safeFilenameSegment`
  * in the writer. Match the writer's full shape — a leading numeric timestamp,
- * then at least one `-`-joined segment, then `.json` — so a crafted `artifactId`
- * can never escape the tool-outputs directory (no separators, no `..`) AND an
- * arbitrary sibling file in a shared/misconfigured `--tool-outputs-dir` (e.g.
- * `credentials.json`) is not served just because it ends in `.json` (issue #5882
- * review). This narrows the readable namespace to the writer's own emissions; it
- * is not full per-artifact provenance tracking (deferred — see #5917).
+ * then at least one `-`-joined segment, then `.json` — as a cheap first gate that
+ * rejects a crafted `artifactId` (no separators, no `..`) with a clear message.
+ * Provenance (the issued-artifact ledger below) is the actual authorization: a
+ * shape-valid id that the writer never issued is still refused (issue #5917).
  */
 const SAFE_ARTIFACT_ID = /^\d+-[A-Za-z0-9._-]+\.json$/;
 
@@ -37,47 +36,49 @@ interface ToolOutputResourceFileSystem {
   readFile(filePath: string): Promise<string>;
 }
 
+// O_NOFOLLOW is POSIX-only; on platforms without it (Windows) the flag is
+// absent, so fall back to a plain read-only open there.
+const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
+
 const nodeToolOutputResourceFileSystem: ToolOutputResourceFileSystem = {
   async readFile(filePath: string): Promise<string> {
-    // The default tool-outputs directory is created 0o700 (owner-only) by the
-    // writer, so a foreign process cannot plant a file or symlink there. Deeper
-    // hardening for a deliberately world-writable `--tool-outputs-dir` — refusing
-    // symlink targets and closing the check-then-read TOCTOU window — is tracked
-    // in #5917; a check-then-read guard here only trades one CodeQL finding
-    // (insecure-temp-file) for another (file-system-race) without a
-    // pathname-based read ever being fully safe in a shared directory.
-    return realFs.readFile(filePath, "utf8");
+    // `filePath` comes from the provenance ledger — a value the writer itself
+    // constructed, never the client-supplied id — so a shared/misconfigured
+    // `--tool-outputs-dir` cannot steer this read to an arbitrary sibling.
+    // Opening with O_NOFOLLOW additionally refuses a planted symlink, and reading
+    // through the single returned handle (fstat + read on the same fd) closes the
+    // check-then-read TOCTOU window (issue #5917).
+    const handle = await realFs.open(filePath, fsConstants.O_RDONLY | O_NOFOLLOW);
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) {
+        throw new Error(`tool-output artifact is not a regular file: ${filePath}`);
+      }
+      return await handle.readFile("utf8");
+    } finally {
+      await handle.close();
+    }
   },
 };
 
 let toolOutputResourceFileSystem: ToolOutputResourceFileSystem = nodeToolOutputResourceFileSystem;
-let resolveToolOutputsDir: () => string = defaultResolveToolOutputsDir;
+let issuedArtifactLedger: Pick<ToolOutputArtifactLedger, "resolve"> = toolOutputArtifactLedger;
 
 export function setToolOutputResourceDependencies(deps: {
   fileSystem?: ToolOutputResourceFileSystem;
-  resolveDirectory?: () => string;
+  ledger?: Pick<ToolOutputArtifactLedger, "resolve">;
 }): void {
   if (deps.fileSystem) {
     toolOutputResourceFileSystem = deps.fileSystem;
   }
-  if (deps.resolveDirectory) {
-    resolveToolOutputsDir = deps.resolveDirectory;
+  if (deps.ledger) {
+    issuedArtifactLedger = deps.ledger;
   }
 }
 
 export function resetToolOutputResourceDependencies(): void {
   toolOutputResourceFileSystem = nodeToolOutputResourceFileSystem;
-  resolveToolOutputsDir = defaultResolveToolOutputsDir;
-}
-
-/**
- * Resolve the tool-outputs directory the way the writer does: the configured
- * directory when set, else the default temp subdir, then normalized against the
- * daemon launch cwd (idempotent for the already-absolute default).
- */
-function defaultResolveToolOutputsDir(): string {
-  const configured = serverConfig.getToolOutputsDir();
-  return resolvePathFromDaemonLaunchWorkingDirectory(configured ?? getDefaultToolOutputsDir());
+  issuedArtifactLedger = toolOutputArtifactLedger;
 }
 
 /** Build the companion resource URI for an artifact file basename. */
@@ -93,6 +94,15 @@ function toolOutputError(uri: string, error: string): ResourceContent {
   };
 }
 
+function notAvailable(uri: string, artifactId: string, detail?: string): ResourceContent {
+  const suffix = detail ? ` (${detail})` : "";
+  return toolOutputError(
+    uri,
+    `Tool-output artifact "${artifactId}" is not available. It may have expired or been ` +
+      `pruned, or it was not issued by this server. Re-run the tool to regenerate it.${suffix}`,
+  );
+}
+
 async function getToolOutputArtifact(params: Record<string, string>): Promise<ResourceContent> {
   const artifactId = params.artifactId ?? "";
   const uri = buildToolOutputResourceUri(artifactId);
@@ -104,25 +114,22 @@ async function getToolOutputArtifact(params: Record<string, string>): Promise<Re
     );
   }
 
-  // `SAFE_ARTIFACT_ID` is a strict allowlist with no path separators, so the join
-  // can never escape `directory` — no dirname re-check is needed. (An earlier
-  // `path.dirname(filePath) !== directory` guard rejected every read when
-  // `--tool-outputs-dir` ended in a separator, since `path.dirname` normalizes
-  // the trailing slash away while the configured directory keeps it — issue #5882
-  // review.)
-  const directory = resolveToolOutputsDir();
-  const filePath = path.join(directory, artifactId);
+  // Provenance gate: only serve files the writer actually issued, and read the
+  // path the writer recorded rather than one re-derived from the client id. A
+  // shape-valid sibling planted in a shared `--tool-outputs-dir` has no ledger
+  // entry, so it is refused before any filesystem access (issue #5917).
+  const issuedPath = issuedArtifactLedger.resolve(artifactId);
+  if (issuedPath === undefined) {
+    return notAvailable(uri, artifactId);
+  }
 
   try {
-    const text = await toolOutputResourceFileSystem.readFile(filePath);
+    const text = await toolOutputResourceFileSystem.readFile(issuedPath);
     return { uri, mimeType: "application/json", text };
   } catch (error) {
     const reason = errorMessage(error);
     logger.warn(`[ToolOutputResources] Failed to read artifact ${artifactId}: ${reason}`);
-    return toolOutputError(
-      uri,
-      `Tool-output artifact "${artifactId}" is not available. It may have expired or been pruned. Re-run the tool to regenerate it. (${reason})`,
-    );
+    return notAvailable(uri, artifactId, reason);
   }
 }
 

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2681,6 +2681,52 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("keeps tool-output artifact reads retrievable after a terminal release (#5917)", async () => {
+      // executePlan auto-releases its bound session, then every resource read is
+      // fenced — except the session-independent tool-output artifact read, whose
+      // diagnostic payload must stay fetchable after auto-release. It is a plain
+      // file read with no device access and no session data, so it forwards with
+      // no session params at all (unlike the fresh-screenshot exemption, which
+      // must still target the released session).
+      const artifactUri = "automobile:tool-output/1788020656886-observe-abc123.json";
+      const expectedResult = {
+        contents: [
+          {
+            uri: artifactUri,
+            mimeType: "application/json",
+            text: JSON.stringify({ viewHierarchy: { hierarchy: { node: { text: "Home" } } } }),
+          },
+        ],
+      };
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        resourceResult: expectedResult,
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.listTools();
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+
+        await expect(proxy.readResource(artifactUri)).resolves.toEqual(expectedResult);
+        // A non-exempt resource read on the same fenced connection still rejects.
+        await expect(proxy.readResource("automobile:observation/latest")).rejects.toThrow(
+          /session-a.*(?:expired|released)/i,
+        );
+        // The tool-output read forwards with no session params — session-independent.
+        expect(fakeClient.readResourceParams).toEqual([{}]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("preserves the daemon heartbeat snapshot on a terminal binding error", async () => {
       const timer = new FakeTimer();
       const fakeClient = new FakeDaemonClient({

--- a/test/server/toolOutputArtifactLedger.test.ts
+++ b/test/server/toolOutputArtifactLedger.test.ts
@@ -14,14 +14,14 @@ describe("ToolOutputArtifactLedger (#5917)", () => {
     expect(ledger.resolve("credentials.json")).toBeUndefined();
   });
 
-  test("carries the filesystem identity captured at creation", () => {
+  test("carries the content hash captured at creation", () => {
     const ledger = new ToolOutputArtifactLedger();
     const issued = path.resolve("/tmp/tool-outputs/1234-observe-abc.json");
-    ledger.record(issued, { dev: 42, ino: 99 });
+    ledger.record(issued, "deadbeef");
 
     expect(ledger.resolve("1234-observe-abc.json")).toEqual({
       path: issued,
-      identity: { dev: 42, ino: 99 },
+      sha256: "deadbeef",
     });
   });
 

--- a/test/server/toolOutputArtifactLedger.test.ts
+++ b/test/server/toolOutputArtifactLedger.test.ts
@@ -8,17 +8,28 @@ describe("ToolOutputArtifactLedger (#5917)", () => {
     const issued = path.resolve("/tmp/tool-outputs/1234-observe-abc.json");
     ledger.record(issued);
 
-    expect(ledger.resolve("1234-observe-abc.json")).toBe(issued);
+    expect(ledger.resolve("1234-observe-abc.json")?.path).toBe(issued);
     // A never-issued, writer-shaped sibling is not resolvable.
     expect(ledger.resolve("1234-observe-def.json")).toBeUndefined();
     expect(ledger.resolve("credentials.json")).toBeUndefined();
+  });
+
+  test("carries the filesystem identity captured at creation", () => {
+    const ledger = new ToolOutputArtifactLedger();
+    const issued = path.resolve("/tmp/tool-outputs/1234-observe-abc.json");
+    ledger.record(issued, { dev: 42, ino: 99 });
+
+    expect(ledger.resolve("1234-observe-abc.json")).toEqual({
+      path: issued,
+      identity: { dev: 42, ino: 99 },
+    });
   });
 
   test("forget removes an issued entry", () => {
     const ledger = new ToolOutputArtifactLedger();
     const issued = path.resolve("/tmp/tool-outputs/1-observe-x.json");
     ledger.record(issued);
-    expect(ledger.resolve("1-observe-x.json")).toBe(issued);
+    expect(ledger.resolve("1-observe-x.json")?.path).toBe(issued);
 
     ledger.forget(issued);
     expect(ledger.resolve("1-observe-x.json")).toBeUndefined();
@@ -37,8 +48,8 @@ describe("ToolOutputArtifactLedger (#5917)", () => {
     expect(ledger.size).toBe(2);
     // Oldest (a) evicted; newest two retained.
     expect(ledger.resolve("1-observe-a.json")).toBeUndefined();
-    expect(ledger.resolve("2-observe-b.json")).toBe(b);
-    expect(ledger.resolve("3-observe-c.json")).toBe(c);
+    expect(ledger.resolve("2-observe-b.json")?.path).toBe(b);
+    expect(ledger.resolve("3-observe-c.json")?.path).toBe(c);
   });
 
   test("re-recording refreshes recency so it survives eviction", () => {
@@ -52,9 +63,9 @@ describe("ToolOutputArtifactLedger (#5917)", () => {
     ledger.record(a); // refresh a's recency
     ledger.record(c); // should evict b, not a
 
-    expect(ledger.resolve("1-observe-a.json")).toBe(a);
+    expect(ledger.resolve("1-observe-a.json")?.path).toBe(a);
     expect(ledger.resolve("2-observe-b.json")).toBeUndefined();
-    expect(ledger.resolve("3-observe-c.json")).toBe(c);
+    expect(ledger.resolve("3-observe-c.json")?.path).toBe(c);
   });
 
   test("clear drops every entry", () => {

--- a/test/server/toolOutputArtifactLedger.test.ts
+++ b/test/server/toolOutputArtifactLedger.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
+
+describe("ToolOutputArtifactLedger (#5917)", () => {
+  test("resolves only paths that were recorded, by basename", () => {
+    const ledger = new ToolOutputArtifactLedger();
+    const issued = path.resolve("/tmp/tool-outputs/1234-observe-abc.json");
+    ledger.record(issued);
+
+    expect(ledger.resolve("1234-observe-abc.json")).toBe(issued);
+    // A never-issued, writer-shaped sibling is not resolvable.
+    expect(ledger.resolve("1234-observe-def.json")).toBeUndefined();
+    expect(ledger.resolve("credentials.json")).toBeUndefined();
+  });
+
+  test("forget removes an issued entry", () => {
+    const ledger = new ToolOutputArtifactLedger();
+    const issued = path.resolve("/tmp/tool-outputs/1-observe-x.json");
+    ledger.record(issued);
+    expect(ledger.resolve("1-observe-x.json")).toBe(issued);
+
+    ledger.forget(issued);
+    expect(ledger.resolve("1-observe-x.json")).toBeUndefined();
+  });
+
+  test("is bounded and evicts the oldest issued entries first", () => {
+    const ledger = new ToolOutputArtifactLedger(2);
+    const a = path.resolve("/tmp/tool-outputs/1-observe-a.json");
+    const b = path.resolve("/tmp/tool-outputs/2-observe-b.json");
+    const c = path.resolve("/tmp/tool-outputs/3-observe-c.json");
+
+    ledger.record(a);
+    ledger.record(b);
+    ledger.record(c);
+
+    expect(ledger.size).toBe(2);
+    // Oldest (a) evicted; newest two retained.
+    expect(ledger.resolve("1-observe-a.json")).toBeUndefined();
+    expect(ledger.resolve("2-observe-b.json")).toBe(b);
+    expect(ledger.resolve("3-observe-c.json")).toBe(c);
+  });
+
+  test("re-recording refreshes recency so it survives eviction", () => {
+    const ledger = new ToolOutputArtifactLedger(2);
+    const a = path.resolve("/tmp/tool-outputs/1-observe-a.json");
+    const b = path.resolve("/tmp/tool-outputs/2-observe-b.json");
+    const c = path.resolve("/tmp/tool-outputs/3-observe-c.json");
+
+    ledger.record(a);
+    ledger.record(b);
+    ledger.record(a); // refresh a's recency
+    ledger.record(c); // should evict b, not a
+
+    expect(ledger.resolve("1-observe-a.json")).toBe(a);
+    expect(ledger.resolve("2-observe-b.json")).toBeUndefined();
+    expect(ledger.resolve("3-observe-c.json")).toBe(c);
+  });
+
+  test("clear drops every entry", () => {
+    const ledger = new ToolOutputArtifactLedger();
+    ledger.record(path.resolve("/tmp/tool-outputs/1-observe-a.json"));
+    ledger.clear();
+    expect(ledger.size).toBe(0);
+    expect(ledger.resolve("1-observe-a.json")).toBeUndefined();
+  });
+});

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -10,6 +10,7 @@ import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
+import { createHash } from "node:crypto";
 
 class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
   ensureCalls: string[] = [];
@@ -28,17 +29,11 @@ class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
     this.assertWritableCalls.push(dirPath);
   }
 
-  writeFileExclusive(
-    filePath: string,
-    content: string,
-    mode: number,
-  ): { dev: number; ino: number } {
+  writeFileExclusive(filePath: string, content: string, mode: number): void {
     if (this.writeError) {
       throw this.writeError;
     }
     this.writes.push({ path: filePath, content, mode });
-    // Synthetic, unique-per-write identity so ledger provenance can be asserted.
-    return { dev: 1, ino: this.writes.length };
   }
 
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
@@ -129,16 +124,20 @@ describe("JsonToolOutputArtifactWriter", () => {
     });
 
     // Only the exact files the writer created are resolvable; a shape-valid
-    // sibling it never wrote is not. Each entry carries the identity the fake
-    // filesystem returned at creation, so the resource can bind reads to it.
+    // sibling it never wrote is not. Each entry carries the SHA-256 of the exact
+    // bytes written, so the resource can authorize reads by content.
+    const firstHash = createHash("sha256")
+      .update(stringifyToolResponse({ updatedAt: 1 }), "utf8")
+      .digest("hex");
     expect(ledger.resolve("1234-observe-id-1.json")).toEqual({
       path: first.artifact.path,
-      identity: { dev: 1, ino: 1 },
+      sha256: firstHash,
     });
-    expect(ledger.resolve("1234-observe-id-2.json")).toEqual({
-      path: path.join(outputDirectory, "1234-observe-id-2.json"),
-      identity: { dev: 1, ino: 2 },
-    });
+    expect(ledger.resolve("1234-observe-id-2.json")?.sha256).toBe(
+      createHash("sha256")
+        .update(stringifyToolResponse({ updatedAt: 2 }), "utf8")
+        .digest("hex"),
+    );
     expect(ledger.resolve("1234-observe-unwritten.json")).toBeUndefined();
   });
 

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -9,6 +9,7 @@ import { stringifyToolResponse } from "../../src/utils/toolUtils";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
 
 class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
   ensureCalls: string[] = [];
@@ -94,6 +95,69 @@ describe("JsonToolOutputArtifactWriter", () => {
     expect(second.artifact.resourceUri).toBe("automobile:tool-output/1234-tapOn-id_2.json");
     expect(fileSystem.listCalls).toEqual([]);
     expect(fileSystem.deleteCalls).toEqual([]);
+  });
+
+  test("records every issued artifact in the provenance ledger (#5917)", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    const ledger = new ToolOutputArtifactLedger();
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1234);
+    const outputDirectory = path.resolve("/tmp/auto-mobile artifacts");
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory,
+      fileSystem,
+      idGenerator: new FakeIdGenerator(["id-1", "id-2"]),
+      timer,
+      ledger,
+    });
+
+    const first = writer.writeJsonArtifact({
+      tool: "observe",
+      payload: "ObserveResult",
+      data: { updatedAt: 1 },
+    });
+    writer.writeJsonArtifact({
+      tool: "observe",
+      payload: "ObserveResult",
+      data: { updatedAt: 2 },
+    });
+
+    // Only the exact files the writer created are resolvable; a shape-valid
+    // sibling it never wrote is not.
+    expect(ledger.resolve("1234-observe-id-1.json")).toBe(first.artifact.path);
+    expect(ledger.resolve("1234-observe-id-2.json")).toBe(
+      path.join(outputDirectory, "1234-observe-id-2.json"),
+    );
+    expect(ledger.resolve("1234-observe-unwritten.json")).toBeUndefined();
+  });
+
+  test("forgets pruned artifacts from the provenance ledger (#5917)", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    const ledger = new ToolOutputArtifactLedger();
+    const outputDirectory = path.resolve("/tmp/auto-mobile artifacts");
+    const stalePath = path.join(outputDirectory, "old-observe.json");
+    ledger.record(stalePath);
+    fileSystem.entries = [
+      { path: stalePath, name: "old-observe.json", isFile: true, mtimeMs: 1_000 },
+    ];
+    const timer = new FakeTimer();
+    timer.setCurrentTime(10_000);
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory,
+      fileSystem,
+      idGenerator: new FakeIdGenerator(["id"]),
+      timer,
+      ledger,
+      retention: { maxAgeMs: 1_000, maxFiles: 500, overflowMinAgeMs: 500 },
+    });
+
+    expect(ledger.resolve("old-observe.json")).toBe(stalePath);
+
+    writer.writeJsonArtifact({ tool: "observe", payload: "ObserveResult", data: { updatedAt: 1 } });
+
+    expect(fileSystem.deleteCalls).toEqual([stalePath]);
+    // A pruned file is no longer resolvable through the ledger.
+    expect(ledger.resolve("old-observe.json")).toBeUndefined();
   });
 
   test("prunes stale JSON artifacts when retention is configured", () => {

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -28,11 +28,17 @@ class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
     this.assertWritableCalls.push(dirPath);
   }
 
-  writeFileExclusive(filePath: string, content: string, mode: number): void {
+  writeFileExclusive(
+    filePath: string,
+    content: string,
+    mode: number,
+  ): { dev: number; ino: number } {
     if (this.writeError) {
       throw this.writeError;
     }
     this.writes.push({ path: filePath, content, mode });
+    // Synthetic, unique-per-write identity so ledger provenance can be asserted.
+    return { dev: 1, ino: this.writes.length };
   }
 
   listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
@@ -123,11 +129,16 @@ describe("JsonToolOutputArtifactWriter", () => {
     });
 
     // Only the exact files the writer created are resolvable; a shape-valid
-    // sibling it never wrote is not.
-    expect(ledger.resolve("1234-observe-id-1.json")).toBe(first.artifact.path);
-    expect(ledger.resolve("1234-observe-id-2.json")).toBe(
-      path.join(outputDirectory, "1234-observe-id-2.json"),
-    );
+    // sibling it never wrote is not. Each entry carries the identity the fake
+    // filesystem returned at creation, so the resource can bind reads to it.
+    expect(ledger.resolve("1234-observe-id-1.json")).toEqual({
+      path: first.artifact.path,
+      identity: { dev: 1, ino: 1 },
+    });
+    expect(ledger.resolve("1234-observe-id-2.json")).toEqual({
+      path: path.join(outputDirectory, "1234-observe-id-2.json"),
+      identity: { dev: 1, ino: 2 },
+    });
     expect(ledger.resolve("1234-observe-unwritten.json")).toBeUndefined();
   });
 
@@ -151,7 +162,7 @@ describe("JsonToolOutputArtifactWriter", () => {
       retention: { maxAgeMs: 1_000, maxFiles: 500, overflowMinAgeMs: 500 },
     });
 
-    expect(ledger.resolve("old-observe.json")).toBe(stalePath);
+    expect(ledger.resolve("old-observe.json")?.path).toBe(stalePath);
 
     writer.writeJsonArtifact({ tool: "observe", payload: "ObserveResult", data: { updatedAt: 1 } });
 

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -157,31 +157,36 @@ describe("tool-output artifact resource (#5882)", () => {
     expect(fileSystem.reads).toEqual([path.join(ARTIFACT_DIR, filename)]);
   });
 
-  test("refuses to follow a symlink to a file outside the issued set (#5917)", async () => {
-    // In a deliberately world-writable --tool-outputs-dir a foreign process could
-    // plant a writer-shaped symlink pointing at an arbitrary file. The node read
-    // opens with O_NOFOLLOW, so the symlink target is never served.
-    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-symlink-"));
-    const secretPath = path.join(dir, "secret.txt");
-    const filename = "1788020656886-observe-evil.json";
-    const linkPath = path.join(dir, filename);
-    try {
-      writeFileSync(secretPath, "top secret");
-      symlinkSync(secretPath, linkPath);
+  // Unprivileged symlink creation is unavailable on Windows (needs admin/developer
+  // mode), and O_NOFOLLOW degrades to a no-op there anyway, so this is POSIX-only.
+  test.skipIf(process.platform === "win32")(
+    "refuses to follow a symlink to a file outside the issued set (#5917)",
+    async () => {
+      // In a deliberately world-writable --tool-outputs-dir a foreign process could
+      // plant a writer-shaped symlink pointing at an arbitrary file. The node read
+      // opens with O_NOFOLLOW, so the symlink target is never served.
+      const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-symlink-"));
+      const secretPath = path.join(dir, "secret.txt");
+      const filename = "1788020656886-observe-evil.json";
+      const linkPath = path.join(dir, filename);
+      try {
+        writeFileSync(secretPath, "top secret");
+        symlinkSync(secretPath, linkPath);
 
-      // Real node filesystem (not the fake), but a ledger that has "issued" the
-      // symlink path — provenance alone must not defeat symlink refusal.
-      const ledger = new ToolOutputArtifactLedger();
-      ledger.record(linkPath);
-      setToolOutputResourceDependencies({ ledger });
+        // Real node filesystem (not the fake), but a ledger that has "issued" the
+        // symlink path — provenance alone must not defeat symlink refusal.
+        const ledger = new ToolOutputArtifactLedger();
+        ledger.record(linkPath);
+        setToolOutputResourceDependencies({ ledger });
 
-      const content = await readArtifact(filename);
+        const content = await readArtifact(filename);
 
-      const parsed = JSON.parse(content.text!) as { error: string };
-      expect(parsed.error).toContain("not available");
-      expect(content.text).not.toContain("top secret");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+        const parsed = JSON.parse(content.text!) as { error: string };
+        expect(parsed.error).toContain("not available");
+        expect(content.text).not.toContain("top secret");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
 import {
   TOOL_OUTPUT_RESOURCE_URI_TEMPLATE,
   buildToolOutputResourceUri,
@@ -31,11 +34,18 @@ class FakeResourceFileSystem {
   }
 }
 
-function installFake(fileSystem: FakeResourceFileSystem): void {
-  setToolOutputResourceDependencies({
-    fileSystem,
-    resolveDirectory: () => ARTIFACT_DIR,
-  });
+/**
+ * Install a fake filesystem plus a provenance ledger seeded so the given
+ * basenames resolve to `ARTIFACT_DIR/<basename>` — i.e. as if the writer had
+ * issued them. The resource reads the path FROM the ledger, so a read is only
+ * reachable for a recorded artifact.
+ */
+function installFake(fileSystem: FakeResourceFileSystem, issuedBasenames: string[] = []): void {
+  const ledger = new ToolOutputArtifactLedger();
+  for (const name of issuedBasenames) {
+    ledger.record(path.join(ARTIFACT_DIR, name));
+  }
+  setToolOutputResourceDependencies({ fileSystem, ledger });
 }
 
 async function readArtifact(artifactId: string) {
@@ -61,7 +71,7 @@ describe("tool-output artifact resource (#5882)", () => {
     const filename = "1788020656886-observe-abc123.json";
     const raw = JSON.stringify({ viewHierarchy: { hierarchy: { node: { text: "Settings" } } } });
     fileSystem.files.set(path.join(ARTIFACT_DIR, filename), raw);
-    installFake(fileSystem);
+    installFake(fileSystem, [filename]);
 
     const content = await readArtifact(filename);
 
@@ -116,33 +126,62 @@ describe("tool-output artifact resource (#5882)", () => {
     expect(fileSystem.reads).toEqual([]);
   });
 
-  test("reads artifacts when the configured directory ends in a separator", async () => {
-    // resolvePathFromDaemonLaunchWorkingDirectory preserves a trailing slash on an
-    // absolute --tool-outputs-dir; the read must still resolve (issue #5882 review).
+  test("rejects a writer-shaped id the writer never issued (provenance, #5917)", async () => {
+    // Shape-valid AND sitting in the tool-outputs dir, but not in the ledger:
+    // a hostile process could plant `<ts>-observe-<id>.json` in a world-writable
+    // --tool-outputs-dir. Provenance tracking refuses it without a read.
     const fileSystem = new FakeResourceFileSystem();
-    const trailingSlashDir = `${ARTIFACT_DIR}/`;
-    const filename = "1788020656886-observe-abc123.json";
-    const raw = JSON.stringify({ ok: true });
-    fileSystem.files.set(path.join(trailingSlashDir, filename), raw);
-    setToolOutputResourceDependencies({
-      fileSystem,
-      resolveDirectory: () => trailingSlashDir,
-    });
+    const planted = "1788020656886-observe-planted.json";
+    fileSystem.files.set(path.join(ARTIFACT_DIR, planted), '{"secret":true}');
+    installFake(fileSystem, []); // ledger empty — nothing issued
 
-    const content = await readArtifact(filename);
+    const content = await readArtifact(planted);
 
-    expect(content.text).toBe(raw);
-    expect(fileSystem.reads).toEqual([path.join(trailingSlashDir, filename)]);
+    const parsed = JSON.parse(content.text!) as { error: string };
+    expect(parsed.error).toContain("not available");
+    expect(fileSystem.reads).toEqual([]);
   });
 
-  test("returns a structured error when the artifact is missing or pruned", async () => {
+  test("returns a structured error when the artifact is issued but missing or pruned", async () => {
     const fileSystem = new FakeResourceFileSystem();
-    installFake(fileSystem);
+    const filename = "1788020656886-observe-gone.json";
+    // Issued by the writer, but the file is gone (pruned/expired): reaches the
+    // read, which fails, and surfaces the graceful error.
+    installFake(fileSystem, [filename]);
 
-    const content = await readArtifact("1788020656886-observe-gone.json");
+    const content = await readArtifact(filename);
 
     expect(content.mimeType).toBe("application/json");
     const parsed = JSON.parse(content.text!) as { error: string };
     expect(parsed.error).toContain("not available");
+    expect(fileSystem.reads).toEqual([path.join(ARTIFACT_DIR, filename)]);
+  });
+
+  test("refuses to follow a symlink to a file outside the issued set (#5917)", async () => {
+    // In a deliberately world-writable --tool-outputs-dir a foreign process could
+    // plant a writer-shaped symlink pointing at an arbitrary file. The node read
+    // opens with O_NOFOLLOW, so the symlink target is never served.
+    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-symlink-"));
+    const secretPath = path.join(dir, "secret.txt");
+    const filename = "1788020656886-observe-evil.json";
+    const linkPath = path.join(dir, filename);
+    try {
+      writeFileSync(secretPath, "top secret");
+      symlinkSync(secretPath, linkPath);
+
+      // Real node filesystem (not the fake), but a ledger that has "issued" the
+      // symlink path — provenance alone must not defeat symlink refusal.
+      const ledger = new ToolOutputArtifactLedger();
+      ledger.record(linkPath);
+      setToolOutputResourceDependencies({ ledger });
+
+      const content = await readArtifact(filename);
+
+      const parsed = JSON.parse(content.text!) as { error: string };
+      expect(parsed.error).toContain("not available");
+      expect(content.text).not.toContain("top secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
-import { mkdtempSync, writeFileSync, symlinkSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
@@ -19,7 +20,7 @@ class FakeResourceFileSystem {
   reads: string[] = [];
   readError: Error | undefined;
 
-  async readFile(filePath: string, _identity?: { dev: number; ino: number }): Promise<string> {
+  async readFile(filePath: string, _sha256?: string): Promise<string> {
     this.reads.push(filePath);
     if (this.readError) {
       throw this.readError;
@@ -190,29 +191,35 @@ describe("tool-output artifact resource (#5882)", () => {
     },
   );
 
-  test("refuses a file whose on-disk identity differs from the recorded one (#5917)", async () => {
-    // Models a regular-file replacement in a world-writable --tool-outputs-dir:
-    // O_NOFOLLOW accepts a regular file at the recorded path, so the read must also
-    // verify the dev/ino captured at creation and reject a swapped file.
-    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-identity-"));
+  test("refuses a file whose content hash differs from the recorded one (#5917)", async () => {
+    // Models a replacement in a world-writable --tool-outputs-dir — a regular-file
+    // swap OR an inode-reuse alias, both of which O_NOFOLLOW and a dev/ino check
+    // accept. The read re-hashes the bytes it is about to return and rejects any
+    // divergence from the hash captured at creation.
+    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-content-"));
     const filename = "1788020656886-observe-swap.json";
     const filePath = path.join(dir, filename);
     try {
-      writeFileSync(filePath, JSON.stringify({ real: true }));
-      const real = statSync(filePath);
+      const realBytes = JSON.stringify({ real: true });
+      writeFileSync(filePath, realBytes);
+      const realHash = createHash("sha256").update(realBytes, "utf8").digest("hex");
 
-      // Correct identity → served.
+      // Correct hash → served.
       const ok = new ToolOutputArtifactLedger();
-      ok.record(filePath, { dev: real.dev, ino: real.ino });
+      ok.record(filePath, realHash);
       setToolOutputResourceDependencies({ ledger: ok });
       expect(JSON.parse((await readArtifact(filename)).text!)).toEqual({ real: true });
 
-      // Mismatched identity (as if the file were replaced after recording) → refused.
+      // The file on disk now differs from the recorded hash (as if swapped after
+      // recording) → refused, and the attacker bytes are never returned.
+      writeFileSync(filePath, JSON.stringify({ attacker: "owned" }));
       const swapped = new ToolOutputArtifactLedger();
-      swapped.record(filePath, { dev: real.dev, ino: real.ino + 1 });
+      swapped.record(filePath, realHash);
       setToolOutputResourceDependencies({ ledger: swapped });
-      const parsed = JSON.parse((await readArtifact(filename)).text!) as { error: string };
+      const content = await readArtifact(filename);
+      const parsed = JSON.parse(content.text!) as { error: string };
       expect(parsed.error).toContain("not available");
+      expect(content.text).not.toContain("owned");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
-import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { ToolOutputArtifactLedger } from "../../src/server/toolOutputArtifactLedger";
@@ -19,7 +19,7 @@ class FakeResourceFileSystem {
   reads: string[] = [];
   readError: Error | undefined;
 
-  async readFile(filePath: string): Promise<string> {
+  async readFile(filePath: string, _identity?: { dev: number; ino: number }): Promise<string> {
     this.reads.push(filePath);
     if (this.readError) {
       throw this.readError;
@@ -189,4 +189,32 @@ describe("tool-output artifact resource (#5882)", () => {
       }
     },
   );
+
+  test("refuses a file whose on-disk identity differs from the recorded one (#5917)", async () => {
+    // Models a regular-file replacement in a world-writable --tool-outputs-dir:
+    // O_NOFOLLOW accepts a regular file at the recorded path, so the read must also
+    // verify the dev/ino captured at creation and reject a swapped file.
+    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-identity-"));
+    const filename = "1788020656886-observe-swap.json";
+    const filePath = path.join(dir, filename);
+    try {
+      writeFileSync(filePath, JSON.stringify({ real: true }));
+      const real = statSync(filePath);
+
+      // Correct identity → served.
+      const ok = new ToolOutputArtifactLedger();
+      ok.record(filePath, { dev: real.dev, ino: real.ino });
+      setToolOutputResourceDependencies({ ledger: ok });
+      expect(JSON.parse((await readArtifact(filename)).text!)).toEqual({ real: true });
+
+      // Mismatched identity (as if the file were replaced after recording) → refused.
+      const swapped = new ToolOutputArtifactLedger();
+      swapped.record(filePath, { dev: real.dev, ino: real.ino + 1 });
+      setToolOutputResourceDependencies({ ledger: swapped });
+      const parsed = JSON.parse((await readArtifact(filename)).text!) as { error: string };
+      expect(parsed.error).toContain("not available");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Hardens the `automobile:tool-output/{artifactId}` MCP resource added in #5908, closing the three shared-dir/misconfiguration edges deferred from that PR's review. Default configuration (0o700 owner-only tool-outputs dir) was never exposed; this makes a deliberately world-writable `--tool-outputs-dir` safe too, and restores retrievability of `executePlan`'s diagnostic artifacts.

## Linked Issue

Closes #5917

> Builds directly on #5908 (merged), which added the resource being hardened.

## Changes

**1. Session-fence exemption (item 1).** `executePlan` auto-releases its bound session; `DaemonMcpProxy.readResource` then fences every resource read except the fresh-screenshot URI, so an emitted `automobile:tool-output/…` URI was a dead affordance. Added `isToolOutputResourceUri(uri)` — a tool-output read is session-independent (a plain host file read, no device access, no session data), so it's exempt from the fence and forwarded with **no** session params (safer than the fresh-screenshot exemption, which still targets its released session).

**2. Provenance ledger (item 2).** New bounded in-memory `ToolOutputArtifactLedger`. `JsonToolOutputArtifactWriter` records every file it creates and forgets pruned files. The resource resolves the read path **from the ledger** (a writer-constructed value) instead of re-deriving it from the client id — so a shape-valid sibling planted in a shared `--tool-outputs-dir` (e.g. `1234-observe-x.json`) is refused before any filesystem access. The `SAFE_ARTIFACT_ID` shape regex stays as a cheap first gate with a clear error message.

**3. Symlink + TOCTOU-free read (item 3, folded into 2).** The node read opens with `O_RDONLY | O_NOFOLLOW` and reads through the single returned handle (`fstat` + read on one fd), refusing a planted symlink and closing the check-then-read window. Reading the ledger's writer-constructed path (never the client id) severs the request→fs-sink dataflow, so the O_NOFOLLOW handle is CodeQL-satisfied rather than trading one temp-dir alert for another.

## Validation

- [x] `bun run lint` + `bun test` — full suite green except one pre-existing, unrelated flake (`test/integration/webrtcDeviceCaptureLatency.test.ts`, a bun-1.3.14 reporter-format mismatch; fails identically on the untouched base)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run format:check` — clean
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [x] No new dependency; no public tool-schema change

## Acceptance criteria → test

| Criterion | Test |
|---|---|
| Tool-output reads survive `executePlan` session auto-release | `test/daemon/daemonMcpProxy.test.ts` — "keeps tool-output artifact reads retrievable after a terminal release (#5917)" |
| Only writer-issued files readable (provenance) | `test/server/toolOutputArtifactWriter.test.ts` (records/forgets) + `test/server/toolOutputResources.test.ts` — "rejects a writer-shaped id the writer never issued" |
| Symlink refused, TOCTOU-free | `test/server/toolOutputResources.test.ts` — "refuses to follow a symlink…" (real-fs O_NOFOLLOW) |
| Ledger bounded/recency/forget | `test/server/toolOutputArtifactLedger.test.ts` |
