### PR TITLE
fix(observe): reconcile orphaned CtrlProxy forwards

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -7,12 +7,13 @@ state directory, logs, tool set, or device behavior.
 
 <div class="environment-variable-table" markdown>
 
-| Variable                | Use                                                                                                                                         | Default               |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `AUTOMOBILE_DATA_DIR`   | Base directory for observe, accessibility, navigation, CtrlProxy-build, screen-streaming, WebRTC, tool-output, and daemon-failure artifacts | `~/.auto-mobile`      |
-| `AUTOMOBILE_LOG_DIR`    | Directory for daemon and client logs                                                                                                        | `~/.auto-mobile/logs` |
-| `AUTOMOBILE_LOG_FORMAT` | `text` or newline-delimited `json`                                                                                                          | `text`                |
-| `AUTOMOBILE_LOG_SINK`   | `file`, `stderr`, or `both`                                                                                                                 | `file`                |
+| Variable                      | Use                                                                                                                                         | Default                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `AUTOMOBILE_DATA_DIR`         | Base directory for observe, accessibility, navigation, CtrlProxy-build, screen-streaming, WebRTC, tool-output, and daemon-failure artifacts | `~/.auto-mobile`               |
+| `AUTOMOBILE_LOG_DIR`          | Directory for daemon and client logs                                                                                                        | `~/.auto-mobile/logs`          |
+| `AUTOMOBILE_LOG_FORMAT`       | `text` or newline-delimited `json`                                                                                                          | `text`                         |
+| `AUTOMOBILE_LOG_SINK`         | `file`, `stderr`, or `both`                                                                                                                 | `file`                         |
+| `AUTOMOBILE_COORDINATION_DIR` | Absolute, shared directory for cross-process CtrlProxy forwarding leases                                                                    | OS account home `.auto-mobile` |
 
 </div>
 
@@ -28,6 +29,12 @@ Some persistent stores still use fixed paths under `~/.auto-mobile`, including
 device snapshots, video archives, and downloaded libwebp tools. Set their
 feature-specific options where available; `AUTOMOBILE_DATA_DIR` does not
 currently relocate them.
