### PR TITLE
fix(mcp): refresh discovery after tool selection

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1804,18 +1804,20 @@ export class DaemonMcpProxy {
     requestedArgs: Record<string, unknown>,
     result: unknown,
   ): void {
-    if (
-      name !== SET_TOOL_ENABLED_TOOL_NAME ||
-      (typeof requestedArgs.sessionUuid === "string" && requestedArgs.sessionUuid.trim().length > 0)
-    ) {
+    if (name !== SET_TOOL_ENABLED_TOOL_NAME) {
       return;
     }
-    const sessionUuid = toolSelectionProfileUuidFromResponse(result);
-    if (sessionUuid) {
-      this.toolSelectionProfileUuid = sessionUuid;
-      this.discoveryEpoch += 1;
-      this.cachedTools = null;
+    const hasExplicitSessionUuid =
+      typeof requestedArgs.sessionUuid === "string" && requestedArgs.sessionUuid.trim().length > 0;
+    if (!hasExplicitSessionUuid) {
+      const sessionUuid = toolSelectionProfileUuidFromResponse(result);
+      if (sessionUuid) {
+        this.toolSelectionProfileUuid = sessionUuid;
+      }
     }
+    // Do not depend solely on the daemon's best-effort list_changed delivery.
+    // The successful update has already changed the authoritative tool surface.
+    this.notifyListChanged("tools");
   }
 
   private isBoundSessionReplayExpired(): boolean {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -3898,6 +3898,120 @@ describe("DaemonMcpProxy", () => {
   });
 
   describe("connection tool-selection profiles", () => {
+    test("invalidates cached discovery after an explicit tool update without waiting for list_changed (#5980)", async () => {
+      const daemonMethodResults = new Map<string, any>([
+        ["tools/list", { tools: [{ name: "setToolEnabled" }] }],
+      ]);
+      const client = new FakeDaemonClient({
+        daemonMethodResults,
+        onCallTool: (toolName) => {
+          if (toolName === "setToolEnabled") {
+            daemonMethodResults.set("tools/list", {
+              tools: [{ name: "setToolEnabled" }, { name: "openLink" }],
+            });
+          }
+        },
+        toolResultFor: (toolName) =>
+          toolName === "setToolEnabled"
+            ? {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      sessionUuid: "device-session-a",
+                      toolName: "openLink",
+                      enabled: true,
+                    }),
+                  },
+                ],
+              }
+            : undefined,
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+      const listChangedKinds: string[] = [];
+      proxy.onListChanged((kind) => listChangedKinds.push(kind));
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "device-session-a" });
+        expect(await proxy.listTools()).toEqual([{ name: "setToolEnabled" }]);
+
+        await proxy.callTool("setToolEnabled", {
+          toolName: "openLink",
+          enabled: true,
+          sessionUuid: "device-session-a",
+        });
+
+        expect(await proxy.listTools()).toEqual([{ name: "setToolEnabled" }, { name: "openLink" }]);
+        expect(listChangedKinds).toEqual(["tools"]);
+        expect(client.callDaemonMethodCalls.filter((call) => call.method === "tools/list")).toEqual(
+          [
+            { method: "tools/list", params: { sessionUuid: "device-session-a" } },
+            { method: "tools/list", params: { sessionUuid: "device-session-a" } },
+          ],
+        );
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("retains explicit tool-selection discovery scope across a daemon reconnect (#5980)", async () => {
+      const firstClient = new FakeDaemonClient({
+        toolResultFor: (toolName) =>
+          toolName === "setToolEnabled"
+            ? {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      sessionUuid: "device-session-a",
+                      toolName: "openLink",
+                      enabled: true,
+                    }),
+                  },
+                ],
+              }
+            : undefined,
+      });
+      const replacementClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "setToolEnabled" }, { name: "openLink" }] }],
+        ]),
+      });
+      const clients: DaemonClientLike[] = [firstClient, replacementClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "device-session-a" });
+        await proxy.callTool("setToolEnabled", {
+          toolName: "openLink",
+          enabled: true,
+          sessionUuid: "device-session-a",
+        });
+        firstClient.emitConnectionClosed();
+        await Promise.resolve();
+
+        expect(await proxy.listTools()).toEqual([{ name: "setToolEnabled" }, { name: "openLink" }]);
+        expect(replacementClient.callDaemonMethodCalls).toContainEqual({
+          method: "tools/list",
+          params: { sessionUuid: "device-session-a" },
+        });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("keeps an omitted tool-selection update on the connection profile after device routing binds", async () => {
       const client = new ScriptedDaemonClient({
         toolResult: {


### PR DESCRIPTION
## Summary

- invalidate the daemon proxy's cached tool catalog after every successful `setToolEnabled` call
- emit `notifications/tools/list_changed` locally so dropped daemon notifications cannot strand a stale host catalog
- preserve and test session-scoped discovery across daemon reconnects

## Linked Issue

Closes #5980

## Bug / Regression Context

- **Prior attempts:** Existing direct selection and notification-forwarding tests covered each layer independently but not the successful explicit-session update boundary.
- **Observed symptom:** A default-off tool such as `openLink` could remain absent after `setToolEnabled` returned success.
- **Repro steps / conditions:** Prewarm the proxy's session-scoped `tools/list` cache, enable `openLink` with the active `sessionUuid`, and refresh after a delayed or dropped daemon list-change notification.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes
- [x] `bun run turbo:validate` passes (lint, build, full test suite, and boundary checks)
- [x] `bun run typecheck` reports no new errors
- [x] Focused daemon proxy, list-change, session discovery, and tool-selection suites pass (177 tests)
- [x] New coverage uses existing fakes and completes in under 100ms per test
- [x] No new helper or dependency
- [x] Rebased onto latest `main`

## Device Verification

Not applicable: this change is isolated to MCP proxy catalog invalidation and is covered through the daemon client fake and host notification forwarding tests.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)