### PR TITLE
fix(ios): capture Spotlight from SpringBoard

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -189,6 +189,8 @@ public class ElementLocator: ElementLocating {
         /// Springboard app for detecting foreground app - always kept
         private lazy var springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
+        private static let spotlightBundleId = "com.apple.Spotlight"
+
         /// Thread-safe cache of resource IDs to XCUIElements
         private let elementCache = ThreadSafeCache<XCUIElement>()
 
@@ -348,6 +350,7 @@ public class ElementLocator: ElementLocating {
             "com.apple.MobileAddressBook", // Contacts
             "com.apple.mobilephone", // Phone
             "com.apple.MobileSMS", // Messages
+            "com.apple.Spotlight", // Spotlight search
             "com.apple.mobileslideshow", // Photos
             "com.apple.camera", // Camera
             "com.apple.AppStore", // App Store
@@ -390,6 +393,17 @@ public class ElementLocator: ElementLocating {
             // with a mutation on another thread (issue #3614).
             let currentBundleId = tracker.bundleId
             let observedBundleIds = tracker.observedBundleIds
+
+            // Spotlight owns its accessibility hierarchy. SpringBoard's snapshot
+            // exposes only the status bar while Spotlight is foreground.
+            if let preferredSystemSurface = Self.preferredSystemSurfaceBundleId(
+                trackedBundleId: currentBundleId,
+                spotlightStateRaw: runOnMainThreadNonThrowing({
+                    XCUIApplication(bundleIdentifier: Self.spotlightBundleId).state.rawValue
+                }, fallback: 0)
+            ) {
+                return preferredSystemSurface
+            }
 
             // First, try to find bundle IDs from springboard's element tree
             // This can work when apps embed their bundle ID in element identifiers
@@ -1521,6 +1535,18 @@ public class ElementLocator: ElementLocating {
         springBoardLookup: () -> Element?
     ) -> Element? {
         foregroundLookup() ?? springBoardLookup()
+    }
+
+    /// Spotlight must take precedence over SpringBoard while it owns the
+    /// foreground accessibility hierarchy; other tracked apps retain their roots.
+    static func preferredSystemSurfaceBundleId(
+        trackedBundleId: String?,
+        spotlightStateRaw: UInt
+    ) -> String? {
+        guard trackedBundleId == "com.apple.springboard", spotlightStateRaw >= 4 else {
+            return nil
+        }
+        return "com.apple.Spotlight"
     }
 
     // MARK: - Same-Type Child Collapsing & Sibling Dedup

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -1053,6 +1053,28 @@ final class ElementLocatorTests: XCTestCase {
         )
     }
 
+    func testPreferredSystemSurfaceBundleId_selectsSpotlightOnlyOverSpringBoard() {
+        XCTAssertEqual(
+            ElementLocator.preferredSystemSurfaceBundleId(
+                trackedBundleId: "com.apple.springboard",
+                spotlightStateRaw: 4
+            ),
+            "com.apple.Spotlight"
+        )
+        XCTAssertNil(
+            ElementLocator.preferredSystemSurfaceBundleId(
+                trackedBundleId: "com.apple.springboard",
+                spotlightStateRaw: 3
+            )
+        )
+        XCTAssertNil(
+            ElementLocator.preferredSystemSurfaceBundleId(
+                trackedBundleId: "com.apple.Preferences",
+                spotlightStateRaw: 4
+            )
+        )
+    }
+
     // AC3: the ~40-app foreground-detection sweep is bounded on the miss path.
     func testShouldRunSystemAppSweep_runsWhenNeverSwept() {
         // lastMissTime == 0 means the sweep has never cached a miss (or a


### PR DESCRIPTION
## Summary

Detects iOS Spotlight as its own foreground system surface so hierarchy and text-input queries target `com.apple.Spotlight`, rather than SpringBoard's status-bar-only tree.

## Linked Issue

Relates to #5991. Close the issue after a versioned release publishes the rebuilt CtrlProxy iOS runner; the immutable 0.0.67 IPA cannot contain this change.

## Bug / Regression Context

- **Observed symptom:** iOS Spotlight returned a verified-fresh hierarchy containing only status-bar nodes.
- **Repro conditions:** the runner retained SpringBoard as the foreground query root although Spotlight owned the visible accessibility hierarchy.

## Validation

- [x] Targeted Swift regression test: `swift test --filter ElementLocatorTests/testPreferredSystemSurfaceBundleId_selectsSpotlightOnlyOverSpringBoard`
- [x] `./scripts/ios/swift-test.sh`
- [x] `bun run typecheck`
- [ ] `./scripts/ios/xcode-build.sh` — blocked: local Xcode lacks the required iOS 26.5 platform.
- [ ] `bun run turbo:validate` and `scripts/all_fast_validate_checks.sh` — intentionally stopped after 60 seconds at requester direction.
