### PR TITLE
feat(apps): add bounded cross-platform crashApp tool

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
@@ -3,7 +3,7 @@ package dev.jasonpearson.automobile.ide.yaml
 object TestPlanToolCategories {
   private val categoryByTool: Map<String, String> =
     mapOf(
-        "App management" to setOf("launchApp", "terminateApp", "installApp"),
+        "App management" to setOf("launchApp", "terminateApp", "crashApp", "installApp"),
         "UI interactions" to setOf("tapOn", "swipeOn", "pinchOn", "dragAndDrop"),
         "Input" to
           setOf(

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
@@ -17,6 +17,7 @@ object ValidTools {
       "clearMockNetwork",
       "clearText",
       "clipboard",
+      "crashApp",
       "criticalSection",
       "debugSearch",
       "deleteSnapshot",

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -515,6 +515,9 @@ class TestPlanValidatorTest {
         - tool: launchApp
           params:
             appId: com.example.app
+        - tool: crashApp
+          params:
+            appId: com.example.app
         - tool: setAppPermissions
           params:
             appId: com.example.app

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -71,10 +71,10 @@ the exact arguments supported by your connection.
     <code>platform</code>, <code>appId</code>, <code>mechanism</code>,
     <code>timestamp</code>, and <code>confirmed</code>. It reports
     <code>wasRunning</code> whenever preflight established process state;
-    successful induction also reports <code>processId</code> when available and may
-    include immediate OS diagnostic evidence. <code>success: true</code> means the
-    induction command was accepted; <code>confirmed: true</code> additionally
-    requires target-specific crash evidence, not merely process disappearance.
+    confirmed crashes also report <code>processId</code> when available and include
+    immediate OS diagnostic evidence. <code>success: true</code> and
+    <code>confirmed: true</code> require fresh, target-specific crash evidence, not
+    merely command dispatch or process disappearance.
 
 ??? example "Copy a fixture into an app container"
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -48,6 +48,7 @@ the exact arguments supported by your connection.
 | 📱 <code>listApps</code>                                                                         | Provides guidance for listing installed apps through MCP resources.                                                        |
 | 🚀 <code>launchApp</code>                                                                        | Launches an app by package name.                                                                                           |
 | ❌ <code>terminateApp</code>                                                                     | Terminates an app by package name.                                                                                         |
+| 💥 <code>crashApp</code>                                                                         | Intentionally crashes a running app through the platform crash path.                                                       |
 | 📦 <code>installApp</code>                                                                       | Installs an APK, app bundle, or IPA.                                                                                       |
 | 🗑️ <code>uninstallApp</code>                                                                     | Uninstalls an app by package name or bundle identifier.                                                                    |
 | 🔗 <code>getDeepLinks</code>                                                                     | Queries an app's deep links.                                                                                               |
@@ -57,6 +58,23 @@ the exact arguments supported by your connection.
 | 🗃️ <code>listDataStores</code> / 🗃️ <code>getDataStore</code>                                    | Lists or reads Android Jetpack DataStore entries with the SDK adapter.                                                     |
 | 🗄️ <code>sqlQuery</code>                                                                         | Executes SQL against an app SQLite database.                                                                               |
 | 🔐 <code>resetKeychain</code>                                                                    | Resets all Keychain data on an iOS Simulator after explicit confirmation; unsupported on Android and physical iOS devices. |
+
+??? note "Intentional crash contract"
+
+    <code>crashApp</code> accepts only an <code>appId</code>; it never accepts a PID,
+    signal, or shell command. Android uses ActivityManager's VM-crash path for the
+    resolved user. iOS Simulator sends SIGABRT to the exact launchd application
+    process. Physical iOS devices return <code>supported: false</code> and never fall
+    back to normal termination.
+
+    Every result reports <code>success</code>, <code>supported</code>,
+    <code>platform</code>, <code>appId</code>, <code>mechanism</code>,
+    <code>timestamp</code>, and <code>confirmed</code>. It reports
+    <code>wasRunning</code> whenever preflight established process state;
+    successful induction also reports <code>processId</code> when available and may
+    include immediate OS diagnostic evidence. <code>success: true</code> means the
+    induction command was accepted; <code>confirmed: true</code> additionally
+    requires target-specific crash evidence, not merely process disappearance.
 
 ??? example "Copy a fixture into an app container"
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -712,6 +712,112 @@
     }
   },
   {
+    "name": "crashApp",
+    "description": "Intentionally crash a running app through the platform crash path",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "appId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": ["appId"],
+      "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "supported": {
+          "type": "boolean"
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"]
+        },
+        "appId": {
+          "type": "string"
+        },
+        "processId": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "mechanism": {
+          "type": "string",
+          "enum": ["android_am_crash", "ios_simulator_sigabrt", "unsupported"]
+        },
+        "timestamp": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "wasRunning": {
+          "type": "boolean"
+        },
+        "confirmed": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["android_logcat", "ios_unified_log"]
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": ["source", "summary"],
+          "additionalProperties": false
+        },
+        "userId": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "success",
+        "supported",
+        "platform",
+        "appId",
+        "mechanism",
+        "timestamp",
+        "confirmed"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "criticalSection",
     "description": "Synchronize multiple devices at a barrier, then run steps serially.",
     "inputSchema": {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -34,7 +34,6 @@ import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
-import { shellQuote } from "../utils/shellQuote";
 import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 import type { SessionReleaseSnapshot } from "./sessionManager";

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -34,6 +34,7 @@ import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { shellQuote } from "../utils/shellQuote";
 import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 import type { SessionReleaseSnapshot } from "./sessionManager";

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -55,7 +55,7 @@ export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
  * A transport timeout after induction falsely reports failure and makes retrying
  * unsafe because the original crash may already have completed.
  */
-export const MIN_CRASH_APP_MCP_TIMEOUT_MS = 60_000;
+export const MIN_CRASH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
  * Compatibility floor while video recording startup moves to a strict,

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -49,6 +49,15 @@ export const MIN_TEARDOWN_DEVICE_MCP_TIMEOUT_MS =
 export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
+ * Floor for `crashApp` — Android ActivityManager can take several seconds to
+ * deliver the in-process exception, and target-specific process/log evidence is
+ * collected afterward. Device readiness also consumes the same request budget.
+ * A transport timeout after induction falsely reports failure and makes retrying
+ * unsafe because the original crash may already have completed.
+ */
+export const MIN_CRASH_APP_MCP_TIMEOUT_MS = 60_000;
+
+/**
  * Compatibility floor while video recording startup moves to a strict,
  * backend-owned five-second budget.
  */
@@ -70,7 +79,8 @@ export const MIN_UNINSTALL_APP_MCP_TIMEOUT_MS = 60_000;
  */
 export const MIN_PREFERENCE_MCP_TIMEOUT_MS = 60_000;
 
-const PREFERENCE_TOOL_TIMEOUT_FLOORS: Readonly<Record<string, number>> = {
+const TOOL_TIMEOUT_FLOORS: Readonly<Record<string, number>> = {
+  crashApp: MIN_CRASH_APP_MCP_TIMEOUT_MS,
   getPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
   setPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
 };
@@ -116,8 +126,8 @@ function resolveEnvTimeoutFloorMs(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
 }
 
-function resolvePreferenceToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
-  return PREFERENCE_TOOL_TIMEOUT_FLOORS[toolName ?? ""];
+function resolveFixedToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
+  return TOOL_TIMEOUT_FLOORS[toolName ?? ""];
 }
 
 function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
@@ -151,7 +161,7 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
         DEFAULT_OBSERVE_MCP_TIMEOUT_MS,
       );
     default:
-      return resolvePreferenceToolTimeoutFloorMs(toolName);
+      return resolveFixedToolTimeoutFloorMs(toolName);
   }
 }
 

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -3,8 +3,10 @@ import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
-import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
-import { findAndroidPackageProcessId } from "../../utils/android-cmdline-tools/androidProcessState";
+import {
+  findAndroidPackageProcesses,
+  type AndroidPackageProcess,
+} from "../../utils/android-cmdline-tools/androidProcessState";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { ANDROID_PACKAGE_NAME_PATTERN } from "../../utils/androidPackageName";
 import { errorMessage } from "../../utils/describeUnknownError";
@@ -22,8 +24,16 @@ const PROCESS_STATE_COMMAND = "shell dumpsys activity processes";
 const CONFIRMATION_ATTEMPTS = 12;
 const CONFIRMATION_POLL_MS = 250;
 
-function androidCrashLogCommand(processId: number): string {
-  return `shell logcat -b crash -d -v threadtime --pid=${processId} -t 200`;
+const ANDROID_CRASH_LOG_COMMAND = "shell logcat -b crash -d -v epoch -t 200";
+
+export interface IosSimulatorAppProcess {
+  pid: number;
+  serviceLabel: string;
+}
+
+interface AndroidCrashMatch {
+  evidence: CrashAppEvidence;
+  processId: number;
 }
 
 export interface SimulatorCrashCommandRunner {
@@ -35,7 +45,6 @@ export interface CrashAppDependencies {
   adbFactory?: AdbClientFactory;
   simctl?: SimulatorCrashCommandRunner;
   timer?: Timer;
-  resolveAndroidUserId?: (appId: string) => Promise<number>;
   cacheInvalidator?: DeviceWindowCacheInvalidator;
 }
 
@@ -43,7 +52,6 @@ export class CrashApp {
   private readonly adb: AdbExecutor;
   private readonly simctl: SimulatorCrashCommandRunner;
   private readonly timer: Timer;
-  private readonly resolveAndroidUserId: (appId: string) => Promise<number>;
   private readonly cacheInvalidator: DeviceWindowCacheInvalidator;
 
   constructor(
@@ -54,12 +62,6 @@ export class CrashApp {
     this.adb = dependencies.adb ?? adbFactory.create(device);
     this.simctl = dependencies.simctl ?? new SimCtlClient(device);
     this.timer = dependencies.timer ?? defaultTimer;
-    this.resolveAndroidUserId =
-      dependencies.resolveAndroidUserId ??
-      (async (appId) => {
-        return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName: appId }))
-          .userId;
-      });
     this.cacheInvalidator =
       dependencies.cacheInvalidator ?? new DefaultDeviceWindowCacheInvalidator();
   }
@@ -119,7 +121,6 @@ export class CrashApp {
       };
     }
 
-    const userId = await this.resolveAndroidUserId(appId);
     const initialProcesses = await this.adb.executeCommand(
       PROCESS_STATE_COMMAND,
       undefined,
@@ -127,20 +128,34 @@ export class CrashApp {
       true,
       signal,
     );
-    const processId = findAndroidPackageProcessId(initialProcesses.stdout, appId, userId);
-    if (processId === null) {
+    const packageProcesses = findAndroidPackageProcesses(initialProcesses.stdout, appId);
+    if (packageProcesses.length === 0) {
       return {
         ...base,
         success: false,
         supported: true,
         wasRunning: false,
-        userId,
-        error: `${appId} is not running for Android user ${userId}`,
+        error: `${appId} is not running`,
       };
     }
 
+    const userId = await this.selectAndroidUserId(appId, packageProcesses, signal);
+    if (userId === null) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: true,
+        error: `${appId} is running under multiple Android users; foreground identity is ambiguous`,
+      };
+    }
+    const targetedProcesses = packageProcesses.filter((process) => process.userId === userId);
+    const preferredProcess =
+      targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
+    const inductionTime = await this.adb.getDeviceTimestampMsWithSource();
+    let commandResult: ExecResult;
     try {
-      await this.adb.executeCommand(
+      commandResult = await this.adb.executeCommand(
         `shell am crash --user ${userId} ${shellQuote(appId)}`,
         undefined,
         undefined,
@@ -156,24 +171,70 @@ export class CrashApp {
         success: false,
         supported: !this.isUnsupportedMechanismError(message),
         wasRunning: true,
-        processId,
+        processId: preferredProcess.pid,
         userId,
         error: message,
       };
+    } finally {
+      this.cacheInvalidator.invalidate(this.device);
     }
 
-    this.cacheInvalidator.invalidate(this.device);
-    const evidence = await this.confirmAndroidCrash(appId, processId, userId, signal);
+    const rejection = findAndroidCrashCommandRejection(commandResult);
+    if (rejection) {
+      return {
+        ...base,
+        success: false,
+        supported: !this.isUnsupportedMechanismError(rejection),
+        wasRunning: true,
+        processId: preferredProcess.pid,
+        userId,
+        error: rejection,
+      };
+    }
+
+    const crashMatch = await this.confirmAndroidCrash(
+      appId,
+      targetedProcesses,
+      inductionTime.timestampMs,
+      signal,
+    );
+    if (!crashMatch) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: true,
+        processId: preferredProcess.pid,
+        userId,
+        error: "Crash command was dispatched, but no fresh OS crash evidence was found",
+      };
+    }
     return {
       ...base,
       success: true,
       supported: true,
       wasRunning: true,
-      processId,
+      processId: crashMatch.processId,
       userId,
-      confirmed: evidence !== undefined,
-      ...(evidence ? { evidence } : {}),
+      confirmed: true,
+      evidence: crashMatch.evidence,
     };
