### PR TITLE
fix(inputText): surface selector target and failures

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -48,7 +48,12 @@ export interface TextInputTargetFocuser {
   focus(
     selector: TextInputTargetSelector,
     signal?: AbortSignal,
-  ): Promise<{ success: boolean; error?: string }>;
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    matchedId?: string;
+    matchedText?: string;
+  }>;
 }
 
 type TextInputTargetFocuserFactory = (device: BootedDevice) => TextInputTargetFocuser;
@@ -60,7 +65,12 @@ const defaultTargetFocuserFactory: TextInputTargetFocuserFactory = (device) => (
       undefined,
       signal,
     );
-    return { success: result.success, error: result.error };
+    return {
+      success: result.success,
+      error: result.error,
+      matchedId: result.selectedElement?.resourceId,
+      matchedText: result.selectedElement?.text,
+    };
   },
 });
 
@@ -145,6 +155,7 @@ export class InputText extends BaseVisualChange {
     // Focus before the observedInteraction captures its baseline, so the "before"
     // snapshot already reflects the focused field. A focus failure short-circuits —
     // typing into an unknown field would be worse than reporting the miss.
+    let targetMetadata: Pick<SendTextResult, "matchedId" | "matchedText"> = {};
     if (selector) {
       assertInputNotAborted(signal);
       const focusResult = await this.targetFocuser.focus(selector, signal);
@@ -157,6 +168,10 @@ export class InputText extends BaseVisualChange {
           method: this.device.platform === "android" ? resolvedMode : "a11y",
         };
       }
+      targetMetadata = {
+        matchedId: focusResult.matchedId,
+        matchedText: focusResult.matchedText,
+      };
     }
 
     assertInputNotAborted(signal);
@@ -211,7 +226,7 @@ export class InputText extends BaseVisualChange {
       },
     );
     assertInputNotAborted(signal);
-    return result;
+    return { ...result, ...targetMetadata };
   }
 
   /**

--- a/src/models/SendTextResult.ts
+++ b/src/models/SendTextResult.ts
@@ -6,6 +6,9 @@ import { BaseActionResult } from "./BaseActionResult";
 export interface SendTextResult extends BaseActionResult {
   text: string;
   imeAction?: string;
+  /** Identity of the field focused by an inputText selector, when available. */
+  matchedId?: string;
+  matchedText?: string;
   /**
    * For the Android `append` mode only: how many leading characters of `text`
    * were confirmed by adb as sent to the device as key events. Append is

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -838,9 +838,7 @@ export function buildInputTextResultMessage(
   if (result.matchedText) {
     identity.push(`text=${JSON.stringify(result.matchedText)}`);
   }
-  return identity.length > 0
-    ? `Input text into element (${identity.join(" ")})`
-    : "Input text";
+  return identity.length > 0 ? `Input text into element (${identity.join(" ")})` : "Input text";
 }
 
 /**

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -25,6 +25,7 @@ import {
   BootedDevice,
   ClipboardResult,
   OpenURLResult,
+  SendTextResult,
   SwipeOnToolPayload,
   type TapOnSelectedElement,
 } from "../models";
@@ -823,6 +824,25 @@ export function formatSwipeOnMessage(
     : `Swiped ${direction}`;
 }
 
+export function buildInputTextResultMessage(
+  result: Pick<SendTextResult, "success" | "error" | "matchedId" | "matchedText">,
+): string {
+  if (!result.success) {
+    return `Failed to input text: ${result.error ?? "unknown error"}`;
+  }
+
+  const identity: string[] = [];
+  if (result.matchedId) {
+    identity.push(`id=${result.matchedId}`);
+  }
+  if (result.matchedText) {
+    identity.push(`text=${JSON.stringify(result.matchedText)}`);
+  }
+  return identity.length > 0
+    ? `Input text into element (${identity.join(" ")})`
+    : "Input text";
+}
+
 /**
  * Build the tapOn success message so it says *what* it matched, not just
  * "Tapped on element" (#5868). A correct tap and a wrong tap were byte-identical;
@@ -1361,11 +1381,12 @@ export function registerInteractionTools() {
       signal,
       args.selector,
     );
-    return createJSONToolResponse({
-      message: `Input text`,
+    const response = createJSONToolResponse({
+      message: buildInputTextResultMessage(result),
       observation: result.observation,
       ...result,
     });
+    return result.success ? response : { ...response, isError: true };
   };
 
   // Wake and unlock handler

--- a/test/features/action/InputText.execute.test.ts
+++ b/test/features/action/InputText.execute.test.ts
@@ -164,7 +164,11 @@ describe("InputText.execute", () => {
       (inputText as any).targetFocuser = {
         focus: async (selector: unknown) => {
           focusCalls.push(selector);
-          return { success: true };
+          return {
+            success: true,
+            matchedId: "com.test:id/first_name",
+            matchedText: "First name",
+          };
         },
       };
 
@@ -173,6 +177,8 @@ describe("InputText.execute", () => {
       });
 
       expect(result.success).toBe(true);
+      expect(result.matchedId).toBe("com.test:id/first_name");
+      expect(result.matchedText).toBe("First name");
       // The field was focused with the caller's selector before any text landed.
       expect(focusCalls).toEqual([{ text: "First name" }]);
       expect(fakeA11yService.getTextInputHistory()).toEqual([

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { buildTapOnResultMessage } from "../../src/server/interactionTools";
+import {
+  buildInputTextResultMessage,
+  buildTapOnResultMessage,
+} from "../../src/server/interactionTools";
 import type { TapOnSelectedElement } from "../../src/models";
 
 const selected = (overrides: Partial<TapOnSelectedElement>): TapOnSelectedElement => ({
@@ -155,5 +158,26 @@ describe("buildTapOnResultMessage", () => {
   test("uses only the search summary when there is no selected element", () => {
     const summary = "2 view hierarchy changes over 5 requests within 300ms";
     expect(buildTapOnResultMessage(undefined, summary)).toBe(`Tapped on element (${summary})`);
+  });
+});
+
+describe("buildInputTextResultMessage", () => {
+  test("names the field targeted by a selector", () => {
+    expect(
+      buildInputTextResultMessage({
+        success: true,
+        matchedId: "com.test:id/first_name",
+        matchedText: "First name",
+      }),
+    ).toBe('Input text into element (id=com.test:id/first_name text="First name")');
+  });
+
+  test("reports selector failures as failures", () => {
+    expect(
+      buildInputTextResultMessage({
+        success: false,
+        error: "Element not found with provided text 'Missing'",
+      }),
+    ).toBe("Failed to input text: Element not found with provided text 'Missing'");
   });
 });


### PR DESCRIPTION
## Summary

`inputText` selector failures were returned as a success envelope with only a nested `success:false` signal. This change preserves the resolved field identity, gives successful selector calls a useful message, and marks failed input operations with `isError: true`.

## Linked Issue

Closes #5902

## Bug / Regression Context

- **Prior attempts:** The selector optimization from #5885 did not receive the postcondition response treatment added to `tapOn` and `launchApp`.
- **Observed symptom:** A selector miss returned `message: "Input text"` without `isError`, requiring clients to parse nested JSON.
- **Repro steps / conditions:** Call `inputText` with an Android selector that does not match any field.

## Validation

- [x] Focused inputText and response-message tests pass
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] `bun run typecheck` reports no new errors
- [x] `scripts/all_fast_validate_checks.sh` passes

## Follow-ups

- [x] No follow-up issues needed.
