### PR TITLE
fix(video): make recording ownership race-safe

### DIFF
--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -316,7 +316,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     // A recording owns its process after this method returns. The request signal
     // must bound only startup, not kill an accepted recording after its caller
     // has moved on to post-tool auditing.
-    const process = await adb.spawn(args);
+    const process = await adb.spawn(args, { signal: config.abortSignal });
     const abortStartup = () => process.kill("SIGTERM");
     config.abortSignal?.addEventListener("abort", abortStartup, { once: true });
     if (config.abortSignal?.aborted) {

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -316,7 +316,10 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     // A recording owns its process after this method returns. The request signal
     // must bound only startup, not kill an accepted recording after its caller
     // has moved on to post-tool auditing.
-    const process = await adb.spawn(args, { signal: config.abortSignal });
+    const process = await adb.spawn(args, {
+      signal: config.abortSignal,
+      abortSignalScope: "startup",
+    });
     const abortStartup = () => process.kill("SIGTERM");
     config.abortSignal?.addEventListener("abort", abortStartup, { once: true });
     if (config.abortSignal?.aborted) {

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -434,6 +434,14 @@ export class VideoRecorderService {
 
   private async handleStartFailure(error: unknown, active: ActiveRecordingState): Promise<never> {
     if (this.retainStartCleanupHandle(error, active)) {
+      try {
+        await this.forceStopOrDiscardRecording(active.recordingId, true);
+      } catch (cleanupError) {
+        this.log.warn(
+          `[VideoRecorderService] Failed to retry cleanup for ${active.recordingId}: ${String(cleanupError)}`,
+          cleanupError,
+        );
+      }
       throw error;
     }
     if (this.activeRecordings.get(active.recordingId) === active && !active.forceStopRequested) {
@@ -464,10 +472,10 @@ export class VideoRecorderService {
       this.log.debug(
         `[VideoRecorderService] Starting recording ${active.recordingId} ended during force stop: ${error}`,
       );
+      this.activeRecordings.delete(active.recordingId);
       if (discardArtifacts) {
         await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
       }
-      this.activeRecordings.delete(active.recordingId);
       return undefined;
     }
   }

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -16,6 +16,7 @@ import {
   defaultSecurePermissions,
   type SecurePermissions,
 } from "../../utils/filesystem/securePermissions";
+import { combineAbortSignals } from "../../utils/AbortContext";
 
 /**
  * Keep only the declared {@link VideoRecordingConfig} fields. A backend that
@@ -115,10 +116,14 @@ export interface VideoRecorderServiceDependencies {
   idGenerator?: IdGenerator | (() => string);
   now?: () => Date;
   securePermissions?: SecurePermissions;
+  fileSystem?: Pick<typeof fsPromises, "rm">;
 }
 
 interface ActiveRecordingState extends ActiveVideoRecording {
-  handle: RecordingHandle;
+  deviceId?: string;
+  handle?: RecordingHandle;
+  startPromise: Promise<RecordingHandle>;
+  startAbortController: AbortController;
   forceStopRequested: boolean;
 }
 
@@ -178,6 +183,7 @@ export class VideoRecorderService {
   private idGenerator: IdGenerator;
   private now: () => Date;
   private securePermissions: SecurePermissions;
+  private fileSystem: Pick<typeof fsPromises, "rm">;
   private activeRecordings = new Map<string, ActiveRecordingState>();
   private stoppingRecordings = new Map<string, Promise<VideoRecordingMetadata>>();
   private forceStoppingRecordings = new Map<string, Promise<void>>();
@@ -190,6 +196,7 @@ export class VideoRecorderService {
     this.idGenerator = normalizeIdGenerator(dependencies.idGenerator);
     this.now = dependencies.now ?? (() => new Date());
     this.securePermissions = dependencies.securePermissions ?? defaultSecurePermissions;
+    this.fileSystem = dependencies.fileSystem ?? fsPromises;
   }
 
   async startRecording(options: StartVideoRecordingOptions = {}): Promise<ActiveVideoRecording> {
@@ -210,78 +217,61 @@ export class VideoRecorderService {
 
     const fileName = buildRecordingFileName(nameSlug, startedAt, config.format);
     const outputPath = path.join(recordingDir, fileName);
-
-    let handle: RecordingHandle;
-    try {
-      handle = await this.backend.start({
-        recordingId,
-        outputDirectory: recordingDir,
-        outputPath,
-        fileName,
-        startedAt,
-        device: options.device,
-        maxDurationSeconds: options.maxDurationSeconds,
-        abortSignal: options.abortSignal,
-        ...config,
-      });
-    } catch (error) {
-      if (error instanceof VideoCaptureStartCleanupError) {
-        const retainedOutputPath = error.handle.outputPath || outputPath;
-        this.activeRecordings.set(recordingId, {
-          recordingId,
-          outputPath: retainedOutputPath,
-          fileName: path.basename(retainedOutputPath),
-          startedAt: error.handle.startedAt || startedAt,
-          config,
-          outputName: options.outputName,
-          handle: error.handle,
-          forceStopRequested: false,
-        });
-        try {
-          await this.forceStopRecording(recordingId);
-          await fsPromises.rm(recordingDir, { recursive: true, force: true });
-        } catch (cleanupError) {
-          this.log.warn(
-            `[VideoRecorderService] Failed to force-stop aborted recording ${recordingId}: ${String(cleanupError)}`,
-          );
-        }
-      } else {
-        try {
-          await fsPromises.rm(recordingDir, { recursive: true, force: true });
-        } catch (cleanupError) {
-          this.log.warn(
-            `[VideoRecorderService] Failed to remove aborted recording directory ${recordingDir}: ${String(cleanupError)}`,
-          );
-        }
-      }
-      throw error;
-    }
-
-    const resolvedOutputPath = handle.outputPath || outputPath;
-    const resolvedFileName = path.basename(resolvedOutputPath);
-    const effectiveConfig = toPublicRecordingConfig(handle.effectiveConfig ?? config);
+    const startAbortController = new AbortController();
+    const captureConfig: VideoCaptureConfig = {
+      recordingId,
+      outputDirectory: recordingDir,
+      outputPath,
+      fileName,
+      startedAt,
+      device: options.device,
+      maxDurationSeconds: options.maxDurationSeconds,
+      abortSignal: combineAbortSignals(options.abortSignal, startAbortController.signal),
+      ...config,
+    };
+    // Defer backend invocation by one microtask so provisional ownership is
+    // visible before any synchronous startup work can run.
+    const startPromise = Promise.resolve().then(
+      async () => await this.backend.start(captureConfig),
+    );
 
     const active: ActiveRecordingState = {
       recordingId,
-      outputPath: resolvedOutputPath,
-      fileName: resolvedFileName,
-      startedAt: handle.startedAt || startedAt,
-      config: effectiveConfig,
+      outputPath,
+      fileName,
+      startedAt,
+      config,
       outputName: options.outputName,
-      handle,
+      deviceId: options.device?.deviceId,
+      startPromise,
+      startAbortController,
       forceStopRequested: false,
     };
 
     this.activeRecordings.set(recordingId, active);
 
-    return {
-      recordingId,
-      outputPath: active.outputPath,
-      fileName: active.fileName,
-      startedAt: active.startedAt,
-      config: active.config,
-      outputName: active.outputName,
-    };
+    try {
+      const handle = await startPromise;
+      active.handle = handle;
+      active.outputPath = handle.outputPath || outputPath;
+      active.fileName = path.basename(active.outputPath);
+      active.startedAt = handle.startedAt || startedAt;
+      active.config = toPublicRecordingConfig(handle.effectiveConfig ?? config);
+      if (active.forceStopRequested || this.activeRecordings.get(recordingId) !== active) {
+        throw new Error(`Recording ${recordingId} was force-stopped while it was starting.`);
+      }
+
+      return {
+        recordingId,
+        outputPath: active.outputPath,
+        fileName: active.fileName,
+        startedAt: active.startedAt,
+        config: active.config,
+        outputName: active.outputName,
+      };
+    } catch (error) {
+      return await this.handleStartFailure(error, active);
+    }
   }
 
   /**
@@ -291,6 +281,12 @@ export class VideoRecorderService {
    */
   listActiveRecordingIds(): string[] {
     return Array.from(this.activeRecordings.keys());
+  }
+
+  hasActiveRecordingForDevice(deviceId: string): boolean {
+    return Array.from(this.activeRecordings.values()).some(
+      (recording) => recording.deviceId === deviceId,
+    );
   }
 
   async stopRecording(recordingId: string): Promise<VideoRecordingMetadata> {
@@ -314,7 +310,8 @@ export class VideoRecorderService {
 
   private async stopActiveRecording(active: ActiveRecordingState): Promise<VideoRecordingMetadata> {
     const recordingId = active.recordingId;
-    const stopResult = await this.backend.stop(active.handle);
+    const handle = active.handle ?? (await active.startPromise);
+    const stopResult = await this.backend.stop(handle);
     if (this.activeRecordings.get(recordingId) !== active || active.forceStopRequested) {
       throw new Error(`Recording ${recordingId} was force-stopped while it was stopping.`);
     }
@@ -353,23 +350,39 @@ export class VideoRecorderService {
   }
 
   async forceStopRecording(recordingId: string): Promise<void> {
+    await this.forceStopOrDiscardRecording(recordingId, false);
+  }
+
+  async discardRecording(recordingId: string): Promise<void> {
+    await this.forceStopOrDiscardRecording(recordingId, true);
+  }
+
+  private async forceStopOrDiscardRecording(
+    recordingId: string,
+    discardArtifacts: boolean,
+  ): Promise<void> {
+    const activeOutputPath = this.activeRecordings.get(recordingId)?.outputPath;
     const forceStopping = this.forceStoppingRecordings.get(recordingId);
     if (forceStopping) {
-      return forceStopping;
+      await forceStopping;
+      if (discardArtifacts) {
+        await this.removeRecordingArtifacts(recordingId, activeOutputPath);
+      }
+      return;
     }
     const active = this.activeRecordings.get(recordingId);
     if (!active) {
       throw new Error(`No active recording found for id ${recordingId}`);
     }
     const backendForceStop = this.backend.forceStop;
-    if (!backendForceStop) {
+    if (!backendForceStop && active.handle) {
       throw new Error("Video capture backend does not support force stopping recordings.");
     }
 
     // Set this before awaiting the backend: the graceful stop may resolve while
     // a device-side force-stop command is still in flight.
     active.forceStopRequested = true;
-    const forceStop = this.forceStopActiveRecording(active, backendForceStop);
+    const forceStop = this.forceStopActiveRecording(active, backendForceStop, discardArtifacts);
     this.forceStoppingRecordings.set(recordingId, forceStop);
     try {
       await forceStop;
@@ -380,17 +393,95 @@ export class VideoRecorderService {
 
   private async forceStopActiveRecording(
     active: ActiveRecordingState,
-    backendForceStop: NonNullable<VideoCaptureBackend["forceStop"]>,
+    backendForceStop: VideoCaptureBackend["forceStop"],
+    discardArtifacts: boolean,
   ): Promise<void> {
+    active.startAbortController.abort();
+    const handle = await this.resolveForceStopHandle(active, discardArtifacts);
+    if (!handle) {
+      return;
+    }
+
+    if (!backendForceStop) {
+      active.forceStopRequested = false;
+      throw new Error("Video capture backend does not support force stopping recordings.");
+    }
+
     try {
-      await backendForceStop.call(this.backend, active.handle);
+      await backendForceStop.call(this.backend, handle);
       this.activeRecordings.delete(active.recordingId);
+      if (discardArtifacts) {
+        await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
+      }
     } catch (error) {
       if (this.activeRecordings.get(active.recordingId) === active) {
         active.forceStopRequested = false;
       }
       throw error;
     }
+  }
+
+  private retainStartCleanupHandle(
+    error: unknown,
+    active: ActiveRecordingState,
+  ): error is VideoCaptureStartCleanupError {
+    if (!(error instanceof VideoCaptureStartCleanupError)) {
+      return false;
+    }
+    active.handle = error.handle;
+    return true;
+  }
+
+  private async handleStartFailure(error: unknown, active: ActiveRecordingState): Promise<never> {
+    if (this.retainStartCleanupHandle(error, active)) {
+      throw error;
+    }
+    if (this.activeRecordings.get(active.recordingId) === active && !active.forceStopRequested) {
+      this.activeRecordings.delete(active.recordingId);
+    }
+    try {
+      await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
+    } catch (cleanupError) {
+      this.log.warn(
+        `[VideoRecorderService] Failed to remove aborted recording directory for ${active.recordingId}: ${String(cleanupError)}`,
+      );
+    }
+    throw error;
+  }
+
+  private async resolveForceStopHandle(
+    active: ActiveRecordingState,
+    discardArtifacts: boolean,
+  ): Promise<RecordingHandle | undefined> {
+    try {
+      return active.handle ?? (await active.startPromise);
+    } catch (error) {
+      if (this.retainStartCleanupHandle(error, active)) {
+        return error.handle;
+      }
+      // A starting backend that honors cancellation owns no live capture after
+      // rejecting, so dropping provisional ownership completes the force stop.
+      this.log.debug(
+        `[VideoRecorderService] Starting recording ${active.recordingId} ended during force stop: ${error}`,
+      );
+      if (discardArtifacts) {
+        await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
+      }
+      this.activeRecordings.delete(active.recordingId);
+      return undefined;
+    }
+  }
+
+  private async removeRecordingArtifacts(recordingId: string, outputPath?: string): Promise<void> {
+    const active = this.activeRecordings.get(recordingId);
+    const resolvedOutputPath = outputPath ?? active?.outputPath;
+    if (!resolvedOutputPath) {
+      return;
+    }
+    await this.fileSystem.rm(path.dirname(resolvedOutputPath), {
+      recursive: true,
+      force: true,
+    });
   }
 
   private getRecordingDir(name: string): string {

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -372,6 +372,7 @@ export class AndroidSegmentedPlanVideoSession {
         logger.warn(
           `[SegmentedPlanVideo] Failed to finalize segment ${id}: ${errorMessage(error)}`,
         );
+        this.pendingRollbackRecordingIds.push(id);
       } finally {
         this.activeRecordingId = undefined;
       }

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -8,8 +8,7 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import {
-  forceStopVideoRecording as defaultForceStopVideoRecording,
-  interruptVideoRecording as defaultInterruptVideoRecording,
+  rollbackVideoRecordingStart as defaultRollbackVideoRecordingStart,
   startVideoRecording as defaultStartVideoRecording,
   stopVideoRecording as defaultStopVideoRecording,
 } from "./videoRecordingManager";
@@ -47,7 +46,7 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   stopVideoRecording?: (
     recordingId?: string,
   ) => Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }>;
-  forceStopVideoRecording?: (recordingId: string) => Promise<void>;
+  rollbackVideoRecordingStart?: (recordingId: string) => Promise<void>;
 }
 
 /**
@@ -94,6 +93,9 @@ export class AndroidSegmentedPlanVideoSession {
   /** Tracks the most recent in-flight rotation so {@link stop} can await it. */
   private pendingRotation: Promise<void> = Promise.resolve();
 
+  /** Cancels a replacement segment start while an abort is draining its rotation. */
+  private rotationAbortController: AbortController | undefined;
+
   private segmentIndex = 0;
 
   private segmentStartedAtMs = 0;
@@ -101,6 +103,9 @@ export class AndroidSegmentedPlanVideoSession {
   private readonly completedFilePaths: string[] = [];
 
   private readonly completedRecordingIds: string[] = [];
+
+  /** IDs whose stop failed during rotation and still need rollback on abort. */
+  private readonly pendingRollbackRecordingIds: string[] = [];
 
   private readonly startVideoRecordingFn: (
     request: Parameters<typeof defaultStartVideoRecording>[0],
@@ -110,7 +115,7 @@ export class AndroidSegmentedPlanVideoSession {
     recordingId?: string,
   ) => Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }>;
 
-  private readonly forceStopVideoRecordingFn: (recordingId: string) => Promise<void>;
+  private readonly rollbackVideoRecordingStartFn: (recordingId: string) => Promise<void>;
 
   constructor(options: AndroidSegmentedPlanVideoSessionOptions) {
     this.device = options.device;
@@ -124,12 +129,8 @@ export class AndroidSegmentedPlanVideoSession {
     this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
-    this.forceStopVideoRecordingFn =
-      options.forceStopVideoRecording ??
-      (async (recordingId) => {
-        await defaultForceStopVideoRecording(recordingId);
-        await defaultInterruptVideoRecording(recordingId);
-      });
+    this.rollbackVideoRecordingStartFn =
+      options.rollbackVideoRecordingStart ?? defaultRollbackVideoRecordingStart;
   }
 
   /** Device this session is recording, so callers can match sessions by device. */
@@ -173,34 +174,14 @@ export class AndroidSegmentedPlanVideoSession {
       this.startupAbortSignal?.throwIfAborted();
     } catch (error) {
       this.timerDriven = false;
-      await this.rollbackStartedSegment();
+      if (this.activeRecordingId) {
+        await this.abort();
+      }
       throw error;
     }
     this.scheduleRotation();
     this.scheduleMaxDurationStop();
     return first;
-  }
-
-  private async rollbackStartedSegment(): Promise<void> {
-    const recordingId = this.activeRecordingId;
-    this.activeRecordingId = undefined;
-    if (!recordingId) {
-      return;
-    }
-    try {
-      await this.stopVideoRecordingFn(recordingId);
-    } catch (stopError) {
-      logger.warn(
-        `[SegmentedPlanVideo] Failed to stop cancelled segment ${recordingId}: ${errorMessage(stopError)}`,
-      );
-      try {
-        await this.forceStopVideoRecordingFn(recordingId);
-      } catch (forceStopError) {
-        logger.warn(
-          `[SegmentedPlanVideo] Failed to force-stop cancelled segment ${recordingId}: ${errorMessage(forceStopError)}`,
-        );
-      }
-    }
   }
 
   private scheduleRotation(): void {
@@ -240,6 +221,46 @@ export class AndroidSegmentedPlanVideoSession {
    */
   async stop(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
     this.timerDriven = false;
+    this.clearTimers();
+    await this.pendingRotation;
+    const result = await this.finalize();
+    this.notifyFinalized();
+    return result;
+  }
+
+  /**
+   * Cancel without publishing completed segments or a manifest. Every segment
+   * owned by this session is force-stopped and removed from durable metadata.
+   */
+  async abort(): Promise<void> {
+    this.timerDriven = false;
+    this.clearTimers();
+    this.rotationAbortController?.abort();
+    await this.pendingRotation;
+    const recordingIds = Array.from(
+      new Set([
+        ...this.completedRecordingIds,
+        ...this.pendingRollbackRecordingIds,
+        ...(this.activeRecordingId ? [this.activeRecordingId] : []),
+      ]),
+    ).toReversed();
+    const results = await Promise.allSettled(
+      recordingIds.map((recordingId) => this.rollbackVideoRecordingStartFn(recordingId)),
+    );
+    const failures = results
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "Failed to roll back every segmented recording");
+    }
+    this.activeRecordingId = undefined;
+    this.completedRecordingIds.splice(0);
+    this.completedFilePaths.splice(0);
+    this.pendingRollbackRecordingIds.splice(0);
+    this.notifyFinalized();
+  }
+
+  private clearTimers(): void {
     if (this.rotationTimerHandle !== undefined) {
       this.timer.clearTimeout(this.rotationTimerHandle);
       this.rotationTimerHandle = undefined;
@@ -248,10 +269,6 @@ export class AndroidSegmentedPlanVideoSession {
       this.timer.clearTimeout(this.maxDurationTimerHandle);
       this.maxDurationTimerHandle = undefined;
     }
-    await this.pendingRotation;
-    const result = await this.finalize();
-    this.notifyFinalized();
-    return result;
   }
 
   /** Fires {@link onFinalized} at most once, so callers can drop the session from any registry. */
@@ -307,6 +324,8 @@ export class AndroidSegmentedPlanVideoSession {
     }
 
     const previousId = this.activeRecordingId;
+    const rotationAbortController = new AbortController();
+    this.rotationAbortController = rotationAbortController;
     try {
       const stopped = await this.stopVideoRecordingFn(previousId);
       this.completedRecordingIds.push(previousId);
@@ -318,16 +337,21 @@ export class AndroidSegmentedPlanVideoSession {
       logger.warn(
         `[SegmentedPlanVideo] Failed to stop segment ${previousId}: ${errorMessage(error)}`,
       );
+      this.pendingRollbackRecordingIds.push(previousId);
     } finally {
       this.activeRecordingId = undefined;
     }
 
     try {
-      await this.startSegment();
+      await this.startSegment(rotationAbortController.signal);
     } catch (error) {
       logger.warn(
         `[SegmentedPlanVideo] Failed to start next segment after ${previousId}: ${errorMessage(error)}`,
       );
+    } finally {
+      if (this.rotationAbortController === rotationAbortController) {
+        this.rotationAbortController = undefined;
+      }
     }
   }
 

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -31,6 +31,8 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   maxDurationSeconds?: number;
   /** Quality/config overrides forwarded to every segment's recording. */
   configOverrides?: VideoRecordingConfigInput;
+  /** Daemon session that owns every segment in this recording session. */
+  ownerSessionUuid?: string;
   /** Cancellation for the caller-owned initial segment startup only. */
   startupAbortSignal?: AbortSignal;
   /**
@@ -73,6 +75,8 @@ export class AndroidSegmentedPlanVideoSession {
 
   private readonly configOverrides: VideoRecordingConfigInput | undefined;
 
+  private readonly ownerSessionUuid: string | undefined;
+
   private readonly startupAbortSignal: AbortSignal | undefined;
 
   private activeRecordingId: string | undefined;
@@ -100,6 +104,8 @@ export class AndroidSegmentedPlanVideoSession {
   /** Cancels a rotation queued after {@link abort} begins. */
   private readonly sessionAbortController = new AbortController();
 
+  private stopPromise: Promise<{ filePaths: string[]; recordingIds: string[] }> | undefined;
+
   private segmentIndex = 0;
 
   private segmentStartedAtMs = 0;
@@ -110,6 +116,9 @@ export class AndroidSegmentedPlanVideoSession {
 
   /** IDs whose stop failed during rotation and still need rollback on abort. */
   private readonly pendingRollbackRecordingIds: string[] = [];
+
+  /** Errors from failed segment stops, retained for a failed finalization report. */
+  private readonly pendingRollbackErrors: unknown[] = [];
 
   private readonly startVideoRecordingFn: (
     request: Parameters<typeof defaultStartVideoRecording>[0],
@@ -129,6 +138,7 @@ export class AndroidSegmentedPlanVideoSession {
       options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
     this.maxDurationSeconds = options.maxDurationSeconds;
     this.configOverrides = options.configOverrides;
+    this.ownerSessionUuid = options.ownerSessionUuid;
     this.startupAbortSignal = options.startupAbortSignal;
     this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
@@ -231,6 +241,18 @@ export class AndroidSegmentedPlanVideoSession {
    * waits for any in-flight rotation, then finalizes and returns every segment.
    */
   async stop(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+    const stopPromise = this.stopInternal();
+    this.stopPromise = stopPromise.catch((error: unknown) => {
+      this.stopPromise = undefined;
+      throw error;
+    });
+    return this.stopPromise;
+  }
+
+  private async stopInternal(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
     this.timerDriven = false;
     this.clearTimers();
     await this.pendingRotation;
@@ -269,6 +291,7 @@ export class AndroidSegmentedPlanVideoSession {
     this.completedRecordingIds.splice(0);
     this.completedFilePaths.splice(0);
     this.pendingRollbackRecordingIds.splice(0);
+    this.pendingRollbackErrors.splice(0);
     this.notifyFinalized();
   }
 
@@ -321,6 +344,7 @@ export class AndroidSegmentedPlanVideoSession {
       outputName: this.segmentOutputName(),
       maxDurationSeconds: ANDROID_SCREENRECORD_MAX_SECONDS,
       configOverrides: this.configOverrides,
+      ownerSessionUuid: this.ownerSessionUuid,
       abortSignal: abortSignal ?? this.sessionAbortController.signal,
     });
     this.activeRecordingId = recording.recordingId;
@@ -352,6 +376,10 @@ export class AndroidSegmentedPlanVideoSession {
         `[SegmentedPlanVideo] Failed to stop segment ${previousId}: ${errorMessage(error)}`,
       );
       this.pendingRollbackRecordingIds.push(previousId);
+      this.pendingRollbackErrors.push(error);
+      this.timerDriven = false;
+      this.clearTimers();
+      return;
     } finally {
       this.activeRecordingId = undefined;
     }
@@ -392,6 +420,13 @@ export class AndroidSegmentedPlanVideoSession {
         this.pendingRollbackRecordingIds.push(id);
         throw error;
       }
+    }
+
+    if (this.pendingRollbackErrors.length > 0) {
+      throw new AggregateError(
+        this.pendingRollbackErrors,
+        "Failed to finalize every segmented recording",
+      );
     }
 
     return {

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -14,6 +14,7 @@ import {
 } from "./videoRecordingManager";
 import type { ActiveVideoRecording } from "../features/video";
 import type { VideoRecordingConfigInput, VideoRecordingMetadata } from "../models";
+import { combineAbortSignals } from "../utils/AbortContext";
 
 export interface AndroidSegmentedPlanVideoSessionOptions {
   device: BootedDevice;
@@ -95,6 +96,9 @@ export class AndroidSegmentedPlanVideoSession {
 
   /** Cancels a replacement segment start while an abort is draining its rotation. */
   private rotationAbortController: AbortController | undefined;
+
+  /** Cancels a rotation queued after {@link abort} begins. */
+  private readonly sessionAbortController = new AbortController();
 
   private segmentIndex = 0;
 
@@ -235,6 +239,7 @@ export class AndroidSegmentedPlanVideoSession {
   async abort(): Promise<void> {
     this.timerDriven = false;
     this.clearTimers();
+    this.sessionAbortController.abort();
     this.rotationAbortController?.abort();
     await this.pendingRotation;
     const recordingIds = Array.from(
@@ -293,7 +298,9 @@ export class AndroidSegmentedPlanVideoSession {
       return;
     }
 
-    await this.rotateToNextSegment();
+    const rotation = this.rotateToNextSegment();
+    this.pendingRotation = rotation;
+    await rotation;
   };
 
   private segmentOutputName(): string {
@@ -307,7 +314,7 @@ export class AndroidSegmentedPlanVideoSession {
       outputName: this.segmentOutputName(),
       maxDurationSeconds: ANDROID_SCREENRECORD_MAX_SECONDS,
       configOverrides: this.configOverrides,
-      abortSignal,
+      abortSignal: abortSignal ?? this.sessionAbortController.signal,
     });
     this.activeRecordingId = recording.recordingId;
     this.segmentStartedAtMs = this.timer.now();
@@ -343,7 +350,9 @@ export class AndroidSegmentedPlanVideoSession {
     }
 
     try {
-      await this.startSegment(rotationAbortController.signal);
+      await this.startSegment(
+        combineAbortSignals(rotationAbortController.signal, this.sessionAbortController.signal),
+      );
     } catch (error) {
       logger.warn(
         `[SegmentedPlanVideo] Failed to start next segment after ${previousId}: ${errorMessage(error)}`,
@@ -365,6 +374,7 @@ export class AndroidSegmentedPlanVideoSession {
         const stopped = await this.stopVideoRecordingFn(id);
         this.completedRecordingIds.push(id);
         this.completedFilePaths.push(stopped.metadata.filePath);
+        this.activeRecordingId = undefined;
         logger.info(
           `[SegmentedPlanVideo] Final stop recordingId=${id} path=${stopped.metadata.filePath}`,
         );
@@ -373,8 +383,7 @@ export class AndroidSegmentedPlanVideoSession {
           `[SegmentedPlanVideo] Failed to finalize segment ${id}: ${errorMessage(error)}`,
         );
         this.pendingRollbackRecordingIds.push(id);
-      } finally {
-        this.activeRecordingId = undefined;
+        throw error;
       }
     }
 

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -179,7 +179,14 @@ export class AndroidSegmentedPlanVideoSession {
     } catch (error) {
       this.timerDriven = false;
       if (this.activeRecordingId) {
-        await this.abort();
+        try {
+          await this.abort();
+        } catch (abortError) {
+          throw new AggregateError(
+            [error, abortError],
+            `${errorMessage(error)}; segmented rollback failed: ${errorMessage(abortError)}`,
+          );
+        }
       }
       throw error;
     }

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -971,7 +971,22 @@ export async function rollbackVideoRecordingStart(recordingId: string): Promise<
 
   const serviceOwnsRecording = videoRecorderService.listActiveRecordingIds().includes(recordingId);
   if (serviceOwnsRecording) {
-    await videoRecorderService.discardRecording(recordingId);
+    try {
+      await videoRecorderService.discardRecording(recordingId);
+    } catch (error) {
+      if (videoRecorderService.listActiveRecordingIds().includes(recordingId)) {
+        throw error;
+      }
+      // The backend stopped, but artifact removal failed. Retain its durable
+      // row for recovery while disarming timers that no longer own a capture.
+      clearAutoStop(recordingId);
+      clearInProgressSizeCap(recordingId);
+      const record = await recordingRepository.getRecording(recordingId);
+      if (record?.status === "recording") {
+        await interruptVideoRecording(recordingId);
+      }
+      throw error;
+    }
   }
 
   // The capture is no longer live once discard succeeds. Keep its safety timers

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -192,11 +192,12 @@ interface VideoRecordingHighlightSession {
 }
 
 let moduleDependencies: VideoRecordingManagerDependencies | null = null;
-let managerInitialized = false;
+let managerInitializationPromise: Promise<void> | undefined;
 let acceptingVideoRecordingStarts = true;
 let inFlightVideoRecordingStarts = 0;
 let videoRecordingStartDrain: { promise: Promise<void>; resolve: () => void } | null = null;
 const inFlightVideoRecordingStartControllers = new Set<AbortController>();
+const startingVideoRecordingDevices = new Set<string>();
 
 const autoStopTimers = new Map<string, { timer: Timer; handle: NodeJS.Timeout }>();
 const highlightSessions = new Map<string, VideoRecordingHighlightSession>();
@@ -223,11 +224,22 @@ async function createRecorderService(): Promise<VideoRecorderService> {
 async function initializeVideoRecordingState(
   deps: VideoRecordingManagerDependencies,
 ): Promise<void> {
-  if (managerInitialized) {
-    return;
+  if (!managerInitializationPromise) {
+    const initialization = performVideoRecordingStateInitialization(deps);
+    const trackedInitialization = initialization.catch((error) => {
+      if (managerInitializationPromise === trackedInitialization) {
+        managerInitializationPromise = undefined;
+      }
+      throw error;
+    });
+    managerInitializationPromise = trackedInitialization;
   }
-  managerInitialized = true;
+  await managerInitializationPromise;
+}
 
+async function performVideoRecordingStateInitialization(
+  deps: VideoRecordingManagerDependencies,
+): Promise<void> {
   ensureRetentionSweep(deps);
 
   const active = await deps.recordingRepository.listRecordings({ status: "recording" });
@@ -325,10 +337,14 @@ function resetVideoRecordingManagerState(): void {
   inFlightVideoRecordingStartControllers.clear();
   videoRecordingStartDrain?.resolve();
   videoRecordingStartDrain = null;
-  managerInitialized = false;
+  startingVideoRecordingDevices.clear();
+  managerInitializationPromise = undefined;
 }
 
-function beginVideoRecordingStart(requestSignal?: AbortSignal): {
+function beginVideoRecordingStart(
+  deviceId: string,
+  requestSignal?: AbortSignal,
+): {
   abortSignal: AbortSignal;
   complete(): void;
 } {
@@ -336,6 +352,10 @@ function beginVideoRecordingStart(requestSignal?: AbortSignal): {
   if (!acceptingVideoRecordingStarts) {
     throw new ActionableError("Video recording is unavailable while the daemon shuts down.");
   }
+  if (startingVideoRecordingDevices.has(deviceId)) {
+    throw new ActionableError(`Video recording start already in progress for device ${deviceId}.`);
+  }
+  startingVideoRecordingDevices.add(deviceId);
   inFlightVideoRecordingStarts++;
   const controller = new AbortController();
   inFlightVideoRecordingStartControllers.add(controller);
@@ -343,6 +363,7 @@ function beginVideoRecordingStart(requestSignal?: AbortSignal): {
   return {
     abortSignal,
     complete: () => {
+      startingVideoRecordingDevices.delete(deviceId);
       inFlightVideoRecordingStarts--;
       inFlightVideoRecordingStartControllers.delete(controller);
       if (inFlightVideoRecordingStarts === 0) {
@@ -836,17 +857,31 @@ export async function updateVideoRecordingConfig(
 export async function startVideoRecording(
   request: StartVideoRecordingRequest,
 ): Promise<ActiveVideoRecording> {
-  const start = beginVideoRecordingStart(request.abortSignal);
+  const start = beginVideoRecordingStart(request.device.deviceId, request.abortSignal);
+  let active: ActiveVideoRecording | undefined;
   try {
     const deps = await getVideoRecordingDependencies();
+    start.abortSignal.throwIfAborted();
     const { videoRecorderService, recordingRepository, timer } = deps;
+    if (videoRecorderService.hasActiveRecordingForDevice(request.device.deviceId)) {
+      throw new ActionableError(
+        `Video recording already active for device ${request.device.deviceId}.`,
+      );
+    }
     const existing = await recordingRepository.listRecordings({
       status: "recording",
       deviceId: request.device.deviceId,
     });
-    if (existing.length > 0) {
+    start.abortSignal.throwIfAborted();
+    const activeRecordingIds = new Set(videoRecorderService.listActiveRecordingIds());
+    if (existing.some((recording) => activeRecordingIds.has(recording.recordingId))) {
       throw new ActionableError(
         `Video recording already active for device ${request.device.deviceId}.`,
+      );
+    }
+    if (existing.length > 0) {
+      await Promise.all(
+        existing.map((recording) => interruptVideoRecording(recording.recordingId)),
       );
     }
     const overrides = request.configOverrides ?? {};
@@ -861,84 +896,100 @@ export async function startVideoRecording(
       normalizeHighlightTiming(highlight);
     }
 
-    const active = await videoRecorderService.startRecording({
+    active = await videoRecorderService.startRecording({
       outputName: request.outputName,
       config: configInput,
       device: request.device,
       maxDurationSeconds,
       abortSignal: start.abortSignal,
     });
+    start.abortSignal.throwIfAborted();
 
-    try {
-      start.abortSignal?.throwIfAborted();
-      await recordingRepository.insertRecording({
-        recordingId: active.recordingId,
-        deviceId: request.device.deviceId,
-        platform: request.device.platform,
-        status: "recording",
-        outputName: active.outputName,
-        fileName: active.fileName,
-        filePath: active.outputPath,
-        format: active.config.format,
-        sizeBytes: 0,
-        durationMs: undefined,
-        codec: undefined,
-        createdAt: active.startedAt,
-        startedAt: active.startedAt,
-        endedAt: undefined,
-        lastAccessedAt: active.startedAt,
-        config: active.config,
-        ownerSessionUuid: request.ownerSessionUuid,
-      });
+    await recordingRepository.insertRecording({
+      recordingId: active.recordingId,
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      status: "recording",
+      outputName: active.outputName,
+      fileName: active.fileName,
+      filePath: active.outputPath,
+      format: active.config.format,
+      sizeBytes: 0,
+      durationMs: undefined,
+      codec: undefined,
+      createdAt: active.startedAt,
+      startedAt: active.startedAt,
+      endedAt: undefined,
+      lastAccessedAt: active.startedAt,
+      config: active.config,
+      ownerSessionUuid: request.ownerSessionUuid,
+    });
+    start.abortSignal.throwIfAborted();
 
-      const highlightSession = createHighlightSession(
-        active.recordingId,
-        request.device,
-        active.startedAt,
-        timer,
-      );
-      highlightSessions.set(active.recordingId, highlightSession);
-      highlightSessionsByDeviceId.set(request.device.deviceId, active.recordingId);
+    const highlightSession = createHighlightSession(
+      active.recordingId,
+      request.device,
+      active.startedAt,
+      timer,
+    );
+    highlightSessions.set(active.recordingId, highlightSession);
+    highlightSessionsByDeviceId.set(request.device.deviceId, active.recordingId);
 
-      if (highlightInputs.length > 0) {
-        await scheduleRecordingHighlights(highlightSession, request.device, highlightInputs, deps);
-      }
-
-      await scheduleAutoStop(active.recordingId, maxDurationSeconds);
-
-      const capBytes = Math.floor((active.config.maxArchiveSizeMb ?? 0) * 1024 * 1024);
-      scheduleInProgressSizeCap(active.recordingId, active.outputPath, capBytes, deps);
-      start.abortSignal?.throwIfAborted();
-      return active;
-    } catch (error) {
-      await cleanUpCancelledVideoRecording(active.recordingId, videoRecorderService);
-      throw error;
+    if (highlightInputs.length > 0) {
+      await scheduleRecordingHighlights(highlightSession, request.device, highlightInputs, deps);
     }
+
+    await scheduleAutoStop(active.recordingId, maxDurationSeconds);
+
+    const capBytes = Math.floor((active.config.maxArchiveSizeMb ?? 0) * 1024 * 1024);
+    scheduleInProgressSizeCap(active.recordingId, active.outputPath, capBytes, deps);
+    start.abortSignal.throwIfAborted();
+    return active;
+  } catch (error) {
+    if (active) {
+      try {
+        await rollbackVideoRecordingStart(active.recordingId);
+      } catch (rollbackError) {
+        logger.warn(
+          `[VideoRecording] Failed to roll back recording ${active.recordingId}: ${rollbackError}`,
+          rollbackError,
+        );
+        throw new AggregateError(
+          [error, rollbackError],
+          `${errorMessage(error)}; recording rollback failed: ${errorMessage(rollbackError)}`,
+        );
+      }
+    }
+    throw error;
   } finally {
     start.complete();
   }
 }
 
-async function cleanUpCancelledVideoRecording(
-  recordingId: string,
-  videoRecorderService: VideoRecorderService,
-): Promise<void> {
-  try {
-    await videoRecorderService.forceStopRecording(recordingId);
-  } catch (cleanupError) {
-    logger.warn(
-      `[VideoRecording] Failed to force-stop cancelled recording ${recordingId}: ${errorMessage(cleanupError)}`,
-      cleanupError,
-    );
-    return;
+export async function rollbackVideoRecordingStart(recordingId: string): Promise<void> {
+  const { videoRecorderService, recordingRepository } = await getVideoRecordingDependencies();
+
+  const serviceOwnsRecording = videoRecorderService.listActiveRecordingIds().includes(recordingId);
+  if (serviceOwnsRecording) {
+    await videoRecorderService.discardRecording(recordingId);
   }
-  try {
+
+  // The capture is no longer live once discard succeeds. Keep its safety timers
+  // armed if teardown fails, so a retained owner remains bounded.
+  clearAutoStop(recordingId);
+  clearInProgressSizeCap(recordingId);
+
+  const record = await recordingRepository.getRecording(recordingId);
+  if (record?.status === "recording") {
     await interruptVideoRecording(recordingId);
-  } catch (cleanupError) {
-    logger.warn(
-      `[VideoRecording] Failed to mark cancelled recording ${recordingId} interrupted: ${errorMessage(cleanupError)}`,
-      cleanupError,
-    );
+  }
+  disposeHighlightSession(recordingId);
+  if (!serviceOwnsRecording && record) {
+    await removeVideoRecordingArtifacts(record.filePath);
+  }
+  const deleted = await recordingRepository.deleteRecording(recordingId);
+  if (deleted) {
+    await notifyVideoRecordingResources([recordingId]);
   }
 }
 
@@ -1124,23 +1175,28 @@ async function deleteVideoRecording(recordingId: string): Promise<boolean> {
     throw new Error(`Cannot delete active recording ${recordingId}`);
   }
 
-  const recordingDir = path.dirname(record.filePath);
-  if (await pathExists(recordingDir)) {
-    // NOTE (issue #4762): `rm` unlinks the directory entry but does NOT overwrite
-    // the underlying blocks, so screen-capture bytes (which may contain OTPs,
-    // credentials, or PII) can remain recoverable from the raw device until the
-    // filesystem reuses them. This is documented as a known limitation in
-    // docs/design-docs/mcp/observe/video-recording.md. A future opt-in
-    // "sensitive mode" would overwrite-before-unlink here; it is deliberately a
-    // follow-up (see the doc) rather than an unconditional cost on every delete.
-    await fsPromises.rm(recordingDir, { recursive: true, force: true });
-  }
+  await removeVideoRecordingArtifacts(record.filePath);
 
   const deleted = await recordingRepository.deleteRecording(recordingId);
   if (deleted) {
     await notifyVideoRecordingResources([recordingId]);
   }
   return deleted;
+}
+
+async function removeVideoRecordingArtifacts(filePath: string): Promise<void> {
+  const recordingDir = path.dirname(filePath);
+  if (!(await pathExists(recordingDir))) {
+    return;
+  }
+  // NOTE (issue #4762): `rm` unlinks the directory entry but does NOT overwrite
+  // the underlying blocks, so screen-capture bytes (which may contain OTPs,
+  // credentials, or PII) can remain recoverable from the raw device until the
+  // filesystem reuses them. This is documented as a known limitation in
+  // docs/design-docs/mcp/observe/video-recording.md. A future opt-in
+  // "sensitive mode" would overwrite-before-unlink here; it is deliberately a
+  // follow-up (see the doc) rather than an unconditional cost on every delete.
+  await fsPromises.rm(recordingDir, { recursive: true, force: true });
 }
 
 async function enforceArchiveLimit(maxArchiveSizeMb: number): Promise<VideoArchiveEvictionResult> {

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -316,9 +316,9 @@ async function throwIfVideoStartAborted(
     return;
   }
 
-  for (const recording of recordings.toReversed()) {
-    await rollbackAbortedVideoStart(recording);
-  }
+  // A stalled teardown must not leave the other fanout captures running until
+  // their individual safety timers fire.
+  await Promise.allSettled(recordings.toReversed().map(rollbackAbortedVideoStart));
   signal.throwIfAborted();
 }
 

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -456,6 +456,7 @@ export function registerVideoRecordingTools(): void {
               device: target,
               outputNamePrefix: args.outputName ?? `recording-${target.deviceId}`,
               configOverrides: buildConfigOverrides(args),
+              ownerSessionUuid: args.sessionUuid,
               timer: segmentedSessions.timer,
               maxDurationSeconds,
               startupAbortSignal: signal,

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -104,8 +104,8 @@ const segmentedSessions = (() => {
       handle: string,
       session: AndroidSegmentedPlanVideoSession,
     ): Promise<StoppedSegmentedSession> {
-      byHandle.delete(handle);
       const { filePaths, recordingIds } = await session.stop();
+      byHandle.delete(handle);
       const segments: StoppedSegment[] = recordingIds.map((id, index) => ({
         recordingId: id,
         filePath: filePaths[index],

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -18,6 +18,7 @@ import {
 import {
   IOS_MAX_DURATION_SECONDS,
   listActiveVideoRecordings,
+  rollbackVideoRecordingStart,
   startVideoRecording,
   stopVideoRecording,
 } from "./videoRecordingManager";
@@ -47,7 +48,7 @@ interface StoppedSegmentedSession {
 
 type SegmentedSessionRecordingDependencies = Pick<
   AndroidSegmentedPlanVideoSessionOptions,
-  "startVideoRecording" | "stopVideoRecording" | "forceStopVideoRecording"
+  "rollbackVideoRecordingStart" | "startVideoRecording" | "stopVideoRecording"
 >;
 
 /**
@@ -112,6 +113,10 @@ const segmentedSessions = (() => {
       }));
       const manifestPath = await writeSegmentManifest(handle, segments);
       return { sessionId: handle, segments, manifestPath };
+    },
+    async abortAndRemove(handle: string, session: AndroidSegmentedPlanVideoSession): Promise<void> {
+      await session.abort();
+      byHandle.delete(handle);
     },
     /** Test seam: inject the Timer used by segmented sessions. */
     setTimer(timer: Timer | undefined): void {
@@ -178,7 +183,7 @@ export async function stopSegmentedVideoRecordingsForDevice(
  * a test's timeout on a loaded macOS CI runner (issue #3943).
  */
 interface ConnectedDeviceDetector {
-  detectConnectedPlatforms(): Promise<BootedDevice[]>;
+  detectConnectedPlatforms(signal?: AbortSignal): Promise<BootedDevice[]>;
 }
 
 let deviceDetectorForTesting: ConnectedDeviceDetector | undefined;
@@ -282,13 +287,14 @@ function shouldTargetAllDevices(args: VideoRecordingArgs): boolean {
 async function resolveTargetDevices(
   device: BootedDevice,
   args: VideoRecordingArgs,
+  signal?: AbortSignal,
 ): Promise<BootedDevice[]> {
   if (!shouldTargetAllDevices(args)) {
     return [device];
   }
 
   const detector = deviceDetectorForTesting ?? DeviceSessionManager.getInstance();
-  const devices = await detector.detectConnectedPlatforms();
+  const devices = await detector.detectConnectedPlatforms(signal);
   const matching = devices.filter((candidate) => candidate.platform === device.platform);
 
   if (matching.length === 0) {
@@ -300,6 +306,41 @@ async function resolveTargetDevices(
     unique.set(candidate.deviceId, candidate);
   }
   return Array.from(unique.values());
+}
+
+async function throwIfVideoStartAborted(
+  recordings: Array<Record<string, unknown>>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal?.aborted) {
+    return;
+  }
+
+  for (const recording of recordings.toReversed()) {
+    await rollbackAbortedVideoStart(recording);
+  }
+  signal.throwIfAborted();
+}
+
+async function rollbackAbortedVideoStart(recording: Record<string, unknown>): Promise<void> {
+  const recordingId = typeof recording.recordingId === "string" ? recording.recordingId : "";
+  if (!recordingId) {
+    return;
+  }
+  try {
+    const segmentedSession =
+      recording.segmented === true ? segmentedSessions.get(recordingId) : undefined;
+    if (segmentedSession) {
+      await segmentedSessions.abortAndRemove(recordingId, segmentedSession);
+      return;
+    }
+    await rollbackVideoRecordingStart(recordingId);
+  } catch (error) {
+    logger.warn(
+      `[VideoRecording] Failed to roll back aborted recording ${recordingId}: ${errorMessage(error)}`,
+      error,
+    );
+  }
 }
 
 function selectLatestRecording(records: VideoRecordingRecord[]): VideoRecordingRecord {
@@ -393,14 +434,16 @@ export function registerVideoRecordingTools(): void {
   ) => {
     signal?.throwIfAborted();
     if (args.action === "start") {
-      const targetDevices = await resolveTargetDevices(device, args);
+      const targetDevices = await resolveTargetDevices(device, args, signal);
       signal?.throwIfAborted();
       const maxDurationSeconds = args.maxDuration ?? DEFAULT_MAX_DURATION_SECONDS;
       const recordings: Array<Record<string, unknown>> = [];
       const failures: Array<Record<string, unknown>> = [];
+      const finalizedBeforeFanoutCommit = new Set<AndroidSegmentedPlanVideoSession>();
+      let fanoutCommitted = !shouldTargetAllDevices(args);
 
       for (const target of targetDevices) {
-        signal?.throwIfAborted();
+        await throwIfVideoStartAborted(recordings, signal);
         try {
           // Android `screenrecord` is hard-capped at 180s. For longer Android
           // recordings, transparently produce ordered segments (<outputName>,
@@ -416,9 +459,15 @@ export function registerVideoRecordingTools(): void {
               timer: segmentedSessions.timer,
               maxDurationSeconds,
               startupAbortSignal: signal,
-              // Auto-stop finalizes without going through stopAndRemove, so drop the
-              // tracked entry here to avoid a registry leak on fire-and-forget recordings.
-              onFinalized: () => segmentedSessions.remove(session),
+              // Keep an auto-finalized session reachable until the all-device
+              // request commits: an abort still must roll back every segment.
+              onFinalized: () => {
+                if (fanoutCommitted) {
+                  segmentedSessions.remove(session);
+                  return;
+                }
+                finalizedBeforeFanoutCommit.add(session);
+              },
               ...segmentedSessions.recordingDependencies,
             });
             const active = await session.start();
@@ -466,13 +515,18 @@ export function registerVideoRecordingTools(): void {
             },
           });
         } catch (error) {
-          signal?.throwIfAborted();
+          await throwIfVideoStartAborted(recordings, signal);
           failures.push({
             deviceId: target.deviceId,
             platform: target.platform,
             error: String(error),
           });
         }
+      }
+      await throwIfVideoStartAborted(recordings, signal);
+      fanoutCommitted = true;
+      for (const session of finalizedBeforeFanoutCommit) {
+        segmentedSessions.remove(session);
       }
 
       if (recordings.length === 0) {

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -383,18 +383,19 @@ export class DeviceSessionManager implements DeviceSessionManager {
   /**
    * Detect the platform of connected devices
    */
-  public async detectConnectedPlatforms(): Promise<BootedDevice[]> {
+  public async detectConnectedPlatforms(signal?: AbortSignal): Promise<BootedDevice[]> {
     const devices: BootedDevice[] = [];
     const perf = createGlobalPerformanceTracker();
 
     try {
       // Check for Android devices via ADB
       perf.startOperation("androidDeviceScan");
-      const androidDevices = await this.adb.getBootedAndroidDevices();
+      const androidDevices = await this.adb.getBootedAndroidDevices({ signal });
       perf.endOperation("androidDeviceScan");
       devices.push(...androidDevices);
     } catch (error) {
       perf.endOperation("androidDeviceScan");
+      signal?.throwIfAborted();
       logger.warn(`Failed to detect Android devices: ${error}`);
     }
 
@@ -402,12 +403,13 @@ export class DeviceSessionManager implements DeviceSessionManager {
       // Check for iOS devices/simulators via xcrun simctl
       if (this.simctl) {
         perf.startOperation("iosSimulatorScan");
-        const iosDevices = await this.simctl.getBootedSimulators();
+        const iosDevices = await this.simctl.getBootedSimulators(undefined, signal);
         perf.endOperation("iosSimulatorScan");
         devices.push(...iosDevices);
       }
     } catch (error) {
       perf.endOperation("iosSimulatorScan");
+      signal?.throwIfAborted();
       logger.warn(`Failed to detect iOS devices: ${error}`);
     }
 

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -640,6 +640,7 @@ export class AdbClient implements AdbExecutor {
     await new Promise<void>((resolve, reject) => {
       const onSpawn = () => {
         child.off("error", onInitialError);
+        signal?.removeEventListener("abort", onAbort);
         settleStart = undefined;
         resolve();
       };

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -597,13 +597,20 @@ export class AdbClient implements AdbExecutor {
     );
     const child = this.spawnFn(adbPath, fullArgs, {
       stdio: ["ignore", "pipe", "pipe"],
-      signal,
+      signal: options.abortSignalScope === "startup" ? undefined : signal,
     });
     this.activeProcesses.add(child);
 
     let timeoutId: NodeJS.Timeout | undefined;
     let cleaned = false;
     let settleStart: ((error?: Error) => void) | undefined;
+    const removeStartupCancellation = () => {
+      signal?.removeEventListener("abort", onAbort);
+      if (timeoutId) {
+        this.timer.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
     const cleanup = () => {
       if (cleaned) {
         return;
@@ -612,10 +619,7 @@ export class AdbClient implements AdbExecutor {
       this.activeProcesses.delete(child);
       child.off("exit", onExit);
       child.off("error", onError);
-      signal?.removeEventListener("abort", onAbort);
-      if (timeoutId) {
-        this.timer.clearTimeout(timeoutId);
-      }
+      removeStartupCancellation();
     };
     const onExit = () => cleanup();
     const onError = (error: Error) => {
@@ -640,8 +644,10 @@ export class AdbClient implements AdbExecutor {
     await new Promise<void>((resolve, reject) => {
       const onSpawn = () => {
         child.off("error", onInitialError);
-        signal?.removeEventListener("abort", onAbort);
         settleStart = undefined;
+        if (options.abortSignalScope === "startup") {
+          removeStartupCancellation();
+        }
         resolve();
       };
       const onInitialError = (error: Error) => {

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -595,7 +595,10 @@ export class AdbClient implements AdbExecutor {
       startTime,
       args.join(" "),
     );
-    const child = this.spawnFn(adbPath, fullArgs, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = this.spawnFn(adbPath, fullArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
+      signal,
+    });
     this.activeProcesses.add(child);
 
     let timeoutId: NodeJS.Timeout | undefined;

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -42,6 +42,12 @@ export interface AdbExecuteOptions {
 export interface AdbSpawnOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
+  /**
+   * Applies `signal` only until the subprocess emits `spawn`. The caller owns
+   * the child after that point, so later request cancellation cannot terminate
+   * an accepted long-running operation.
+   */
+  abortSignalScope?: "startup";
 }
 
 export type DeviceTimestampSource = "device-ms" | "device-seconds" | "host";

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -171,7 +171,7 @@ export interface SimCtl {
    * Get the list of booted simulator UDIDs
    * @returns Promise with an array of booted devices
    */
-  getBootedSimulators(timeoutMs?: number): Promise<BootedDevice[]>;
+  getBootedSimulators(timeoutMs?: number, signal?: AbortSignal): Promise<BootedDevice[]>;
 
   /**
    * Get device information by UDID
@@ -803,10 +803,10 @@ export class SimCtlClient implements SimCtl {
    * Get the list of all simulators and devices
    * @returns Promise with simulator list data
    */
-  private async listSimulators(timeoutMs?: number): Promise<SimulatorList> {
+  private async listSimulators(timeoutMs?: number, signal?: AbortSignal): Promise<SimulatorList> {
     const perf = createGlobalPerformanceTracker();
     perf.startOperation("simctlListDevices");
-    const result = await this.executeCommandArgs(["list", "devices", "--json"], timeoutMs);
+    const result = await this.executeCommandArgs(["list", "devices", "--json"], timeoutMs, signal);
     perf.endOperation("simctlListDevices");
 
     try {
@@ -1511,10 +1511,11 @@ export class SimCtlClient implements SimCtl {
    * Get the list of booted simulator UDIDs
    * @returns Promise with an array of booted device UDIDs
    */
-  async getBootedSimulators(timeoutMs?: number): Promise<BootedDevice[]> {
+  async getBootedSimulators(timeoutMs?: number, signal?: AbortSignal): Promise<BootedDevice[]> {
     try {
-      return await this.getBootedSimulatorsChecked(timeoutMs);
+      return await this.getBootedSimulatorsChecked(timeoutMs, signal);
     } catch (error) {
+      signal?.throwIfAborted();
       logger.debug(`Failed to get booted iOS devices: ${error}`);
       return [];
     }
@@ -1525,8 +1526,11 @@ export class SimCtlClient implements SimCtl {
    * swallowing them into an empty list. Callers that must distinguish "no
    * simulators are booted" from "simctl discovery failed" should use this.
    */
-  async getBootedSimulatorsChecked(timeoutMs?: number): Promise<BootedDevice[]> {
-    const simulatorList = await this.listSimulators(timeoutMs);
+  async getBootedSimulatorsChecked(
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<BootedDevice[]> {
+    const simulatorList = await this.listSimulators(timeoutMs, signal);
     logger.debug(`Found simulator list: ${simulatorList}`);
     const observedAt = this.observationSequence.next();
     const bootedDevices: BootedDevice[] = [];

--- a/test/fakes/FakeAdbClient.test.ts
+++ b/test/fakes/FakeAdbClient.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { FakeAdbClient } from "./FakeAdbClient";
+
+describe("FakeAdbClient", () => {
+  test("clears recorded spawned processes on reset", async () => {
+    const adb = new FakeAdbClient();
+
+    await adb.spawn(["shell", "screenrecord", "/sdcard/capture.mp4"]);
+    expect(adb.getSpawnedProcesses()).toHaveLength(1);
+
+    adb.reset();
+
+    expect(adb.getSpawnedProcesses()).toEqual([]);
+  });
+
+  test("does not expose a process for a rejected spawn", async () => {
+    const adb = new FakeAdbClient();
+    adb.setSpawnRejection("screenrecord", new Error("spawn rejected"));
+
+    await expect(adb.spawn(["shell", "screenrecord", "/sdcard/capture.mp4"])).rejects.toThrow(
+      "spawn rejected",
+    );
+
+    expect(adb.getSpawnedProcesses()).toEqual([]);
+  });
+});

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -56,6 +56,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private deviceTimestampSource: DeviceTimestampSource = "device-ms";
   private spawnCalls: string[][] = [];
   private spawnOptions: Array<AdbSpawnOptions | undefined> = [];
+  private spawnedProcesses: FakeAdbProcess[] = [];
   private spawnBehaviors: SpawnBehavior[] = [];
 
   /**
@@ -139,6 +140,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.spawnCalls.push([...args]);
     this.spawnOptions.push(options);
     const proc = new FakeAdbProcess();
+    this.spawnedProcesses.push(proc);
     const joined = args.join(" ");
     const behavior = this.spawnBehaviors.find((b) => joined.includes(b.match));
     if (behavior?.outcome.kind === "reject") {
@@ -175,6 +177,10 @@ export class FakeAdbClient implements FakeAdbClientContract {
 
   getSpawnOptions(): Array<AdbSpawnOptions | undefined> {
     return [...this.spawnOptions];
+  }
+
+  getSpawnedProcesses(): FakeAdbProcess[] {
+    return [...this.spawnedProcesses];
   }
 
   /** True if any spawned command's argv contained `match`. */

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -139,13 +139,14 @@ export class FakeAdbClient implements FakeAdbClientContract {
   async spawn(args: string[], options?: AdbSpawnOptions): Promise<AdbProcess> {
     this.spawnCalls.push([...args]);
     this.spawnOptions.push(options);
-    const proc = new FakeAdbProcess();
-    this.spawnedProcesses.push(proc);
     const joined = args.join(" ");
     const behavior = this.spawnBehaviors.find((b) => joined.includes(b.match));
     if (behavior?.outcome.kind === "reject") {
       throw behavior.outcome.error;
-    } else if (behavior?.outcome.kind === "error") {
+    }
+    const proc = new FakeAdbProcess();
+    this.spawnedProcesses.push(proc);
+    if (behavior?.outcome.kind === "error") {
       proc.scheduleError(behavior.outcome.error);
     } else {
       proc.scheduleExit(behavior?.outcome.kind === "exit" ? behavior.outcome.code : 0);
@@ -370,6 +371,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.foregroundAppError = null;
     this.hangingCommandPatterns = [];
     this.spawnCalls = [];
+    this.spawnedProcesses = [];
     this.spawnBehaviors = [];
     this.deviceTimestampMs = null;
   }

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -132,7 +132,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       abortSignal: controller.signal,
     });
 
-    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBeUndefined();
+    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBe(controller.signal);
   });
 
   describe("Stop Operation", () => {

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -107,7 +107,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
     ).rejects.toThrow(/FfmpegVideoProcessingBackend/);
   });
 
-  test("does not retain startup cancellation on an active Android capture", async () => {
+  test("does not retain startup cancellation after an Android capture starts", async () => {
     const fakeFactory = new FakeAdbClientFactory();
     const backend = new PlatformVideoCaptureBackend(fakeFactory);
     const controller = new AbortController();
@@ -132,7 +132,15 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       abortSignal: controller.signal,
     });
 
-    expect(fakeFactory.getFakeClient().getSpawnOptions()[0]?.signal).toBe(controller.signal);
+    const fakeClient = fakeFactory.getFakeClient();
+    expect(fakeClient.getSpawnOptions()[0]).toEqual({
+      signal: controller.signal,
+      abortSignalScope: "startup",
+    });
+
+    controller.abort();
+
+    expect(fakeClient.getSpawnedProcesses()[0]?.killed).toBe(false);
   });
 
   describe("Stop Operation", () => {

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -196,8 +196,6 @@ describe("VideoRecorderService", () => {
       }),
     ).rejects.toThrow("startup cleanup timed out");
 
-    expect(service.listActiveRecordingIds()).toEqual(["rec-1"]);
-    await service.discardRecording("rec-1");
     expect(backend.forceStopCalls).toEqual([retainedHandle!]);
     expect(service.listActiveRecordingIds()).toEqual([]);
   });

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -141,19 +141,100 @@ describe("VideoRecorderService", () => {
     );
   });
 
-  test("force-stops a failed-start cleanup handle before rethrowing", async () => {
-    const retainedHandle = {
-      recordingId: "rec-1",
-      outputPath: path.join(archiveRoot, "rec-1", "capture.mp4"),
-      startedAt: "2024-01-15T10:30:00.000Z",
-    };
-    backend.start = async () => {
+  test("discard force-stops a capture and removes its artifact directory", async () => {
+    const recording = await service.startRecording();
+    await fsPromises.writeFile(recording.outputPath, "capture");
+    expect(service.hasActiveRecordingForDevice("test-device")).toBe(false);
+
+    await service.discardRecording(recording.recordingId);
+
+    expect(backend.forceStopCalls).toEqual([backend.startResults[0]]);
+    expect(await pathExists(path.dirname(recording.outputPath))).toBe(false);
+    expect(service.listActiveRecordingIds()).toEqual([]);
+  });
+
+  test("discard releases ownership when artifact deletion fails", async () => {
+    const cleanupError = new Error("artifact cleanup failed");
+    const failingService = new VideoRecorderService({
+      backend,
+      archiveRoot,
+      idGenerator: new CountingIdGenerator("rec"),
+      now: () => new Date("2024-01-15T10:30:00.000Z"),
+      securePermissions,
+      fileSystem: {
+        rm: async () => {
+          throw cleanupError;
+        },
+      },
+    });
+    const recording = await failingService.startRecording({
+      device: { deviceId: "test-device", platform: "android", name: "Android" },
+    });
+
+    await expect(failingService.discardRecording(recording.recordingId)).rejects.toThrow(
+      cleanupError.message,
+    );
+
+    expect(failingService.listActiveRecordingIds()).toEqual([]);
+    expect(failingService.hasActiveRecordingForDevice("test-device")).toBe(false);
+  });
+
+  test("retains a backend cleanup handle after startup rejects", async () => {
+    let retainedHandle: (typeof backend.startResults)[number] | undefined;
+    backend.start = async (config) => {
+      retainedHandle = {
+        recordingId: config.recordingId,
+        outputPath: config.outputPath,
+        startedAt: config.startedAt,
+      };
       throw new VideoCaptureStartCleanupError("startup cleanup timed out", retainedHandle);
     };
 
-    await expect(service.startRecording()).rejects.toThrow("startup cleanup timed out");
+    await expect(
+      service.startRecording({
+        device: { deviceId: "test-device", platform: "android", name: "Android" },
+      }),
+    ).rejects.toThrow("startup cleanup timed out");
 
-    expect(backend.forceStopCalls).toEqual([retainedHandle]);
+    expect(service.listActiveRecordingIds()).toEqual(["rec-1"]);
+    await service.discardRecording("rec-1");
+    expect(backend.forceStopCalls).toEqual([retainedHandle!]);
+    expect(service.listActiveRecordingIds()).toEqual([]);
+  });
+
+  test("exposes and force-stops provisional ownership while backend startup is pending", async () => {
+    let resolveStart: ((handle: (typeof backend.startResults)[number]) => void) | undefined;
+    let startedConfig: Parameters<typeof backend.start>[0] | undefined;
+    let markBackendStarted: (() => void) | undefined;
+    const backendStarted = new Promise<void>((resolve) => {
+      markBackendStarted = resolve;
+    });
+    backend.start = async (config) => {
+      startedConfig = config;
+      markBackendStarted?.();
+      const handle = await new Promise<(typeof backend.startResults)[number]>((resolve) => {
+        resolveStart = resolve;
+      });
+      backend.startResults.push(handle);
+      return handle;
+    };
+
+    const starting = service.startRecording();
+    await backendStarted;
+    expect(service.listActiveRecordingIds()).toEqual(["rec-1"]);
+
+    const forcing = service.forceStopRecording("rec-1");
+    expect(startedConfig?.abortSignal?.aborted).toBe(true);
+    const handle = {
+      recordingId: "rec-1",
+      outputPath: startedConfig!.outputPath,
+      startedAt: startedConfig!.startedAt,
+    };
+    resolveStart?.(handle);
+
+    await expect(starting).rejects.toThrow("force-stopped while it was starting");
+    await forcing;
+    expect(backend.forceStopCalls).toEqual([handle]);
     expect(service.listActiveRecordingIds()).toEqual([]);
   });
 

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -276,6 +276,33 @@ describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
     expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
+  test("rolls back a segment whose auto-finalization stop failed", async () => {
+    const timer = new FakeTimer();
+    const rolledBack: string[] = [];
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      maxDurationSeconds: 0.5,
+      startVideoRecording: async () => makeActiveRecording("id-vid", "/tmp/id-vid.mp4"),
+      stopVideoRecording: async () => {
+        throw new Error("final stop failed");
+      },
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    await session.start();
+    timer.advanceTime(500);
+    await flush();
+    await session.abort();
+
+    expect(rolledBack).toEqual(["id-vid"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
   test("aborts a replacement segment start before waiting for rotation", async () => {
     const timer = new FakeTimer();
     const rolledBack: string[] = [];

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -343,6 +343,33 @@ describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
     expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
+  test("preserves startup and rollback failures when initial cleanup fails", async () => {
+    const controller = new AbortController();
+    const startupError = new Error("startup cancelled");
+    controller.abort(startupError);
+    const rollbackError = new Error("rollback failed");
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      startupAbortSignal: controller.signal,
+      startVideoRecording: async () => makeActiveRecording("id-vid", "/tmp/id-vid.mp4"),
+      stopVideoRecording: async () => ({
+        metadata: makeStopMetadata("id-vid", "/tmp/id-vid.mp4"),
+        evictedRecordingIds: [],
+      }),
+      rollbackVideoRecordingStart: async () => {
+        throw rollbackError;
+      },
+    });
+
+    const failure = await session.start().catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(AggregateError);
+    const aggregate = failure as AggregateError;
+    expect(aggregate.errors[0]).toBe(startupError);
+    expect(aggregate.errors[1]).toBeInstanceOf(AggregateError);
+    expect((aggregate.errors[1] as AggregateError).errors).toEqual([rollbackError]);
+  });
+
   test("waits for a plan-step rotation to observe cancellation before rollback", async () => {
     let now = 0;
     let resolveReplacement!: () => void;

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -50,6 +50,24 @@ function makeActiveRecording(id: string, outputPath: string) {
 }
 
 describe("AndroidSegmentedPlanVideoSession", () => {
+  test("forwards session ownership to every segment", async () => {
+    const requests: Array<{ ownerSessionUuid?: string }> = [];
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "owned",
+      ownerSessionUuid: "owner-a",
+      startVideoRecording: async (request) => {
+        requests.push(request);
+        return makeActiveRecording(`r${requests.length}`, `/tmp/r${requests.length}.mp4`);
+      },
+    });
+
+    await session.startFirstSegment();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.ownerSessionUuid).toBe("owner-a");
+  });
+
   test("finalize stops the active segment and returns its path", async () => {
     const start = mock(async () => makeActiveRecording("r1", "/tmp/r1.mp4"));
     const stop = mock(async () => ({

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -303,6 +303,111 @@ describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
     expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
+  test("retains ownership until a failed final stop is retried or aborted", async () => {
+    const timer = new FakeTimer();
+    const rolledBack: string[] = [];
+    let finalized = 0;
+    let stopAttempts = 0;
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      startVideoRecording: async () => makeActiveRecording("id-vid", "/tmp/id-vid.mp4"),
+      stopVideoRecording: async () => {
+        stopAttempts += 1;
+        if (stopAttempts === 1) {
+          throw new Error("final stop failed");
+        }
+        return {
+          metadata: makeStopMetadata("id-vid", "/tmp/id-vid.mp4"),
+          evictedRecordingIds: [],
+        };
+      },
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+      onFinalized: () => {
+        finalized += 1;
+      },
+    });
+
+    await session.start();
+
+    await expect(session.stop()).rejects.toThrow("final stop failed");
+    expect(finalized).toBe(0);
+
+    await session.abort();
+
+    expect(rolledBack).toEqual(["id-vid"]);
+    expect(finalized).toBe(1);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("waits for a plan-step rotation to observe cancellation before rollback", async () => {
+    let now = 0;
+    let resolveReplacement!: () => void;
+    let replacementSignal: AbortSignal | undefined;
+    let markReplacementStarted!: () => void;
+    const replacementStarted = new Promise<void>((resolve) => {
+      markReplacementStarted = resolve;
+    });
+    const rolledBack: string[] = [];
+    let startCalls = 0;
+    const timer: Timer = {
+      now: () => now,
+      sleep: defaultTimer.sleep.bind(defaultTimer),
+      setTimeout: defaultTimer.setTimeout.bind(defaultTimer),
+      clearTimeout: defaultTimer.clearTimeout.bind(defaultTimer),
+      setInterval: defaultTimer.setInterval.bind(defaultTimer),
+      clearInterval: defaultTimer.clearInterval.bind(defaultTimer),
+    };
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: async (request) => {
+        startCalls += 1;
+        if (startCalls === 1) {
+          return makeActiveRecording("id-vid", "/tmp/id-vid.mp4");
+        }
+        replacementSignal = request.abortSignal;
+        markReplacementStarted();
+        await new Promise<void>((resolve) => {
+          resolveReplacement = resolve;
+        });
+        request.abortSignal?.throwIfAborted();
+        throw new Error("replacement continued after cancellation");
+      },
+      stopVideoRecording: async () => ({
+        metadata: makeStopMetadata("id-vid", "/tmp/id-vid.mp4"),
+        evictedRecordingIds: [],
+      }),
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    await session.startFirstSegment();
+    now = 1000;
+    const rotating = session.onBeforePlanStep();
+    await replacementStarted;
+
+    let abortFinished = false;
+    const aborting = session.abort().then(() => {
+      abortFinished = true;
+    });
+    expect(replacementSignal?.aborted).toBe(true);
+    await flush();
+    expect(abortFinished).toBe(false);
+
+    resolveReplacement();
+    await rotating;
+    await aborting;
+
+    expect(rolledBack).toEqual(["id-vid"]);
+  });
+
   test("aborts a replacement segment start before waiting for rotation", async () => {
     const timer = new FakeTimer();
     const rolledBack: string[] = [];

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -216,6 +216,109 @@ describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
     expect(start).toHaveBeenCalledTimes(1);
   });
 
+  test("abort rolls back active and completed segments without publishing them", async () => {
+    const timer = new FakeTimer();
+    const { stop } = makeSession(timer);
+    const rolledBack: string[] = [];
+    const abortableSession = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: async (request) =>
+        makeActiveRecording(`id-${request.outputName}`, `/tmp/id-${request.outputName}.mp4`),
+      stopVideoRecording: stop,
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    await abortableSession.start();
+    timer.advanceTime(1000);
+    await flush();
+    await abortableSession.abort();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(rolledBack).toEqual(["id-vid-seg1", "id-vid"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("rolls back a segment whose rotation stop failed", async () => {
+    const timer = new FakeTimer();
+    const rolledBack: string[] = [];
+    let startCalls = 0;
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: async (request) => {
+        startCalls += 1;
+        if (startCalls === 1) {
+          return makeActiveRecording("id-vid", "/tmp/id-vid.mp4");
+        }
+        throw new Error(`replacement ${request.outputName} rejected`);
+      },
+      stopVideoRecording: async () => {
+        throw new Error("segment stop failed");
+      },
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    await session.start();
+    timer.advanceTime(1000);
+    await flush();
+    await session.abort();
+
+    expect(rolledBack).toEqual(["id-vid"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("aborts a replacement segment start before waiting for rotation", async () => {
+    const timer = new FakeTimer();
+    const rolledBack: string[] = [];
+    let startCalls = 0;
+    let rotationSignal: AbortSignal | undefined;
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: async (request) => {
+        startCalls += 1;
+        if (startCalls === 1) {
+          return makeActiveRecording("id-vid", "/tmp/id-vid.mp4");
+        }
+        rotationSignal = request.abortSignal;
+        await new Promise<void>((resolve) => {
+          request.abortSignal?.addEventListener("abort", resolve, { once: true });
+        });
+        request.abortSignal?.throwIfAborted();
+        throw new Error("replacement start unexpectedly continued");
+      },
+      stopVideoRecording: async (recordingId) => ({
+        metadata: makeStopMetadata(recordingId ?? "unknown", "/tmp/id-vid.mp4"),
+        evictedRecordingIds: [],
+      }),
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    await session.start();
+    timer.advanceTime(1000);
+    await flush();
+    expect(rotationSignal).toBeDefined();
+
+    await session.abort();
+
+    expect(rotationSignal?.aborted).toBe(true);
+    expect(rolledBack).toEqual(["id-vid"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
   test("auto-stops at maxDurationSeconds, finalizing every segment recorded so far (review: PR #3847)", async () => {
     // maxDurationSeconds=2.5 does not align with the 1000ms rotation cadence, matching
     // the reported bug: without a session-level bound, rotation reschedules indefinitely

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -352,6 +352,41 @@ describe("videoRecordingManager", () => {
     expect(cleanupFailingService.listActiveRecordingIds()).toHaveLength(0);
   });
 
+  test("disarms timers and exposes a stopped recording when rollback artifact cleanup fails", async () => {
+    const cleanupError = new Error("artifact cleanup failed");
+    const cleanupFailingService = new VideoRecorderService({
+      backend: fakeBackend,
+      archiveRoot,
+      now: () => new Date(fakeTimer.now()),
+      fileSystem: {
+        rm: async () => {
+          throw cleanupError;
+        },
+      },
+    });
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: cleanupFailingService,
+      recordingRepository: fakeRepository,
+      configRepository: new FakeVideoRecordingConfigRepository(),
+      highlightClient: fakeHighlightClient,
+      timer: fakeTimer,
+      now: () => new Date(fakeTimer.now()),
+    });
+    const active = await startVideoRecording({
+      device: testDevice,
+      maxDurationSeconds: 3,
+    });
+
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+    await expect(rollbackVideoRecordingStart(active.recordingId)).rejects.toThrow(cleanupError);
+
+    expect(cleanupFailingService.listActiveRecordingIds()).toEqual([]);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(await fakeRepository.getRecording(active.recordingId)).toMatchObject({
+      status: "interrupted",
+    });
+  });
+
   test("retains durable metadata and ownership when backend discard fails", async () => {
     const active = await startVideoRecording({ device: testDevice });
     const pendingTimers = fakeTimer.getPendingTimeoutCount();

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -1,4 +1,13 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 import os from "node:os";
 import path from "node:path";
 import { promises as fsPromises } from "node:fs";
@@ -15,6 +24,7 @@ import {
   recordVideoRecordingHighlightAdded,
   resetVideoRecordingManagerDependencies,
   resolveVideoRetentionPolicy,
+  rollbackVideoRecordingStart,
   runRetentionSweep,
   setVideoRecordingManagerDependencies,
   startVideoRecording,
@@ -24,12 +34,18 @@ import {
 } from "../../src/server/videoRecordingManager";
 import type { VideoRecordingRecord } from "../../src/db/videoRecordingRepository";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import {
+  buildVideoArchiveItemUri,
+  VIDEO_RESOURCE_URIS,
+} from "../../src/server/videoRecordingResourceUris";
 
 describe("videoRecordingManager", () => {
   let fakeTimer: FakeTimer;
   let fakeBackend: FakeVideoCaptureBackend;
   let fakeHighlightClient: FakeHighlightClient;
   let fakeRepository: FakeVideoRecordingRepository;
+  let service: VideoRecorderService;
   let archiveRoot: string;
   let testDevice: BootedDevice;
   const iosDevice: BootedDevice = {
@@ -51,7 +67,7 @@ describe("videoRecordingManager", () => {
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
     await fsPromises.mkdir(archiveRoot, { recursive: true });
 
-    const service = new VideoRecorderService({
+    service = new VideoRecorderService({
       backend: fakeBackend,
       archiveRoot,
       now: () => new Date(fakeTimer.now()),
@@ -181,53 +197,52 @@ describe("videoRecordingManager", () => {
     expect(record?.durationMs).toBe(1000);
   });
 
-  test("cancellation after backend startup force-stops and interrupts the capture", async () => {
-    const controller = new AbortController();
-    const originalInsert = fakeRepository.insertRecording.bind(fakeRepository);
-    let insertedRecordingId: string | undefined;
-    fakeRepository.insertRecording = async (record) => {
-      insertedRecordingId = record.recordingId;
-      controller.abort(new Error("request cancelled"));
-      await originalInsert(record);
-    };
+  test("in-memory ownership blocks a second start when durable status is stale", async () => {
+    const active = await startVideoRecording({ device: testDevice });
+    await interruptVideoRecording(active.recordingId);
 
-    await expect(
-      startVideoRecording({
-        device: testDevice,
-        maxDurationSeconds: 3,
-        abortSignal: controller.signal,
-      }),
-    ).rejects.toThrow("request cancelled");
+    await expect(startVideoRecording({ device: testDevice })).rejects.toThrow(
+      "already active for device",
+    );
 
-    expect(fakeBackend.forceStopCalls).toHaveLength(1);
-    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
-    expect(insertedRecordingId).toBeDefined();
-    expect((await fakeRepository.getRecording(insertedRecordingId!))?.status).toBe("interrupted");
+    await service.forceStopRecording(active.recordingId);
   });
 
-  test("keeps a recording discoverable when cancellation force-stop fails", async () => {
-    const controller = new AbortController();
-    const originalInsert = fakeRepository.insertRecording.bind(fakeRepository);
-    let insertedRecordingId: string | undefined;
-    fakeBackend.forceStop = async () => {
-      throw new Error("force stop failed");
-    };
-    fakeRepository.insertRecording = async (record) => {
-      insertedRecordingId = record.recordingId;
-      controller.abort(new Error("request cancelled"));
-      await originalInsert(record);
-    };
+  test("reconciles an ownerless active row through canonical interruption", async () => {
+    const recordingDir = path.join(archiveRoot, "stale-recording");
+    const filePath = path.join(recordingDir, "capture.mp4");
+    await fsPromises.mkdir(recordingDir, { recursive: true });
+    await fsPromises.writeFile(filePath, "1234567");
+    const startedAt = new Date(fakeTimer.now()).toISOString();
+    await fakeRepository.insertRecording({
+      recordingId: "stale-recording",
+      deviceId: testDevice.deviceId,
+      platform: testDevice.platform,
+      filePath,
+      fileName: "capture.mp4",
+      format: "mp4",
+      sizeBytes: 0,
+      status: "recording",
+      createdAt: startedAt,
+      startedAt,
+      lastAccessedAt: startedAt,
+      config: {
+        qualityPreset: "low",
+        targetBitrateKbps: 1000,
+        maxThroughputMbps: 5,
+        fps: 15,
+        maxArchiveSizeMb: 100,
+        format: "mp4",
+      },
+    });
 
-    await expect(
-      startVideoRecording({
-        device: testDevice,
-        maxDurationSeconds: 3,
-        abortSignal: controller.signal,
-      }),
-    ).rejects.toThrow("request cancelled");
+    await startVideoRecording({ device: testDevice });
 
-    expect(insertedRecordingId).toBeDefined();
-    expect((await fakeRepository.getRecording(insertedRecordingId!))?.status).toBe("recording");
+    expect(await fakeRepository.getRecording("stale-recording")).toMatchObject({
+      status: "interrupted",
+      sizeBytes: 7,
+      endedAt: new Date(fakeTimer.now()).toISOString(),
+    });
   });
 
   test("rejects recording starts once shutdown begins", async () => {
@@ -259,6 +274,244 @@ describe("videoRecordingManager", () => {
 
     await expect(Promise.all([firstDrain, secondDrain])).resolves.toEqual([undefined, undefined]);
     await expect(startResult).resolves.toThrow("start aborted");
+  });
+
+  test("reserves a device before asynchronous admission checks", async () => {
+    let resolveStart: (() => void) | undefined;
+    let markBackendStarted: (() => void) | undefined;
+    const backendStarted = new Promise<void>((resolve) => {
+      markBackendStarted = resolve;
+    });
+    fakeBackend.start = async (config) => {
+      fakeBackend.startCalls.push(config);
+      markBackendStarted?.();
+      await new Promise<void>((resolve) => {
+        resolveStart = resolve;
+      });
+      const handle = {
+        recordingId: config.recordingId,
+        outputPath: config.outputPath,
+        startedAt: config.startedAt,
+      };
+      fakeBackend.startResults.push(handle);
+      return handle;
+    };
+
+    const first = startVideoRecording({ device: testDevice });
+    await backendStarted;
+    const second = startVideoRecording({ device: testDevice });
+
+    await expect(second).rejects.toThrow("start already in progress");
+    expect(fakeBackend.startCalls).toHaveLength(1);
+    resolveStart?.();
+    await first;
+  });
+
+  test("force-stops backend success and removes ownership when persistence fails", async () => {
+    fakeRepository.insertRecording = async () => {
+      throw new Error("database unavailable");
+    };
+
+    await expect(startVideoRecording({ device: testDevice })).rejects.toThrow(
+      "database unavailable",
+    );
+
+    expect(fakeBackend.forceStopCalls).toEqual([fakeBackend.startResults[0]]);
+    expect(service.listActiveRecordingIds()).toEqual([]);
+    expect(await fakeRepository.listRecordings()).toEqual([]);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(await fsPromises.readdir(archiveRoot)).toEqual([]);
+  });
+
+  test("releases provisional ownership when rollback artifact deletion fails", async () => {
+    const cleanupError = new Error("artifact cleanup failed");
+    const cleanupFailingService = new VideoRecorderService({
+      backend: fakeBackend,
+      archiveRoot,
+      now: () => new Date(fakeTimer.now()),
+      fileSystem: {
+        rm: async () => {
+          throw cleanupError;
+        },
+      },
+    });
+    fakeRepository.insertRecording = async () => {
+      throw new Error("database unavailable");
+    };
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: cleanupFailingService,
+      recordingRepository: fakeRepository,
+      configRepository: new FakeVideoRecordingConfigRepository(),
+      highlightClient: fakeHighlightClient,
+      timer: fakeTimer,
+      now: () => new Date(fakeTimer.now()),
+    });
+
+    await expect(startVideoRecording({ device: testDevice })).rejects.toThrow(cleanupError.message);
+
+    expect(cleanupFailingService.listActiveRecordingIds()).toHaveLength(0);
+  });
+
+  test("retains durable metadata and ownership when backend discard fails", async () => {
+    const active = await startVideoRecording({ device: testDevice });
+    const pendingTimers = fakeTimer.getPendingTimeoutCount();
+    fakeBackend.forceStop = async () => {
+      throw new Error("device temp cleanup failed");
+    };
+
+    await expect(rollbackVideoRecordingStart(active.recordingId)).rejects.toThrow(
+      "device temp cleanup failed",
+    );
+
+    expect(await fakeRepository.getRecording(active.recordingId)).not.toBeNull();
+    expect(service.listActiveRecordingIds()).toEqual([active.recordingId]);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(pendingTimers);
+  });
+
+  test("notifies video resources after rollback removes the durable row", async () => {
+    const updates = spyOn(ResourceRegistry, "notifyResourcesUpdated").mockResolvedValue(undefined);
+    const active = await startVideoRecording({ device: testDevice });
+
+    try {
+      await rollbackVideoRecordingStart(active.recordingId);
+
+      expect(updates).toHaveBeenCalledTimes(2);
+      expect(updates).toHaveBeenLastCalledWith([
+        VIDEO_RESOURCE_URIS.LATEST,
+        VIDEO_RESOURCE_URIS.ARCHIVE,
+        buildVideoArchiveItemUri(active.recordingId),
+      ]);
+    } finally {
+      updates.mockRestore();
+    }
+  });
+
+  test("stops an in-memory owner before a failing repository read", async () => {
+    const active = await startVideoRecording({ device: testDevice });
+    const originalGet = fakeRepository.getRecording.bind(fakeRepository);
+    fakeRepository.getRecording = async () => {
+      throw new Error("database read failed");
+    };
+
+    await expect(rollbackVideoRecordingStart(active.recordingId)).rejects.toThrow(
+      "database read failed",
+    );
+
+    expect(fakeBackend.forceStopCalls).toEqual([fakeBackend.startResults[0]]);
+    expect(service.listActiveRecordingIds()).toEqual([]);
+
+    fakeRepository.getRecording = originalGet;
+    await expect(startVideoRecording({ device: testDevice })).resolves.toBeDefined();
+    expect((await originalGet(active.recordingId))?.status).toBe("interrupted");
+  });
+
+  test("delete failure leaves an interrupted row that does not block retry", async () => {
+    const active = await startVideoRecording({ device: testDevice });
+    const highlightShape = {
+      type: "box",
+      bounds: { x: 5, y: 15, width: 50, height: 60 },
+    } as const;
+    fakeTimer.advanceTime(500);
+    await recordVideoRecordingHighlightAdded(testDevice, {
+      shape: highlightShape,
+    });
+    fakeTimer.advanceTime(500);
+    const originalDelete = fakeRepository.deleteRecording.bind(fakeRepository);
+    fakeRepository.deleteRecording = async () => {
+      throw new Error("database delete failed");
+    };
+
+    await expect(rollbackVideoRecordingStart(active.recordingId)).rejects.toThrow(
+      "database delete failed",
+    );
+
+    expect(await fakeRepository.getRecording(active.recordingId)).toMatchObject({
+      status: "interrupted",
+      highlights: [
+        {
+          shape: highlightShape,
+          timeline: { appearedAtSeconds: 0.5, disappearedAtSeconds: 1 },
+        },
+      ],
+    });
+    expect(service.listActiveRecordingIds()).toEqual([]);
+
+    fakeRepository.deleteRecording = originalDelete;
+    await expect(startVideoRecording({ device: testDevice })).resolves.toBeDefined();
+  });
+
+  test("rollback removes artifacts for an already completed segment", async () => {
+    const recordingDir = path.join(archiveRoot, "completed-segment");
+    const filePath = path.join(recordingDir, "segment.mp4");
+    await fsPromises.mkdir(recordingDir, { recursive: true });
+    await fsPromises.writeFile(filePath, "segment");
+    await fakeRepository.insertRecording({
+      recordingId: "completed-segment",
+      deviceId: testDevice.deviceId,
+      platform: testDevice.platform,
+      filePath,
+      fileName: "segment.mp4",
+      format: "mp4",
+      sizeBytes: 7,
+      status: "completed",
+      createdAt: new Date(fakeTimer.now()).toISOString(),
+      startedAt: new Date(fakeTimer.now()).toISOString(),
+      lastAccessedAt: new Date(fakeTimer.now()).toISOString(),
+      config: {
+        qualityPreset: "low",
+        targetBitrateKbps: 1000,
+        maxThroughputMbps: 5,
+        fps: 15,
+        maxArchiveSizeMb: 100,
+        format: "mp4",
+      },
+    });
+
+    await rollbackVideoRecordingStart("completed-segment");
+
+    expect(await fakeRepository.getRecording("completed-segment")).toBeNull();
+    await expect(fsPromises.access(recordingDir)).rejects.toThrow();
+  });
+
+  test("rolls back the durable row when post-start scheduling fails", async () => {
+    fakeTimer.setTimeout = () => {
+      throw new Error("timer scheduling failed");
+    };
+
+    await expect(
+      startVideoRecording({
+        device: testDevice,
+        maxDurationSeconds: 10,
+      }),
+    ).rejects.toThrow("timer scheduling failed");
+
+    expect(fakeBackend.forceStopCalls).toEqual([fakeBackend.startResults[0]]);
+    expect(await fakeRepository.listRecordings()).toEqual([]);
+    expect(service.listActiveRecordingIds()).toEqual([]);
+  });
+
+  test("shares initialization work and retries after initialization failure", async () => {
+    const originalList = fakeRepository.listRecordings.bind(fakeRepository);
+    let initializationCalls = 0;
+    let failInitialization = true;
+    fakeRepository.listRecordings = async (query = {}) => {
+      if (query.status === "recording") {
+        initializationCalls++;
+        if (failInitialization) {
+          throw new Error("initialization failed");
+        }
+      }
+      return originalList(query);
+    };
+
+    const first = listVideoRecordings();
+    const concurrent = listVideoRecordings();
+    await expect(Promise.all([first, concurrent])).rejects.toThrow("initialization failed");
+    expect(initializationCalls).toBe(1);
+
+    failInitialization = false;
+    await expect(listVideoRecordings()).resolves.toEqual([]);
+    expect(initializationCalls).toBe(2);
   });
 
   test("records highlight timelines for scheduled highlights", async () => {

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -162,6 +162,139 @@ describe("videoRecording tool segmentation branch", () => {
 
   const handler = () => ToolRegistry.getTool("videoRecording")!.deviceAwareHandler!;
 
+  test("request abort rolls back every device that already started during fanout", async () => {
+    const secondDevice: BootedDevice = {
+      deviceId: "test-device-2",
+      platform: "android",
+      name: "Test Device 2",
+    };
+    fakeDeviceSessionManager.setConnectedDevices([androidDevice, secondDevice]);
+    const controller = new AbortController();
+    let markSecondStart: (() => void) | undefined;
+    const secondStart = new Promise<void>((resolve) => {
+      markSecondStart = resolve;
+    });
+    fakeBackend.start = async (config) => {
+      fakeBackend.startCalls.push(config);
+      if (fakeBackend.startCalls.length === 2) {
+        markSecondStart?.();
+        await new Promise<void>((resolve) => {
+          config.abortSignal?.addEventListener("abort", resolve, { once: true });
+        });
+        throw new Error("fanout start aborted");
+      }
+      const handle = {
+        recordingId: config.recordingId,
+        outputPath: config.outputPath,
+        startedAt: config.startedAt,
+      };
+      fakeBackend.startResults.push(handle);
+      return handle;
+    };
+
+    const starting = handler()(
+      androidDevice,
+      { action: "start", platform: "android" },
+      undefined,
+      controller.signal,
+    );
+    await secondStart;
+    controller.abort();
+
+    await expect(starting).rejects.toThrow();
+    expect(fakeBackend.startCalls).toHaveLength(2);
+    expect(fakeBackend.forceStopCalls).toEqual([fakeBackend.startResults[0]]);
+    expect(await fakeRepository.listRecordings()).toEqual([]);
+  });
+
+  test("retains auto-finalized segments until an all-device start commits", async () => {
+    const secondDevice: BootedDevice = {
+      deviceId: "test-device-2",
+      platform: "android",
+      name: "Test Device 2",
+    };
+    fakeDeviceSessionManager.setConnectedDevices([androidDevice, secondDevice]);
+    const controller = new AbortController();
+    const rolledBack: string[] = [];
+    let secondStartSignal: AbortSignal | undefined;
+    let markSecondStart: (() => void) | undefined;
+    const secondStart = new Promise<void>((resolve) => {
+      markSecondStart = resolve;
+    });
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async (request) => {
+        if (request.device.deviceId === secondDevice.deviceId) {
+          secondStartSignal = request.abortSignal;
+          markSecondStart?.();
+          await new Promise<void>((resolve) => {
+            request.abortSignal?.addEventListener("abort", resolve, { once: true });
+          });
+          request.abortSignal?.throwIfAborted();
+        }
+        const recordingId = `${request.device.deviceId}-${request.outputName}`;
+        return makeSegmentRecording(recordingId, request.outputName);
+      },
+      stopVideoRecording: async (recordingId) => ({
+        metadata: makeSegmentMetadata(recordingId ?? "missing"),
+        evictedRecordingIds: [],
+      }),
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rolledBack.push(recordingId);
+      },
+    });
+
+    const starting = handler()(
+      androidDevice,
+      { action: "start", platform: "android", maxDuration: 181, outputName: "fanout" },
+      undefined,
+      controller.signal,
+    );
+    await secondStart;
+    segmentTimer.advanceTime(181_000);
+    await drainMicrotasks();
+
+    controller.abort(new Error("fanout cancelled"));
+    await expect(starting).rejects.toThrow("fanout cancelled");
+
+    expect(secondStartSignal?.aborted).toBe(true);
+    expect(rolledBack.some((recordingId) => recordingId.startsWith(androidDevice.deviceId))).toBe(
+      true,
+    );
+  });
+
+  test("request abort cancels all-device discovery before backend startup", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    let markDiscoveryStarted: (() => void) | undefined;
+    const discoveryStarted = new Promise<void>((resolve) => {
+      markDiscoveryStarted = resolve;
+    });
+    setVideoRecordingDeviceDetectorForTesting({
+      detectConnectedPlatforms: async (signal) => {
+        receivedSignal = signal;
+        markDiscoveryStarted?.();
+        await new Promise<void>((resolve) => {
+          signal?.addEventListener("abort", resolve, { once: true });
+        });
+        signal?.throwIfAborted();
+        return [];
+      },
+    });
+
+    const starting = handler()(
+      androidDevice,
+      { action: "start", platform: "android" },
+      undefined,
+      controller.signal,
+    );
+    await discoveryStarted;
+    controller.abort(new Error("discovery cancelled"));
+
+    await expect(starting).rejects.toThrow("discovery cancelled");
+    expect(receivedSignal).toBe(controller.signal);
+    expect(fakeBackend.startCalls).toEqual([]);
+  });
+
   test("android recording <= 180s stays single (not segmented)", async () => {
     const res = parse(
       await handler()(androidDevice, {
@@ -289,14 +422,13 @@ describe("videoRecording tool segmentation branch", () => {
     );
   });
 
-  test("cancellation reaches initial segmented startup and finalizes a raced successful start", async () => {
+  test("cancellation reaches initial segmented startup and discards a raced successful start", async () => {
     const controller = new AbortController();
     let resolveStart!: (recording: ActiveVideoRecording) => void;
     const startMayComplete = new Promise<ActiveVideoRecording>((resolve) => {
       resolveStart = resolve;
     });
     let receivedSignal: AbortSignal | undefined;
-    const forceStopped: string[] = [];
     setSegmentedSessionRecordingDependencies({
       startVideoRecording: async (request) => {
         receivedSignal = request.abortSignal;
@@ -307,8 +439,8 @@ describe("videoRecording tool segmentation branch", () => {
         segmentStops.push(id);
         throw new Error(`graceful stop failed for ${id}`);
       },
-      forceStopVideoRecording: async (recordingId) => {
-        forceStopped.push(recordingId);
+      rollbackVideoRecordingStart: async (recordingId) => {
+        segmentStops.push(recordingId);
       },
     });
 
@@ -332,7 +464,6 @@ describe("videoRecording tool segmentation branch", () => {
     await expect(starting).rejects.toThrow("request cancelled");
     expect(receivedSignal).toBe(controller.signal);
     expect(segmentStops).toEqual(["cancelled"]);
-    expect(forceStopped).toEqual(["cancelled"]);
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
   });
 

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -207,6 +207,74 @@ describe("videoRecording tool segmentation branch", () => {
     expect(await fakeRepository.listRecordings()).toEqual([]);
   });
 
+  test("request abort starts every fanout rollback while another rollback is stalled", async () => {
+    const secondDevice: BootedDevice = {
+      deviceId: "test-device-2",
+      platform: "android",
+      name: "Test Device 2",
+    };
+    const thirdDevice: BootedDevice = {
+      deviceId: "test-device-3",
+      platform: "android",
+      name: "Test Device 3",
+    };
+    fakeDeviceSessionManager.setConnectedDevices([androidDevice, secondDevice, thirdDevice]);
+    const controller = new AbortController();
+    let markThirdStart: (() => void) | undefined;
+    const thirdStart = new Promise<void>((resolve) => {
+      markThirdStart = resolve;
+    });
+    let releaseSecondRollback!: () => void;
+    const secondRollback = new Promise<void>((resolve) => {
+      releaseSecondRollback = resolve;
+    });
+    const rollbackCalls: string[] = [];
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async (request) => {
+        if (request.device.deviceId !== thirdDevice.deviceId) {
+          return makeSegmentRecording(request.device.deviceId, request.outputName);
+        }
+        markThirdStart?.();
+        await new Promise<void>((resolve) => {
+          request.abortSignal?.addEventListener("abort", resolve, { once: true });
+        });
+        request.abortSignal?.throwIfAborted();
+        throw new Error("unreachable");
+      },
+      stopVideoRecording: async (recordingId) => ({
+        metadata: makeSegmentMetadata(recordingId ?? "missing"),
+        evictedRecordingIds: [],
+      }),
+      rollbackVideoRecordingStart: async (recordingId) => {
+        rollbackCalls.push(recordingId);
+        if (recordingId === secondDevice.deviceId) {
+          await secondRollback;
+        }
+      },
+    });
+
+    const starting = handler()(
+      androidDevice,
+      { action: "start", platform: "android", maxDuration: 181 },
+      undefined,
+      controller.signal,
+    );
+    await thirdStart;
+    controller.abort(new Error("fanout cancelled"));
+
+    for (let attempt = 0; attempt < 20 && rollbackCalls.length < 2; attempt++) {
+      await new Promise<void>(setImmediate);
+    }
+    const rollbackCallsBeforeRelease = [...rollbackCalls];
+    releaseSecondRollback();
+
+    await expect(starting).rejects.toThrow("fanout cancelled");
+    expect(rollbackCallsBeforeRelease.toSorted()).toEqual(
+      [androidDevice.deviceId, secondDevice.deviceId].toSorted(),
+    );
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+  });
+
   test("retains auto-finalized segments until an all-device start commits", async () => {
     const secondDevice: BootedDevice = {
       deviceId: "test-device-2",

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -266,6 +266,43 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     expect(child.killCalls).toEqual(["SIGTERM"]);
   });
 
+  test("does not terminate a child after startup-scoped cancellation", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      stdin: null,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      killCalls: [] as string[],
+      kill(signal?: string) {
+        this.killCalls.push(signal ?? "SIGTERM");
+        return true;
+      },
+    });
+    let receivedSignal: AbortSignal | undefined;
+    const adb = new AdbClient(
+      { name: "Pixel 8", platform: "android", deviceId: "emulator-5554" },
+      async (): Promise<ExecResult> => createExecResult(""),
+      ((_file: string, _args: string[], options?: { signal?: AbortSignal }) => {
+        receivedSignal = options?.signal;
+        return child;
+      }) as never,
+    );
+    const controller = new AbortController();
+
+    const pending = adb.spawn(["shell", "screenrecord", "/sdcard/recording.mp4"], {
+      signal: controller.signal,
+      abortSignalScope: "startup",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    child.emit("spawn");
+    await pending;
+
+    controller.abort();
+
+    expect(receivedSignal).toBeUndefined();
+    expect(child.killCalls).toEqual([]);
+  });
+
   test("does not spawn when cancellation arrives during executable resolution", async () => {
     let resolveBase: ((value: { adbPath: string; baseArgs: string[] }) => void) | undefined;
     let spawnCalls = 0;


### PR DESCRIPTION
## Summary

- Reserve a device synchronously before any asynchronous recording admission work.
- Publish provisional in-memory ownership before backend startup so cancellation and shutdown can find starting captures.
- Force-stop and remove artifacts after persistence or post-start failures while retaining ownership when cleanup itself fails.
- Replace sticky initialization state with a shared promise that clears after failure and retries.
- Reconcile stale durable rows through canonical interruption, preserving file size, highlights, and resource notifications.
- Roll back every successful device start when a multi-device request is aborted, while preserving best-effort behavior for ordinary per-device failures.

## Root cause

Recording admission used a check-then-act repository query, so concurrent same-device starts could both pass. Service ownership appeared only after backend startup, leaving shutdown unable to discover an in-flight capture. A database failure after backend success leaked that live capture, and aborted fanout could return without reporting or stopping devices that had already started.

## Validation

- 434 changed-suite tests pass across all three stacked PRs.
- A final 249-test lifecycle/ownership regression pass is green after restacking.
- `bun run typecheck` passes with no new errors.
- `bun run build` passes.
- Full formatting/lint validation is currently blocked by defects already present on `origin/main`: unformatted `src/daemon/manager.ts` and `src/features/observe/output/ObserveResultOutput.ts`, plus the latter's unused `_diagnostics` lint error.
- Three unrelated observe projection/schema tests also fail identically on `origin/main`; all changed video suites pass.

Stacked on [#5960](https://github.com/kaeawc/auto-mobile/pull/5960).
