### PR TITLE
fix(android): unlock direct-boot user before runner readiness

### DIFF
--- a/src/models/AndroidUser.ts
+++ b/src/models/AndroidUser.ts
@@ -32,6 +32,12 @@ export interface AndroidUser {
    * Whether the user is currently running
    */
   running: boolean;
+
+  /**
+   * Raw lifecycle state from `dumpsys user` when available, such as
+   * `RUNNING_LOCKED` or `RUNNING_UNLOCKED`.
+   */
+  startState?: string;
 }
 
 export function classifyAndroidUser(flags: number): NonNullable<AndroidUser["profileType"]> {

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -1,5 +1,5 @@
 import { errorMessage } from "./describeUnknownError";
-import type { BootedDevice } from "../models";
+import type { BootedDevice, DeviceLockState } from "../models";
 import { ActionableError } from "../models";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -7,10 +7,12 @@ import { AndroidCtrlProxyManager } from "./CtrlProxyManager";
 import { IOSCtrlProxyManager } from "./IOSCtrlProxyManager";
 import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 import { redactAndroidCommandOutput } from "./android-cmdline-tools/redactAndroidCommandOutput";
+import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import type { PerformanceTracker } from "./PerformanceTracker";
 import type { ProxySetupResult } from "./interfaces/ProxyManager";
 import { runWithAbortSignal } from "./AbortContext";
+import { logger } from "./logger";
 import {
   centerOfBounds,
   findSystemUiAnrDialog,
@@ -22,6 +24,7 @@ const READINESS_RETRY_DELAY_MS = 250;
 const READINESS_PROBE_TIMEOUT_MS = 2_000;
 const MAX_DIAGNOSTIC_LENGTH = 4_000;
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
+const RUNNER_CONNECT_DIAGNOSTIC_TIMEOUT_MS = 2_000;
 const SYSTEM_UI_ANR_RECOVERY_POLL_MS = 1_000;
 const SYSTEM_UI_ANR_RECOVERY_HEALTHY_POLLS = 2;
 const SYSTEM_UI_ANR_RECOVERY_TIMEOUT_MS = 5_000;
@@ -109,6 +112,11 @@ export interface ReadinessClient {
   ): Promise<{ success: boolean; error?: string }>;
 }
 
+export interface AndroidRunnerConnectDiagnostic {
+  deviceLock: DeviceLockState | null;
+  primaryUserStartState?: string;
+}
+
 interface SystemUiAnrReadinessClient {
   getAccessibilityHierarchy: NonNullable<ReadinessClient["getAccessibilityHierarchy"]>;
   requestTapCoordinates: NonNullable<ReadinessClient["requestTapCoordinates"]>;
@@ -122,6 +130,10 @@ export interface RunnerReadinessDependencies {
   getIosClient(device: BootedDevice, port: number): ReadinessClient;
   checkIosOverride(): Promise<{ present: boolean; usable: boolean; reason?: string }>;
   awaitIosStartupMaintenance(): Promise<void>;
+  getAndroidRunnerConnectDiagnostic?(
+    device: BootedDevice,
+    signal: AbortSignal,
+  ): Promise<AndroidRunnerConnectDiagnostic>;
 }
 
 export interface RunnerReadinessRequest {
@@ -754,12 +766,64 @@ export class RunnerReadinessService {
         await this.dependencies.timer.sleep(Math.min(READINESS_RETRY_DELAY_MS, remaining));
       }
     }
+    const diagnostic = await this.runnerConnectFailureDiagnostic(context, phase);
     this.fail(
       context,
       phase,
       attempts,
-      "runner did not become responsive before the readiness deadline",
+      `runner did not become responsive before the readiness deadline${diagnostic}`,
     );
+  }
+
+  private async runnerConnectFailureDiagnostic(
+    context: ReadinessAttemptContext,
+    phase: RunnerReadinessPhase,
+  ): Promise<string> {
+    const getDiagnostic = this.dependencies.getAndroidRunnerConnectDiagnostic;
+    if (context.device.platform !== "android" || phase !== "runner-connect" || !getDiagnostic) {
+      return "";
+    }
+
+    const controller = new AbortController();
+    const signal = context.signal
+      ? AbortSignal.any([context.signal, controller.signal])
+      : controller.signal;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    try {
+      const diagnosticPromise = getDiagnostic(context.device, signal);
+      // The timeout returns first if an ADB diagnostic command hangs. Its
+      // rejection after abort is intentionally observed below.
+      void diagnosticPromise.catch(() => {});
+      const diagnostic = await Promise.race([
+        diagnosticPromise,
+        new Promise<undefined>((resolve) => {
+          timeoutHandle = this.dependencies.timer.setTimeout(() => {
+            controller.abort(new Error("runner-connect diagnostic timed out"));
+            resolve(undefined);
+          }, RUNNER_CONNECT_DIAGNOSTIC_TIMEOUT_MS);
+        }),
+      ]);
+      if (!diagnostic) {
+        return "";
+      }
+      const details = [
+        diagnostic.primaryUserStartState
+          ? `primaryUserStartState=${diagnostic.primaryUserStartState}`
+          : undefined,
+        diagnostic.deviceLock
+          ? `deviceLock=${diagnostic.deviceLock.locked ? "locked" : "unlocked"}`
+          : undefined,
+      ].filter((detail): detail is string => Boolean(detail));
+      return details.length > 0 ? `; ${details.join(" ")}` : "";
+    } catch (error) {
+      // This supplemental probe must not hide the original runner-connect timeout.
+      logger.debug(`Failed to collect Android runner-connect diagnostic: ${errorMessage(error)}`);
+      return "";
+    } finally {
+      if (timeoutHandle) {
+        this.dependencies.timer.clearTimeout(timeoutHandle);
+      }
+    }
   }
 
   private async runPhase<T>(
@@ -901,5 +965,14 @@ export function createDefaultRunnerReadinessService(
     getIosClient: (device, port) => IOSCtrlProxyClient.getInstance(device, port),
     checkIosOverride: checkIosCtrlProxyOverride,
     awaitIosStartupMaintenance: () => IOSCtrlProxyManager.awaitStartupOrphanRunnerReap(),
+    getAndroidRunnerConnectDiagnostic: async (device, signal) => {
+      const adb = defaultAdbClientFactory.create(device);
+      const [deviceLock, users] = await Promise.all([
+        adb.getDeviceLock(signal),
+        adb.listUsers(signal),
+      ]);
+      const primaryUser = users.find((user) => user.profileType === "primary" || user.userId === 0);
+      return { deviceLock, primaryUserStartState: primaryUser?.startState };
+    },
   });
 }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1386,6 +1386,7 @@ export class AdbClient implements AdbExecutor {
 
         // Look for the State line in the next few lines
         let running = false;
+        let startState: string | undefined;
         for (let j = i + 1; j < Math.min(i + 10, lines.length); j++) {
           const stateLine = lines[j];
 
@@ -1394,15 +1395,10 @@ export class AdbClient implements AdbExecutor {
             break;
           }
 
-          // Check for State: RUNNING_UNLOCKED or RUNNING_LOCKED
-          if (stateLine.match(/State:\s+(RUNNING_UNLOCKED|RUNNING_LOCKED)/)) {
-            running = true;
-            break;
-          }
-
-          // If we see State: SHUTDOWN, mark as not running
-          if (stateLine.match(/State:\s+SHUTDOWN/)) {
-            running = false;
+          const stateMatch = stateLine.match(/State:\s+(\S+)/);
+          if (stateMatch) {
+            startState = stateMatch[1];
+            running = startState === "RUNNING_UNLOCKED" || startState === "RUNNING_LOCKED";
             break;
           }
         }
@@ -1424,6 +1420,7 @@ export class AdbClient implements AdbExecutor {
           flags,
           profileType: classifyAndroidUser(flags),
           running,
+          ...(startState ? { startState } : {}),
         });
       }
     }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -37,6 +37,8 @@ const MIN_EMULATOR_CONSOLE_PORT = 5554;
 const MAX_EMULATOR_CONSOLE_PORT = 5682;
 const EMULATOR_CONSOLE_PORT_STEP = 2;
 const MAX_READINESS_DIAGNOSTIC_CHARS = 512;
