### PR TITLE
feat(tapOn): report post-tap screen effect

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -10275,6 +10275,28 @@
           "required": ["mode", "reason"],
           "additionalProperties": {}
         },
+        "effect": {
+          "type": "object",
+          "properties": {
+            "screenChanged": {
+              "type": "boolean"
+            },
+            "basis": {
+              "type": "string",
+              "enum": [
+                "screenIdentity changed",
+                "screenIdentity unchanged",
+                "activeWindow+layoutSeqSum changed",
+                "activeWindow+layoutSeqSum unchanged",
+                "viewHierarchy changed",
+                "viewHierarchy unchanged",
+                "insufficient observation data"
+              ]
+            }
+          },
+          "required": ["screenChanged", "basis"],
+          "additionalProperties": {}
+        },
         "selectedElement": {
           "type": "object",
           "properties": {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -480,6 +480,84 @@ export class TapOnElement extends BaseVisualChange {
     }
   }
 
+  private compareScreenIdentity(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+  ): TapOnElementResult["effect"] | undefined {
+    const previous = previousObservation.screenIdentity;
+    const current = currentObservation.screenIdentity;
+    if (!previous || !current || previous.platform !== current.platform) {
+      return undefined;
+    }
+    const changed = previous.key !== current.key;
+    return {
+      screenChanged: changed,
+      basis: changed ? "screenIdentity changed" : "screenIdentity unchanged",
+    };
+  }
+
+  private compareActiveWindow(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+  ): TapOnElementResult["effect"] | undefined {
+    const previous = previousObservation.activeWindow;
+    const current = currentObservation.activeWindow;
+    if (!this.hasCompleteActiveWindow(previous) || !this.hasCompleteActiveWindow(current)) {
+      return undefined;
+    }
+    const changed =
+      previous.appId !== current.appId ||
+      previous.activityName !== current.activityName ||
+      previous.layoutSeqSum !== current.layoutSeqSum;
+    return {
+      screenChanged: changed,
+      basis: changed ? "activeWindow+layoutSeqSum changed" : "activeWindow+layoutSeqSum unchanged",
+    };
+  }
+
+  private hasCompleteActiveWindow(
+    activeWindow: ObserveResult["activeWindow"],
+  ): activeWindow is NonNullable<ObserveResult["activeWindow"]> {
+    return Boolean(
+      activeWindow?.appId &&
+      activeWindow.activityName &&
+      Number.isInteger(activeWindow.layoutSeqSum),
+    );
+  }
+
+  private compareViewHierarchy(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+  ): TapOnElementResult["effect"] | undefined {
+    const previousHash = this.hashViewHierarchy(previousObservation.viewHierarchy ?? null);
+    const currentHash = this.hashViewHierarchy(currentObservation.viewHierarchy ?? null);
+    if (!previousHash || !currentHash) {
+      return undefined;
+    }
+    const changed = previousHash !== currentHash;
+    return {
+      screenChanged: changed,
+      basis: changed ? "viewHierarchy changed" : "viewHierarchy unchanged",
+    };
+  }
+
+  private deriveTapEffect(
+    previousObservation: ObserveResult | null,
+    currentObservation: ObserveResult | undefined,
+  ): TapOnElementResult["effect"] | undefined {
+    if (!previousObservation || !currentObservation) {
+      return undefined;
+    }
+    return (
+      this.compareScreenIdentity(previousObservation, currentObservation) ??
+      this.compareActiveWindow(previousObservation, currentObservation) ??
+      this.compareViewHierarchy(previousObservation, currentObservation) ?? {
+        screenChanged: false,
+        basis: "insufficient observation data",
+      }
+    );
+  }
+
   private isElementTapTargetOffScreen(
     element: Element,
     screenSize?: ObserveResult["screenSize"],
@@ -1614,6 +1692,7 @@ export class TapOnElement extends BaseVisualChange {
       );
 
       if (result.success && result.observation && result.element) {
+        result.effect = this.deriveTapEffect(previousObserveResult, result.observation);
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,
           selectionState: selectionCapture,

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -5,6 +5,20 @@ import { BaseActionResult } from "./BaseActionResult";
 import { ToolDebugInfo } from "../utils/DebugContextBuilder";
 import type { ScreenReaderNavigationResult } from "../features/talkback/TalkBackTapStrategy";
 
+export type TapEffectBasis =
+  | "screenIdentity changed"
+  | "screenIdentity unchanged"
+  | "activeWindow+layoutSeqSum changed"
+  | "activeWindow+layoutSeqSum unchanged"
+  | "viewHierarchy changed"
+  | "viewHierarchy unchanged"
+  | "insufficient observation data";
+
+export interface TapEffect {
+  screenChanged: boolean;
+  basis: TapEffectBasis;
+}
+
 export interface TapOnSelectedElementBounds extends ElementBounds {
   centerX: number;
   centerY: number;
@@ -27,6 +41,7 @@ export interface TapOnSelectedElement {
 export interface TapOnElementResult extends BaseActionResult {
   action: string;
   element: Element;
+  effect?: TapEffect;
   /** Semantic link confirmed by the native runner. */
   activatedSubtext?: {
     text: string;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -218,6 +218,21 @@ const screenReaderNavigationSchema = z
   })
   .passthrough();
 
+const tapEffectSchema = z
+  .object({
+    screenChanged: z.boolean(),
+    basis: z.enum([
+      "screenIdentity changed",
+      "screenIdentity unchanged",
+      "activeWindow+layoutSeqSum changed",
+      "activeWindow+layoutSeqSum unchanged",
+      "viewHierarchy changed",
+      "viewHierarchy unchanged",
+      "insufficient observation data",
+    ]),
+  })
+  .passthrough();
+
 export const tapOnResultSchema = z
   .object({
     success: z.boolean(),
@@ -226,6 +241,7 @@ export const tapOnResultSchema = z
     element: elementSchema.optional(),
     observation: z.union([observationSummarySchema, toolOutputArtifactMetadataSchema]).optional(),
     observationDiff: observationDiffMetadataSchema.optional(),
+    effect: tapEffectSchema.optional(),
     selectedElement: selectedElementSchema.optional(),
     activatedSubtext: z
       .object({

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Element, ViewHierarchyResult } from "../../../src/models";
+import type { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -15,6 +15,14 @@ function makeElement(): Element {
 
 function makeHierarchy(marker: string): ViewHierarchyResult {
   return { hierarchy: { node: { marker } } } as unknown as ViewHierarchyResult;
+}
+
+function makeObservation(overrides: Partial<ObserveResult>): ObserveResult {
+  return {
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    ...overrides,
+  };
 }
 
 function createTapOnElement(): { tap: TapOnElement; timer: FakeTimer } {
@@ -143,6 +151,60 @@ describe("retryTapIfNoChange", () => {
     );
 
     expect(sleepDurations).toEqual([300, 100]);
+  });
+});
+
+describe("deriveTapEffect", () => {
+  test("reports a changed screen identity", () => {
+    const { tap } = createTapOnElement();
+    const previous = makeObservation({
+      screenIdentity: {
+        platform: "android",
+        source: "heuristic",
+        confidence: "high",
+        key: "clock:alarms",
+        components: {},
+      },
+    });
+    const current = makeObservation({
+      screenIdentity: {
+        platform: "android",
+        source: "heuristic",
+        confidence: "high",
+        key: "clock:select-time",
+        components: {},
+      },
+    });
+
+    expect((tap as any).deriveTapEffect(previous, current)).toEqual({
+      screenChanged: true,
+      basis: "screenIdentity changed",
+    });
+  });
+
+  test("reports an unchanged active window when screen identity is unavailable", () => {
+    const { tap } = createTapOnElement();
+    const activeWindow = {
+      appId: "com.example.clock",
+      activityName: "AlarmActivity",
+      layoutSeqSum: 42,
+    };
+    const previous = makeObservation({ activeWindow });
+    const current = makeObservation({ activeWindow: { ...activeWindow } });
+
+    expect((tap as any).deriveTapEffect(previous, current)).toEqual({
+      screenChanged: false,
+      basis: "activeWindow+layoutSeqSum unchanged",
+    });
+  });
+
+  test("reports insufficient data without claiming a screen change", () => {
+    const { tap } = createTapOnElement();
+
+    expect((tap as any).deriveTapEffect(makeObservation({}), makeObservation({}))).toEqual({
+      screenChanged: false,
+      basis: "insufficient observation data",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Add an additive `effect` signal to successful `tapOn` results.
- Compare screen identity, active-window metadata, or hierarchy hashes to report whether the post-tap screen changed.
- Keep `success` and existing retry behavior unchanged so clients can distinguish dispatch success from visible effect.

## Root cause
`tapOn` already captured a post-action observation, but the comparison result was only used internally for retry behavior and was not exposed to MCP clients.

## Validation
- `bun test test/features/action/TapOnElement.retryIfNoChange.test.ts test/server/interactionTools.tapOnMessage.test.ts test/server/tools/tapOnTapAnySchema.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `bunx oxfmt --check ...`

Closes #5910
