### PR TITLE
fix(observe): reconcile same-app activity attribution

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -570,14 +570,14 @@ export class TapOnElement extends BaseVisualChange {
     previousObservation: ObserveResult | null,
     currentObservation: ObserveResult,
     signal?: AbortSignal,
-  ): Promise<TapOnElementResult["effect"]> {
+  ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
     const immediateEffect = this.deriveTapEffect(previousObservation, currentObservation);
     if (
       this.device.platform !== "android" ||
       !previousObservation ||
       immediateEffect?.screenChanged === true
     ) {
-      return immediateEffect;
+      return { effect: immediateEffect, observation: currentObservation };
     }
 
     // A stable source tree can arrive before Android begins the activity
@@ -593,7 +593,10 @@ export class TapOnElement extends BaseVisualChange {
         signal,
       },
     );
-    return this.deriveTapEffect(previousObservation, effectObservation.observation);
+    return {
+      effect: this.deriveTapEffect(previousObservation, effectObservation.observation),
+      observation: effectObservation.observation,
+    };
   }
 
   private isElementTapTargetOffScreen(
@@ -1730,11 +1733,15 @@ export class TapOnElement extends BaseVisualChange {
       );
 
       if (result.success && result.observation && result.element) {
-        result.effect = await this.deriveTapEffectAfterPostTapObservation(
+        const postTapEffect = await this.deriveTapEffectAfterPostTapObservation(
           previousObserveResult,
           result.observation,
           signal,
         );
+        result.effect = postTapEffect.effect;
+        // The delayed observation established the reported effect, so it must
+        // also be the observation delivered to the caller and diff baseline.
+        result.observation = postTapEffect.observation;
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,
           selectionState: selectionCapture,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -951,16 +951,43 @@ export class RealObserveScreen implements ObserveScreen {
     if (!hierarchy) {
       return false;
     }
+    if (hierarchy.packageName !== expected.packageName) {
+      return false;
+    }
+
+    // DeviceStateCollector deliberately treats a back-stack failure as
+    // best-effort and records it on its target. Keep the original result out of
+    // this confirmation read: a failed second query must not relabel the
+    // original hierarchy using its first (stale) back-stack value.
+    const recapturedState: ObserveResult = { ...result, backStack: undefined, errors: undefined };
+    await this.deviceStateCollector.collectBackStack(
+      recapturedState,
+      new NoOpPerformanceTracker(),
+      signal,
+    );
+    if (resolveBackStackActivityAttribution(recapturedState)?.activityName !== expected.activityName) {
+      return false;
+    }
+
     result.viewHierarchy = hierarchy;
     result.updatedAt = hierarchy.updatedAt ?? result.updatedAt;
+    if (hierarchy.screenWidth && hierarchy.screenHeight) {
+      result.screenSize = { width: hierarchy.screenWidth, height: hierarchy.screenHeight };
+      if (hierarchy.rotation !== undefined) {
+        result.rotation = hierarchy.rotation;
+      }
+      if (hierarchy.systemInsets) {
+        result.systemInsets = hierarchy.systemInsets;
+      }
+      if (hierarchy.insets) {
+        result.insets = hierarchy.insets;
+      }
+    }
     result.focusedElement = this.viewHierarchy.findFocusedElement(hierarchy) ?? undefined;
     result.accessibilityFocusedElement =
       this.viewHierarchy.findAccessibilityFocusedElement(hierarchy) ?? undefined;
-    if (result.viewHierarchy?.packageName !== expected.packageName) {
-      return false;
-    }
-    await this.deviceStateCollector.collectBackStack(result, new NoOpPerformanceTracker(), signal);
-    return resolveBackStackActivityAttribution(result)?.activityName === expected.activityName;
+    result.backStack = recapturedState.backStack;
+    return true;
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -132,6 +132,10 @@ function isAccessibilityViewClass(foregroundActivity: string): boolean {
   );
 }
 
+function isActivityInPackage(activityName: string, packageName: string): boolean {
+  return activityName === packageName || activityName.startsWith(`${packageName}.`);
+}
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -860,9 +864,21 @@ export class RealObserveScreen implements ObserveScreen {
     if (
       observed === undefined ||
       activeWindow === undefined ||
-      activeWindow.appId === observed ||
       SYSTEM_UI_WINDOW_PACKAGES.has(observed)
     ) {
+      return { sampled: false, identity: undefined };
+    }
+
+    const currentActivity =
+      result.backStack?.source === "adb" ? result.backStack.currentActivity?.name : undefined;
+    if (currentActivity && isActivityInPackage(currentActivity, observed)) {
+      // The tree and adb agree on the application, while CtrlProxy can keep a
+      // prior activity (or a view class) across same-package navigation (#5992).
+      result.activeWindow = { ...activeWindow, appId: observed, activityName: currentActivity };
+      return { sampled: false, identity: undefined };
+    }
+
+    if (activeWindow.appId === observed) {
       return { sampled: false, identity: undefined };
     }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -152,6 +152,20 @@ function isBackStackActivityInPackage(
   );
 }
 
+function resolveBackStackActivityAttribution(
+  result: ObserveResult,
+): { packageName: string; activityName: string } | undefined {
+  const packageName = result.viewHierarchy?.packageName;
+  const activityName =
+    result.backStack?.source === "adb" ? result.backStack.currentActivity?.name : undefined;
+  if (!packageName || !activityName) {
+    return undefined;
+  }
+  return isBackStackActivityInPackage(result.backStack, activityName, packageName)
+    ? { packageName, activityName }
+    : undefined;
+}
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -885,15 +899,21 @@ export class RealObserveScreen implements ObserveScreen {
       return { sampled: false, identity: undefined };
     }
 
-    const currentActivity =
-      result.backStack?.source === "adb" ? result.backStack.currentActivity?.name : undefined;
+    const backStackAttribution = resolveBackStackActivityAttribution(result);
     if (
-      currentActivity &&
-      isBackStackActivityInPackage(result.backStack, currentActivity, observed)
+      backStackAttribution &&
+      activeWindow.activityName !== backStackAttribution.activityName &&
+      (await this.recaptureHierarchyForBackStackAttribution(result, backStackAttribution, signal))
     ) {
       // The tree and adb agree on the application, while CtrlProxy can keep a
       // prior activity (or a view class) across same-package navigation (#5992).
-      result.activeWindow = { ...activeWindow, appId: observed, activityName: currentActivity };
+      // Do not pair a later adb activity with the earlier tree: the recapture
+      // and repeated back-stack read establish their ordering before relabeling.
+      result.activeWindow = {
+        ...activeWindow,
+        appId: backStackAttribution.packageName,
+        activityName: backStackAttribution.activityName,
+      };
       return { sampled: false, identity: undefined };
     }
 
@@ -906,6 +926,41 @@ export class RealObserveScreen implements ObserveScreen {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
     return { sampled: true, identity: confirmed };
+  }
+
+  private async recaptureHierarchyForBackStackAttribution(
+    result: ObserveResult,
+    expected: { packageName: string; activityName: string },
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    let hierarchy: ObserveResult["viewHierarchy"];
+    try {
+      hierarchy = await this.viewHierarchy.getViewHierarchy(
+        undefined,
+        new NoOpPerformanceTracker(),
+        false,
+        0,
+        signal,
+      );
+    } catch (error) {
+      logger.debug(
+        `[OBSERVE] Attribution recapture failed; preserving original hierarchy: ${error}`,
+      );
+      return false;
+    }
+    if (!hierarchy) {
+      return false;
+    }
+    result.viewHierarchy = hierarchy;
+    result.updatedAt = hierarchy.updatedAt ?? result.updatedAt;
+    result.focusedElement = this.viewHierarchy.findFocusedElement(hierarchy) ?? undefined;
+    result.accessibilityFocusedElement =
+      this.viewHierarchy.findAccessibilityFocusedElement(hierarchy) ?? undefined;
+    if (result.viewHierarchy?.packageName !== expected.packageName) {
+      return false;
+    }
+    await this.deviceStateCollector.collectBackStack(result, new NoOpPerformanceTracker(), signal);
+    return resolveBackStackActivityAttribution(result)?.activityName === expected.activityName;
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -136,6 +136,22 @@ function isActivityInPackage(activityName: string, packageName: string): boolean
   return activityName === packageName || activityName.startsWith(`${packageName}.`);
 }
 
+function isBackStackActivityInPackage(
+  backStack: ObserveResult["backStack"],
+  activityName: string,
+  packageName: string,
+): boolean {
+  if (isActivityInPackage(activityName, packageName)) {
+    return true;
+  }
+  const currentTaskId = backStack?.currentActivity?.taskId;
+  return (
+    backStack?.tasks.some(
+      (task) => task.id === currentTaskId && task.packageName === packageName,
+    ) === true
+  );
+}
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -871,7 +887,10 @@ export class RealObserveScreen implements ObserveScreen {
 
     const currentActivity =
       result.backStack?.source === "adb" ? result.backStack.currentActivity?.name : undefined;
-    if (currentActivity && isActivityInPackage(currentActivity, observed)) {
+    if (
+      currentActivity &&
+      isBackStackActivityInPackage(result.backStack, currentActivity, observed)
+    ) {
       // The tree and adb agree on the application, while CtrlProxy can keep a
       // prior activity (or a view class) across same-package navigation (#5992).
       result.activeWindow = { ...activeWindow, appId: observed, activityName: currentActivity };

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -452,10 +452,12 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         } else if (
           shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))
         ) {
-          observationOut = diffObserveResult(baseline, sanitized);
+          const diff = diffObserveResult(baseline, sanitized);
+          const screenChangedWithEmptyDiff = hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
+          observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;
           observationDiff = {
-            mode: "diff",
-            reason: "diff_emitted",
+            mode: screenChangedWithEmptyDiff ? "full" : "diff",
+            reason: screenChangedWithEmptyDiff ? "screen_changed" : "diff_emitted",
             fromScreen: observationScreenIdentity(baseline),
             toScreen: observationScreenIdentity(sanitized),
           };
@@ -808,6 +810,24 @@ function isObserveResult(value: unknown): value is ObserveResult {
 
 function hasRenderableHierarchy(observation: ObserveResult): boolean {
   return !!observation.viewHierarchy?.hierarchy;
+}
+
+function hasScreenChangedEffect(payload: Record<string, unknown>): boolean {
+  const effect = payload.effect;
+  return (
+    effect !== null &&
+    typeof effect === "object" &&
+    (effect as Record<string, unknown>).screenChanged === true
+  );
+}
+
+function isEmptyObserveDiff(diff: ReturnType<typeof diffObserveResult>): boolean {
+  return (
+    diff.added.length === 0 &&
+    diff.removed.length === 0 &&
+    diff.changed.length === 0 &&
+    diff.fields === undefined
+  );
 }
 
 function observationScreenIdentity(observation: ObserveResult): ObservationDiffScreenIdentity {

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -453,7 +453,8 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
           shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))
         ) {
           const diff = diffObserveResult(baseline, sanitized);
-          const screenChangedWithEmptyDiff = hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
+          const screenChangedWithEmptyDiff =
+            hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
           observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;
           observationDiff = {
             mode: screenChangedWithEmptyDiff ? "full" : "diff",

--- a/test/fakes/FakeViewHierarchy.ts
+++ b/test/fakes/FakeViewHierarchy.ts
@@ -8,6 +8,7 @@ import type { Element, ScreenIdentity, ViewHierarchyResult } from "../../src/mod
 export class FakeViewHierarchy implements ViewHierarchy {
   private calls: { skipWaitForFresh?: boolean; minTimestamp?: number }[] = [];
   private configuredHierarchy: ViewHierarchyResult = { hierarchy: {} };
+  private configuredHierarchySequence: ViewHierarchyResult[] = [];
   private configuredFocusedElement: Element | null = null;
   private configuredAccessibilityFocusedElement: Element | null = null;
   private configuredScreenIdentity: ScreenIdentity | undefined;
@@ -29,7 +30,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
     }
 
     this.calls.push({ skipWaitForFresh, minTimestamp });
-    return { ...this.configuredHierarchy };
+    return { ...(this.configuredHierarchySequence.shift() ?? this.configuredHierarchy) };
   }
 
   /**
@@ -93,6 +94,12 @@ export class FakeViewHierarchy implements ViewHierarchy {
     this.configuredHierarchy = hierarchy;
   }
 
+  /** Configure consecutive hierarchy reads, then fall back to the final configured value. */
+  configureHierarchySequence(hierarchies: ViewHierarchyResult[]): void {
+    this.configuredHierarchy = hierarchies.at(-1) ?? this.configuredHierarchy;
+    this.configuredHierarchySequence = [...hierarchies];
+  }
+
   /**
    * Configure the focused element to return.
    */
@@ -148,6 +155,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
   reset(): void {
     this.calls = [];
     this.configuredHierarchy = { hierarchy: {} };
+    this.configuredHierarchySequence = [];
     this.configuredFocusedElement = null;
     this.configuredAccessibilityFocusedElement = null;
     this.configuredScreenIdentity = undefined;

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -246,13 +246,14 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("android", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
 
     expect(waitCalls).toBe(1);
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: true,
       basis: "activeWindow changed",
     });
+    expect(postTap.observation).toBe(destination);
   });
 
   test("does not wait when the initial Android observation shows a change", async () => {
@@ -286,12 +287,13 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("android", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, destination);
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, destination);
 
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: true,
       basis: "activeWindow changed",
     });
+    expect(postTap.observation).toBe(destination);
     expect(waitCalls).toBe(0);
   });
 