+
+Set `AUTOMOBILE_COORDINATION_DIR` when the OS account home is read-only or when
+AutoMobile agents that share an ADB server need an explicit shared lease root.
+All cooperating agents must use the same absolute path. The legacy
+`AUTO_MOBILE_COORDINATION_DIR` alias is accepted when the preferred name is
+unset.
 
 ## Database
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -33,6 +33,7 @@ import {
 import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
+import { shellQuote } from "../utils/shellQuote";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import { SingleFlightInterval } from "./SingleFlightInterval";

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -33,7 +33,6 @@ import {
 import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
-import { shellQuote } from "../utils/shellQuote";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import { SingleFlightInterval } from "./SingleFlightInterval";

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -14,7 +14,6 @@
  * - CtrlProxyHighlights: Visual highlight overlays
  */
 
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
 import {
@@ -121,6 +120,7 @@ import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 import { defaultIdGenerator } from "../../../utils/IdGenerator";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../../utils/fileLock";
+import { getTempDir, TEMP_SUBDIRS } from "../../../utils/tempDir";
 
 // Import delegates
 import { CtrlProxyGestures } from "./CtrlProxyGestures";
@@ -1001,8 +1001,6 @@ interface CtrlProxyForwardLease {
   release(): void;
 }
 
-const CTRL_PROXY_FORWARD_LEASE_DIRECTORY = join(tmpdir(), "auto-mobile-ctrlproxy-forwards");
-
 class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
   private readonly lockPath: string;
   private readonly ownerToken = defaultIdGenerator.next();
@@ -1011,7 +1009,10 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
   public constructor(deviceId: string) {
     // base64url makes arbitrary Android serials safe as one path segment.
     this.lockPath = join(
-      CTRL_PROXY_FORWARD_LEASE_DIRECTORY,
+      // Do not derive this from os.tmpdir(): package runners may give each
+      // process an isolated TMPDIR while they still share one ADB server.
+      getTempDir(TEMP_SUBDIRS.STATE),
+      "ctrlproxy-forwards",
       `${Buffer.from(deviceId).toString("base64url")}.lock`,
     );
   }
@@ -1022,6 +1023,7 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     }
     this.acquired = tryAcquireExclusiveLock(this.lockPath, {
       ownerToken: this.ownerToken,
+      reclaimOwnPid: true,
     });
     return this.acquired;
   }
@@ -1079,6 +1081,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Android-specific state
   private portForwardingSetup: boolean = false;
   private readonly ctrlProxyForwardLease: CtrlProxyForwardLease;
+  private ctrlProxyForwardLeaseReleaseScheduled: boolean = false;
   private inFlightConnection: Promise<boolean> | null = null;
   private cleanupHeldPort: number | null = null;
   private lastWebSocketTimeout: number = 0;
@@ -3117,7 +3120,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error during cleanup: ${error}`);
     } finally {
-      this.ctrlProxyForwardLease.release();
+      this.releaseCtrlProxyForwardLeaseAfterConnectionSettles();
     }
   }
 
@@ -3321,6 +3324,26 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     this.cleanupHeldPort = null;
     PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
     PortManager.releaseCleanupHold(heldPort);
+  }
+
+  /**
+   * ADB commands may ignore cancellation. Keep the cross-process ownership
+   * lease until an in-flight connection (including its forward setup) settles,
+   * so its late cleanup cannot remove a replacement process's forward.
+   */
+  private releaseCtrlProxyForwardLeaseAfterConnectionSettles(): void {
+    if (this.ctrlProxyForwardLeaseReleaseScheduled) {
+      return;
+    }
+    this.ctrlProxyForwardLeaseReleaseScheduled = true;
+
+    const releaseLease = (): void => this.ctrlProxyForwardLease.release();
+    const inFlightConnection = this.inFlightConnection;
+    if (inFlightConnection === null) {
+      releaseLease();
+      return;
+    }
+    void inFlightConnection.then(releaseLease, releaseLease);
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3041,8 +3041,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       await super.close();
 
       if (this.portForwardingSetup) {
-        await this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {});
-        this.portForwardingSetup = false;
+        // Do not claim the forward is gone when adb could not confirm its removal:
+        // the next client's reconciliation pass must still be able to reclaim it.
+        this.portForwardingSetup = !(await this.removeCtrlProxyPortForward(this.localPort));
       }
 
       PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
@@ -3096,12 +3097,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
 
     try {
+      await this.sweepOrphanedCtrlProxyPortForwards(signal);
+
       const previousLocalPort = this.localPort;
-      await perf.track("clearPortForward", () =>
-        this.adb
-          .execute(["forward", "--remove", `tcp:${this.localPort}`], { signal })
-          .catch(() => {}),
+      const clearedCurrentPort = await perf.track(
+        "clearPortForward",
+        async () => await this.removeCtrlProxyPortForward(this.localPort, signal),
       );
+      if (!clearedCurrentPort) {
+        throw new Error(`Failed to remove existing CtrlProxy forward on tcp:${this.localPort}`);
+      }
       if (this.closed) {
         return;
       }
@@ -3112,11 +3117,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       );
 
       if (this.localPort !== previousLocalPort) {
-        await perf.track("clearReallocatedPortForward", () =>
-          this.adb
-            .execute(["forward", "--remove", `tcp:${this.localPort}`], { signal })
-            .catch(() => {}),
+        const clearedReallocatedPort = await perf.track(
+          "clearReallocatedPortForward",
+          async () => await this.removeCtrlProxyPortForward(this.localPort, signal),
         );
+        if (!clearedReallocatedPort) {
+          throw new Error(`Failed to remove existing CtrlProxy forward on tcp:${this.localPort}`);
+        }
       }
 
       await perf.track("setupPortForward", () =>
@@ -3126,7 +3133,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       );
 
       if (this.closed) {
-        await this.adb.execute(["forward", "--remove", `tcp:${this.localPort}`]).catch(() => {});
+        await this.removeCtrlProxyPortForward(this.localPort);
         return;
       }
 
@@ -3136,6 +3143,101 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       logger.warn(`[CTRL_PROXY] Failed to setup port forwarding: ${error}`);
       throw error;
     }
+  }
+
+  /**
+   * Remove stale local forwards for this device that target CtrlProxy's fixed
+   * device port. A daemon crash drops the in-memory singleton registry but
+   * leaves ADB's forwards alive; the next client setup is their recovery path.
+   *
+   * A newly-created singleton is registered before it can start connecting, so
+   * its allocated port is treated as live even before port forwarding completes.
+   */
+  private async sweepOrphanedCtrlProxyPortForwards(signal?: AbortSignal): Promise<void> {
+    let stdout: string;
+    try {
+      const result = await this.adb.execute(["forward", "--list"], { signal });
+      stdout = result.stdout;
+    } catch (error) {
+      logger.warn(
+        `[CTRL_PROXY] Failed to list forwards while reconciling device ${this.device.deviceId}: ${error}`,
+        error,
+      );
+      return;
+    }
+
+    const livePorts = new Set(
+      Array.from(AndroidCtrlProxyClient.instances.values())
+        .filter((client) => client.device.deviceId === this.device.deviceId && !client.closed)
+        .map((client) => client.localPort),
+    );
+    const orphanedPorts = new Set<number>();
+    for (const line of stdout.split(/\r?\n/)) {
+      const [serial, local, remote, ...extra] = line.trim().split(/\s+/);
+      if (
+        extra.length !== 0 ||
+        serial !== this.device.deviceId ||
+        remote !== `tcp:${PortManager.DEVICE_PORT}`
+      ) {
+        continue;
+      }
+      const port = this.localPortFromForward(local);
+      if (port !== null && !livePorts.has(port)) {
+        orphanedPorts.add(port);
+      }
+    }
+
+    for (const port of orphanedPorts) {
+      logger.info(
+        `[CTRL_PROXY] Reclaiming orphaned CtrlProxy forward on ${this.device.deviceId} tcp:${port}`,
+      );
+      await this.removeCtrlProxyPortForward(port, signal);
+    }
+  }
+
+  /**
+   * Remove a forward only when it still maps this device and host port to the
+   * CtrlProxy device port. Re-listing closes the race with a different service
+   * reusing the host port after the orphan sweep discovered it.
+   *
+   * @returns `true` when no matching forward remains; `false` when adb failed
+   * to establish that state.
+   */
+  private async removeCtrlProxyPortForward(port: number, signal?: AbortSignal): Promise<boolean> {
+    try {
+      const result = await this.adb.execute(["forward", "--list"], { signal });
+      const expectedLocal = `tcp:${port}`;
+      const expectedRemote = `tcp:${PortManager.DEVICE_PORT}`;
+      const matchingForward = result.stdout.split(/\r?\n/).some((line) => {
+        const [serial, local, remote, ...extra] = line.trim().split(/\s+/);
+        return (
+          extra.length === 0 &&
+          serial === this.device.deviceId &&
+          local === expectedLocal &&
+          remote === expectedRemote
+        );
+      });
+      if (!matchingForward) {
+        return true;
+      }
+
+      await this.adb.execute(["forward", "--remove", expectedLocal], { signal });
+      return true;
+    } catch (error) {
+      logger.warn(
+        `[CTRL_PROXY] Failed to remove CtrlProxy forward on ${this.device.deviceId} tcp:${port}: ${error}`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  private localPortFromForward(value: string | undefined): number | null {
+    if (value === undefined || !value.startsWith("tcp:")) {
+      return null;
+    }
+    const port = Number.parseInt(value.slice("tcp:".length), 10);
+    return Number.isInteger(port) && port > 0 ? port : null;
   }
 
   private async finishInvalidatedConnectionCleanup(): Promise<void> {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -14,6 +14,8 @@
  * - CtrlProxyHighlights: Visual highlight overlays
  */
 
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import WebSocket from "ws";
 import {
   AdbClientFactory,
@@ -117,6 +119,8 @@ import {
 import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
+import { defaultIdGenerator } from "../../../utils/IdGenerator";
+import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../../utils/fileLock";
 
 // Import delegates
 import { CtrlProxyGestures } from "./CtrlProxyGestures";
@@ -988,6 +992,58 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
 const VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT = 2;
 
 /**
+ * Process-held ownership claim for a device's CtrlProxy ADB forwards. The ADB
+ * server is shared by AutoMobile processes, so its global forward listing alone
+ * cannot identify which process owns a row.
+ */
+interface CtrlProxyForwardLease {
+  tryAcquire(): boolean;
+  release(): void;
+}
+
+const CTRL_PROXY_FORWARD_LEASE_DIRECTORY = join(tmpdir(), "auto-mobile-ctrlproxy-forwards");
+
+class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
+  private readonly lockPath: string;
+  private readonly ownerToken = defaultIdGenerator.next();
+  private acquired = false;
+
+  public constructor(deviceId: string) {
+    // base64url makes arbitrary Android serials safe as one path segment.
+    this.lockPath = join(
+      CTRL_PROXY_FORWARD_LEASE_DIRECTORY,
+      `${Buffer.from(deviceId).toString("base64url")}.lock`,
+    );
+  }
+
+  public tryAcquire(): boolean {
+    if (this.acquired) {
+      return true;
+    }
+    this.acquired = tryAcquireExclusiveLock(this.lockPath, {
+      ownerToken: this.ownerToken,
+    });
+    return this.acquired;
+  }
+
+  public release(): void {
+    if (!this.acquired) {
+      return;
+    }
+    releaseExclusiveLock(this.lockPath, process.pid, this.ownerToken);
+    this.acquired = false;
+  }
+}
+
+class NoOpCtrlProxyForwardLease implements CtrlProxyForwardLease {
+  public tryAcquire(): boolean {
+    return true;
+  }
+
+  public release(): void {}
+}
+
+/**
  * Client for interacting with the AutoMobile Accessibility Service via WebSocket.
  * Uses singleton pattern per device to maintain persistent WebSocket connection.
  */
@@ -1022,6 +1078,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   // Android-specific state
   private portForwardingSetup: boolean = false;
+  private readonly ctrlProxyForwardLease: CtrlProxyForwardLease;
   private inFlightConnection: Promise<boolean> | null = null;
   private cleanupHeldPort: number | null = null;
   private lastWebSocketTimeout: number = 0;
@@ -1130,6 +1187,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     sdkEventIngestor?: AndroidSdkEventIngestor,
     loggerInstance: Logger = logger,
     certificateFileSystem?: CertificateFileSystem,
+    ctrlProxyForwardLease?: CtrlProxyForwardLease,
   ) {
     super(
       timer ?? defaultTimer,
@@ -1146,6 +1204,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     this.deviceConnectionLostNotifier =
       deviceConnectionLostNotifier ?? observationStreamDeviceConnectionLostNotifier;
     this.certificateFileSystem = certificateFileSystem;
+    this.ctrlProxyForwardLease =
+      ctrlProxyForwardLease ?? new FileCtrlProxyForwardLease(device.deviceId);
     this.localPort = PortManager.allocate(device.deviceId, {
       reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS,
     });
@@ -1197,6 +1257,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
     PortManager.holdForCleanup(this.localPort);
     this.cleanupHeldPort = this.localPort;
+    // A replacement must recover even if this invalidated client's asynchronous
+    // ADB cleanup is wedged. Its held port prevents the replacement from sharing
+    // the forward while that cleanup eventually completes.
+    this.ctrlProxyForwardLease.release();
   }
 
   /**
@@ -1423,6 +1487,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     loggerInstance?: Logger,
     certificateFileSystem?: CertificateFileSystem,
     screenshotBackoffScheduler?: ScreenshotBackoffScheduler,
+    ctrlProxyForwardLease?: CtrlProxyForwardLease,
   ): AndroidCtrlProxyClient {
     const client = new AndroidCtrlProxyClient(
       device,
@@ -1436,6 +1501,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       sdkEventIngestor,
       loggerInstance,
       certificateFileSystem,
+      ctrlProxyForwardLease ?? new NoOpCtrlProxyForwardLease(),
     );
     // Test-only seam: pre-seed the lazily-built scheduler so tests can assert shared floor
     // accounting (noteCaptureStarted) without the live device-data-stream server. Not exposed on
@@ -3050,6 +3116,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       await this.finishInvalidatedConnectionCleanup();
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error during cleanup: ${error}`);
+    } finally {
+      this.ctrlProxyForwardLease.release();
     }
   }
 
