### PR TITLE
fix(ios): expose image capability inventories

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -22,6 +22,7 @@ import { PlistClient, type PlistReader } from "./PlistClient";
 import { inferIosFormFactor, isIosSimulatorUdid } from "./iosDeviceType";
 import { getAbortSignal } from "../AbortContext";
 import { Mutex } from "async-mutex";
+import { iosSimulatorCapabilityInventory } from "../../features/device-control/virtualDeviceCapabilities";
 
 const COMMAND_SETTLEMENT_GRACE_MS = 1_000;
 const SIMCTL_AVAILABILITY_PROBE_TIMEOUT_MS = 10_000;
@@ -1473,6 +1474,11 @@ export class SimCtlClient implements SimCtl {
             runtime: runtimeId,
             model: device.model,
             architecture: device.architecture,
+            capabilityInventory: iosSimulatorCapabilityInventory({
+              isAvailable: device.isAvailable,
+              availabilityError: device.availabilityError,
+              runtime: runtimeId,
+            }),
           } as DeviceInfo);
         }
       }

--- a/test/server/deviceTools.listDeviceImages.test.ts
+++ b/test/server/deviceTools.listDeviceImages.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  registerDeviceTools,
+  resetDeviceToolsDependencies,
+  setDeviceToolsDependencies,
+} from "../../src/server/deviceTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+
+describe("listDeviceImages", function () {
+  afterEach(function () {
+    resetDeviceToolsDependencies();
+    ToolRegistry.unregister("listDeviceImages");
+  });
+
+  test("returns iOS capability inventories from image discovery", async function () {
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () =>
+        new FakeDeviceManager([
+          {
+            name: "iPhone 17 Pro",
+            platform: "ios",
+            deviceId: "iphone-17-pro-udid",
+            isRunning: false,
+            capabilityInventory: {
+              schemaVersion: 1,
+              capabilities: [
+                { id: "ios.simulator.biometric", state: "available", source: "platform" },
+                {
+                  id: "ios.simulator.nfc",
+                  state: "unsupported",
+                  source: "platform",
+                  reason: "iOS Simulator cannot emulate NFC hardware.",
+                },
+              ],
+            },
+          },
+        ]),
+    });
+    registerDeviceTools();
+
+    const response = await ToolRegistry.getRegisteredTool("listDeviceImages")!.handler({
+      platform: "ios",
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(payload.images).toHaveLength(1);
+    expect(payload.images[0].capabilityInventory).toEqual({
+      schemaVersion: 1,
+      capabilities: [
+        { id: "ios.simulator.biometric", state: "available", source: "platform" },
+        {
+          id: "ios.simulator.nfc",
+          state: "unsupported",
+          source: "platform",
+          reason: "iOS Simulator cannot emulate NFC hardware.",
+        },
+      ],
+    });
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -518,6 +518,18 @@ describe("Simctl", function () {
       const devices = await simctl.listSimulatorImages();
 
       expect(devices.map((device) => device.name)).toEqual(["iPhone 17 Pro"]);
+      expect(devices[0]?.capabilityInventory).toEqual({
+        schemaVersion: 1,
+        capabilities: [
+          { id: "ios.simulator.biometric", state: "available", source: "platform" },
+          {
+            id: "ios.simulator.nfc",
+            state: "unsupported",
+            source: "platform",
+            reason: "iOS Simulator cannot emulate NFC hardware.",
+          },
+        ],
+      });
       expect(commands).toEqual(["xcrun simctl list devices --json"]);
     });
 


### PR DESCRIPTION
## Summary

`listDeviceImages --platform ios` now returns the same pre-session capability inventory exposed by the iOS device-image resource. The inventory is attached at iOS simulator discovery, matching the Android producer contract, and is preserved unchanged by the tool response.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/5965

## Bug / Regression Context

- **Prior attempts:** The resource added the inventory fallback, but simulator discovery still omitted the field.
- **Observed symptom:** iOS tool responses had no `capabilityInventory`, while the equivalent resource did.
- **Repro steps / conditions:** Invoke `listDeviceImages` with `platform: "ios"`.

## Validation

- [x] Focused device-image tests pass: `bun test test/utils/ios-cmdline-tools/simctl.test.ts test/server/deviceTools.listDeviceImages.test.ts test/server/resources/deviceImages.test.ts test/features/device-control/virtualDeviceCapabilities.test.ts`
- [x] Changed-file lint and format checks pass: `bunx oxlint …` and `bunx oxfmt --check …`
- [x] `bun run typecheck` reports no new errors
- [x] `bun run build` passes
- [ ] Full `bun run lint` is blocked by an existing unused `_diagnostics` error in untouched `src/features/observe/output/ObserveResultOutput.ts`.
- [ ] Full `bun test` has three existing failures in untouched tool-registry/schema/finalizer tests.
- [ ] Live iOS CLI verification could not run: an existing unreachable daemon (PID 94346) refused to be terminated.
- [x] New code uses existing interfaces and `FakeDeviceManager`; no dependency or generic helper added.
- [x] Branch starts at the latest local `origin/main` revision (`2e9d1bea`).

## Device Verification

Not run: this is an additive discovery payload change. The live CLI attempt was blocked by the pre-existing daemon conflict above.

Made with [Cursor](https://cursor.com)