### PR TITLE
fix(android): detect privileged app processes in launch and terminate

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -24,6 +24,7 @@ import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { isAndroidPackageRunning } from "../../utils/android-cmdline-tools/androidProcessState";
 
 const LAUNCH_OBSERVATION_TIMEOUT_MS = 5000;
 const LAUNCH_OBSERVATION_POLL_INTERVAL_MS = 200;
@@ -742,11 +743,13 @@ export class LaunchApp extends BaseVisualChange {
 
     // Check if app is running
     const isRunning = await perf.track("checkRunning", async () => {
-      const isRunningCmd = `shell dumpsys activity processes | grep -E "${packageName}/u${targetUserId}a" | wc -l`;
+      const isRunningCmd = "shell dumpsys activity processes";
       logger.info(`[LaunchApp] Checking if app is running: ${isRunningCmd}`);
       const isRunningOutput = await this.adb.executeCommand(isRunningCmd);
-      const result = parseInt(isRunningOutput.trim(), 10) > 0;
-      logger.info(`[LaunchApp] App running: ${result} (output: "${isRunningOutput.trim()}")`);
+      const result = isAndroidPackageRunning(isRunningOutput.stdout, packageName, targetUserId);
+      logger.info(
+        `[LaunchApp] App running: ${result} (output: "${isRunningOutput.stdout.trim()}")`,
+      );
       return result;
     });
     this.assertLaunchNotAborted(signal);

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -15,6 +15,7 @@ import { ListInstalledApps } from "../observe/ListInstalledApps";
 import { getIosInstalledAppBundleId } from "../../utils/ios-cmdline-tools/iosInstalledApp";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { RealObserveScreen } from "../observe/ObserveScreen";
+import { isAndroidPackageRunning } from "../../utils/android-cmdline-tools/androidProcessState";
 
 /**
  * Invalidates the host-side cached window/hierarchy record for a device after
@@ -166,7 +167,7 @@ export class TerminateApp extends BaseVisualChange {
             undefined,
             true,
           );
-          return result.stdout.includes(`${packageName}/u${targetUserId}a`);
+          return isAndroidPackageRunning(result.stdout, packageName, targetUserId);
         } catch (error) {
           logger.warn(`[TerminateApp] Running-state check failed for user ${targetUserId}`, error);
           throw new ActionableError(

--- a/src/utils/android-cmdline-tools/androidProcessState.ts
+++ b/src/utils/android-cmdline-tools/androidProcessState.ts
@@ -1,0 +1,33 @@
+const PROCESS_RECORD_PATTERN = /(?:^|\s)\d+:([A-Za-z0-9_.]+)\/(u(\d+)a\d+|\d+)(?=[\s}]|$)/gm;
+
+/**
+ * Determines whether an Android package has a process for the selected user.
+ *
+ * App UIDs identify the user as `u<userId>a<appId>`, while system and
+ * privileged processes use a numeric UID such as `1000`. Numeric system UIDs
+ * belong to user 0; multi-user numeric UIDs encode the user in the leading
+ * digits.
+ */
+export function isAndroidPackageRunning(
+  processesOutput: string,
+  packageName: string,
+  userId: number,
+): boolean {
+  PROCESS_RECORD_PATTERN.lastIndex = 0;
+
+  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
+    if (match[1] !== packageName) {
+      continue;
+    }
+
+    const uid = match[2];
+    const processUserId = uid.startsWith("u")
+      ? Number(match[3])
+      : Math.floor(Number(uid) / 100_000);
+    if (processUserId === userId) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -82,10 +82,10 @@ describe("LaunchApp", () => {
   test("returns observation when app is already in foreground", async () => {
     const controller = new AbortController();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "1\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", {
+      stdout: "123:com.example.app/u0a123\n",
+      stderr: "",
+    });
 
     const result = await launchApp.execute(
       packageName,
@@ -107,6 +107,35 @@ describe("LaunchApp", () => {
         .every((options) => options.signal === controller.signal),
     ).toBe(true);
     expect(fakeAwaitIdle.wasMethodCalled("initializeUiStabilityTracking")).toBe(true);
+  });
+
+  test("recognizes a running app whose process uses a numeric system UID", async () => {
+    const controller = new AbortController();
+    const settingsPackageName = "com.android.settings";
+    fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      stdout: `package:${settingsPackageName}\n`,
+      stderr: "",
+    });
+    fakeAdb.setCommandResponse("shell pm list packages -s --user 0", { stdout: "", stderr: "" });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", {
+      stdout: "*APP* UID 1000 ProcessRecord{3dc154f 30779:com.android.settings/1000}",
+      stderr: "",
+    });
+    fakeAdb.setForegroundApp({ packageName: settingsPackageName, userId: 0 });
+
+    const result = await launchApp.execute(
+      settingsPackageName,
+      false,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBe("App is already in foreground");
+    expect(fakeAdb.wasCommandExecuted("shell dumpsys activity processes")).toBe(true);
   });
 
   test("stops launch when device loss cancels the operation during preflight", async () => {
@@ -338,13 +367,10 @@ describe("LaunchApp", () => {
       stdout: "Starting: Intent { act=android.intent.action.MAIN }",
       stderr: "",
     });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${settingsPackageName}/u0a" | wc -l`,
-      {
-        stdout: "0\n",
-        stderr: "",
-      },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", {
+      stdout: "",
+      stderr: "",
+    });
     fakeAdb.setForegroundApp({ packageName: settingsPackageName, userId: 0 });
     fakeObserveScreen.setObserveResult(createObserveResult(settingsPackageName));
 
@@ -367,10 +393,10 @@ describe("LaunchApp", () => {
   test("clears Android app data through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "1\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", {
+      stdout: "123:com.example.app/u0a123\n",
+      stderr: "",
+    });
 
     const clearCalls: Array<{
       device: BootedDevice;
@@ -416,10 +442,7 @@ describe("LaunchApp", () => {
   test("clears Android app data through the injected action before relaunch when not running", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
 
     const clearCalls: Array<{
       device: BootedDevice;
@@ -449,10 +472,10 @@ describe("LaunchApp", () => {
   test("cold boots Android through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "1\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", {
+      stdout: "123:com.example.app/u0a123\n",
+      stderr: "",
+    });
 
     const clearCalls: string[] = [];
     const coldBootCalls: Array<{ device: BootedDevice; packageName: string; options: unknown }> =
@@ -499,10 +522,7 @@ describe("LaunchApp", () => {
 
   test("waits for foreground before returning observation", async () => {
     fakeAdb.setForegroundApp(null);
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
 
     const resultPromise = launchApp.execute(packageName, false, false);
 
@@ -532,10 +552,7 @@ describe("LaunchApp", () => {
     ];
 
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
     fakeObserveScreen.setObserveResult(
       () => observations.shift() ?? createObserveResult(packageName),
     );
@@ -566,10 +583,7 @@ describe("LaunchApp", () => {
     const permissionControllerPackageName = "com.google.android.permissioncontroller";
 
     fakeAdb.setForegroundApp({ packageName: permissionControllerPackageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
     fakeObserveScreen.setObserveResult({
       ...createObserveResult(permissionControllerPackageName),
       activeWindow: {
@@ -595,10 +609,7 @@ describe("LaunchApp", () => {
     const previousPackageName = "com.example.previous";
 
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
     fakeObserveScreen.setObserveResult(() => createObserveResult(previousPackageName));
 
     const result = await launchApp.execute(packageName, false, false);
@@ -618,10 +629,7 @@ describe("LaunchApp", () => {
     const previousPackageName = "com.example.previous";
 
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(
-      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
-      { stdout: "0\n", stderr: "" },
-    );
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
     fakeObserveScreen.setObserveResult(() => createObserveResult(previousPackageName));
 
     const result = await launchApp.execute(packageName, false, false);

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -303,6 +303,29 @@ describe("TerminateApp (Android)", () => {
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(true);
   });
 
+  test("terminates an installed app running under a numeric system UID", async () => {
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.android.settings | grep -c com.android.settings",
+      "1",
+    );
+    fakeAdb.setCommandResult(
+      "shell dumpsys activity processes",
+      "*APP* UID 1000 ProcessRecord{3dc154f 30779:com.android.settings/1000}",
+    );
+    fakeAdb.setCommandResult("shell am force-stop --user 0 com.android.settings", "");
+
+    const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
+    const result = await terminateApp.execute("com.android.settings", { skipObservation: true });
+
+    expect(result.wasRunning).toBe(true);
+    expect(result.wasForeground).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("shell am force-stop --user 0 com.android.settings")).toBe(
+      true,
+    );
+  });
+
   test("invalidates the cached window record after a successful force-stop (issue #5867)", async () => {
     fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
     fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);


### PR DESCRIPTION
## Summary

- Fix `launchApp` and `terminateApp` running-state detection for privileged Android packages that use numeric system UIDs.
- Replace shell-side `grep`/`wc` filtering with structured parsing of `dumpsys activity processes`, preserving user scoping and no-match handling.
- Add deterministic regression coverage for ordinary app UIDs and `com.android.settings` running as UID `1000`.

## Root cause

Both actions assumed every process record used an app UID such as `u0a123`. Android system and privileged packages can instead use numeric UIDs such as `1000`, causing running apps to be treated as stopped.

## Validation

- `bun test test/features/action/TerminateApp.test.ts test/features/action/LaunchApp.test.ts` — 63 passed
- `bun test test/features/action` — passed
- `bun run format:check` — passed
- `bun run lint` — passed with existing baseline warnings
- `bun run build` — passed
- `bun run typecheck` — passed; no new type errors
- `bun run turbo:validate` — stopped at the requested 60-second limit while the full suite was still running

Closes https://github.com/kaeawc/auto-mobile/issues/5932.
