### PR TITLE
test(video): assert recordings retain duration

### DIFF
--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -39,6 +39,12 @@ interface FfprobeStream {
   width?: number;
   height?: number;
   duration?: string;
+  nb_read_frames?: string;
+}
+
+interface FfprobeResult {
+  streams?: FfprobeStream[];
+  format?: { duration?: string };
 }
 
 function parseToolResult(response: ToolTextResponse): RecordingToolResult {
@@ -91,24 +97,34 @@ async function assertCommandAvailable(command: string, args: string[]): Promise<
   }
 }
 
-async function assertPlayableMp4(filePath: string): Promise<FfprobeStream> {
+async function assertPlayableMp4(
+  filePath: string,
+): Promise<{ stream: FfprobeStream; duration: number; frames: number }> {
   const { stdout } = await execFileAsync("ffprobe", [
     "-v",
     "error",
+    "-count_frames",
     "-select_streams",
     "v:0",
     "-show_entries",
-    "stream=codec_type,codec_name,width,height,duration",
+    "stream=codec_type,codec_name,width,height,duration,nb_read_frames:format=duration",
     "-of",
     "json",
     filePath,
   ]);
-  const parsed = JSON.parse(stdout) as { streams?: FfprobeStream[] };
+  const parsed = JSON.parse(stdout) as FfprobeResult;
   const stream = parsed.streams?.find((candidate) => candidate.codec_type === "video");
   if (!stream) {
     throw new Error(`ffprobe did not find a video stream in ${filePath}: ${stdout}`);
   }
-  return stream;
+  const duration = Number.parseFloat(parsed.format?.duration ?? "NaN");
+  const frames = Number.parseInt(stream.nb_read_frames ?? "0", 10);
+  if (!Number.isFinite(duration) || duration <= 0 || frames <= 1) {
+    throw new Error(
+      `ffprobe expected a multi-frame recording with positive duration: ${JSON.stringify(parsed)}`,
+    );
+  }
+  return { stream, duration, frames };
 }
 
 describeIntegration("iOS videoRecording start-stop integration", () => {
@@ -180,8 +196,10 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
           0,
         );
 
-        const videoStream = await assertPlayableMp4(mp4Path!);
-        expect(videoStream.codec_type).toBe("video");
+        const video = await assertPlayableMp4(mp4Path!);
+        expect(video.stream.codec_type).toBe("video");
+        expect(video.duration).toBeGreaterThan(0);
+        expect(video.frames).toBeGreaterThan(1);
       } catch (error) {
         let cleanupError: string | undefined;
         if (recordingId && !stopped) {


### PR DESCRIPTION
## Summary

- Strengthens the iOS `videoRecording` start/stop integration assertion to require a positive duration and more than one decoded video frame.
- This makes the single-frame/no-duration regression from #5982 fail instead of accepting a merely non-empty MP4.
- The production Android lifecycle fix is already present on `main` via #5961; this PR adds the missing regression coverage.

## Linked Issue

Closes #5982

## Bug / Regression Context

- **Prior attempts:** The production fix landed in #5961, but the integration test only checked that the output file was non-empty and contained a video stream.
- **Observed symptom:** `videoRecording` could report success for a structurally valid MP4 containing exactly one frame and no duration.
- **Repro steps / conditions:** Start `videoRecording`, wait several seconds, stop it, then inspect the resulting MP4 with `ffprobe`.

## Validation

- [x] `bun test --isolate` — 15,138 passed, 14 skipped, 0 failed
- [x] `bun test test/features/video/PlatformVideoCaptureBackend.test.ts test/features/video/FfmpegVideoProcessingBackend.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run format:check`
- [ ] Real iOS integration test — attempted after rebuilding and restarting the daemon; the local CLI could not advertise `getIos`, so no recording session could be bound.

## Risk

The change only tightens device integration assertions and does not alter runtime recording behavior.
