### PR TITLE
fix(daemon): stop health-check worker kqueue leak

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -133,7 +133,6 @@ src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
-src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
 src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
@@ -188,7 +187,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 15 :: src/server/networkTools.ts: error TS2459: Module '"../utils/deviceUtils"' declares 'BootedDevice' locally, but it is not exported.
 # swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 16 :: src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
-# swap-fp: 18 :: src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 # swap-fp: 19 :: src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type '{ id: string; type: FailureType; signature: string; title: string; message: string; severity: FailureSeverity; first_occurrence: number; last_occurrence: number; ... 4 more ...; updated_at: string; }' is not assignable to parameter of type 'InsertExpression<Database, "failure_groups">'.
 # swap-fp: 19 :: src/server/networkGraph.ts: error TS2345: Argument of type 'EventGroup | undefined' is not assignable to parameter of type 'EventGroup'.
 # swap-fp: 19,19,19,19 :: src/doctor/checks/ios.ts: error TS18048: 'elements' is possibly 'undefined'.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -2313,7 +2313,10 @@ export class Daemon {
         },
         {
           name: "health check timer",
-          run: () => this.stopHealthCheckTimer(),
+          run: async () => {
+            this.stopHealthCheckTimer();
+            await this.databaseHealthProbe.dispose?.();
+          },
         },
         {
           name: "shutdown monitors",

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -4,9 +4,44 @@ import { defaultTimer, type Timer } from "../utils/SystemTimer";
 
 const DATABASE_HEALTH_PROBE_TIMEOUT_MS = 1_000;
 const DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS = 50;
+const SQLITE_PROBE_WORKER_SOURCE = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  const { Database } = require("bun:sqlite");
+  const db = new Database(workerData.dbPath, { readonly: true, create: false });
+  db.exec("PRAGMA busy_timeout = " + Number(workerData.sqliteBusyTimeoutMs) + ";");
+  parentPort.on("message", (request) => {
+    try {
+      db.query("SELECT 1 as ok").get();
+      parentPort.postMessage({ id: request.id, ok: true });
+    } catch (error) {
+      parentPort.postMessage({
+        id: request.id,
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  });
+`;
 
 export interface DatabaseHealthProbe {
   check(): Promise<void>;
+  dispose?(): Promise<void>;
+}
+
+interface ProbeWorker {
+  postMessage(message: { id: number }): void;
+  on(event: "message", listener: (message: ProbeWorkerMessage) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "exit", listener: (code: number) => void): this;
+  terminate(): Promise<number>;
+}
+
+interface ProbeWorkerMessage {
+  id: number;
+  ok: boolean;
+  message?: string;
+  stack?: string;
 }
 
 interface DatabaseHealthProbeDependencies {
@@ -16,6 +51,7 @@ interface DatabaseHealthProbeDependencies {
   getDatabasePath?: () => string;
   timeoutMs?: number;
   sqliteBusyTimeoutMs?: number;
+  workerFactory?: (source: string, workerData: Record<string, unknown>) => ProbeWorker;
 }
 
 export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
@@ -25,6 +61,17 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
   private readonly getDatabasePath: () => string;
   private readonly timeoutMs: number;
   private readonly sqliteBusyTimeoutMs: number;
+  private readonly workerFactory: (
+    source: string,
+    workerData: Record<string, unknown>,
+  ) => ProbeWorker;
+  private worker: ProbeWorker | null = null;
+  private workerRequestId = 0;
+  private pendingRequest: {
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeoutHandle: NodeJS.Timeout;
+  } | null = null;
 
   constructor(dependencies: DatabaseHealthProbeDependencies = {}) {
     this.timer = dependencies.timer ?? defaultTimer;
@@ -33,15 +80,11 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
     this.timeoutMs = dependencies.timeoutMs ?? DATABASE_HEALTH_PROBE_TIMEOUT_MS;
     this.sqliteBusyTimeoutMs =
       dependencies.sqliteBusyTimeoutMs ?? DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS;
+    this.workerFactory =
+      dependencies.workerFactory ??
+      ((source, workerData) => new Worker(source, { eval: true, workerData }));
     this.executeSelectOne =
-      dependencies.executeSelectOne ??
-      (() =>
-        executeSqliteSelectOneInWorker(
-          this.getDatabasePath(),
-          this.sqliteBusyTimeoutMs,
-          this.timeoutMs,
-          this.timer,
-        ));
+      dependencies.executeSelectOne ?? (() => this.executeSelectOneInWorker());
   }
 
   async check(): Promise<void> {
@@ -69,79 +112,88 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
     }
   }
-}
 
-function executeSqliteSelectOneInWorker(
-  dbPath: string,
-  sqliteBusyTimeoutMs: number,
-  timeoutMs: number,
-  timer: Timer,
-): Promise<void> {
-  const worker = new Worker(
-    `
-    const { parentPort, workerData } = require("node:worker_threads");
-    try {
-      const { Database } = require("bun:sqlite");
-      const db = new Database(workerData.dbPath, { readonly: true, create: false });
-      try {
-        db.exec("PRAGMA busy_timeout = " + Number(workerData.sqliteBusyTimeoutMs) + ";");
-        db.query("SELECT 1 as ok").get();
-        parentPort.postMessage({ ok: true });
-      } finally {
-        db.close();
-      }
-    } catch (error) {
-      parentPort.postMessage({
-        ok: false,
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      });
+  async dispose(): Promise<void> {
+    const worker = this.worker;
+    this.worker = null;
+    if (this.pendingRequest) {
+      const pending = this.pendingRequest;
+      this.pendingRequest = null;
+      this.timer.clearTimeout(pending.timeoutHandle);
+      pending.reject(new Error("Database health probe disposed"));
     }
-  `,
-    {
-      eval: true,
-      workerData: { dbPath, sqliteBusyTimeoutMs },
-    },
-  );
+    if (worker) {
+      await worker.terminate();
+    }
+  }
 
-  return new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const finish = (callback: () => void): void => {
-      if (settled) {
+  private executeSelectOneInWorker(): Promise<void> {
+    if (this.pendingRequest) {
+      return Promise.reject(new Error("Database health probe is already running"));
+    }
+    const worker = this.getWorker();
+    const requestId = ++this.workerRequestId;
+    return new Promise<void>((resolve, reject) => {
+      const timeoutHandle = this.timer.setTimeout(() => {
+        this.pendingRequest = null;
+        this.worker = null;
+        void worker.terminate();
+        reject(new Error(`Database health probe timed out after ${this.timeoutMs}ms`));
+      }, this.timeoutMs);
+      if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
+        (timeoutHandle as { unref: () => void }).unref();
+      }
+      this.pendingRequest = { resolve, reject, timeoutHandle };
+      worker.postMessage({ id: requestId });
+    });
+  }
+
+  private getWorker(): ProbeWorker {
+    if (this.worker) {
+      return this.worker;
+    }
+    const worker = this.workerFactory(SQLITE_PROBE_WORKER_SOURCE, {
+      dbPath: this.getDatabasePath(),
+      sqliteBusyTimeoutMs: this.sqliteBusyTimeoutMs,
+    });
+    worker.on("message", (message: ProbeWorkerMessage) => {
+      if (!this.pendingRequest || message.id !== this.workerRequestId) {
         return;
       }
-      settled = true;
-      timer.clearTimeout(timeoutHandle);
-      callback();
-    };
-    const timeoutHandle = timer.setTimeout(() => {
-      void worker.terminate();
-      finish(() => reject(new Error(`Database health probe timed out after ${timeoutMs}ms`)));
-    }, timeoutMs);
-    if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
-      (timeoutHandle as { unref: () => void }).unref();
-    }
-
-    worker.once("message", (message: { ok: boolean; message?: string; stack?: string }) => {
-      void worker.terminate();
+      const pending = this.pendingRequest;
+      this.pendingRequest = null;
+      this.timer.clearTimeout(pending.timeoutHandle);
       if (message.ok) {
-        finish(resolve);
+        pending.resolve();
         return;
       }
       const error = new Error(message.message ?? "Database health probe failed");
       if (message.stack) {
         error.stack = message.stack;
       }
-      finish(() => reject(error));
+      pending.reject(error);
     });
-    worker.once("error", (error) => {
-      void worker.terminate();
-      finish(() => reject(error));
-    });
-    worker.once("exit", (code) => {
-      if (code !== 0) {
-        finish(() => reject(new Error(`Database health probe worker exited with code ${code}`)));
+    worker.on("error", (error) => {
+      if (!this.pendingRequest) {
+        return;
       }
+      const pending = this.pendingRequest;
+      this.pendingRequest = null;
+      this.timer.clearTimeout(pending.timeoutHandle);
+      this.worker = null;
+      pending.reject(error);
     });
-  });
+    worker.on("exit", (code) => {
+      if (code === 0 || !this.pendingRequest) {
+        return;
+      }
+      const pending = this.pendingRequest;
+      this.pendingRequest = null;
+      this.timer.clearTimeout(pending.timeoutHandle);
+      this.worker = null;
+      pending.reject(new Error(`Database health probe worker exited with code ${code}`));
+    });
+    this.worker = worker;
+    return worker;
+  }
 }

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -157,7 +157,7 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       sqliteBusyTimeoutMs: this.sqliteBusyTimeoutMs,
     });
     worker.on("message", (message: ProbeWorkerMessage) => {
-      if (!this.pendingRequest || message.id !== this.workerRequestId) {
+      if (this.worker !== worker || !this.pendingRequest || message.id !== this.workerRequestId) {
         return;
       }
       const pending = this.pendingRequest;
@@ -174,23 +174,29 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       pending.reject(error);
     });
     worker.on("error", (error) => {
+      if (this.worker !== worker) {
+        return;
+      }
+      this.worker = null;
       if (!this.pendingRequest) {
         return;
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
       this.timer.clearTimeout(pending.timeoutHandle);
-      this.worker = null;
       pending.reject(error);
     });
     worker.on("exit", (code) => {
-      if (code === 0 || !this.pendingRequest) {
+      if (this.worker !== worker || code === 0) {
+        return;
+      }
+      this.worker = null;
+      if (!this.pendingRequest) {
         return;
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
       this.timer.clearTimeout(pending.timeoutHandle);
-      this.worker = null;
       pending.reject(new Error(`Database health probe worker exited with code ${code}`));
     });
     this.worker = worker;

--- a/test/db/DatabaseHealthProbe.test.ts
+++ b/test/db/DatabaseHealthProbe.test.ts
@@ -24,6 +24,7 @@ function createSqliteFile(dbPath: string): void {
 
 class FakeProbeWorker {
   private messageListener: ((message: { id: number; ok: boolean }) => void) | undefined;
+  private errorListener: ((error: Error) => void) | undefined;
   private exitListener: ((code: number) => void) | undefined;
   terminateCalls = 0;
 
@@ -40,6 +41,8 @@ class FakeProbeWorker {
   ): this {
     if (event === "message") {
       this.messageListener = listener as (message: { id: number; ok: boolean }) => void;
+    } else if (event === "error") {
+      this.errorListener = listener as (error: Error) => void;
     } else if (event === "exit") {
       this.exitListener = listener as (code: number) => void;
     }
@@ -50,6 +53,10 @@ class FakeProbeWorker {
     this.terminateCalls++;
     this.exitListener?.(0);
     return 0;
+  }
+
+  fail(error: Error): void {
+    this.errorListener?.(error);
   }
 }
 
@@ -139,5 +146,24 @@ describe("DefaultDatabaseHealthProbe", () => {
 
     await probe.dispose();
     expect(workers[0]?.terminateCalls).toBe(1);
+  });
+
+  test("replaces a worker that fails between checks", async () => {
+    const workers: FakeProbeWorker[] = [];
+    const probe = new DefaultDatabaseHealthProbe({
+      getMigrationsError: () => null,
+      getDatabasePath: () => "/tmp/auto-mobile-test.db",
+      workerFactory: () => {
+        const worker = new FakeProbeWorker();
+        workers.push(worker);
+        return worker;
+      },
+    });
+
+    await probe.check();
+    workers[0]?.fail(new Error("worker stopped"));
+    await probe.check();
+
+    expect(workers).toHaveLength(2);
   });
 });

--- a/test/db/DatabaseHealthProbe.test.ts
+++ b/test/db/DatabaseHealthProbe.test.ts
@@ -22,6 +22,37 @@ function createSqliteFile(dbPath: string): void {
   }
 }
 
+class FakeProbeWorker {
+  private messageListener: ((message: { id: number; ok: boolean }) => void) | undefined;
+  private exitListener: ((code: number) => void) | undefined;
+  terminateCalls = 0;
+
+  postMessage(message: { id: number }): void {
+    queueMicrotask(() => this.messageListener?.({ id: message.id, ok: true }));
+  }
+
+  on(
+    event: "message" | "error" | "exit",
+    listener:
+      | ((message: { id: number; ok: boolean }) => void)
+      | ((error: Error) => void)
+      | ((code: number) => void),
+  ): this {
+    if (event === "message") {
+      this.messageListener = listener as (message: { id: number; ok: boolean }) => void;
+    } else if (event === "exit") {
+      this.exitListener = listener as (code: number) => void;
+    }
+    return this;
+  }
+
+  async terminate(): Promise<number> {
+    this.terminateCalls++;
+    this.exitListener?.(0);
+    return 0;
+  }
+}
+
 describe("DefaultDatabaseHealthProbe", () => {
   let tempDirs: string[] = [];
 
@@ -87,5 +118,26 @@ describe("DefaultDatabaseHealthProbe", () => {
     await expect(timer.resolvePromise(probe.check(), 25)).rejects.toThrow(
       "Database health probe timed out after 25ms",
     );
+  });
+
+  test("reuses one worker across checks and terminates it on dispose", async () => {
+    const workers: FakeProbeWorker[] = [];
+    const probe = new DefaultDatabaseHealthProbe({
+      getMigrationsError: () => null,
+      getDatabasePath: () => "/tmp/auto-mobile-test.db",
+      workerFactory: () => {
+        const worker = new FakeProbeWorker();
+        workers.push(worker);
+        return worker;
+      },
+    });
+
+    await probe.check();
+    await probe.check();
+    expect(workers).toHaveLength(1);
+    expect(workers[0]?.terminateCalls).toBe(0);
+
+    await probe.dispose();
+    expect(workers[0]?.terminateCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Reuse a single SQLite health-probe worker for the daemon lifetime instead of spawning and terminating one every 30 seconds.
- Dispose the worker during daemon shutdown, while retaining timeout and worker-error recovery behavior.
- Add deterministic coverage for worker reuse and shutdown cleanup.

## Root cause

Bun 1.3.14 leaks a kqueue descriptor when a worker is repeatedly terminated. The periodic database health check created a fresh worker on every tick, causing the daemon's descriptor count to grow with uptime.

## Validation

- `bun test test/db/DatabaseHealthProbe.test.ts test/daemon/daemonDatabaseHealthCheck.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run typecheck`

The full test suite reached 2,764 tests but is blocked by a pre-existing export failure in `test/utils/nonFiniteJson.property.test.ts`: `reviveNonFiniteNumbers` is not exported by `src/utils/nonFiniteJson.ts`.

Closes #5930
