### PR TITLE
fix(observe): trim advisory data from skeleton projection

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -133,7 +133,6 @@ src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
-src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
 src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
@@ -188,7 +187,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 15 :: src/server/networkTools.ts: error TS2459: Module '"../utils/deviceUtils"' declares 'BootedDevice' locally, but it is not exported.
 # swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 16 :: src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
-# swap-fp: 18 :: src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 # swap-fp: 19 :: src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type '{ id: string; type: FailureType; signature: string; title: string; message: string; severity: FailureSeverity; first_occurrence: number; last_occurrence: number; ... 4 more ...; updated_at: string; }' is not assignable to parameter of type 'InsertExpression<Database, "failure_groups">'.
 # swap-fp: 19 :: src/server/networkGraph.ts: error TS2345: Argument of type 'EventGroup | undefined' is not assignable to parameter of type 'EventGroup'.
 # swap-fp: 19,19,19,19 :: src/doctor/checks/ios.ts: error TS18048: 'elements' is possibly 'undefined'.

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -120,6 +120,7 @@ export function sanitizeObserveResult(
 
   stripPerformanceAudit(out);
   reduceTopLevelDebugPerfTelemetry(out);
+  reduceAdvisoryOutput(out, cfg.project);
 
   if (cfg.trimNodes !== false) {
     const roots = toNodeArray(out.viewHierarchy?.hierarchy?.node);
@@ -242,6 +243,30 @@ function stripPerformanceAudit(out: ObserveResult): void {
     if (markerIndex !== -1) {
       audit.diagnostics = audit.diagnostics.slice(0, markerIndex).trimEnd();
     }
+  }
+
+  if (audit.violations !== undefined) {
+    const { diagnostics: _diagnostics, ...auditWithoutDiagnostics } = audit;
+    out.performanceAudit = auditWithoutDiagnostics as NonNullable<ObserveResult["performanceAudit"]>;
+  }
+}
+
+/**
+ * Remove advisory data from the actionable skeleton projection. These fields
+ * remain available through the full projection, while the skeleton keeps the
+ * response focused on UI-driving information.
+ */
+function reduceAdvisoryOutput(
+  out: ObserveResult,
+  project?: SanitizeObserveConfig["project"],
+): void {
+  if (project === "skeleton") {
+    delete out.layoutWarnings;
+    delete out.performanceAudit;
+  }
+
+  if (out.backStack?.tasks) {
+    out.backStack.tasks = out.backStack.tasks.filter((task) => task.numActivities !== 0);
   }
 }
 

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -133,6 +133,7 @@ describe("sanitizeObserveResult", () => {
 
     test("perf-audit strip truncates diagnostics to the summary above the GFXINFO DUMP marker", () => {
       const { observe } = loadAndroidHomeObserve();
+      delete observe.performanceAudit!.violations;
       const original = observe.performanceAudit!.diagnostics!;
       expect(original).toContain(GFXINFO_DUMP_MARKER);
       const expectedSummary = original.slice(0, original.indexOf(GFXINFO_DUMP_MARKER)).trimEnd();
@@ -162,6 +163,18 @@ describe("sanitizeObserveResult", () => {
       expect(m.threadCount).toBe(om.threadCount);
       expect(m.touchLatencyMs).toBe(om.touchLatencyMs);
       expect(m.anrDetected).toBe(om.anrDetected);
+      expect(out.performanceAudit!.violations).toEqual(observe.performanceAudit!.violations);
+    });
+
+    test("perf-audit strip drops redundant diagnostics when violations are present", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.performanceAudit!.diagnostics = "Summary restates violations";
+      observe.performanceAudit!.violations = [...(observe.performanceAudit!.violations ?? [])];
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.performanceAudit).toBeDefined();
+      expect(out.performanceAudit).not.toHaveProperty("diagnostics");
       expect(out.performanceAudit!.violations).toEqual(observe.performanceAudit!.violations);
     });
 
@@ -917,6 +930,18 @@ describe("sanitizeObserveResult", () => {
       expect(out.elements).toBeUndefined();
     });
 
+    test("project 'skeleton' omits advisory layout and performance blocks", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.layoutWarnings = { scope: "full", warnings: [] };
+      expect(observe.layoutWarnings).toBeDefined();
+      expect(observe.performanceAudit).toBeDefined();
+
+      const out = sanitizeObserveResult(observe, { dropElements: false, project: "skeleton" });
+
+      expect(out.layoutWarnings).toBeUndefined();
+      expect(out.performanceAudit).toBeUndefined();
+    });
+
     test("skeleton entries carry tuple bounds regardless of the compact flag", () => {
       const { observe } = loadAndroidHomeObserve();
       const out = sanitizeObserveResult(observe, { dropElements: false, project: "skeleton" });
@@ -969,6 +994,29 @@ describe("sanitizeObserveResult", () => {
       expect(card).toBeDefined();
       expect(card?.label).toBe("Basic long press card");
       expect(card?.sublabel).toContain("Long press me");
+    });
+  });
+
+  describe("back-stack reduction", () => {
+    test("drops task placeholders with no activities while preserving populated tasks", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.backStack = {
+        depth: 1,
+        activities: [],
+        tasks: [
+          { id: 1, numActivities: 0 },
+          { id: 2, numActivities: 2, packageName: "com.example.app" },
+          { id: 3 },
+        ],
+      };
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.backStack?.tasks).toEqual([
+        { id: 2, numActivities: 2, packageName: "com.example.app" },
+        { id: 3 },
+      ]);
+      expect(observe.backStack.tasks).toHaveLength(3);
     });
   });
 
@@ -1213,6 +1261,7 @@ describe("sanitizeObserveResult", () => {
   describe("GFXINFO diagnostics-marker boundaries (A6)", () => {
     function strippedDiagnostics(diagnostics: string): string {
       const { observe } = loadAndroidHomeObserve();
+      delete observe.performanceAudit!.violations;
       observe.performanceAudit!.diagnostics = diagnostics;
       return sanitizeObserveResult(observe, DROP_NONE).performanceAudit!.diagnostics!;
     }


### PR DESCRIPTION
## Summary
- Omit `layoutWarnings` and `performanceAudit` from the `skeleton` observe projection.
- Remove redundant performance diagnostics when violations are present and filter empty back-stack task placeholders.
- Preserve full-projection data and output-only behavior with regression coverage.

## Validation
- `bun test test/features/observe/output/ObserveResultOutput.test.ts`
- `bun test test/features/observe/output test/server/observeAppResource.test.ts test/server/observeOutputSchema.test.ts`
- `bun run typecheck`
- `bun run lint` (fails on existing repository-wide ratchet warnings)
- `bun run turbo:validate` (stopped after exceeding the requested 60-second limit)

Closes #5914