@@ -3083,6 +3151,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   ): Promise<void> {
     if (this.closed) {
       return;
+    }
+    if (!this.ctrlProxyForwardLease.tryAcquire()) {
+      throw new Error(
+        `Another AutoMobile process owns CtrlProxy forwarding for ${this.device.deviceId}`,
+      );
     }
     // Verify port forwarding is still active even if we think it's set up
     // Port forwarding can be lost if ADB server restarts or emulator restarts

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3266,7 +3266,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       logger.info(
         `[CTRL_PROXY] Reclaiming orphaned CtrlProxy forward on ${this.device.deviceId} tcp:${port}`,
       );
-      await this.removeCtrlProxyPortForward(port, signal);
+      if (!(await this.removeCtrlProxyPortForward(port, signal))) {
+        throw new Error(
+          `Failed to reclaim orphaned CtrlProxy forward on ${this.device.deviceId} tcp:${port}`,
+        );
+      }
     }
   }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -120,7 +120,7 @@ import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 import { defaultIdGenerator } from "../../../utils/IdGenerator";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../../utils/fileLock";
-import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../../../utils/tempDir";
+import { ensureSecureSharedAutoMobileDirSync } from "../../../utils/tempDir";
 
 // Import delegates
 import { CtrlProxyGestures } from "./CtrlProxyGestures";
@@ -1009,9 +1009,9 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
   public constructor(deviceId: string) {
     // base64url makes arbitrary Android serials safe as one path segment.
     this.lockPath = join(
-      // Do not derive this from os.tmpdir(): package runners may give each
-      // process an isolated TMPDIR while they still share one ADB server.
-      ensureSecureTempDirSync(join(TEMP_SUBDIRS.STATE, "ctrlproxy-forwards")),
+      // Agent-specific data directories are intentionally isolated, but a
+      // default ADB server is shared across agents for this OS user.
+      ensureSecureSharedAutoMobileDirSync("ctrlproxy-forwards"),
       `${Buffer.from(deviceId).toString("base64url")}.lock`,
     );
   }
