### PR TITLE
fix(daemon): close the four narrow double-lock-contention residuals (#5904)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1311,9 +1311,13 @@ export class DaemonMcpProxy {
     // (early-owner record present, socket unreachable, no live holder finishing the
     // start) is then reported now instead of at the client's deadline, while the
     // concurrent-cold-start case keeps the budget it needs.
-    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS, undefined, () =>
-      this.daemonManager.isStartupLockHeldByLiveProcess(),
-    );
+    // Re-arbitrate across replacement holders under one deadline, exactly like the
+    // double-lock-contention loop in DaemonManager.start (issue #5904): if the live
+    // holder A crashes and a replacement B reclaims the lock to finish the start, a
+    // single liveness-gated waitForReady would give up on A and throw even though B
+    // is now bringing the daemon up. waitForLockHolderReadiness keeps the full budget
+    // per live holder and only reports failure once no live holder remains.
+    const ready = await this.daemonManager.waitForLockHolderReadiness(DAEMON_STARTUP_TIMEOUT_MS);
     if (!ready) {
       throw new DaemonUnavailableError(
         `Daemon reported running but its socket did not become reachable, and no live ` +

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -48,6 +48,7 @@ import { DaemonState, type DaemonStateLike } from "./daemonState";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { cleanupDaemonFiles, isProcessRunning as isDaemonProcessRunning } from "./daemonFiles";
 import { parseLockContent, releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import {
   DAEMON_LAUNCH_CWD_ENV,
   resolveDaemonLaunchWorkingDirectory,
@@ -375,6 +376,29 @@ const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 
 /**
+ * Cadence at which the liveness watchdog re-samples the "keep waiting" predicate
+ * while a full-budget readiness probe is in flight (issue #5904). A per-poll
+ * precheck only samples liveness between probes; if the holder dies *during* a
+ * probe whose `connect()` stalls (an accepts-but-never-responds socket), nothing
+ * interrupts that probe and it can absorb the client's whole `tools/list`
+ * deadline before the actionable error is produced. The watchdog aborts the probe
+ * the instant no live holder remains. Matched to the readiness poll interval so it
+ * reacts within one poll without hammering the process table.
+ */
+const LIVENESS_WATCHDOG_INTERVAL_MS = 100;
+
+/**
+ * A snapshot of the daemon startup lock's current holder, as read from the lock
+ * file. `token` carries the holder's per-instance owner token (issue #5904) so a
+ * replacement holder is distinguishable from the prior one even under PID reuse.
+ */
+interface StartupLockHolder {
+  present: boolean;
+  livePid: number | undefined;
+  token: string | undefined;
+}
+
+/**
  * Surface of DaemonManager used by clients (e.g. DaemonMcpProxy).
  * Allows injecting fakes in tests without subclassing the concrete class.
  */
@@ -394,6 +418,13 @@ export interface DaemonManagerLike {
    * live one keeps it (issue #5878).
    */
   isStartupLockHeldByLiveProcess(): boolean;
+  /**
+   * Wait for the current live startup-lock holder to publish a connectable socket,
+   * re-arbitrating across replacement holders under one deadline (issue #5904).
+   * Returns false only once no live holder remains, so the caller delivers its
+   * actionable error rather than racing the client's `tools/list` deadline.
+   */
+  waitForLockHolderReadiness(timeoutMs: number): Promise<boolean>;
 }
 
 /**
@@ -420,6 +451,16 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly fallbackLauncher: DaemonLauncher;
   private readonly launchCommandResolver: (() => DaemonLaunchCommand) | undefined;
   private heldLockLogPath: string | undefined;
+  /**
+   * A per-instance owner token written into the startup lock alongside the PID
+   * (issue #5904). It distinguishes a genuinely new lock holder from the prior one
+   * even when the OS recycled the prior holder's PID, or when a *different*
+   * `DaemonManager` instance in this same process reacquires the lock with an
+   * identical `process.pid` — cases a PID-only identity check reads as "same
+   * holder" and stops waiting on. Generated from the injected `IdGenerator` so it
+   * is the one canonical randomness primitive rather than an ad-hoc UUID path.
+   */
+  private readonly startupLockOwnerToken: string;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -435,7 +476,9 @@ export class DaemonManager implements DaemonManagerLike {
     extractionCleaner: ExtractionCleaner = fileSystemExtractionCleaner,
     launcher: DaemonLauncher | (() => DaemonLaunchCommand) | undefined = undefined,
     processSignaler: DaemonProcessSignaler = defaultDaemonProcessSignaler,
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
+    this.startupLockOwnerToken = idGenerator.next();
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = resolvePathFromDaemonLaunchWorkingDirectory(lockFilePath);
@@ -484,6 +527,12 @@ export class DaemonManager implements DaemonManagerLike {
     const logPath = this.daemonLaunchLogPath();
     const acquired = tryAcquireExclusiveLock(this.lockFilePath, {
       isProcessRunning: (pid) => this.isProcessRunning(pid),
+      // Written on line 2 so a follower can tell a replacement holder apart from
+      // the one it was already waiting on even under PID reuse (issue #5904).
+      // `reclaimOwnPid` stays false (the daemon's documented same-process contract),
+      // so the token does not change acquire's stale-reclaim decision — it only
+      // feeds the replacement-identity read in `readStartupLockHolder`.
+      ownerToken: this.startupLockOwnerToken,
       metadata: Buffer.from(logPath, "utf8").toString("base64url"),
     });
     this.heldLockLogPath = acquired ? logPath : undefined;
@@ -495,7 +544,11 @@ export class DaemonManager implements DaemonManagerLike {
    * holds our PID, so it can't delete a lock another opener reclaimed.
    */
   releaseLock(): void {
-    releaseExclusiveLock(this.lockFilePath);
+    // Pass the token so release is incarnation-aware and symmetric with acquire: a
+    // same-PID lock bearing a DIFFERENT token belongs to another instance/incarnation
+    // that recycled our PID and must not be deleted (issue #5904). A lock with no
+    // token line (a pre-token incarnation) is still treated as ours on a PID match.
+    releaseExclusiveLock(this.lockFilePath, process.pid, this.startupLockOwnerToken);
     this.heldLockLogPath = undefined;
   }
 
@@ -592,7 +645,7 @@ export class DaemonManager implements DaemonManagerLike {
    */
   private async startByAwaitingLockHolder(options: DaemonOptions): Promise<void> {
     let holderLogPath: string | null = null;
-    let waitedOnPid = this.readStartupLockHolder().livePid;
+    let waitedOnHolder = this.readStartupLockHolder();
 
     // ONE arbitration deadline across every holder, replacements included, and the
     // final confirm bounded by whatever time is left under it — so a chain of
@@ -636,11 +689,15 @@ export class DaemonManager implements DaemonManagerLike {
       // We could not take over, so the lock is still held. Keep waiting only for a
       // genuinely different live holder (a replacement that reclaimed the lock while
       // the prior one died); a stuck same holder or a now-dead lock ends the loop.
-      const current = this.readStartupLockHolder().livePid;
-      if (current === undefined || current === waitedOnPid) {
+      // Identity is by owner token, not PID, so a replacement that reused the prior
+      // holder's PID — OS recycling, or a same-process sibling manager instance — is
+      // still recognized as a replacement rather than read as the same stuck holder
+      // (issue #5904).
+      const current = this.readStartupLockHolder();
+      if (current.livePid === undefined || this.isSameStartupLockHolder(current, waitedOnHolder)) {
         break;
       }
-      waitedOnPid = current;
+      waitedOnHolder = current;
       stderrLog("Startup lock reclaimed by another process, waiting again...");
     }
 
@@ -976,13 +1033,16 @@ export class DaemonManager implements DaemonManagerLike {
    * `present` is true while there is a holder worth waiting for — a live PID, or a
    * lock file mid-write whose PID is not yet readable; it is false once the lock is
    * gone or its holder has died. `livePid` is that holder's PID when it is both
-   * readable and alive, else `undefined`, so a caller can tell a *replacement*
-   * holder (a different live PID) from the same one it was already waiting on.
+   * readable and alive, else `undefined`. `token` is the holder's per-instance owner
+   * token (issue #5904) when present, so a caller can tell a *replacement* holder
+   * from the same one it was already waiting on even when the PID is identical (OS
+   * PID reuse, or a different `DaemonManager` instance in this same process) — a
+   * gap a PID-only comparison misses. See {@link isSameStartupLockHolder}.
    *
    * Reuses the injected liveness checker and the shared lock format so there is one
    * canonical primitive per concern rather than a second PID reader (issue #5878).
    */
-  private readStartupLockHolder(): { present: boolean; livePid: number | undefined } {
+  private readStartupLockHolder(): StartupLockHolder {
     let content: string;
     try {
       content = readFileSync(this.lockFilePath, "utf-8").trim();
@@ -992,22 +1052,40 @@ export class DaemonManager implements DaemonManagerLike {
       logger.debug(
         `[DaemonManager] Startup lock unreadable while waiting for holder: ${this.describeError(error)}`,
       );
-      return { present: false, livePid: undefined };
+      return { present: false, livePid: undefined, token: undefined };
     }
     if (content.length === 0) {
       // A holder created the lock but has not written its PID yet (mirrors the
       // fileLock mid-write window); treat as still held so we do not abandon it,
       // but with no comparable identity yet.
-      return { present: true, livePid: undefined };
+      return { present: true, livePid: undefined, token: undefined };
     }
-    const { pid } = parseLockContent(content);
+    const { pid, token } = parseLockContent(content);
     if (!Number.isSafeInteger(pid) || pid <= 0) {
       // Unreadable PID — a holder may still be filling it in; keep waiting.
-      return { present: true, livePid: undefined };
+      return { present: true, livePid: undefined, token };
     }
     return this.isProcessRunning(pid)
-      ? { present: true, livePid: pid }
-      : { present: false, livePid: undefined };
+      ? { present: true, livePid: pid, token }
+      : { present: false, livePid: undefined, token };
+  }
+
+  /**
+   * Whether two startup-lock reads refer to the same holder (issue #5904).
+   *
+   * Prefers owner-token identity: a replacement holder that reused the prior
+   * holder's PID — the OS recycling it, or a *different* `DaemonManager` instance in
+   * this same process re-acquiring with an identical `process.pid` — writes a
+   * different token and so reads as a genuinely new holder still worth waiting on,
+   * which a bare PID comparison would wrongly collapse to "same stuck holder". Falls
+   * back to PID identity only when a token is missing on either side (a pre-token
+   * lock, or a holder still mid-write), preserving the earlier PID-only behavior.
+   */
+  private isSameStartupLockHolder(a: StartupLockHolder, b: StartupLockHolder): boolean {
+    if (a.token !== undefined && b.token !== undefined) {
+      return a.token === b.token;
+    }
+    return a.livePid !== undefined && a.livePid === b.livePid;
   }
 
   /**
@@ -1026,6 +1104,67 @@ export class DaemonManager implements DaemonManagerLike {
    */
   isStartupLockHeldByLiveProcess(): boolean {
     return this.readStartupLockHolder().present;
+  }
+
+  /**
+   * Wait for whichever live process currently holds the startup lock to publish a
+   * connectable socket, re-arbitrating across *replacement* holders under ONE
+   * deadline (issue #5904).
+   *
+   * This is the waiting core shared with {@link startByAwaitingLockHolder}: a single
+   * liveness-gated {@link waitForReady} keeps the full budget while a live holder is
+   * bringing the daemon up, but the moment that holder is gone this re-reads the
+   * lock — and if a *different* live holder (by owner token, so PID reuse and
+   * same-process sibling instances don't read as "the same holder") reclaimed it,
+   * waits on that replacement under the remaining budget instead of giving up. It
+   * returns false only once no live holder remains, so the caller can deliver its
+   * actionable error rather than racing the client's ~30s `tools/list` deadline.
+   *
+   * Unlike `startByAwaitingLockHolder` it never takes over the lock itself — it is
+   * for callers (e.g. `DaemonMcpProxy.startDaemon`'s "reports running but socket not
+   * yet published" branch, #5664) that only wait for a holder to finish publishing.
+   */
+  async waitForLockHolderReadiness(timeoutMs: number): Promise<boolean> {
+    const deadline = this.timer.now() + timeoutMs;
+    let waitedOnHolder = this.readStartupLockHolder();
+
+    while (this.remainingTime(deadline) > 0) {
+      const ready = await this.waitForReady(this.remainingTime(deadline), undefined, () =>
+        this.isStartupLockHeldByLiveProcess(),
+      );
+      if (ready) {
+        return true;
+      }
+
+      // The holder we waited on is gone. Re-arbitrate: if a genuinely different live
+      // holder reclaimed the lock (A crashed, B took over between the predicate's
+      // lock read and its liveness check), wait on B under the remaining budget; a
+      // stuck same holder or a now-dead lock ends the wait.
+      const current = this.readStartupLockHolder();
+      if (current.livePid === undefined || this.isSameStartupLockHolder(current, waitedOnHolder)) {
+        break;
+      }
+      waitedOnHolder = current;
+    }
+
+    // A holder can publish its socket and release its lock in the window between a
+    // poll's socket check and its liveness check — and the liveness watchdog widens
+    // that window, since it aborts a slow-but-healthy in-flight probe the instant
+    // the lock is released rather than letting that probe complete. Confirm
+    // reachability directly before reporting failure, exactly as
+    // startByAwaitingLockHolder does: a bounded, NON-destructive probe that never
+    // unlinks a socket, so a healthy-but-slow daemon that just came up is reported
+    // ready instead of failed (issue #5904). Cap it to whatever time is left so it
+    // cannot push total elapsed past the client deadline (issue #5878).
+    const confirmBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
+    if (
+      confirmBudget > 0 &&
+      existsSync(this.socketPath) &&
+      (await this.verifyDaemonConnection(confirmBudget))
+    ) {
+      return true;
+    }
+    return false;
   }
 
   private async getLockHolderStartupLogPath(): Promise<string | null> {
@@ -1374,13 +1513,12 @@ export class DaemonManager implements DaemonManagerLike {
       const keepWaiting = shouldContinueWaiting();
       if (existsSync(this.socketPath)) {
         socketObserved = true;
-        const probeDeadline = keepWaiting
-          ? deadline
-          : Math.min(deadline, this.timer.now() + ABANDONED_WAIT_CONFIRM_TIMEOUT_MS);
-        // Only the full-budget wait (holder still live) is authoritative enough to
-        // unlink a stale socket; a capped probe must not, or it could remove a
-        // healthy-but-slow daemon's socket (issue #5878).
-        const outcome = await this.probeObservedSocket(probeDeadline, signal, keepWaiting);
+        const outcome = await this.probeObservedSocketWithWatchdog(
+          keepWaiting,
+          deadline,
+          signal,
+          shouldContinueWaiting,
+        );
         if (outcome === "ready") {
           stderrLog(
             `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
@@ -1388,7 +1526,15 @@ export class DaemonManager implements DaemonManagerLike {
           );
           return true;
         }
+        // A probe abort is either the caller's own cancellation or the liveness
+        // watchdog firing because the holder died mid-probe (issue #5904); both end
+        // the wait, and reporting not-ready lets the caller deliver its actionable
+        // error rather than racing the client's ~30s deadline.
         if (outcome === "aborted") {
+          stderrLog(
+            `Daemon readiness probe aborted after ${this.timer.now() - startTime}ms ` +
+              `(${pollCount} polls); no longer waiting on the process bringing up the daemon`,
+          );
           return false;
         }
       }
@@ -1419,6 +1565,37 @@ export class DaemonManager implements DaemonManagerLike {
         `(${pollCount} polls; socket ${socketObserved ? "observed" : "not observed"})`,
     );
     return false;
+  }
+
+  /**
+   * Run a single observed-socket readiness probe, arming a liveness watchdog on the
+   * full-budget path so it cannot outlive its holder (issue #5904).
+   *
+   * On the full-budget probe (holder still live at the poll boundary) a stalled
+   * `connect()` would otherwise absorb the whole deadline if the holder died while
+   * the per-poll precheck was blocked; the watchdog aborts the probe the instant no
+   * live holder remains. The capped probe (holder already gone) is short enough to
+   * never race the client's deadline, so it needs no watchdog. Only the full-budget
+   * wait is authoritative enough to unlink a stale socket, so `allowSocketRemoval`
+   * tracks `keepWaiting` (issue #5878).
+   */
+  private async probeObservedSocketWithWatchdog(
+    keepWaiting: boolean,
+    deadline: number,
+    signal: AbortSignal | undefined,
+    shouldContinueWaiting: () => boolean,
+  ): Promise<"ready" | "aborted" | "unready"> {
+    const probeDeadline = keepWaiting
+      ? deadline
+      : Math.min(deadline, this.timer.now() + ABANDONED_WAIT_CONFIRM_TIMEOUT_MS);
+    const watchdog = keepWaiting
+      ? this.startLivenessWatchdog(signal, shouldContinueWaiting)
+      : undefined;
+    try {
+      return await this.probeObservedSocket(probeDeadline, watchdog?.signal ?? signal, keepWaiting);
+    } finally {
+      watchdog?.dispose();
+    }
   }
 
   /**
@@ -1456,6 +1633,50 @@ export class DaemonManager implements DaemonManagerLike {
       }
     }
     return "unready";
+  }
+
+  /**
+   * Arm a liveness watchdog for a single in-flight readiness probe (issue #5904).
+   *
+   * Returns an {@link AbortSignal} that fires when either the caller's own signal
+   * fires or a periodic `shouldContinueWaiting()` sample reports the process being
+   * waited on is gone. Racing this against the probe means a stalled `connect()`
+   * against an accepts-but-never-responds socket cannot keep running for the full
+   * startup budget after its holder dies — the actionable failure is delivered
+   * before the client's `tools/list` deadline instead of at it. The caller MUST
+   * invoke `dispose()` (in a `finally`) to clear the interval and detach the
+   * forwarded-abort listener, or the watchdog interval leaks past the probe.
+   */
+  private startLivenessWatchdog(
+    callerSignal: AbortSignal | undefined,
+    shouldContinueWaiting: () => boolean,
+  ): { signal: AbortSignal; dispose: () => void } {
+    const controller = new AbortController();
+    if (callerSignal?.aborted) {
+      controller.abort();
+    }
+    const onCallerAbort = () => controller.abort();
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+    const interval = this.timer.setInterval(() => {
+      // Runs on a real timer tick, not an awaited path, so a throwing predicate here
+      // would surface as an unhandled exception (today's predicate cannot throw, but
+      // guard it so a future one cannot crash the process). On error, keep waiting —
+      // the budget deadline still bounds the probe.
+      try {
+        if (!shouldContinueWaiting()) {
+          controller.abort();
+        }
+      } catch (error) {
+        logger.debug(`[DaemonManager] liveness watchdog predicate threw: ${errorMessage(error)}`);
+      }
+    }, LIVENESS_WATCHDOG_INTERVAL_MS);
+    return {
+      signal: controller.signal,
+      dispose: () => {
+        this.timer.clearInterval(interval);
+        callerSignal?.removeEventListener("abort", onCallerAbort);
+      },
+    };
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -235,8 +235,9 @@ export function tryAcquireExclusiveLock(
  * process could delete a lock now held by a *different* incarnation that recycled
  * the same PID and wrote a different token (issue #3006, follow-up 1). A lock file
  * with NO token line (a pre-token incarnation) is treated as ours on a PID match,
- * preserving the legacy PID-only behavior. The daemon caller passes no token and
- * stays PID-only, as before.
+ * preserving the legacy PID-only behavior. The daemon caller now passes its
+ * per-instance startup-lock owner token too (issue #5904), so its release is
+ * incarnation-aware rather than PID-only.
  */
 export function releaseExclusiveLock(
   lockFilePath: string,

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test, afterEach } from "bun:test";
-import { existsSync, mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, mkdtempSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { DaemonManager } from "../../src/daemon/manager";
+import { parseLockContent } from "../../src/utils/fileLock";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("DaemonManager file lock", () => {
@@ -40,6 +41,41 @@ describe("DaemonManager file lock", () => {
       expect(existsSync(lockPath)).toBe(true);
 
       manager.releaseLock();
+    });
+
+    test("writes a per-instance owner token alongside the PID (#5904)", () => {
+      const lockPath = createTempLockPath();
+      const manager = new DaemonManager(undefined, undefined, new FakeTimer(), lockPath);
+
+      expect(manager.acquireLock()).toBe(true);
+      const { pid, token } = parseLockContent(readFileSync(lockPath, "utf-8").trim());
+      // PID stays on line 1 (liveness readers are unaffected); the owner token is a
+      // non-empty line-2 value used to tell replacement holders apart under PID reuse.
+      expect(pid).toBe(process.pid);
+      expect(token).toBeDefined();
+      expect(token).not.toBe("");
+
+      manager.releaseLock();
+    });
+
+    test("two managers in one process write distinct owner tokens (#5904)", () => {
+      const lockPath = createTempLockPath();
+
+      const first = new DaemonManager(undefined, undefined, new FakeTimer(), lockPath);
+      expect(first.acquireLock()).toBe(true);
+      const tokenA = parseLockContent(readFileSync(lockPath, "utf-8").trim()).token;
+      first.releaseLock();
+
+      const second = new DaemonManager(undefined, undefined, new FakeTimer(), lockPath);
+      expect(second.acquireLock()).toBe(true);
+      const tokenB = parseLockContent(readFileSync(lockPath, "utf-8").trim()).token;
+      second.releaseLock();
+
+      // Same process, same PID — only the per-instance token distinguishes the two
+      // holders, which is what lets a same-PID replacement be re-arbitrated (#5904).
+      expect(tokenA).toBeDefined();
+      expect(tokenB).toBeDefined();
+      expect(tokenA).not.toBe(tokenB);
     });
 
     test("fails when lock is held by a live process", () => {
@@ -246,6 +282,52 @@ describe("DaemonManager file lock", () => {
       // pre-failure confirm is a direct probe, not a waitForReady call (#5878).
       // Diagnostics are captured before the retry holder releases, so they survive
       // into the thrown error.
+      expect(waitCount).toBe(2);
+    });
+
+    test("re-arbitrates for a same-PID replacement holder distinguished by owner token (#5904)", async () => {
+      const lockPath = createTempLockPath();
+      const socketPath = join(dirname(lockPath), "daemon.sock");
+      const pidPath = join(dirname(lockPath), "daemon.pid");
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      // Initial holder: this process's PID with token A.
+      writeFileSync(lockPath, `${process.pid}\ntoken-a`);
+      let waitCount = 0;
+
+      class TestDaemonManager extends DaemonManager {
+        override acquireLock(): boolean {
+          return false;
+        }
+        override async waitForReady(): Promise<boolean> {
+          waitCount++;
+          if (waitCount === 1) {
+            // A replacement reclaims the lock with the SAME PID but a DIFFERENT token
+            // (a different DaemonManager instance in this process). A PID-only identity
+            // check would read this as the same stuck holder and stop after one wait.
+            writeFileSync(lockPath, `${process.pid}\ntoken-b`);
+          }
+          return false;
+        }
+        override findAllDaemonProcesses(): number[] {
+          return [];
+        }
+      }
+
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        lockPath,
+        pidPath,
+        socketPath,
+      );
+
+      await expect(manager.start()).rejects.toThrow();
+      // Wait #1 on holder A, then the token-B replacement is recognized as a genuinely
+      // new holder and waited on (#2); it then stays the same token-B holder so the
+      // loop stops. Two waits, not the single wait a PID-only check would allow.
       expect(waitCount).toBe(2);
     });
 

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -377,6 +377,182 @@ describe("DaemonManager readiness", () => {
     expect(clients[0].connectionSignals[0].aborted).toBe(true);
   });
 
+  test("aborts a stalled full-budget probe the instant the lock holder dies mid-probe (#5904)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    writePidFile(pidPath, socketPath);
+    writeFileSync(socketPath, "socket placeholder");
+
+    const clients: ProbeClient[] = [];
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        // Model an accepts-but-never-responds socket: connect() stalls forever and
+        // only settles when the probe's abort signal fires.
+        client.connect = async (timeoutMs?: number, signal?: AbortSignal) => {
+          client.connectCallCount++;
+          if (timeoutMs !== undefined) {
+            client.connectionTimeouts.push(timeoutMs);
+          }
+          if (signal !== undefined) {
+            client.connectionSignals.push(signal);
+          }
+          await new Promise<void>((_resolve, reject) => {
+            if (signal?.aborted) {
+              reject(new Error("probe aborted"));
+              return;
+            }
+            signal?.addEventListener("abort", () => reject(new Error("probe aborted")), {
+              once: true,
+            });
+          });
+        };
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    // The holder is alive at the poll boundary (so the full budget is taken) but
+    // dies during the stalled probe; the liveness watchdog must interrupt the probe
+    // rather than let it absorb the whole DAEMON_STARTUP_TIMEOUT_MS budget (#5904).
+    let holderAlive = true;
+    let samples = 0;
+    const shouldContinueWaiting = () => {
+      samples++;
+      // Alive for the first sample (the poll-boundary precheck), dead thereafter.
+      if (samples > 1) {
+        holderAlive = false;
+      }
+      return holderAlive;
+    };
+
+    await expect(manager.waitForReady(30_000, undefined, shouldContinueWaiting)).resolves.toBe(
+      false,
+    );
+    // Interrupted early: fake time is nowhere near the 30s budget the un-watched
+    // probe would have consumed.
+    expect(fakeTimer.getCurrentTime()).toBeLessThan(1_000);
+    expect(clients).toHaveLength(1);
+    expect(clients[0].connectionSignals[0]?.aborted).toBe(true);
+  });
+
+  test("waitForLockHolderReadiness re-arbitrates across a token-distinguished replacement holder (#5904)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    // Initial holder: this process's PID with token A.
+    writeFileSync(lockPath, `${process.pid}\ntoken-a`);
+    let waits = 0;
+
+    class TestDaemonManager extends DaemonManager {
+      override async waitForReady(): Promise<boolean> {
+        waits++;
+        if (waits === 1) {
+          // A replacement reclaims the lock with the same PID but a different token
+          // between this wait ending and the re-arbitration read (A crashed, B took
+          // over). Path 1 must wait on B rather than throwing on A being gone.
+          writeFileSync(lockPath, `${process.pid}\ntoken-b`);
+        }
+        return false;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    await expect(manager.waitForLockHolderReadiness(30_000)).resolves.toBe(false);
+    // Wait on holder A, then re-arbitrate onto the token-B replacement (#2); B stays
+    // put so the wait then ends. Two waits, not the single wait a lone liveness-gated
+    // waitForReady would allow before throwing.
+    expect(waits).toBe(2);
+  });
+
+  test("waitForLockHolderReadiness confirms a daemon that published its socket before releasing the lock (#5904)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    writePidFile(pidPath, socketPath);
+    writeFileSync(socketPath, "socket placeholder");
+    // Initial holder present and alive.
+    writeFileSync(lockPath, `${process.pid}\ntoken-a`);
+
+    const clients: ProbeClient[] = [];
+
+    class TestDaemonManager extends DaemonManager {
+      override async waitForReady(): Promise<boolean> {
+        // The holder published the socket, then released its lock during our probe
+        // (the watchdog aborts a slow-but-healthy in-flight connect the instant the
+        // lock is gone). Model that: the lock file vanishes, but the socket stays
+        // connectable. The loop then sees the holder gone; only the final confirm
+        // catches that the daemon is actually up.
+        rmSync(lockPath, { force: true });
+        return false;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    // Without the final non-destructive confirm, the holder-gone exit would report
+    // false and the proxy would throw DaemonUnavailableError for a reachable daemon.
+    await expect(manager.waitForLockHolderReadiness(30_000)).resolves.toBe(true);
+    expect(clients.length).toBeGreaterThan(0);
+  });
+
+  test("waitForLockHolderReadiness stops on the same live holder without re-arbitrating (#5904)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    writeFileSync(lockPath, `${process.pid}\ntoken-a`);
+    let waits = 0;
+
+    class TestDaemonManager extends DaemonManager {
+      override async waitForReady(): Promise<boolean> {
+        waits++;
+        // Holder never changes: same PID, same token — a genuinely stuck holder.
+        return false;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    await expect(manager.waitForLockHolderReadiness(30_000)).resolves.toBe(false);
+    // No replacement, so exactly one wait: the loop must not spin on an unchanging
+    // live holder.
+    expect(waits).toBe(1);
+  });
+
   test("reports elapsed readiness timing when no daemon socket appears", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -665,6 +665,51 @@ describe("DaemonMcpProxy", () => {
           await proxy.close();
         }
       });
+
+      test("path 1 re-arbitrates onto a replacement holder that publishes the socket (#5904)", async () => {
+        // Model the double-lock-contention edge: the holder the proxy first waits on
+        // never publishes, but a replacement holder reclaims the lock and finishes the
+        // start. Path 1 must wait that replacement out (via waitForLockHolderReadiness)
+        // rather than throwing the moment the first holder is gone.
+        class ReArbitratingManager extends StartingDaemonManager {
+          lockHolderReadinessCalls = 0;
+          override async waitForLockHolderReadiness(_timeoutMs: number): Promise<boolean> {
+            this.lockHolderReadinessCalls++;
+            // The replacement publishes the socket; readiness succeeds.
+            this.socketPublished = true;
+            return true;
+          }
+        }
+
+        const fakeManager = new ReArbitratingManager();
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+        };
+        const client = new SocketGatedClient(fakeManager);
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(false);
+
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => client,
+          daemonManager: fakeManager,
+          autoStartDaemon: true,
+        });
+
+        try {
+          await proxy.listTools();
+
+          // The re-arbitration entry point was used, and the client connected once the
+          // replacement published the socket.
+          expect(fakeManager.lockHolderReadinessCalls).toBe(1);
+          expect(client.connectCallCount).toBe(1);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
     });
 
     describe("version-mismatch handling", () => {

--- a/test/fakes/FakeDaemonManager.ts
+++ b/test/fakes/FakeDaemonManager.ts
@@ -51,4 +51,14 @@ export class FakeDaemonManager implements DaemonManagerLike {
   isStartupLockHeldByLiveProcess(): boolean {
     return this.startupLockHeldByLiveProcess;
   }
+
+  /**
+   * Default fake: delegate to `waitForReady` with the live-holder predicate, so
+   * subclasses that model readiness by overriding `waitForReady` keep driving this
+   * path and the timeout / predicate they observe are unchanged (issue #5904).
+   * Override for tests that need to model replacement re-arbitration directly.
+   */
+  async waitForLockHolderReadiness(timeoutMs: number): Promise<boolean> {
+    return this.waitForReady(timeoutMs, undefined, () => this.isStartupLockHeldByLiveProcess());
+  }
 }


### PR DESCRIPTION
## Summary

Closes the four narrow deliverability/identity residuals from PR #5891's review, all deep in the daemon double-lock-contention path and all self-recovering (the next `tools/list` succeeds once a holder publishes). #5891 already handles the common cases (single holder, dead holder, live holder publishing, one replacement); this closes the edges it deferred.

1. **Abort a stalled full-budget readiness probe the instant the startup-lock holder dies mid-probe.** `waitForReady` sampled the liveness predicate only once per poll, so if the holder was alive at the poll boundary but died while a `connect()` on an accepts-but-never-responds socket *stalled*, that full-budget probe ran uninterrupted and could consume the client's whole ~30s `tools/list` deadline before the actionable error was produced. The probe now races a **liveness watchdog** — an `AbortController` driven by a periodic `shouldContinueWaiting()` sample — that aborts the probe the instant no live holder remains.

2. **& 3. Identify replacement lock holders by owner token, not PID.** `startByAwaitingLockHolder` (and now path 1, see item 4) distinguished a replacement holder from the prior one by comparing the live lock-holder PID. The OS can recycle a PID, and two `DaemonManager` instances in one process share `process.pid`, so a genuinely new holder reusing the prior PID read as "same holder" and the loop stopped, giving the replacement only the bounded confirm. The daemon startup lock now carries a **per-instance owner token** (from the injected `IdGenerator`, via the existing `fileLock` `ownerToken` slot); `readStartupLockHolder` reads it and `isSameStartupLockHolder` compares by token, falling back to PID only when a token is absent (pre-token lock / mid-write). Release is made token-symmetric too.

4. **Give `DaemonMcpProxy.startDaemon`'s #5664 branch the same replacement re-arbitration as `startByAwaitingLockHolder`.** Path 1 ran a single liveness-gated `waitForReady` and threw the moment the holder was reported gone — it did not re-arbitrate for a replacement that reclaimed the lock (A crashes, B reclaims between the predicate's lock read and its liveness check). Both paths now share a `waitForLockHolderReadiness` loop that keeps the full budget per live holder under **one** preserved deadline and reports failure only once no live holder remains.

## Linked Issue

Closes #5904

## Bug / Regression Context

- **Prior attempts:** #5891 made the two daemon start-waits deliverable for the common contention cases; these four items were explicitly deferred out of its review.
- **Observed symptom:** in the narrow edges, the actionable startup error was produced only as the client's ~30s `tools/list` deadline expired (AutoMobile shows connected with zero tools and no error text), or a same-PID replacement holder was abandoned early.
- **Repro conditions:** (1) a stalling accepts-but-never-responds socket whose holder dies precisely during the stall; (2)/(3) a same-user PID recycled (or a same-process sibling `DaemonManager`) re-taken by a new daemon-start holder inside one ~30s window; (4) holder A crashes and replacement B reclaims the lock between the proxy predicate's lock read and its liveness check. All astronomically narrow and self-recovering.

## Validation

- [x] `bun run lint` — exit 0, oxlint ratchet reports no new violations (`waitForReady` refactored to stay under the complexity/max-depth thresholds)
- [x] `bun run build` — success
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun test` — full suite green except two failures confirmed **pre-existing** on the clean base and unrelated to this diff (`toolRegistration` zod `~standard` serialization drift; `webrtcDeviceCaptureLatency` environment-gated integration test)
- [x] New tests use interfaces + fakes + `FakeTimer`; unit tests run in <100ms

### Acceptance criteria → test

- Item 1 → `daemonManagerReadiness.test.ts` "aborts a stalled full-budget probe the instant the lock holder dies mid-probe" (resolves `false` at fake-time ≪ the 30s budget)
- Items 2 & 3 → `daemonManagerLock.test.ts` "writes a per-instance owner token", "two managers in one process write distinct owner tokens", "re-arbitrates for a same-PID replacement holder distinguished by owner token"
- Item 4 → `daemonManagerReadiness.test.ts` "waitForLockHolderReadiness re-arbitrates across a token-distinguished replacement holder" / "stops on the same live holder without re-arbitrating"; `daemonMcpProxy.test.ts` "path 1 re-arbitrates onto a replacement holder that publishes the socket"

## Follow-ups

- [ ] None required.
