### PR TITLE
fix(observe): make stale window warning actionable

### DIFF
--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -189,7 +189,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       ageMs,
       verified: false,
       isFresh: false,
-      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { button: "home" } (or relaunch the target app) and observe again.`,
+      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
     };
   }
 

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -189,7 +189,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       ageMs,
       verified: false,
       isFresh: false,
-      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app.`,
+      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { button: "home" } (or relaunch the target app) and observe again.`,
     };
   }
 

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -91,6 +91,8 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.isFresh).toBe(false);
     expect(result.freshness?.warning).toContain("com.google.android.calendar");
     expect(result.freshness?.warning).toContain("com.android.settings");
+    expect(result.freshness?.warning).toContain('pressButton { button: "home" }');
+    expect(result.freshness?.warning).toContain("relaunch the target app");
   });
 
   test("the freshness verdict is present when the result is cached (survives serialization)", async () => {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -91,7 +91,9 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.isFresh).toBe(false);
     expect(result.freshness?.warning).toContain("com.google.android.calendar");
     expect(result.freshness?.warning).toContain("com.android.settings");
-    expect(result.freshness?.warning).toContain('pressButton { button: "home" }');
+    expect(result.freshness?.warning).toContain(
+      'pressButton { platform: "android", button: "home" }',
+    );
     expect(result.freshness?.warning).toContain("relaunch the target app");
   });
 


### PR DESCRIPTION
## Summary
- Make `observe`'s stale wrong-window freshness warning actionable.
- Tell clients to call `pressButton { button: "home" }` or relaunch the target app, then observe again.
- Add regression assertions covering both recovery paths.

## Root cause
The window-identity check correctly detected and reported a persistent stale capture, but its warning stopped after describing the mismatch. Clients had no recovery guidance in the tool response.

## Validation
- `bun test test/features/observe/ObserveScreenWindowIdentity.test.ts`
- `bun run format:check -- src/features/observe/observationFreshness.ts test/features/observe/ObserveScreenWindowIdentity.test.ts`
- `bunx oxlint src/features/observe/observationFreshness.ts test/features/observe/ObserveScreenWindowIdentity.test.ts`
- `bun run build`
- `bun run typecheck`
- Whole-repository `bun run turbo:validate` was stopped after exceeding the requested 60-second limit.

Closes #5915
