### PR TITLE
test(desktop): guard onboarding storage copy stays platform-neutral (#4721 item 1)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
@@ -30,7 +30,9 @@ private data class Capability(val icon: String, val text: String)
 private val CAPABILITIES =
   listOf(
     Capability("🖥", "Observe devices — pick booted devices and open them as side-by-side panes"),
-    Capability("🧭", "Inspect per device — dock the logs and storage tools into each pane"),
+    // Storage tooling is Android-only (#4708), so qualify it rather than naming storage as a
+    // universal capability the iOS panes don't have yet (#4721).
+    Capability("🧭", "Inspect per device — dock the logs, and storage on Android, into each pane"),
     Capability("⧉", "Compare devices — open the same tool across devices for a like-for-like view"),
   )
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
@@ -30,9 +30,10 @@ private data class Capability(val icon: String, val text: String)
 private val CAPABILITIES =
   listOf(
     Capability("🖥", "Observe devices — pick booted devices and open them as side-by-side panes"),
-    // Storage tooling is Android-only (#4708), so qualify it rather than naming storage as a
-    // universal capability the iOS panes don't have yet (#4721).
-    Capability("🧭", "Inspect per device — dock the logs, and storage on Android, into each pane"),
+    // Storage docks into both Android and iOS panes as of #5020 (iOS key-value mutation routing
+    // through WorkspaceFacet -> StorageFacet), so this copy stays platform-neutral — qualifying
+    // storage as Android-only would now under-promise on iOS (#4721 item 1, premise superseded).
+    Capability("🧭", "Inspect per device — dock the logs and storage tools into each pane"),
     Capability("⧉", "Compare devices — open the same tool across devices for a like-for-like view"),
   )
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
@@ -32,6 +32,16 @@ class OnboardingScreenUiTest {
   }
 
   @Test
+  fun `qualifies storage as Android-only so the inspect copy doesn't over-promise on iOS`() =
+    runComposeUiTest {
+      setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
+      // Storage tooling is Android-only (#4708): WorkspaceFacet routes Tool.Storage to a
+      // placeholder on iOS. The inspect capability copy must platform-qualify storage rather
+      // than naming it as universally available (#4721).
+      onNodeWithText("storage on Android", substring = true, ignoreCase = true).assertIsDisplayed()
+    }
+
+  @Test
   fun `carries no AI or assistant framing`() = runComposeUiTest {
     setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
     // The onboarding must stay free of AI/LLM/assistant connotations (explicit product

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
@@ -36,10 +36,11 @@ class OnboardingScreenUiTest {
     runComposeUiTest {
       setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
       // Storage docks into both Android and iOS panes as of #5020, so the inspect copy names
-      // storage as a capability of every pane. It must NOT platform-gate storage (e.g. "storage
-      // on Android"), which would under-promise on iOS (#4721 item 1, premise superseded).
-      onNodeWithText("storage tools", substring = true, ignoreCase = true).assertIsDisplayed()
-      onNodeWithText("storage on Android", substring = true, ignoreCase = true).assertDoesNotExist()
+      // storage as a capability of every pane and carries no platform qualifier (#4721 item 1,
+      // premise superseded). Pin the exact approved line so any Android-gating of the copy
+      // (e.g. "storage on Android", "each Android pane", "Android storage tools") fails here.
+      onNodeWithText("Inspect per device — dock the logs and storage tools into each pane")
+        .assertIsDisplayed()
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
@@ -32,13 +32,14 @@ class OnboardingScreenUiTest {
   }
 
   @Test
-  fun `qualifies storage as Android-only so the inspect copy doesn't over-promise on iOS`() =
+  fun `describes storage platform-neutrally so the inspect copy doesn't under-promise on iOS`() =
     runComposeUiTest {
       setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
-      // Storage tooling is Android-only (#4708): WorkspaceFacet routes Tool.Storage to a
-      // placeholder on iOS. The inspect capability copy must platform-qualify storage rather
-      // than naming it as universally available (#4721).
-      onNodeWithText("storage on Android", substring = true, ignoreCase = true).assertIsDisplayed()
+      // Storage docks into both Android and iOS panes as of #5020, so the inspect copy names
+      // storage as a capability of every pane. It must NOT platform-gate storage (e.g. "storage
+      // on Android"), which would under-promise on iOS (#4721 item 1, premise superseded).
+      onNodeWithText("storage tools", substring = true, ignoreCase = true).assertIsDisplayed()
+      onNodeWithText("storage on Android", substring = true, ignoreCase = true).assertDoesNotExist()
     }
 
   @Test


### PR DESCRIPTION
## What

Addresses **#4721 item 1** (platform-qualify onboarding capability copy).

On review (Codex P2 on this PR), the item's premise turned out to be **stale**: it assumed storage tooling is Android-only until #4708. But storage already docks into **both** Android and iOS panes as of **#5020** (iOS key-value mutation routing) — `AutoMobileDesktopApp.kt:629-631` routes `Tool.Storage -> StorageFacet` for both platforms, and `StorageFacet` maps `Platform.Ios -> StoragePlatform.iOS`. Only *live* storage subscriptions remain Android-only; the storage dashboard itself works on iOS.

So qualifying the copy as *"storage on Android"* would **under-promise on iOS**. The correct outcome is to keep the capability line platform-neutral.

## Change

- **OnboardingScreen.kt** — capability copy reverts to the neutral wording (now identical to `main`); adds a comment recording why it stays platform-neutral (supersession by #5020).
- **OnboardingScreenUiTest.kt** — repurposes the added test into a regression guard: the inspect copy names `storage tools` and must **not** platform-gate storage (`assertDoesNotExist("storage on Android")`).

Net diff vs `main` is a source comment plus a test-only regression guard — no runtime behavior change.

## Validation

- `:desktop-core:test` (full module) — green
- `:desktop-core:detekt` — green
- ktfmt — tree-clean (942 files)

References #4721 (item 1); item 2 — interactive basics checklist — remains open, so not `Closes`.