### PR TITLE
fix(daemon): use canonical shell quoting

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1,4 +1,5 @@
 import { errorMessage } from "../utils/describeUnknownError";
+import { shellQuote } from "../utils/shellQuote";
 import {
   DaemonClient,
   DaemonUnavailableError,
@@ -99,10 +100,6 @@ function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
     throw new Error("heartbeat interval must be a positive finite number");
   }
   return Math.max(1, interval);
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 /**

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
+import { FakeTalkBackNavigationDriver } from "../../fakes/FakeTalkBackNavigationDriver";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeTalkBackTapStrategy } from "../../fakes/FakeTalkBackTapStrategy";
 import type { FeatureFlagService } from "../../../src/features/featureFlags/FeatureFlagService";
@@ -927,6 +929,18 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 });
 
 describe("TapOnElement screen-reader navigation result", () => {
+  let androidGetInstanceSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    androidGetInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      {} as AndroidCtrlProxyClient,
+    );
+  });
+
+  afterEach(() => {
+    androidGetInstanceSpy.mockRestore();
+  });
+
   const element = {
     "resource-id": "test:id/button",
     bounds: { left: 0, top: 0, right: 100, bottom: 100 },
@@ -944,6 +958,8 @@ describe("TapOnElement screen-reader navigation result", () => {
     accessibilityDetector.setTalkBackEnabled(true);
     const strategy = new FakeTalkBackTapStrategy();
     strategy.setTapResult(tapResult);
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
     const observation = {
       viewHierarchy: { hierarchy: {} },
       screenSize: { width: 100, height: 100 },
@@ -953,8 +969,11 @@ describe("TapOnElement screen-reader navigation result", () => {
       new FakeAdbClient() as any,
       {
         accessibilityDetector,
-        timer: new FakeTimer(),
+        timer,
         talkBackStrategy: strategy,
+        talkBackDriverFactory: {
+          createDriver: () => new FakeTalkBackNavigationDriver(),
+        },
         waitForCondition: {
           execute: async () => ({
             matched: false,
@@ -984,6 +1003,7 @@ describe("TapOnElement screen-reader navigation result", () => {
       element,
       usedParent: false,
     });
+    spyOn(command as any, "executeAndroidTapWithCoordinates").mockResolvedValue(undefined);
     spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
     spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
     return command;

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -944,6 +944,10 @@ describe("TapOnElement screen-reader navigation result", () => {
     accessibilityDetector.setTalkBackEnabled(true);
     const strategy = new FakeTalkBackTapStrategy();
     strategy.setTapResult(tapResult);
+    const observation = {
+      viewHierarchy: { hierarchy: {} },
+      screenSize: { width: 100, height: 100 },
+    } as any;
     const command = new TapOnElement(
       { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
       new FakeAdbClient() as any,
@@ -951,15 +955,21 @@ describe("TapOnElement screen-reader navigation result", () => {
         accessibilityDetector,
         timer: new FakeTimer(),
         talkBackStrategy: strategy,
+        waitForCondition: {
+          execute: async () => ({
+            matched: false,
+            candidates: [],
+            observation,
+            polls: 0,
+            waitMs: 0,
+            timedOut: true,
+          }),
+        },
         featureFlags: {
           isEnabled: (key: string) => key === "screen-reader-navigation",
         } as FeatureFlagService,
       },
     );
-    const observation = {
-      viewHierarchy: { hierarchy: {} },
-      screenSize: { width: 100, height: 100 },
-    } as any;
     spyOn(command as any, "observedInteraction").mockImplementation(async (block: any) => ({
       ...(await block(observation)),
       observation,


### PR DESCRIPTION
## Summary
- replace daemon-local shell quoting with the canonical shared helper
- restore the shell-quote boundary gate on fresh PR checks

## Validation
- `bun test --isolate test/daemon/daemonMcpProxy.test.ts`
- `bun run lint`
- `bun run typecheck`

Made with [Cursor](https://cursor.com)