### PR TITLE
fix(tapOn): wait for Android screen effects

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -10286,8 +10286,8 @@
               "enum": [
                 "screenIdentity changed",
                 "screenIdentity unchanged",
-                "activeWindow+layoutSeqSum changed",
-                "activeWindow+layoutSeqSum unchanged",
+                "activeWindow changed",
+                "activeWindow unchanged",
                 "viewHierarchy changed",
                 "viewHierarchy unchanged",
                 "insufficient observation data"

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -65,6 +65,8 @@ import type { TapStrategy } from "../../utils/interfaces/TapStrategy";
 import { FeatureFlagService } from "../featureFlags/FeatureFlagService";
 import { createTapStrategy } from "./strategies/createTapStrategy";
 import { LongPressMetadataDetector, type LongPressMetadata } from "./LongPressMetadataDetector";
+import { RealWaitForCondition } from "../observe/WaitForCondition";
+import type { WaitForCondition } from "../observe/interfaces/WaitForCondition";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
@@ -83,6 +85,7 @@ interface TapOnElementDependencies {
   talkBackDriverFactory?: TalkBackNavigationDriverFactory;
   iosVoiceOverDetector?: IosVoiceOverDetector;
   featureFlags?: FeatureFlagService;
+  waitForCondition?: WaitForCondition;
   /**
    * Override the platform-specific {@link TapStrategy}. Tests use this
    * to inject a fake; production code leaves it unset so the constructor
@@ -104,6 +107,8 @@ interface TapOnElementDependencies {
  */
 const POST_TAP_SETTLE_MS = 300;
 const POST_TAP_REFRESH_TIMEOUT_MS = 1500;
+const POST_TAP_EFFECT_TIMEOUT_MS = 2500;
+const POST_TAP_EFFECT_POLL_MS = 150;
 
 /** Brief debounce between the original tap and the retry tap when a ghost tap
  *  was detected. Just enough to let any inflight gesture queue drain. */
@@ -130,6 +135,7 @@ export class TapOnElement extends BaseVisualChange {
   private iosVoiceOverDetector: IosVoiceOverDetector;
   private strategy: TapStrategy;
   private longPressMetadataDetector: LongPressMetadataDetector;
+  private readonly waitForCondition: WaitForCondition;
   private static readonly SEARCH_UNTIL_DEFAULT_MS = 1500;
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
@@ -199,6 +205,8 @@ export class TapOnElement extends BaseVisualChange {
     options: TapOnElementDependencies = {},
   ) {
     super(device, adb, options.timer);
+    this.waitForCondition =
+      options.waitForCondition ?? new RealWaitForCondition(this.observeScreen, this.timer);
     this.finder = new DefaultElementFinder();
     this.geometry = new DefaultElementGeometry();
     this.elementParser = new DefaultElementParser();
@@ -511,7 +519,7 @@ export class TapOnElement extends BaseVisualChange {
       previous.layoutSeqSum !== current.layoutSeqSum;
     return {
       screenChanged: changed,
-      basis: changed ? "activeWindow+layoutSeqSum changed" : "activeWindow+layoutSeqSum unchanged",
+      basis: changed ? "activeWindow changed" : "activeWindow unchanged",
     };
   }
 
@@ -556,6 +564,36 @@ export class TapOnElement extends BaseVisualChange {
         basis: "insufficient observation data",
       }
     );
+  }
+
+  private async deriveTapEffectAfterPostTapObservation(
+    previousObservation: ObserveResult | null,
+    currentObservation: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<TapOnElementResult["effect"]> {
+    const immediateEffect = this.deriveTapEffect(previousObservation, currentObservation);
+    if (
+      this.device.platform !== "android" ||
+      !previousObservation ||
+      immediateEffect?.screenChanged === true
+    ) {
+      return immediateEffect;
+    }
+
+    // A stable source tree can arrive before Android begins the activity
+    // transition. Wait for an actual post-tap difference instead of treating
+    // that transient stability as proof that the tap had no effect.
+    const effectObservation = await this.waitForCondition.execute(
+      (observation) => ({
+        matched: this.deriveTapEffect(previousObservation, observation)?.screenChanged === true,
+      }),
+      {
+        timeoutMs: POST_TAP_EFFECT_TIMEOUT_MS,
+        pollMs: POST_TAP_EFFECT_POLL_MS,
+        signal,
+      },
+    );
+    return this.deriveTapEffect(previousObservation, effectObservation.observation);
   }
 
   private isElementTapTargetOffScreen(
@@ -1692,7 +1730,11 @@ export class TapOnElement extends BaseVisualChange {
       );
 
       if (result.success && result.observation && result.element) {
-        result.effect = this.deriveTapEffect(previousObserveResult, result.observation);
+        result.effect = await this.deriveTapEffectAfterPostTapObservation(
+          previousObserveResult,
+          result.observation,
+          signal,
+        );
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,
           selectionState: selectionCapture,

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -8,8 +8,8 @@ import type { ScreenReaderNavigationResult } from "../features/talkback/TalkBack
 export type TapEffectBasis =
   | "screenIdentity changed"
   | "screenIdentity unchanged"
-  | "activeWindow+layoutSeqSum changed"
-  | "activeWindow+layoutSeqSum unchanged"
+  | "activeWindow changed"
+  | "activeWindow unchanged"
   | "viewHierarchy changed"
   | "viewHierarchy unchanged"
   | "insufficient observation data";

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -224,8 +224,8 @@ const tapEffectSchema = z
     basis: z.enum([
       "screenIdentity changed",
       "screenIdentity unchanged",
-      "activeWindow+layoutSeqSum changed",
-      "activeWindow+layoutSeqSum unchanged",
+      "activeWindow changed",
+      "activeWindow unchanged",
       "viewHierarchy changed",
       "viewHierarchy unchanged",
       "insufficient observation data",

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import type {
+  ConditionPredicate,
+  WaitForCondition,
+} from "../../../src/features/observe/interfaces/WaitForCondition";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
@@ -25,17 +29,20 @@ function makeObservation(overrides: Partial<ObserveResult>): ObserveResult {
   };
 }
 
-function createTapOnElement(): { tap: TapOnElement; timer: FakeTimer } {
+function createTapOnElement(
+  platform: "android" | "ios" = "android",
+  waitForCondition?: WaitForCondition,
+): { tap: TapOnElement; timer: FakeTimer } {
   const timer = new FakeTimer();
   timer.enableAutoAdvance();
   const tap = new TapOnElement(
     {
       name: "test-device",
-      platform: "android",
+      platform,
       deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
-    { timer },
+    { timer, waitForCondition },
   );
   return { tap, timer };
 }
@@ -194,7 +201,7 @@ describe("deriveTapEffect", () => {
 
     expect((tap as any).deriveTapEffect(previous, current)).toEqual({
       screenChanged: false,
-      basis: "activeWindow+layoutSeqSum unchanged",
+      basis: "activeWindow unchanged",
     });
   });
 
@@ -205,6 +212,123 @@ describe("deriveTapEffect", () => {
       screenChanged: false,
       basis: "insufficient observation data",
     });
+  });
+
+  test("waits for a changed Android observation before deriving the effect", async () => {
+    const stale = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SettingsHomepageActivity",
+        layoutSeqSum: 0,
+      },
+    });
+    const destination = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SubSettings",
+        layoutSeqSum: 0,
+      },
+    });
+    let waitCalls = 0;
+    const waitForCondition: WaitForCondition = {
+      execute: async (predicate: ConditionPredicate) => {
+        waitCalls++;
+        expect(predicate(destination).matched).toBe(true);
+        return {
+          matched: true,
+          candidates: [],
+          observation: destination,
+          polls: 3,
+          waitMs: 300,
+          timedOut: false,
+        };
+      },
+    };
+    const { tap } = createTapOnElement("android", waitForCondition);
+
+    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
+
+    expect(waitCalls).toBe(1);
+    expect(effect).toEqual({
+      screenChanged: true,
+      basis: "activeWindow changed",
+    });
+  });
+
+  test("does not wait when the initial Android observation shows a change", async () => {
+    const stale = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SettingsHomepageActivity",
+        layoutSeqSum: 0,
+      },
+    });
+    const destination = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SubSettings",
+        layoutSeqSum: 0,
+      },
+    });
+    let waitCalls = 0;
+    const waitForCondition: WaitForCondition = {
+      execute: async () => {
+        waitCalls++;
+        return {
+          matched: true,
+          candidates: [],
+          observation: destination,
+          polls: 1,
+          waitMs: 0,
+          timedOut: false,
+        };
+      },
+    };
+    const { tap } = createTapOnElement("android", waitForCondition);
+
+    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, destination);
+
+    expect(effect).toEqual({
+      screenChanged: true,
+      basis: "activeWindow changed",
+    });
+    expect(waitCalls).toBe(0);
+  });
+
+  test("does not add a post-tap wait for iOS effects", async () => {
+    const observation = makeObservation({
+      activeWindow: {
+        appId: "com.apple.Preferences",
+        activityName: ".Root",
+        layoutSeqSum: 0,
+      },
+    });
+    let waitCalls = 0;
+    const waitForCondition: WaitForCondition = {
+      execute: async () => {
+        waitCalls++;
+        return {
+          matched: true,
+          candidates: [],
+          observation,
+          polls: 2,
+          waitMs: 150,
+          timedOut: false,
+        };
+      },
+    };
+    const { tap } = createTapOnElement("ios", waitForCondition);
+
+    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(
+      observation,
+      observation,
+    );
+
+    expect(effect).toEqual({
+      screenChanged: false,
+      basis: "activeWindow unchanged",
+    });
+    expect(waitCalls).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Wait for a fresh Android observation that confirms a post-tap screen change before reporting `tapOn.effect`.
- Preserve immediate effect results and existing iOS behavior.
- Rename the active-window effect basis so it does not claim the CtrlProxy-hot-path `layoutSeqSum` value contributed to the result.

## Linked Issue

Closes [#5964](https://github.com/kaeawc/auto-mobile/issues/5964)

## Bug / Regression Context

- **Prior attempts:** The effect signal introduced in [#5943](https://github.com/kaeawc/auto-mobile/pull/5943) used a single post-tap observation.
- **Observed symptom:** Android activity navigation could return `screenChanged: false` when that observation still represented the source activity.
- **Repro steps / conditions:** Tap an in-app Settings navigation row on Android while the transition has not yet produced a destination hierarchy push.

## Validation

- [x] `bun test test/features/action/TapOnElement.retryIfNoChange.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] New code injects the existing `WaitForCondition` interface; deterministic unit tests use the existing fake timer.
- [x] No new dependency or generic helper added.
- [x] Stacked on [#5942](https://github.com/kaeawc/auto-mobile/pull/5942), which fixes the inherited lint failure on `main`.

## Device Verification

Not run locally. The Android transition race is pinned with scripted fresh observations; the issue contains the API 31 and API 35 device reproductions.
