### PR TITLE
test(daemon): cover storage observer cleanup on socket close

### DIFF
--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -2647,6 +2647,55 @@ describe("DeviceDataStreamSocketServer", () => {
       ]);
     });
 
+    it("releases only a closing socket's final owned observers", async () => {
+      const calls: StorageSubReq[] = [];
+      const secondaryReleased = Promise.withResolvers<void>();
+      const sharedReleased = Promise.withResolvers<void>();
+      server.setOnStorageSubscriptionRequested(async (request) => {
+        calls.push(request);
+        if (!request.subscribe && request.fileName === "secondary.xml") {
+          secondaryReleased.resolve();
+        }
+        if (!request.subscribe && request.fileName === "prefs.xml") {
+          sharedReleased.resolve();
+        }
+      });
+      const first = new FakeSocket();
+      const second = new FakeSocket();
+      const subscribe = (socket: FakeSocket, id: string, fileName: string) =>
+        server.processLineForTest(
+          socket,
+          JSON.stringify({
+            id,
+            command: "subscribe_storage",
+            deviceId: "emulator-5554",
+            packageName: "com.example.app",
+            fileName,
+          }),
+        );
+
+      await subscribe(first, "first-shared", "prefs.xml");
+      await subscribe(first, "first-secondary", "secondary.xml");
+      await subscribe(second, "second-shared", "prefs.xml");
+
+      server.closeConnectionForTest(first);
+      await secondaryReleased.promise;
+      expect(calls).toEqual([
+        expect.objectContaining({ subscribe: true, fileName: "prefs.xml" }),
+        expect.objectContaining({ subscribe: true, fileName: "secondary.xml" }),
+        expect.objectContaining({ subscribe: false, fileName: "secondary.xml" }),
+      ]);
+
+      server.closeConnectionForTest(second);
+      await sharedReleased.promise;
+      expect(calls).toEqual([
+        expect.objectContaining({ subscribe: true, fileName: "prefs.xml" }),
+        expect.objectContaining({ subscribe: true, fileName: "secondary.xml" }),
+        expect.objectContaining({ subscribe: false, fileName: "secondary.xml" }),
+        expect.objectContaining({ subscribe: false, fileName: "prefs.xml" }),
+      ]);
+    });
+
     it("keeps the observer when a session UUID rotates before the retired socket closes", async () => {
       const calls: StorageSubReq[] = [];
       server.setOnStorageSubscriptionRequested(async (request) => {


### PR DESCRIPTION
## Summary

The parent [#5924](https://github.com/kaeawc/auto-mobile/pull/5924) already implements socket-owned, reference-counted storage observers. This stacked PR completes [#5969](https://github.com/kaeawc/auto-mobile/issues/5969)'s required coverage with a deterministic socket-close test: disconnecting one pane releases only its exclusive observer, leaves its peer's shared observer active, and releases that shared observer only when the final pane closes.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/5969

## Bug / Regression Context

- **Prior attempts:** The implementation was added during review of [#5924](https://github.com/kaeawc/auto-mobile/pull/5924), but socket-close teardown was not directly tested.
- **Observed symptom:** A viewer that closes could remove another viewer's device-side content observer.
- **Repro steps / conditions:** Two panes subscribe to one file; one pane also owns a second file; close panes in sequence.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalent: `bun run lint` and `bun test` pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit test runs in <100ms
- [x] No new generic code or direct dependencies
- [x] Based on current head of [#5924](https://github.com/kaeawc/auto-mobile/pull/5924); rebase onto `main` after its merge