### PR TITLE
fix(tool-output): hide filesystem errors from clients

### DIFF
--- a/src/server/toolOutputResources.ts
+++ b/src/server/toolOutputResources.ts
@@ -107,12 +107,11 @@ function toolOutputError(uri: string, error: string): ResourceContent {
   };
 }
 
-function notAvailable(uri: string, artifactId: string, detail?: string): ResourceContent {
-  const suffix = detail ? ` (${detail})` : "";
+function notAvailable(uri: string, artifactId: string): ResourceContent {
   return toolOutputError(
     uri,
     `Tool-output artifact "${artifactId}" is not available. It may have expired or been ` +
-      `pruned, or it was not issued by this server. Re-run the tool to regenerate it.${suffix}`,
+      `pruned, or it was not issued by this server. Re-run the tool to regenerate it.`,
   );
 }
 
@@ -142,7 +141,7 @@ async function getToolOutputArtifact(params: Record<string, string>): Promise<Re
   } catch (error) {
     const reason = errorMessage(error);
     logger.warn(`[ToolOutputResources] Failed to read artifact ${artifactId}: ${reason}`);
-    return notAvailable(uri, artifactId, reason);
+    return notAvailable(uri, artifactId);
   }
 }
 

--- a/test/server/toolOutputResources.test.ts
+++ b/test/server/toolOutputResources.test.ts
@@ -155,6 +155,8 @@ describe("tool-output artifact resource (#5882)", () => {
     expect(content.mimeType).toBe("application/json");
     const parsed = JSON.parse(content.text!) as { error: string };
     expect(parsed.error).toContain("not available");
+    expect(parsed.error).not.toContain(ARTIFACT_DIR);
+    expect(parsed.error).not.toContain("ENOENT");
     expect(fileSystem.reads).toEqual([path.join(ARTIFACT_DIR, filename)]);
   });
 


### PR DESCRIPTION
## Summary

- Hide filesystem paths and error details from tool-output resource clients.
- Continue logging the underlying read failure server-side for diagnostics.
- Add regression assertions covering absolute paths and `ENOENT`.

## Root cause

The read-failure path passed the filesystem error string into the client-facing unavailable response, exposing host paths and internal filesystem details.

## Validation

- `bun test test/server/toolOutputResources.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run turbo:validate` started but exceeded the requested 60-second limit and was stopped.

Closes #5933
