### PR TITLE
fix(observe): restore Android activity matching for View roots

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2787,6 +2787,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val pkg = rootPackage
       val className = windowClass
       if (pkg != null && className != null) {
+        if (isFrameworkViewClass(className)) {
+          // Accessibility reports the root View class for many app windows,
+          // which is not the resumed Activity and must not shadow the ADB
+          // fallback on the host.
+          return null
+        }
         // Use short class name format if it starts with the package
         val shortName =
           if (className.startsWith(pkg)) {
@@ -2805,6 +2811,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       null
     }
   }
+
+  private fun isFrameworkViewClass(className: String): Boolean =
+    className.startsWith("android.widget.") ||
+      className.startsWith("android.view.") ||
+      className.endsWith("DecorView")
 
   /** Get display density in DPI. */
   private fun getDensity(): Int {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -90,6 +90,15 @@ function boundCachedLayoutWarnings(result: ObserveResult | undefined): ObserveRe
  */
 const SYSTEM_UI_WINDOW_PACKAGES = new Set<string>(["com.android.systemui"]);
 
+function isAccessibilityViewClass(foregroundActivity: string): boolean {
+  const activityName = foregroundActivity.split("/")[1] ?? "";
+  return (
+    activityName.startsWith("android.widget.") ||
+    activityName.startsWith("android.view.") ||
+    activityName.endsWith("DecorView")
+  );
+}
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -607,7 +616,10 @@ export class RealObserveScreen implements ObserveScreen {
           if (hierarchy.insets) {
             result.insets = hierarchy.insets;
           }
-          if (hierarchy.foregroundActivity) {
+          if (
+            hierarchy.foregroundActivity &&
+            !isAccessibilityViewClass(hierarchy.foregroundActivity)
+          ) {
             const parts = hierarchy.foregroundActivity.split("/");
             const packageName = parts[0];
             const activityName = parts[1]?.startsWith(".")
@@ -667,20 +679,21 @@ export class RealObserveScreen implements ObserveScreen {
           await Promise.all(tasks);
         }
 
-        // Populate activeWindow from view hierarchy packageName if not already set.
+        // CtrlProxy is installed lazily. Preserve active-window attribution for
+        // that bootstrap interval only; once CtrlProxy supplied an app/activity
+        // or hierarchy package, never make the legacy Window query.
+        if (!result.activeWindow) {
+          await this.deviceStateCollector.collectActiveWindow(result);
+        }
+
+        // Preserve package attribution when the accessibility service did not
+        // provide a usable activity and the legacy window query also failed.
         if (result.viewHierarchy?.packageName && !result.activeWindow) {
           result.activeWindow = {
             appId: result.viewHierarchy.packageName,
             activityName: "",
             layoutSeqSum: 0,
           };
-        }
-
-        // CtrlProxy is installed lazily. Preserve active-window attribution for
-        // that bootstrap interval only; once CtrlProxy supplied an app/activity
-        // or hierarchy package, never make the legacy Window query.
-        if (!result.activeWindow) {
-          await this.deviceStateCollector.collectActiveWindow(result);
         }
 
         if (result.notificationPermissionDetected && result.activeWindow) {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -59,6 +59,64 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     resetObserveCacheStore();
   });
 
+  test("falls back when accessibility foreground metadata is a View class", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.example.app",
+      foregroundActivity: "com.example.app/android.widget.FrameLayout",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+    const fallbackWindow = {
+      getActive: async () => ({
+        appId: "com.example.app",
+        activityName: "com.example.app.MainActivity",
+        layoutSeqSum: 0,
+      }),
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    };
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: fallbackWindow,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow).toEqual({
+      appId: "com.example.app",
+      activityName: "com.example.app.MainActivity",
+      layoutSeqSum: 0,
+    });
+  });
+
   test("retracts freshness when the observed window is not the top resumed activity", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();


### PR DESCRIPTION
## Summary

- Ignore accessibility window-root View classes when deriving Android foreground activity metadata.
- Allow the existing ADB active-window fallback to provide the resumed Activity, preserving package-only attribution only when no fallback is available.
- Add regression coverage for `android.widget.FrameLayout` root metadata.

## Root cause

CtrlProxy used the accessibility window root's class name as the activity name. Most Android app roots are Views such as `android.widget.FrameLayout`, so `observe.waitFor.activeWindow.activityName` compared against the wrong value and timed out.

Closes [#5931](https://github.com/kaeawc/auto-mobile/issues/5931).

## Validation

- `bun test test/features/observe/ObserveScreenWindowIdentity.test.ts`
- `bun test test/features/observe`
- `bun run format:check`
- `bun run build`
- `bun run typecheck`
- `bun run lint`

Android Gradle tests were attempted but are blocked by the local Gradle/JDK setup: the selected cached JDK 21 rejects `--sun-misc-unsafe-memory-access=allow`.
