### PR TITLE
fix(observe): reconcile stale active window attribution

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -368,7 +368,7 @@ export class RealObserveScreen implements ObserveScreen {
         this.platformValidator,
       );
 
-      await this.reconcileActiveWindowAttribution(result, foregroundIdentity);
+      await this.reconcileActiveWindowAttribution(result, foregroundIdentity, signal);
 
       // Uncapped here; the output boundary (sanitizeObserveResult / the observe
       // served path in finalizeToolResponse) caps AFTER any scope narrowing so an
@@ -810,14 +810,27 @@ export class RealObserveScreen implements ObserveScreen {
    * they are safer than the stale activity name for `activeWindow` consumers
    * such as `waitFor` (issue #5972). System UI is intentionally excluded: a
    * system panel can validly be the accessible window while another app remains
-   * the resumed activity beneath it.
+   * the resumed activity beneath it. A pre-capture sample that disagrees with
+   * the hierarchy is confirmed after capture before it can reject the correction.
    */
   private async reconcileActiveWindowAttribution(
     result: ObserveResult,
     foregroundIdentity: Promise<string | undefined>,
+    signal?: AbortSignal,
   ): Promise<void> {
-    const foreground = await foregroundIdentity;
     const observed = result.viewHierarchy?.packageName;
+    let foreground = await foregroundIdentity;
+    if (
+      foreground !== undefined &&
+      observed !== undefined &&
+      foreground !== observed &&
+      !SYSTEM_UI_WINDOW_PACKAGES.has(observed)
+    ) {
+      const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
+      if (confirmed === observed) {
+        foreground = confirmed;
+      }
+    }
     const activeWindow = result.activeWindow;
     const hasConfirmedReplacement =
       foreground !== undefined &&
@@ -825,7 +838,7 @@ export class RealObserveScreen implements ObserveScreen {
       activeWindow !== undefined &&
       activeWindow.appId !== foreground &&
       !SYSTEM_UI_WINDOW_PACKAGES.has(observed);
-    if (!hasConfirmedReplacement) {
+    if (!hasConfirmedReplacement || foreground === undefined) {
       return;
     }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -90,6 +90,11 @@ function boundCachedLayoutWarnings(result: ObserveResult | undefined): ObserveRe
  */
 const SYSTEM_UI_WINDOW_PACKAGES = new Set<string>(["com.android.systemui"]);
 
+interface PostCaptureForegroundIdentity {
+  sampled: boolean;
+  identity: string | undefined;
+}
+
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
   const activityName = foregroundActivity.split("/")[1] ?? "";
   return (
@@ -368,7 +373,7 @@ export class RealObserveScreen implements ObserveScreen {
         this.platformValidator,
       );
 
-      await this.reconcileActiveWindowAttribution(result, foregroundIdentity, signal);
+      const postCaptureForeground = await this.reconcileActiveWindowAttribution(result, signal);
 
       // Uncapped here; the output boundary (sanitizeObserveResult / the observe
       // served path in finalizeToolResponse) caps AFTER any scope narrowing so an
@@ -441,6 +446,7 @@ export class RealObserveScreen implements ObserveScreen {
         windowIdentityMismatch: await this.resolveWindowIdentityMismatch(
           result,
           foregroundIdentity,
+          postCaptureForeground,
           signal,
         ),
       });
@@ -810,39 +816,29 @@ export class RealObserveScreen implements ObserveScreen {
    * they are safer than the stale activity name for `activeWindow` consumers
    * such as `waitFor` (issue #5972). System UI is intentionally excluded: a
    * system panel can validly be the accessible window while another app remains
-   * the resumed activity beneath it. A pre-capture sample that disagrees with
-   * the hierarchy is confirmed after capture before it can reject the correction.
+   * the resumed activity beneath it. The post-capture sample is returned so
+   * freshness diagnostics can reuse the same ground-truth check.
    */
   private async reconcileActiveWindowAttribution(
     result: ObserveResult,
-    foregroundIdentity: Promise<string | undefined>,
     signal?: AbortSignal,
-  ): Promise<void> {
+  ): Promise<PostCaptureForegroundIdentity> {
     const observed = result.viewHierarchy?.packageName;
-    let foreground = await foregroundIdentity;
-    if (
-      foreground !== undefined &&
-      observed !== undefined &&
-      foreground !== observed &&
-      !SYSTEM_UI_WINDOW_PACKAGES.has(observed)
-    ) {
-      const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
-      if (confirmed === observed) {
-        foreground = confirmed;
-      }
-    }
     const activeWindow = result.activeWindow;
-    const hasConfirmedReplacement =
-      foreground !== undefined &&
-      observed === foreground &&
-      activeWindow !== undefined &&
-      activeWindow.appId !== foreground &&
-      !SYSTEM_UI_WINDOW_PACKAGES.has(observed);
-    if (!hasConfirmedReplacement || foreground === undefined) {
-      return;
+    if (
+      observed === undefined ||
+      activeWindow === undefined ||
+      activeWindow.appId === observed ||
+      SYSTEM_UI_WINDOW_PACKAGES.has(observed)
+    ) {
+      return { sampled: false, identity: undefined };
     }
 
-    result.activeWindow = { ...activeWindow, appId: foreground, activityName: "" };
+    const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
+    if (confirmed === observed) {
+      result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
+    }
+    return { sampled: true, identity: confirmed };
   }
 
   /**
@@ -881,18 +877,22 @@ export class RealObserveScreen implements ObserveScreen {
   private async resolveWindowIdentityMismatch(
     result: ObserveResult,
     foregroundIdentity: Promise<string | undefined>,
+    postCaptureForeground: PostCaptureForegroundIdentity,
     signal?: AbortSignal,
   ): Promise<{ observed: string; foreground: string } | undefined> {
     const foreground = await foregroundIdentity;
     const observed = result.viewHierarchy?.packageName ?? result.activeWindow?.appId;
-    if (!foreground || !observed || observed === foreground) {
+    if (!foreground || !observed) {
       return undefined;
     }
     if (SYSTEM_UI_WINDOW_PACKAGES.has(observed) || SYSTEM_UI_WINDOW_PACKAGES.has(foreground)) {
       return undefined;
     }
-    // Confirm the mismatch is steady-state, not a transient transition (see above).
-    const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
+    const confirmed = postCaptureForeground.sampled
+      ? postCaptureForeground.identity
+      : foreground === observed
+        ? undefined
+        : await this.deviceStateCollector.collectForegroundIdentity(signal);
     if (!confirmed || confirmed !== foreground || confirmed === observed) {
       return undefined;
     }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -407,6 +407,8 @@ export class RealObserveScreen implements ObserveScreen {
         }
       }
 
+      await this.reconcileActiveWindowAttribution(result, foregroundIdentity);
+
       // Freshness diagnostics.
       //
       // This used to read `isFresh = requestedAfter === undefined ? true : …`,
@@ -797,6 +799,38 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   // ---------- Helpers ----------
+
+  /**
+   * Correct stale accessibility-service window metadata when both the captured
+   * hierarchy and the device's resumed activity identify the same app.
+   *
+   * CtrlProxy can retain a prior `foregroundActivity` after a window transition
+   * even when its hierarchy has already caught up. The hierarchy package and
+   * the device's foreground activity independently confirm the replacement, so
+   * they are safer than the stale activity name for `activeWindow` consumers
+   * such as `waitFor` (issue #5972). System UI is intentionally excluded: a
+   * system panel can validly be the accessible window while another app remains
+   * the resumed activity beneath it.
+   */
+  private async reconcileActiveWindowAttribution(
+    result: ObserveResult,
+    foregroundIdentity: Promise<string | undefined>,
+  ): Promise<void> {
+    const foreground = await foregroundIdentity;
+    const observed = result.viewHierarchy?.packageName;
+    const activeWindow = result.activeWindow;
+    const hasConfirmedReplacement =
+      foreground !== undefined &&
+      observed === foreground &&
+      activeWindow !== undefined &&
+      activeWindow.appId !== foreground &&
+      !SYSTEM_UI_WINDOW_PACKAGES.has(observed);
+    if (!hasConfirmedReplacement) {
+      return;
+    }
+
+    result.activeWindow = { ...activeWindow, appId: foreground, activityName: "" };
+  }
 
   /**
    * Compare the app the observed hierarchy was captured from against the

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -888,15 +888,31 @@ export class RealObserveScreen implements ObserveScreen {
     if (SYSTEM_UI_WINDOW_PACKAGES.has(observed) || SYSTEM_UI_WINDOW_PACKAGES.has(foreground)) {
       return undefined;
     }
-    const confirmed = postCaptureForeground.sampled
-      ? postCaptureForeground.identity
-      : foreground === observed
-        ? undefined
-        : await this.deviceStateCollector.collectForegroundIdentity(signal);
+    const confirmed = await this.resolvePostCaptureForegroundIdentity(
+      foreground,
+      observed,
+      postCaptureForeground,
+      signal,
+    );
     if (!confirmed || confirmed !== foreground || confirmed === observed) {
       return undefined;
     }
     return { observed, foreground };
+  }
+
+  private async resolvePostCaptureForegroundIdentity(
+    foreground: string,
+    observed: string,
+    postCaptureForeground: PostCaptureForegroundIdentity,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    if (postCaptureForeground.sampled) {
+      return postCaptureForeground.identity;
+    }
+    if (foreground === observed) {
+      return undefined;
+    }
+    return this.deviceStateCollector.collectForegroundIdentity(signal);
   }
 
   private resolveObservationTimestampMs(result: ObserveResult): number | undefined {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -368,6 +368,8 @@ export class RealObserveScreen implements ObserveScreen {
         this.platformValidator,
       );
 
+      await this.reconcileActiveWindowAttribution(result, foregroundIdentity);
+
       // Uncapped here; the output boundary (sanitizeObserveResult / the observe
       // served path in finalizeToolResponse) caps AFTER any scope narrowing so an
       // in-scope warning is never lost to a cap taken against the full tree (#5074).
@@ -406,8 +408,6 @@ export class RealObserveScreen implements ObserveScreen {
           logger.warn(`[PredictiveUIState] Failed to generate predictions: ${error}`);
         }
       }
-
-      await this.reconcileActiveWindowAttribution(result, foregroundIdentity);
 
       // Freshness diagnostics.
       //

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -354,10 +354,14 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     timer.setCurrentTime(now);
 
     const viewHierarchy = new FakeViewHierarchy();
-    viewHierarchy.configureHierarchy(calendarHierarchy(now)); // observed = calendar
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(now),
+      // CtrlProxy has not yet updated the active window from Settings.
+      foregroundActivity: "com.android.settings/.Settings",
+    }); // observed = calendar
 
     // First getForegroundApp read lags (still reports settings); the confirming
-    // read reports calendar, matching the observed window.
+    // read reports calendar, matching the observed hierarchy.
     const sequence = [
       { packageName: "com.android.settings", userId: 0 },
       { packageName: "com.google.android.calendar", userId: 0 },
@@ -384,6 +388,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
 
+    expect(result.activeWindow?.appId).toBe("com.google.android.calendar");
     expect(result.freshness?.isFresh).toBe(true);
     expect(result.freshness?.verified).toBe(true);
   });

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -262,6 +262,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     const fakeAdb = new FakeAdbExecutor();
     fakeAdb.setForegroundApp({ packageName: "com.google.android.apps.nexuslauncher", userId: 0 });
+    let performanceAuditAppId: string | undefined;
 
     const screen = new RealObserveScreen(
       androidDevice,
@@ -269,7 +270,11 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       {
         viewHierarchy,
         cacheStore: new FakeObserveCacheStore(new FakeTimer()),
-        performanceAuditor: { run: async () => undefined } as any,
+        performanceAuditor: {
+          run: async (observedResult: ObserveResult) => {
+            performanceAuditAppId = observedResult.activeWindow?.appId;
+          },
+        } as any,
         accessibilityAuditor: { run: async () => undefined } as any,
         accessibilityStateDetector: { run: async () => undefined } as any,
       },
@@ -283,6 +288,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       activityName: "",
       layoutSeqSum: 0,
     });
+    expect(performanceAuditAppId).toBe("com.google.android.apps.nexuslauncher");
     expect(result.freshness?.isFresh).toBe(true);
     expect(result.freshness?.verified).toBe(true);
     expect(result.freshness?.warning).toBeUndefined();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -236,6 +236,58 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("reconciles stale CtrlProxy attribution when hierarchy and foreground agree", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      // The recovered hierarchy is the launcher, but CtrlProxy still attributes
+      // its active root to Calendar (issue #5972).
+      packageName: "com.google.android.apps.nexuslauncher",
+      foregroundActivity: "com.google.android.calendar/.AllInOneCalendarActivity",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Gmail", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.apps.nexuslauncher", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow).toEqual({
+      appId: "com.google.android.apps.nexuslauncher",
+      activityName: "",
+      layoutSeqSum: 0,
+    });
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.warning).toBeUndefined();
+  });
+
   test("an expanded system-UI shade is not flagged as a wrong-window capture", async () => {
     // When the notification shade / quick settings takes accessibility focus,
     // the observed window is com.android.systemui while the resumed activity
@@ -377,6 +429,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     expect(result.freshness?.isFresh).toBe(true);
     expect(result.freshness?.verified).toBe(true);
+    expect(result.activeWindow?.appId).toBe("com.google.android.calendar");
   });
 
   test("no ground-truth foreground app leaves freshness unchanged (no false alarm)", async () => {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -393,6 +393,50 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("does not overwrite a newer active window with a stale hierarchy", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(now),
+      foregroundActivity: "com.android.settings/.Settings",
+    });
+
+    // The initial parallel sample agrees with the stale Calendar hierarchy,
+    // while the post-capture sample confirms the newer Settings window.
+    const sequence = [
+      { packageName: "com.google.android.calendar", userId: 0 },
+      { packageName: "com.android.settings", userId: 0 },
+    ];
+    class SequencedForegroundAdb extends FakeAdbExecutor {
+      async getForegroundApp(): Promise<{ packageName: string; userId: number } | null> {
+        return sequence.shift() ?? { packageName: "com.android.settings", userId: 0 };
+      }
+    }
+    const fakeAdb = new SequencedForegroundAdb();
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.android.settings");
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("an active IME is not flagged: the check uses the captured hierarchy's package", async () => {
     // With a soft keyboard active, the a11y foregroundActivity (→ activeWindow.appId)
     // can be the IME root's package while the captured hierarchy is the underlying


### PR DESCRIPTION
## Summary

Reconcile Android `activeWindow` attribution with the confirmed live foreground package when the captured hierarchy independently names that same package. This prevents stale CtrlProxy `foregroundActivity` metadata after Home recovery from making `waitFor.activeWindow` match an app that is no longer foregrounded.

## Linked Issue

Closes [#5972](https://github.com/kaeawc/auto-mobile/issues/5972)

## Bug / Regression Context

- **Prior attempts:** [#5949](https://github.com/kaeawc/auto-mobile/pull/5949) made the loud wrong-window warning actionable, but its Home recovery exposed this silent attribution split.
- **Observed symptom:** The hierarchy and live foreground were the launcher, while `activeWindow` still reported Calendar with `freshness.verified: true`.
- **Repro steps / conditions:** Reach the stale wrong-window state, call `pressButton { button: "home" }`, then observe or wait on `activeWindow`.

## Validation

- [x] `bun test test/features/observe/ObserveScreenWindowIdentity.test.ts`
- [x] `bun test test/features/observe/observationFreshness.test.ts`
- [x] `bun test test/server/observeWaitForSchema.test.ts`
- [x] `bun run format:check -- src/features/observe/ObserveScreen.ts test/features/observe/ObserveScreenWindowIdentity.test.ts`
- [x] `bunx oxlint src/features/observe/ObserveScreen.ts test/features/observe/ObserveScreenWindowIdentity.test.ts`
- [x] `bun run build`
- [x] `bun run typecheck`
- [ ] `bun run turbo:validate` — blocked by pre-existing `check-no-local-shell-quote.sh` failure in untouched `src/daemon/daemonMcpProxy.ts`; the full suite also times out two unrelated TapOnElement tests that pass in isolation.
- [x] Rebased onto latest `main`

## Device Verification

- [ ] Requires API-34 emulator reproduction of the device-specific stale CtrlProxy condition.
