### PR TITLE
fix(ios): start video recording without CtrlProxy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2024,6 +2024,13 @@ jobs:
       # failure surface loudly here instead of silently skipping the test (#2730);
       # `auto-mobile` (installed to ~/.bun/bin by `bun add -g .`) is thereby on PATH
       # for the swift-test steps.
+      - name: "Prepare isolated video recording database"
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
+        run: |
+          integration_db_dir="${RUNNER_TEMP}/auto-mobile-video-recording-db"
+          mkdir -p "${integration_db_dir}"
+          echo "AUTOMOBILE_DB_DIR=${integration_db_dir}" >> "${GITHUB_ENV}"
+
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2029,9 +2029,8 @@ jobs:
         env:
           AUTOMOBILE_DAEMON_DEBUG: "1"
           AUTOMOBILE_DAEMON_EMBEDDED_SDK: "1"
-          # These integration workflows exercise advanced tools deliberately;
-          # keep the daemon's ordinary session surface core-only.
-          AUTOMOBILE_ENABLED_TOOLS: "navigateTo,getNavigationGraph,explore"
+          # Keep one stable daemon profile across warm-up and both integrations.
+          AUTOMOBILE_ENABLED_TOOLS: "videoRecording,navigateTo,getNavigationGraph,explore"
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
@@ -2054,15 +2053,14 @@ jobs:
       - name: "Run videoRecording MP4 integration test"
         timeout-minutes: 10
         env:
-          AUTOMOBILE_ENABLED_TOOLS: "videoRecording"
+          AUTOMOBILE_ENABLED_TOOLS: "videoRecording,navigateTo,getNavigationGraph,explore"
         run: ./scripts/ios/video-recording-start-stop-integration.sh
 
       - name: "Run iOS navigation graph Simulator workflow"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 5
         env:
-          # Also supply this on the client in case it restarts the daemon.
-          AUTOMOBILE_ENABLED_TOOLS: "navigateTo,getNavigationGraph,explore"
+          AUTOMOBILE_ENABLED_TOOLS: "videoRecording,navigateTo,getNavigationGraph,explore"
         run: |
           ./scripts/ios/navigation-graph-sdk-event-integration.sh "${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}"
 

--- a/scripts/ios/video-recording-start-stop-integration.sh
+++ b/scripts/ios/video-recording-start-stop-integration.sh
@@ -87,8 +87,13 @@ rm -rf "${DISPLAY_WARMUP_DIR}"
 # AUTOMOBILE_DB_PATH=':memory:' —
 # is used deliberately, since :memory: additionally trips the #3071 production
 # in-memory guard unless AUTOMOBILE_ALLOW_IN_MEMORY_DB is set.
-INTEGRATION_DB_DIR="$(mktemp -d)"
-export AUTOMOBILE_DB_DIR="${INTEGRATION_DB_DIR}"
+# The workflow may have started its stable warmed daemon with an isolated
+# database already. Reuse that override so the CLI does not silently talk to a
+# daemon backed by ~/.auto-mobile while this test process points elsewhere.
+if [[ -z "${AUTOMOBILE_DB_DIR:-}" ]]; then
+  AUTOMOBILE_DB_DIR="$(mktemp -d)"
+fi
+export AUTOMOBILE_DB_DIR
 # `auto-mobile --cli` may start or restart the shared daemon with this database.
 # The following navigation integration step reuses that daemon, so deleting its
 # live database here causes SQLite disk-I/O failures. The directory is under the

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -49,13 +49,10 @@ export const MIN_TEARDOWN_DEVICE_MCP_TIMEOUT_MS =
 export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
- * Floor for `videoRecording` — an iOS recording can be the first operation
- * that starts CtrlProxy on a cold simulator. The recording backend can spend
- * 30s waiting for simctl's first-frame handshake, then clean up and retry once.
- * Give that bounded recovery path enough transport time to return its actual
- * failure or recording ID instead of letting the socket abort mid-start.
+ * Compatibility floor while video recording startup moves to a strict,
+ * backend-owned five-second budget.
  */
-export const MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS = 180_000;
+export const MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS = 90_000;
 
 /**
  * Floor for `uninstallApp` — the Android command has a 20s local deadline,

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -50,11 +50,12 @@ export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
  * Floor for `videoRecording` — an iOS recording can be the first operation
- * that starts CtrlProxy on a cold simulator. Aborting at the generic 30s
- * deadline leaves the recording active while the client reports a failure,
- * making a retry collide with that still-live recording.
+ * that starts CtrlProxy on a cold simulator. The recording backend can spend
+ * 30s waiting for simctl's first-frame handshake, then clean up and retry once.
+ * Give that bounded recovery path enough transport time to return its actual
+ * failure or recording ID instead of letting the socket abort mid-start.
  */
-export const MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS = 90_000;
+export const MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS = 180_000;
 
 /**
  * Floor for `uninstallApp` — the Android command has a 20s local deadline,

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -14,6 +14,7 @@ import { defaultRecordingCodecProbe, type RecordingCodecProbe } from "./recordin
 import {
   DefaultFfmpegClient,
   type FfmpegClient,
+  type FfmpegProbeResult,
   type FfmpegProcess,
 } from "../../utils/media/FfmpegClient";
 import {
@@ -26,11 +27,12 @@ import {
   type ProcessTracker,
   type StoppableProcess,
 } from "../../utils/ChildProcessTracker";
-import type {
-  RecordingHandle,
-  RecordingResult,
-  VideoCaptureBackend,
-  VideoCaptureConfig,
+import {
+  VideoCaptureStartCleanupError,
+  type RecordingHandle,
+  type RecordingResult,
+  type VideoCaptureBackend,
+  type VideoCaptureConfig,
 } from "./VideoRecorderService";
 
 export { PROCESS_EXIT_TIMEOUT_MS, waitForExit };
@@ -52,7 +54,8 @@ export const IOS_RECORDING_FILE_READY_TIMEOUT_MS = 15000;
 const IOS_RECORDING_FILE_READY_INITIAL_BACKOFF_MS = 100;
 const IOS_RECORDING_FILE_READY_MAX_BACKOFF_MS = 1000;
 const FFMPEG_POST_PROCESS_TIMEOUT_MS = 60000;
-const IOS_RECORDING_START_TIMEOUT_MS = 30000;
+const IOS_RECORDING_START_TIMEOUT_MS = 5000;
+const IOS_RECORDING_START_CLEANUP_TIMEOUT_MS = 500;
 // A cold or loaded simulator can silently miss the very first `recordVideo`
 // start handshake (#4076): simctl produces no "Recording started" and no error,
 // and the single attempt times out. Retry the start a bounded number of times
@@ -191,6 +194,60 @@ function stderrMessages(messages: string | string[]): string[] {
   return Array.isArray(messages) ? messages : [messages];
 }
 
+async function waitWithinDeadline<T>(
+  operation: Promise<T>,
+  deadlineMs: number,
+  timer: Timer,
+  timeoutMessage: string,
+): Promise<T> {
+  const remainingMs = Math.max(0, deadlineMs - timer.now());
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = timer.setTimeout(() => reject(new Error(timeoutMessage)), remainingMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timeoutId) {
+      timer.clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function runWithinDeadline<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  deadlineMs: number,
+  timer: Timer,
+  callerSignal: AbortSignal | undefined,
+  timeoutMessage: string,
+): Promise<T> {
+  callerSignal?.throwIfAborted();
+  const deadlineController = new AbortController();
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, deadlineController.signal])
+    : deadlineController.signal;
+  const timeoutError = new Error(timeoutMessage);
+  const remainingMs = Math.max(0, deadlineMs - timer.now());
+  let rejectOnAbort: ((reason?: unknown) => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort?.(signal.reason ?? timeoutError);
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+  const operationPromise = operation(signal);
+  const timeoutId = timer.setTimeout(() => deadlineController.abort(timeoutError), remainingMs);
+
+  try {
+    return await Promise.race([operationPromise, aborted]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    timer.clearTimeout(timeoutId);
+  }
+}
+
 function hasStderrMessage(
   tracker: Pick<ProcessTracker, "stderr">,
   messages: string | string[],
@@ -201,6 +258,11 @@ function hasStderrMessage(
 
 export function containsIosRecordingStartMessage(stderr: string): boolean {
   return IOS_RECORDING_START_MESSAGES.some((message) => stderr.includes(message));
+}
+
+export interface WaitForStderrMessageOptions {
+  timer?: Timer;
+  signal?: AbortSignal;
 }
 
 /**
@@ -238,13 +300,23 @@ export async function waitForStderrMessage(
   tracker: ProcessTracker,
   messages: string | string[],
   timeoutMs: number,
+  options: WaitForStderrMessageOptions = {},
 ): Promise<void> {
   const expected = stderrMessages(messages);
   const expectedDescription = expected.join(" or ");
+  const timer = options.timer ?? defaultTimer;
 
   if (hasStderrMessage(tracker, expected)) {
     return;
   }
+  if (
+    tracker.exitState.endedAt !== undefined ||
+    (tracker.process.exitCode !== null && tracker.process.exitCode !== undefined) ||
+    (tracker.process.signalCode !== null && tracker.process.signalCode !== undefined)
+  ) {
+    throw new Error(`Process exited before ${expectedDescription}`);
+  }
+  options.signal?.throwIfAborted();
   const stderrStream = tracker.process.stderr;
   if (!stderrStream) {
     throw new Error(`Cannot wait for ${expectedDescription}: process stderr is not captured`);
@@ -257,8 +329,9 @@ export async function waitForStderrMessage(
       stderrStream.off("data", onData);
       tracker.process.off("exit", onExit);
       tracker.process.off("error", onError);
+      options.signal?.removeEventListener("abort", onAbort);
       if (timeoutId) {
-        clearTimeout(timeoutId);
+        timer.clearTimeout(timeoutId);
       }
     };
     const complete = (callback: () => void) => {
@@ -280,12 +353,16 @@ export async function waitForStderrMessage(
     const onError = (error: Error) => {
       complete(() => reject(error));
     };
+    const onAbort = () => {
+      complete(() => reject(options.signal?.reason ?? new Error("Recording start was cancelled.")));
+    };
 
     stderrStream.on("data", onData);
     tracker.process.once("exit", onExit);
     tracker.process.once("error", onError);
+    options.signal?.addEventListener("abort", onAbort, { once: true });
     onData();
-    timeoutId = defaultTimer.setTimeout(() => {
+    timeoutId = timer.setTimeout(() => {
       if (hasStderrMessage(tracker, expected)) {
         complete(resolve);
         return;
@@ -293,34 +370,6 @@ export async function waitForStderrMessage(
       complete(() => reject(new Error(`Timed out waiting for ${expectedDescription}`)));
     }, timeoutMs);
   });
-}
-
-async function waitForStderrMessageOrAbort(
-  tracker: ProcessTracker,
-  messages: string | string[],
-  timeoutMs: number,
-  abortSignal: AbortSignal | undefined,
-): Promise<void> {
-  if (!abortSignal) {
-    await waitForStderrMessage(tracker, messages, timeoutMs);
-    return;
-  }
-  if (abortSignal.aborted) {
-    throw new Error("Recording start was cancelled during shutdown.");
-  }
-
-  let rejectAbort: (() => void) | undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = () => reject(new Error("Recording start was cancelled during shutdown."));
-    abortSignal.addEventListener("abort", rejectAbort, { once: true });
-  });
-  try {
-    await Promise.race([waitForStderrMessage(tracker, messages, timeoutMs), aborted]);
-  } finally {
-    if (rejectAbort) {
-      abortSignal.removeEventListener("abort", rejectAbort);
-    }
-  }
 }
 
 function forceStopStartingProcess(process: StoppableProcess | undefined): void {
@@ -349,6 +398,7 @@ function throwAndroidRecordingStartFailure(
 
 export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
   private hwAccelCache: Map<string, HardwareAccelInfo> = new Map();
+  private ffmpegProbeResult: FfmpegProbeResult | undefined;
   // Overridable in tests so the retry path can be exercised without real waits.
   private readonly iosRecordingStartTimeoutMs: number = IOS_RECORDING_START_TIMEOUT_MS;
   private readonly iosRecordingStartMaxAttempts: number = IOS_RECORDING_START_MAX_ATTEMPTS;
@@ -364,22 +414,27 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     // Injectable so the codec label can be asserted from synthetic files without
     // producing real recordings (#4965).
     private readonly codecProbe: RecordingCodecProbe = defaultRecordingCodecProbe,
+    private readonly timer: Timer = defaultTimer,
   ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
-    await this.ensureFfmpegAvailable();
-
     const device = config.device;
     if (!device) {
       throw new ActionableError("Device is required to start video recording.");
     }
+    const iosStartDeadlineMs =
+      device.platform === "ios" ? this.timer.now() + this.iosRecordingStartTimeoutMs : undefined;
+    await this.ensureFfmpegAvailable(
+      iosStartDeadlineMs,
+      device.platform === "ios" ? config.abortSignal : undefined,
+    );
 
     if (device.platform === "android") {
       return this.startAndroid(device, config);
     }
 
     if (device.platform === "ios") {
-      return this.startIos(device, config);
+      return this.startIos(device, config, iosStartDeadlineMs!);
     }
 
     throw new ActionableError(`Unsupported platform for video recording: ${device.platform}`);
@@ -442,11 +497,23 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       throw new Error("Missing backend handle for FFmpeg video recording.");
     }
 
-    const trackers = [backendHandle.ffmpegTracker, backendHandle.captureTracker];
-    for (const tracker of trackers) {
-      if (tracker && tracker.process.exitCode === null && !tracker.process.killed) {
-        tracker.process.kill("SIGKILL");
-      }
+    const trackers = [backendHandle.ffmpegTracker, backendHandle.captureTracker].filter(
+      (tracker): tracker is ProcessTracker => tracker !== undefined,
+    );
+    const results = await Promise.allSettled(
+      trackers.map(async (tracker) => {
+        await waitForExit(tracker.process, tracker.exitPromise, {
+          timeoutMs: 0,
+          forceKillTimeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+          signal: "SIGKILL",
+        });
+      }),
+    );
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure) {
+      throw failure.reason;
     }
   }
 
@@ -460,8 +527,12 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
 
     logger.info(`[FfmpegVideo] Starting screenrecord: ${screenrecordArgs.join(" ")}`);
 
-    const captureProcess = await adb.spawn(screenrecordArgs);
+    const captureProcess = await adb.spawn(screenrecordArgs, {
+      signal: config.abortSignal,
+    });
+    const captureTracker = trackProcess(captureProcess);
     let ffmpegProcess: FfmpegProcess | undefined;
+    let ffmpegTracker: ProcessTracker | undefined;
     const forceStopStartingProcesses = () => {
       forceStopStartingProcess(captureProcess);
       forceStopStartingProcess(ffmpegProcess);
@@ -502,6 +573,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
         stdio: ["pipe", "pipe", "pipe"],
       });
       ffmpegProcess = startedFfmpeg.process;
+      ffmpegTracker = startedFfmpeg.tracker;
       throwIfRecordingStartAborted(config.abortSignal, "Android");
 
       this.ffmpegClient.pipe({
@@ -514,9 +586,6 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
 
       await waitForSpawn(ffmpegProcess);
       logger.info(`[FfmpegVideo] ffmpeg process spawned`);
-
-      const captureTracker = trackProcess(captureProcess);
-      const ffmpegTracker = trackProcess(ffmpegProcess);
 
       const backendHandle: FfmpegBackendHandle = {
         kind: "ffmpeg",
@@ -534,18 +603,86 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       };
     } catch (error) {
       forceStopStartingProcesses();
+      const cleanupError = await this.cleanupStartingTrackers([
+        captureTracker,
+        ...(ffmpegTracker ? [ffmpegTracker] : []),
+      ]);
+      if (cleanupError) {
+        throw new VideoCaptureStartCleanupError(
+          `Failed to clean up Android recording after startup failed: ${errorMessage(cleanupError)}`,
+          {
+            recordingId: config.recordingId,
+            outputPath: config.outputPath,
+            startedAt: config.startedAt,
+            backendHandle: {
+              kind: "ffmpeg",
+              platform: "android",
+              captureTracker,
+              ffmpegTracker,
+              config,
+            } satisfies FfmpegBackendHandle,
+          },
+          { cause: error },
+        );
+      }
       return throwAndroidRecordingStartFailure(error, config.abortSignal);
     } finally {
       config.abortSignal?.removeEventListener("abort", abortStartingCapture);
     }
   }
 
+  private async cleanupStartingTrackers(trackers: ProcessTracker[]): Promise<unknown | undefined> {
+    const results = await Promise.allSettled(
+      trackers.map((tracker) =>
+        waitForExit(tracker.process, tracker.exitPromise, {
+          timeoutMs: 0,
+          forceKillTimeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+          signal: "SIGKILL",
+          timer: this.timer,
+        }),
+      ),
+    );
+    const failures = results
+      .map((result, index) => ({ result, tracker: trackers[index] }))
+      .filter(
+        (outcome): outcome is { result: PromiseRejectedResult; tracker: ProcessTracker } =>
+          outcome.result.status === "rejected" && outcome.tracker.process.pid !== undefined,
+      )
+      .map((outcome) => outcome.result.reason);
+    return failures.length > 0
+      ? new AggregateError(failures, "Failed to reap recording startup processes")
+      : undefined;
+  }
+
   private async startIos(
     device: BootedDevice,
     config: VideoCaptureConfig,
+    startDeadlineMs: number,
   ): Promise<RecordingHandle> {
+    throwIfRecordingStartAborted(config.abortSignal, "iOS");
+    if (this.timer.now() >= startDeadlineMs) {
+      throw new ActionableError(
+        `Failed to start iOS recording within ${this.iosRecordingStartTimeoutMs}ms.`,
+      );
+    }
     const simctl = this.simctlFactory(device);
-    const available = await simctl.isAvailable();
+    const available = await runWithinDeadline(
+      async (signal) =>
+        await simctl.isAvailable({
+          timeoutMs: Math.max(0, startDeadlineMs - this.timer.now()),
+          signal,
+        }),
+      startDeadlineMs,
+      this.timer,
+      config.abortSignal,
+      `Timed out checking simctl availability within ${this.iosRecordingStartTimeoutMs}ms`,
+    );
+    throwIfRecordingStartAborted(config.abortSignal, "iOS");
+    if (this.timer.now() >= startDeadlineMs) {
+      throw new ActionableError(
+        `Failed to start iOS recording within ${this.iosRecordingStartTimeoutMs}ms.`,
+      );
+    }
     if (!available) {
       throw new ActionableError("simctl is not available. Install Xcode command line tools.");
     }
@@ -558,26 +695,39 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     const attemptFailures: string[] = [];
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      throwIfRecordingStartAborted(config.abortSignal, "iOS");
+      const remainingBeforeSpawn = startDeadlineMs - this.timer.now();
+      if (remainingBeforeSpawn <= 0) {
+        break;
+      }
       const captureProcess = await simctl.startCommandArgs(args, {
         stdio: ["ignore", "ignore", "pipe"],
+        signal: config.abortSignal,
       });
-
-      try {
-        await waitForSpawn(captureProcess);
-      } catch (error) {
-        // A spawn failure is a simctl/environment problem, not a cold-simulator
-        // miss — retrying won't help, so fail fast.
-        throw new ActionableError(`Failed to start iOS recording: ${error}`);
-      }
-
       const captureTracker = trackProcess(captureProcess);
+      let spawned = false;
 
       try {
-        await waitForStderrMessageOrAbort(
+        await waitWithinDeadline(
+          waitForSpawn(captureProcess),
+          startDeadlineMs,
+          this.timer,
+          `Timed out waiting for simctl to spawn within ${this.iosRecordingStartTimeoutMs}ms`,
+        );
+        spawned = true;
+        const attemptsRemaining = maxAttempts - attempt + 1;
+        const remainingMs = Math.max(0, startDeadlineMs - this.timer.now());
+        const reservedCleanupMs =
+          Math.min(IOS_RECORDING_START_CLEANUP_TIMEOUT_MS, remainingMs) * attemptsRemaining;
+        const handshakeTimeoutMs = Math.max(
+          0,
+          Math.floor((remainingMs - reservedCleanupMs) / attemptsRemaining),
+        );
+        await waitForStderrMessage(
           captureTracker,
           IOS_RECORDING_START_MESSAGES,
-          this.iosRecordingStartTimeoutMs,
-          config.abortSignal,
+          handshakeTimeoutMs,
+          { signal: config.abortSignal, timer: this.timer },
         );
 
         const backendHandle: FfmpegBackendHandle = {
@@ -595,30 +745,42 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
           backendHandle,
         };
       } catch (error) {
-        if (config.abortSignal?.aborted) {
-          await waitForExit(captureTracker.process, captureTracker.exitPromise, {
-            timeoutMs: 1_500,
-            signal: "SIGKILL",
-          });
-          throw new ActionableError("iOS recording start was cancelled during shutdown.");
+        const failedAttempt = await this.describeFailedIosStartAttempt({
+          attempt,
+          captureTracker,
+          config,
+          device,
+          error,
+          maxAttempts,
+          simctl,
+          spawned,
+          startDeadlineMs,
+        });
+        attemptFailures.push(failedAttempt.description);
+        if (failedAttempt.cleanupError) {
+          const message = this.buildProcessFailureMessage(
+            `Failed to clean up iOS recording after startup failed: ${failedAttempt.description}`,
+            "xcrun simctl",
+            args,
+            captureTracker,
+          );
+          throw new VideoCaptureStartCleanupError(
+            message,
+            {
+              recordingId: config.recordingId,
+              outputPath: config.outputPath,
+              startedAt: config.startedAt,
+              backendHandle: {
+                kind: "ffmpeg",
+                platform: "ios",
+                captureTracker,
+                capturePath,
+                config,
+              } satisfies FfmpegBackendHandle,
+            },
+            { cause: failedAttempt.cleanupError },
+          );
         }
-        // The handshake timed out. Tear down this attempt's process, snapshot the
-        // simulator so a genuine wedge is diagnosable, then retry if budget remains.
-        let stopError: unknown;
-        try {
-          await waitForExit(captureTracker.process, captureTracker.exitPromise);
-        } catch (cleanupError) {
-          stopError = cleanupError;
-        }
-
-        const cleanupSuffix = stopError ? `; cleanup failed: ${stopError}` : "";
-        const diagnostics = await this.captureSimulatorDiagnostics(simctl, device);
-        attemptFailures.push(
-          `attempt ${attempt}/${maxAttempts}: ${error}${cleanupSuffix}; ${diagnostics}`,
-        );
-        logger.warn(
-          `[FfmpegVideo] iOS recording start attempt ${attempt}/${maxAttempts} failed: ${error} (${diagnostics})`,
-        );
 
         if (attempt >= maxAttempts) {
           throw new ActionableError(
@@ -633,8 +795,82 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       }
     }
 
-    // Loop always returns or throws above; this satisfies the type checker.
-    throw new ActionableError("Failed to start iOS recording: exhausted start attempts.");
+    throw new ActionableError(
+      `Failed to start iOS recording within ${this.iosRecordingStartTimeoutMs}ms` +
+        (attemptFailures.length > 0 ? `: ${attemptFailures.join(" | ")}` : "."),
+    );
+  }
+
+  private async describeFailedIosStartAttempt(input: {
+    attempt: number;
+    captureTracker: ProcessTracker;
+    config: VideoCaptureConfig;
+    device: BootedDevice;
+    error: unknown;
+    maxAttempts: number;
+    simctl: SimCtl;
+    spawned: boolean;
+    startDeadlineMs: number;
+  }): Promise<{ description: string; cleanupError?: unknown }> {
+    const stopError = await this.cleanupFailedIosStart(input.captureTracker, input.startDeadlineMs);
+    const descriptionPrefix = `attempt ${input.attempt}/${input.maxAttempts}: ${input.error}`;
+    if (!input.spawned && input.captureTracker.process.pid === undefined) {
+      throw new ActionableError(`Failed to start iOS recording: ${input.error}`);
+    }
+    if (stopError) {
+      return {
+        description: `${descriptionPrefix}; cleanup failed: ${errorMessage(stopError)}`,
+        cleanupError: stopError,
+      };
+    }
+    if (input.config.abortSignal?.aborted) {
+      throw new ActionableError("iOS recording start was cancelled during shutdown.");
+    }
+    if (!input.spawned) {
+      throw new ActionableError(`Failed to start iOS recording: ${input.error}`);
+    }
+
+    const diagnostics = await this.diagnoseFailedIosStart(
+      input.simctl,
+      input.device,
+      input.startDeadlineMs,
+    );
+    logger.warn(
+      `[FfmpegVideo] iOS recording start attempt ${input.attempt}/${input.maxAttempts} failed: ${input.error} (${diagnostics})`,
+    );
+    return { description: `${descriptionPrefix}; ${diagnostics}` };
+  }
+
+  private async cleanupFailedIosStart(
+    captureTracker: ProcessTracker,
+    startDeadlineMs: number,
+  ): Promise<unknown | undefined> {
+    const cleanupTimeoutMs = Math.max(
+      0,
+      Math.min(IOS_RECORDING_START_CLEANUP_TIMEOUT_MS, startDeadlineMs - this.timer.now()),
+    );
+    try {
+      await waitForExit(captureTracker.process, captureTracker.exitPromise, {
+        timeoutMs: cleanupTimeoutMs,
+        forceKillTimeoutMs: 0,
+        timer: this.timer,
+        signal: "SIGKILL",
+      });
+      return undefined;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  private async diagnoseFailedIosStart(
+    simctl: SimCtl,
+    device: BootedDevice,
+    startDeadlineMs: number,
+  ): Promise<string> {
+    const diagnosticBudgetMs = Math.max(0, Math.min(250, startDeadlineMs - this.timer.now()));
+    return diagnosticBudgetMs > 0
+      ? await this.captureSimulatorDiagnostics(simctl, device, diagnosticBudgetMs)
+      : "simulator state unavailable: startup budget exhausted";
   }
 
   /**
@@ -642,11 +878,15 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
    * start-timeout failure. Never throws: a diagnostics failure must not mask the
    * original recording error.
    */
