### PR TITLE
fix(daemon): invalidate stale proxy connection on socket close

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -95,6 +95,7 @@ export class DaemonClient {
   private buffer: string = "";
   private connected: boolean = false;
   private notificationHandlers: Set<(notification: DaemonNotification) => void> = new Set();
+  private connectionClosedHandlers: Set<() => void> = new Set();
   private recoveryOptions: DaemonClientRecoveryOptions;
   private readonly clientIdentity: { version: string; build: BuildIdentity } | null;
   private readonly idGenerator: IdGenerator;
@@ -338,6 +339,9 @@ export class DaemonClient {
         this.connected = false;
         this.socket = null;
         logger.info("Daemon socket connection closed");
+        for (const handler of this.connectionClosedHandlers) {
+          handler();
+        }
         // A daemon restart/crash closes the socket. Over a Unix domain socket
         // (no TCP RST) a dying daemon delivers EOF -> "close" with no "error"
         // event, so any in-flight request would otherwise hang until its request
@@ -418,6 +422,18 @@ export class DaemonClient {
     this.notificationHandlers.add(handler);
     return () => {
       this.notificationHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Register a handler for passive socket closure. Unlike request failures,
+   * EOF can arrive while no request is in flight, so callers that cache
+   * connection state must be notified separately.
+   */
+  onConnectionClosed(handler: () => void): () => void {
+    this.connectionClosedHandlers.add(handler);
+    return () => {
+      this.connectionClosedHandlers.delete(handler);
     };
   }
 
@@ -594,6 +610,7 @@ export class DaemonClient {
     }
     this.pendingRequests.clear();
     this.notificationHandlers.clear();
+    this.connectionClosedHandlers.clear();
   }
 }
 
@@ -610,6 +627,7 @@ export interface DaemonClientLike {
    */
   onNotification?(handler: (notification: DaemonNotification) => void): () => void;
   subscribeToNotifications?(): Promise<void>;
+  onConnectionClosed?(handler: () => void): () => void;
 }
 
 export type DaemonClientFactory = () => DaemonClientLike;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -723,6 +723,9 @@ export class DaemonMcpProxy {
   // clientFactory may return a shared/reused client (test fakes do); without it
   // every reconnect would stack another handler on that client.
   private notificationUnsubscribe: (() => void) | null = null;
+  // A daemon can close an idle socket without any request failing. Keep the
+  // proxy's connection state synchronized with that passive transport loss.
+  private connectionClosedUnsubscribe: (() => void) | null = null;
 
   constructor(config: DaemonMcpProxyConfig = {}) {
     this.config = {
@@ -843,6 +846,7 @@ export class DaemonMcpProxy {
         this.handleDaemonNotification(notification),
       );
     }
+    this.subscribeToClientConnectionClosed(client);
     await client.connect();
     if (this.closing) {
       await client.close();
@@ -1420,6 +1424,8 @@ export class DaemonMcpProxy {
     this.client = null;
     this.notificationUnsubscribe?.();
     this.notificationUnsubscribe = null;
+    this.connectionClosedUnsubscribe?.();
+    this.connectionClosedUnsubscribe = null;
     this.invalidateCache();
 
     if (!staleClient) {
@@ -1431,6 +1437,18 @@ export class DaemonMcpProxy {
     } catch (error) {
       logger.warn(`[DaemonMcpProxy] Failed to close stale daemon client: ${error}`);
     }
+  }
+
+  private subscribeToClientConnectionClosed(client: DaemonClientLike): void {
+    if (typeof client.onConnectionClosed !== "function") {
+      return;
+    }
+    this.connectionClosedUnsubscribe?.();
+    this.connectionClosedUnsubscribe = client.onConnectionClosed(() => {
+      if (this.client === client) {
+        void this.resetConnection();
+      }
+    });
   }
 
   /**
@@ -2328,6 +2346,8 @@ export class DaemonMcpProxy {
     }
     this.notificationUnsubscribe?.();
     this.notificationUnsubscribe = null;
+    this.connectionClosedUnsubscribe?.();
+    this.connectionClosedUnsubscribe = null;
     this.connected = false;
     this.clearBoundSessionUuid();
     this.ownedDeviceSessions.clear();

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -116,6 +116,38 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
     }
   });
 
+  test("serves the static surface after an idle daemon connection closes", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([
+        ["tools/list", { tools: [{ name: "liveOnlyTool", inputSchema: {} }] }],
+      ]),
+    });
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      staticToolDefinitionsProvider: () => [
+        { name: "staticTool", inputSchema: { type: "object" } },
+      ],
+    });
+
+    try {
+      await proxy.callTool("observe", {});
+      expect(proxy.isConnected()).toBe(true);
+
+      // A passive EOF while idle must invalidate the proxy's stale connected state.
+      fakeClient.emitConnectionClosed();
+      expect(proxy.isConnected()).toBe(false);
+      expect(await proxy.listAdvertisedTools()).toEqual([
+        { name: "staticTool", inputSchema: { type: "object" } },
+      ]);
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
   test("prompts a tools/list re-fetch once the deferred connection is established (AC5)", async () => {
     const fakeClient = new FakeDaemonClient({
       daemonMethodResults: new Map([["tools/list", { tools: [] }]]),

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -42,6 +42,7 @@ export class FakeDaemonClient implements DaemonClientLike {
     params: Record<string, any>,
   ) => void | Promise<void>;
   private readonly notificationHandlers = new Set<(notification: DaemonNotification) => void>();
+  private readonly connectionClosedHandlers = new Set<() => void>();
   subscribeToNotificationsCalls = 0;
   shouldFailConnect = false;
   shouldFailSubscribe = false;
@@ -104,6 +105,20 @@ export class FakeDaemonClient implements DaemonClientLike {
     return () => {
       this.notificationHandlers.delete(handler);
     };
+  }
+
+  onConnectionClosed(handler: () => void): () => void {
+    this.connectionClosedHandlers.add(handler);
+    return () => {
+      this.connectionClosedHandlers.delete(handler);
+    };
+  }
+
+  emitConnectionClosed(): void {
+    this.connected = false;
+    for (const handler of this.connectionClosedHandlers) {
+      handler();
+    }
   }
 
   async subscribeToNotifications(): Promise<void> {


### PR DESCRIPTION
## Summary

- Fix stale `DaemonMcpProxy.connected` state after a daemon socket closes while idle.
- Notify the proxy of passive socket EOF so `tools/list` falls back to the static tool surface.
- Add deterministic regression coverage for idle connection loss.

## Root cause

`DaemonClient` detected socket closure internally, but `DaemonMcpProxy` retained its client and connected flag when no request was in flight. A subsequent `tools/list` therefore entered the live path and could block or fail while trying to use the dead daemon.

## Validation

- `bun test test/daemon/daemonMcpProxyLazyToolList.test.ts test/daemon/daemonMcpProxy.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run typecheck`
- Full `bun test` reaches the existing unrelated `nonFiniteJson.property.test.ts` module-export failure.

Closes #5900
