### PR TITLE
fix(errors): make validation and daemon mismatch guidance actionable

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -116,22 +116,31 @@ export class DaemonVersionMismatchError extends DaemonUnavailableError {
     reason: VersionMismatchReason;
     detail: string;
     retryAfterMs?: number;
+    clientBuild?: BuildIdentity;
+    daemonBuild?: BuildIdentity;
   }) {
-    // The git-SHA build metadata on dev builds is not an installable npm tag,
-    // so the bunx hint must point at the plain published version.
+    // Use the client's own entrypoint when available. Direct callers that do not
+    // provide build identity retain the published-version fallback.
     const installableVersion = releaseVersion(params.clientVersion);
-    const restartCommand =
-      installableVersion.length > 0 && installableVersion !== "unknown"
+    const restartCommand = params.clientBuild?.entryScript
+      ? `${params.clientBuild.entryScript} --daemon restart`
+      : installableVersion.length > 0 && installableVersion !== "unknown"
         ? `bunx @kaeawc/auto-mobile@${installableVersion} --daemon restart`
         : "the same installed auto-mobile package";
     const retryGuidance =
       params.retryAfterMs !== undefined
-        ? ` Retry after ${params.retryAfterMs}ms or restart the daemon with: ${restartCommand}`
-        : ` Restart the daemon with: ${restartCommand}`;
-    super(
-      `AutoMobile daemon version mismatch: daemon=${params.daemonVersion}, client=${params.clientVersion} ` +
-        `(${params.detail}).${retryGuidance}`,
-    );
+        ? ` Retry after ${params.retryAfterMs}ms or restart the daemon from this client's build: ${restartCommand}`
+        : ` Restart the daemon from this client's build: ${restartCommand}`;
+    const sameRelease =
+      releaseVersion(params.daemonVersion) === releaseVersion(params.clientVersion) &&
+      params.daemonVersion !== params.clientVersion;
+    const mismatchMessage =
+      sameRelease && params.clientBuild && params.daemonBuild
+        ? `AutoMobile daemon build mismatch: daemon build ${describeBuildIdentity(params.daemonBuild)} != ` +
+          `client build ${describeBuildIdentity(params.clientBuild)} (${params.detail}).${retryGuidance}`
+        : `AutoMobile daemon version mismatch: daemon=${params.daemonVersion}, client=${params.clientVersion} ` +
+          `(${params.detail}).${retryGuidance}`;
+    super(mismatchMessage);
     this.name = "DaemonVersionMismatchError";
     this.clientVersion = params.clientVersion;
     this.daemonVersion = params.daemonVersion;
@@ -1039,6 +1048,8 @@ export class DaemonMcpProxy {
         runningVersion,
         "autoStartDisabled",
         "auto-start is disabled",
+        undefined,
+        buildIdentityFromStatus(status),
       );
     }
 
@@ -1053,6 +1064,8 @@ export class DaemonMcpProxy {
           runningVersion,
           "nonNumeric",
           "version comparison is not numeric",
+          undefined,
+          buildIdentityFromStatus(status),
         );
       }
 
@@ -1061,6 +1074,8 @@ export class DaemonMcpProxy {
           runningVersion,
           "daemonNewer",
           "the running daemon is newer than this client",
+          undefined,
+          buildIdentityFromStatus(status),
         );
       }
     }
@@ -1084,6 +1099,7 @@ export class DaemonMcpProxy {
           "cooldown",
           "restart is in cooldown",
           DAEMON_VERSION_RESTART_COOLDOWN_MS - daemonAgeMs,
+          buildIdentityFromStatus(status),
         );
       }
     }
@@ -1112,6 +1128,8 @@ export class DaemonMcpProxy {
         restartedVersion,
         "restartMismatch",
         "daemon restart completed but version still differs",
+        undefined,
+        buildIdentityFromStatus(restartedStatus),
       );
     }
   }
