### PR TITLE
fix(resources): retry cold background daemon connection

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -56,6 +56,7 @@ export type VersionMismatchReason =
 export type BuildMismatchReason = "autoStartDisabled" | "cooldown" | "restartMismatch";
 
 const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
+const COLD_RESOURCE_CONNECT_RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
 
 function isFreshSessionScreenshotUri(uri: string, sessionUuid: string): boolean {
   return uri === `automobile:device-session/${sessionUuid}/screenshot`;
@@ -710,6 +711,8 @@ export class DaemonMcpProxy {
   // resources (issue #5879 review — a host that enumerates resources on init
   // must not block on a wedged daemon before the first tool call).
   private servedStaticResourceList = false;
+  private backgroundConnectRetry: NodeJS.Timeout | null = null;
+  private backgroundConnectRetryAttempt = 0;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -878,6 +881,7 @@ export class DaemonMcpProxy {
     // close() ran last). Mirrors the closing rechecks above.
     this.throwIfClosing();
     this.connected = true;
+    this.cancelBackgroundConnectRetry();
 
     if (supportsNotifications) {
       try {
@@ -1502,17 +1506,48 @@ export class DaemonMcpProxy {
   // dedupes concurrent/polled calls, so at most one attempt is in flight.
   private serveResourcesColdAndConnectInBackground(): void {
     this.servedStaticResourceList = true;
-    if (this.connecting || this.closing) {
+    if (this.connecting || this.backgroundConnectRetry || this.closing) {
       return;
     }
-    void this.ensureConnected().catch((error) => {
+    void this.ensureBackgroundResourceConnection();
+  }
+
+  private async ensureBackgroundResourceConnection(): Promise<void> {
+    try {
+      await this.ensureConnected();
+    } catch (error) {
       // Best-effort: the cold roster already returned, and the tool surface is
       // visible via tools/list. A wedged/absent daemon must not surface here; the
-      // next actual request still reports the failure to the client.
+      // the next actual request still reports the failure to the client. Retry
+      // transient failures a bounded number of times for resource-only clients.
       logger.debug(
         `[DaemonMcpProxy] background connect after cold resource discovery failed: ${error}`,
       );
-    });
+      this.scheduleBackgroundConnectRetry();
+    }
+  }
+
+  private scheduleBackgroundConnectRetry(): void {
+    if (this.closing || this.connected || this.backgroundConnectRetry) {
+      return;
+    }
+    const delay = COLD_RESOURCE_CONNECT_RETRY_DELAYS_MS[this.backgroundConnectRetryAttempt];
+    if (delay === undefined) {
+      return;
+    }
+    this.backgroundConnectRetryAttempt += 1;
+    this.backgroundConnectRetry = this.timer.setTimeout(() => {
+      this.backgroundConnectRetry = null;
+      void this.ensureBackgroundResourceConnection();
+    }, delay);
+  }
+
+  private cancelBackgroundConnectRetry(): void {
+    if (this.backgroundConnectRetry) {
+      this.timer.clearTimeout(this.backgroundConnectRetry);
+      this.backgroundConnectRetry = null;
+    }
+    this.backgroundConnectRetryAttempt = 0;
   }
 
   /**
@@ -2320,6 +2355,7 @@ export class DaemonMcpProxy {
    */
   async close(): Promise<void> {
     this.closing = true;
+    this.cancelBackgroundConnectRetry();
     this.connectionCloseReject?.(new DaemonUnavailableError("MCP proxy is closing"));
     await this.stopBoundSessionHeartbeat();
     if (this.client) {

--- a/test/daemon/daemonMcpProxyLazyToolList.test.ts
+++ b/test/daemon/daemonMcpProxyLazyToolList.test.ts
@@ -5,6 +5,7 @@ import { DAEMON_VERSION } from "../../src/daemon/constants";
 import { getStaticToolDefinitions } from "../../src/daemon/staticToolDefinitions";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeTimer } from "../fakes/FakeTimer";
 import type { ListChangedKind } from "../../src/server/listChangedBroadcast";
 
 // A FakeDaemonManager reporting a running daemon whose version matches this
@@ -230,6 +231,80 @@ describe("DaemonMcpProxy.listAdvertisedTools (lazy tools/list — issue #5879)",
       ]);
     } finally {
       await proxy.close();
+    }
+  });
+
+  test("retries a transient background resource connection failure", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map<string, any>([
+        ["resources/list", { resources: [{ uri: "automobile:live", name: "live" }] }],
+      ]),
+    });
+    fakeClient.shouldFailConnect = true;
+    let connectAttempts = 0;
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => {
+        connectAttempts += 1;
+        if (connectAttempts === 3) {
+          fakeClient.shouldFailConnect = false;
+        }
+        return fakeClient;
+      },
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer: fakeTimer,
+    });
+    const kinds: ListChangedKind[] = [];
+    proxy.onListChanged((kind) => kinds.push(kind));
+
+    try {
+      await proxy.listAdvertisedResources();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(connectAttempts).toBe(1);
+      expect(fakeTimer.getPendingTimeouts()).toEqual([250]);
+
+      await fakeTimer.advanceTimeAsync(250);
+      expect(connectAttempts).toBe(2);
+      expect(fakeTimer.getPendingTimeouts()).toEqual([1_000]);
+
+      await fakeTimer.advanceTimeAsync(1_000);
+      expect(connectAttempts).toBe(3);
+      expect(proxy.isConnected()).toBe(true);
+      expect(kinds).toContain("resources");
+    } finally {
+      isAvailableSpy.mockRestore();
+      await proxy.close();
+    }
+  });
+
+  test("cancels pending background resource retries when closed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeClient = new FakeDaemonClient();
+    fakeClient.shouldFailConnect = true;
+    let connectAttempts = 0;
+    const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => {
+        connectAttempts += 1;
+        return fakeClient;
+      },
+      daemonManager: matchingDaemonManager(),
+      autoStartDaemon: false,
+      timer: fakeTimer,
+    });
+
+    try {
+      await proxy.listAdvertisedResources();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(fakeTimer.getPendingTimeouts()).toEqual([250]);
+
+      await proxy.close();
+      await fakeTimer.advanceTimeAsync(10_000);
+      expect(connectAttempts).toBe(1);
+    } finally {
+      isAvailableSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

Retry cold resource-discovery background daemon connections with bounded, injected-timer backoff. Pending retries are cancelled on close or once any connection succeeds, keeping resource-only MCP clients able to receive reconciliation notifications after transient daemon outages.

## Linked Issue

Closes #5920

## Bug / Regression Context

- **Prior attempts:** PR #5890 added a one-shot background connection after cold resource discovery.
- **Observed symptom:** A transient daemon-unavailable failure permanently stopped the background connection, leaving resource-only clients without live resource discovery.
- **Repro steps / conditions:** List resources during a transient daemon outage, then restore daemon availability without making another request.

## Validation

- [x] Focused `bun test test/daemon/daemonMcpProxyLazyToolList.test.ts`
- [x] `bun run build`
- [x] `bun run typecheck` (no new baseline errors)
- [x] `bun run lint`
- [ ] `scripts/all_fast_validate_checks.sh` (started; continued checks exceeded the requested 60-second limit)
- [x] New retry behavior uses the existing `Timer` / `FakeTimer` seams

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: none
