### PR TITLE
fix(tool-output): retain custom output artifacts

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -905,7 +905,7 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
     const artifactDirectory = configuredArtifactDirectory ?? getDefaultToolOutputsDir();
     const artifactWriter = !internalCall
       ? configuredArtifactDirectory
-        ? this.createArtifactWriter(artifactDirectory, timer)
+        ? this.createArtifactWriter(artifactDirectory, timer, AUTOMATIC_TOOL_OUTPUT_RETENTION)
         : this.createArtifactWriter(artifactDirectory, timer, AUTOMATIC_TOOL_OUTPUT_RETENTION)
       : undefined;
 

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -309,7 +309,13 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
 
     expect(result.durationMs).toBe(5);
     expect(requestedDirectories).toEqual(["/tmp/artifacts"]);
-    expect(requestedRetentions).toEqual([undefined]);
+    expect(requestedRetentions).toEqual([
+      {
+        maxAgeMs: 24 * 60 * 60 * 1000,
+        maxFiles: 500,
+        overflowMinAgeMs: 60 * 60 * 1000,
+      },
+    ]);
     expect(writer.writes).toHaveLength(1);
     expect((writer.writes[0].data as any).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
     expect(result.finalizedResponse.structuredContent).toEqual({


### PR DESCRIPTION
## Summary

- Apply the existing bounded tool-output retention policy to explicitly configured `--tool-outputs-dir` directories.
- Keep retained files aligned with the in-memory provenance ledger so long-lived custom-directory daemons do not accumulate unbounded artifacts or lose retrievability after ledger eviction.
- Add regression coverage for retention propagation.

## Root cause

The configured-directory path constructed `JsonToolOutputArtifactWriter` without retention, while the default temporary-directory path already used the 24-hour/500-file policy. This allowed custom output directories to grow without bound despite the ledger being capped at 1024 entries.

## Validation

- `bun test test/server/toolRegistry.pipeline.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- `bun run lint` started but exceeded the requested 60-second check limit and was stopped; it had reported no new lint violations before stopping.

Fixes [#5929](https://github.com/kaeawc/auto-mobile/issues/5929).
