### PR TITLE
harden(tool-output): omit filesystem error detail from client errors

### DIFF
--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -108,10 +108,11 @@ function toolOutputError(uri: string, error: string): ResourceContent {
 }
 
 function notAvailable(uri: string, artifactId: string): ResourceContent {
+  // Keep filesystem / host-path detail in the warn log only (CWE-209, #5933).
   return toolOutputError(
     uri,
     `Tool-output artifact "${artifactId}" is not available. It may have expired or been ` +
-      `pruned, or it was not issued by this server. Re-run the tool to regenerate it.`,
+      "pruned, or it was not issued by this server. Re-run the tool to regenerate it.",
   );
 }
 

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import path from "node:path";
 import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
 import { createHash } from "node:crypto";
@@ -12,6 +12,7 @@ import {
   resetToolOutputResourceDependencies,
   setToolOutputResourceDependencies,
 } from "../../src/server/toolOutputResources";
+import { logger } from "../../src/utils/logger";
 
 const ARTIFACT_DIR = path.resolve("/tmp/auto-mobile-tool-outputs");
 
@@ -59,6 +60,21 @@ async function readArtifact(artifactId: string) {
     return match!.template.handler(match!.params);
   }
   throw new Error("tool-output resource must be a plain template handler");
+}
+
+function genericUnavailableMessage(artifactId: string): string {
+  return (
+    `Tool-output artifact "${artifactId}" is not available. It may have expired or been ` +
+    "pruned, or it was not issued by this server. Re-run the tool to regenerate it."
+  );
+}
+
+function expectGenericUnavailable(text: string, artifactId: string, leaked: string[]): void {
+  const parsed = JSON.parse(text) as { error: string };
+  expect(parsed.error).toBe(genericUnavailableMessage(artifactId));
+  for (const fragment of leaked) {
+    expect(text).not.toContain(fragment);
+  }
 }
 
 describe("tool-output artifact resource (#5882)", () => {
@@ -138,14 +154,14 @@ describe("tool-output artifact resource (#5882)", () => {
 
     const content = await readArtifact(planted);
 
-    const parsed = JSON.parse(content.text!) as { error: string };
-    expect(parsed.error).toContain("not available");
+    expectGenericUnavailable(content.text!, planted, []);
     expect(fileSystem.reads).toEqual([]);
   });
 
   test("returns a structured error when the artifact is issued but missing or pruned", async () => {
     const fileSystem = new FakeResourceFileSystem();
     const filename = "1788020656886-observe-gone.json";
+    const issuedPath = path.join(ARTIFACT_DIR, filename);
     // Issued by the writer, but the file is gone (pruned/expired): reaches the
     // read, which fails, and surfaces the graceful error.
     installFake(fileSystem, [filename]);
@@ -153,11 +169,33 @@ describe("tool-output artifact resource (#5882)", () => {
     const content = await readArtifact(filename);
 
     expect(content.mimeType).toBe("application/json");
-    const parsed = JSON.parse(content.text!) as { error: string };
-    expect(parsed.error).toContain("not available");
-    expect(parsed.error).not.toContain(ARTIFACT_DIR);
-    expect(parsed.error).not.toContain("ENOENT");
-    expect(fileSystem.reads).toEqual([path.join(ARTIFACT_DIR, filename)]);
+    expectGenericUnavailable(content.text!, filename, [issuedPath, "ENOENT"]);
+    expect(fileSystem.reads).toEqual([issuedPath]);
+  });
+
+  test("omits filesystem error detail from the client-facing not-available message (#5933)", async () => {
+    // CWE-209: the read-failure path used to append the Node fs error (absolute
+    // host path, ENOENT, hash-mismatch text) to the MCP client envelope.
+    const fileSystem = new FakeResourceFileSystem();
+    const filename = "1788020656886-observe-gone.json";
+    const hostPath = "/Users/ci/.auto-mobile/tool-outputs/1788020656886-observe-gone.json";
+    fileSystem.readError = Object.assign(new Error(`ENOENT: no such file, open '${hostPath}'`), {
+      code: "ENOENT",
+    });
+    installFake(fileSystem, [filename]);
+
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const content = await readArtifact(filename);
+
+      expectGenericUnavailable(content.text!, filename, [hostPath, "ENOENT"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`[ToolOutputResources] Failed to read artifact ${filename}`),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(hostPath));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   // Unprivileged symlink creation is unavailable on Windows (needs admin/developer
@@ -184,9 +222,7 @@ describe("tool-output artifact resource (#5882)", () => {
 
         const content = await readArtifact(filename);
 
-        const parsed = JSON.parse(content.text!) as { error: string };
-        expect(parsed.error).toContain("not available");
-        expect(content.text).not.toContain("top secret");
+        expectGenericUnavailable(content.text!, filename, [linkPath, "top secret"]);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
@@ -219,9 +255,7 @@ describe("tool-output artifact resource (#5882)", () => {
       swapped.record(filePath, realHash);
       setToolOutputResourceDependencies({ ledger: swapped });
       const content = await readArtifact(filename);
-      const parsed = JSON.parse(content.text!) as { error: string };
-      expect(parsed.error).toContain("not available");
-      expect(content.text).not.toContain("owned");
+      expectGenericUnavailable(content.text!, filename, [filePath, "owned", "hash mismatch"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Stop returning Node filesystem error text from the `automobile:tool-output/{artifactId}` resource. The read-failure path appended the underlying `errorMessage` (absolute host path, `ENOENT`, hash-mismatch wording) to the MCP client envelope. The client now gets the same generic not-available message as the "not issued" path; the existing `logger.warn` still records the filesystem detail server-side.

## Linked Issue

Closes [#5933](https://github.com/kaeawc/auto-mobile/issues/5933)

Follow-up from [#5926](https://github.com/kaeawc/auto-mobile/pull/5926) / [#5917](https://github.com/kaeawc/auto-mobile/issues/5917).

## Bug / Regression Context

- **Prior attempts:** [#5926](https://github.com/kaeawc/auto-mobile/pull/5926) added provenance + `O_NOFOLLOW` reads, but the catch path still forwarded `reason` to `notAvailable(...)`.
- **Observed symptom:** A missing, pruned, swapped, or non-regular artifact produced a client error like `...not available. ... (ENOENT: no such file, open '/Users/.../.auto-mobile/tool-outputs/....json')` (CWE-209).
- **Repro steps / conditions:** Fetch `automobile:tool-output/{artifactId}` for an issued artifact whose file is gone or whose content hash no longer matches.

## Validation

- [x] Focused: `bun test test/server/toolOutputResources.test.ts` (10 pass)
- [x] `bun run lint` (oxlint ratchet + boundary checks)
- [x] `bun run typecheck` (no new errors)
- [x] `scripts/all_fast_validate_checks.sh --skip lychee`
- [x] New code uses existing `logger.warn` + FakeResourceFileSystem / `spyOn(logger)`; unit tests run in <100ms
- [x] No new helpers or dependencies
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

None. Invalid-id and not-issued messages were already generic.