+  }
+
+  private async selectAndroidUserId(
+    appId: string,
+    processes: AndroidPackageProcess[],
+    signal?: AbortSignal,
+  ): Promise<number | null> {
+    const userIds = new Set(processes.map((process) => process.userId));
+    if (userIds.size === 1) {
+      return userIds.values().next().value ?? null;
+    }
+
+    const foreground = await this.adb.getForegroundApp(signal);
+    return foreground?.packageName === appId && userIds.has(foreground.userId)
+      ? foreground.userId
+      : null;
   }
 
   private async executeIos(
@@ -195,7 +256,6 @@ export class CrashApp {
         success: false,
         supported: false,
         mechanism: "unsupported",
-        wasRunning: false,
         error:
           "crashApp is not supported on physical iOS devices; " +
           "AutoMobile will not fall back to normal termination",
@@ -203,8 +263,8 @@ export class CrashApp {
     }
 
     const initialProcesses = await this.listIosSimulatorProcesses(signal);
-    const processId = findIosSimulatorAppProcessId(initialProcesses, appId);
-    if (processId === null) {
+    const appProcess = findIosSimulatorAppProcess(initialProcesses, appId);
+    if (!appProcess) {
       return {
         ...base,
         success: false,
@@ -215,9 +275,17 @@ export class CrashApp {
       };
     }
 
+    const inductionTimestampMs = this.timer.now();
     try {
       await this.simctl.executeCommandArgs(
-        ["spawn", this.device.deviceId, "/bin/kill", "-ABRT", String(processId)],
+        [
+          "spawn",
+          this.device.deviceId,
+          "launchctl",
+          "kill",
+          "SIGABRT",
+          `user/501/${appProcess.serviceLabel}`,
+        ],
         undefined,
         signal,
       );
@@ -231,47 +299,67 @@ export class CrashApp {
         supported: !this.isUnsupportedMechanismError(message),
         mechanism: "ios_simulator_sigabrt",
         wasRunning: true,
-        processId,
+        processId: appProcess.pid,
         error: message,
       };
+    } finally {
+      this.cacheInvalidator.invalidate(this.device);
     }
-    this.cacheInvalidator.invalidate(this.device);
 
-    const evidence = await this.confirmIosSimulatorCrash(appId, processId, signal);
+    const evidence = await this.confirmIosSimulatorCrash(
+      appId,
+      appProcess.pid,
+      inductionTimestampMs,
+      signal,
+    );
+    if (!evidence) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        mechanism: "ios_simulator_sigabrt",
+        wasRunning: true,
+        processId: appProcess.pid,
+        error: "Crash signal was dispatched, but no fresh OS crash evidence was found",
+      };
+    }
     return {
       ...base,
       success: true,
       supported: true,
       mechanism: "ios_simulator_sigabrt",
       wasRunning: true,
-      processId,
-      confirmed: evidence !== undefined,
-      ...(evidence ? { evidence } : {}),
+      processId: appProcess.pid,
+      confirmed: true,
+      evidence,
     };
   }
 
   private async confirmAndroidCrash(
     appId: string,
-    processId: number,
-    userId: number,
+    initialProcesses: AndroidPackageProcess[],
+    notBeforeTimestampMs: number,
     signal?: AbortSignal,
-  ): Promise<CrashAppEvidence | undefined> {
+  ): Promise<AndroidCrashMatch | undefined> {
+    const initialProcessIds = initialProcesses.map((process) => process.pid);
     for (let attempt = 0; attempt < CONFIRMATION_ATTEMPTS; attempt += 1) {
       signal?.throwIfAborted();
       const [processOutput, logOutput] = await Promise.all([
         this.tryAndroidCommand(PROCESS_STATE_COMMAND, signal),
-        this.tryAndroidCommand(androidCrashLogCommand(processId), signal),
+        this.tryAndroidCommand(ANDROID_CRASH_LOG_COMMAND, signal),
       ]);
-      const currentPid =
-        processOutput === undefined
-          ? processId
-          : findAndroidPackageProcessId(processOutput, appId, userId);
-      const evidence = logOutput
-        ? findAndroidCrashEvidence(logOutput, appId, processId)
+      const crashMatch = logOutput
+        ? findAndroidCrashMatch(logOutput, appId, initialProcessIds, notBeforeTimestampMs)
         : undefined;
+      const currentProcessIds =
+        processOutput === undefined
+          ? new Set(initialProcessIds)
+          : new Set(
+              findAndroidPackageProcesses(processOutput, appId).map((process) => process.pid),
+            );
 
-      if (currentPid !== processId && evidence) {
-        return evidence;
+      if (crashMatch && !currentProcessIds.has(crashMatch.processId)) {
+        return crashMatch;
       }
       if (attempt + 1 < CONFIRMATION_ATTEMPTS) {
         await this.timer.sleep(CONFIRMATION_POLL_MS);
@@ -296,6 +384,7 @@ export class CrashApp {
   private async confirmIosSimulatorCrash(
     appId: string,
     processId: number,
+    notBeforeTimestampMs: number,
     signal?: AbortSignal,
   ): Promise<CrashAppEvidence | undefined> {
     for (let attempt = 0; attempt < CONFIRMATION_ATTEMPTS; attempt += 1) {
@@ -309,7 +398,7 @@ export class CrashApp {
           ? processId
           : findIosSimulatorAppProcessId(processOutput, appId);
       const evidence = logOutput
-        ? findIosSimulatorCrashEvidence(logOutput, appId, processId)
+        ? findIosSimulatorCrashEvidence(logOutput, appId, processId, notBeforeTimestampMs)
         : undefined;
 
       if (currentPid !== processId && evidence) {
@@ -355,6 +444,8 @@ export class CrashApp {
             "1m",
             "--style",
             "compact",
+            "--timezone",
+            "UTC",
             "--predicate",
             'eventMessage CONTAINS[c] "SIGABRT"',
           ],
@@ -376,45 +467,96 @@ export class CrashApp {
   }
 }
 
-export function findIosSimulatorAppProcessId(processList: string, appId: string): number | null {
+export function findIosSimulatorAppProcess(
+  processList: string,
+  appId: string,
+): IosSimulatorAppProcess | null {
   for (const line of processList.split("\n")) {
-    const match = line.trim().match(/^(\d+)\s+\S+\s+UIKitApplication:(.+?)\[[^\]]+\]\[[^\]]+\]$/);
-    if (match?.[2] === appId) {
-      return Number(match[1]);
+    const match = line.trim().match(/^(\d+)\s+\S+\s+(UIKitApplication:(.+?)\[[^\]]+\]\[[^\]]+\])$/);
+    if (match?.[3] === appId) {
+      return { pid: Number(match[1]), serviceLabel: match[2] };
     }
   }
   return null;
+}
+
+export function findIosSimulatorAppProcessId(processList: string, appId: string): number | null {
+  return findIosSimulatorAppProcess(processList, appId)?.pid ?? null;
+}
+
+export function findAndroidCrashCommandRejection(result: ExecResult): string | undefined {
+  const line = `${result.stdout}\n${result.stderr}`
+    .split("\n")
+    .map((candidate) => candidate.trim())
+    .find((candidate) =>
+      /unknown command(?::)?\s*crash|does not have permission to crash|permission denial|not allowed to crash/i.test(
+        candidate,
+      ),
+    );
+  return line || undefined;
 }
 
 export function findAndroidCrashEvidence(
   logOutput: string,
   appId: string,
   processId: number,
+  notBeforeTimestampMs = 0,
 ): CrashAppEvidence | undefined {
-  const lines = logOutput.split("\n");
-  const identityIndex = lines.findIndex(
-    (line) =>
-      line.includes(`Process: ${appId}, PID: ${processId}`) ||
-      line.includes(`${appId}, PID: ${processId}`),
-  );
-  if (identityIndex < 0) {
-    return undefined;
-  }
+  return findAndroidCrashMatch(logOutput, appId, [processId], notBeforeTimestampMs)?.evidence;
+}
 
-  const targetCrashBlock = lines.slice(Math.max(0, identityIndex - 1), identityIndex + 7);
-  const marker = targetCrashBlock.find(
-    (line) => line.includes("shell-induced crash") || line.includes("CrashedByAdbException"),
-  );
-  return marker ? { source: "android_logcat", summary: marker.trim() } : undefined;
+function findAndroidCrashMatch(
+  logOutput: string,
+  appId: string,
+  processIds: number[],
+  notBeforeTimestampMs: number,
+): AndroidCrashMatch | undefined {
+  const lines = logOutput.split("\n");
+  const expectedProcessIds = new Set(processIds);
+  for (const [identityIndex, identityLine] of lines.entries()) {
+    const identity = identityLine.match(
+      new RegExp(`Process:\\s*${escapeRegExp(appId)}(?::[A-Za-z0-9_.]+)?,\\s*PID:\\s*(\\d+)`),
+    );
+    const processId = Number(identity?.[1]);
+    if (
+      !identity ||
+      !expectedProcessIds.has(processId) ||
+      !isLogLineFresh(identityLine, notBeforeTimestampMs)
+    ) {
+      continue;
+    }
+
+    const nextBlockOffset = lines
+      .slice(identityIndex + 1)
+      .findIndex((line) => line.includes("FATAL EXCEPTION") || line.includes("Process:"));
+    const blockEnd =
+      nextBlockOffset < 0
+        ? Math.min(lines.length, identityIndex + 7)
+        : identityIndex + 1 + nextBlockOffset;
+    const targetCrashBlock = lines.slice(identityIndex, blockEnd);
+    const marker = targetCrashBlock.find(
+      (line) =>
+        (line.includes("shell-induced crash") || line.includes("CrashedByAdbException")) &&
+        isLogLineFresh(line, notBeforeTimestampMs),
+    );
+    if (marker) {
+      return {
+        processId,
+        evidence: { source: "android_logcat", summary: marker.trim() },
+      };
+    }
+  }
+  return undefined;
 }
 
 export function findIosSimulatorCrashEvidence(
   logOutput: string,
   appId: string,
   processId: number,
+  notBeforeTimestampMs = 0,
 ): CrashAppEvidence | undefined {
   const line = logOutput.split("\n").find((candidate) => {
-    if (!candidate.includes("SIGABRT")) {
+    if (!candidate.includes("SIGABRT") || !isLogLineFresh(candidate, notBeforeTimestampMs)) {
       return false;
     }
     const launchdIdentity =
@@ -428,4 +570,35 @@ export function findIosSimulatorCrashEvidence(
     return launchdIdentity || runningBoardIdentity;
   });
   return line ? { source: "ios_unified_log", summary: line.trim() } : undefined;
+}
+
+function isLogLineFresh(line: string, notBeforeTimestampMs: number): boolean {
+  if (notBeforeTimestampMs <= 0) {
+    return true;
+  }
+  const timestampMs = parseLogTimestampMs(line);
+  return timestampMs !== null && timestampMs >= notBeforeTimestampMs;
+}
+
+function parseLogTimestampMs(line: string): number | null {
+  const epoch = line.match(/^\s*(\d{10})(?:\.(\d{1,9}))?/);
+  if (epoch) {
+    const fractionMs = Number((epoch[2] ?? "").padEnd(3, "0").slice(0, 3));
+    return Number(epoch[1]) * 1000 + fractionMs;
+  }
+
+  const formatted = line.match(
+    /^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?([+-]\d{4})?/,
+  );
+  if (!formatted) {
+    return null;
+  }
+  const fractionMs = (formatted[3] ?? "").padEnd(3, "0").slice(0, 3);
+  const timezone = formatted[4] ? `${formatted[4].slice(0, 3)}:${formatted[4].slice(3)}` : "Z";
+  const timestampMs = Date.parse(`${formatted[1]}T${formatted[2]}.${fractionMs}${timezone}`);
+  return Number.isNaN(timestampMs) ? null : timestampMs;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -177,6 +177,7 @@ export class CrashApp {
       return dispatch;
     }
     const { notBeforeTimestampMs, preferredProcess, targetedProcesses } = dispatch;
+    const attemptBase = { ...base, timestamp: this.timer.now() };
     let commandResult: ExecResult;
     try {
       commandResult = await this.adb.executeCommand(
@@ -191,7 +192,7 @@ export class CrashApp {
       const message = errorMessage(error);
       logger.warn(`[CrashApp] Android crash command failed for ${appId}: ${message}`, error);
       return {
-        ...base,
+        ...attemptBase,
         success: false,
         supported: !this.isUnsupportedMechanismError(message),
         wasRunning: true,
@@ -206,7 +207,7 @@ export class CrashApp {
     const rejection = findAndroidCrashCommandRejection(commandResult);
     if (rejection) {
       return {
-        ...base,
+        ...attemptBase,
         success: false,
         supported: !this.isUnsupportedMechanismError(rejection),
         wasRunning: true,
@@ -224,7 +225,7 @@ export class CrashApp {
     );
     if (!crashMatch) {
       return {
-        ...base,
+        ...attemptBase,
         success: false,
         supported: true,
         wasRunning: true,
@@ -234,7 +235,7 @@ export class CrashApp {
       };
     }
     return {
-      ...base,
+      ...attemptBase,
       success: true,
       supported: true,
       wasRunning: true,
@@ -354,7 +355,6 @@ export class CrashApp {
       };
     }
 
-    const inductionTimestampMs = this.timer.now();
     const dispatchProcesses = await this.listIosSimulatorProcesses(signal);
     const appProcess = findIosSimulatorAppProcess(dispatchProcesses, appId);
     if (!appProcess) {
@@ -367,6 +367,8 @@ export class CrashApp {
         error: `${appId} stopped before the crash signal could be dispatched`,
       };
     }
+    const inductionTimestampMs = this.timer.now();
+    const attemptBase = { ...base, timestamp: inductionTimestampMs };
     try {
       await this.simctl.executeCommandArgs(
         [
@@ -385,7 +387,7 @@ export class CrashApp {
       const message = errorMessage(error);
       logger.warn(`[CrashApp] iOS Simulator SIGABRT failed for ${appId}: ${message}`, error);
       return {
-        ...base,
+        ...attemptBase,
         success: false,
         supported: !this.isUnsupportedMechanismError(message),
         mechanism: "ios_simulator_sigabrt",
@@ -405,7 +407,7 @@ export class CrashApp {
     );
     if (!evidence) {
       return {
-        ...base,
+        ...attemptBase,
         success: false,
         supported: true,
         mechanism: "ios_simulator_sigabrt",
@@ -415,7 +417,7 @@ export class CrashApp {
       };
     }
     return {
-      ...base,
+      ...attemptBase,
       success: true,
       supported: true,
       mechanism: "ios_simulator_sigabrt",
@@ -440,7 +442,7 @@ export class CrashApp {
         this.tryAndroidCommand(ANDROID_CRASH_LOG_COMMAND, signal),
       ]);
       const crashMatch = logOutput
-        ? findAndroidCrashMatch(logOutput, appId, initialProcessIds, notBeforeTimestampMs)
+        ? findAndroidCrashMatch(logOutput, initialProcesses, notBeforeTimestampMs)
         : undefined;
       const currentProcessIds =
         processOutput === undefined
@@ -601,25 +603,27 @@ export function findAndroidCrashEvidence(
   processId: number,
   notBeforeTimestampMs = 0,
 ): CrashAppEvidence | undefined {
-  return findAndroidCrashMatch(logOutput, appId, [processId], notBeforeTimestampMs)?.evidence;
+  return findAndroidCrashMatch(
+    logOutput,
+    [{ pid: processId, processName: appId, userId: 0 }],
+    notBeforeTimestampMs,
+  )?.evidence;
 }
 
 function findAndroidCrashMatch(
   logOutput: string,
-  appId: string,
-  processIds: number[],
+  processes: AndroidPackageProcess[],
   notBeforeTimestampMs: number,
 ): AndroidCrashMatch | undefined {
   const lines = logOutput.split("\n");
-  const expectedProcessIds = new Set(processIds);
+  const expectedProcesses = new Map(processes.map((process) => [process.pid, process.processName]));
   for (const [identityIndex, identityLine] of lines.entries()) {
-    const identity = identityLine.match(
-      new RegExp(`Process:\\s*${escapeRegExp(appId)}(?::[A-Za-z0-9_.]+)?,\\s*PID:\\s*(\\d+)`),
-    );
-    const processId = Number(identity?.[1]);
+    const identity = identityLine.match(/Process:\s*([A-Za-z0-9_.:]+),\s*PID:\s*(\d+)/);
+    const processName = identity?.[1];
+    const processId = Number(identity?.[2]);
     if (
       !identity ||
-      !expectedProcessIds.has(processId) ||
+      expectedProcesses.get(processId) !== processName ||
       !isLogLineFresh(identityLine, notBeforeTimestampMs)
     ) {
       continue;
@@ -696,8 +700,4 @@ function parseLogTimestampMs(line: string): number | null {
   const timezone = formatted[4] ? `${formatted[4].slice(0, 3)}:${formatted[4].slice(3)}` : "Z";
   const timestampMs = Date.parse(`${formatted[1]}T${formatted[2]}.${fractionMs}${timezone}`);
   return Number.isNaN(timestampMs) ? null : timestampMs;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -166,13 +166,7 @@ export class CrashApp {
         error: `${appId} is running under multiple Android users; foreground identity is ambiguous`,
       };
     }
-    const dispatch = await this.prepareAndroidDispatch(
-      appId,
-      userId,
-      packageProcesses,
-      base,
-      signal,
-    );
+    const dispatch = await this.prepareAndroidDispatch(appId, userId, base, signal);
     if ("success" in dispatch) {
       return dispatch;
     }
@@ -265,29 +259,9 @@ export class CrashApp {
   private async prepareAndroidDispatch(
     appId: string,
     userId: number,
-    preflightProcesses: AndroidPackageProcess[],
     base: AndroidCrashResultBase,
     signal?: AbortSignal,
   ): Promise<AndroidDispatchPreparation | CrashAppResult> {
-    const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
-      PREFLIGHT_COMMAND_TIMEOUT_MS,
-      signal,
-    );
-    if (inductionTime.source === "host") {
-      const userProcesses = preflightProcesses.filter((process) => process.userId === userId);
-      const preflightProcess =
-        userProcesses.find((process) => process.processName === appId) ?? userProcesses[0];
-      return {
-        ...base,
-        success: false,
-        supported: true,
-        wasRunning: true,
-        processId: preflightProcess?.pid,
-        userId,
-        error: "Unable to establish Android device time for fresh crash evidence",
-      };
-    }
-
     const dispatchProcessesOutput = await this.adb.executeCommand(
       PROCESS_STATE_COMMAND,
       PREFLIGHT_COMMAND_TIMEOUT_MS,
@@ -307,6 +281,23 @@ export class CrashApp {
         wasRunning: false,
         userId,
         error: `${appId} stopped before the crash command could be dispatched`,
+      };
+    }
+    const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
+      signal,
+    );
+    if (inductionTime.source === "host") {
+      const preflightProcess =
+        targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: true,
+        processId: preflightProcess.pid,
+        userId,
+        error: "Unable to establish Android device time for fresh crash evidence",
       };
     }
     return {

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -152,13 +152,33 @@ export class CrashApp {
         error: `${appId} is running under multiple Android users; foreground identity is ambiguous`,
       };
     }
-    const targetedProcesses = packageProcesses.filter((process) => process.userId === userId);
-    const preferredProcess =
-      targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
     const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
       PREFLIGHT_COMMAND_TIMEOUT_MS,
       signal,
     );
+    const dispatchProcessesOutput = await this.adb.executeCommand(
+      PROCESS_STATE_COMMAND,
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
+      undefined,
+      true,
+      signal,
+    );
+    const targetedProcesses = findAndroidPackageProcesses(
+      dispatchProcessesOutput.stdout,
+      appId,
+    ).filter((process) => process.userId === userId);
+    if (targetedProcesses.length === 0) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: false,
+        userId,
+        error: `${appId} stopped before the crash command could be dispatched`,
+      };
+    }
+    const preferredProcess =
+      targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
     let commandResult: ExecResult;
     try {
       commandResult = await this.adb.executeCommand(

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -1,0 +1,431 @@
+import type { BootedDevice, CrashAppEvidence, CrashAppResult, ExecResult } from "../../models";
+import {
+  defaultAdbClientFactory,
+  type AdbClientFactory,
+} from "../../utils/android-cmdline-tools/AdbClientFactory";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
+import { findAndroidPackageProcessId } from "../../utils/android-cmdline-tools/androidProcessState";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { ANDROID_PACKAGE_NAME_PATTERN } from "../../utils/androidPackageName";
+import { errorMessage } from "../../utils/describeUnknownError";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { logger } from "../../utils/logger";
+import { shellQuote } from "../../utils/shellQuote";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
+import {
+  DefaultDeviceWindowCacheInvalidator,
+  type DeviceWindowCacheInvalidator,
+} from "./TerminateApp";
+
+const PROCESS_STATE_COMMAND = "shell dumpsys activity processes";
+const CONFIRMATION_ATTEMPTS = 12;
+const CONFIRMATION_POLL_MS = 250;
+
+function androidCrashLogCommand(processId: number): string {
+  return `shell logcat -b crash -d -v threadtime --pid=${processId} -t 200`;
+}
+
+export interface SimulatorCrashCommandRunner {
+  executeCommandArgs(args: string[], timeoutMs?: number, signal?: AbortSignal): Promise<ExecResult>;
+}
+
+export interface CrashAppDependencies {
+  adb?: AdbExecutor;
+  adbFactory?: AdbClientFactory;
+  simctl?: SimulatorCrashCommandRunner;
+  timer?: Timer;
+  resolveAndroidUserId?: (appId: string) => Promise<number>;
+  cacheInvalidator?: DeviceWindowCacheInvalidator;
+}
+
+export class CrashApp {
+  private readonly adb: AdbExecutor;
+  private readonly simctl: SimulatorCrashCommandRunner;
+  private readonly timer: Timer;
+  private readonly resolveAndroidUserId: (appId: string) => Promise<number>;
+  private readonly cacheInvalidator: DeviceWindowCacheInvalidator;
+
+  constructor(
+    private readonly device: BootedDevice,
+    dependencies: CrashAppDependencies = {},
+  ) {
+    const adbFactory = dependencies.adbFactory ?? defaultAdbClientFactory;
+    this.adb = dependencies.adb ?? adbFactory.create(device);
+    this.simctl = dependencies.simctl ?? new SimCtlClient(device);
+    this.timer = dependencies.timer ?? defaultTimer;
+    this.resolveAndroidUserId =
+      dependencies.resolveAndroidUserId ??
+      (async (appId) => {
+        return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName: appId }))
+          .userId;
+      });
+    this.cacheInvalidator =
+      dependencies.cacheInvalidator ?? new DefaultDeviceWindowCacheInvalidator();
+  }
+
+  async execute(appId: string, signal?: AbortSignal): Promise<CrashAppResult> {
+    const timestamp = this.timer.now();
+    try {
+      signal?.throwIfAborted();
+      return this.device.platform === "android"
+        ? await this.executeAndroid(appId, timestamp, signal)
+        : await this.executeIos(appId, timestamp, signal);
+    } catch (error) {
+      signal?.throwIfAborted();
+      const message = errorMessage(error);
+      logger.warn(
+        `[CrashApp] Failed to crash ${appId} on ${this.device.platform}: ${message}`,
+        error,
+      );
+      return {
+        success: false,
+        supported: !this.isUnsupportedMechanismError(message),
+        platform: this.device.platform,
+        appId,
+        mechanism:
+          this.device.platform === "android"
+            ? "android_am_crash"
+            : isIosSimulatorUdid(this.device.deviceId)
+              ? "ios_simulator_sigabrt"
+              : "unsupported",
+        timestamp,
+        confirmed: false,
+        error: message,
+      };
+    }
+  }
+
+  private async executeAndroid(
+    appId: string,
+    timestamp: number,
+    signal?: AbortSignal,
+  ): Promise<CrashAppResult> {
+    const base = {
+      platform: "android" as const,
+      appId,
+      mechanism: "android_am_crash" as const,
+      timestamp,
+      confirmed: false,
+    };
+
+    if (!ANDROID_PACKAGE_NAME_PATTERN.test(appId)) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: false,
+        error: `${appId} is not a valid Android package name`,
+      };
+    }
+
+    const userId = await this.resolveAndroidUserId(appId);
+    const initialProcesses = await this.adb.executeCommand(
+      PROCESS_STATE_COMMAND,
+      undefined,
+      undefined,
+      true,
+      signal,
+    );
+    const processId = findAndroidPackageProcessId(initialProcesses.stdout, appId, userId);
+    if (processId === null) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: false,
+        userId,
+        error: `${appId} is not running for Android user ${userId}`,
+      };
+    }
+
+    try {
+      await this.adb.executeCommand(
+        `shell am crash --user ${userId} ${shellQuote(appId)}`,
+        undefined,
+        undefined,
+        true,
+        signal,
+      );
+    } catch (error) {
+      signal?.throwIfAborted();
+      const message = errorMessage(error);
+      logger.warn(`[CrashApp] Android crash command failed for ${appId}: ${message}`, error);
+      return {
+        ...base,
+        success: false,
+        supported: !this.isUnsupportedMechanismError(message),
+        wasRunning: true,
+        processId,
+        userId,
+        error: message,
+      };
+    }
+
+    this.cacheInvalidator.invalidate(this.device);
+    const evidence = await this.confirmAndroidCrash(appId, processId, userId, signal);
+    return {
+      ...base,
+      success: true,
+      supported: true,
+      wasRunning: true,
+      processId,
+      userId,
+      confirmed: evidence !== undefined,
+      ...(evidence ? { evidence } : {}),
+    };
+  }
+
+  private async executeIos(
+    appId: string,
+    timestamp: number,
+    signal?: AbortSignal,
+  ): Promise<CrashAppResult> {
+    const simulator = isIosSimulatorUdid(this.device.deviceId);
+    const base = {
+      platform: "ios" as const,
+      appId,
+      timestamp,
+      confirmed: false,
+    };
+
+    if (!simulator) {
+      return {
+        ...base,
+        success: false,
+        supported: false,
+        mechanism: "unsupported",
+        wasRunning: false,
+        error:
+          "crashApp is not supported on physical iOS devices; " +
+          "AutoMobile will not fall back to normal termination",
+      };
+    }
+
+    const initialProcesses = await this.listIosSimulatorProcesses(signal);
+    const processId = findIosSimulatorAppProcessId(initialProcesses, appId);
+    if (processId === null) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        mechanism: "ios_simulator_sigabrt",
+        wasRunning: false,
+        error: `${appId} is not running on iOS Simulator ${this.device.deviceId}`,
+      };
+    }
+
+    try {
+      await this.simctl.executeCommandArgs(
+        ["spawn", this.device.deviceId, "/bin/kill", "-ABRT", String(processId)],
+        undefined,
+        signal,
+      );
+    } catch (error) {
+      signal?.throwIfAborted();
+      const message = errorMessage(error);
+      logger.warn(`[CrashApp] iOS Simulator SIGABRT failed for ${appId}: ${message}`, error);
+      return {
+        ...base,
+        success: false,
+        supported: !this.isUnsupportedMechanismError(message),
+        mechanism: "ios_simulator_sigabrt",
+        wasRunning: true,
+        processId,
+        error: message,
+      };
+    }
+    this.cacheInvalidator.invalidate(this.device);
+
+    const evidence = await this.confirmIosSimulatorCrash(appId, processId, signal);
+    return {
+      ...base,
+      success: true,
+      supported: true,
+      mechanism: "ios_simulator_sigabrt",
+      wasRunning: true,
+      processId,
+      confirmed: evidence !== undefined,
+      ...(evidence ? { evidence } : {}),
+    };
+  }
+
+  private async confirmAndroidCrash(
+    appId: string,
+    processId: number,
+    userId: number,
+    signal?: AbortSignal,
+  ): Promise<CrashAppEvidence | undefined> {
+    for (let attempt = 0; attempt < CONFIRMATION_ATTEMPTS; attempt += 1) {
+      signal?.throwIfAborted();
+      const [processOutput, logOutput] = await Promise.all([
+        this.tryAndroidCommand(PROCESS_STATE_COMMAND, signal),
+        this.tryAndroidCommand(androidCrashLogCommand(processId), signal),
+      ]);
+      const currentPid =
+        processOutput === undefined
+          ? processId
+          : findAndroidPackageProcessId(processOutput, appId, userId);
+      const evidence = logOutput
+        ? findAndroidCrashEvidence(logOutput, appId, processId)
+        : undefined;
+
+      if (currentPid !== processId && evidence) {
+        return evidence;
+      }
+      if (attempt + 1 < CONFIRMATION_ATTEMPTS) {
+        await this.timer.sleep(CONFIRMATION_POLL_MS);
+      }
+    }
+    return undefined;
+  }
+
+  private async tryAndroidCommand(
+    command: string,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    try {
+      return (await this.adb.executeCommand(command, undefined, undefined, true, signal)).stdout;
+    } catch (error) {
+      signal?.throwIfAborted();
+      logger.warn(`[CrashApp] Android confirmation command failed: ${command}`, error);
+      return undefined;
+    }
+  }
+
+  private async confirmIosSimulatorCrash(
+    appId: string,
+    processId: number,
+    signal?: AbortSignal,
+  ): Promise<CrashAppEvidence | undefined> {
+    for (let attempt = 0; attempt < CONFIRMATION_ATTEMPTS; attempt += 1) {
+      signal?.throwIfAborted();
+      const [processOutput, logOutput] = await Promise.all([
+        this.tryListIosSimulatorProcesses(signal),
+        this.tryReadIosSimulatorCrashLog(signal),
+      ]);
+      const currentPid =
+        processOutput === undefined
+          ? processId
+          : findIosSimulatorAppProcessId(processOutput, appId);
+      const evidence = logOutput
+        ? findIosSimulatorCrashEvidence(logOutput, appId, processId)
+        : undefined;
+
+      if (currentPid !== processId && evidence) {
+        return evidence;
+      }
+      if (attempt + 1 < CONFIRMATION_ATTEMPTS) {
+        await this.timer.sleep(CONFIRMATION_POLL_MS);
+      }
+    }
+    return undefined;
+  }
+
+  private async listIosSimulatorProcesses(signal?: AbortSignal): Promise<string> {
+    return (
+      await this.simctl.executeCommandArgs(
+        ["spawn", this.device.deviceId, "launchctl", "list"],
+        undefined,
+        signal,
+      )
+    ).stdout;
+  }
+
+  private async tryListIosSimulatorProcesses(signal?: AbortSignal): Promise<string | undefined> {
+    try {
+      return await this.listIosSimulatorProcesses(signal);
+    } catch (error) {
+      signal?.throwIfAborted();
+      logger.warn("[CrashApp] iOS Simulator process confirmation failed", error);
+      return undefined;
+    }
+  }
+
+  private async tryReadIosSimulatorCrashLog(signal?: AbortSignal): Promise<string | undefined> {
+    try {
+      return (
+        await this.simctl.executeCommandArgs(
+          [
+            "spawn",
+            this.device.deviceId,
+            "log",
+            "show",
+            "--last",
+            "1m",
+            "--style",
+            "compact",
+            "--predicate",
+            'eventMessage CONTAINS[c] "SIGABRT"',
+          ],
+          undefined,
+          signal,
+        )
+      ).stdout;
+    } catch (error) {
+      signal?.throwIfAborted();
+      logger.warn("[CrashApp] iOS Simulator crash-log confirmation failed", error);
+      return undefined;
+    }
+  }
+
+  private isUnsupportedMechanismError(message: string): boolean {
+    return (
+      /unknown command(?::)?\s*crash/i.test(message) || /no such file or directory/i.test(message)
+    );
+  }
+}
+
+export function findIosSimulatorAppProcessId(processList: string, appId: string): number | null {
+  for (const line of processList.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+\S+\s+UIKitApplication:(.+?)\[[^\]]+\]\[[^\]]+\]$/);
+    if (match?.[2] === appId) {
+      return Number(match[1]);
+    }
+  }
+  return null;
+}
+
+export function findAndroidCrashEvidence(
+  logOutput: string,
+  appId: string,
+  processId: number,
+): CrashAppEvidence | undefined {
+  const lines = logOutput.split("\n");
+  const identityIndex = lines.findIndex(
+    (line) =>
+      line.includes(`Process: ${appId}, PID: ${processId}`) ||
+      line.includes(`${appId}, PID: ${processId}`),
+  );
+  if (identityIndex < 0) {
+    return undefined;
+  }
+
+  const targetCrashBlock = lines.slice(Math.max(0, identityIndex - 1), identityIndex + 7);
+  const marker = targetCrashBlock.find(
+    (line) => line.includes("shell-induced crash") || line.includes("CrashedByAdbException"),
+  );
+  return marker ? { source: "android_logcat", summary: marker.trim() } : undefined;
+}
+
+export function findIosSimulatorCrashEvidence(
+  logOutput: string,
+  appId: string,
+  processId: number,
+): CrashAppEvidence | undefined {
+  const line = logOutput.split("\n").find((candidate) => {
+    if (!candidate.includes("SIGABRT")) {
+      return false;
+    }
+    const launchdIdentity =
+      candidate.includes(`UIKitApplication:${appId}[`) &&
+      candidate.includes(`[${processId}]`) &&
+      candidate.includes("exited due to SIGABRT");
+    const runningBoardIdentity =
+      candidate.includes(`app<${appId}`) &&
+      candidate.includes(`:${processId}]`) &&
+      candidate.includes("code:SIGABRT(6)");
+    return launchdIdentity || runningBoardIdentity;
+  });
+  return line ? { source: "ios_unified_log", summary: line.trim() } : undefined;
+}

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -156,6 +156,21 @@ export class CrashApp {
       PREFLIGHT_COMMAND_TIMEOUT_MS,
       signal,
     );
+    if (inductionTime.source === "host") {
+      const preflightProcesses = packageProcesses.filter((process) => process.userId === userId);
+      const preflightProcess =
+        preflightProcesses.find((process) => process.processName === appId) ??
+        preflightProcesses[0];
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: true,
+        processId: preflightProcess?.pid,
+        userId,
+        error: "Unable to establish Android device time for fresh crash evidence",
+      };
+    }
     const dispatchProcessesOutput = await this.adb.executeCommand(
       PROCESS_STATE_COMMAND,
       PREFLIGHT_COMMAND_TIMEOUT_MS,
@@ -289,8 +304,8 @@ export class CrashApp {
     }
 
     const initialProcesses = await this.listIosSimulatorProcesses(signal);
-    const appProcess = findIosSimulatorAppProcess(initialProcesses, appId);
-    if (!appProcess) {
+    const preflightProcess = findIosSimulatorAppProcess(initialProcesses, appId);
+    if (!preflightProcess) {
       return {
         ...base,
         success: false,
@@ -302,6 +317,18 @@ export class CrashApp {
     }
 
     const inductionTimestampMs = this.timer.now();
+    const dispatchProcesses = await this.listIosSimulatorProcesses(signal);
+    const appProcess = findIosSimulatorAppProcess(dispatchProcesses, appId);
+    if (!appProcess) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        mechanism: "ios_simulator_sigabrt",
+        wasRunning: false,
+        error: `${appId} stopped before the crash signal could be dispatched`,
+      };
+    }
     try {
       await this.simctl.executeCommandArgs(
         [

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -39,6 +39,20 @@ interface AndroidCrashMatch {
   processId: number;
 }
 
+interface AndroidCrashResultBase {
+  platform: "android";
+  appId: string;
+  mechanism: "android_am_crash";
+  timestamp: number;
+  confirmed: boolean;
+}
+
+interface AndroidDispatchPreparation {
+  notBeforeTimestampMs: number;
+  preferredProcess: AndroidPackageProcess;
+  targetedProcesses: AndroidPackageProcess[];
+}
+
 export interface SimulatorCrashCommandRunner {
   executeCommandArgs(args: string[], timeoutMs?: number, signal?: AbortSignal): Promise<ExecResult>;
 }
@@ -152,48 +166,17 @@ export class CrashApp {
         error: `${appId} is running under multiple Android users; foreground identity is ambiguous`,
       };
     }
-    const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
-      PREFLIGHT_COMMAND_TIMEOUT_MS,
-      signal,
-    );
-    if (inductionTime.source === "host") {
-      const preflightProcesses = packageProcesses.filter((process) => process.userId === userId);
-      const preflightProcess =
-        preflightProcesses.find((process) => process.processName === appId) ??
-        preflightProcesses[0];
-      return {
-        ...base,
-        success: false,
-        supported: true,
-        wasRunning: true,
-        processId: preflightProcess?.pid,
-        userId,
-        error: "Unable to establish Android device time for fresh crash evidence",
-      };
-    }
-    const dispatchProcessesOutput = await this.adb.executeCommand(
-      PROCESS_STATE_COMMAND,
-      PREFLIGHT_COMMAND_TIMEOUT_MS,
-      undefined,
-      true,
-      signal,
-    );
-    const targetedProcesses = findAndroidPackageProcesses(
-      dispatchProcessesOutput.stdout,
+    const dispatch = await this.prepareAndroidDispatch(
       appId,
-    ).filter((process) => process.userId === userId);
-    if (targetedProcesses.length === 0) {
-      return {
-        ...base,
-        success: false,
-        supported: true,
-        wasRunning: false,
-        userId,
-        error: `${appId} stopped before the crash command could be dispatched`,
-      };
+      userId,
+      packageProcesses,
+      base,
+      signal,
+    );
+    if ("success" in dispatch) {
+      return dispatch;
     }
-    const preferredProcess =
-      targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
+    const { notBeforeTimestampMs, preferredProcess, targetedProcesses } = dispatch;
     let commandResult: ExecResult;
     try {
       commandResult = await this.adb.executeCommand(
@@ -236,7 +219,7 @@ export class CrashApp {
     const crashMatch = await this.confirmAndroidCrash(
       appId,
       targetedProcesses,
-      inductionTime.timestampMs,
+      notBeforeTimestampMs,
       signal,
     );
     if (!crashMatch) {
@@ -276,6 +259,61 @@ export class CrashApp {
     return foreground?.packageName === appId && userIds.has(foreground.userId)
       ? foreground.userId
       : null;
+  }
+
+  private async prepareAndroidDispatch(
+    appId: string,
+    userId: number,
+    preflightProcesses: AndroidPackageProcess[],
+    base: AndroidCrashResultBase,
+    signal?: AbortSignal,
+  ): Promise<AndroidDispatchPreparation | CrashAppResult> {
+    const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
+      signal,
+    );
+    if (inductionTime.source === "host") {
+      const userProcesses = preflightProcesses.filter((process) => process.userId === userId);
+      const preflightProcess =
+        userProcesses.find((process) => process.processName === appId) ?? userProcesses[0];
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: true,
+        processId: preflightProcess?.pid,
+        userId,
+        error: "Unable to establish Android device time for fresh crash evidence",
+      };
+    }
+
+    const dispatchProcessesOutput = await this.adb.executeCommand(
+      PROCESS_STATE_COMMAND,
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
+      undefined,
+      true,
+      signal,
+    );
+    const targetedProcesses = findAndroidPackageProcesses(
+      dispatchProcessesOutput.stdout,
+      appId,
+    ).filter((process) => process.userId === userId);
+    if (targetedProcesses.length === 0) {
+      return {
+        ...base,
+        success: false,
+        supported: true,
+        wasRunning: false,
+        userId,
+        error: `${appId} stopped before the crash command could be dispatched`,
+      };
+    }
+    return {
+      notBeforeTimestampMs: inductionTime.timestampMs,
+      preferredProcess:
+        targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0],
+      targetedProcesses,
+    };
   }
 
   private async executeIos(

--- a/src/features/action/CrashApp.ts
+++ b/src/features/action/CrashApp.ts
@@ -21,8 +21,11 @@ import {
 } from "./TerminateApp";
 
 const PROCESS_STATE_COMMAND = "shell dumpsys activity processes";
-const CONFIRMATION_ATTEMPTS = 12;
+const CONFIRMATION_ATTEMPTS = 10;
 const CONFIRMATION_POLL_MS = 250;
+const PREFLIGHT_COMMAND_TIMEOUT_MS = 5_000;
+const CRASH_COMMAND_TIMEOUT_MS = 15_000;
+const CONFIRMATION_COMMAND_TIMEOUT_MS = 2_000;
 
 const ANDROID_CRASH_LOG_COMMAND = "shell logcat -b crash -d -v epoch -t 200";
 
@@ -123,7 +126,7 @@ export class CrashApp {
 
     const initialProcesses = await this.adb.executeCommand(
       PROCESS_STATE_COMMAND,
-      undefined,
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
       undefined,
       true,
       signal,
@@ -152,12 +155,15 @@ export class CrashApp {
     const targetedProcesses = packageProcesses.filter((process) => process.userId === userId);
     const preferredProcess =
       targetedProcesses.find((process) => process.processName === appId) ?? targetedProcesses[0];
-    const inductionTime = await this.adb.getDeviceTimestampMsWithSource();
+    const inductionTime = await this.adb.getDeviceTimestampMsWithSource(
+      PREFLIGHT_COMMAND_TIMEOUT_MS,
+      signal,
+    );
     let commandResult: ExecResult;
     try {
       commandResult = await this.adb.executeCommand(
         `shell am crash --user ${userId} ${shellQuote(appId)}`,
-        undefined,
+        CRASH_COMMAND_TIMEOUT_MS,
         undefined,
         true,
         signal,
@@ -231,7 +237,7 @@ export class CrashApp {
       return userIds.values().next().value ?? null;
     }
 
-    const foreground = await this.adb.getForegroundApp(signal);
+    const foreground = await this.adb.getForegroundApp(signal, PREFLIGHT_COMMAND_TIMEOUT_MS);
     return foreground?.packageName === appId && userIds.has(foreground.userId)
       ? foreground.userId
       : null;
@@ -286,7 +292,7 @@ export class CrashApp {
           "SIGABRT",
           `user/501/${appProcess.serviceLabel}`,
         ],
-        undefined,
+        CRASH_COMMAND_TIMEOUT_MS,
         signal,
       );
     } catch (error) {
@@ -373,7 +379,15 @@ export class CrashApp {
     signal?: AbortSignal,
   ): Promise<string | undefined> {
     try {
-      return (await this.adb.executeCommand(command, undefined, undefined, true, signal)).stdout;
+      return (
+        await this.adb.executeCommand(
+          command,
+          CONFIRMATION_COMMAND_TIMEOUT_MS,
+          undefined,
+          true,
+          signal,
+        )
+      ).stdout;
     } catch (error) {
       signal?.throwIfAborted();
       logger.warn(`[CrashApp] Android confirmation command failed: ${command}`, error);
@@ -415,7 +429,7 @@ export class CrashApp {
     return (
       await this.simctl.executeCommandArgs(
         ["spawn", this.device.deviceId, "launchctl", "list"],
-        undefined,
+        PREFLIGHT_COMMAND_TIMEOUT_MS,
         signal,
       )
     ).stdout;
@@ -449,7 +463,7 @@ export class CrashApp {
             "--predicate",
             'eventMessage CONTAINS[c] "SIGABRT"',
           ],
-          undefined,
+          CONFIRMATION_COMMAND_TIMEOUT_MS,
           signal,
         )
       ).stdout;

--- a/src/features/record/McpCallRecorder.ts
+++ b/src/features/record/McpCallRecorder.ts
@@ -10,6 +10,7 @@ export const PLAN_RELEVANT_TOOLS = new Set([
   // App lifecycle
   "launchApp",
   "terminateApp",
+  "crashApp",
   // Observation
   "observe",
   // Interaction

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -16,6 +16,9 @@ import fs from "fs/promises";
 import path from "path";
 import { shellQuote } from "../../utils/shellQuote";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../utils/workingDirectory";
+import { ANDROID_PACKAGE_NAME_PATTERN } from "../../utils/androidPackageName";
+
+export { ANDROID_PACKAGE_NAME_PATTERN } from "../../utils/androidPackageName";
 
 interface PostNotificationAction {
   label: string;
@@ -38,7 +41,6 @@ const NOTIFICATION_RECEIVER =
   "dev.jasonpearson.automobile.sdk.notifications.AutoMobileNotificationReceiver";
 const SDK_RESULT_SUCCESS = 1;
 const DEVICE_IMAGE_DIR = "/sdcard/Download/automobile";
-export const ANDROID_PACKAGE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
 
 export class PostNotification {
   private device: BootedDevice;

--- a/src/models/CrashAppResult.ts
+++ b/src/models/CrashAppResult.ts
@@ -11,9 +11,8 @@ export interface CrashAppEvidence {
 /**
  * Stable result of an intentional application-crash request.
  *
- * `success` means the crash-induction command was accepted. `confirmed` is
- * stricter: it requires OS crash evidence for the target process, not merely
- * that the process disappeared.
+ * `success` and `confirmed` require fresh OS crash evidence for the target
+ * process, not merely command dispatch or process disappearance.
  */
 export interface CrashAppResult extends BaseActionResult {
   supported: boolean;

--- a/src/models/CrashAppResult.ts
+++ b/src/models/CrashAppResult.ts
@@ -1,0 +1,32 @@
+import { BaseActionResult } from "./BaseActionResult";
+import type { Platform } from "./Platform";
+
+export type CrashAppMechanism = "android_am_crash" | "ios_simulator_sigabrt" | "unsupported";
+
+export interface CrashAppEvidence {
+  source: "android_logcat" | "ios_unified_log";
+  summary: string;
+}
+
+/**
+ * Stable result of an intentional application-crash request.
+ *
+ * `success` means the crash-induction command was accepted. `confirmed` is
+ * stricter: it requires OS crash evidence for the target process, not merely
+ * that the process disappeared.
+ */
+export interface CrashAppResult extends BaseActionResult {
+  supported: boolean;
+  platform: Platform;
+  appId: string;
+  processId?: number;
+  mechanism: CrashAppMechanism;
+  /** Epoch milliseconds when crash induction was attempted. */
+  timestamp: number;
+  /** Whether a target process was running. Omitted when preflight failed. */
+  wasRunning?: boolean;
+  confirmed: boolean;
+  evidence?: CrashAppEvidence;
+  /** Android user/profile targeted by ActivityManager. */
+  userId?: number;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -11,6 +11,7 @@ export * from "./AppStatusResult";
 export * from "./ClearAppDataResult";
 export * from "./ClearTextResult";
 export * from "./ClipboardResult";
+export * from "./CrashAppResult";
 export * from "./CurrentFocusResult";
 export * from "./DeepLinkResult";
 export * from "./DisplayedTimeMetric";

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -16,6 +16,7 @@ import { AppPermissions } from "../features/action/AppPermissions";
 import { ResetKeychain } from "../features/action/ResetKeychain";
 import {
   createJSONToolResponse,
+  createStructuredToolResponse,
   DefaultToolResponseFormatter,
   ToolResponseFormatter,
 } from "../utils/toolUtils";
@@ -539,7 +540,7 @@ export function registerAppTools() {
             result.confirmed ? " (OS crash confirmed)" : " (confirmation unavailable)"
           }`
         : (result.error ?? `Failed to crash app ${args.appId}`);
-      return createJSONToolResponse({ message, ...result });
+      return createStructuredToolResponse({ message, ...result });
     } catch (error) {
       if (isDeviceLostError(error) || error instanceof ActionableError) {
         throw error;

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -3,9 +3,11 @@ import { ToolRegistry } from "./toolRegistry";
 import {
   ActionableError,
   BootedDevice,
+  type CrashAppResult,
   type LaunchAppResult,
   type TerminateAppResult,
 } from "../models";
+import { CrashApp } from "../features/action/CrashApp";
 import { LaunchApp } from "../features/action/LaunchApp";
 import { TerminateApp } from "../features/action/TerminateApp";
 import { InstallApp } from "../features/action/InstallApp";
@@ -94,6 +96,36 @@ export function resetTerminateAppToolDependencies(): void {
   terminateAppToolDependencies = null;
 }
 
+export interface CrashAppExecutor {
+  execute(appId: string, signal?: AbortSignal): Promise<CrashAppResult>;
+}
+
+export interface CrashAppToolDependencies {
+  createCrashApp(device: BootedDevice): CrashAppExecutor;
+}
+
+let crashAppToolDependencies: CrashAppToolDependencies | null = null;
+
+function getCrashAppToolDependencies(): CrashAppToolDependencies {
+  if (!crashAppToolDependencies) {
+    crashAppToolDependencies = {
+      createCrashApp: (device) => new CrashApp(device),
+    };
+  }
+  return crashAppToolDependencies;
+}
+
+export function setCrashAppToolDependencies(deps: Partial<CrashAppToolDependencies>): void {
+  const currentDeps = getCrashAppToolDependencies();
+  crashAppToolDependencies = {
+    createCrashApp: deps.createCrashApp ?? currentDeps.createCrashApp,
+  };
+}
+
+export function resetCrashAppToolDependencies(): void {
+  crashAppToolDependencies = null;
+}
+
 /**
  * Build the launchApp tool response from a {@link LaunchAppResult}, enforcing the
  * launch postcondition instead of reporting a flat "Launched app X" success
@@ -157,6 +189,35 @@ export const terminateAppSchema = withAppIdAliases(
     }),
   ),
 );
+
+export const crashAppSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string().trim().min(1),
+    }),
+  ),
+);
+
+export const crashAppResultSchema = z.object({
+  message: z.string(),
+  success: z.boolean(),
+  supported: z.boolean(),
+  platform: z.enum(["android", "ios"]),
+  appId: z.string(),
+  processId: z.number().int().positive().optional(),
+  mechanism: z.enum(["android_am_crash", "ios_simulator_sigabrt", "unsupported"]),
+  timestamp: z.number().int().nonnegative(),
+  wasRunning: z.boolean().optional(),
+  confirmed: z.boolean(),
+  evidence: z
+    .object({
+      source: z.enum(["android_logcat", "ios_unified_log"]),
+      summary: z.string(),
+    })
+    .optional(),
+  userId: z.number().int().nonnegative().optional(),
+  error: z.string().optional(),
+});
 
 export const launchAppSchema = withAppIdAliases(
   addDeviceTargetingToSchema(
@@ -326,6 +387,10 @@ export interface AppActionArgs {
   appId: string;
 }
 
+export interface CrashAppActionArgs {
+  appId: string;
+}
+
 export interface LaunchAppActionArgs {
   appId: string;
   clearAppData?: boolean;
@@ -452,6 +517,42 @@ export function registerAppTools() {
         await notifyInstalledAppResourceUpdated(device.deviceId);
       } catch (error) {
         logger.warn(`[AppTools] Failed to refresh app resources after terminate: ${error}`);
+      }
+    }
+  };
+
+  const crashAppHandler = async (
+    device: BootedDevice,
+    args: CrashAppActionArgs,
+    _progress?: unknown,
+    signal?: AbortSignal,
+  ) => {
+    try {
+      signal?.throwIfAborted();
+      const result = await getCrashAppToolDependencies()
+        .createCrashApp(device)
+        .execute(args.appId, signal);
+      signal?.throwIfAborted();
+
+      const message = result.success
+        ? `Crashed app ${args.appId} via ${result.mechanism}${
+            result.confirmed ? " (OS crash confirmed)" : " (confirmation unavailable)"
+          }`
+        : (result.error ?? `Failed to crash app ${args.appId}`);
+      return createJSONToolResponse({ message, ...result });
+    } catch (error) {
+      if (isDeviceLostError(error) || error instanceof ActionableError) {
+        throw error;
+      }
+      throw new ActionableError(`Failed to crash app: ${error}`);
+    } finally {
+      if (!signal?.aborted) {
+        try {
+          invalidateInstalledAppResourceCache(device.deviceId);
+          await notifyInstalledAppResourceUpdated(device.deviceId);
+        } catch (error) {
+          logger.warn(`[AppTools] Failed to refresh app resources after crash: ${error}`);
+        }
       }
     }
   };
@@ -592,6 +693,14 @@ export function registerAppTools() {
     terminateAppSchema,
     terminateAppHandler,
     { defaultEnabled: true },
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "crashApp",
+    "Intentionally crash a running app through the platform crash path",
+    crashAppSchema,
+    crashAppHandler,
+    { defaultEnabled: true, outputSchema: crashAppResultSchema },
   );
 
   ToolRegistry.registerDeviceAware(

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -103,6 +103,8 @@ export interface CrashAppExecutor {
 
 export interface CrashAppToolDependencies {
   createCrashApp(device: BootedDevice): CrashAppExecutor;
+  invalidateAppResourceCache(deviceId: string): void;
+  notifyAppResourceUpdated(deviceId: string): Promise<void>;
 }
 
 let crashAppToolDependencies: CrashAppToolDependencies | null = null;
@@ -111,6 +113,8 @@ function getCrashAppToolDependencies(): CrashAppToolDependencies {
   if (!crashAppToolDependencies) {
     crashAppToolDependencies = {
       createCrashApp: (device) => new CrashApp(device),
+      invalidateAppResourceCache: invalidateInstalledAppResourceCache,
+      notifyAppResourceUpdated: notifyInstalledAppResourceUpdated,
     };
   }
   return crashAppToolDependencies;
@@ -120,6 +124,9 @@ export function setCrashAppToolDependencies(deps: Partial<CrashAppToolDependenci
   const currentDeps = getCrashAppToolDependencies();
   crashAppToolDependencies = {
     createCrashApp: deps.createCrashApp ?? currentDeps.createCrashApp,
+    invalidateAppResourceCache:
+      deps.invalidateAppResourceCache ?? currentDeps.invalidateAppResourceCache,
+    notifyAppResourceUpdated: deps.notifyAppResourceUpdated ?? currentDeps.notifyAppResourceUpdated,
   };
 }
 
@@ -528,11 +535,10 @@ export function registerAppTools() {
     _progress?: unknown,
     signal?: AbortSignal,
   ) => {
+    const dependencies = getCrashAppToolDependencies();
     try {
       signal?.throwIfAborted();
-      const result = await getCrashAppToolDependencies()
-        .createCrashApp(device)
-        .execute(args.appId, signal);
+      const result = await dependencies.createCrashApp(device).execute(args.appId, signal);
       signal?.throwIfAborted();
 
       const message = result.success
@@ -547,10 +553,10 @@ export function registerAppTools() {
       }
       throw new ActionableError(`Failed to crash app: ${error}`);
     } finally {
+      dependencies.invalidateAppResourceCache(device.deviceId);
       if (!signal?.aborted) {
         try {
-          invalidateInstalledAppResourceCache(device.deviceId);
-          await notifyInstalledAppResourceUpdated(device.deviceId);
+          await dependencies.notifyAppResourceUpdated(device.deviceId);
         } catch (error) {
           logger.warn(`[AppTools] Failed to refresh app resources after crash: ${error}`);
         }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -670,9 +670,18 @@ export class AdbClient implements AdbExecutor {
    * Get device time in milliseconds since epoch and identify its clock source.
    * Falls back to host time if the device timestamp cannot be retrieved.
    */
-  async getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult> {
+  async getDeviceTimestampMsWithSource(
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<DeviceTimestampResult> {
     try {
-      const result = await this.executeCommand("shell date +%s%3N");
+      const result = await this.executeCommand(
+        "shell date +%s%3N",
+        timeoutMs,
+        undefined,
+        true,
+        signal,
+      );
       const trimmed = result.stdout.trim();
       if (/^\d+$/.test(trimmed)) {
         const parsed = Number(trimmed);
@@ -681,11 +690,18 @@ export class AdbClient implements AdbExecutor {
         }
       }
     } catch (error) {
+      signal?.throwIfAborted();
       logger.debug(`[ADB] Failed to read device time with ms precision: ${error}`);
     }
 
     try {
-      const result = await this.executeCommand("shell date +%s");
+      const result = await this.executeCommand(
+        "shell date +%s",
+        timeoutMs,
+        undefined,
+        true,
+        signal,
+      );
       const trimmed = result.stdout.trim();
       if (/^\d+$/.test(trimmed)) {
         const parsed = Number(trimmed);
@@ -695,6 +711,7 @@ export class AdbClient implements AdbExecutor {
         }
       }
     } catch (error) {
+      signal?.throwIfAborted();
       logger.debug(`[ADB] Failed to read device time in seconds: ${error}`);
     }
 
@@ -1494,11 +1511,12 @@ export class AdbClient implements AdbExecutor {
    */
   async getForegroundApp(
     signal?: AbortSignal,
+    timeoutMs?: number,
   ): Promise<{ packageName: string; userId: number } | null> {
     try {
       const result = await this.executeCommand(
         'shell dumpsys activity activities | grep -E "(mResumedActivity|mFocusedActivity|topResumedActivity)" | head -1',
-        undefined,
+        timeoutMs,
         undefined,
         true,
         signal,
@@ -1521,6 +1539,7 @@ export class AdbClient implements AdbExecutor {
       logger.debug("[ADB] No foreground app detected");
       return null;
     } catch (error) {
+      signal?.throwIfAborted();
       logger.debug(`[ADB] Failed to get foreground app: ${(error as Error).message}`);
       return null;
     }

--- a/src/utils/android-cmdline-tools/androidProcessState.ts
+++ b/src/utils/android-cmdline-tools/androidProcessState.ts
@@ -1,4 +1,40 @@
-const PROCESS_RECORD_PATTERN = /(?:^|\s)\d+:([A-Za-z0-9_.:]+)\/(u(\d+)a\d+|\d+)(?=[\s}]|$)/gm;
+const PROCESS_RECORD_PATTERN = /(?:^|\s)(\d+):([A-Za-z0-9_.:]+)\/(u(\d+)a\d+|\d+)(?=[\s}]|$)/gm;
+
+/**
+ * Finds a process PID for an Android package in the selected user, preferring
+ * the package's main process over a `package:suffix` secondary process.
+ */
+export function findAndroidPackageProcessId(
+  processesOutput: string,
+  packageName: string,
+  userId: number,
+): number | null {
+  PROCESS_RECORD_PATTERN.lastIndex = 0;
+  let secondaryPid: number | null = null;
+
+  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
+    const processName = match[2];
+    if (processName !== packageName && !processName.startsWith(`${packageName}:`)) {
+      continue;
+    }
+
+    const uid = match[3];
+    const processUserId = uid.startsWith("u")
+      ? Number(match[4])
+      : Math.floor(Number(uid) / 100_000);
+    if (processUserId !== userId) {
+      continue;
+    }
+
+    const pid = Number(match[1]);
+    if (processName === packageName) {
+      return pid;
+    }
+    secondaryPid ??= pid;
+  }
+
+  return secondaryPid;
+}
 
 /**
  * Determines whether an Android package has a process for the selected user.
@@ -21,13 +57,13 @@ export function isAndroidPackageRunning(
   PROCESS_RECORD_PATTERN.lastIndex = 0;
 
   for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
-    if (match[1] !== packageName && !match[1].startsWith(`${packageName}:`)) {
+    if (match[2] !== packageName && !match[2].startsWith(`${packageName}:`)) {
       continue;
     }
 
-    const uid = match[2];
+    const uid = match[3];
     const processUserId = uid.startsWith("u")
-      ? Number(match[3])
+      ? Number(match[4])
       : Math.floor(Number(uid) / 100_000);
     if (userId === undefined || processUserId === userId) {
       return true;

--- a/src/utils/android-cmdline-tools/androidProcessState.ts
+++ b/src/utils/android-cmdline-tools/androidProcessState.ts
@@ -1,4 +1,41 @@
-const PROCESS_RECORD_PATTERN = /(?:^|\s)(\d+):([A-Za-z0-9_.:]+)\/(u(\d+)a\d+|\d+)(?=[\s}]|$)/gm;
+const PROCESS_RECORD_PATTERN =
+  /(?:^|\s)(\d+):([A-Za-z0-9_.:]+)\/(u(\d+)(?:a\d+(?:i\d+)?|i\d+)|\d+)(?=[\s}]|$)/gm;
+
+export interface AndroidPackageProcess {
+  pid: number;
+  processName: string;
+  userId: number;
+}
+
+/**
+ * Lists every process owned by an Android package across users. The exact
+ * process identities let destructive callers reject ambiguous user targeting
+ * and account for package-owned secondary processes.
+ */
+export function findAndroidPackageProcesses(
+  processesOutput: string,
+  packageName: string,
+): AndroidPackageProcess[] {
+  PROCESS_RECORD_PATTERN.lastIndex = 0;
+  const processes: AndroidPackageProcess[] = [];
+
+  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
+    const processName = match[2];
+    if (processName !== packageName && !processName.startsWith(`${packageName}:`)) {
+      continue;
+    }
+
+    const uid = match[3];
+    const userId = uid.startsWith("u") ? Number(match[4]) : Math.floor(Number(uid) / 100_000);
+    processes.push({
+      pid: Number(match[1]),
+      processName,
+      userId,
+    });
+  }
+
+  return processes;
+}
 
 /**
  * Finds a process PID for an Android package in the selected user, preferring
@@ -9,31 +46,14 @@ export function findAndroidPackageProcessId(
   packageName: string,
   userId: number,
 ): number | null {
-  PROCESS_RECORD_PATTERN.lastIndex = 0;
-  let secondaryPid: number | null = null;
-
-  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
-    const processName = match[2];
-    if (processName !== packageName && !processName.startsWith(`${packageName}:`)) {
-      continue;
-    }
-
-    const uid = match[3];
-    const processUserId = uid.startsWith("u")
-      ? Number(match[4])
-      : Math.floor(Number(uid) / 100_000);
-    if (processUserId !== userId) {
-      continue;
-    }
-
-    const pid = Number(match[1]);
-    if (processName === packageName) {
-      return pid;
-    }
-    secondaryPid ??= pid;
-  }
-
-  return secondaryPid;
+  const processes = findAndroidPackageProcesses(processesOutput, packageName).filter(
+    (process) => process.userId === userId,
+  );
+  return (
+    processes.find((process) => process.processName === packageName)?.pid ??
+    processes[0]?.pid ??
+    null
+  );
 }
 
 /**

--- a/src/utils/android-cmdline-tools/androidProcessState.ts
+++ b/src/utils/android-cmdline-tools/androidProcessState.ts
@@ -18,10 +18,18 @@ export function findAndroidPackageProcesses(
 ): AndroidPackageProcess[] {
   PROCESS_RECORD_PATTERN.lastIndex = 0;
   const processes: AndroidPackageProcess[] = [];
+  const records = Array.from(processesOutput.matchAll(PROCESS_RECORD_PATTERN));
 
-  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
+  for (const [index, match] of records.entries()) {
     const processName = match[2];
-    if (processName !== packageName && !processName.startsWith(`${packageName}:`)) {
+    const recordStart = match.index ?? 0;
+    const recordEnd = records[index + 1]?.index ?? processesOutput.length;
+    const record = processesOutput.slice(recordStart, recordEnd);
+    if (
+      processName !== packageName &&
+      !processName.startsWith(`${packageName}:`) &&
+      !processRecordOwnsPackage(record, packageName)
+    ) {
       continue;
     }
 
@@ -35,6 +43,11 @@ export function findAndroidPackageProcesses(
   }
 
   return processes;
+}
+
+function processRecordOwnsPackage(record: string, packageName: string): boolean {
+  const packageList = record.match(/^\s*packageList=\{([^}]*)\}/m)?.[1];
+  return packageList?.split(/[,\s]+/).some((candidate) => candidate === packageName) ?? false;
 }
 
 /**
@@ -74,21 +87,7 @@ export function isAndroidPackageRunning(
   packageName: string,
   userId?: number,
 ): boolean {
-  PROCESS_RECORD_PATTERN.lastIndex = 0;
-
-  for (const match of processesOutput.matchAll(PROCESS_RECORD_PATTERN)) {
-    if (match[2] !== packageName && !match[2].startsWith(`${packageName}:`)) {
-      continue;
-    }
-
-    const uid = match[3];
-    const processUserId = uid.startsWith("u")
-      ? Number(match[4])
-      : Math.floor(Number(uid) / 100_000);
-    if (userId === undefined || processUserId === userId) {
-      return true;
-    }
-  }
-
-  return false;
+  return findAndroidPackageProcesses(processesOutput, packageName).some(
+    (process) => userId === undefined || process.userId === userId,
+  );
 }

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -93,7 +93,10 @@ export interface AdbExecutor {
    * Get the device time with the clock source used to derive it.
    * Host fallback is retained for callers that accept a best-effort timestamp.
    */
-  getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult>;
+  getDeviceTimestampMsWithSource(
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<DeviceTimestampResult>;
 
   /**
    * Get the list of booted Android devices
@@ -140,7 +143,10 @@ export interface AdbExecutor {
    * Get the current foreground app package name and user ID
    * @returns Promise with { packageName: string, userId: number } or null if no app in foreground
    */
-  getForegroundApp(signal?: AbortSignal): Promise<{ packageName: string; userId: number } | null>;
+  getForegroundApp(
+    signal?: AbortSignal,
+    timeoutMs?: number,
+  ): Promise<{ packageName: string; userId: number } | null>;
 
   /** Get device time in milliseconds. */
   getDeviceTimestampMs(): Promise<number>;

--- a/src/utils/androidPackageName.ts
+++ b/src/utils/androidPackageName.ts
@@ -1,0 +1,6 @@
+/**
+ * Android application ID accepted at destructive package-scoped shell
+ * boundaries. Requiring at least two Java-style segments also prevents a
+ * numeric value from being interpreted as a PID by commands such as `am crash`.
+ */
+export const ANDROID_PACKAGE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -228,7 +228,7 @@ const migrateStepFields = (
 
   step.tool = normalizedTool;
 
-  if (["launchApp", "terminateApp", "stopApp"].includes(normalizedTool)) {
+  if (["launchApp", "terminateApp", "crashApp", "stopApp"].includes(normalizedTool)) {
     if (mergedParams.appId === undefined && typeof mergedParams.packageName === "string") {
       mergedParams.appId = mergedParams.packageName;
       delete mergedParams.packageName;

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -399,11 +399,13 @@ describe("resolveMcpRequestTimeoutMs", () => {
   // Constant relationships (not resolve() calls): the observe/openLink default
   // floors must exceed the standard request timeout, or a cold start would abort
   // (issues #2834 / #2723).
-  test("default observe and openLink floors exceed the standard request timeout", () => {
+  test("default observe, openLink, and crashApp floors exceed the standard timeout", () => {
     expect(DEFAULT_OBSERVE_MCP_TIMEOUT_MS).toBe(90_000);
     expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBe(90_000);
+    expect(MIN_CRASH_APP_MCP_TIMEOUT_MS).toBe(90_000);
     expect(DEFAULT_OBSERVE_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
     expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+    expect(MIN_CRASH_APP_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
   });
 
   test("videoRecording preserves the compatibility floor", () => {

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS,
   LEGACY_OBSERVE_MCP_TIMEOUT_ENV_VAR,
   LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
+  MIN_CRASH_APP_MCP_TIMEOUT_MS,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
   MIN_PREFERENCE_MCP_TIMEOUT_MS,
@@ -101,6 +102,11 @@ describe("resolveMcpRequestTimeoutMs", () => {
       expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
     },
     {
+      name: "crashApp floor when timeoutMs omitted",
+      tool: "crashApp",
+      expected: MIN_CRASH_APP_MCP_TIMEOUT_MS,
+    },
+    {
       name: "videoRecording floor when timeoutMs omitted",
       tool: "videoRecording",
       expected: MIN_VIDEO_RECORDING_MCP_TIMEOUT_MS,
@@ -161,6 +167,12 @@ describe("resolveMcpRequestTimeoutMs", () => {
       tool: "launchApp",
       timeoutMs: 10_000,
       expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+    },
+    {
+      name: "raises short crashApp to floor",
+      tool: "crashApp",
+      timeoutMs: 30_000,
+      expected: MIN_CRASH_APP_MCP_TIMEOUT_MS,
     },
     {
       name: "raises short videoRecording to floor",

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, test } from "bun:test";
+import type { ExecResult } from "../../../src/models";
+import {
+  CrashApp,
+  type CrashAppDependencies,
+  findAndroidCrashEvidence,
+} from "../../../src/features/action/CrashApp";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const androidDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android" as const,
+};
+
+const iosSimulator = {
+  deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+  name: "iPhone",
+  platform: "ios" as const,
+};
+
+const iosPhysicalDevice = {
+  deviceId: "00008110-001A2B3C4D5E6F70",
+  name: "iPhone",
+  platform: "ios" as const,
+};
+
+const execResult = (stdout = "", stderr = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (search) => stdout.includes(search),
+});
+
+class FakeSimulatorCommands {
+  readonly calls: string[][] = [];
+  private launchctlResults: string[];
+  private readonly logOutput: string;
+  private readonly errors = new Map<string, Error>();
+
+  constructor(launchctlResults: string[], logOutput = "") {
+    this.launchctlResults = [...launchctlResults];
+    this.logOutput = logOutput;
+  }
+
+  setError(match: string, error: Error): void {
+    this.errors.set(match, error);
+  }
+
+  async executeCommandArgs(args: string[]): Promise<ExecResult> {
+    this.calls.push([...args]);
+    const command = args.join(" ");
+    for (const [match, error] of this.errors) {
+      if (command.includes(match)) {
+        throw error;
+      }
+    }
+    if (args.at(-2) === "launchctl" && args.at(-1) === "list") {
+      return execResult(this.launchctlResults.shift() ?? "");
+    }
+    if (args.includes("log")) {
+      return execResult(this.logOutput);
+    }
+    return execResult();
+  }
+}
+
+const dependencies = (overrides: Partial<CrashAppDependencies> = {}): CrashAppDependencies => ({
+  resolveAndroidUserId: async () => 0,
+  cacheInvalidator: { invalidate: () => {} },
+  ...overrides,
+});
+
+describe("CrashApp (Android)", () => {
+  test("ties Android evidence summary to the target PID's crash block", () => {
+    const output = [
+      "E AndroidRuntime: FATAL EXCEPTION: main",
+      "E AndroidRuntime: Process: com.example.app, PID: 111",
+      "E AndroidRuntime: CrashedByAdbException: old shell-induced crash",
+      "E AndroidRuntime: FATAL EXCEPTION: main",
+      "E AndroidRuntime: Process: com.example.app, PID: 222",
+      "E AndroidRuntime: CrashedByAdbException: target shell-induced crash",
+    ].join("\n");
+
+    expect(findAndroidCrashEvidence(output, "com.example.app", 222)?.summary).toContain(
+      "target shell-induced crash",
+    );
+  });
+
+  test("induces and confirms an ActivityManager crash for the selected package", async () => {
+    const adb = new FakeAdbClient();
+    const timer = new FakeTimer();
+    timer.advanceTime(1234);
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      "*APP* UID u10a123 ProcessRecord{abc 3220:com.example.app/u10a123}",
+      "*APP* UID u10a123 ProcessRecord{def 4881:com.example.other/u10a123}",
+    ]);
+    adb.setCommandResult(
+      "shell logcat -b crash -d -v threadtime --pid=3220 -t 200",
+      [
+        "E AndroidRuntime: FATAL EXCEPTION: main",
+        "E AndroidRuntime: Process: com.example.app, PID: 3220",
+        "E AndroidRuntime: android.app.RemoteServiceException$CrashedByAdbException: shell-induced crash",
+      ].join("\n"),
+    );
+    let invalidations = 0;
+    const action = new CrashApp(
+      androidDevice,
+      dependencies({
+        adb,
+        timer,
+        resolveAndroidUserId: async () => 10,
+        cacheInvalidator: { invalidate: () => invalidations++ },
+      }),
+    );
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: true,
+      supported: true,
+      platform: "android",
+      appId: "com.example.app",
+      processId: 3220,
+      userId: 10,
+      mechanism: "android_am_crash",
+      timestamp: 1234,
+      wasRunning: true,
+      confirmed: true,
+      evidence: {
+        source: "android_logcat",
+      },
+    });
+    expect(adb.wasCommandExecuted("shell am crash --user 10 'com.example.app'")).toBe(true);
+    expect(adb.wasCommandExecuted("force-stop")).toBe(false);
+    expect(invalidations).toBe(1);
+  });
+
+  test("returns a typed not-running result without inducing a crash", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult(
+      "shell dumpsys activity processes",
+      "*APP* UID u0a123 ProcessRecord{abc 4881:com.example.other/u0a123}",
+    );
+    const action = new CrashApp(androidDevice, dependencies({ adb }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      wasRunning: false,
+      confirmed: false,
+      mechanism: "android_am_crash",
+    });
+    expect(result.error).toContain("not running");
+    expect(adb.wasCommandExecuted("shell am crash")).toBe(false);
+  });
+
+  test("rejects a non-package appId before it reaches the device shell", async () => {
+    const adb = new FakeAdbClient();
+    const action = new CrashApp(androidDevice, dependencies({ adb }));
+
+    const result = await action.execute("com.example.app; reboot");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      confirmed: false,
+    });
+    expect(result.error).toContain("valid Android package name");
+    expect(adb.wasCommandExecuted("shell")).toBe(false);
+  });
+
+  test("reports unsupported when ActivityManager has no crash command and never force-stops", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult(
+      "shell dumpsys activity processes",
+      "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
+    );
+    adb.setCommandError(
+      "shell am crash --user 0 'com.example.app'",
+      new Error("Unknown command: crash"),
+    );
+    const action = new CrashApp(androidDevice, dependencies({ adb }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: false,
+      processId: 3220,
+      confirmed: false,
+    });
+    expect(result.error).toContain("Unknown command: crash");
+    expect(adb.wasCommandExecuted("force-stop")).toBe(false);
+  });
+
+  test("reports accepted but unconfirmed when crash-specific evidence does not arrive", async () => {
+    const adb = new FakeAdbClient();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
+      "",
+    ]);
+    adb.setCommandResult("shell logcat -b crash -d -v threadtime --pid=3220 -t 200", "");
+    const action = new CrashApp(androidDevice, dependencies({ adb, timer }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: true,
+      supported: true,
+      wasRunning: true,
+      confirmed: false,
+      processId: 3220,
+    });
+    expect(result.evidence).toBeUndefined();
+  });
+});
+
+describe("CrashApp (iOS)", () => {
+  test("signals and confirms the exact simulator app process", async () => {
+    const processList = [
+      "PID\tStatus\tLabel",
+      "111\t0\tUIKitApplication:com.example.app.beta[aaaa][rb-legacy]",
+      "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
+    ].join("\n");
+    const commands = new FakeSimulatorCommands(
+      [processList, "PID\tStatus\tLabel\n"],
+      "launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT",
+    );
+    const timer = new FakeTimer();
+    timer.advanceTime(5678);
+    const action = new CrashApp(iosSimulator, dependencies({ simctl: commands, timer }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: true,
+      supported: true,
+      platform: "ios",
+      appId: "com.example.app",
+      processId: 27955,
+      mechanism: "ios_simulator_sigabrt",
+      timestamp: 5678,
+      wasRunning: true,
+      confirmed: true,
+      evidence: {
+        source: "ios_unified_log",
+      },
+    });
+    expect(commands.calls).toContainEqual([
+      "spawn",
+      iosSimulator.deviceId,
+      "/bin/kill",
+      "-ABRT",
+      "27955",
+    ]);
+    expect(commands.calls.flat()).not.toContain("terminate");
+  });
+
+  test("returns a typed not-running result without signaling another bundle", async () => {
+    const commands = new FakeSimulatorCommands([
+      "111\t0\tUIKitApplication:com.example.app.beta[aaaa][rb-legacy]",
+    ]);
+    const action = new CrashApp(iosSimulator, dependencies({ simctl: commands }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      wasRunning: false,
+      confirmed: false,
+    });
+    expect(commands.calls).toHaveLength(1);
+  });
+
+  test("preserves known running metadata when SIGABRT is rejected", async () => {
+    const commands = new FakeSimulatorCommands([
+      "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
+    ]);
+    commands.setError("/bin/kill", new Error("Operation not permitted"));
+    const action = new CrashApp(iosSimulator, dependencies({ simctl: commands }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      wasRunning: true,
+      processId: 27955,
+      confirmed: false,
+      error: "Operation not permitted",
+    });
+    expect(commands.calls.flat()).not.toContain("terminate");
+  });
+
+  test("reports accepted but unconfirmed when unified-log evidence is unavailable", async () => {
+    const commands = new FakeSimulatorCommands([
+      "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
+      "",
+    ]);
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const action = new CrashApp(iosSimulator, dependencies({ simctl: commands, timer }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: true,
+      supported: true,
+      wasRunning: true,
+      processId: 27955,
+      confirmed: false,
+    });
+    expect(result.evidence).toBeUndefined();
+  });
+
+  test("returns explicit unsupported metadata for a physical device without running commands", async () => {
+    const commands = new FakeSimulatorCommands([]);
+    const action = new CrashApp(iosPhysicalDevice, dependencies({ simctl: commands }));
+
+    const result = await action.execute("com.example.app");
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: false,
+      platform: "ios",
+      appId: "com.example.app",
+      mechanism: "unsupported",
+      wasRunning: false,
+      confirmed: false,
+    });
+    expect(result.error).toContain("physical iOS");
+    expect(commands.calls).toEqual([]);
+  });
+});

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -37,6 +37,7 @@ const execResult = (stdout = "", stderr = ""): ExecResult => ({
 
 class FakeSimulatorCommands {
   readonly calls: string[][] = [];
+  readonly timeouts: Array<number | undefined> = [];
   private launchctlResults: string[];
   private readonly logOutput: string;
   private readonly errors = new Map<string, Error>();
@@ -50,8 +51,9 @@ class FakeSimulatorCommands {
     this.errors.set(match, error);
   }
 
-  async executeCommandArgs(args: string[]): Promise<ExecResult> {
+  async executeCommandArgs(args: string[], timeoutMs?: number): Promise<ExecResult> {
     this.calls.push([...args]);
+    this.timeouts.push(timeoutMs);
     const command = args.join(" ");
     for (const [match, error] of this.errors) {
       if (command.includes(match)) {
@@ -149,6 +151,7 @@ describe("CrashApp (Android)", () => {
     });
     expect(adb.wasCommandExecuted("shell am crash --user 10 'com.example.app'")).toBe(true);
     expect(adb.wasCommandExecuted("force-stop")).toBe(false);
+    expect(adb.getCommandCalls().every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
     expect(invalidations).toBe(1);
   });
 
@@ -397,6 +400,7 @@ describe("CrashApp (iOS)", () => {
       "user/501/UIKitApplication:com.example.app[bbbb][rb-legacy]",
     ]);
     expect(commands.calls.flat()).not.toContain("terminate");
+    expect(commands.timeouts.every((timeoutMs) => (timeoutMs ?? 0) > 0)).toBe(true);
   });
 
   test("invalidates cached hierarchy when abort happens after signal dispatch", async () => {

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -112,6 +112,7 @@ describe("CrashApp (Android)", () => {
     timer.advanceTime(1234);
     adb.setCommandResultSequence("shell dumpsys activity processes", [
       "*APP* UID u10a123 ProcessRecord{abc 3220:com.example.app/u10a123}",
+      "*APP* UID u10a123 ProcessRecord{abc 3220:com.example.app/u10a123}",
       "*APP* UID u10a123 ProcessRecord{def 4881:com.example.other/u10a123}",
     ]);
     adb.setCommandResult(
@@ -159,6 +160,10 @@ describe("CrashApp (Android)", () => {
     const adb = new FakeAdbClient();
     adb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
     adb.setCommandResultSequence("shell dumpsys activity processes", [
+      [
+        "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+        "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
+      ].join("\n"),
       [
         "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
         "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
@@ -214,6 +219,10 @@ describe("CrashApp (Android)", () => {
         "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
         "*APP* UID u0a123 ProcessRecord{bbb 222:com.example.app:worker/u0a123}",
       ].join("\n"),
+      [
+        "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+        "*APP* UID u0a123 ProcessRecord{bbb 222:com.example.app:worker/u0a123}",
+      ].join("\n"),
       "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
     ]);
     adb.setCommandResult(
@@ -230,6 +239,34 @@ describe("CrashApp (Android)", () => {
     );
 
     expect(result).toMatchObject({ success: true, processId: 222, confirmed: true });
+  });
+
+  test("refreshes a relaunched app PID immediately before dispatch", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+      "*APP* UID u0a123 ProcessRecord{bbb 222:com.example.app/u0a123}",
+      "",
+    ]);
+    adb.setCommandResult(
+      "shell logcat -b crash -d -v epoch -t 200",
+      [
+        "E AndroidRuntime: FATAL EXCEPTION: main",
+        "E AndroidRuntime: Process: com.example.app, PID: 222",
+        "E AndroidRuntime: CrashedByAdbException: shell-induced crash",
+      ].join("\n"),
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      processId: 222,
+      userId: 0,
+      confirmed: true,
+    });
   });
 
   test("returns a typed not-running result without inducing a crash", async () => {
@@ -327,6 +364,7 @@ describe("CrashApp (Android)", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     adb.setCommandResultSequence("shell dumpsys activity processes", [
+      "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
       "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
       "",
     ]);

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -4,6 +4,7 @@ import {
   CrashApp,
   type CrashAppDependencies,
   findAndroidCrashEvidence,
+  findIosSimulatorCrashEvidence,
 } from "../../../src/features/action/CrashApp";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -68,7 +69,6 @@ class FakeSimulatorCommands {
 }
 
 const dependencies = (overrides: Partial<CrashAppDependencies> = {}): CrashAppDependencies => ({
-  resolveAndroidUserId: async () => 0,
   cacheInvalidator: { invalidate: () => {} },
   ...overrides,
 });
@@ -89,6 +89,21 @@ describe("CrashApp (Android)", () => {
     );
   });
 
+  test("rejects Android crash evidence older than the induction time", () => {
+    const output = [
+      "1700000000.000 E AndroidRuntime: FATAL EXCEPTION: main",
+      "1700000000.001 E AndroidRuntime: Process: com.example.app, PID: 222",
+      "1700000000.002 E AndroidRuntime: CrashedByAdbException: shell-induced crash",
+    ].join("\n");
+
+    expect(findAndroidCrashEvidence(output, "com.example.app", 222, 1_700_000_001_000)).toBe(
+      undefined,
+    );
+    expect(
+      findAndroidCrashEvidence(output, "com.example.app", 222, 1_700_000_000_000),
+    ).toBeDefined();
+  });
+
   test("induces and confirms an ActivityManager crash for the selected package", async () => {
     const adb = new FakeAdbClient();
     const timer = new FakeTimer();
@@ -98,7 +113,7 @@ describe("CrashApp (Android)", () => {
       "*APP* UID u10a123 ProcessRecord{def 4881:com.example.other/u10a123}",
     ]);
     adb.setCommandResult(
-      "shell logcat -b crash -d -v threadtime --pid=3220 -t 200",
+      "shell logcat -b crash -d -v epoch -t 200",
       [
         "E AndroidRuntime: FATAL EXCEPTION: main",
         "E AndroidRuntime: Process: com.example.app, PID: 3220",
@@ -111,7 +126,6 @@ describe("CrashApp (Android)", () => {
       dependencies({
         adb,
         timer,
-        resolveAndroidUserId: async () => 10,
         cacheInvalidator: { invalidate: () => invalidations++ },
       }),
     );
@@ -136,6 +150,83 @@ describe("CrashApp (Android)", () => {
     expect(adb.wasCommandExecuted("shell am crash --user 10 'com.example.app'")).toBe(true);
     expect(adb.wasCommandExecuted("force-stop")).toBe(false);
     expect(invalidations).toBe(1);
+  });
+
+  test("uses the foreground instance when a package runs under multiple users", async () => {
+    const adb = new FakeAdbClient();
+    adb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      [
+        "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+        "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
+      ].join("\n"),
+      "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
+    ]);
+    adb.setCommandResult(
+      "shell logcat -b crash -d -v epoch -t 200",
+      [
+        "E AndroidRuntime: FATAL EXCEPTION: main",
+        "E AndroidRuntime: Process: com.example.app, PID: 111",
+        "E AndroidRuntime: CrashedByAdbException: shell-induced crash",
+      ].join("\n"),
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({ success: true, userId: 0, processId: 111 });
+    expect(adb.wasCommandExecuted("shell am crash --user 0 'com.example.app'")).toBe(true);
+  });
+
+  test("rejects ambiguous multi-user instances instead of guessing a profile", async () => {
+    const adb = new FakeAdbClient();
+    adb.setForegroundApp({ packageName: "com.example.other", userId: 10 });
+    adb.setCommandResult(
+      "shell dumpsys activity processes",
+      [
+        "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+        "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
+      ].join("\n"),
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      wasRunning: true,
+      confirmed: false,
+    });
+    expect(result.error).toContain("multiple Android users");
+    expect(adb.wasCommandExecuted("shell am crash")).toBe(false);
+  });
+
+  test("reports the package-owned secondary process that actually crashed", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      [
+        "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+        "*APP* UID u0a123 ProcessRecord{bbb 222:com.example.app:worker/u0a123}",
+      ].join("\n"),
+      "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+    ]);
+    adb.setCommandResult(
+      "shell logcat -b crash -d -v epoch -t 200",
+      [
+        "E AndroidRuntime: FATAL EXCEPTION: main",
+        "E AndroidRuntime: Process: com.example.app:worker, PID: 222",
+        "E AndroidRuntime: CrashedByAdbException: shell-induced crash",
+      ].join("\n"),
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({ success: true, processId: 222, confirmed: true });
   });
 
   test("returns a typed not-running result without inducing a crash", async () => {
@@ -184,7 +275,11 @@ describe("CrashApp (Android)", () => {
       "shell am crash --user 0 'com.example.app'",
       new Error("Unknown command: crash"),
     );
-    const action = new CrashApp(androidDevice, dependencies({ adb }));
+    let invalidations = 0;
+    const action = new CrashApp(
+      androidDevice,
+      dependencies({ adb, cacheInvalidator: { invalidate: () => invalidations++ } }),
+    );
 
     const result = await action.execute("com.example.app");
 
@@ -196,9 +291,35 @@ describe("CrashApp (Android)", () => {
     });
     expect(result.error).toContain("Unknown command: crash");
     expect(adb.wasCommandExecuted("force-stop")).toBe(false);
+    expect(invalidations).toBe(1);
   });
 
-  test("reports accepted but unconfirmed when crash-specific evidence does not arrive", async () => {
+  test("treats an exit-zero ActivityManager permission refusal as failure", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult(
+      "shell dumpsys activity processes",
+      "*APP* UID u10a123 ProcessRecord{abc 3220:com.example.app/u10a123}",
+    );
+    adb.setCommandResult(
+      "shell am crash --user 10 'com.example.app'",
+      "Shell does not have permission to crash packages for user 10",
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      processId: 3220,
+      userId: 10,
+      confirmed: false,
+    });
+    expect(result.error).toContain("does not have permission");
+  });
+
+  test("reports failure when crash-specific evidence does not arrive", async () => {
     const adb = new FakeAdbClient();
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
@@ -206,23 +327,37 @@ describe("CrashApp (Android)", () => {
       "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
       "",
     ]);
-    adb.setCommandResult("shell logcat -b crash -d -v threadtime --pid=3220 -t 200", "");
+    adb.setCommandResult("shell logcat -b crash -d -v epoch -t 200", "");
     const action = new CrashApp(androidDevice, dependencies({ adb, timer }));
 
     const result = await action.execute("com.example.app");
 
     expect(result).toMatchObject({
-      success: true,
+      success: false,
       supported: true,
       wasRunning: true,
       confirmed: false,
       processId: 3220,
     });
+    expect(result.error).toContain("no fresh OS crash evidence");
     expect(result.evidence).toBeUndefined();
   });
 });
 
 describe("CrashApp (iOS)", () => {
+  test("rejects unified-log crash evidence older than the induction time", () => {
+    const output =
+      "2023-11-14 22:13:20.100+0000 launchd_sim: " +
+      "UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT";
+
+    expect(
+      findIosSimulatorCrashEvidence(output, "com.example.app", 27955, 1_700_000_001_000),
+    ).toBeUndefined();
+    expect(
+      findIosSimulatorCrashEvidence(output, "com.example.app", 27955, 1_700_000_000_000),
+    ).toBeDefined();
+  });
+
   test("signals and confirms the exact simulator app process", async () => {
     const processList = [
       "PID\tStatus\tLabel",
@@ -231,10 +366,10 @@ describe("CrashApp (iOS)", () => {
     ].join("\n");
     const commands = new FakeSimulatorCommands(
       [processList, "PID\tStatus\tLabel\n"],
-      "launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT",
+      "2023-11-14 22:13:20.100 launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT",
     );
     const timer = new FakeTimer();
-    timer.advanceTime(5678);
+    timer.advanceTime(1_700_000_000_000);
     const action = new CrashApp(iosSimulator, dependencies({ simctl: commands, timer }));
 
     const result = await action.execute("com.example.app");
@@ -246,7 +381,7 @@ describe("CrashApp (iOS)", () => {
       appId: "com.example.app",
       processId: 27955,
       mechanism: "ios_simulator_sigabrt",
-      timestamp: 5678,
+      timestamp: 1_700_000_000_000,
       wasRunning: true,
       confirmed: true,
       evidence: {
@@ -256,11 +391,41 @@ describe("CrashApp (iOS)", () => {
     expect(commands.calls).toContainEqual([
       "spawn",
       iosSimulator.deviceId,
-      "/bin/kill",
-      "-ABRT",
-      "27955",
+      "launchctl",
+      "kill",
+      "SIGABRT",
+      "user/501/UIKitApplication:com.example.app[bbbb][rb-legacy]",
     ]);
     expect(commands.calls.flat()).not.toContain("terminate");
+  });
+
+  test("invalidates cached hierarchy when abort happens after signal dispatch", async () => {
+    const controller = new AbortController();
+    let invalidations = 0;
+    const simctl = {
+      executeCommandArgs: async (
+        args: string[],
+        _timeoutMs?: number,
+        signal?: AbortSignal,
+      ): Promise<ExecResult> => {
+        if (args.at(-2) === "launchctl" && args.at(-1) === "list") {
+          return execResult("27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]");
+        }
+        controller.abort();
+        signal?.throwIfAborted();
+        return execResult();
+      },
+    };
+    const action = new CrashApp(
+      iosSimulator,
+      dependencies({
+        simctl,
+        cacheInvalidator: { invalidate: () => invalidations++ },
+      }),
+    );
+
+    await expect(action.execute("com.example.app", controller.signal)).rejects.toThrow();
+    expect(invalidations).toBe(1);
   });
 
   test("returns a typed not-running result without signaling another bundle", async () => {
@@ -284,8 +449,15 @@ describe("CrashApp (iOS)", () => {
     const commands = new FakeSimulatorCommands([
       "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
     ]);
-    commands.setError("/bin/kill", new Error("Operation not permitted"));
-    const action = new CrashApp(iosSimulator, dependencies({ simctl: commands }));
+    commands.setError("launchctl kill", new Error("Operation not permitted"));
+    let invalidations = 0;
+    const action = new CrashApp(
+      iosSimulator,
+      dependencies({
+        simctl: commands,
+        cacheInvalidator: { invalidate: () => invalidations++ },
+      }),
+    );
 
     const result = await action.execute("com.example.app");
 
@@ -298,9 +470,10 @@ describe("CrashApp (iOS)", () => {
       error: "Operation not permitted",
     });
     expect(commands.calls.flat()).not.toContain("terminate");
+    expect(invalidations).toBe(1);
   });
 
-  test("reports accepted but unconfirmed when unified-log evidence is unavailable", async () => {
+  test("reports failure when unified-log evidence is unavailable", async () => {
     const commands = new FakeSimulatorCommands([
       "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
       "",
@@ -312,12 +485,13 @@ describe("CrashApp (iOS)", () => {
     const result = await action.execute("com.example.app");
 
     expect(result).toMatchObject({
-      success: true,
+      success: false,
       supported: true,
       wasRunning: true,
       processId: 27955,
       confirmed: false,
     });
+    expect(result.error).toContain("no fresh OS crash evidence");
     expect(result.evidence).toBeUndefined();
   });
 
@@ -333,9 +507,9 @@ describe("CrashApp (iOS)", () => {
       platform: "ios",
       appId: "com.example.app",
       mechanism: "unsupported",
-      wasRunning: false,
       confirmed: false,
     });
+    expect(result.wasRunning).toBeUndefined();
     expect(result.error).toContain("physical iOS");
     expect(commands.calls).toEqual([]);
   });

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -41,10 +41,12 @@ class FakeSimulatorCommands {
   private launchctlResults: string[];
   private readonly logOutput: string;
   private readonly errors = new Map<string, Error>();
+  private readonly onExecute?: () => void;
 
-  constructor(launchctlResults: string[], logOutput = "") {
+  constructor(launchctlResults: string[], logOutput = "", onExecute?: () => void) {
     this.launchctlResults = [...launchctlResults];
     this.logOutput = logOutput;
+    this.onExecute = onExecute;
   }
 
   setError(match: string, error: Error): void {
@@ -52,6 +54,7 @@ class FakeSimulatorCommands {
   }
 
   async executeCommandArgs(args: string[], timeoutMs?: number): Promise<ExecResult> {
+    this.onExecute?.();
     this.calls.push([...args]);
     this.timeouts.push(timeoutMs);
     const command = args.join(" ");
@@ -239,6 +242,39 @@ describe("CrashApp (Android)", () => {
     );
 
     expect(result).toMatchObject({ success: true, processId: 222, confirmed: true });
+  });
+
+  test("crashes an app running only in a fully qualified custom process", async () => {
+    const adb = new FakeAdbClient();
+    const customProcess = [
+      "*APP* UID u0a123 ProcessRecord{aaa 777:com.example.shared/u0a123}",
+      "    packageList={com.example.app}",
+    ].join("\n");
+    adb.setCommandResultSequence("shell dumpsys activity processes", [
+      customProcess,
+      customProcess,
+      "",
+    ]);
+    adb.setCommandResult(
+      "shell logcat -b crash -d -v epoch -t 200",
+      [
+        "E AndroidRuntime: FATAL EXCEPTION: main",
+        "E AndroidRuntime: Process: com.example.shared, PID: 777",
+        "E AndroidRuntime: CrashedByAdbException: shell-induced crash",
+      ].join("\n"),
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      processId: 777,
+      userId: 0,
+      confirmed: true,
+    });
+    expect(adb.wasCommandExecuted("shell am crash --user 0 'com.example.app'")).toBe(true);
   });
 
   test("refreshes a relaunched app PID immediately before dispatch", async () => {
@@ -463,6 +499,24 @@ describe("CrashApp (iOS)", () => {
     ]);
     expect(commands.calls.flat()).not.toContain("terminate");
     expect(commands.timeouts.every((timeoutMs) => (timeoutMs ?? 0) > 0)).toBe(true);
+  });
+
+  test("timestamps induction after simulator process preflight", async () => {
+    const process = "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]";
+    const timer = new FakeTimer();
+    timer.advanceTime(1_000);
+    const commands = new FakeSimulatorCommands(
+      [process, process, ""],
+      "2023-11-14 22:13:20.100 launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT",
+      () => timer.advanceTime(100),
+    );
+
+    const result = await new CrashApp(
+      iosSimulator,
+      dependencies({ simctl: commands, timer }),
+    ).execute("com.example.app");
+
+    expect(result).toMatchObject({ success: true, timestamp: 1_200, confirmed: true });
   });
 
   test("refreshes a relaunched simulator PID immediately before signaling", async () => {

--- a/test/features/action/CrashApp.test.ts
+++ b/test/features/action/CrashApp.test.ts
@@ -305,6 +305,30 @@ describe("CrashApp (Android)", () => {
     expect(adb.wasCommandExecuted("shell")).toBe(false);
   });
 
+  test("does not compare host fallback time against device-authored crash logs", async () => {
+    const adb = new FakeAdbClient();
+    adb.setDeviceTimestampSource("host");
+    adb.setCommandResult(
+      "shell dumpsys activity processes",
+      "*APP* UID u0a123 ProcessRecord{abc 3220:com.example.app/u0a123}",
+    );
+
+    const result = await new CrashApp(androidDevice, dependencies({ adb })).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      supported: true,
+      wasRunning: true,
+      processId: 3220,
+      userId: 0,
+      confirmed: false,
+    });
+    expect(result.error).toContain("Android device time");
+    expect(adb.wasCommandExecuted("shell am crash")).toBe(false);
+  });
+
   test("reports unsupported when ActivityManager has no crash command and never force-stops", async () => {
     const adb = new FakeAdbClient();
     adb.setCommandResult(
@@ -406,7 +430,7 @@ describe("CrashApp (iOS)", () => {
       "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
     ].join("\n");
     const commands = new FakeSimulatorCommands(
-      [processList, "PID\tStatus\tLabel\n"],
+      [processList, processList, "PID\tStatus\tLabel\n"],
       "2023-11-14 22:13:20.100 launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [27955]: exited due to SIGABRT",
     );
     const timer = new FakeTimer();
@@ -439,6 +463,32 @@ describe("CrashApp (iOS)", () => {
     ]);
     expect(commands.calls.flat()).not.toContain("terminate");
     expect(commands.timeouts.every((timeoutMs) => (timeoutMs ?? 0) > 0)).toBe(true);
+  });
+
+  test("refreshes a relaunched simulator PID immediately before signaling", async () => {
+    const before = "111\t0\tUIKitApplication:com.example.app[aaaa][rb-legacy]";
+    const atDispatch = "222\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]";
+    const commands = new FakeSimulatorCommands(
+      [before, atDispatch, ""],
+      "2023-11-14 22:13:20.100 launchd_sim: UIKitApplication:com.example.app[bbbb][rb-legacy] [222]: exited due to SIGABRT",
+    );
+    const timer = new FakeTimer();
+    timer.advanceTime(1_700_000_000_000);
+
+    const result = await new CrashApp(
+      iosSimulator,
+      dependencies({ simctl: commands, timer }),
+    ).execute("com.example.app");
+
+    expect(result).toMatchObject({ success: true, processId: 222, confirmed: true });
+    expect(commands.calls).toContainEqual([
+      "spawn",
+      iosSimulator.deviceId,
+      "launchctl",
+      "kill",
+      "SIGABRT",
+      "user/501/UIKitApplication:com.example.app[bbbb][rb-legacy]",
+    ]);
   });
 
   test("invalidates cached hierarchy when abort happens after signal dispatch", async () => {
@@ -490,6 +540,7 @@ describe("CrashApp (iOS)", () => {
   test("preserves known running metadata when SIGABRT is rejected", async () => {
     const commands = new FakeSimulatorCommands([
       "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
+      "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
     ]);
     commands.setError("launchctl kill", new Error("Operation not permitted"));
     let invalidations = 0;
@@ -517,6 +568,7 @@ describe("CrashApp (iOS)", () => {
 
   test("reports failure when unified-log evidence is unavailable", async () => {
     const commands = new FakeSimulatorCommands([
+      "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
       "27955\t0\tUIKitApplication:com.example.app[bbbb][rb-legacy]",
       "",
     ]);

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -1006,6 +1006,7 @@ describe("TapOnElement screen-reader navigation result", () => {
     spyOn(command as any, "executeAndroidTapWithCoordinates").mockResolvedValue(undefined);
     spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
     spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
+    spyOn(command as any, "deriveTapEffectAfterPostTapObservation").mockResolvedValue(undefined);
     return command;
   };
 

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -1006,7 +1006,6 @@ describe("TapOnElement screen-reader navigation result", () => {
     spyOn(command as any, "executeAndroidTapWithCoordinates").mockResolvedValue(undefined);
     spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
     spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
-    spyOn(command as any, "deriveTapEffectAfterPostTapObservation").mockResolvedValue(undefined);
     return command;
   };
 

--- a/test/features/record/McpCallRecorder.test.ts
+++ b/test/features/record/McpCallRecorder.test.ts
@@ -73,6 +73,19 @@ describe("McpCallRecorder", () => {
       expect(recorder.stepCount).toBe(7);
     });
 
+    test("records crashApp with only reproducible plan parameters", () => {
+      const recorder = new McpCallRecorder();
+      recorder.start();
+
+      recorder.record("crashApp", {
+        appId: "com.test",
+        platform: "android",
+        deviceId: "emulator-5554",
+      });
+
+      expect(recorder.stop()).toEqual([{ tool: "crashApp", params: { appId: "com.test" } }]);
+    });
+
     test("records clearText and dragAndDrop as plan steps", () => {
       const recorder = new McpCallRecorder();
       recorder.start();

--- a/test/models/BaseActionResult.test.ts
+++ b/test/models/BaseActionResult.test.ts
@@ -59,6 +59,7 @@ const EXTENDS_TYPES: Record<string, string> = {
   AppStatusResult: "isInstalled",
   BiometricAuthResult: "modality",
   ClearAppDataResult: "packageName",
+  CrashAppResult: "supported",
   DragAndDropResult: "distance",
   ExitDialogResult: "elementFound",
   InstallAppResult: "artifactPath",

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -254,6 +254,33 @@ describe("crashApp tool", () => {
     expect(payload.message).toContain("OS crash confirmed");
     expect(payload.confirmed).toBe(true);
   });
+
+  test("invalidates cached app resources when cancellation follows crash dispatch", async () => {
+    const controller = new AbortController();
+    let invalidations = 0;
+    let notifications = 0;
+    setCrashAppToolDependencies({
+      createCrashApp: () => ({
+        execute: async () => {
+          controller.abort();
+          controller.signal.throwIfAborted();
+          throw new Error("unreachable");
+        },
+      }),
+      invalidateAppResourceCache: () => invalidations++,
+      notifyAppResourceUpdated: async () => {
+        notifications++;
+      },
+    });
+    const tool = ToolRegistry.getTool("crashApp");
+
+    await expect(
+      tool!.deviceAwareHandler!(device, { appId: "com.example.app" }, undefined, controller.signal),
+    ).rejects.toThrow();
+
+    expect(invalidations).toBe(1);
+    expect(notifications).toBe(0);
+  });
 });
 
 describe("app permission tools", () => {

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -2,8 +2,10 @@ import Ajv2020 from "ajv/dist/2020";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   registerAppTools,
+  resetCrashAppToolDependencies,
   resetListAppsToolDependencies,
   resetTerminateAppToolDependencies,
+  setCrashAppToolDependencies,
   setListAppsToolDependencies,
   setTerminateAppToolDependencies,
 } from "../../src/server/appTools";
@@ -169,6 +171,84 @@ describe("terminateApp tool", () => {
     await expect(tool!.deviceAwareHandler!(device, { appId: "com.example.app" })).rejects.toThrow(
       "The installed-app listing failed",
     );
+  });
+});
+
+describe("crashApp tool", () => {
+  const device: BootedDevice = {
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    resetCrashAppToolDependencies();
+    registerAppTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    resetCrashAppToolDependencies();
+  });
+
+  test("returns an explicit unsupported result as structured JSON", async () => {
+    setCrashAppToolDependencies({
+      createCrashApp: () => ({
+        execute: async () => ({
+          success: false,
+          supported: false,
+          platform: "ios",
+          appId: "com.example.app",
+          mechanism: "unsupported",
+          timestamp: 1234,
+          wasRunning: false,
+          confirmed: false,
+          error: "Physical iOS devices are unsupported",
+        }),
+      }),
+    });
+    const tool = ToolRegistry.getTool("crashApp");
+
+    const response = await tool!.deviceAwareHandler!(device, {
+      appId: "com.example.app",
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(payload).toMatchObject({
+      message: "Physical iOS devices are unsupported",
+      success: false,
+      supported: false,
+      confirmed: false,
+    });
+  });
+
+  test("reports the mechanism and OS confirmation on success", async () => {
+    setCrashAppToolDependencies({
+      createCrashApp: () => ({
+        execute: async () => ({
+          success: true,
+          supported: true,
+          platform: "ios",
+          appId: "com.example.app",
+          processId: 42,
+          mechanism: "ios_simulator_sigabrt",
+          timestamp: 1234,
+          wasRunning: true,
+          confirmed: true,
+        }),
+      }),
+    });
+    const tool = ToolRegistry.getTool("crashApp");
+
+    const response = await tool!.deviceAwareHandler!(device, {
+      appId: "com.example.app",
+    });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(payload.message).toContain("ios_simulator_sigabrt");
+    expect(payload.message).toContain("OS crash confirmed");
+    expect(payload.confirmed).toBe(true);
   });
 });
 

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -1,6 +1,7 @@
 import Ajv2020 from "ajv/dist/2020";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  crashAppResultSchema,
   registerAppTools,
   resetCrashAppToolDependencies,
   resetListAppsToolDependencies,
@@ -202,7 +203,6 @@ describe("crashApp tool", () => {
           appId: "com.example.app",
           mechanism: "unsupported",
           timestamp: 1234,
-          wasRunning: false,
           confirmed: false,
           error: "Physical iOS devices are unsupported",
         }),
@@ -215,6 +215,8 @@ describe("crashApp tool", () => {
     });
     const payload = JSON.parse(response.content[0].text);
 
+    expect(response.structuredContent).toEqual(payload);
+    expect(crashAppResultSchema.safeParse(response.structuredContent).success).toBe(true);
     expect(payload).toMatchObject({
       message: "Physical iOS devices are unsupported",
       success: false,
@@ -246,6 +248,8 @@ describe("crashApp tool", () => {
     });
     const payload = JSON.parse(response.content[0].text);
 
+    expect(response.structuredContent).toEqual(payload);
+    expect(crashAppResultSchema.safeParse(response.structuredContent).success).toBe(true);
     expect(payload.message).toContain("ios_simulator_sigabrt");
     expect(payload.message).toContain("OS crash confirmed");
     expect(payload.confirmed).toBe(true);

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../src/server/toolSchemaHelpers";
 import { accessibilitySchema } from "../../src/server/accessibilityTools";
 import {
+  crashAppSchema,
   packageNameSchema,
   launchAppSchema,
   installAppSchema,
@@ -222,6 +223,19 @@ describe("appId aliases on tool schemas", () => {
     }
   });
 
+  test("crashAppSchema accepts bundleId as an appId alias", () => {
+    const result = crashAppSchema.safeParse({
+      bundleId: "com.example.app",
+      platform: "ios",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("com.example.app");
+      expect("bundleId" in result.data).toBe(false);
+    }
+  });
+
   test("launchAppSchema accepts natural app identifier aliases", () => {
     for (const alias of [
       "package",
@@ -368,6 +382,7 @@ describe("generated tool definitions", () => {
 describe("platform field accepted by all device-targeting tool schemas", () => {
   const toolSchemas: [string, z.ZodType<any>, Record<string, unknown>][] = [
     ["accessibilitySchema", accessibilitySchema, {}],
+    ["crashAppSchema", crashAppSchema, { appId: "com.example" }],
     ["packageNameSchema", packageNameSchema, { appId: "com.example" }],
     ["launchAppSchema", launchAppSchema, { appId: "com.example" }],
     ["installAppSchema", installAppSchema, { artifactPath: "/tmp/app.apk" }],

--- a/test/server/tools/registry.test.ts
+++ b/test/server/tools/registry.test.ts
@@ -26,6 +26,7 @@ describe("MCP Tools Registry", () => {
     // Should include app management tools (MCP app lifecycle)
     expect(toolNames).toContain("launchApp");
     expect(toolNames).toContain("terminateApp");
+    expect(toolNames).toContain("crashApp");
     expect(toolNames).toContain("listApps");
   });
 
@@ -61,7 +62,7 @@ describe("MCP Tools Registry", () => {
   test("should expose registered output schemas in generated MCP tool definitions", () => {
     const toolDefinitions = ToolRegistry.getToolDefinitions();
 
-    for (const toolName of ["executePlan", "tapOn"]) {
+    for (const toolName of ["executePlan", "tapOn", "crashApp"]) {
       const tool = toolDefinitions.find((definition) => definition.name === toolName);
       expect(tool).toBeDefined();
       expect(tool).toHaveProperty("outputSchema");
@@ -112,7 +113,7 @@ describe("MCP Tools Registry", () => {
         "dragAndDrop",
         "pinchOn",
       ],
-      app: ["launchApp", "terminateApp", "installApp", "uninstallApp", "listApps"],
+      app: ["launchApp", "terminateApp", "crashApp", "installApp", "uninstallApp", "listApps"],
       utility: ["rotate", "setActiveDevice", "openLink", "getDeviceState", "setDeviceState"],
       device: [
         "listDeviceImages",

--- a/test/utils/android-cmdline-tools/androidProcessState.test.ts
+++ b/test/utils/android-cmdline-tools/androidProcessState.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findAndroidPackageProcessId,
+  isAndroidPackageRunning,
+} from "../../../src/utils/android-cmdline-tools/androidProcessState";
+
+describe("androidProcessState", () => {
+  test("finds the main process PID for the selected app user", () => {
+    const output = [
+      "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+      "*APP* UID u10a123 ProcessRecord{bbb 222:com.example.app/u10a123}",
+    ].join("\n");
+
+    expect(findAndroidPackageProcessId(output, "com.example.app", 10)).toBe(222);
+    expect(isAndroidPackageRunning(output, "com.example.app", 10)).toBe(true);
+  });
+
+  test("maps numeric system UIDs to their Android user", () => {
+    const output = "*APP* UID 1000 ProcessRecord{aaa 30779:com.android.settings/1000}";
+
+    expect(findAndroidPackageProcessId(output, "com.android.settings", 0)).toBe(30779);
+    expect(findAndroidPackageProcessId(output, "com.android.settings", 10)).toBeNull();
+  });
+
+  test("prefers the main process over a secondary package process", () => {
+    const output = [
+      "*APP* UID u0a123 ProcessRecord{aaa 444:com.example.app:worker/u0a123}",
+      "*APP* UID u0a123 ProcessRecord{bbb 555:com.example.app/u0a123}",
+    ].join("\n");
+
+    expect(findAndroidPackageProcessId(output, "com.example.app", 0)).toBe(555);
+  });
+
+  test("returns a secondary process when it is the package's only running process", () => {
+    const output = "*APP* UID u0a123 ProcessRecord{aaa 444:com.example.app:worker/u0a123}";
+
+    expect(findAndroidPackageProcessId(output, "com.example.app", 0)).toBe(444);
+  });
+});

--- a/test/utils/android-cmdline-tools/androidProcessState.test.ts
+++ b/test/utils/android-cmdline-tools/androidProcessState.test.ts
@@ -53,4 +53,19 @@ describe("androidProcessState", () => {
       { pid: 444, processName: "com.example.app:isolated", userId: 10 },
     ]);
   });
+
+  test("finds a package running only in a fully qualified custom process", () => {
+    const output = [
+      "*APP* UID u10a123 ProcessRecord{aaa 777:com.example.shared/u10a123}",
+      "    packageList={com.example.app, com.example.library}",
+      "*APP* UID u0a456 ProcessRecord{bbb 888:com.example.other/u0a456}",
+      "    packageList={com.example.other}",
+    ].join("\n");
+
+    expect(findAndroidPackageProcesses(output, "com.example.app")).toEqual([
+      { pid: 777, processName: "com.example.shared", userId: 10 },
+    ]);
+    expect(isAndroidPackageRunning(output, "com.example.app", 10)).toBe(true);
+    expect(findAndroidPackageProcessId(output, "com.example.app", 10)).toBe(777);
+  });
 });

--- a/test/utils/android-cmdline-tools/androidProcessState.test.ts
+++ b/test/utils/android-cmdline-tools/androidProcessState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   findAndroidPackageProcessId,
+  findAndroidPackageProcesses,
   isAndroidPackageRunning,
 } from "../../../src/utils/android-cmdline-tools/androidProcessState";
 
@@ -35,5 +36,21 @@ describe("androidProcessState", () => {
     const output = "*APP* UID u0a123 ProcessRecord{aaa 444:com.example.app:worker/u0a123}";
 
     expect(findAndroidPackageProcessId(output, "com.example.app", 0)).toBe(444);
+  });
+
+  test("lists package-owned process identities across Android users", () => {
+    const output = [
+      "*APP* UID u0a123 ProcessRecord{aaa 111:com.example.app/u0a123}",
+      "*APP* UID u0a123 ProcessRecord{bbb 222:com.example.app:worker/u0a123}",
+      "*APP* UID u10a123 ProcessRecord{ccc 333:com.example.app/u10a123}",
+      "*APP* UID u10i42 ProcessRecord{ddd 444:com.example.app:isolated/u10i42}",
+    ].join("\n");
+
+    expect(findAndroidPackageProcesses(output, "com.example.app")).toEqual([
+      { pid: 111, processName: "com.example.app", userId: 0 },
+      { pid: 222, processName: "com.example.app:worker", userId: 0 },
+      { pid: 333, processName: "com.example.app", userId: 10 },
+      { pid: 444, processName: "com.example.app:isolated", userId: 10 },
+    ]);
   });
 });

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -268,6 +268,18 @@ describe("PlanMigrator", () => {
         expect(plan.steps[0].params.bundleId).toBeUndefined();
       });
 
+      test("renames packageName to appId for crashApp", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "crashApp", params: { packageName: "com.example.app" } }],
+        });
+
+        expect(plan.steps[0].params.appId).toBe("com.example.app");
+        expect(plan.steps[0].params.packageName).toBeUndefined();
+      });
+
       test("defaults tapOn.action to tap", () => {
         const { plan } = migratePlan({
           name: "Plan",


### PR DESCRIPTION
## Summary
- add a bounded `crashApp` MCP tool that uses Android ActivityManager's real crash path and iOS Simulator `SIGABRT`
- confirm crashes with process-specific OS evidence while never falling back to force-stop or `SIGKILL`
- keep physical iOS explicitly unsupported and wire schemas, timeout handling, plan tooling, docs, and generated definitions

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test --isolate` (15,069 passed, 14 skipped)
- [x] `scripts/all_fast_validate_checks.sh` (35 passed)
- [x] Android `:test-plan-validation:test` and `:ide-plugin:test`
- [x] Manual Android emulator crash and iOS Simulator crash verification

Closes https://github.com/kaeawc/auto-mobile/issues/5977

Made with [Cursor](https://cursor.com)