### PR TITLE
fix(observe-cache): reap expired disk entries

### DIFF
--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -296,9 +296,22 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
 
       const now = this.timer.now();
       const currentGeneration = this.currentGeneration(deviceId);
+      const expiredFiles: string[] = [];
       let mostRecentFile: { path: string; mtime: number } | undefined;
 
       for (const file of jsonFiles) {
+        const filePath = path.join(this.cacheDir, file);
+        const stats = await statAsync(filePath);
+        const age = now - stats.mtime.getTime();
+
+        if (age >= OBSERVE_RESULT_CACHE_TTL_MS) {
+          expiredFiles.push(file);
+          logger.debug(
+            `[OBSERVE_CACHE] Disk cache file expired: ${file} (age: ${age}ms > TTL: ${OBSERVE_RESULT_CACHE_TTL_MS}ms)`,
+          );
+          continue;
+        }
+
         // Residual 2: never re-warm memory from a file whose stamped generation
         // is older than the device's current generation — a clear() has advanced
         // past it (issue #5892). Unstamped files can't be proven stale; serve
@@ -312,20 +325,12 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
           continue;
         }
 
-        const filePath = path.join(this.cacheDir, file);
-        const stats = await statAsync(filePath);
-        const age = now - stats.mtime.getTime();
-
-        if (age < OBSERVE_RESULT_CACHE_TTL_MS) {
-          if (!mostRecentFile || stats.mtime.getTime() > mostRecentFile.mtime) {
-            mostRecentFile = { path: filePath, mtime: stats.mtime.getTime() };
-          }
-        } else {
-          logger.debug(
-            `[OBSERVE_CACHE] Disk cache file expired: ${file} (age: ${age}ms > TTL: ${OBSERVE_RESULT_CACHE_TTL_MS}ms)`,
-          );
+        if (!mostRecentFile || stats.mtime.getTime() > mostRecentFile.mtime) {
+          mostRecentFile = { path: filePath, mtime: stats.mtime.getTime() };
         }
       }
+
+      await Promise.all(expiredFiles.map((file) => this.deleteDiskFile(file)));
 
       if (!mostRecentFile) {
         logger.debug("[OBSERVE_CACHE] No valid files in disk cache");

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -157,6 +157,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       const filename = this.diskFilename(cacheKey, stampGeneration);
       this.cache.set(cacheKey, { timestamp, deviceId, observeResult: result });
       await this.saveObserveResultToDisk(filename, result);
+      await this.reapExpiredDiskFiles(deviceId);
       // Residual 1: a clear() can land during the disk write above, and its
       // deletion snapshot predates our file — so it survives on disk. Re-check
       // and clean up ourselves rather than leaving a stale file for checkDisk to
@@ -396,6 +397,29 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       await unlinkAsync(path.join(this.cacheDir, filename));
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Failed to delete stale cache file ${filename}: ${error}`);
+    }
+  }
+
+  private async reapExpiredDiskFiles(deviceId: string): Promise<void> {
+    try {
+      const devicePrefix = `observe_${this.sanitizeDeviceId(deviceId)}_`;
+      const files = await readdirAsync(this.cacheDir);
+      const now = this.timer.now();
+      const expiredFiles: string[] = [];
+
+      for (const file of files) {
+        if (!file.endsWith(".json") || !file.startsWith(devicePrefix)) {
+          continue;
+        }
+        const stats = await statAsync(path.join(this.cacheDir, file));
+        if (now - stats.mtime.getTime() >= OBSERVE_RESULT_CACHE_TTL_MS) {
+          expiredFiles.push(file);
+        }
+      }
+
+      await Promise.all(expiredFiles.map((file) => this.deleteDiskFile(file)));
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Failed to reap expired disk files: ${error}`);
     }
   }
 

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import os from "os";
-import { mkdirSync, rmSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, readdirSync, existsSync, writeFileSync, utimesSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { writeFileAsync } from "../../../../src/utils/io";
 import {
@@ -198,6 +198,30 @@ describe("FileSystemObserveCacheStore", function () {
   test("getMostRecent returns undefined when nothing cached", async function () {
     const result = await store.getMostRecent("device-1");
     expect(result).toBeUndefined();
+  });
+
+  test("getMostRecent reaps expired disk files while scanning", async function () {
+    const expiredFiles = [
+      `observe_device-1_${timer.now()}_g0.json`,
+      `observe_device-1_${timer.now()}_g1.json`,
+    ];
+    const expiredAt = timer.now() - OBSERVE_RESULT_CACHE_TTL_MS - 1;
+    for (const file of expiredFiles) {
+      const filePath = path.join(cacheDir, file);
+      writeFileSync(filePath, JSON.stringify(makeResult("expired")));
+      utimesSync(filePath, new Date(expiredAt), new Date(expiredAt));
+    }
+
+    const currentFile = `observe_device-1_${timer.now()}_g0-current.json`;
+    const currentPath = path.join(cacheDir, currentFile);
+    writeFileSync(currentPath, JSON.stringify(makeResult("current")));
+    utimesSync(currentPath, new Date(timer.now()), new Date(timer.now()));
+
+    const restored = await store.getMostRecent("device-1");
+
+    expect(restored?.updatedAt).toBe("current");
+    expect(expiredFiles.every((file) => !existsSync(path.join(cacheDir, file)))).toBe(true);
+    expect(existsSync(currentPath)).toBe(true);
   });
 
   // --- Generation-stamped disk files (#5892) -------------------------------

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -224,6 +224,20 @@ describe("FileSystemObserveCacheStore", function () {
     expect(existsSync(currentPath)).toBe(true);
   });
 
+  test("put reaps expired disk files even when memory has a fresh result", async function () {
+    await store.put("device-1", makeResult("old"));
+    const oldFile = readdirSync(cacheDir).find((file) => file.endsWith(".json"));
+    expect(oldFile).toBeDefined();
+    const expiredAt = timer.now() - OBSERVE_RESULT_CACHE_TTL_MS - 1;
+    utimesSync(path.join(cacheDir, oldFile!), new Date(expiredAt), new Date(expiredAt));
+
+    timer.advanceTime(1);
+    await store.put("device-1", makeResult("fresh"));
+
+    expect(store.getRecentInMemoryForDevice("device-1")?.updatedAt).toBe("fresh");
+    expect(existsSync(path.join(cacheDir, oldFile!))).toBe(false);
+  });
+
   // --- Generation-stamped disk files (#5892) -------------------------------
 
   test("put stamps the write generation into the disk filename", async function () {


### PR DESCRIPTION
## Summary

- Reap expired observe cache JSON files during disk cache scans.
- Preserve the newest valid cache entry while removing same-timestamp expired generation variants.
- Add regression coverage for expired-file cleanup.

The root cause was that `checkDisk` skipped expired files but never deleted them, allowing old generation-stamped variants to accumulate until an explicit cache clear.

## Validation

- `bun test test/features/observe/cache/FileSystemObserveCacheStore.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate` (stopped after exceeding 60 seconds per request; build/tests had started, but the aggregate command did not complete)

Closes #5913
