### PR TITLE
test: stabilize Xcodebuild spawn errors

### DIFF
--- a/test/fakes/FakeChildProcess.ts
+++ b/test/fakes/FakeChildProcess.ts
@@ -50,6 +50,9 @@ export class FakeChildProcess
         callback();
       },
     });
+    // Deterministic fake pid: a fake must not reach for real randomness. A
+    // process-wide counter gives every instance a distinct, reproducible pid.
+    this.pid = FakeChildProcess.nextPid++;
   }
 
   private static nextPid = 1000;
@@ -109,9 +112,6 @@ export class FakeChildProcess
         return;
       }
 
-      // Deterministic fake pid: a fake must not reach for real randomness. A
-      // process-wide counter gives every spawned process a reproducible pid.
-      this.pid = FakeChildProcess.nextPid++;
       this.emit("spawn");
 
       // Write any configured stdout/stderr data

--- a/test/fakes/FakeChildProcess.ts
+++ b/test/fakes/FakeChildProcess.ts
@@ -17,7 +17,7 @@ export class FakeChildProcess
   exitCode: number | null = null;
   signalCode: NodeJS.Signals | null = null;
   killed = false;
-  pid: number;
+  pid: number | undefined;
 
   private spawnDelay: number = 0;
   private exitDelay: number = 0;
@@ -50,9 +50,6 @@ export class FakeChildProcess
         callback();
       },
     });
-    // Deterministic fake pid: a fake must not reach for real randomness. A
-    // process-wide counter gives every instance a distinct, reproducible pid.
-    this.pid = FakeChildProcess.nextPid++;
   }
 
   private static nextPid = 1000;
@@ -77,6 +74,7 @@ export class FakeChildProcess
   setSpawnError(message = "Failed to spawn"): void {
     this.shouldError = true;
     this.errorMessage = message;
+    this.pid = undefined;
   }
 
   /**
@@ -111,6 +109,9 @@ export class FakeChildProcess
         return;
       }
 
+      // Deterministic fake pid: a fake must not reach for real randomness. A
+      // process-wide counter gives every spawned process a reproducible pid.
+      this.pid = FakeChildProcess.nextPid++;
       this.emit("spawn");
 
       // Write any configured stdout/stderr data

--- a/test/fakes/FakeChildProcess.ts
+++ b/test/fakes/FakeChildProcess.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 import { Readable, Writable } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { defaultTimer, Timer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake ChildProcess for testing without spawning real processes
@@ -28,7 +28,7 @@ export class FakeChildProcess
   private stdinData: Buffer[] = [];
   private stdinError: Error | null = null;
 
-  constructor() {
+  constructor(private readonly timer: Timer = defaultTimer) {
     super();
     this.stdout = new Readable({
       read() {
@@ -105,7 +105,7 @@ export class FakeChildProcess
    * Simulate the spawn lifecycle
    */
   simulateSpawn(): void {
-    defaultTimer.setTimeout(() => {
+    this.timer.setTimeout(() => {
       if (this.shouldError) {
         this.emit("error", new Error(this.errorMessage));
         return;
@@ -127,7 +127,7 @@ export class FakeChildProcess
    * Simulate process exit
    */
   simulateExit(code: number = 0, signal: NodeJS.Signals | null = null): void {
-    defaultTimer.setTimeout(() => {
+    this.timer.setTimeout(() => {
       this.exitCode = code;
       this.signalCode = signal;
       this.stdout.push(null); // End stdout stream

--- a/test/lint/fakeHygiene.test.ts
+++ b/test/lint/fakeHygiene.test.ts
@@ -42,9 +42,8 @@ const ALLOWLIST: Record<string, string[]> = {
     "constructor(timer: Timer = defaultTimer) {",
   ],
   "FakeChildProcess.ts": [
-    'import { defaultTimer } from "../../src/utils/SystemTimer";',
-    "defaultTimer.setTimeout(() => {",
-    "defaultTimer.setTimeout(() => {",
+    'import { defaultTimer, Timer } from "../../src/utils/SystemTimer";',
+    "constructor(private readonly timer: Timer = defaultTimer) {",
   ],
   "FakeNavigationGraphManager.ts": ["timestamp: Date.now(),"],
   "FakeAdbExecutor.ts": ["return this.deviceTimestampMs ?? Date.now();"],

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -227,19 +227,20 @@ describe("XcodebuildClient streaming runner", () => {
   });
 
   test("handles an asynchronous spawn error before returning the child", async () => {
-    const child = new FakeChildProcess();
+    const timer = new FakeTimer();
+    const child = new FakeChildProcess(timer);
     child.setSpawnError("posix_spawn: executable missing");
     const client = new XcodebuildClient(
       async () => createExecResult("Xcode 26.5", ""),
-      new FakeTimer(),
+      timer,
       () => {
         child.simulateSpawn();
         return child as never;
       },
     );
 
-    await expect(client.startStreaming(["test-without-building"])).rejects.toThrow(
-      "xcodebuild failed to start: Error: posix_spawn: executable missing",
-    );
+    await expect(
+      timer.resolvePromise(client.startStreaming(["test-without-building"])),
+    ).rejects.toThrow("xcodebuild failed to start: Error: posix_spawn: executable missing");
   });
 });

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -230,6 +230,7 @@ describe("XcodebuildClient streaming runner", () => {
     const timer = new FakeTimer();
     const child = new FakeChildProcess(timer);
     child.setSpawnError("posix_spawn: executable missing");
+    expect(child.pid).toBeUndefined();
     const client = new XcodebuildClient(
       async () => createExecResult("Xcode 26.5", ""),
       timer,


### PR DESCRIPTION
## Summary
- inject a timer into `FakeChildProcess`, preserving the real timer default
- drive the Xcodebuild spawn-error case with its injected fake clock

## Validation
- `bun test --isolate test/utils/ios-cmdline-tools/XcodebuildClient.test.ts` (20 consecutive runs)
- `bunx oxfmt --check test/fakes/FakeChildProcess.ts test/utils/ios-cmdline-tools/XcodebuildClient.test.ts`
- `bun run typecheck`

Fixes the recurring Windows-only ordering failure that affected the video PR stack.

Made with [Cursor](https://cursor.com)