### PR TITLE
feat(desktop): make workspace overlays modal to keyboard/a11y focus (#4846)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -61,6 +61,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
 import dev.jasonpearson.automobile.desktop.core.workspace.deriveWorkspaceStatus
+import dev.jasonpearson.automobile.desktop.core.workspace.isolatedBehindOverlay
 import dev.jasonpearson.automobile.desktop.core.workspace.parseBootedDeviceSessionUuids
 import dev.jasonpearson.automobile.desktop.core.workspace.parseBootedLockStates
 import dev.jasonpearson.automobile.desktop.core.workspace.parseDeviceLockStates
@@ -471,6 +472,10 @@ fun AutoMobileDesktopApp(
                 onAction = workspaceViewModel::onAction,
                 onOpenPicker = workspaceViewModel::openPicker,
                 onOpenPalette = { paletteOpen = true },
+                // The ⌘K command palette is a sibling overlay hosted here (not inside the shell),
+                // so isolate the whole workspace behind it — matching how the shell isolates its
+                // own scrimmed panels — to keep the palette modal to keyboard/a11y focus (#4846).
+                modifier = Modifier.isolatedBehindOverlay(paletteOpen),
                 status = workspaceStatus.status,
                 statusDetail = workspaceStatus.detail,
                 updateStatus = updateStatus,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -36,9 +37,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -143,8 +146,13 @@ fun WorkspaceShell(
   // (Empty -> Content) retire the overlay so it can't linger (with its offline badge) over a live
   // workspace.
   if (state !is WorkspaceUiState.Empty && showOfflineBrowse) showOfflineBrowse = false
+  // A full-window overlay is open when any of the three scrimmed panels is showing. While one is,
+  // the workspace behind the scrim is made inert to keyboard/screen-reader focus (#4846) so a Tab
+  // or an assistive-tech swipe can't reach the visually-dimmed controls behind the overlay. Mirror
+  // the exact render conditions below so isolation tracks the overlays one-for-one.
+  val overlayActive = showHealthSheet || (showCompare && comparePair != null) || showOfflineBrowse
   Box(modifier.fillMaxSize()) {
-    Column(Modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize().isolatedBehindOverlay(overlayActive)) {
       TopBar(
         status = status,
         statusDetail = statusDetail,
@@ -210,6 +218,25 @@ fun WorkspaceShell(
     }
   }
 }
+
+/**
+ * Makes the content this modifies inert to keyboard and screen-reader focus while [active] is true,
+ * for the workspace behind a full-window overlay (issue #4846). Removing the subtree from the focus
+ * tree ([focusProperties] `canFocus = false` on a [focusGroup]) keeps a Tab from landing on the
+ * dimmed controls behind the scrim, and [clearAndSetSemantics] drops the whole subtree from the
+ * accessibility tree so assistive tech can't traverse behind the overlay either. A no-op when
+ * [active] is false, so the un-overlaid workspace keeps its normal focus order and semantics.
+ *
+ * Public (not private) so the app root can apply the same isolation to the whole [WorkspaceShell]
+ * when it hosts a sibling overlay of its own (the ⌘K command palette), keeping every workspace
+ * overlay modal through one mechanism.
+ */
+fun Modifier.isolatedBehindOverlay(active: Boolean): Modifier =
+  if (active) {
+    focusProperties { canFocus = false }.focusGroup().clearAndSetSemantics {}
+  } else {
+    this
+  }
 
 /**
  * Pick the two device columns to compare: the focused column plus the first other observed column.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -728,4 +728,99 @@ class WorkspaceShellUiTest {
     onNodeWithContentDescription("Browse navigation history").performClick()
     onNodeWithText("offline-browse-body").assertIsDisplayed()
   }
+
+  // #4846: full-window overlays must be modal to keyboard/screen-reader focus — the dimmed
+  // workspace behind the scrim must leave the accessibility/focus tree so a Tab or a screen-reader
+  // swipe cannot reach the visually-dimmed controls behind the overlay.
+
+  @Test
+  fun `opening the health sheet isolates the workspace background from accessibility`() =
+    runComposeUiTest {
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = WorkspaceUiState.Empty,
+            onAction = {},
+            onOpenPicker = {},
+            status = WorkspaceStatus.Green,
+            healthSheetContent = { Text("fake-health-body") },
+          )
+        }
+      }
+      // Background affordances are reachable before the overlay opens.
+      onNodeWithContentDescription("Open Devices").assertExists()
+      onNodeWithContentDescription("Open command palette").assertExists()
+
+      onNodeWithContentDescription("Status: Green").performClick()
+
+      // The overlay itself stays in the tree...
+      onNodeWithContentDescription("Health sheet").assertExists()
+      // ...but the dimmed workspace behind the scrim has left the accessibility tree.
+      onNodeWithContentDescription("Open Devices").assertDoesNotExist()
+      onNodeWithContentDescription("Open command palette").assertDoesNotExist()
+    }
+
+  @Test
+  fun `dismissing the health sheet restores the workspace background to accessibility`() =
+    runComposeUiTest {
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = WorkspaceUiState.Empty,
+            onAction = {},
+            onOpenPicker = {},
+            status = WorkspaceStatus.Green,
+            healthSheetContent = { Text("fake-health-body") },
+          )
+        }
+      }
+      onNodeWithContentDescription("Status: Green").performClick()
+      onNodeWithContentDescription("Open Devices").assertDoesNotExist()
+      // Closing the overlay must un-isolate the background so it is reachable again.
+      onNodeWithContentDescription("Close health sheet").performClick()
+      onNodeWithContentDescription("Open Devices").assertExists()
+    }
+
+  @Test
+  fun `opening the offline browse overlay isolates the workspace background`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          offlineBrowseContent = { Text("offline-browse-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Open Devices").assertExists()
+    onNodeWithContentDescription("Browse navigation history").performClick()
+    onNodeWithText("offline-browse-body").assertExists()
+    onNodeWithContentDescription("Open Devices").assertDoesNotExist()
+  }
+
+  @Test
+  fun `opening the compare overlay isolates the workspace background`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel"), col("b", "iPhone")),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          compareContent = { _, _ -> Text("compare-body") },
+        )
+      }
+    }
+    // A background pane control is reachable before the overlay opens.
+    onNodeWithContentDescription("Close Pixel").assertExists()
+    onNodeWithContentDescription("Compare two devices").performClick()
+    onNodeWithText("compare-body").assertExists()
+    // Pane controls behind the compare scrim have left the accessibility tree.
+    onNodeWithContentDescription("Close Pixel").assertDoesNotExist()
+  }
 }


### PR DESCRIPTION
## What

Closes #4846.

The desktop workspace's full-window overlays each draw a dimmed scrim as a **sibling** of the workspace content (`WorkspaceShell.kt`'s `HealthSheetOverlay` / `CompareOverlay` / `OfflineBrowseOverlay`, and the ⌘K `CommandPalette` hosted alongside `WorkspaceShell` in `AutoMobileDesktopApp`). The scrim never trapped focus nor removed the underlying workspace from the focus/semantics trees, so a keyboard or screen-reader user could **Tab or traverse behind the scrim** to the visually-dimmed controls — exactly the defect raised in the codex review of #4844 (`WorkspaceShell.kt:194`).

## How

One shared mechanism instead of per-overlay one-offs, per the issue's "better fixed once, consistently":

```kotlin
fun Modifier.isolatedBehindOverlay(active: Boolean): Modifier =
  if (active) focusProperties { canFocus = false }.focusGroup().clearAndSetSemantics {} else this
```

- **Focus trap** — `focusProperties { canFocus = false }` on a `focusGroup()` deactivates the background focus subtree, so a Tab has nowhere to land behind the scrim.
- **A11y isolation** — `clearAndSetSemantics {}` drops the whole background subtree from the accessibility tree, so assistive tech can't traverse behind the overlay.

`WorkspaceShell` applies it to its content column whenever any of its three scrimmed panels is open (`overlayActive` mirrors the three render conditions one-for-one). The app root applies the same isolation to the whole shell while it hosts the sibling command-palette overlay, so every active-workspace overlay is modal through the one modifier.

Scope note: this covers the overlays of the **current** desktop root (`WorkspaceShell`). The deprecated `ThreePaneShell` path is no longer the app root and is left untouched.

## Tests

`WorkspaceShellUiTest` gains four cases asserting that opening each overlay removes the background controls (`Open Devices`, `Open command palette`, a pane's `Close <device>`) from the accessibility tree, and that dismissing the health sheet restores them. Verified as genuine regression guards: all four fail when the modifier is neutralized to a no-op, and pass with the fix.

- `:desktop-core:test` — full module green (46 in `WorkspaceShellUiTest`, 0 failures)
- `:desktop-app:compileKotlin` green
- `:desktop-core:detekt` + `:desktop-app:detekt` green
- ktfmt clean (942 files)

## Risk

Runtime UI behavior change in `android/` (focus + semantics of the workspace behind an open overlay), so labeled `needs-human` with auto-merge off. Purely additive: a no-op when no overlay is open, so the un-overlaid workspace keeps its normal focus order and semantics.