### PR TITLE
fix(desktop): prevent orphaned video readers during startup

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -190,6 +190,7 @@ class VideoStreamClient(
 
   private var channel: SocketChannel? = null
   private var readerJob: Job? = null
+  private val sessionLock = Any()
 
   // Session identity so a superseded reader's teardown can't clobber a newer session's state. A
   // rapid disconnect()+connect() (the stall / first-frame watchdog) installs the replacement reader
@@ -222,10 +223,12 @@ class VideoStreamClient(
   override fun disconnect() {
     // Invalidate the current session first so the cancelled reader's terminal state write is
     // dropped rather than racing an Unavailable over a subsequent Idle/Connecting.
-    activeSessionId = sessionIds.incrementAndGet()
-    readerJob?.cancel()
-    readerJob = null
-    closeChannel()
+    synchronized(sessionLock) {
+      activeSessionId = sessionIds.incrementAndGet()
+      readerJob?.cancel()
+      readerJob = null
+      closeChannel()
+    }
     _state.value = VideoStreamState.Idle
   }
 
@@ -253,30 +256,41 @@ class VideoStreamClient(
         return
       }
 
+    if (!isCurrent()) {
+      decoder.close()
+      return
+    }
+
     try {
       SocketChannel.open(UnixDomainSocketAddress.of(socketPathValue)).use { socket ->
-        if (isCurrent()) channel = socket
+        synchronized(sessionLock) {
+          if (!isCurrent()) return
+          channel = socket
+        }
         val input = Channels.newInputStream(socket)
         val writer =
           BufferedWriter(
             OutputStreamWriter(Channels.newOutputStream(socket), StandardCharsets.UTF_8)
           )
 
-        writer.write(
-          json.encodeToString(
-            serializer<VideoStreamRequest>(),
-            VideoStreamRequest(
-              id = UUID.randomUUID().toString(),
-              sessionUuid = sessionUuidProvider(),
-              deviceId = deviceId,
-              quality = quality?.wire,
-              fps = fps,
-              bitrateKbps = bitrateKbps,
-            ),
+        synchronized(sessionLock) {
+          if (!isCurrent()) return
+          writer.write(
+            json.encodeToString(
+              serializer<VideoStreamRequest>(),
+              VideoStreamRequest(
+                id = UUID.randomUUID().toString(),
+                sessionUuid = sessionUuidProvider(),
+                deviceId = deviceId,
+                quality = quality?.wire,
+                fps = fps,
+                bitrateKbps = bitrateKbps,
+              ),
+            )
           )
-        )
-        writer.newLine()
-        writer.flush()
+          writer.newLine()
+          writer.flush()
+        }
 
         val ackLine = readAckLine(input)
         val ack = json.decodeFromString(serializer<VideoStreamResponse>(), ackLine)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -12,6 +12,8 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -283,6 +285,37 @@ class VideoStreamClientTest {
   }
 
   @Test
+  fun `a disconnect during decoder startup does not subscribe`() = runBlocking {
+    val server = relay(payload = sampleH264())
+    val decoderStarted = CountDownLatch(1)
+    val releaseDecoder = CountDownLatch(1)
+    val decoderFinished = CountDownLatch(1)
+    val client =
+      VideoStreamClient(
+        socketPathValue = server.socketPath.toString(),
+        decoderFactory = {
+          decoderStarted.countDown()
+          try {
+            check(releaseDecoder.await(5, TimeUnit.SECONDS))
+            throw H264DecodeException("startup cancelled")
+          } finally {
+            decoderFinished.countDown()
+          }
+        },
+      )
+
+    client.connect("emulator-5554")
+    assertTrue(decoderStarted.await(5, TimeUnit.SECONDS))
+
+    client.disconnect()
+    releaseDecoder.countDown()
+
+    assertTrue(decoderFinished.await(5, TimeUnit.SECONDS))
+    assertEquals(false, server.receivedRequest())
+    client.dispose()
+  }
+
+  @Test
   fun `an orderly relay close reports the stream as unavailable`() = runBlocking {
     val server = relay()
     val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
@@ -462,6 +495,8 @@ class VideoStreamClientTest {
       }
       throw AssertionError("Client did not send a subscribe request")
     }
+
+    fun receivedRequest(): Boolean = captured != null
 
     override fun close() {
       thread.interrupt()


### PR DESCRIPTION
## Summary

Closes #5859.

`VideoStreamClient` could leave a superseded reader blocked during decoder or socket startup. That orphaned reader could subscribe after disconnect, keep the device encoder alive, and monopolize the client's single reader thread so reconnects never started.

This change:

- Rejects superseded sessions before opening or subscribing on a socket.
- Synchronizes session invalidation, socket tracking, and subscription startup.
- Adds deterministic regression coverage for disconnect during decoder startup.

## Validation

- `bash scripts/ktfmt/validate_ktfmt.sh` — passed.
- Focused Gradle test was attempted but could not start because the local Gradle Java setup passes unsupported JVM option `--sun-misc-unsafe-memory-access=allow`.