@@ -1121,6 +1139,7 @@ export class DaemonMcpProxy {
     reason: VersionMismatchReason,
     detail: string,
     retryAfterMs?: number,
+    daemonBuild?: BuildIdentity,
   ): DaemonVersionMismatchError {
     const daemonVersion = runningVersion.length > 0 ? runningVersion : "unknown";
     const clientVersion = this.clientVersion.trim();
@@ -1130,6 +1149,8 @@ export class DaemonMcpProxy {
       reason,
       detail,
       retryAfterMs,
+      clientBuild: this.buildIdentity,
+      daemonBuild,
     });
   }
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -100,6 +100,10 @@ function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
   return Math.max(1, interval);
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 /**
  * Raised before connecting when the running daemon and MCP client package
  * versions differ but the proxy cannot safely reconcile them immediately.
@@ -123,7 +127,7 @@ export class DaemonVersionMismatchError extends DaemonUnavailableError {
     // provide build identity retain the published-version fallback.
     const installableVersion = releaseVersion(params.clientVersion);
     const restartCommand = params.clientBuild?.entryScript
-      ? `${params.clientBuild.entryScript} --daemon restart`
+      ? `${shellQuote(process.execPath)} ${shellQuote(params.clientBuild.entryScript)} --daemon restart`
       : installableVersion.length > 0 && installableVersion !== "unknown"
         ? `bunx @kaeawc/auto-mobile@${installableVersion} --daemon restart`
         : "the same installed auto-mobile package";

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -90,7 +90,9 @@ function formatMissingPlatformIssue(
   if (issue.code !== "invalid_value" || path !== "platform") {
     return undefined;
   }
-  return isProvidedInput(rawInput, issue.path) ? undefined : `${path} is required`;
+  return rawInput !== undefined && !isProvidedInput(rawInput, issue.path)
+    ? `${path} is required`
+    : undefined;
 }
 
 function formatIssue(issue: ZodIssue, toolName: string, rawInput: unknown): string {

--- a/src/server/toolParamError.ts
+++ b/src/server/toolParamError.ts
@@ -75,8 +75,31 @@ function coverageKey(unionId: number, path: ReadonlyArray<PropertyKey>): string 
   return `${unionId}#${path.map(String).join(".")}`;
 }
 
-function formatIssue(issue: ZodIssue): string {
+function formatSelectorIssue(issue: ZodIssue, toolName: string, path: string): string | undefined {
+  if (issue.code !== "unrecognized_keys" || toolName !== "tapOn" || path !== "selector") {
+    return undefined;
+  }
+  return `${path} ${issue.message} Accepted: elementId, testTag, text, accessibilityLink, textAny (content-desc is matched by "text")`;
+}
+
+function formatMissingPlatformIssue(
+  issue: ZodIssue,
+  path: string,
+  rawInput: unknown,
+): string | undefined {
+  if (issue.code !== "invalid_value" || path !== "platform") {
+    return undefined;
+  }
+  return isProvidedInput(rawInput, issue.path) ? undefined : `${path} is required`;
+}
+
+function formatIssue(issue: ZodIssue, toolName: string, rawInput: unknown): string {
   const path = issue.path.length ? issue.path.join(".") : "parameters";
+  const actionableIssue =
+    formatSelectorIssue(issue, toolName, path) ?? formatMissingPlatformIssue(issue, path, rawInput);
+  if (actionableIssue) {
+    return actionableIssue;
+  }
   if (issue.code === "invalid_type") {
     // zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the base
     // `z.number()` check, so no `.finite()` refinement can carry a custom
@@ -233,7 +256,7 @@ export function formatToolParamError(toolName: string, error: unknown, rawInput?
   const seen = new Set<string>();
   const issues: string[] = [];
   for (const { issue } of selectedIssues) {
-    const formatted = formatIssue(issue);
+    const formatted = formatIssue(issue, toolName, rawInput);
     if (!seen.has(formatted)) {
       seen.add(formatted);
       issues.push(formatted);

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -34,6 +34,8 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     version?: string;
     startedAt?: number;
     assetVersion?: string;
+    entryScript?: string;
+    buildId?: string;
   }): void {
     const data: PidFileData = {
       pid: process.pid,
@@ -42,6 +44,8 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       startedAt: fields.startedAt ?? 1,
       version: fields.version ?? "",
       assetVersion: fields.assetVersion,
+      entryScript: fields.entryScript,
+      buildId: fields.buildId,
     };
     writeFileSync(pidFilePath, JSON.stringify(data));
   }
@@ -152,6 +156,33 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     });
     try {
       await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("same-release build mismatch identifies both scripts and the client restart command", async () => {
+    writePidFile({
+      version: "0.0.39+gdaemon",
+      startedAt: fakeTimer.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+      entryScript: "/stale/checkout/dist/index.js",
+      buildId: "daemon-build",
+    });
+    const tracked = makeTracked();
+    const fakeClient = new FakeDaemonClient();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: tracked,
+      autoStartDaemon: true,
+      timer: fakeTimer,
+      clientVersion: "0.0.39+gclient",
+      buildIdentity: { entryScript: "/current/checkout/dist/index.js", buildId: "client-build" },
+    });
+    try {
+      await expect(proxy.listTools()).rejects.toThrow(
+        /daemon build daemon-build.*stale\/checkout.*client build client-build.*current\/checkout.*current\/checkout\/dist\/index\.js --daemon restart/,
+      );
       expect(tracked.restartCalled).toBe(false);
     } finally {
       await proxy.close();

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -180,8 +180,16 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       buildIdentity: { entryScript: "/current/checkout/dist/index.js", buildId: "client-build" },
     });
     try {
-      await expect(proxy.listTools()).rejects.toThrow(
-        /daemon build daemon-build.*stale\/checkout.*client build client-build.*current\/checkout.*current\/checkout\/dist\/index\.js --daemon restart/,
+      let errorMessage = "";
+      try {
+        await proxy.listTools();
+      } catch (error) {
+        errorMessage = String(error);
+      }
+      expect(errorMessage).toContain("daemon build daemon-build (/stale/checkout/dist/index.js)");
+      expect(errorMessage).toContain("client build client-build (/current/checkout/dist/index.js)");
+      expect(errorMessage).toContain(
+        `'${process.execPath}' '/current/checkout/dist/index.js' --daemon restart`,
       );
       expect(tracked.restartCalled).toBe(false);
     } finally {

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -61,6 +61,34 @@ describe("formatToolParamError container hint", () => {
   });
 });
 
+describe("formatToolParamError actionable validation hints", () => {
+  test("explains selector keys when a closed selector receives an unknown key", () => {
+    const result = tapOnSchema.safeParse({
+      platform: "android",
+      selector: { contentDesc: "Add alarm" },
+    });
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("tapOn", result.error, {
+      platform: "android",
+      selector: { contentDesc: "Add alarm" },
+    });
+    expect(message).toContain('Unrecognized key: "contentDesc"');
+    expect(message).toContain(
+      'Accepted: elementId, testTag, text, accessibilityLink, textAny (content-desc is matched by "text")',
+    );
+  });
+
+  test("calls an omitted required platform required instead of an invalid option", () => {
+    const result = observeSchema.safeParse({ deviceId: "emulator-5554" });
+    expect(result.success).toBe(false);
+    const message = formatToolParamError("observe", result.error, {
+      deviceId: "emulator-5554",
+    });
+    expect(message).toContain("platform is required");
+    expect(message).not.toContain("Invalid option");
+  });
+});
+
 // Issue #5769: zod v4 rejects non-finite numbers (Infinity/-Infinity/NaN) at the
 // base `z.number()` check, so its default `invalid_type` text renders as the
 // self-contradictory "<param> expected number, received number" — which reads


### PR DESCRIPTION
## Summary
Improve error messages so MCP callers can act on validation and daemon skew failures instead of guessing.

## Linked Issue
Closes #5916

## Bug / Regression Context
- **Observed symptom:** selector unknown-key errors omitted valid keys; omitted platform looked like an invalid enum; same-release daemon skew suggested restarting a published package.
- **Repro steps / conditions:** call `tapOn` with `selector.contentDesc`, call `observe` without `platform`, or connect to a daemon from another same-release checkout.

## Validation
- [x] Focused formatter and daemon integration tests pass (44 tests).
- [x] `bun run typecheck` reports no new errors.
- [x] Formatting and changed-file lint pass.
- [ ] Full `bun run turbo:validate` — skipped after exceeding 60 seconds per request.

Made with [Cursor](https://cursor.com)