+const PRIMARY_USER_UNLOCK_WAIT_MS = 5_000;
+const PRIMARY_USER_UNLOCK_POLL_INTERVAL_MS = 250;
 
 type LaunchFailureCategory =
   | "display_initialization_failed"
@@ -3157,7 +3159,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           deviceId: foundDeviceId,
         } as BootedDevice;
         perf.startOperation("wakeAndUnlock");
-        await this.wakeAndUnlock(bootedDevice);
+        await this.wakeAndUnlock(bootedDevice, signal);
         perf.endOperation("wakeAndUnlock");
         return bootedDevice;
       }
@@ -3182,7 +3184,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         deviceId: foundDeviceId,
       } as BootedDevice;
       perf.startOperation("wakeAndUnlock");
-      await this.wakeAndUnlock(bootedDevice);
+      await this.wakeAndUnlock(bootedDevice, signal);
       perf.endOperation("wakeAndUnlock");
       return bootedDevice;
     }
@@ -3210,13 +3212,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * device is still ready and the user can unlock it with the tool (#4360).
    * @param device - The booted device to wake and unlock
    */
-  private async wakeAndUnlock(device: BootedDevice): Promise<void> {
+  private async wakeAndUnlock(device: BootedDevice, signal?: AbortSignal): Promise<void> {
     try {
       const wakeAndUnlock = new WakeAndUnlock(device, this.adbFactory, {
         timer: this.timer,
         credentialStore: new DeviceLockStore(),
       });
       const result = await wakeAndUnlock.execute();
+      await this.waitForPrimaryUserUnlock(device, signal);
       if (!result.unlocked && result.secure) {
         logger.info(
           `[WakeAndUnlock] Device ${device.deviceId} is secure-locked and no PIN is remembered; ` +
@@ -3228,9 +3231,42 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         );
       }
     } catch (error) {
+      this.throwIfReadinessAborted(signal);
       // Log but don't fail - the device is still ready, just might need manual interaction.
       // A secure lock with no remembered PIN throws ActionableError here; that is expected.
       logger.warn(`[WakeAndUnlock] Failed to wake/unlock device ${device.deviceId}: ${error}`);
+    }
+  }
+
+  private async waitForPrimaryUserUnlock(
+    device: BootedDevice,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const adb = this.adbFactory.create(device);
+    let elapsedMs = 0;
+    try {
+      while (elapsedMs < PRIMARY_USER_UNLOCK_WAIT_MS) {
+        this.throwIfReadinessAborted(signal);
+        const users = await adb.listUsers(signal);
+        const primaryUser = users.find(
+          (user) => user.profileType === "primary" || user.userId === 0,
+        );
+        if (primaryUser?.startState !== "RUNNING_LOCKED") {
+          return;
+        }
+        await this.timer.sleep(PRIMARY_USER_UNLOCK_POLL_INTERVAL_MS);
+        elapsedMs += PRIMARY_USER_UNLOCK_POLL_INTERVAL_MS;
+      }
+      logger.warn(
+        `[WakeAndUnlock] Primary user on ${device.deviceId} is still RUNNING_LOCKED after ` +
+          `${PRIMARY_USER_UNLOCK_WAIT_MS}ms; CtrlProxy cannot bind until the device unlocks.`,
+      );
+    } catch (error) {
+      // User-state inspection is supplementary; preserve the completed unlock result if unavailable.
+      this.throwIfReadinessAborted(signal);
+      logger.debug(
+        `[WakeAndUnlock] Could not confirm primary-user unlock state for ${device.deviceId}: ${error}`,
+      );
     }
   }
 

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -34,6 +34,7 @@ export class FakeAdbExecutor implements AdbExecutor {
   private devices: BootedDevice[] = [];
   private deviceStates: AdbDeviceState[] = [];
   private users: AndroidUser[] = [{ userId: 0, name: "Owner", flags: 13, running: true }];
+  private usersSequence: AndroidUser[][] | null = null;
   private foregroundApp: { packageName: string; userId: number } | null = null;
   private deviceTimestampMs: number | null = null;
   private androidApiLevel: number | null = null;
@@ -130,6 +131,11 @@ export class FakeAdbExecutor implements AdbExecutor {
    */
   setUsers(users: AndroidUser[]): void {
     this.users = users;
+  }
+
+  /** Configure ordered user snapshots; the final snapshot repeats once exhausted. */
+  setUsersSequence(users: AndroidUser[][]): void {
+    this.usersSequence = users.map((snapshot) => [...snapshot]);
   }
 
   /**
@@ -333,6 +339,9 @@ export class FakeAdbExecutor implements AdbExecutor {
   }
 
   async listUsers(): Promise<AndroidUser[]> {
+    if (this.usersSequence && this.usersSequence.length > 0) {
+      return this.usersSequence.length > 1 ? this.usersSequence.shift()! : this.usersSequence[0];
+    }
     return this.users;
   }
 

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -176,6 +176,10 @@ function createService(
     getIosClient?: (device: BootedDevice, port: number) => FakeReadinessClient;
     autoAdvance?: boolean;
     awaitIosStartupMaintenance?: () => Promise<void>;
+    getAndroidRunnerConnectDiagnostic?: () => Promise<{
+      deviceLock: { locked: boolean; keyguardShowing: boolean; secure?: boolean } | null;
+      primaryUserStartState?: string;
+    }>;
   } = {},
 ) {
   const timer = options.timer ?? new FakeTimer();
@@ -200,6 +204,7 @@ function createService(
       getIosClient: options.getIosClient ?? (() => iosClient),
       checkIosOverride: async () => ({ present: false, usable: true }),
       awaitIosStartupMaintenance: options.awaitIosStartupMaintenance ?? (async () => {}),
+      getAndroidRunnerConnectDiagnostic: options.getAndroidRunnerConnectDiagnostic,
     }),
   };
 }
@@ -1042,5 +1047,27 @@ describe("RunnerReadinessService", () => {
     ).rejects.toThrow(
       /platform=android.*requested=\[platform=android name=Pixel_9_Pro\].*resolved=\[Pixel_9_Pro \(emulator-5554\)\].*phase=runner-connect.*attempts=[1-9].*remainingBudgetMs=0/,
     );
+  });
+
+  test("diagnoses a locked primary user when runner connection times out", async () => {
+    const client = new FakeReadinessClient();
+    client.connected = false;
+    client.connectionResults = [];
+    const { service } = createService({
+      androidClient: client,
+      getAndroidRunnerConnectDiagnostic: async () => ({
+        deviceLock: { locked: true, keyguardShowing: true, secure: true },
+        primaryUserStartState: "RUNNING_LOCKED",
+      }),
+    });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(/phase=runner-connect.*RUNNING_LOCKED/);
   });
 });

--- a/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
@@ -50,7 +50,7 @@ Users:
 
   Owner name: Owner`,
     ],
-    expectedUsers: [owner],
+    expectedUsers: [{ ...owner, startState: "RUNNING_UNLOCKED" }],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
@@ -70,7 +70,10 @@ Users:
 
   Owner name: Owner`,
     ],
-    expectedUsers: [owner, workProfile],
+    expectedUsers: [
+      { ...owner, startState: "RUNNING_UNLOCKED" },
+      { ...workProfile, startState: "RUNNING_UNLOCKED" },
+    ],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
@@ -86,19 +89,20 @@ Users:
   Owner name: Owner`,
     ],
     expectedUsers: [
-      owner,
+      { ...owner, startState: "RUNNING_UNLOCKED" },
       {
         userId: 10,
         name: "Secondary User",
         flags: 0,
         profileType: "unknown",
         running: false,
+        startState: "SHUTDOWN",
       },
     ],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
-    name: "treats a locked user as running",
+    name: "preserves a locked user's start state",
     outcomes: [
       `Users:
   UserInfo{0:null:4c13} serialNo=0 isPrimary=true
@@ -106,7 +110,7 @@ Users:
 
   Owner name: Owner`,
     ],
-    expectedUsers: [owner],
+    expectedUsers: [{ ...owner, startState: "RUNNING_LOCKED" }],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
@@ -117,7 +121,14 @@ Users:
     State: RUNNING_UNLOCKED`,
     ],
     expectedUsers: [
-      { userId: 10, name: "User 10", flags: 0x30, profileType: "managed", running: true },
+      {
+        userId: 10,
+        name: "User 10",
+        flags: 0x30,
+        profileType: "managed",
+        running: true,
+        startState: "RUNNING_UNLOCKED",
+      },
     ],
     expectedCommandFragments: ["shell dumpsys user"],
   },

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
@@ -99,6 +99,36 @@ describe("AndroidEmulatorClient wakeAndUnlock", () => {
     expect(fakeAdb.wasCommandExecuted("wm dismiss-keyguard")).toBe(false);
   });
 
+  test("waits for direct boot to finish unlocking the primary user", async () => {
+    fakeAdb.setDeviceLock(UNLOCKED);
+    fakeAdb.setUsersSequence([
+      [
+        {
+          userId: 0,
+          name: "Owner",
+          flags: 0x4c13,
+          profileType: "primary",
+          running: true,
+          startState: "RUNNING_LOCKED",
+        },
+      ],
+      [
+        {
+          userId: 0,
+          name: "Owner",
+          flags: 0x4c13,
+          profileType: "primary",
+          running: true,
+          startState: "RUNNING_UNLOCKED",
+        },
+      ],
+    ]);
+
+    await runWakeAndUnlock();
+
+    expect(fakeTimer.now()).toBe(250);
+  });
+
   test("a failed wake keyevent aborts before wm dismiss-keyguard (single-try)", async () => {
     // REWRITE-1: the previous test asserted only that the boot wrapper swallows
     // the error ("does not throw"), which passes for any behavior. The load-


### PR DESCRIPTION
## Summary
- Wait briefly for Android's primary user to complete the `RUNNING_LOCKED` to `RUNNING_UNLOCKED` direct-boot transition after the shared unlock flow.
- Preserve the user start state from `dumpsys user` and report it with Android `runner-connect` timeout diagnostics.

Closes [#5963](https://github.com/kaeawc/auto-mobile/issues/5963)

## Validation
- `bun test test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts test/utils/RunnerReadinessService.test.ts`
- `bun run build`
- `bun run typecheck`
- Changed-file type-aware lint check

`bun run turbo:validate` remains blocked by an unrelated baseline lint error in `src/features/observe/output/ObserveResultOutput.ts`. `bun test --isolate` also reports three unrelated existing failures in tool registry/schema/output-finalization tests.