-  private async captureSimulatorDiagnostics(simctl: SimCtl, device: BootedDevice): Promise<string> {
+  private async captureSimulatorDiagnostics(
+    simctl: SimCtl,
+    device: BootedDevice,
+    timeoutMs: number,
+  ): Promise<string> {
     try {
       const result = await simctl.executeCommandArgs(
         ["list", "devices", device.deviceId],
-        IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS,
+        Math.min(IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS, timeoutMs),
       );
       const text = (result.stdout || result.stderr || "").replace(/\s+/g, " ").trim();
       return text ? `simulator state: ${text.slice(0, 500)}` : "simulator state: (empty)";
@@ -884,13 +1124,17 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
   }
 
   private async listEncoders(): Promise<string[]> {
-    return (await this.ffmpegClient.probe()).encoders;
+    return (await this.probeFfmpeg()).encoders;
   }
 
-  private async ensureFfmpegAvailable(): Promise<void> {
+  private async ensureFfmpegAvailable(
+    deadlineMs?: number,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
     try {
-      await this.checkFfmpegVersion();
+      await this.checkFfmpegVersion(deadlineMs, abortSignal);
     } catch (error) {
+      throwIfRecordingStartAborted(abortSignal, "iOS");
       throw new ActionableError(
         `FFmpeg is not available. Please install FFmpeg to use video recording.\n` +
           `  macOS: brew install ffmpeg\n` +
@@ -900,9 +1144,35 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     }
   }
 
-  private async checkFfmpegVersion(): Promise<void> {
-    const { version } = await this.ffmpegClient.probe();
+  private async checkFfmpegVersion(deadlineMs?: number, abortSignal?: AbortSignal): Promise<void> {
+    const { version } = await this.probeFfmpeg(deadlineMs, abortSignal);
     logger.debug(`[FfmpegVideo] Found FFmpeg ${version}`);
+  }
+
+  private async probeFfmpeg(
+    deadlineMs?: number,
+    abortSignal?: AbortSignal,
+  ): Promise<FfmpegProbeResult> {
+    if (this.ffmpegProbeResult) {
+      return this.ffmpegProbeResult;
+    }
+    const probe =
+      deadlineMs === undefined
+        ? this.ffmpegClient.probe()
+        : runWithinDeadline(
+            async (signal) =>
+              await this.ffmpegClient.probe({
+                timeoutMs: Math.max(0, deadlineMs - this.timer.now()),
+                signal,
+              }),
+            deadlineMs,
+            this.timer,
+            abortSignal,
+            `Timed out checking FFmpeg availability within ${this.iosRecordingStartTimeoutMs}ms`,
+          );
+    const result = await probe;
+    this.ffmpegProbeResult = result;
+    return result;
   }
 
   private async assertFfmpegOutputReady(

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -527,9 +527,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
 
     logger.info(`[FfmpegVideo] Starting screenrecord: ${screenrecordArgs.join(" ")}`);
 
-    const captureProcess = await adb.spawn(screenrecordArgs, {
-      signal: config.abortSignal,
-    });
+    const captureProcess = await adb.spawn(screenrecordArgs);
     const captureTracker = trackProcess(captureProcess);
     let ffmpegProcess: FfmpegProcess | undefined;
     let ffmpegTracker: ProcessTracker | undefined;
@@ -702,12 +700,12 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       }
       const captureProcess = await simctl.startCommandArgs(args, {
         stdio: ["ignore", "ignore", "pipe"],
-        signal: config.abortSignal,
       });
       const captureTracker = trackProcess(captureProcess);
       let spawned = false;
 
       try {
+        throwIfRecordingStartAborted(config.abortSignal, "iOS");
         await waitWithinDeadline(
           waitForSpawn(captureProcess),
           startDeadlineMs,

--- a/src/features/video/HybridVideoCaptureBackend.ts
+++ b/src/features/video/HybridVideoCaptureBackend.ts
@@ -1,11 +1,12 @@
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { isIosPhysicalUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
-import type {
-  RecordingHandle,
-  RecordingResult,
-  VideoCaptureBackend,
-  VideoCaptureConfig,
+import {
+  VideoCaptureStartCleanupError,
+  type RecordingHandle,
+  type RecordingResult,
+  type VideoCaptureBackend,
+  type VideoCaptureConfig,
 } from "./VideoRecorderService";
 import { FfmpegVideoProcessingBackend } from "./FfmpegVideoProcessingBackend";
 import { IosPhysicalVideoCaptureBackend } from "./IosPhysicalVideoCaptureBackend";
@@ -41,8 +42,24 @@ export class HybridVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     const backend = this.selectBackend(device);
-    const handle = await backend.start(config);
+    let handle: RecordingHandle;
+    try {
+      handle = await backend.start(config);
+    } catch (error) {
+      if (error instanceof VideoCaptureStartCleanupError) {
+        throw new VideoCaptureStartCleanupError(
+          error.message,
+          this.wrapHandle(error.handle, backend),
+          { cause: error },
+        );
+      }
+      throw error;
+    }
 
+    return this.wrapHandle(handle, backend);
+  }
+
+  private wrapHandle(handle: RecordingHandle, backend: VideoCaptureBackend): RecordingHandle {
     return {
       ...handle,
       backendHandle: {

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -841,7 +841,8 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     state: CaptureState,
   ): Promise<void> {
     state.stopRequested = true;
-    const cleanupOperations: Promise<unknown>[] = [helper.stop()];
+    await helper.stop();
+    const cleanupOperations: Promise<unknown>[] = [];
     const encoder = state.encoder;
     if (encoder && state.encoderTracker) {
       cleanupOperations.push(

--- a/src/features/video/IosPhysicalVideoCaptureBackend.ts
+++ b/src/features/video/IosPhysicalVideoCaptureBackend.ts
@@ -1,7 +1,12 @@
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { errorMessage } from "../../utils/describeUnknownError";
-import { getFileSize, waitForExit, type ProcessTracker } from "../../utils/ChildProcessTracker";
+import {
+  getFileSize,
+  PROCESS_EXIT_TIMEOUT_MS,
+  waitForExit,
+  type ProcessTracker,
+} from "../../utils/ChildProcessTracker";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import {
   DefaultHostCommandExecutor,
@@ -23,11 +28,12 @@ import {
   readScreenCaptureHelperEnvOverride,
   resolveIosScreenCaptureHelperPath,
 } from "../screen-stream/screenCaptureHelperPath";
-import type {
-  RecordingHandle,
-  RecordingResult,
-  VideoCaptureBackend,
-  VideoCaptureConfig,
+import {
+  VideoCaptureStartCleanupError,
+  type RecordingHandle,
+  type RecordingResult,
+  type VideoCaptureBackend,
+  type VideoCaptureConfig,
 } from "./VideoRecorderService";
 
 /** Hardware H.264 encoder used whenever the host ffmpeg exposes it. */
@@ -97,12 +103,12 @@ export interface CaptureDeviceInfo {
  * `ScreenCaptureHelper/main.swift`), so the mapping has to be resolved here.
  */
 export interface CaptureDeviceLister {
-  list(binaryPath: string): Promise<CaptureDeviceInfo[]>;
+  list(binaryPath: string, signal?: AbortSignal): Promise<CaptureDeviceInfo[]>;
 }
 
 /** Resolution seam for the signed `screen-capture-helper` binary. */
 export interface ScreenCaptureHelperEnsurer {
-  ensure(): Promise<string | null>;
+  ensure(signal?: AbortSignal): Promise<string | null>;
 }
 
 /**
@@ -247,11 +253,11 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
 
     const { abortSignal } = config;
     throwIfCaptureStartAborted(abortSignal);
-    const encoderName = await this.resolveEncoder();
+    const encoderName = await this.resolveEncoder(abortSignal);
     throwIfCaptureStartAborted(abortSignal);
-    const binaryPath = await this.resolveHelperBinary();
+    const binaryPath = await this.resolveHelperBinary(abortSignal);
     throwIfCaptureStartAborted(abortSignal);
-    const uniqueId = await this.resolveCaptureUniqueId(binaryPath, device);
+    const uniqueId = await this.resolveCaptureUniqueId(binaryPath, device, abortSignal);
     throwIfCaptureStartAborted(abortSignal);
 
     const captureFps = clampCaptureFps(config.fps);
@@ -319,24 +325,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     });
     helper.on("frame", (frame) => this.onFrame(frame, state, captureConfig));
 
-    try {
-      await helper.start();
-    } catch (error) {
-      // The frame listener is already wired, so a helper that emitted a frame
-      // before rejecting may have spawned ffmpeg. No handle is returned here, so
-      // nothing else could ever stop it.
-      await this.abandonStartedCapture(helper, state);
-      throw error;
-    }
-
-    if (abortSignal?.aborted) {
-      // Shutdown landed while the helper was spawning: tear it down here, or the
-      // capture process outlives the recording that was never handed back.
-      await this.abandonStartedCapture(helper, state);
-      throwIfCaptureStartAborted(abortSignal);
-    }
-
-    return {
+    const handle: RecordingHandle = {
       recordingId: captureConfig.recordingId,
       outputPath: captureConfig.outputPath,
       startedAt: captureConfig.startedAt,
@@ -348,6 +337,40 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
         config: captureConfig,
       } satisfies IosPhysicalBackendHandle,
     };
+
+    try {
+      await waitForCaptureStart(Promise.resolve(helper.start()), abortSignal);
+    } catch (error) {
+      // The frame listener is already wired, so a helper that emitted a frame
+      // before rejecting may have spawned ffmpeg. No handle is returned here, so
+      // nothing else could ever stop it.
+      try {
+        await this.abandonStartedCapture(helper, state);
+      } catch (cleanupError) {
+        throw new VideoCaptureStartCleanupError(
+          `Failed to clean up physical iOS recording after startup failed: ${errorMessage(cleanupError)}`,
+          handle,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+
+    if (abortSignal?.aborted) {
+      // Shutdown landed while the helper was spawning: tear it down here, or the
+      // capture process outlives the recording that was never handed back.
+      try {
+        await this.abandonStartedCapture(helper, state);
+      } catch (cleanupError) {
+        throw new VideoCaptureStartCleanupError(
+          `Failed to clean up physical iOS recording after startup was cancelled: ${errorMessage(cleanupError)}`,
+          handle,
+        );
+      }
+      throwIfCaptureStartAborted(abortSignal);
+    }
+
+    return handle;
   }
 
   async stop(handle: RecordingHandle): Promise<RecordingResult> {
@@ -412,12 +435,31 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     if (!backendHandle || backendHandle.kind !== "ios-physical") {
       throw new Error("Missing backend handle for physical iOS video recording.");
     }
-    const helperStop = backendHandle.helper.stop();
+    backendHandle.state.stopRequested = true;
+    const cleanupOperations: Promise<unknown>[] = [backendHandle.helper.stop()];
     const encoder = backendHandle.state.encoder;
-    if (encoder && encoder.exitCode === null && !encoder.killed) {
+    if (encoder && backendHandle.state.encoderTracker) {
+      cleanupOperations.push(
+        waitForExit(encoder, backendHandle.state.encoderTracker.exitPromise, {
+          timeoutMs: 0,
+          forceKillTimeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+          signal: "SIGKILL",
+          timer: this.timer,
+        }),
+      );
+    } else if (encoder && encoder.exitCode === null) {
       encoder.kill("SIGKILL");
     }
-    await helperStop;
+    const results = await Promise.allSettled(cleanupOperations);
+    const failures = results
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `Failed to fully stop physical iOS recording: ${failures.map(errorMessage).join("; ")}`,
+      );
+    }
   }
 
   private onFrame(frame: DecodedFrame, state: CaptureState, config: VideoCaptureConfig): void {
@@ -799,18 +841,29 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     state: CaptureState,
   ): Promise<void> {
     state.stopRequested = true;
-    try {
-      await helper.stop();
-    } catch (error) {
-      // Already-aborting path: report the leak risk but keep the abort as the
-      // error the caller sees.
-      logger.warn(
-        `[IosPhysicalVideo] failed to stop the capture helper after an aborted start: ${errorMessage(error)}`,
-      );
-    }
+    const cleanupOperations: Promise<unknown>[] = [helper.stop()];
     const encoder = state.encoder;
-    if (encoder && encoder.exitCode === null && !encoder.killed) {
+    if (encoder && state.encoderTracker) {
+      cleanupOperations.push(
+        waitForExit(encoder, state.encoderTracker.exitPromise, {
+          timeoutMs: 0,
+          forceKillTimeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+          signal: "SIGKILL",
+          timer: this.timer,
+        }),
+      );
+    } else if (encoder && encoder.exitCode === null) {
       encoder.kill("SIGKILL");
+    }
+    const results = await Promise.allSettled(cleanupOperations);
+    const failures = results
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `Failed to abandon physical iOS recording start: ${failures.map(errorMessage).join("; ")}`,
+      );
     }
   }
 
@@ -819,11 +872,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * supported macOS host, but a self-built ffmpeg can lack it, so fall back to
    * software encoding rather than failing the recording.
    */
-  private async resolveEncoder(): Promise<string> {
+  private async resolveEncoder(signal?: AbortSignal): Promise<string> {
     let encoders: string[];
     try {
-      encoders = (await this.ffmpegClient.probe()).encoders;
+      encoders = (await waitForCaptureStart(this.ffmpegClient.probe({ signal }), signal)).encoders;
     } catch (error) {
+      throwIfCaptureStartAborted(signal);
       throw new ActionableError(
         "FFmpeg is not available. Please install FFmpeg to use video recording.\n" +
           "  macOS: brew install ffmpeg\n" +
@@ -866,7 +920,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
     );
   }
 
-  private async resolveHelperBinary(): Promise<string> {
+  private async resolveHelperBinary(signal?: AbortSignal): Promise<string> {
     // Daemon startup skips the release prefetch when the developer override is
     // set, so a local build must win over the pinned release asset — the same
     // order IosH264Source.resolveHelperPath() uses.
@@ -878,7 +932,7 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
       });
     }
 
-    const binaryPath = await this.helperProvider.ensure();
+    const binaryPath = await waitForCaptureStart(this.helperProvider.ensure(signal), signal);
     if (!binaryPath) {
       throw new ActionableError(
         "Physical iOS video recording requires the signed screen-capture-helper from the matching GitHub Release, " +
@@ -895,8 +949,12 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
    * without the UDID's hyphen, so fall back to a normalized comparison and then
    * — only when exactly one device is attached — to that device.
    */
-  private async resolveCaptureUniqueId(binaryPath: string, device: BootedDevice): Promise<string> {
-    const devices = await this.deviceLister.list(binaryPath);
+  private async resolveCaptureUniqueId(
+    binaryPath: string,
+    device: BootedDevice,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const devices = await waitForCaptureStart(this.deviceLister.list(binaryPath, signal), signal);
     if (devices.length === 0) {
       throw new ActionableError(
         `No muxed external capture devices found for ${device.deviceId}. Connect the iPhone/iPad over USB, ` +
@@ -940,6 +998,26 @@ export class IosPhysicalVideoCaptureBackend implements VideoCaptureBackend {
 function throwIfCaptureStartAborted(abortSignal: AbortSignal | undefined): void {
   if (abortSignal?.aborted) {
     throw new ActionableError("Physical iOS recording start was cancelled during shutdown.");
+  }
+}
+
+async function waitForCaptureStart<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  throwIfCaptureStartAborted(signal);
+  if (!signal) {
+    return operation;
+  }
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    abortListener = () =>
+      reject(new ActionableError("Physical iOS recording start was cancelled during shutdown."));
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
   }
 }
 
@@ -1049,9 +1127,10 @@ export class HelperCaptureDeviceLister implements CaptureDeviceLister {
     private readonly timeoutMs: number = 15000,
   ) {}
 
-  async list(binaryPath: string): Promise<CaptureDeviceInfo[]> {
+  async list(binaryPath: string, signal?: AbortSignal): Promise<CaptureDeviceInfo[]> {
     const result = await this.executor.executeCommand(binaryPath, ["--list-devices"], {
       timeoutMs: this.timeoutMs,
+      signal,
     });
     return parseCaptureDeviceList(result.stdout);
   }

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -313,8 +313,15 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       `[VideoCapture] Bitrate: ${bitrateKbps}kbps (${bitrateBps}bps), Time limit: ${timeLimitSeconds}s`,
     );
 
-    const process = await adb.spawn(args, { signal: config.abortSignal });
-
+    // A recording owns its process after this method returns. The request signal
+    // must bound only startup, not kill an accepted recording after its caller
+    // has moved on to post-tool auditing.
+    const process = await adb.spawn(args);
+    const abortStartup = () => process.kill("SIGTERM");
+    config.abortSignal?.addEventListener("abort", abortStartup, { once: true });
+    if (config.abortSignal?.aborted) {
+      abortStartup();
+    }
     const stderr: string[] = [];
     const { exitState, exitPromise } = createExitTracker(process, stderr);
 
@@ -327,7 +334,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       device,
       deviceTempPath,
     };
-
+    config.abortSignal?.removeEventListener("abort", abortStartup);
     return {
       recordingId: config.recordingId,
       outputPath: config.outputPath,

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -8,8 +8,10 @@ import { logger } from "../../utils/logger";
 import {
   createExitTracker,
   getFileSize,
+  PROCESS_EXIT_TIMEOUT_MS,
   type ProcessExitState,
   type TrackedChildProcess,
+  waitForExit,
 } from "../../utils/ChildProcessTracker";
 import type {
   RecordingHandle,
@@ -228,17 +230,42 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       throw new Error("Missing backend handle for video recording.");
     }
 
-    if (backendHandle.process.exitCode === null) {
-      backendHandle.process.kill("SIGKILL");
-    }
+    const hostReapOutcome = waitForExit(backendHandle.process, backendHandle.exitPromise, {
+      timeoutMs: 0,
+      forceKillTimeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+      signal: "SIGKILL",
+      timer: this.timer,
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
 
     // Do not wait for a potentially wedged device command before killing the
     // directly owned adb process. Shutdown has a short outer deadline.
     const adb = this.adbFactory.create(backendHandle.device);
+    const failures: string[] = [];
     try {
       await adb.executeCommand("shell pkill -9 screenrecord", 8000);
     } catch (error) {
       logger.warn(`[VideoCapture] Device-side force-stop failed: ${error}`);
+      failures.push(`screenrecord force-stop failed: ${errorMessage(error)}`);
+    }
+    try {
+      await adb.execute(["shell", "rm", "-f", backendHandle.deviceTempPath], {
+        timeoutMs: 8000,
+      });
+    } catch (error) {
+      logger.warn(`[VideoCapture] Device temp-file cleanup failed: ${error}`);
+      failures.push(`device temp-file cleanup failed: ${errorMessage(error)}`);
+    }
+    const hostReapError = await hostReapOutcome;
+    if (hostReapError) {
+      failures.push(`host adb process cleanup failed: ${errorMessage(hostReapError)}`);
+    }
+    if (failures.length > 0) {
+      throw new ActionableError(
+        `Failed to fully discard Android recording ${handle.recordingId}: ${failures.join("; ")}`,
+      );
     }
   }
 
@@ -286,7 +313,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       `[VideoCapture] Bitrate: ${bitrateKbps}kbps (${bitrateBps}bps), Time limit: ${timeLimitSeconds}s`,
     );
 
-    const process = await adb.spawn(args);
+    const process = await adb.spawn(args, { signal: config.abortSignal });
 
     const stderr: string[] = [];
     const { exitState, exitPromise } = createExitTracker(process, stderr);

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -60,6 +60,21 @@ export interface RecordingHandle {
   backendHandle?: unknown;
 }
 
+/**
+ * A backend rejected startup but still owns a process that cleanup could not
+ * reap. Retaining this handle lets shutdown or rollback retry force-stop.
+ */
+export class VideoCaptureStartCleanupError extends Error {
+  constructor(
+    message: string,
+    readonly handle: RecordingHandle,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "VideoCaptureStartCleanupError";
+  }
+}
+
 export interface RecordingResult {
   recordingId: string;
   outputPath: string;
@@ -196,17 +211,35 @@ export class VideoRecorderService {
     const fileName = buildRecordingFileName(nameSlug, startedAt, config.format);
     const outputPath = path.join(recordingDir, fileName);
 
-    const handle = await this.backend.start({
-      recordingId,
-      outputDirectory: recordingDir,
-      outputPath,
-      fileName,
-      startedAt,
-      device: options.device,
-      maxDurationSeconds: options.maxDurationSeconds,
-      abortSignal: options.abortSignal,
-      ...config,
-    });
+    let handle: RecordingHandle;
+    try {
+      handle = await this.backend.start({
+        recordingId,
+        outputDirectory: recordingDir,
+        outputPath,
+        fileName,
+        startedAt,
+        device: options.device,
+        maxDurationSeconds: options.maxDurationSeconds,
+        abortSignal: options.abortSignal,
+        ...config,
+      });
+    } catch (error) {
+      if (error instanceof VideoCaptureStartCleanupError) {
+        const retainedOutputPath = error.handle.outputPath || outputPath;
+        this.activeRecordings.set(recordingId, {
+          recordingId,
+          outputPath: retainedOutputPath,
+          fileName: path.basename(retainedOutputPath),
+          startedAt: error.handle.startedAt || startedAt,
+          config,
+          outputName: options.outputName,
+          handle: error.handle,
+          forceStopRequested: false,
+        });
+      }
+      throw error;
+    }
 
     const resolvedOutputPath = handle.outputPath || outputPath;
     const resolvedFileName = path.basename(resolvedOutputPath);

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -237,6 +237,14 @@ export class VideoRecorderService {
           handle: error.handle,
           forceStopRequested: false,
         });
+        try {
+          await this.forceStopRecording(recordingId);
+          await fsPromises.rm(recordingDir, { recursive: true, force: true });
+        } catch (cleanupError) {
+          this.log.warn(
+            `[VideoRecorderService] Failed to force-stop aborted recording ${recordingId}: ${String(cleanupError)}`,
+          );
+        }
       } else {
         try {
           await fsPromises.rm(recordingDir, { recursive: true, force: true });

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -237,6 +237,14 @@ export class VideoRecorderService {
           handle: error.handle,
           forceStopRequested: false,
         });
+      } else {
+        try {
+          await fsPromises.rm(recordingDir, { recursive: true, force: true });
+        } catch (cleanupError) {
+          this.log.warn(
+            `[VideoRecorderService] Failed to remove aborted recording directory ${recordingDir}: ${String(cleanupError)}`,
+          );
+        }
       }
       throw error;
     }

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -29,6 +29,8 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   maxDurationSeconds?: number;
   /** Quality/config overrides forwarded to every segment's recording. */
   configOverrides?: VideoRecordingConfigInput;
+  /** Cancellation for the caller-owned initial segment startup only. */
+  startupAbortSignal?: AbortSignal;
   /**
    * Invoked exactly once when the session finalizes (via {@link stop}), whether that
    * stop was caller-driven or the {@link maxDurationSeconds} auto-stop. Lets the owning
@@ -67,6 +69,8 @@ export class AndroidSegmentedPlanVideoSession {
   private readonly maxDurationSeconds: number | undefined;
 
   private readonly configOverrides: VideoRecordingConfigInput | undefined;
+
+  private readonly startupAbortSignal: AbortSignal | undefined;
 
   private activeRecordingId: string | undefined;
 
@@ -111,6 +115,7 @@ export class AndroidSegmentedPlanVideoSession {
       options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
     this.maxDurationSeconds = options.maxDurationSeconds;
     this.configOverrides = options.configOverrides;
+    this.startupAbortSignal = options.startupAbortSignal;
     this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
@@ -151,7 +156,17 @@ export class AndroidSegmentedPlanVideoSession {
    */
   async start(): Promise<ActiveVideoRecording> {
     this.timerDriven = true;
-    const first = await this.startFirstSegment();
+    let first: ActiveVideoRecording;
+    try {
+      first = await this.startSegment(this.startupAbortSignal);
+      this.startupAbortSignal?.throwIfAborted();
+    } catch (error) {
+      this.timerDriven = false;
+      if (this.activeRecordingId) {
+        await this.stop();
+      }
+      throw error;
+    }
     this.scheduleRotation();
     this.scheduleMaxDurationStop();
     return first;
@@ -238,12 +253,13 @@ export class AndroidSegmentedPlanVideoSession {
     return `${this.outputNamePrefix}${suffix}`;
   }
 
-  private async startSegment(): Promise<ActiveVideoRecording> {
+  private async startSegment(abortSignal?: AbortSignal): Promise<ActiveVideoRecording> {
     const recording = await this.startVideoRecordingFn({
       device: this.device,
       outputName: this.segmentOutputName(),
       maxDurationSeconds: ANDROID_SCREENRECORD_MAX_SECONDS,
       configOverrides: this.configOverrides,
+      abortSignal,
     });
     this.activeRecordingId = recording.recordingId;
     this.segmentStartedAtMs = this.timer.now();

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -8,6 +8,8 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import {
+  forceStopVideoRecording as defaultForceStopVideoRecording,
+  interruptVideoRecording as defaultInterruptVideoRecording,
   startVideoRecording as defaultStartVideoRecording,
   stopVideoRecording as defaultStopVideoRecording,
 } from "./videoRecordingManager";
@@ -45,6 +47,7 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   stopVideoRecording?: (
     recordingId?: string,
   ) => Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }>;
+  forceStopVideoRecording?: (recordingId: string) => Promise<void>;
 }
 
 /**
@@ -107,6 +110,8 @@ export class AndroidSegmentedPlanVideoSession {
     recordingId?: string,
   ) => Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }>;
 
+  private readonly forceStopVideoRecordingFn: (recordingId: string) => Promise<void>;
+
   constructor(options: AndroidSegmentedPlanVideoSessionOptions) {
     this.device = options.device;
     this.outputNamePrefix = options.outputNamePrefix;
@@ -119,6 +124,12 @@ export class AndroidSegmentedPlanVideoSession {
     this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
+    this.forceStopVideoRecordingFn =
+      options.forceStopVideoRecording ??
+      (async (recordingId) => {
+        await defaultForceStopVideoRecording(recordingId);
+        await defaultInterruptVideoRecording(recordingId);
+      });
   }
 
   /** Device this session is recording, so callers can match sessions by device. */
@@ -162,14 +173,34 @@ export class AndroidSegmentedPlanVideoSession {
       this.startupAbortSignal?.throwIfAborted();
     } catch (error) {
       this.timerDriven = false;
-      if (this.activeRecordingId) {
-        await this.stop();
-      }
+      await this.rollbackStartedSegment();
       throw error;
     }
     this.scheduleRotation();
     this.scheduleMaxDurationStop();
     return first;
+  }
+
+  private async rollbackStartedSegment(): Promise<void> {
+    const recordingId = this.activeRecordingId;
+    this.activeRecordingId = undefined;
+    if (!recordingId) {
+      return;
+    }
+    try {
+      await this.stopVideoRecordingFn(recordingId);
+    } catch (stopError) {
+      logger.warn(
+        `[SegmentedPlanVideo] Failed to stop cancelled segment ${recordingId}: ${errorMessage(stopError)}`,
+      );
+      try {
+        await this.forceStopVideoRecordingFn(recordingId);
+      } catch (forceStopError) {
+        logger.warn(
+          `[SegmentedPlanVideo] Failed to force-stop cancelled segment ${recordingId}: ${errorMessage(forceStopError)}`,
+        );
+      }
+    }
   }
 
   private scheduleRotation(): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,7 @@ import { reviveNonFiniteArguments } from "../utils/nonFiniteJson";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
-import { runWithAbortSignal } from "../utils/AbortContext";
+import { combineAbortSignals, runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 import { SessionToolBinding } from "./SessionToolBinding";
 import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
@@ -459,7 +459,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     };
   });
 
-  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     // Revive non-finite arguments the daemon client encoded as sentinels so they
     // survive the socket + loopback-HTTP hops (#5854 §2). Done BEFORE logging and
     // validation so the request trace shows the real Infinity/-Infinity/NaN
@@ -623,6 +623,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       executionSessionUuid,
       sessionId,
     );
+    const requestSignal = combineAbortSignals(execution.abortController.signal, extra.signal);
     const handlerParams =
       parsedParams && typeof parsedParams === "object"
         ? {
@@ -656,7 +657,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       : undefined;
 
     try {
-      const result = await runWithAbortSignal(execution.abortController.signal, () =>
+      const result = await runWithAbortSignal(requestSignal, () =>
         runWithToolSelectionContext(
           {
             // A bound derived session may still target a sibling label. Resolve
@@ -677,7 +678,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
               options.sessionToolSelectionService ??
               (name === "executePlan" ? getSessionToolSelectionService() : undefined),
           },
-          () => tool.handler(handlerParams, progressCallback, execution.abortController.signal),
+          () => tool.handler(handlerParams, progressCallback, requestSignal),
         ),
       );
       if (

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod/v4";
-import { DeviceSessionManager } from "../utils/DeviceSessionManager";
+import { DeviceSessionManager, type DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 import { ActionableError, BootedDevice, SomePlatform } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
@@ -154,6 +154,7 @@ interface ToolRegistrationOptions {
 
 interface DeviceAwareToolOptions<T = any> extends ToolRegistrationOptions {
   shouldEnsureDevice?: (args: T) => boolean;
+  deviceReadiness?: DeviceReadinessLevel | ((args: T) => DeviceReadinessLevel);
   nonDeviceHandler?: ToolHandler<T>;
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
@@ -210,6 +211,7 @@ interface ExecutionTargetInput {
   args: any;
   options: DeviceAwareToolOptions;
   deviceSessionManager: DeviceSessionManager;
+  signal?: AbortSignal;
 }
 
 interface ExecutionTargetContext {
@@ -362,7 +364,8 @@ interface ToolRegistryPipelineOverrides {
 class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
   constructor(private readonly logger: Logger = logger) {}
   async resolveExecutionTarget(input: ExecutionTargetInput): Promise<ExecutionTargetContext> {
-    const { name, args, options, deviceSessionManager } = input;
+    const { name, args, options, deviceSessionManager, signal } = input;
+    signal?.throwIfAborted();
     const shouldResolveDevice = options.shouldEnsureDevice
       ? options.shouldEnsureDevice(args)
       : true;
@@ -544,6 +547,11 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         );
         device = await deviceSessionManager.ensureDeviceReady(platform, providedDeviceId, {
           skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled(),
+          readiness:
+            typeof options.deviceReadiness === "function"
+              ? options.deviceReadiness(args)
+              : options.deviceReadiness,
+          signal,
         });
         logger.info(`[ToolRegistry] ${name}: Using device ${device.deviceId}`);
       }
@@ -1143,7 +1151,9 @@ export class ToolRegistryClass {
           args: handlerArgs,
           options,
           deviceSessionManager: this.deviceSessionManager,
+          signal,
         });
+        signal?.throwIfAborted();
         sessionUuid = resolvedTarget.sessionUuid;
         return await runWithToolSelectionContext(
           // Bind the ROUTING session, not the selection profile, so

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -22,6 +22,7 @@ import { logger } from "../utils/logger";
 import { redactHomeDir } from "../utils/redactPath";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { createTimestampedId } from "../utils/IdGenerator";
+import { combineAbortSignals } from "../utils/AbortContext";
 import { ResourceRegistry } from "./resourceRegistry";
 import {
   VideoRecordingRepository,
@@ -132,6 +133,7 @@ interface StartVideoRecordingRequest {
    * do not carry a session (the recording stays legacy/unowned).
    */
   ownerSessionUuid?: string;
+  abortSignal?: AbortSignal;
 }
 
 interface StopVideoRecordingResult {
@@ -325,15 +327,20 @@ function resetVideoRecordingManagerState(): void {
   managerInitialized = false;
 }
 
-function beginVideoRecordingStart(): { abortSignal: AbortSignal; complete(): void } {
+function beginVideoRecordingStart(requestSignal?: AbortSignal): {
+  abortSignal: AbortSignal;
+  complete(): void;
+} {
+  requestSignal?.throwIfAborted();
   if (!acceptingVideoRecordingStarts) {
     throw new ActionableError("Video recording is unavailable while the daemon shuts down.");
   }
   inFlightVideoRecordingStarts++;
   const controller = new AbortController();
   inFlightVideoRecordingStartControllers.add(controller);
+  const abortSignal = combineAbortSignals(requestSignal, controller.signal)!;
   return {
-    abortSignal: controller.signal,
+    abortSignal,
     complete: () => {
       inFlightVideoRecordingStarts--;
       inFlightVideoRecordingStartControllers.delete(controller);
@@ -828,7 +835,7 @@ export async function updateVideoRecordingConfig(
 export async function startVideoRecording(
   request: StartVideoRecordingRequest,
 ): Promise<ActiveVideoRecording> {
-  const start = beginVideoRecordingStart();
+  const start = beginVideoRecordingStart(request.abortSignal);
   try {
     const deps = await getVideoRecordingDependencies();
     const { videoRecorderService, recordingRepository, timer } = deps;

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -20,6 +20,7 @@ import {
 import { serverConfig } from "../utils/ServerConfig";
 import { logger } from "../utils/logger";
 import { redactHomeDir } from "../utils/redactPath";
+import { errorMessage } from "../utils/describeUnknownError";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { createTimestampedId } from "../utils/IdGenerator";
 import { combineAbortSignals } from "../utils/AbortContext";
@@ -868,45 +869,66 @@ export async function startVideoRecording(
       abortSignal: start.abortSignal,
     });
 
-    await recordingRepository.insertRecording({
-      recordingId: active.recordingId,
-      deviceId: request.device.deviceId,
-      platform: request.device.platform,
-      status: "recording",
-      outputName: active.outputName,
-      fileName: active.fileName,
-      filePath: active.outputPath,
-      format: active.config.format,
-      sizeBytes: 0,
-      durationMs: undefined,
-      codec: undefined,
-      createdAt: active.startedAt,
-      startedAt: active.startedAt,
-      endedAt: undefined,
-      lastAccessedAt: active.startedAt,
-      config: active.config,
-      ownerSessionUuid: request.ownerSessionUuid,
-    });
+    try {
+      start.abortSignal?.throwIfAborted();
+      await recordingRepository.insertRecording({
+        recordingId: active.recordingId,
+        deviceId: request.device.deviceId,
+        platform: request.device.platform,
+        status: "recording",
+        outputName: active.outputName,
+        fileName: active.fileName,
+        filePath: active.outputPath,
+        format: active.config.format,
+        sizeBytes: 0,
+        durationMs: undefined,
+        codec: undefined,
+        createdAt: active.startedAt,
+        startedAt: active.startedAt,
+        endedAt: undefined,
+        lastAccessedAt: active.startedAt,
+        config: active.config,
+        ownerSessionUuid: request.ownerSessionUuid,
+      });
 
-    const highlightSession = createHighlightSession(
-      active.recordingId,
-      request.device,
-      active.startedAt,
-      timer,
-    );
-    highlightSessions.set(active.recordingId, highlightSession);
-    highlightSessionsByDeviceId.set(request.device.deviceId, active.recordingId);
+      const highlightSession = createHighlightSession(
+        active.recordingId,
+        request.device,
+        active.startedAt,
+        timer,
+      );
+      highlightSessions.set(active.recordingId, highlightSession);
+      highlightSessionsByDeviceId.set(request.device.deviceId, active.recordingId);
 
-    if (highlightInputs.length > 0) {
-      await scheduleRecordingHighlights(highlightSession, request.device, highlightInputs, deps);
+      if (highlightInputs.length > 0) {
+        await scheduleRecordingHighlights(highlightSession, request.device, highlightInputs, deps);
+      }
+
+      await scheduleAutoStop(active.recordingId, maxDurationSeconds);
+
+      const capBytes = Math.floor((active.config.maxArchiveSizeMb ?? 0) * 1024 * 1024);
+      scheduleInProgressSizeCap(active.recordingId, active.outputPath, capBytes, deps);
+      start.abortSignal?.throwIfAborted();
+      return active;
+    } catch (error) {
+      try {
+        await videoRecorderService.forceStopRecording(active.recordingId);
+      } catch (cleanupError) {
+        logger.warn(
+          `[VideoRecording] Failed to force-stop cancelled recording ${active.recordingId}: ${errorMessage(cleanupError)}`,
+          cleanupError,
+        );
+      }
+      try {
+        await interruptVideoRecording(active.recordingId);
+      } catch (cleanupError) {
+        logger.warn(
+          `[VideoRecording] Failed to mark cancelled recording ${active.recordingId} interrupted: ${errorMessage(cleanupError)}`,
+          cleanupError,
+        );
+      }
+      throw error;
     }
-
-    await scheduleAutoStop(active.recordingId, maxDurationSeconds);
-
-    const capBytes = Math.floor((active.config.maxArchiveSizeMb ?? 0) * 1024 * 1024);
-    scheduleInProgressSizeCap(active.recordingId, active.outputPath, capBytes, deps);
-
-    return active;
   } finally {
     start.complete();
   }

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -911,30 +911,34 @@ export async function startVideoRecording(
       start.abortSignal?.throwIfAborted();
       return active;
     } catch (error) {
-      let forceStopped = false;
-      try {
-        await videoRecorderService.forceStopRecording(active.recordingId);
-        forceStopped = true;
-      } catch (cleanupError) {
-        logger.warn(
-          `[VideoRecording] Failed to force-stop cancelled recording ${active.recordingId}: ${errorMessage(cleanupError)}`,
-          cleanupError,
-        );
-      }
-      if (forceStopped) {
-        try {
-          await interruptVideoRecording(active.recordingId);
-        } catch (cleanupError) {
-          logger.warn(
-            `[VideoRecording] Failed to mark cancelled recording ${active.recordingId} interrupted: ${errorMessage(cleanupError)}`,
-            cleanupError,
-          );
-        }
-      }
+      await cleanUpCancelledVideoRecording(active.recordingId, videoRecorderService);
       throw error;
     }
   } finally {
     start.complete();
+  }
+}
+
+async function cleanUpCancelledVideoRecording(
+  recordingId: string,
+  videoRecorderService: VideoRecorderService,
+): Promise<void> {
+  try {
+    await videoRecorderService.forceStopRecording(recordingId);
+  } catch (cleanupError) {
+    logger.warn(
+      `[VideoRecording] Failed to force-stop cancelled recording ${recordingId}: ${errorMessage(cleanupError)}`,
+      cleanupError,
+    );
+    return;
+  }
+  try {
+    await interruptVideoRecording(recordingId);
+  } catch (cleanupError) {
+    logger.warn(
+      `[VideoRecording] Failed to mark cancelled recording ${recordingId} interrupted: ${errorMessage(cleanupError)}`,
+      cleanupError,
+    );
   }
 }
 

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -911,21 +911,25 @@ export async function startVideoRecording(
       start.abortSignal?.throwIfAborted();
       return active;
     } catch (error) {
+      let forceStopped = false;
       try {
         await videoRecorderService.forceStopRecording(active.recordingId);
+        forceStopped = true;
       } catch (cleanupError) {
         logger.warn(
           `[VideoRecording] Failed to force-stop cancelled recording ${active.recordingId}: ${errorMessage(cleanupError)}`,
           cleanupError,
         );
       }
-      try {
-        await interruptVideoRecording(active.recordingId);
-      } catch (cleanupError) {
-        logger.warn(
-          `[VideoRecording] Failed to mark cancelled recording ${active.recordingId} interrupted: ${errorMessage(cleanupError)}`,
-          cleanupError,
-        );
+      if (forceStopped) {
+        try {
+          await interruptVideoRecording(active.recordingId);
+        } catch (cleanupError) {
+          logger.warn(
+            `[VideoRecording] Failed to mark cancelled recording ${active.recordingId} interrupted: ${errorMessage(cleanupError)}`,
+            cleanupError,
+          );
+        }
       }
       throw error;
     }

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -1,6 +1,6 @@
 import { errorMessage } from "../utils/describeUnknownError";
 import { z } from "zod/v4";
-import { ToolRegistry } from "./toolRegistry";
+import { ToolRegistry, type ProgressCallback } from "./toolRegistry";
 import {
   ActionableError,
   BootedDevice,
@@ -385,14 +385,22 @@ async function stopRecordingById(recordingId: string) {
 }
 
 export function registerVideoRecordingTools(): void {
-  const videoRecordingHandler = async (device: BootedDevice, args: VideoRecordingArgs) => {
+  const videoRecordingHandler = async (
+    device: BootedDevice,
+    args: VideoRecordingArgs,
+    _progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    signal?.throwIfAborted();
     if (args.action === "start") {
       const targetDevices = await resolveTargetDevices(device, args);
+      signal?.throwIfAborted();
       const maxDurationSeconds = args.maxDuration ?? DEFAULT_MAX_DURATION_SECONDS;
       const recordings: Array<Record<string, unknown>> = [];
       const failures: Array<Record<string, unknown>> = [];
 
       for (const target of targetDevices) {
+        signal?.throwIfAborted();
         try {
           // Android `screenrecord` is hard-capped at 180s. For longer Android
           // recordings, transparently produce ordered segments (<outputName>,
@@ -440,6 +448,7 @@ export function registerVideoRecordingTools(): void {
             maxDurationSeconds: args.maxDuration,
             highlights: args.highlights,
             ownerSessionUuid: args.sessionUuid,
+            abortSignal: signal,
           });
 
           recordings.push({
@@ -456,6 +465,7 @@ export function registerVideoRecordingTools(): void {
             },
           });
         } catch (error) {
+          signal?.throwIfAborted();
           failures.push({
             deviceId: target.deviceId,
             platform: target.platform,
@@ -602,7 +612,12 @@ export function registerVideoRecordingTools(): void {
     throw new ActionableError(`Unsupported videoRecording action: ${args.action}`);
   };
 
-  const videoRecordingNonDeviceHandler = async (args: VideoRecordingArgs) => {
+  const videoRecordingNonDeviceHandler = async (
+    args: VideoRecordingArgs,
+    _progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    signal?.throwIfAborted();
     if (args.action === "stop" && args.recordingId) {
       return stopRecordingById(args.recordingId);
     }
@@ -620,6 +635,10 @@ export function registerVideoRecordingTools(): void {
     {
       defaultEnabled: false,
       shouldEnsureDevice: (args) => !(args.action === "stop" && args.recordingId),
+      deviceReadiness: (args) =>
+        args.action === "start" && (!args.highlights || args.highlights.length === 0)
+          ? "booted"
+          : "automationReady",
       nonDeviceHandler: videoRecordingNonDeviceHandler,
     },
   );

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -47,7 +47,7 @@ interface StoppedSegmentedSession {
 
 type SegmentedSessionRecordingDependencies = Pick<
   AndroidSegmentedPlanVideoSessionOptions,
-  "startVideoRecording" | "stopVideoRecording"
+  "startVideoRecording" | "stopVideoRecording" | "forceStopVideoRecording"
 >;
 
 /**

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -415,6 +415,7 @@ export function registerVideoRecordingTools(): void {
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
               maxDurationSeconds,
+              startupAbortSignal: signal,
               // Auto-stop finalizes without going through stopAndRemove, so drop the
               // tracked entry here to avoid a registry leak on fire-and-forget recordings.
               onFinalized: () => segmentedSessions.remove(session),

--- a/src/utils/AbortContext.ts
+++ b/src/utils/AbortContext.ts
@@ -6,6 +6,16 @@ type AbortContextState = {
 
 const abortContext = new AsyncLocalStorage<AbortContextState>();
 
+export const combineAbortSignals = (
+  ...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined => {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+  return activeSignals.length === 1 ? activeSignals[0] : AbortSignal.any(activeSignals);
+};
+
 export const runWithAbortSignal = async <T>(
   signal: AbortSignal | undefined,
   fn: () => Promise<T>,

--- a/src/utils/ChildProcessTracker.ts
+++ b/src/utils/ChildProcessTracker.ts
@@ -30,16 +30,19 @@ export interface StoppableProcess {
 
 export interface WaitForExitOptions {
   timeoutMs?: number;
+  forceKillTimeoutMs?: number;
   timer?: Timer;
   signal?: NodeJS.Signals | null;
 }
 
 export interface SpawnableProcess {
+  pid?: number;
   once(event: "spawn", listener: () => void): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
 }
 
 export interface TrackedChildProcess extends StoppableProcess {
+  pid?: number;
   signalCode: NodeJS.Signals | null;
   stderr: {
     on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
@@ -51,14 +54,23 @@ export interface TrackedChildProcess extends StoppableProcess {
     listener: (code: number | null, signal: NodeJS.Signals | null) => void,
   ): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
-  off(event: "exit", listener: () => void): unknown;
+  off(
+    event: "exit",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
   off(event: "error", listener: (error: Error) => void): unknown;
+}
+
+interface CloseAwareProcess {
+  once(event: "close", listener: () => void): unknown;
+  off(event: "close", listener: () => void): unknown;
 }
 
 export function createExitTracker(
   process: TrackedChildProcess,
   stderr: string[],
 ): { exitState: ProcessExitState; exitPromise: Promise<void> } {
+  const closeAwareProcess = process as TrackedChildProcess & CloseAwareProcess;
   const exitState: ProcessExitState = {};
   let resolvePromise: () => void = () => undefined;
   let rejectPromise: (error: Error) => void = () => undefined;
@@ -68,25 +80,59 @@ export function createExitTracker(
     rejectPromise = reject;
   });
 
-  process.once("error", (error) => {
+  const cleanupProcessListeners = () => {
+    process.off("error", onError);
+    process.off("exit", onExit);
+  };
+  const cleanup = () => {
+    cleanupProcessListeners();
+    closeAwareProcess.off("close", onClose);
+    process.stderr?.off("data", onStderr);
+  };
+  const onError = (error: Error) => {
+    // Node emits AbortError when an already-spawned child's AbortSignal fires,
+    // then emits exit once signal delivery completes. Keep the exit listener
+    // and promise alive so callers can prove the child was actually reaped.
+    if (error.name === "AbortError" && process.pid !== undefined) {
+      return;
+    }
+    exitState.endedAt = new Date().toISOString();
+    cleanupProcessListeners();
+    if (!process.stderr) {
+      cleanup();
+    }
     rejectPromise(error instanceof Error ? error : new Error(String(error)));
-  });
+  };
 
-  process.once("exit", (code, signal) => {
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
     exitState.exitCode = code;
     exitState.signal = signal;
     exitState.endedAt = new Date().toISOString();
+    cleanupProcessListeners();
+    if (!process.stderr) {
+      cleanup();
+    }
     resolvePromise();
-  });
+  };
 
-  process.stderr?.on("data", (chunk) => {
+  // Node emits child `exit` before stdio necessarily drains, then `close` after
+  // the streams are closed. Keep collecting diagnostics through that gap.
+  const onClose = () => cleanup();
+
+  const onStderr = (chunk: Buffer | string) => {
     stderr.push(chunk.toString());
-  });
+  };
 
-  if (process.exitCode !== null) {
+  process.once("error", onError);
+  process.once("exit", onExit);
+  closeAwareProcess.once("close", onClose);
+  process.stderr?.on("data", onStderr);
+
+  if (process.exitCode !== null && process.exitCode !== undefined) {
     exitState.exitCode = process.exitCode;
     exitState.signal = process.signalCode;
     exitState.endedAt = new Date().toISOString();
+    cleanup();
     resolvePromise();
   }
 
@@ -113,53 +159,77 @@ export async function waitForExit(
 ): Promise<void> {
   const timer = options.timer ?? defaultTimer;
   const timeoutMs = options.timeoutMs ?? PROCESS_EXIT_TIMEOUT_MS;
+  const forceKillTimeoutMs = options.forceKillTimeoutMs ?? PROCESS_EXIT_TIMEOUT_MS;
   const signal = options.signal === undefined ? "SIGINT" : options.signal;
 
-  if (process.exitCode !== null) {
+  if (hasExited(process)) {
     await exitPromise;
     return;
   }
 
-  // `killed` means a prior graceful stop already sent a signal; it does not
-  // mean the child has been reaped. Await that stop rather than truncating an
-  // in-progress iOS recording with a second signal. Backend force-stop paths
-  // intentionally use `exitCode` alone when escalation is required.
-  if (process.killed) {
-    await exitPromise;
-    return;
+  // `killed` means only that a signal was sent, not that the process was
+  // reaped. Preserve the original grace window, then escalate if it remains.
+  sendInitialSignal(process, signal);
+
+  let gracefulResult: "exited" | "timeout";
+  try {
+    gracefulResult = await waitForExitOrTimeout(exitPromise, timeoutMs, timer);
+  } catch (error) {
+    forceKillIfRunning(process);
+    throw error;
   }
 
-  if (signal !== null) {
+  if (gracefulResult === "exited") {
+    return;
+  }
+  forceKillIfRunning(process);
+
+  const forceResult = await waitForExitOrTimeout(exitPromise, forceKillTimeoutMs, timer);
+  if (forceResult === "timeout") {
+    throw new Error(
+      `Process did not exit within ${timeoutMs}ms plus ${forceKillTimeoutMs}ms after SIGKILL`,
+    );
+  }
+}
+
+function hasExited(process: StoppableProcess): boolean {
+  return process.exitCode !== null && process.exitCode !== undefined;
+}
+
+function sendInitialSignal(process: StoppableProcess, signal: NodeJS.Signals | null): void {
+  if (!process.killed && signal !== null) {
     process.kill(signal);
   }
+}
 
+function forceKillIfRunning(process: StoppableProcess): void {
+  if (!hasExited(process)) {
+    process.kill("SIGKILL");
+  }
+}
+
+async function waitForExitOrTimeout(
+  exitPromise: Promise<void>,
+  timeoutMs: number,
+  timer: Timer,
+): Promise<"exited" | "timeout"> {
   let timeoutId: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<void>((resolve) => {
-    timeoutId = timer.setTimeout(() => {
-      if (process.exitCode === null) {
-        process.kill("SIGKILL");
-      }
-      resolve();
-    }, timeoutMs);
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeoutId = timer.setTimeout(() => resolve("timeout"), Math.max(0, timeoutMs));
   });
-
-  // Clear the SIGKILL timer in `finally`: `exitPromise` rejects on the child's
-  // 'error' event (see createExitTracker), which makes the race throw. Clearing
-  // only on the resolve path leaked the timer, so it later fired process.kill
-  // ("SIGKILL") on the already-failed process and kept the event loop alive up to
-  // `timeoutMs` (#3617).
   try {
-    await Promise.race([exitPromise, timeoutPromise]);
+    return await Promise.race([exitPromise.then(() => "exited" as const), timeoutPromise]);
   } finally {
     if (timeoutId) {
       timer.clearTimeout(timeoutId);
     }
   }
-
-  await exitPromise;
 }
 
 export async function waitForSpawn(process: SpawnableProcess): Promise<void> {
+  if (process.pid !== undefined) {
+    return;
+  }
   await new Promise<void>((resolve, reject) => {
     process.once("spawn", () => resolve());
     process.once("error", (error) => reject(error));

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -627,22 +627,19 @@ export class DeviceSessionManager implements DeviceSessionManager {
 
       const window = this.provider.getWindow(device);
 
-      let activeWindow = await window.getActive();
+      const activeWindow = await window.getActive(true);
       if (!activeWindow || !activeWindow.appId || !activeWindow.activityName) {
-        activeWindow = await window.getActive(true);
-        if (!activeWindow || !activeWindow.appId || !activeWindow.activityName) {
-          logger.warn(`[DeviceSessionManager] Android device ${deviceId} is not fully ready`);
-          if (activeWindow) {
-            logger.warn(
-              `[DeviceSessionManager] activeWindow.appId: ${activeWindow.appId} | activeWindow.activityName: ${activeWindow.activityName}`,
-            );
-          } else {
-            logger.warn(`[DeviceSessionManager] activeWindow: ${activeWindow}`);
-          }
-          throw new ActionableError(
-            `Cannot get active window information from Android device ${deviceId}. The device may not be fully booted or is in an unusual state.`,
+        logger.warn(`[DeviceSessionManager] Android device ${deviceId} is not fully ready`);
+        if (activeWindow) {
+          logger.warn(
+            `[DeviceSessionManager] activeWindow.appId: ${activeWindow.appId} | activeWindow.activityName: ${activeWindow.activityName}`,
           );
+        } else {
+          logger.warn(`[DeviceSessionManager] activeWindow: ${activeWindow}`);
         }
+        throw new ActionableError(
+          `Cannot get active window information from Android device ${deviceId}. The device may not be fully booted or is in an unusual state.`,
+        );
       }
     } catch (error) {
       const errorMsg = errorMessage(error);

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -240,9 +240,17 @@ export interface DeviceSessionManager {
   findOrStartIosDevice(options?: DeviceReadyOptions): Promise<BootedDevice>;
 }
 
+export type DeviceReadinessLevel = "booted" | "automationReady";
+
 export interface DeviceReadyOptions {
   skipCtrlProxyDownload?: boolean;
   signal?: AbortSignal;
+  /**
+   * `booted` verifies only that the target is connected and booted.
+   * `automationReady` additionally prepares CtrlProxy. Defaults to
+   * `automationReady` for existing device-aware tools.
+   */
+  readiness?: DeviceReadinessLevel;
   /**
    * @deprecated Use skipCtrlProxyDownload instead.
    */
@@ -600,6 +608,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
    * Verify an Android device is connected and ready
    */
   public async verifyAndroidDevice(deviceId: string, options?: DeviceReadyOptions): Promise<void> {
+    options?.signal?.throwIfAborted();
     const allDevices = await this.adb.getBootedAndroidDevices();
     const device = allDevices.find((device) => device.deviceId === deviceId);
 
@@ -607,6 +616,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
       throw new ActionableError(
         `Android device ${deviceId} is not connected. Available devices: ${describeDevices(allDevices)}`,
       );
+    }
+    options?.signal?.throwIfAborted();
+    if (options?.readiness === "booted") {
+      return;
     }
 
     // Check if we can get an active window from the device
@@ -832,6 +845,8 @@ export class DeviceSessionManager implements DeviceSessionManager {
    * Verify an iOS device is connected and ready
    */
   public async verifyIosDevice(deviceId: string, options?: DeviceReadyOptions): Promise<void> {
+    options?.signal?.throwIfAborted();
+    const readiness = options?.readiness ?? "automationReady";
     // An explicit runner override that cannot be used must fail closed before any
     // other path, whatever the simulator/runner state. Every downstream branch
     // (already-connected, already-running, cached-start) skips the builder that
@@ -839,17 +854,20 @@ export class DeviceSessionManager implements DeviceSessionManager {
     // AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH would silently run the cached released
     // runner and the caller would attribute results to a local build that never
     // loaded (#4221).
-    const iosOverride = await checkIosCtrlProxyOverride();
-    if (iosOverride.present && !iosOverride.usable) {
-      throw new ActionableError(
-        `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`,
-      );
+    if (readiness === "automationReady") {
+      const iosOverride = await checkIosCtrlProxyOverride();
+      if (iosOverride.present && !iosOverride.usable) {
+        throw new ActionableError(
+          `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`,
+        );
+      }
     }
 
     if (!this.simctl) {
       throw new ActionableError("iOS simulator tools not available");
     }
     const deviceInfo = await this.simctl.getDeviceInfo(deviceId);
+    options?.signal?.throwIfAborted();
 
     if (!deviceInfo) {
       throw new ActionableError(
@@ -867,6 +885,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
     if (deviceInfo.state !== "Booted") {
       logger.info(`iOS simulator ${deviceId} is not booted (state: ${deviceInfo.state})`);
       // Note: We could auto-boot here if desired, but keeping consistent with current behavior
+      return;
+    }
+
+    if (readiness === "booted") {
       return;
     }
 

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -533,6 +533,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
         deviceVerified = true;
         deviceSource = "current";
       } catch (error) {
+        // Request cancellation does not make the selected device stale. Preserve
+        // the user's explicit selection so a later platform-implicit call does
+        // not become ambiguous merely because this caller disconnected.
+        options?.signal?.throwIfAborted();
         if (error instanceof RunnerReadinessError) {
           throw error;
         }
@@ -617,11 +621,6 @@ export class DeviceSessionManager implements DeviceSessionManager {
         `Android device ${deviceId} is not connected. Available devices: ${describeDevices(allDevices)}`,
       );
     }
-    options?.signal?.throwIfAborted();
-    if (options?.readiness === "booted") {
-      return;
-    }
-
     // Check if we can get an active window from the device
     try {
       logger.info(`[DeviceSessionManager] Verifying Android device ${deviceId} readiness`);
@@ -650,6 +649,11 @@ export class DeviceSessionManager implements DeviceSessionManager {
       throw new ActionableError(
         `Failed to verify Android device ${deviceId} readiness: ${errorMsg}`,
       );
+    }
+
+    options?.signal?.throwIfAborted();
+    if (options?.readiness === "booted") {
+      return;
     }
 
     // Always track setup timing (one-time per session, valuable for debugging)

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -113,7 +113,7 @@ export interface SimCtl {
    * Check if simctl is available
    * @returns Promise with boolean indicating availability
    */
-  isAvailable(): Promise<boolean>;
+  isAvailable(options?: { timeoutMs?: number; signal?: AbortSignal }): Promise<boolean>;
 
   /**
    * Check if a simulator is running by name
@@ -741,14 +741,20 @@ export class SimCtlClient implements SimCtl {
    * Check if simctl is available
    * @returns Promise with boolean indicating availability
    */
-  async isAvailable(): Promise<boolean> {
-    return this.isLocalSimctlAvailable();
+  async isAvailable(options?: { timeoutMs?: number; signal?: AbortSignal }): Promise<boolean> {
+    return this.isLocalSimctlAvailable(options);
   }
 
-  private async isLocalSimctlAvailable(): Promise<boolean> {
+  private async isLocalSimctlAvailable(options?: {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
     const controller = new AbortController();
     let timeoutId: NodeJS.Timeout | undefined;
-    const probe = this.execAsync("xcrun", ["--find", "simctl"], undefined, controller.signal);
+    const signal = options?.signal
+      ? AbortSignal.any([options.signal, controller.signal])
+      : controller.signal;
+    const probe = this.execAsync("xcrun", ["--find", "simctl"], undefined, signal);
     probe.catch(() => {
       // The race below owns the result; this also handles an abort after it wins.
     });
@@ -756,7 +762,7 @@ export class SimCtlClient implements SimCtl {
       timeoutId = this.timer.setTimeout(() => {
         controller.abort();
         resolve(false);
-      }, SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS);
+      }, options?.timeoutMs ?? SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS);
     });
 
     try {

--- a/src/utils/media/FfmpegClient.ts
+++ b/src/utils/media/FfmpegClient.ts
@@ -23,6 +23,7 @@ export interface FfmpegStartRequest {
 
 export interface FfmpegRunRequest extends FfmpegStartRequest {
   readonly timeoutMs?: number;
+  readonly forceKillTimeoutMs?: number;
   readonly signal?: AbortSignal;
 }
 
@@ -47,6 +48,8 @@ export interface FfmpegPipeRequest {
 
 export interface FfmpegProbeRequest {
   readonly requiredEncoders?: string[];
+  readonly timeoutMs?: number;
+  readonly signal?: AbortSignal;
 }
 
 export interface FfmpegProbeResult {
@@ -141,6 +144,7 @@ export class DefaultFfmpegClient implements FfmpegClient {
     try {
       await waitForExit(started.process, started.tracker.exitPromise, {
         timeoutMs: request.timeoutMs,
+        forceKillTimeoutMs: request.forceKillTimeoutMs,
         timer: this.timer,
         signal: null,
       });
@@ -163,16 +167,24 @@ export class DefaultFfmpegClient implements FfmpegClient {
   }
 
   async probe(request: FfmpegProbeRequest = {}): Promise<FfmpegProbeResult> {
-    const versionResult = await this.run({ args: ["-version"], context: "FFmpeg version probe" });
+    const deadlineMs =
+      request.timeoutMs === undefined ? undefined : this.timer.now() + request.timeoutMs;
+    const runProbe = async (args: string[], context: string): Promise<FfmpegCommandResult> =>
+      await this.run({
+        args,
+        context,
+        timeoutMs:
+          deadlineMs === undefined ? undefined : Math.max(0, deadlineMs - this.timer.now()),
+        forceKillTimeoutMs: deadlineMs === undefined ? undefined : 0,
+        signal: request.signal,
+      });
+    const versionResult = await runProbe(["-version"], "FFmpeg version probe");
     const version = /ffmpeg version (\S+)/.exec(versionResult.stdout)?.[1];
     if (!version) {
       throw new ActionableError("FFmpeg version probe returned invalid version output.");
     }
 
-    const encodersResult = await this.run({
-      args: ["-hide_banner", "-encoders"],
-      context: "FFmpeg encoder probe",
-    });
+    const encodersResult = await runProbe(["-hide_banner", "-encoders"], "FFmpeg encoder probe");
     const encoders = encodersResult.stdout
       .split("\n")
       .filter((line) => line.trim().startsWith("V"))

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -394,9 +394,8 @@ describe("resolveMcpRequestTimeoutMs", () => {
     expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
   });
 
-  test("videoRecording has transport time for bounded iOS startup recovery", () => {
-    expect(MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS).toBe(180_000);
-    expect(MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS).toBeGreaterThan(90_000);
+  test("videoRecording preserves the compatibility floor", () => {
+    expect(MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS).toBe(90_000);
   });
 
   test("keeps transport alive beyond the startDevice tool budget", () => {

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -394,6 +394,11 @@ describe("resolveMcpRequestTimeoutMs", () => {
     expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
   });
 
+  test("videoRecording has transport time for bounded iOS startup recovery", () => {
+    expect(MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS).toBe(180_000);
+    expect(MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS).toBeGreaterThan(90_000);
+  });
+
   test("keeps transport alive beyond the startDevice tool budget", () => {
     const request: DaemonRequest = {
       id: "1",

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -55,6 +55,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private deviceTimestampMs: number | null = null;
   private deviceTimestampSource: DeviceTimestampSource = "device-ms";
   private spawnCalls: string[][] = [];
+  private spawnOptions: Array<AdbSpawnOptions | undefined> = [];
   private spawnBehaviors: SpawnBehavior[] = [];
 
   /**
@@ -134,8 +135,9 @@ export class FakeAdbClient implements FakeAdbClientContract {
    * a clean exit code 0). The exit/error event fires after the caller attaches
    * its listeners, matching the real spawn's async lifecycle.
    */
-  async spawn(args: string[], _options?: AdbSpawnOptions): Promise<AdbProcess> {
+  async spawn(args: string[], options?: AdbSpawnOptions): Promise<AdbProcess> {
     this.spawnCalls.push([...args]);
+    this.spawnOptions.push(options);
     const proc = new FakeAdbProcess();
     const joined = args.join(" ");
     const behavior = this.spawnBehaviors.find((b) => joined.includes(b.match));
@@ -169,6 +171,10 @@ export class FakeAdbClient implements FakeAdbClientContract {
   /** All recorded spawn argv arrays, in order. */
   getSpawnCalls(): string[][] {
     return this.spawnCalls.map((call) => [...call]);
+  }
+
+  getSpawnOptions(): Array<AdbSpawnOptions | undefined> {
+    return [...this.spawnOptions];
   }
 
   /** True if any spawned command's argv contained `match`. */

--- a/test/fakes/FakeWindow.ts
+++ b/test/fakes/FakeWindow.ts
@@ -11,6 +11,7 @@ export class FakeWindow implements Window {
   private configuredActiveWindow: ActiveWindow | null = null;
   private cachedActiveWindowCallCount: number = 0;
   private getActiveCallCount: number = 0;
+  private getActiveForceRefreshes: boolean[] = [];
   private configuredActiveHash: string = "fake-active-hash";
 
   /**
@@ -62,6 +63,7 @@ export class FakeWindow implements Window {
     this.executedOperations = [];
     this.cachedActiveWindowCallCount = 0;
     this.getActiveCallCount = 0;
+    this.getActiveForceRefreshes = [];
   }
 
   /**
@@ -78,6 +80,10 @@ export class FakeWindow implements Window {
     return this.getActiveCallCount;
   }
 
+  getGetActiveForceRefreshes(): boolean[] {
+    return [...this.getActiveForceRefreshes];
+  }
+
   // Implementation of Window interface
 
   async getCachedActiveWindow(): Promise<ActiveWindow | null> {
@@ -89,6 +95,7 @@ export class FakeWindow implements Window {
   async getActive(forceRefresh: boolean = false): Promise<ActiveWindow> {
     this.executedOperations.push("getActive");
     this.getActiveCallCount++;
+    this.getActiveForceRefreshes.push(forceRefresh);
     if (!forceRefresh && this.configuredCachedActiveWindow) {
       return this.configuredCachedActiveWindow;
     }

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -20,14 +20,17 @@ import {
   type RecordingFileProbe,
   type StoppableProcess,
 } from "../../../src/features/video/FfmpegVideoProcessingBackend";
-import type { VideoCaptureConfig } from "../../../src/features/video/VideoRecorderService";
+import {
+  VideoCaptureStartCleanupError,
+  type VideoCaptureConfig,
+} from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
 import type { SimCtl } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeAdbProcess } from "../../fakes/FakeAdbProcess";
 import type { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
-import { defaultTimer } from "../../../src/utils/SystemTimer";
+import { defaultTimer, type Timer } from "../../../src/utils/SystemTimer";
 
 function commandVersionAvailable(command: string): boolean {
   const result = spawnSync(command, ["-version"], { stdio: "ignore" });
@@ -156,7 +159,7 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
 
   // A fake capture process: emits "spawn" then, when asked, the recordVideo start
   // handshake. kill() emits "exit" so waitForExit's SIGINT teardown resolves.
-  function makeCaptureChild(emitHandshake: boolean): ChildProcess {
+  function makeCaptureChild(emitHandshake: boolean, timer: Timer = defaultTimer): ChildProcess {
     const stderr = new PassThrough();
     const child = new EventEmitter() as ChildProcess;
     Object.assign(child, {
@@ -168,11 +171,14 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
       signalCode: null,
       kill: () => {
         (child as unknown as { killed: boolean }).killed = true;
-        queueMicrotask(() => child.emit("exit", 0, "SIGINT"));
+        queueMicrotask(() => {
+          child.emit("exit", 0, "SIGINT");
+          child.emit("close");
+        });
         return true;
       },
     });
-    defaultTimer.setTimeout(() => {
+    timer.setTimeout(() => {
       child.emit("spawn");
       if (emitHandshake) {
         stderr.write("Recording started\n");
@@ -194,11 +200,13 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
   test("retries the iOS recording start handshake and succeeds on a later attempt (#4076)", async function () {
     const started: ChildProcess[] = [];
     let diagnosticCalls = 0;
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
     const simctl = {
       isAvailable: async () => true,
       // First attempt never emits the handshake (cold-simulator miss); the retry does.
       startCommandArgs: async () => {
-        const child = makeCaptureChild(started.length >= 1);
+        const child = makeCaptureChild(started.length >= 1, timer);
         started.push(child);
         return child;
       },
@@ -208,7 +216,14 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
       },
     } as unknown as SimCtl;
 
-    backend = new FfmpegVideoProcessingBackend(undefined, () => simctl);
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
     (backend as any).ensureFfmpegAvailable = async () => {};
     (backend as any).iosRecordingStartTimeoutMs = 25;
     mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-retry-udid" };
@@ -223,9 +238,16 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
   test("kills an iOS recorder that is still waiting for its start handshake when shutdown aborts", async function () {
     const child = makeCaptureChild(false);
     const controller = new AbortController();
+    let markStartRequested: (() => void) | undefined;
+    const startRequested = new Promise<void>((resolve) => {
+      markStartRequested = resolve;
+    });
     const simctl = {
       isAvailable: async () => true,
-      startCommandArgs: async () => child,
+      startCommandArgs: async () => {
+        markStartRequested?.();
+        return child;
+      },
     } as unknown as SimCtl;
     backend = new FfmpegVideoProcessingBackend(undefined, () => simctl);
     (backend as any).ensureFfmpegAvailable = async () => {};
@@ -233,7 +255,7 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     mockConfig.abortSignal = controller.signal;
 
     const starting = backend.start(mockConfig);
-    await Promise.resolve();
+    await startRequested;
     controller.abort();
 
     await expect(starting).rejects.toThrow("cancelled during shutdown");
@@ -270,16 +292,25 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
 
   test("fails after exhausting start attempts and reports simulator diagnostics (#4076)", async function () {
     let starts = 0;
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
     const simctl = {
       isAvailable: async () => true,
       startCommandArgs: async () => {
         starts++;
-        return makeCaptureChild(false); // never emits the handshake
+        return makeCaptureChild(false, timer); // never emits the handshake
       },
       executeCommandArgs: async () => diagnosticsExecResult("iPhone 17 Pro (udid) (Shutdown)"),
     } as unknown as SimCtl;
 
-    backend = new FfmpegVideoProcessingBackend(undefined, () => simctl);
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
     (backend as any).ensureFfmpegAvailable = async () => {};
     (backend as any).iosRecordingStartTimeoutMs = 25;
     mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-wedge-udid" };
@@ -296,6 +327,223 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
     expect(error!.message).toContain("simulator state");
     expect(error!.message).toContain("Shutdown");
     expect(starts).toBe(2); // exhausted the bounded retry budget
+  });
+
+  test("fails and reaps a slow iOS start within the five-second total budget", async function () {
+    const timer = new FakeTimer();
+    const stderr = new PassThrough();
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    const child = new EventEmitter() as ChildProcess;
+    Object.assign(child, {
+      stderr,
+      stdout: null,
+      stdin: null,
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      pid: 123,
+      kill: (signal?: NodeJS.Signals | number) => {
+        signals.push(signal);
+        (child as unknown as { killed: boolean }).killed = true;
+        queueMicrotask(() => {
+          child.emit("exit", null, signal);
+          child.emit("close");
+        });
+        return true;
+      },
+    });
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => child,
+      executeCommandArgs: async () => diagnosticsExecResult("Booted"),
+    } as unknown as SimCtl;
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartMaxAttempts = 1;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-slow-udid" };
+
+    const starting = backend.start(mockConfig);
+    for (let i = 0; i < 20 && !timer.getPendingTimeouts().includes(4500); i++) {
+      await Promise.resolve();
+    }
+    expect(timer.getPendingTimeouts()).toEqual([4500]);
+
+    timer.advanceTime(4500);
+    await expect(starting).rejects.toThrow("Failed to start iOS recording");
+
+    expect(timer.now()).toBeLessThanOrEqual(5000);
+    expect(signals).toEqual(["SIGKILL"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(stderr.listenerCount("data")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+  });
+
+  test("returns a retriable handle when failed iOS startup cannot reap its child", async function () {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const stderr = new PassThrough();
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    const child = new EventEmitter() as ChildProcess;
+    Object.assign(child, {
+      stderr,
+      stdout: null,
+      stdin: null,
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      pid: 123,
+      kill: (signal?: NodeJS.Signals | number) => {
+        signals.push(signal);
+        return true;
+      },
+    });
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => child,
+      executeCommandArgs: async () => diagnosticsExecResult("Booted"),
+    } as unknown as SimCtl;
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      undefined,
+      undefined,
+      undefined,
+      timer,
+    );
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartMaxAttempts = 1;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-unreaped-udid" };
+
+    let error: unknown;
+    try {
+      await backend.start(mockConfig);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(VideoCaptureStartCleanupError);
+    expect((error as VideoCaptureStartCleanupError).handle.recordingId).toBe(
+      mockConfig.recordingId,
+    );
+    expect(signals).toEqual(["SIGKILL", "SIGKILL"]);
+  });
+
+  test("bounds and aborts a hanging FFmpeg prerequisite within the iOS startup budget", async () => {
+    const timer = new FakeTimer();
+    let probeSignal: AbortSignal | undefined;
+    const ffmpegClient = {
+      binaryPath: "ffmpeg",
+      probe: async (request?: { signal?: AbortSignal }) => {
+        probeSignal = request?.signal;
+        return await new Promise<never>((_resolve, reject) => {
+          const abort = () => reject(probeSignal?.reason ?? new Error("probe aborted"));
+          if (probeSignal?.aborted) {
+            abort();
+            return;
+          }
+          probeSignal?.addEventListener("abort", abort, { once: true });
+        });
+      },
+    };
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      undefined,
+      ffmpegClient as any,
+      undefined,
+      undefined,
+      timer,
+    );
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-probe-udid" };
+
+    const starting = backend.start(mockConfig);
+    for (let attempt = 0; attempt < 20 && probeSignal === undefined; attempt++) {
+      await Promise.resolve();
+    }
+    expect(timer.getPendingTimeouts()).toEqual([5000]);
+
+    timer.advanceTime(5000);
+    await expect(starting).rejects.toThrow("FFmpeg is not available");
+    expect(probeSignal?.aborted).toBe(true);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("bounds and aborts a hanging simctl prerequisite within the iOS startup budget", async () => {
+    const timer = new FakeTimer();
+    let availabilitySignal: AbortSignal | undefined;
+    let captureStarts = 0;
+    const simctl = {
+      isAvailable: async (options?: { signal?: AbortSignal }) => {
+        availabilitySignal = options?.signal;
+        return await new Promise<never>((_resolve, reject) => {
+          const abort = () =>
+            reject(availabilitySignal?.reason ?? new Error("availability aborted"));
+          if (availabilitySignal?.aborted) {
+            abort();
+            return;
+          }
+          availabilitySignal?.addEventListener("abort", abort, { once: true });
+        });
+      },
+      startCommandArgs: async () => {
+        captureStarts++;
+        return makeCaptureChild(true);
+      },
+    } as unknown as SimCtl;
+    const ffmpegClient = {
+      binaryPath: "ffmpeg",
+      probe: async () => ({ version: "7.1", encoders: [] }),
+    };
+    backend = new FfmpegVideoProcessingBackend(
+      undefined,
+      () => simctl,
+      ffmpegClient as any,
+      undefined,
+      undefined,
+      timer,
+    );
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-simctl-udid" };
+
+    const starting = backend.start(mockConfig);
+    for (let attempt = 0; attempt < 20 && availabilitySignal === undefined; attempt++) {
+      await Promise.resolve();
+    }
+    expect(timer.getPendingTimeouts()).toEqual([5000]);
+
+    timer.advanceTime(5000);
+    await expect(starting).rejects.toThrow("Timed out checking simctl availability");
+    expect(availabilitySignal?.aborted).toBe(true);
+    expect(captureStarts).toBe(0);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("shares one successful FFmpeg capability probe across availability and encoder checks", async function () {
+    let probeCalls = 0;
+    const ffmpegClient = {
+      binaryPath: "ffmpeg",
+      async probe() {
+        probeCalls++;
+        return { version: "7.1", encoders: ["h264_videotoolbox"] };
+      },
+    };
+    const scoped = new FfmpegVideoProcessingBackend(
+      undefined,
+      undefined,
+      ffmpegClient as any,
+      () => "darwin",
+    );
+
+    await (scoped as any).ensureFfmpegAvailable();
+    await (scoped as any).detectHardwareAccel();
+
+    expect(probeCalls).toBe(1);
   });
 
   describe("Hardware Acceleration Detection", function () {
@@ -579,6 +827,40 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function () {
       await expect(waitForStderrMessage(tracker, "Recording started", 1)).rejects.toThrow(
         /Timed out waiting for Recording started/,
       );
+    });
+
+    test("fails immediately when the tracked process exited before listeners attach", async function () {
+      const timer = new FakeTimer();
+      const tracker = createProcessTracker();
+      tracker.exitState.endedAt = new Date().toISOString();
+      tracker.process.exitCode = 1;
+
+      await expect(
+        waitForStderrMessage(tracker, "Recording started", 5000, { timer }),
+      ).rejects.toThrow("Process exited before Recording started");
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("abort removes handshake listeners and its timeout", async function () {
+      const timer = new FakeTimer();
+      const tracker = createProcessTracker();
+      const controller = new AbortController();
+      const stderr = tracker.process.stderr as unknown as EventEmitter;
+      const waiting = waitForStderrMessage(tracker, "Recording started", 5000, {
+        timer,
+        signal: controller.signal,
+      });
+
+      expect(timer.getPendingTimeoutCount()).toBe(1);
+      expect(stderr.listenerCount("data")).toBe(1);
+      controller.abort(new Error("cancelled"));
+
+      await expect(waiting).rejects.toThrow("cancelled");
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+      expect(stderr.listenerCount("data")).toBe(0);
+      const processEmitter = tracker.process as unknown as EventEmitter;
+      expect(processEmitter.listenerCount("exit")).toBe(0);
+      expect(processEmitter.listenerCount("error")).toBe(0);
     });
 
     test("should include command, stderr, and missing output path for opaque post-processing failures", function () {

--- a/test/features/video/HybridVideoCaptureBackend.test.ts
+++ b/test/features/video/HybridVideoCaptureBackend.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { HybridVideoCaptureBackend } from "../../../src/features/video/HybridVideoCaptureBackend";
-import type {
-  RecordingHandle,
-  RecordingResult,
-  VideoCaptureBackend,
-  VideoCaptureConfig,
+import {
+  VideoCaptureStartCleanupError,
+  type RecordingHandle,
+  type RecordingResult,
+  type VideoCaptureBackend,
+  type VideoCaptureConfig,
 } from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
 
@@ -12,6 +13,7 @@ class FakeBackend implements VideoCaptureBackend {
   readonly name: string;
   startCalls: VideoCaptureConfig[] = [];
   stopCalls: RecordingHandle[] = [];
+  forceStopCalls: RecordingHandle[] = [];
   constructor(name: string) {
     this.name = name;
   }
@@ -36,6 +38,10 @@ class FakeBackend implements VideoCaptureBackend {
       sizeBytes: 123,
       codec: "h264",
     };
+  }
+
+  async forceStop(handle: RecordingHandle): Promise<void> {
+    this.forceStopCalls.push(handle);
   }
 }
 
@@ -200,6 +206,31 @@ describe("HybridVideoCaptureBackend - Unit Tests", function () {
         backendHandle: { kind: "not-hybrid" } as never,
       }),
     ).rejects.toThrow("Missing backend handle for hybrid");
+  });
+
+  test("wraps a failed-start cleanup handle so force-stop reaches its backend", async function () {
+    const rawHandle: RecordingHandle = {
+      recordingId: baseConfig.recordingId,
+      outputPath: baseConfig.outputPath,
+      startedAt: baseConfig.startedAt,
+      backendHandle: { backend: "platform" },
+    };
+    platformBackend.start = async () => {
+      throw new VideoCaptureStartCleanupError("cleanup timed out", rawHandle);
+    };
+
+    let cleanupError: VideoCaptureStartCleanupError | undefined;
+    try {
+      await backend.start(baseConfig);
+    } catch (error) {
+      if (error instanceof VideoCaptureStartCleanupError) {
+        cleanupError = error;
+      }
+    }
+
+    expect(cleanupError).toBeDefined();
+    await backend.forceStop(cleanupError!.handle);
+    expect(platformBackend.forceStopCalls).toEqual([rawHandle]);
   });
 
   test("routes iOS recording to ffmpeg backend", async function () {

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -865,6 +865,20 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(harness.helper.stopped).toBe(1);
   });
 
+  test("start force-stops an encoder spawned while cancelled helper shutdown settles", async function () {
+    const controller = new AbortController();
+    const harness = makeHarness();
+    harness.helper.on("started", () => controller.abort());
+    harness.helper.onStop = () => harness.helper.emitFrame(4, 2);
+
+    await expect(
+      harness.backend.start(makeConfig({ abortSignal: controller.signal })),
+    ).rejects.toThrow("cancelled during shutdown");
+
+    expect(harness.ffmpeg.processes).toHaveLength(1);
+    expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
   test("start rejects on a non-macOS host before spawning anything", async function () {
     const harness = makeHarness({ platform: "linux" });
 

--- a/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
+++ b/test/features/video/IosPhysicalVideoCaptureBackend.test.ts
@@ -18,6 +18,7 @@ import type { VideoCaptureConfig } from "../../../src/features/video/VideoRecord
 import type { DecodedFrame } from "../../../src/features/screen-stream/frameProtocol";
 import type {
   FfmpegClient,
+  FfmpegProbeRequest,
   FfmpegProbeResult,
   FfmpegProcess,
   FfmpegStartRequest,
@@ -25,6 +26,8 @@ import type {
 } from "../../../src/utils/media/FfmpegClient";
 import { trackProcess } from "../../../src/utils/ChildProcessTracker";
 import type { BootedDevice } from "../../../src/models";
+import type { Timer } from "../../../src/utils/SystemTimer";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 const PHYSICAL_UDID = "00008030-001C2D3E1234567A";
 
@@ -96,6 +99,7 @@ class FakeFfmpegClient implements FfmpegClient {
   readonly startRequests: FfmpegStartRequest[] = [];
   readonly processes: FakeFfmpegProcess[] = [];
   probeError: Error | null = null;
+  probeRequest?: FfmpegProbeRequest;
   encoders: string[] = [VIDEOTOOLBOX_H264_ENCODER, SOFTWARE_H264_ENCODER];
 
   start(request: FfmpegStartRequest): FfmpegStartedProcess {
@@ -110,7 +114,8 @@ class FakeFfmpegClient implements FfmpegClient {
     throw new Error("run() is not used by the physical iOS backend");
   }
 
-  async probe(): Promise<FfmpegProbeResult> {
+  async probe(request?: FfmpegProbeRequest): Promise<FfmpegProbeResult> {
+    this.probeRequest = request;
     if (this.probeError) {
       throw this.probeError;
     }
@@ -222,6 +227,7 @@ function makeHarness(
     platform?: NodeJS.Platform;
     sizeBytes?: number;
     now?: () => number;
+    timer?: Timer;
   } = {},
 ): Harness {
   const ffmpeg = new FakeFfmpegClient();
@@ -245,6 +251,7 @@ function makeHarness(
     platformProvider: () => options.platform ?? "darwin",
     fileSize: async () => options.sizeBytes ?? 4096,
     now: options.now,
+    timer: options.timer,
   });
 
   return { backend, ffmpeg, helper, lister, helperOptions };
@@ -799,6 +806,28 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     expect(harness.helper.started).toBe(0);
   });
 
+  test("abort cancels a pending ffmpeg prerequisite probe", async function () {
+    const harness = makeHarness();
+    const controller = new AbortController();
+    let markProbeStarted: (() => void) | undefined;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    harness.ffmpeg.probe = async (request) => {
+      harness.ffmpeg.probeRequest = request;
+      markProbeStarted?.();
+      return await new Promise<FfmpegProbeResult>(() => {});
+    };
+
+    const starting = harness.backend.start(makeConfig({ abortSignal: controller.signal }));
+    await probeStarted;
+    controller.abort();
+
+    await expect(starting).rejects.toThrow("cancelled during shutdown");
+    expect(harness.ffmpeg.probeRequest?.signal).toBe(controller.signal);
+    expect(harness.helper.started).toBe(0);
+  });
+
   test("start cleans up an encoder spawned before helper.start() rejected", async function () {
     const ffmpeg = new FakeFfmpegClient();
     const helper = new FakeCaptureHelper();
@@ -940,6 +969,22 @@ describe("IosPhysicalVideoCaptureBackend - Unit Tests", function () {
     await expect(harness.backend.forceStop(handle)).rejects.toThrow("helper shutdown failed");
 
     expect(harness.ffmpeg.processes[0].killSignals).toEqual(["SIGKILL"]);
+  });
+
+  test("forceStop fails boundedly when the encoder cannot be reaped", async function () {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const harness = makeHarness({ timer });
+    const handle = await harness.backend.start(makeConfig());
+    harness.helper.emitFrame(2, 2);
+    const encoder = harness.ffmpeg.processes[0];
+    encoder.kill = (signal?: NodeJS.Signals | number) => {
+      encoder.killSignals.push(signal);
+      return true;
+    };
+
+    await expect(harness.backend.forceStop(handle)).rejects.toThrow("Process did not exit");
+    expect(encoder.killSignals).toEqual(["SIGKILL", "SIGKILL"]);
   });
 
   test("stop rejects a recording the capture helper aborted mid-stream", async function () {

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -107,6 +107,34 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
     ).rejects.toThrow(/FfmpegVideoProcessingBackend/);
   });
 
+  test("passes startup cancellation through Android adb path resolution and spawn", async () => {
+    const fakeFactory = new FakeAdbClientFactory();
+    const backend = new PlatformVideoCaptureBackend(fakeFactory);
+    const controller = new AbortController();
+
+    await backend.start({
+      recordingId: "recording",
+      outputDirectory: tempDir,
+      outputPath: path.join(tempDir, "video.mp4"),
+      fileName: "video.mp4",
+      startedAt: new Date().toISOString(),
+      qualityPreset: "low",
+      targetBitrateKbps: 1000,
+      maxThroughputMbps: 5,
+      fps: 15,
+      maxArchiveSizeMb: 2048,
+      format: "mp4",
+      device: {
+        platform: "android",
+        deviceId: "android-emulator",
+        name: "Android Emulator",
+      },
+      abortSignal: controller.signal,
+    });
+
+    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBe(controller.signal);
+  });
+
   describe("Stop Operation", () => {
     test("rejects stop when backend handle is missing", async () => {
       const invalidHandle: RecordingHandle = {
@@ -135,6 +163,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
     function buildAndroidStopHandle(
       outputPath: string,
       fakeProcess: FakeChildProcess,
+      exitPromise: Promise<void> = Promise.resolve(),
     ): RecordingHandle {
       const androidHandle = {
         kind: "android" as const,
@@ -145,7 +174,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
           signal: fakeProcess.signalCode,
           endedAt: new Date().toISOString(),
         },
-        exitPromise: Promise.resolve(),
+        exitPromise,
         stderr: [] as string[],
         device: {
           platform: "android",
@@ -185,7 +214,23 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       expect(fakeFactory.getFakeClient().wasCommandExecuted("shell pkill -9 screenrecord")).toBe(
         true,
       );
+      expect(
+        fakeFactory.getFakeClient().wasCommandExecuted("shell rm -f /sdcard/auto-mobile-test.mp4"),
+      ).toBe(true);
       expect(signals).toContain("SIGKILL");
+    });
+
+    test("forceStop surfaces device temp-file cleanup failures", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      fakeFactory
+        .getFakeClient()
+        .setCommandError("shell rm -f /sdcard/auto-mobile-test.mp4", new Error("device offline"));
+      const fakeProcess = new FakeChildProcess();
+      const backend = new PlatformVideoCaptureBackend(fakeFactory);
+
+      await expect(
+        backend.forceStop(buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess)),
+      ).rejects.toThrow("device temp-file cleanup failed: device offline");
     });
 
     test("forceStop kills host adb before a stalled device command can consume shutdown time", async () => {
@@ -208,10 +253,20 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       const fakeFactory = new FakeAdbClientFactory();
       const fakeProcess = new FakeChildProcess();
       fakeProcess.killed = true;
-      const backend = new PlatformVideoCaptureBackend(fakeFactory);
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
       const signals = spyOnKill(fakeProcess);
 
-      await backend.forceStop(buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess));
+      await expect(
+        backend.forceStop(
+          buildAndroidStopHandle(
+            path.join(tempDir, "out.mp4"),
+            fakeProcess,
+            new Promise<void>(() => {}),
+          ),
+        ),
+      ).rejects.toThrow("host adb process cleanup failed");
 
       expect(signals).toContain("SIGKILL");
     });

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -107,7 +107,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
     ).rejects.toThrow(/FfmpegVideoProcessingBackend/);
   });
 
-  test("passes startup cancellation through Android adb path resolution and spawn", async () => {
+  test("does not retain startup cancellation on an active Android capture", async () => {
     const fakeFactory = new FakeAdbClientFactory();
     const backend = new PlatformVideoCaptureBackend(fakeFactory);
     const controller = new AbortController();
@@ -132,7 +132,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       abortSignal: controller.signal,
     });
 
-    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBe(controller.signal);
+    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBeUndefined();
   });
 
   describe("Stop Operation", () => {

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -5,6 +5,7 @@ import { promises as fsPromises } from "node:fs";
 import { pathExists } from "../../../src/utils/filesystem/DefaultFileSystem";
 import {
   VideoRecorderService,
+  VideoCaptureStartCleanupError,
   parseVideoRecordingConfig,
   DEFAULT_VIDEO_RECORDING_CONFIG,
 } from "../../../src/features/video/VideoRecorderService";
@@ -138,6 +139,24 @@ describe("VideoRecorderService", () => {
     await expect(service.stopRecording(recording.recordingId)).rejects.toThrow(
       "No active recording found",
     );
+  });
+
+  test("retains a failed-start cleanup handle for a force-stop retry", async () => {
+    const retainedHandle = {
+      recordingId: "rec-1",
+      outputPath: path.join(archiveRoot, "rec-1", "capture.mp4"),
+      startedAt: "2024-01-15T10:30:00.000Z",
+    };
+    backend.start = async () => {
+      throw new VideoCaptureStartCleanupError("startup cleanup timed out", retainedHandle);
+    };
+
+    await expect(service.startRecording()).rejects.toThrow("startup cleanup timed out");
+
+    expect(service.listActiveRecordingIds()).toEqual(["rec-1"]);
+    await service.forceStopRecording("rec-1");
+    expect(backend.forceStopCalls).toEqual([retainedHandle]);
+    expect(service.listActiveRecordingIds()).toEqual([]);
   });
 
   test("allows a later graceful stop after a force-stop failure", async () => {

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -141,7 +141,7 @@ describe("VideoRecorderService", () => {
     );
   });
 
-  test("retains a failed-start cleanup handle for a force-stop retry", async () => {
+  test("force-stops a failed-start cleanup handle before rethrowing", async () => {
     const retainedHandle = {
       recordingId: "rec-1",
       outputPath: path.join(archiveRoot, "rec-1", "capture.mp4"),
@@ -153,8 +153,6 @@ describe("VideoRecorderService", () => {
 
     await expect(service.startRecording()).rejects.toThrow("startup cleanup timed out");
 
-    expect(service.listActiveRecordingIds()).toEqual(["rec-1"]);
-    await service.forceStopRecording("rec-1");
     expect(backend.forceStopCalls).toEqual([retainedHandle]);
     expect(service.listActiveRecordingIds()).toEqual([]);
   });

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -299,6 +299,17 @@ describe("VideoRecorderService", () => {
       expect(await pathExists(dir)).toBe(true);
     });
 
+    test("removes partial output when startup rejects without a cleanup handle", async () => {
+      backend.start = async (config) => {
+        await fsPromises.writeFile(config.outputPath, "partial video");
+        throw new Error("capture startup aborted");
+      };
+
+      await expect(service.startRecording()).rejects.toThrow("capture startup aborted");
+
+      expect(await pathExists(path.join(archiveRoot, "rec-1"))).toBe(false);
+    });
+
     test("passes outputName through", async () => {
       const result = await service.startRecording({ outputName: "my-video" });
       expect(result.outputName).toBe("my-video");

--- a/test/scripts/ffmpegInstallHoist.test.ts
+++ b/test/scripts/ffmpegInstallHoist.test.ts
@@ -80,4 +80,15 @@ describe("#4124 ffmpeg install hoist", () => {
     expect(videoStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(enabledTools);
     expect(navigationStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(enabledTools);
   });
+
+  test("the stable daemon starts with the integration database override", () => {
+    const databaseStep = stepNamed(steps, "Prepare isolated video recording database");
+    const databaseIndex = indexOfNamed(steps, "Prepare isolated video recording database");
+    const daemonIndex = indexOfNamed(steps, "Ensure AutoMobile daemon ready (Xcode 26.5)");
+
+    expect(databaseStep?.run).toContain("AUTOMOBILE_DB_DIR=");
+    expect(databaseStep?.run).toContain("GITHUB_ENV");
+    expect(databaseIndex).toBeGreaterThanOrEqual(0);
+    expect(databaseIndex).toBeLessThan(daemonIndex);
+  });
 });

--- a/test/scripts/ffmpegInstallHoist.test.ts
+++ b/test/scripts/ffmpegInstallHoist.test.ts
@@ -70,15 +70,14 @@ describe("#4124 ffmpeg install hoist", () => {
     expect(videoStep?.run).toContain("video-recording-start-stop-integration.sh");
   });
 
-  test("advanced iOS integrations opt in without widening the default tool surface", () => {
+  test("advanced iOS integrations reuse one stable daemon tool profile", () => {
     const videoStep = stepNamed(steps, "Run videoRecording MP4 integration test");
     const daemonStep = stepNamed(steps, "Ensure AutoMobile daemon ready (Xcode 26.5)");
     const navigationStep = stepNamed(steps, "Run iOS navigation graph Simulator workflow");
+    const enabledTools = "videoRecording,navigateTo,getNavigationGraph,explore";
 
-    expect(videoStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe("videoRecording");
-    expect(daemonStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe("navigateTo,getNavigationGraph,explore");
-    expect(navigationStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(
-      "navigateTo,getNavigationGraph,explore",
-    );
+    expect(daemonStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(enabledTools);
+    expect(videoStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(enabledTools);
+    expect(navigationStep?.env?.AUTOMOBILE_ENABLED_TOOLS).toBe(enabledTools);
   });
 });

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -203,6 +203,80 @@ describe("ToolRegistry device-aware pipeline", () => {
       (AndroidCtrlProxyClient as any).getInstance = originalGetInstance;
     }
   });
+
+  test("passes argument-selected readiness and the request signal into device resolution", async () => {
+    const registry = new ToolRegistryClass();
+    const controller = new AbortController();
+    const fakeManager = new FakeDeviceSessionManager();
+    fakeManager.setConnectedDevices([device]);
+    (registry as any).deviceSessionManager = fakeManager;
+    (registry as any).toolCallRepository = {
+      async recordToolCall(): Promise<void> {},
+    };
+
+    registry.registerDeviceAware(
+      "readinessProbe",
+      "Readiness probe",
+      z.object({ quick: z.boolean() }),
+      async () => ({ success: true }),
+      {
+        deviceReadiness: (args: { quick: boolean }) => (args.quick ? "booted" : "automationReady"),
+      },
+    );
+
+    const response = await registry
+      .getTool("readinessProbe")!
+      .handler({ platform: "android", quick: true }, undefined, controller.signal);
+
+    expect(response).toEqual({ success: true });
+    expect(fakeManager.getLastOptions()?.readiness).toBe("booted");
+    expect(fakeManager.getLastOptions()?.signal).toBe(controller.signal);
+  });
+
+  test("abort during target resolution prevents the device handler from starting", async () => {
+    const registry = new ToolRegistryClass();
+    const controller = new AbortController();
+    let markResolutionStarted: (() => void) | undefined;
+    const resolutionStarted = new Promise<void>((resolve) => {
+      markResolutionStarted = resolve;
+    });
+    let releaseResolution: (() => void) | undefined;
+    const resolutionGate = new Promise<void>((resolve) => {
+      releaseResolution = resolve;
+    });
+    let handlerCalls = 0;
+
+    const fakeManager = new FakeDeviceSessionManager();
+    fakeManager.setConnectedDevices([device]);
+    fakeManager.ensureDeviceReady = async () => {
+      markResolutionStarted?.();
+      await resolutionGate;
+      return device;
+    };
+    (registry as any).deviceSessionManager = fakeManager;
+    (registry as any).toolCallRepository = {
+      async recordToolCall(): Promise<void> {},
+    };
+    registry.registerDeviceAware(
+      "abortResolutionProbe",
+      "Abort resolution probe",
+      z.object({}),
+      async () => {
+        handlerCalls++;
+        return { success: true };
+      },
+    );
+
+    const call = registry
+      .getTool("abortResolutionProbe")!
+      .handler({ platform: "android" }, undefined, controller.signal);
+    await resolutionStarted;
+    controller.abort();
+    releaseResolution?.();
+
+    await expect(call).rejects.toThrow();
+    expect(handlerCalls).toBe(0);
+  });
 });
 
 describe("DefaultAfterToolCallHandler observation artifact config path", () => {

--- a/test/server/toolRegistry.postTimeoutLog.test.ts
+++ b/test/server/toolRegistry.postTimeoutLog.test.ts
@@ -18,18 +18,31 @@ describe("ToolRegistry post-timeout result logging", () => {
     ToolRegistry.clearTools();
   });
 
-  function registerProbe(): void {
+  function registerProbe(
+    handler = async (): Promise<{ success: boolean }> => ({ success: true }),
+  ): void {
     ToolRegistry.registerDeviceAware(
       "postTimeoutProbe",
       "Resolves with success regardless of caller state",
       z.object({}),
-      async () => ({ success: true }),
-      { shouldEnsureDevice: () => false, nonDeviceHandler: async () => ({ success: true }) },
+      handler,
+      { shouldEnsureDevice: () => false, nonDeviceHandler: handler },
     );
   }
 
   test("warns (not infos) when the caller's request already timed out", async () => {
-    registerProbe();
+    let resolveHandler: (() => void) | undefined;
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    registerProbe(async () => {
+      markHandlerStarted?.();
+      await new Promise<void>((resolve) => {
+        resolveHandler = resolve;
+      });
+      return { success: true };
+    });
     const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
 
@@ -37,7 +50,12 @@ describe("ToolRegistry post-timeout result logging", () => {
       const tool = ToolRegistry.getTool("postTimeoutProbe");
       expect(tool).toBeDefined();
 
-      const response = await tool!.handler({}, undefined, AbortSignal.abort());
+      const request = new AbortController();
+      const responsePromise = tool!.handler({}, undefined, request.signal);
+      await handlerStarted;
+      request.abort();
+      resolveHandler?.();
+      const response = await responsePromise;
 
       // The handler still returns its result (work already completed).
       expect(response).toEqual({ success: true });

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -205,6 +205,31 @@ describe("videoRecordingManager", () => {
     expect((await fakeRepository.getRecording(insertedRecordingId!))?.status).toBe("interrupted");
   });
 
+  test("keeps a recording discoverable when cancellation force-stop fails", async () => {
+    const controller = new AbortController();
+    const originalInsert = fakeRepository.insertRecording.bind(fakeRepository);
+    let insertedRecordingId: string | undefined;
+    fakeBackend.forceStop = async () => {
+      throw new Error("force stop failed");
+    };
+    fakeRepository.insertRecording = async (record) => {
+      insertedRecordingId = record.recordingId;
+      controller.abort(new Error("request cancelled"));
+      await originalInsert(record);
+    };
+
+    await expect(
+      startVideoRecording({
+        device: testDevice,
+        maxDurationSeconds: 3,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("request cancelled");
+
+    expect(insertedRecordingId).toBeDefined();
+    expect((await fakeRepository.getRecording(insertedRecordingId!))?.status).toBe("recording");
+  });
+
   test("rejects recording starts once shutdown begins", async () => {
     await stopAcceptingVideoRecordingStarts();
 

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -181,6 +181,30 @@ describe("videoRecordingManager", () => {
     expect(record?.durationMs).toBe(1000);
   });
 
+  test("cancellation after backend startup force-stops and interrupts the capture", async () => {
+    const controller = new AbortController();
+    const originalInsert = fakeRepository.insertRecording.bind(fakeRepository);
+    let insertedRecordingId: string | undefined;
+    fakeRepository.insertRecording = async (record) => {
+      insertedRecordingId = record.recordingId;
+      controller.abort(new Error("request cancelled"));
+      await originalInsert(record);
+    };
+
+    await expect(
+      startVideoRecording({
+        device: testDevice,
+        maxDurationSeconds: 3,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("request cancelled");
+
+    expect(fakeBackend.forceStopCalls).toHaveLength(1);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(insertedRecordingId).toBeDefined();
+    expect((await fakeRepository.getRecording(insertedRecordingId!))?.status).toBe("interrupted");
+  });
+
   test("rejects recording starts once shutdown begins", async () => {
     await stopAcceptingVideoRecordingStarts();
 

--- a/test/server/videoRecordingReadiness.test.ts
+++ b/test/server/videoRecordingReadiness.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  registerVideoRecordingTools,
+  type VideoRecordingArgs,
+} from "../../src/server/videoRecordingTools";
+
+test("video recording requires CtrlProxy only when startup highlights need it", () => {
+  const registry = ToolRegistry as any;
+  const originalRegister = registry.registerDeviceAware;
+  let readiness: ((args: VideoRecordingArgs) => string) | undefined;
+
+  registry.registerDeviceAware = (...args: any[]) => {
+    readiness = args[4]?.deviceReadiness;
+  };
+
+  try {
+    registerVideoRecordingTools();
+  } finally {
+    registry.registerDeviceAware = originalRegister;
+  }
+
+  expect(readiness).toBeDefined();
+  expect(readiness!({ action: "start", platform: "ios" })).toBe("booted");
+  expect(
+    readiness!({
+      action: "start",
+      platform: "ios",
+      highlights: [{ description: "Tap target" }],
+    }),
+  ).toBe("automationReady");
+  expect(readiness!({ action: "stop", platform: "ios", recordingId: "recording-1" })).toBe(
+    "automationReady",
+  );
+});

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -296,6 +296,7 @@ describe("videoRecording tool segmentation branch", () => {
       resolveStart = resolve;
     });
     let receivedSignal: AbortSignal | undefined;
+    const forceStopped: string[] = [];
     setSegmentedSessionRecordingDependencies({
       startVideoRecording: async (request) => {
         receivedSignal = request.abortSignal;
@@ -304,10 +305,10 @@ describe("videoRecording tool segmentation branch", () => {
       stopVideoRecording: async (recordingId) => {
         const id = recordingId ?? "segment-0";
         segmentStops.push(id);
-        return {
-          metadata: makeSegmentMetadata(id),
-          evictedRecordingIds: [],
-        };
+        throw new Error(`graceful stop failed for ${id}`);
+      },
+      forceStopVideoRecording: async (recordingId) => {
+        forceStopped.push(recordingId);
       },
     });
 
@@ -331,6 +332,7 @@ describe("videoRecording tool segmentation branch", () => {
     await expect(starting).rejects.toThrow("request cancelled");
     expect(receivedSignal).toBe(controller.signal);
     expect(segmentStops).toEqual(["cancelled"]);
+    expect(forceStopped).toEqual(["cancelled"]);
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
   });
 

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -289,6 +289,51 @@ describe("videoRecording tool segmentation branch", () => {
     );
   });
 
+  test("cancellation reaches initial segmented startup and finalizes a raced successful start", async () => {
+    const controller = new AbortController();
+    let resolveStart!: (recording: ActiveVideoRecording) => void;
+    const startMayComplete = new Promise<ActiveVideoRecording>((resolve) => {
+      resolveStart = resolve;
+    });
+    let receivedSignal: AbortSignal | undefined;
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async (request) => {
+        receivedSignal = request.abortSignal;
+        return await startMayComplete;
+      },
+      stopVideoRecording: async (recordingId) => {
+        const id = recordingId ?? "segment-0";
+        segmentStops.push(id);
+        return {
+          metadata: makeSegmentMetadata(id),
+          evictedRecordingIds: [],
+        };
+      },
+    });
+
+    const starting = handler()(
+      androidDevice,
+      {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        maxDuration: 300,
+        outputName: "cancelled",
+      },
+      undefined,
+      controller.signal,
+    );
+    await waitFor(() => receivedSignal !== undefined, "segmented start to receive abort signal");
+
+    controller.abort(new Error("request cancelled"));
+    resolveStart(makeSegmentRecording("cancelled", "cancelled"));
+
+    await expect(starting).rejects.toThrow("request cancelled");
+    expect(receivedSignal).toBe(controller.signal);
+    expect(segmentStops).toEqual(["cancelled"]);
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+  });
+
   test("bare (by-device) stop finalizes the segmented session and leaves no rotation timer", async () => {
     setSegmentedSessionRecordingDependencies({
       startVideoRecording: async (request) => {

--- a/test/utils/ChildProcessTracker.test.ts
+++ b/test/utils/ChildProcessTracker.test.ts
@@ -67,6 +67,25 @@ describe("ChildProcessTracker", () => {
       expect(exitState.exitCode).toBe(0);
       expect(exitState.signal).toBeNull();
     });
+
+    test("keeps tracking an aborted spawned child until its exit event", async () => {
+      const process = new EventEmitter() as TrackedChildProcess;
+      process.pid = 123;
+      process.exitCode = null;
+      process.signalCode = null;
+      process.killed = true;
+      process.stderr = null;
+      process.kill = () => true;
+
+      const { exitState, exitPromise } = createExitTracker(process, []);
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      process.emit("error", abortError);
+      process.emit("exit", null, "SIGTERM");
+
+      await expect(exitPromise).resolves.toBeUndefined();
+      expect(exitState.signal).toBe("SIGTERM");
+    });
   });
 
   describe("waitForExit", () => {
@@ -134,10 +153,11 @@ describe("ChildProcessTracker", () => {
 
       // Regression (#3617): the timer must be cleared despite the reject path...
       expect(timer.getPendingTimeoutCount()).toBe(0);
+      expect(process.signals).toEqual(["SIGINT", "SIGKILL"]);
 
       // ...so advancing past the timeout fires no stray SIGKILL.
       timer.advanceTime(5000);
-      expect(process.signals).toEqual(["SIGINT"]);
+      expect(process.signals).toEqual(["SIGINT", "SIGKILL"]);
     });
   });
 
@@ -181,6 +201,15 @@ describe("ChildProcessTracker", () => {
   });
 
   describe("waitForSpawn", () => {
+    test("resolves when the child already has a pid before listeners attach", async () => {
+      const process = new EventEmitter() as EventEmitter & { pid?: number };
+      process.pid = 123;
+
+      await expect(waitForSpawn(process)).resolves.toBeUndefined();
+      expect(process.listenerCount("spawn")).toBe(0);
+      expect(process.listenerCount("error")).toBe(0);
+    });
+
     test("resolves when the process emits spawn", async () => {
       const process = new EventEmitter();
       const spawnPromise = waitForSpawn(process);
@@ -224,6 +253,31 @@ describe("ChildProcessTracker", () => {
       expect(stderr).toEqual(["boom ", "second"]);
     });
 
+    test("keeps collecting stderr after exit until the child close event", async () => {
+      const process = new EventEmitter() as TrackedChildProcess;
+      process.exitCode = null;
+      process.signalCode = null;
+      process.killed = false;
+      const stderrEmitter = new EventEmitter();
+      process.stderr = stderrEmitter as unknown as TrackedChildProcess["stderr"];
+      process.kill = () => true;
+
+      const stderr: string[] = [];
+      const { exitPromise } = createExitTracker(process, stderr);
+
+      process.emit("exit", 1, null);
+      await exitPromise;
+      stderrEmitter.emit("data", "late diagnostic");
+
+      expect(stderr).toEqual(["late diagnostic"]);
+      expect(stderrEmitter.listenerCount("data")).toBe(1);
+
+      process.emit("close");
+      stderrEmitter.emit("data", "discarded after close");
+      expect(stderr).toEqual(["late diagnostic"]);
+      expect(stderrEmitter.listenerCount("data")).toBe(0);
+    });
+
     test("attributes the terminating signal when the process has already exited", async () => {
       const process = new EventEmitter() as TrackedChildProcess;
       process.exitCode = 137;
@@ -243,17 +297,45 @@ describe("ChildProcessTracker", () => {
   });
 
   describe("waitForExit killed-but-unreaped guard", () => {
-    test("does not re-signal a process that was already killed but not yet reaped", async () => {
+    test("escalates an already-killed process that remains unreaped", async () => {
       const timer = new FakeTimer();
-      const process = new FakeStoppableProcess();
+      const process = new FakeStoppableProcess("SIGKILL");
       process.killed = true;
       process.exitCode = null;
 
-      // A second stop on an already-killed process must await the existing exit,
-      // not send another signal that would truncate the iOS simctl moov atom.
-      await waitForExit(process, Promise.resolve(), { timer });
+      const wait = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 123,
+        timer,
+      });
 
       expect(process.signals).toEqual([]);
+      expect(timer.getPendingTimeouts()).toEqual([123]);
+
+      timer.advanceTime(123);
+      await wait;
+
+      expect(process.signals).toEqual(["SIGKILL"]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("bounds the final reap when SIGKILL does not terminate the process", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess();
+      const wait = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 100,
+        forceKillTimeoutMs: 50,
+        timer,
+      });
+
+      timer.advanceTime(100);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(process.signals).toEqual(["SIGINT", "SIGKILL"]);
+      expect(timer.getPendingTimeouts()).toEqual([50]);
+
+      timer.advanceTime(50);
+      await expect(wait).rejects.toThrow("did not exit");
       expect(timer.getPendingTimeoutCount()).toBe(0);
     });
   });

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -211,6 +211,24 @@ describe("DeviceSessionManager", () => {
     expect(fakeWindow.wasMethodCalled("getActive")).toBe(true);
   });
 
+  test("booted Android readiness bypasses stale active-window cache", async () => {
+    fakeWindow.configureCachedActiveWindow({
+      appId: "com.example.previous",
+      activityName: "PreviousActivity",
+      layoutSeqSum: 0,
+    });
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
+
+    await expect(
+      manager.verifyAndroidDevice(device.deviceId, { readiness: "booted" }),
+    ).resolves.toBeUndefined();
+
+    expect(fakeWindow.getGetActiveForceRefreshes()).toEqual([true]);
+  });
+
   test("booted Android readiness rejects a device whose UI has not finished booting", async () => {
     const notReadyWindow = new FakeWindow();
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -198,6 +198,31 @@ describe("DeviceSessionManager", () => {
     expect(accessibilityManager.wasMethodCalled("setup")).toBe(true);
   });
 
+  test("booted Android readiness verifies the active window without initializing CtrlProxy", async () => {
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
+
+    await expect(
+      manager.verifyAndroidDevice(device.deviceId, { readiness: "booted" }),
+    ).resolves.toBeUndefined();
+
+    expect(fakeWindow.wasMethodCalled("getActive")).toBe(true);
+  });
+
+  test("booted Android readiness rejects a device whose UI has not finished booting", async () => {
+    const notReadyWindow = new FakeWindow();
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: notReadyWindow,
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
+
+    await expect(
+      manager.verifyAndroidDevice(device.deviceId, { readiness: "booted" }),
+    ).rejects.toThrow("Failed to verify Android device device-1 readiness");
+  });
+
   test("should skip setup when accessibility is already enabled and WebSocket connects", async () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(true);
@@ -1048,6 +1073,23 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     // The device should still be set (not cleared by a failed iOS verification)
     expect(manager.getCurrentPlatform()).toBe("android");
     expect(manager.getCurrentDevice()?.deviceId).toBe("emulator-5554");
+  });
+
+  test("request cancellation preserves the current device selection", async () => {
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
+    const controller = new AbortController();
+    manager.setCurrentDevice(androidDevice, "android");
+    controller.abort(new Error("request cancelled"));
+
+    await expect(
+      manager.ensureDeviceReady("either", undefined, {
+        readiness: "booted",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("request cancelled");
+
+    expect(manager.getCurrentPlatform()).toBe("android");
+    expect(manager.getCurrentDevice()?.deviceId).toBe(androidDevice.deviceId);
   });
 
   test("reserves the current simulator through readiness verification", async () => {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -361,6 +361,22 @@ describe("DeviceSessionManager iOS push-update cache invalidation", () => {
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
 
+  test("booted readiness does not initialize iOS CtrlProxy collaborators", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-booted-only", {
+      udid: "ios-booted-only",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any);
+    const manager = DeviceSessionManager.createInstance(provider);
+
+    await expect(
+      manager.verifyIosDevice("ios-booted-only", { readiness: "booted" }),
+    ).resolves.toBeUndefined();
+  });
+
   test("push update fires clearForDevice on the injected ObserveScreenCache", async () => {
     const fakeSimctl = new FakeSimCtlClient();
     fakeSimctl.setDeviceInfo("ios-push-1", {

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -133,9 +133,11 @@ describe("Simctl", function () {
       };
       simctl = new Simctl(null, mockExecAsync, timer);
 
-      const availability = simctl.isAvailable();
+      const caller = new AbortController();
+      const availability = simctl.isAvailable({ timeoutMs: 123, signal: caller.signal });
       expect(probeSignal?.aborted).toBe(false);
-      timer.advanceTime(10_000);
+      expect(timer.getPendingTimeouts()).toEqual([123]);
+      timer.advanceTime(123);
 
       await expect(availability).resolves.toBe(false);
       expect(probeSignal?.aborted).toBe(true);

--- a/test/utils/media/FfmpegClient.test.ts
+++ b/test/utils/media/FfmpegClient.test.ts
@@ -6,6 +6,7 @@ import {
   resolveFfmpegBinary,
   type FfmpegProcess,
 } from "../../../src/utils/media/FfmpegClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 class FakeFfmpegProcess extends EventEmitter implements FfmpegProcess {
   readonly stdin = new PassThrough();
@@ -26,6 +27,7 @@ class FakeFfmpegProcess extends EventEmitter implements FfmpegProcess {
     this.exitCode = code;
     this.signalCode = signal;
     this.emit("exit", code, signal);
+    this.emit("close");
   }
 }
 
@@ -94,6 +96,44 @@ describe("FfmpegClient", () => {
       version: "7.1",
       encoders: ["h264_videotoolbox"],
     });
+  });
+
+  test("shares one timeout budget across both prerequisite probe commands", async () => {
+    const timer = new FakeTimer();
+    const versionProcess = new FakeFfmpegProcess();
+    const encodersProcess = new FakeFfmpegProcess();
+    encodersProcess.kill = (signal?: NodeJS.Signals | number): boolean => {
+      encodersProcess.killSignals.push(signal);
+      encodersProcess.killed = true;
+      queueMicrotask(() => encodersProcess.exit(0, signal as NodeJS.Signals));
+      return true;
+    };
+    const processes = [versionProcess, encodersProcess];
+    const client = new DefaultFfmpegClient({
+      timer,
+      spawn: () => {
+        const process = processes.shift();
+        if (!process) {
+          throw new Error("unexpected spawn");
+        }
+        return process;
+      },
+    });
+
+    const probing = client.probe({ timeoutMs: 100 });
+    timer.setTimeout(() => {
+      versionProcess.stdout.write("ffmpeg version 7.1\n");
+      versionProcess.exit();
+    }, 80);
+    timer.advanceTime(80);
+    for (let attempt = 0; attempt < 20 && processes.length > 0; attempt++) {
+      await Promise.resolve();
+    }
+
+    expect(timer.getPendingTimeouts()).toContain(20);
+    timer.advanceTime(20);
+    await expect(probing).rejects.toThrow("FFmpeg encoder probe failed");
+    expect(encodersProcess.killSignals).toEqual(["SIGKILL"]);
   });
 
   test("reports non-zero exits with the command context and stderr", async () => {


### PR DESCRIPTION
## Summary

- Keep the existing 90-second transport compatibility floor instead of masking startup stalls.
- Add explicit `booted` versus `automationReady` device readiness, so no-highlight recording starts never provision CtrlProxy.
- Preserve request cancellation through MCP dispatch and device resolution.
- Keep the XCTestRunner daemon on one stable union of enabled tools across warm-up, video, and navigation integration steps.

## Root cause

The timed-out request was not spending its time starting `simctl recordVideo`; device-aware dispatch was first provisioning CtrlProxy, which video recording does not need unless highlight overlays are requested. The transport timeout also did not reach the startup chain, so a timed-out caller could leave work continuing in the daemon. CI then changed the enabled-tool profile between warm-up and the integration call, replacing the warmed daemon.

## Validation

- 128 focused readiness, cancellation, timeout, and dispatch tests pass.
- `bun run typecheck` passes with no new errors.
- `bun run build` passes.
- Full formatting/lint validation is currently blocked by defects already present on `origin/main`: unformatted `src/daemon/manager.ts` and `src/features/observe/output/ObserveResultOutput.ts`, plus the latter's unused `_diagnostics` lint error.
- Three unrelated observe projection/schema tests also fail identically on `origin/main`; all changed video suites pass.

Closes https://github.com/kaeawc/auto-mobile/issues/5921
