### PR TITLE
fix(daemon): abort readiness probes on lock-holder replacement

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1624,7 +1624,11 @@ export class DaemonManager implements DaemonManagerLike {
       ? this.startLivenessWatchdog(signal, shouldContinueWaiting)
       : undefined;
     try {
-      return await this.probeObservedSocket(probeDeadline, watchdog?.signal ?? signal, keepWaiting);
+      return await this.probeObservedSocket(
+        probeDeadline,
+        watchdog?.signal ?? signal,
+        keepWaiting && maxProbeDurationMs === undefined,
+      );
     } finally {
       watchdog?.dispose();
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -388,6 +388,13 @@ const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 const LIVENESS_WATCHDOG_INTERVAL_MS = 100;
 
 /**
+ * Maximum duration of one socket probe while waiting on another startup-lock
+ * holder. A stale socket owned by an unrelated daemon must not pin the entire
+ * readiness budget (issue #5928).
+ */
+const LOCK_HOLDER_PROBE_TIMEOUT_MS = 1000;
+
+/**
  * A snapshot of the daemon startup lock's current holder, as read from the lock
  * file. `token` carries the holder's per-instance owner token (issue #5904) so a
  * replacement holder is distinguishable from the prior one even under PID reuse.
@@ -410,6 +417,7 @@ export interface DaemonManagerLike {
     timeout: number,
     signal?: AbortSignal,
     shouldContinueWaiting?: () => boolean,
+    maxProbeDurationMs?: number,
   ): Promise<boolean>;
   /**
    * Whether the daemon startup lock is held by a still-live process — used as the
@@ -667,8 +675,11 @@ export class DaemonManager implements DaemonManagerLike {
       // Capture diagnostics while the current holder still holds the lock, so they
       // survive into the failure message if the holder later releases on failure.
       holderLogPath = (await this.getLockHolderStartupLogPath()) ?? holderLogPath;
-      const ready = await this.waitForReady(remaining, undefined, () =>
-        this.isStartupLockHeldByLiveProcess(),
+      const ready = await this.waitForReady(
+        remaining,
+        undefined,
+        () => this.isStillWaitingOnStartupLockHolder(waitedOnHolder),
+        LOCK_HOLDER_PROBE_TIMEOUT_MS,
       );
       if (ready) {
         stderrLog("Daemon started by another process");
@@ -1106,6 +1117,16 @@ export class DaemonManager implements DaemonManagerLike {
     return this.readStartupLockHolder().present;
   }
 
+  private isStillWaitingOnStartupLockHolder(waitedOnHolder: StartupLockHolder): boolean {
+    const current = this.readStartupLockHolder();
+    return (
+      current.present &&
+      (current.livePid === undefined ||
+        waitedOnHolder.livePid === undefined ||
+        this.isSameStartupLockHolder(current, waitedOnHolder))
+    );
+  }
+
   /**
    * Wait for whichever live process currently holds the startup lock to publish a
    * connectable socket, re-arbitrating across *replacement* holders under ONE
@@ -1129,8 +1150,11 @@ export class DaemonManager implements DaemonManagerLike {
     let waitedOnHolder = this.readStartupLockHolder();
 
     while (this.remainingTime(deadline) > 0) {
-      const ready = await this.waitForReady(this.remainingTime(deadline), undefined, () =>
-        this.isStartupLockHeldByLiveProcess(),
+      const ready = await this.waitForReady(
+        this.remainingTime(deadline),
+        undefined,
+        () => this.isStillWaitingOnStartupLockHolder(waitedOnHolder),
+        LOCK_HOLDER_PROBE_TIMEOUT_MS,
       );
       if (ready) {
         return true;
@@ -1492,6 +1516,7 @@ export class DaemonManager implements DaemonManagerLike {
     // synchronous through to the poll sleep (a caller that inspects pending timers
     // right after invocation relies on that); a predicate is consulted each poll.
     shouldContinueWaiting: () => boolean = () => true,
+    maxProbeDurationMs?: number,
   ): Promise<boolean> {
     const startTime = this.timer.now();
     const deadline = startTime + timeout;
@@ -1518,6 +1543,7 @@ export class DaemonManager implements DaemonManagerLike {
           deadline,
           signal,
           shouldContinueWaiting,
+          maxProbeDurationMs,
         );
         if (outcome === "ready") {
           stderrLog(
@@ -1584,9 +1610,15 @@ export class DaemonManager implements DaemonManagerLike {
     deadline: number,
     signal: AbortSignal | undefined,
     shouldContinueWaiting: () => boolean,
+    maxProbeDurationMs: number | undefined,
   ): Promise<"ready" | "aborted" | "unready"> {
     const probeDeadline = keepWaiting
-      ? deadline
+      ? Math.min(
+          deadline,
+          maxProbeDurationMs === undefined
+            ? deadline
+            : this.timer.now() + maxProbeDurationMs,
+        )
       : Math.min(deadline, this.timer.now() + ABANDONED_WAIT_CONFIRM_TIMEOUT_MS);
     const watchdog = keepWaiting
       ? this.startLivenessWatchdog(signal, shouldContinueWaiting)

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1096,6 +1096,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (a.token !== undefined && b.token !== undefined) {
       return a.token === b.token;
     }
+    if (a.token !== b.token) {
+      return false;
+    }
     return a.livePid !== undefined && a.livePid === b.livePid;
   }
 

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -553,6 +553,53 @@ describe("DaemonManager readiness", () => {
     expect(waits).toBe(1);
   });
 
+  test("aborts a stalled probe when the lock holder identity changes (#5928)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    writeFileSync(lockPath, `${process.pid}\ntoken-a`);
+    writeFileSync(socketPath, "socket placeholder");
+
+    const clients: ProbeClient[] = [];
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(false);
+        client.connect = async (_timeoutMs?: number, signal?: AbortSignal) => {
+          client.connectCallCount++;
+          if (signal !== undefined) {
+            client.connectionSignals.push(signal);
+          }
+          await new Promise<void>((_resolve, reject) => {
+            if (signal?.aborted) {
+              reject(new Error("probe aborted"));
+              return;
+            }
+            signal?.addEventListener("abort", () => reject(new Error("probe aborted")), {
+              once: true,
+            });
+          });
+        };
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    // Change the holder after the initial poll-boundary check, while the socket
+    // probe is stalled. The identity-aware watchdog must interrupt that probe.
+    fakeTimer.setTimeout(() => {
+      writeFileSync(lockPath, `${process.pid}\ntoken-b`);
+    }, 100);
+
+    await expect(manager.waitForLockHolderReadiness(250)).resolves.toBe(false);
+    expect(clients.length).toBeGreaterThanOrEqual(2);
+    expect(clients[0]?.connectionSignals[0]?.aborted).toBe(true);
+  });
+
   test("reports elapsed readiness timing when no daemon socket appears", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -480,6 +480,36 @@ describe("DaemonManager readiness", () => {
     expect(waits).toBe(2);
   });
 
+  test("re-arbitrates when a legacy holder gains an owner token (#5928)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    writeFileSync(lockPath, String(process.pid));
+    let waits = 0;
+
+    class TestDaemonManager extends DaemonManager {
+      override async waitForReady(): Promise<boolean> {
+        waits++;
+        if (waits === 1) {
+          writeFileSync(lockPath, `${process.pid}\ntoken-b`);
+        }
+        return false;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+    );
+
+    await expect(manager.waitForLockHolderReadiness(30_000)).resolves.toBe(false);
+    expect(waits).toBe(2);
+  });
+
   test("waitForLockHolderReadiness confirms a daemon that published its socket before releasing the lock (#5904)", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();


### PR DESCRIPTION
## Summary

- Recheck startup-lock holder identity during in-flight readiness probes and abort when a replacement holder appears.
- Cap each socket probe while waiting on a lock holder so a wedged unrelated socket cannot consume the full startup budget.
- Add a regression test covering same-PID holder replacement.

## Root cause

The readiness watchdog previously checked only whether any live process still held the startup lock. When holder A was replaced by holder B, the predicate remained true; a stalled probe against a third-party socket therefore continued until the full startup deadline.

## Validation

- `bun test test/daemon/daemonManagerReadiness.test.ts`
- `bun test test/daemon/manager.test.ts test/daemon/daemonMcpProxy.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test --bail` (stopped after 60 seconds; the suite reached a pre-existing `nonFiniteJson` module export error)

Closes #5928