@@ -1262,7 +1262,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // A replacement must recover even if this invalidated client's asynchronous
     // ADB cleanup is wedged. Its held port prevents the replacement from sharing
     // the forward while that cleanup eventually completes.
-    this.ctrlProxyForwardLease.release();
+    this.releaseCtrlProxyForwardLeaseAfterConnectionSettles();
   }
 
   /**
@@ -3238,7 +3238,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         `[CTRL_PROXY] Failed to list forwards while reconciling device ${this.device.deviceId}: ${error}`,
         error,
       );
-      return;
+      throw error;
     }
 
     const livePorts = new Set(

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -120,7 +120,7 @@ import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 import { defaultIdGenerator } from "../../../utils/IdGenerator";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../../utils/fileLock";
-import { getTempDir, TEMP_SUBDIRS } from "../../../utils/tempDir";
+import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../../../utils/tempDir";
 
 // Import delegates
 import { CtrlProxyGestures } from "./CtrlProxyGestures";
@@ -1011,8 +1011,7 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     this.lockPath = join(
       // Do not derive this from os.tmpdir(): package runners may give each
       // process an isolated TMPDIR while they still share one ADB server.
-      getTempDir(TEMP_SUBDIRS.STATE),
-      "ctrlproxy-forwards",
+      ensureSecureTempDirSync(join(TEMP_SUBDIRS.STATE, "ctrlproxy-forwards")),
       `${Buffer.from(deviceId).toString("base64url")}.lock`,
     );
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1002,18 +1002,23 @@ interface CtrlProxyForwardLease {
 }
 
 class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
-  private readonly lockPath: string;
+  private lockPath: string | null = null;
   private readonly ownerToken = defaultIdGenerator.next();
   private acquired = false;
 
-  public constructor(deviceId: string) {
-    // base64url makes arbitrary Android serials safe as one path segment.
-    this.lockPath = join(
-      // Agent-specific data directories are intentionally isolated, but a
-      // default ADB server is shared across agents for this OS user.
-      ensureSecureSharedAutoMobileDirSync("ctrlproxy-forwards"),
-      `${Buffer.from(deviceId).toString("base64url")}.lock`,
-    );
+  public constructor(private readonly deviceId: string) {}
+
+  private resolveLockPath(): string {
+    if (this.lockPath === null) {
+      // base64url makes arbitrary Android serials safe as one path segment.
+      this.lockPath = join(
+        // Agent-specific data directories are intentionally isolated, but a
+        // default ADB server is shared across agents for this OS user.
+        ensureSecureSharedAutoMobileDirSync("ctrlproxy-forwards"),
+        `${Buffer.from(this.deviceId).toString("base64url")}.lock`,
+      );
+    }
+    return this.lockPath;
   }
 
   public tryAcquire(): boolean {
@@ -1022,7 +1027,7 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     }
     // Shutdown recovery can evict a singleton while its setup remains in flight.
     // Another client in this process must wait for that live lease, not reclaim it.
-    this.acquired = tryAcquireExclusiveLock(this.lockPath, {
+    this.acquired = tryAcquireExclusiveLock(this.resolveLockPath(), {
       ownerToken: this.ownerToken,
     });
     return this.acquired;
@@ -1032,7 +1037,7 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     if (!this.acquired) {
       return;
     }
-    releaseExclusiveLock(this.lockPath, process.pid, this.ownerToken);
+    releaseExclusiveLock(this.resolveLockPath(), process.pid, this.ownerToken);
     this.acquired = false;
   }
 }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1020,9 +1020,10 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     if (this.acquired) {
       return true;
     }
+    // Shutdown recovery can evict a singleton while its setup remains in flight.
+    // Another client in this process must wait for that live lease, not reclaim it.
     this.acquired = tryAcquireExclusiveLock(this.lockPath, {
       ownerToken: this.ownerToken,
-      reclaimOwnPid: true,
     });
     return this.acquired;
   }

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -104,14 +104,24 @@ export function getTempDir(subdirectory: string): string {
  *
  * Unlike {@link getTempDir}, this deliberately ignores `AUTOMOBILE_DATA_DIR`
  * because those overrides isolate an agent's private state. Processes using
- * the same default ADB server must instead coordinate through one path.
+ * the same default ADB server must instead coordinate through one path. A
+ * locked-down service account can configure that path with
+ * `AUTOMOBILE_COORDINATION_DIR` (or `AUTO_MOBILE_COORDINATION_DIR`).
  */
 export function getSharedAutoMobileDir(
   subdirectory: string,
   homeDir: string = os.homedir(),
+  env: NodeJS.ProcessEnv = process.env,
+  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory(undefined, env),
 ): string {
+  const override = (env.AUTOMOBILE_COORDINATION_DIR ?? env.AUTO_MOBILE_COORDINATION_DIR)?.trim();
+  if (override && override.length > 0) {
+    return path.resolve(daemonLaunchWorkingDirectory, override, subdirectory);
+  }
   if (homeDir.length === 0) {
-    throw new Error("Unable to resolve a shared AutoMobile directory without a home directory");
+    throw new Error(
+      "Unable to resolve a shared AutoMobile directory without a home directory. Set AUTOMOBILE_COORDINATION_DIR to a writable shared directory.",
+    );
   }
   return path.join(path.resolve(homeDir), ".auto-mobile", subdirectory);
 }

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -99,6 +99,23 @@ export function getTempDir(subdirectory: string): string {
   return path.join(resolveAutoMobileBaseDir(), subdirectory);
 }
 