@@ -319,15 +321,16 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("ios", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(
       observation,
       observation,
     );
 
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: false,
       basis: "activeWindow unchanged",
     });
+    expect(postTap.observation).toBe(observation);
     expect(waitCalls).toBe(0);
   });
 });

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -294,6 +294,59 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toBeUndefined();
   });
 
+  test("prefers the adb back-stack activity over stale same-package CtrlProxy attribution", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.android.settings",
+      foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Apps", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.backStack?.currentActivity?.name).toBe("com.android.settings.SubSettings");
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("an expanded system-UI shade is not flagged as a wrong-window capture", async () => {
     // When the notification shade / quick settings takes accessibility focus,
     // the observed window is com.android.systemui while the resumed activity

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -347,6 +347,80 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("recaptures the hierarchy before applying a later same-package back-stack activity", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        updatedAt: now,
+        receivedAt: now,
+        fresh: true,
+        screenWidth: 1080,
+        screenHeight: 2400,
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+            node: [
+              { text: "Settings home", bounds: { left: 0, top: 100, right: 300, bottom: 160 } },
+            ],
+          },
+        },
+      },
+      {
+        updatedAt: now,
+        receivedAt: now,
+        fresh: true,
+        screenWidth: 1080,
+        screenHeight: 2400,
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.SubSettings",
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+            node: [
+              { text: "Connected devices", bounds: { left: 0, top: 100, right: 300, bottom: 160 } },
+            ],
+          },
+        },
+      },
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Connected devices");
+  });
+
   test("uses the back-stack task owner for an activity outside its package namespace", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -347,6 +347,63 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("uses the back-stack task owner for an activity outside its package namespace", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.google.android.contacts",
+      foregroundActivity: "com.google.android.contacts/.ContactsActivity",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Contacts", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.contacts", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [{ id: 7, packageName: "com.google.android.contacts" }],
+            currentActivity: {
+              name: "com.google.android.apps.contacts.activities.OnboardingSignInActivity",
+              taskId: 7,
+            },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe(
+      "com.google.android.apps.contacts.activities.OnboardingSignInActivity",
+    );
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("an expanded system-UI shade is not flagged as a wrong-window capture", async () => {
     // When the notification shade / quick settings takes accessibility focus,
     // the observed window is com.android.systemui while the resumed activity

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -375,8 +375,10 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
         updatedAt: now,
         receivedAt: now,
         fresh: true,
-        screenWidth: 1080,
-        screenHeight: 2400,
+        screenWidth: 2400,
+        screenHeight: 1080,
+        rotation: 1,
+        systemInsets: { top: 0, right: 63, bottom: 0, left: 0 },
         packageName: "com.android.settings",
         foregroundActivity: "com.android.settings/.SubSettings",
         hierarchy: {
@@ -419,6 +421,118 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(viewHierarchy.getCallCount()).toBe(2);
     expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
     expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Connected devices");
+    expect(result.screenSize).toEqual({ width: 2400, height: 1080 });
+    expect(result.rotation).toBe(1);
+    expect(result.systemInsets).toEqual({ top: 0, right: 63, bottom: 0, left: 0 });
+  });
+
+  test("preserves the original hierarchy when the attribution recapture is unusable", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+        hierarchy: { node: { node: [{ text: "Settings home" }] } },
+      },
+      { error: "CtrlProxy timed out" },
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe(
+      "com.android.settings.homepage.SettingsHomepageActivity",
+    );
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Settings home");
+  });
+
+  test("requires a successful second back-stack read before relabeling the recaptured hierarchy", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+        hierarchy: { node: { node: [{ text: "Settings home" }] } },
+      },
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.SubSettings",
+        hierarchy: { node: { node: [{ text: "Connected devices" }] } },
+      },
+    ] as any);
+
+    let backStackCalls = 0;
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => {
+            backStackCalls++;
+            if (backStackCalls === 1) {
+              return {
+                depth: 1,
+                activities: [],
+                tasks: [],
+                currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+                source: "adb",
+              };
+            }
+            throw new Error("second dumpsys failed");
+          },
+        } as any,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(backStackCalls).toBe(2);
+    expect(result.activeWindow?.activityName).toBe(
+      "com.android.settings.homepage.SettingsHomepageActivity",
+    );
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Settings home");
   });
 
   test("uses the back-stack task owner for an activity outside its package namespace", async () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -856,6 +856,29 @@ describe("finalizeToolResponse", () => {
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 
+    test("falls back to full when the action detected a screen change but the diff is empty", () => {
+      const { store } = makeStore();
+      finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({
+          success: true,
+          effect: { screenChanged: true, basis: "viewHierarchy changed" },
+          observation: sameScreenObserve(),
+        }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store, args: { project: "full" } },
+      );
+
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.isDiff).toBeUndefined();
+      expect(observation.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+    });
+
     test("hierarchy-less action observations emit full sanitized payloads, not empty diffs", () => {
       const { store, map } = makeStore();
       const baseline = sameScreenObserve();


### PR DESCRIPTION
## Summary
- Prefer the adb-backed back-stack activity when CtrlProxy activity metadata is stale within the captured app.
- Return a full observation rather than a contradictory empty diff when an action reports a screen change.

Fixes [#5992](https://github.com/kaeawc/auto-mobile/issues/5992).

## Validation
- `bun test test/features/observe/ObserveScreenWindowIdentity.test.ts test/server/finalizeToolResponse.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run turbo:validate` (still running; publishing per requested 60-second limit)

Made with [Cursor](https://cursor.com)