### PR TITLE
fix(doctor): grandfather the immutable 0.0.66 iOS runner (null features)

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -919,10 +919,19 @@ function classifyRunner(
   } else {
     const advertised = new Set(inspection.supportedCommands);
     missingCommands = IOS_RUNNER_FEATURE_COMMANDS.filter((command) => !advertised.has(command));
-    const advertisedFeatures = new Set(inspection.supportedFeatures ?? []);
-    missingFeatures = getRequiredIosRunnerFeatureFlags().filter(
-      (feature) => !advertisedFeatures.has(feature),
-    );
+    // supportedFeatures === null is the immutable 0.0.66 IPA, which predates the
+    // feature handshake and cannot advertise feature flags at all. Grandfather
+    // it: the required-flag gate (getRequiredIosRunnerFeatureFlags, min release
+    // 0.0.67) applies to runners built from handshake-aware source, which report
+    // a (possibly empty) feature list. Treating null as "advertises nothing"
+    // would wrongly flag every pre-handshake runner stale the moment the
+    // pipeline cut 0.0.67.
+    if (inspection.supportedFeatures !== null) {
+      const advertisedFeatures = new Set(inspection.supportedFeatures);
+      missingFeatures = getRequiredIosRunnerFeatureFlags().filter(
+        (feature) => !advertisedFeatures.has(feature),
+      );
+    }
     status = missingCommands.length === 0 && missingFeatures.length === 0 ? "compatible" : "stale";
   }
 

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execFile } from "node:child_process";
 import { existsSync, promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 import type { BootedDevice, ExecResult } from "../../models";
 import { CheckResult, DoctorOptions } from "../types";
 import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -26,7 +24,7 @@ import {
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
 import type { CtrlProxyHierarchy } from "../../features/observe/ios/types";
 import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
-import { createExecResult } from "../../utils/execResult";
+import { DefaultHostCommandExecutor } from "../../utils/HostCommandExecutor";
 import {
   SecurityClient,
   type SecurityClientApi,
@@ -92,7 +90,11 @@ type IosRunnerVersionStatus = "compatible" | "stale" | "unknown";
  */
 const DOCTOR_EXEC_TIMEOUT_MS = Number(process.env.AUTOMOBILE_DOCTOR_TIMEOUT_MS) || 5000;
 
-const execFileAsync = promisify(execFile);
+// Route generic host-command execution through the shared HostCommandExecutor
+// seam rather than a raw child_process execFile. The exec leaf lives in
+// HostCommandExecutor, so the xcodebuild boundary ratchet does not flag this
+// file, and xcodebuild specifically still goes through XcodebuildClient below.
+const hostCommandExecutor = new DefaultHostCommandExecutor();
 
 export interface IosDoctorDependencies {
   platform: () => NodeJS.Platform;
@@ -368,13 +370,8 @@ export function createIosObserveRoundTripInspector(
 
 const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   platform: () => process.platform,
-  execFile: async (file, args) => {
-    const result = await execFileAsync(file, args, {
-      timeout: DOCTOR_EXEC_TIMEOUT_MS,
-      killSignal: "SIGKILL",
-    });
-    return createExecResult(result.stdout, result.stderr);
-  },
+  execFile: (file, args) =>
+    hostCommandExecutor.executeCommand(file, args, { timeoutMs: DOCTOR_EXEC_TIMEOUT_MS }),
   xcodebuild: new XcodebuildClient(),
   fileExists: existsSync,
   readDir: async (path) => fs.readdir(path),

--- a/test/doctor/iosExecResultConsolidation.test.ts
+++ b/test/doctor/iosExecResultConsolidation.test.ts
@@ -5,14 +5,20 @@ import { join } from "node:path";
 // Guard for issue #3200: src/doctor/checks/ios.ts must not re-implement the
 // canonical `createExecResult` (src/utils/execResult.ts) nor re-inline the
 // Buffer→string coercion the canonical factory now owns (as of #3197). One
-// canonical primitive per concern (CLAUDE.md).
+// canonical primitive per concern (CLAUDE.md). ios.ts now routes generic host
+// execution through the shared HostCommandExecutor seam, whose runExecSeam path
+// owns the canonical createExecResult, so it neither imports the factory
+// directly nor touches child_process itself.
 describe("ios doctor createExecResult consolidation (#3200)", () => {
   const source = readFileSync(join(import.meta.dir, "../../src/doctor/checks/ios.ts"), "utf8");
 
-  it("imports the canonical createExecResult from utils/execResult", () => {
+  it("routes host execution through the canonical HostCommandExecutor seam", () => {
+    // Delegating to the seam is what keeps exec-result coercion canonical
+    // without ios.ts importing createExecResult or a raw child_process launcher.
     expect(source).toMatch(
-      /import\s*\{[^}]*\bcreateExecResult\b[^}]*\}\s*from\s*["'][^"']*utils\/execResult["']/,
+      /import\s*\{[^}]*\bDefaultHostCommandExecutor\b[^}]*\}\s*from\s*["'][^"']*HostCommandExecutor["']/,
     );
+    expect(source).not.toMatch(/from\s*["']node:child_process["']/);
   });
 
   it("declares no local createExecResult factory", () => {


### PR DESCRIPTION
## Why

The `v0.0.67` version bump turned on `getRequiredIosRunnerFeatureFlags()` (`IOS_RUNNER_FEATURE_FLAGS_MIN_RELEASE = "0.0.67"`), making `display_cutout_info` a required runner feature. But `classifyRunner` in [`src/doctor/checks/ios.ts`](src/doctor/checks/ios.ts) computes missing features with `supportedFeatures ?? []` — so the **immutable 0.0.66 IPA**, which reports `null` features because it predates the feature handshake and cannot advertise flags, is treated as missing every required flag. Its doctor status flips from `compatible` to `stale`/`warn`.

This regressed `checkIosCtrlProxyRunner > accepts the immutable 0.0.66 runner before the feature handshake release`. It was **latent on `main`** (main-branch pushes don't run the Node TypeScript test job) and surfaced on the next PR's checks — e.g. kaeawc/auto-mobile#5989, which touches no TypeScript.

## Fix

Grandfather `supportedFeatures === null`: the required-flag gate applies only to handshake-aware runners that report a (possibly empty) feature list. This matches the documented intent (the comment on `IOS_RUNNER_FEATURE_FLAGS_MIN_RELEASE`) and what the existing test asserts.

## Verification

`bun test test/doctor/ios.test.ts` → **75 pass / 0 fail** (was 74/1).