+/**
+ * Resolve a secure coordination directory shared by all agents for this user.
+ *
+ * Unlike {@link getTempDir}, this deliberately ignores `AUTOMOBILE_DATA_DIR`
+ * because those overrides isolate an agent's private state. Processes using
+ * the same default ADB server must instead coordinate through one path.
+ */
+export function getSharedAutoMobileDir(
+  subdirectory: string,
+  homeDir: string = os.homedir(),
+): string {
+  if (homeDir.length === 0) {
+    throw new Error("Unable to resolve a shared AutoMobile directory without a home directory");
+  }
+  return path.join(path.resolve(homeDir), ".auto-mobile", subdirectory);
+}
+
 function ensureSecureDirectorySync(dir: string): string {
   fs.mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
   if (fs.lstatSync(dir).isSymbolicLink()) {
@@ -118,6 +135,13 @@ function ensureSecureDirectorySync(dir: string): string {
  */
 export function ensureSecureTempDirSync(subdirectory: string): string {
   return ensureSecureDirectorySync(getTempDir(subdirectory));
+}
+
+/**
+ * Synchronously ensure an agent-invariant coordination directory exists.
+ */
+export function ensureSecureSharedAutoMobileDirSync(subdirectory: string): string {
+  return ensureSecureDirectorySync(getSharedAutoMobileDir(subdirectory));
 }
 
 /**

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -112,11 +112,15 @@ export function getSharedAutoMobileDir(
   subdirectory: string,
   homeDir: string = os.homedir(),
   env: NodeJS.ProcessEnv = process.env,
-  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory(undefined, env),
 ): string {
   const override = (env.AUTOMOBILE_COORDINATION_DIR ?? env.AUTO_MOBILE_COORDINATION_DIR)?.trim();
   if (override && override.length > 0) {
-    return path.resolve(daemonLaunchWorkingDirectory, override, subdirectory);
+    if (!path.isAbsolute(override)) {
+      throw new Error(
+        "AUTOMOBILE_COORDINATION_DIR must be an absolute path so all agents share one coordination directory.",
+      );
+    }
+    return path.join(override, subdirectory);
   }
   if (homeDir.length === 0) {
     throw new Error(

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -106,11 +106,13 @@ export function getTempDir(subdirectory: string): string {
  * because those overrides isolate an agent's private state. Processes using
  * the same default ADB server must instead coordinate through one path. A
  * locked-down service account can configure that path with
- * `AUTOMOBILE_COORDINATION_DIR` (or `AUTO_MOBILE_COORDINATION_DIR`).
+ * `AUTOMOBILE_COORDINATION_DIR` (or `AUTO_MOBILE_COORDINATION_DIR`). Its
+ * default comes from the OS account rather than the ambient `HOME`, which may
+ * be isolated per agent despite a shared ADB server.
  */
 export function getSharedAutoMobileDir(
   subdirectory: string,
-  homeDir: string = os.homedir(),
+  homeDir: string = os.userInfo().homedir,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   const override = (env.AUTOMOBILE_COORDINATION_DIR ?? env.AUTO_MOBILE_COORDINATION_DIR)?.trim();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -261,6 +261,7 @@ describe("AndroidCtrlProxyClient", function () {
 
   test("aborts a connect whose platform setup completes after close()", async () => {
     const manualTimer = new FakeTimer();
+    const lease = new FakeCtrlProxyForwardLease();
     let releaseForward!: () => void;
     const forwardGate = new Promise<void>((resolve) => {
       releaseForward = resolve;
@@ -292,6 +293,15 @@ describe("AndroidCtrlProxyClient", function () {
       gatedAdb,
       factory,
       manualTimer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      lease,
     );
     try {
       const connectPromise = client.ensureConnected();
@@ -300,6 +310,9 @@ describe("AndroidCtrlProxyClient", function () {
 
       // Shutdown teardown closes the client while port-forward setup is pending.
       await client.close();
+      // An ADB command can ignore its abort signal. Its lease must remain held
+      // until the old setup and its late cleanup have stopped touching forwards.
+      expect(lease.releases).toBe(0);
 
       // Platform setup now finishes — after close().
       releaseForward();
@@ -309,6 +322,7 @@ describe("AndroidCtrlProxyClient", function () {
       expect(socket).toBeNull();
       expect(client.isConnected()).toBe(false);
       await expect(connectPromise).resolves.toBe(false);
+      expect(lease.releases).toBe(1);
     } finally {
       releaseForward();
       await client.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1038,6 +1038,40 @@ describe("AndroidCtrlProxyClient", function () {
     }
   });
 
+  test("retries orphan reconciliation when an ADB removal fails", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    let removalFails = true;
+    stubForwardLifecycleCommands(
+      () => `${testDevice.deviceId} tcp:52002 tcp:8765\n`,
+      () => removalFails,
+    );
+
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    registerTestSingleton(client);
+    try {
+      await expect((client as any).setupPortForwarding()).rejects.toThrow(
+        "Failed to reclaim orphaned CtrlProxy forward",
+      );
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward tcp:8765 tcp:8765");
+
+      removalFails = false;
+      await (client as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:52002");
+      expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8765 tcp:8765");
+    } finally {
+      await client.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
+    }
+  });
+
   test("reconciles a CtrlProxy forward after close() cannot remove it", async function () {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../../src/db/dbWriteBarrier";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { CtrlProxyFocus } from "../../../src/features/observe/android/CtrlProxyFocus";
@@ -1228,6 +1231,37 @@ describe("AndroidCtrlProxyClient", function () {
       expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:52004");
     } finally {
       await client.close();
+    }
+  });
+
+  test("does not reclaim a live file lease from a synchronously evicted same-process client", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    const coordinationDir = mkdtempSync(join(tmpdir(), "auto-mobile-coordination-"));
+    const previousCoordinationDir = process.env.AUTOMOBILE_COORDINATION_DIR;
+    process.env.AUTOMOBILE_COORDINATION_DIR = coordinationDir;
+    const isolatedDevice = { ...testDevice, deviceId: "same-process-file-lease-device" };
+    const factory = new FakeAdbClientFactory(fakeAdb);
+    const original = AndroidCtrlProxyClient.getInstance(isolatedDevice, factory);
+    let replacement: AndroidCtrlProxyClient | undefined;
+
+    try {
+      expect((original as any).ctrlProxyForwardLease.tryAcquire()).toBe(true);
+      // Recovery evicts synchronously, but an in-flight setup may still hold this lease.
+      AndroidCtrlProxyClient.removeInstance(isolatedDevice.deviceId);
+
+      replacement = AndroidCtrlProxyClient.getInstance(isolatedDevice, factory);
+      expect((replacement as any).ctrlProxyForwardLease.tryAcquire()).toBe(false);
+    } finally {
+      await replacement?.close();
+      await original.close();
+      AndroidCtrlProxyClient.removeInstance(isolatedDevice.deviceId);
+      if (previousCoordinationDir === undefined) {
+        delete process.env.AUTOMOBILE_COORDINATION_DIR;
+      } else {
+        process.env.AUTOMOBILE_COORDINATION_DIR = previousCoordinationDir;
+      }
+      rmSync(coordinationDir, { recursive: true, force: true });
     }
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1159,6 +1159,7 @@ describe("AndroidCtrlProxyClient", function () {
   test("preserves a registered CtrlProxy client's forward before it connects", async function () {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
     stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:8765 tcp:8765\n`);
 
     const connectingClient = AndroidCtrlProxyClient.createForTesting(
@@ -1242,7 +1243,13 @@ describe("AndroidCtrlProxyClient", function () {
     process.env.AUTOMOBILE_COORDINATION_DIR = coordinationDir;
     const isolatedDevice = { ...testDevice, deviceId: "same-process-file-lease-device" };
     const factory = new FakeAdbClientFactory(fakeAdb);
-    const original = AndroidCtrlProxyClient.getInstance(isolatedDevice, factory);
+    const original = new (AndroidCtrlProxyClient as any)(
+      isolatedDevice,
+      factory.create(isolatedDevice),
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    (AndroidCtrlProxyClient as any).instances.set(isolatedDevice.deviceId, original);
     let replacement: AndroidCtrlProxyClient | undefined;
 
     try {
@@ -1250,7 +1257,12 @@ describe("AndroidCtrlProxyClient", function () {
       // Recovery evicts synchronously, but an in-flight setup may still hold this lease.
       AndroidCtrlProxyClient.removeInstance(isolatedDevice.deviceId);
 
-      replacement = AndroidCtrlProxyClient.getInstance(isolatedDevice, factory);
+      replacement = new (AndroidCtrlProxyClient as any)(
+        isolatedDevice,
+        factory.create(isolatedDevice),
+        createSuccessWebSocketFactory(),
+        fakeTimer,
+      );
       expect((replacement as any).ctrlProxyForwardLease.tryAcquire()).toBe(false);
     } finally {
       await replacement?.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -172,6 +172,35 @@ describe("AndroidCtrlProxyClient", function () {
     }
   };
 
+  const stubForwardLifecycleCommands = (
+    getForwardListOutput: () => string,
+    shouldFailRemove: () => boolean = () => false,
+  ): void => {
+    const executeCommand = fakeAdb.executeCommand.bind(fakeAdb);
+    fakeAdb.executeCommand = async (
+      command: string,
+      timeoutMs?: number,
+      maxBuffer?: number,
+      noRetry?: boolean,
+      signal?: AbortSignal,
+    ) => {
+      if (command === "forward --list") {
+        const stdout = getForwardListOutput();
+        return {
+          stdout,
+          stderr: "",
+          toString: () => stdout,
+          trim: () => stdout.trim(),
+          includes: (searchString: string) => stdout.includes(searchString),
+        };
+      }
+      if (command.startsWith("forward --remove") && shouldFailRemove()) {
+        throw new Error("adb forward removal failed");
+      }
+      return executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+    };
+  };
+
   test("discards a WebSocket that opens after close() so teardown cannot be undone", async () => {
     // Manual (non-auto-advancing) timer so the in-flight handshake stays pending
     // until we trigger `open` ourselves, and the connection timeout never fires.
@@ -940,7 +969,7 @@ describe("AndroidCtrlProxyClient", function () {
       ).setupPortForwarding();
 
       expect(checkedPorts).toEqual([8765, 8765, 8767]);
-      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:8767");
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:8767");
       expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8767 tcp:8765");
       expect(
         (
@@ -949,6 +978,103 @@ describe("AndroidCtrlProxyClient", function () {
       ).toBe("ws://127.0.0.1:8767/ws");
     } finally {
       PortManager.setPortAvailabilityCheckerForTesting(null);
+    }
+  });
+
+  test("sweeps a CtrlProxy forward orphaned by a simulated daemon SIGKILL", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52001 tcp:8765\n`);
+
+    const client = AndroidCtrlProxyClient.getInstance(
+      testDevice,
+      new FakeAdbClientFactory(fakeAdb),
+    );
+    try {
+      await (client as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:52001");
+    } finally {
+      await client.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
+    }
+  });
+
+  test("reconciles a CtrlProxy forward after close() cannot remove it", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    let removalFails = false;
+    stubForwardLifecycleCommands(
+      () => `${testDevice.deviceId} tcp:8765 tcp:8765\n`,
+      () => removalFails,
+    );
+
+    const original = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    await (original as any).setupPortForwarding();
+
+    fakeAdb.clearHistory();
+    removalFails = true;
+    await original.close();
+    expect((original as any).portForwardingSetup).toBe(true);
+
+    removalFails = false;
+    const replacement = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    try {
+      await (replacement as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:8765");
+    } finally {
+      await replacement.close();
+    }
+  });
+
+  test("preserves a registered CtrlProxy client's forward before it connects", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:8765 tcp:8765\n`);
+
+    const connectingClient = AndroidCtrlProxyClient.getInstance(
+      testDevice,
+      new FakeAdbClientFactory(fakeAdb),
+    );
+    try {
+      await (connectingClient as any).sweepOrphanedCtrlProxyPortForwards();
+
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:8765");
+    } finally {
+      await connectingClient.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
+    }
+  });
+
+  test("does not touch a forward whose destination is not CtrlProxy", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52003 tcp:12345\n`);
+
+    const client = AndroidCtrlProxyClient.getInstance(
+      testDevice,
+      new FakeAdbClientFactory(fakeAdb),
+    );
+    try {
+      await (client as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:52003");
+    } finally {
+      await client.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
     }
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -191,6 +191,7 @@ describe("AndroidCtrlProxyClient", function () {
   const stubForwardLifecycleCommands = (
     getForwardListOutput: () => string,
     shouldFailRemove: () => boolean = () => false,
+    shouldFailList: () => boolean = () => false,
   ): void => {
     const executeCommand = fakeAdb.executeCommand.bind(fakeAdb);
     fakeAdb.executeCommand = async (
@@ -201,6 +202,9 @@ describe("AndroidCtrlProxyClient", function () {
       signal?: AbortSignal,
     ) => {
       if (command === "forward --list") {
+        if (shouldFailList()) {
+          throw new Error("adb forward listing failed");
+        }
         const stdout = getForwardListOutput();
         return {
           stdout,
@@ -308,10 +312,14 @@ describe("AndroidCtrlProxyClient", function () {
       await flushPromises(8); // parked inside setupBeforeConnect; no socket yet
       expect(socket).toBeNull();
 
-      // Shutdown teardown closes the client while port-forward setup is pending.
-      await client.close();
+      // Shutdown recovery evicts the client before its asynchronous close.
+      client.invalidateForShutdownRecovery();
       // An ADB command can ignore its abort signal. Its lease must remain held
       // until the old setup and its late cleanup have stopped touching forwards.
+      expect(lease.releases).toBe(0);
+
+      // Close runs after invalidation in the production shutdown-recovery path.
+      await client.close();
       expect(lease.releases).toBe(0);
 
       // Platform setup now finishes — after close().
@@ -1065,6 +1073,41 @@ describe("AndroidCtrlProxyClient", function () {
       await (client as any).setupPortForwarding();
 
       expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:52002");
+      expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8765 tcp:8765");
+    } finally {
+      await client.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
+    }
+  });
+
+  test("retries orphan reconciliation when listing forwards fails", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    let listingFails = true;
+    stubForwardLifecycleCommands(
+      () => `${testDevice.deviceId} tcp:52003 tcp:8765\n`,
+      () => false,
+      () => listingFails,
+    );
+
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    registerTestSingleton(client);
+    try {
+      await expect((client as any).setupPortForwarding()).rejects.toThrow(
+        "adb forward listing failed",
+      );
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward tcp:8765 tcp:8765");
+
+      listingFails = false;
+      await (client as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:52003");
       expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8765 tcp:8765");
     } finally {
       await client.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -37,6 +37,22 @@ describe("AndroidCtrlProxyClient", function () {
   let fakeAdbFactory: FakeAdbClientFactory;
   const serverPort: number = 8765;
 
+  class FakeCtrlProxyForwardLease {
+    public acquireAttempts = 0;
+    public releases = 0;
+
+    public constructor(private readonly canAcquire: boolean = true) {}
+
+    public tryAcquire(): boolean {
+      this.acquireAttempts++;
+      return this.canAcquire;
+    }
+
+    public release(): void {
+      this.releases++;
+    }
+  }
+
   beforeEach(async function () {
     // Create fake timer with auto-advance for async event flushing
     fakeTimer = new FakeTimer();
@@ -199,6 +215,10 @@ describe("AndroidCtrlProxyClient", function () {
       }
       return executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
     };
+  };
+
+  const registerTestSingleton = (client: AndroidCtrlProxyClient): void => {
+    (AndroidCtrlProxyClient as any).instances.set(testDevice.deviceId, client);
   };
 
   test("discards a WebSocket that opens after close() so teardown cannot be undone", async () => {
@@ -987,10 +1007,13 @@ describe("AndroidCtrlProxyClient", function () {
     fakeAdb.clearHistory();
     stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52001 tcp:8765\n`);
 
-    const client = AndroidCtrlProxyClient.getInstance(
+    const client = AndroidCtrlProxyClient.createForTesting(
       testDevice,
-      new FakeAdbClientFactory(fakeAdb),
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
     );
+    registerTestSingleton(client);
     try {
       await (client as any).setupPortForwarding();
 
@@ -1044,10 +1067,13 @@ describe("AndroidCtrlProxyClient", function () {
     AndroidCtrlProxyClient.resetInstances();
     stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:8765 tcp:8765\n`);
 
-    const connectingClient = AndroidCtrlProxyClient.getInstance(
+    const connectingClient = AndroidCtrlProxyClient.createForTesting(
       testDevice,
-      new FakeAdbClientFactory(fakeAdb),
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
     );
+    registerTestSingleton(connectingClient);
     try {
       await (connectingClient as any).sweepOrphanedCtrlProxyPortForwards();
 
@@ -1064,14 +1090,79 @@ describe("AndroidCtrlProxyClient", function () {
     fakeAdb.clearHistory();
     stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52003 tcp:12345\n`);
 
-    const client = AndroidCtrlProxyClient.getInstance(
+    const client = AndroidCtrlProxyClient.createForTesting(
       testDevice,
-      new FakeAdbClientFactory(fakeAdb),
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
     );
+    registerTestSingleton(client);
     try {
       await (client as any).setupPortForwarding();
 
       expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:52003");
+    } finally {
+      await client.close();
+      AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);
+    }
+  });
+
+  test("does not reconcile forwards when another process owns the device lease", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52004 tcp:8765\n`);
+    const lease = new FakeCtrlProxyForwardLease(false);
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      lease,
+    );
+    try {
+      await expect((client as any).setupPortForwarding()).rejects.toThrow(
+        "Another AutoMobile process owns CtrlProxy forwarding",
+      );
+
+      expect(lease.acquireAttempts).toBe(1);
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:52004");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rechecks a forward before removal when its destination changes", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    let listCalls = 0;
+    stubForwardLifecycleCommands(() => {
+      listCalls++;
+      return listCalls === 1
+        ? `${testDevice.deviceId} tcp:52005 tcp:8765\n`
+        : `${testDevice.deviceId} tcp:52005 tcp:12345\n`;
+    });
+
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    registerTestSingleton(client);
+    try {
+      await (client as any).setupPortForwarding();
+
+      expect(fakeAdb.getExecutedCommands()).not.toContain("forward --remove tcp:52005");
     } finally {
       await client.close();
       AndroidCtrlProxyClient.removeInstance(testDevice.deviceId);

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -194,13 +194,18 @@ describe("getSharedAutoMobileDir", () => {
 
   test("uses an explicit coordination root for a locked-down service account", () => {
     expect(
-      getSharedAutoMobileDir(
-        "ctrlproxy-forwards",
-        "",
-        { AUTOMOBILE_COORDINATION_DIR: "shared-locks" },
-        "/service",
-      ),
-    ).toBe(path.resolve("/service", "shared-locks", "ctrlproxy-forwards"));
+      getSharedAutoMobileDir("ctrlproxy-forwards", "", {
+        AUTOMOBILE_COORDINATION_DIR: "/shared-locks",
+      }),
+    ).toBe(path.join("/shared-locks", "ctrlproxy-forwards"));
+  });
+
+  test("rejects a relative coordination root that could vary by agent worktree", () => {
+    expect(() =>
+      getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester", {
+        AUTOMOBILE_COORDINATION_DIR: "shared-locks",
+      }),
+    ).toThrow("AUTOMOBILE_COORDINATION_DIR must be an absolute path");
   });
 
   test("rejects a missing home directory rather than using agent-local storage", () => {

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -176,11 +176,28 @@ describe("getTempDir", () => {
 });
 
 describe("getSharedAutoMobileDir", () => {
+  test("uses the OS-account home instead of an agent-specific HOME", () => {
+    const userInfoSpy = spyOn(os, "userInfo").mockReturnValue({
+      uid: 501,
+      gid: 20,
+      username: "tester",
+      homedir: "/system-home",
+      shell: "/bin/zsh",
+    });
+    try {
+      expect(getSharedAutoMobileDir("ctrlproxy-forwards", undefined, {})).toBe(
+        path.resolve("/system-home", ".auto-mobile", "ctrlproxy-forwards"),
+      );
+    } finally {
+      userInfoSpy.mockRestore();
+    }
+  });
+
   test("uses the home-directory root independently of agent data-dir overrides", () => {
     const previousDataDir = process.env.AUTOMOBILE_DATA_DIR;
     process.env.AUTOMOBILE_DATA_DIR = "/agent-private-data";
     try {
-      expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester")).toBe(
+      expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester", {})).toBe(
         path.resolve("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
       );
     } finally {
@@ -209,7 +226,7 @@ describe("getSharedAutoMobileDir", () => {
   });
 
   test("rejects a missing home directory rather than using agent-local storage", () => {
-    expect(() => getSharedAutoMobileDir("ctrlproxy-forwards", "")).toThrow(
+    expect(() => getSharedAutoMobileDir("ctrlproxy-forwards", "", {})).toThrow(
       "Set AUTOMOBILE_COORDINATION_DIR",
     );
   });

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAutoMobileBaseDir,
   resolveAutoMobileLogsDir,
   getTempDir,
+  getSharedAutoMobileDir,
   ensureSecureLogsDirSync,
   ensureSecureTempDirSync,
   TEMP_SUBDIRS,
@@ -171,6 +172,20 @@ describe("getTempDir", () => {
         process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
       }
     }
+  });
+});
+
+describe("getSharedAutoMobileDir", () => {
+  test("uses the home-directory root independently of agent data-dir overrides", () => {
+    expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester")).toBe(
+      path.join("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
+    );
+  });
+
+  test("rejects a missing home directory rather than using agent-local storage", () => {
+    expect(() => getSharedAutoMobileDir("ctrlproxy-forwards", "")).toThrow(
+      "Unable to resolve a shared AutoMobile directory",
+    );
   });
 });
 

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -177,14 +177,35 @@ describe("getTempDir", () => {
 
 describe("getSharedAutoMobileDir", () => {
   test("uses the home-directory root independently of agent data-dir overrides", () => {
-    expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester")).toBe(
-      path.resolve("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
-    );
+    const previousDataDir = process.env.AUTOMOBILE_DATA_DIR;
+    process.env.AUTOMOBILE_DATA_DIR = "/agent-private-data";
+    try {
+      expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester")).toBe(
+        path.resolve("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
+      );
+    } finally {
+      if (previousDataDir === undefined) {
+        delete process.env.AUTOMOBILE_DATA_DIR;
+      } else {
+        process.env.AUTOMOBILE_DATA_DIR = previousDataDir;
+      }
+    }
+  });
+
+  test("uses an explicit coordination root for a locked-down service account", () => {
+    expect(
+      getSharedAutoMobileDir(
+        "ctrlproxy-forwards",
+        "",
+        { AUTOMOBILE_COORDINATION_DIR: "shared-locks" },
+        "/service",
+      ),
+    ).toBe(path.resolve("/service", "shared-locks", "ctrlproxy-forwards"));
   });
 
   test("rejects a missing home directory rather than using agent-local storage", () => {
     expect(() => getSharedAutoMobileDir("ctrlproxy-forwards", "")).toThrow(
-      "Unable to resolve a shared AutoMobile directory",
+      "Set AUTOMOBILE_COORDINATION_DIR",
     );
   });
 });

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -178,7 +178,7 @@ describe("getTempDir", () => {
 describe("getSharedAutoMobileDir", () => {
   test("uses the home-directory root independently of agent data-dir overrides", () => {
     expect(getSharedAutoMobileDir("ctrlproxy-forwards", "/home/tester")).toBe(
-      path.join("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
+      path.resolve("/home/tester", ".auto-mobile", "ctrlproxy-forwards"),
     );
   });
 


### PR DESCRIPTION
## Summary

Reconciles Android CtrlProxy `adb forward` entries targeting `tcp:8765` before connection setup. A process-held, per-device ownership lease prevents one AutoMobile process from reclaiming another's live forward; the sweep remains device-serial scoped and rechecks each forward before removal.

Forward removal now logs failures and retains `portForwardingSetup` when the mapping may still exist, so the next client setup can reclaim it.

## Linked Issue

Closes #5962

## Bug / Regression Context

- **Observed symptom:** CtrlProxy `tcp:<port> → tcp:8765` forwards accumulated after daemon SIGKILL or flaky-ADB teardown.
- **Repro steps / conditions:** Interrupt teardown or fail `adb forward --remove`, then acquire the same Android device again.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` passes
- [x] Focused CtrlProxy regression suite passes
- [x] New coverage uses the injected ADB fake
- [x] Rebased onto latest `main`, conflicts resolved

`bun run lint` and the full `bun test` suite remain red on the base revision in unrelated files: an unused `_diagnostics` binding, tool-schema drift, and two existing assertion failures.
