### PR TITLE
fix(desktop): seal overlay focus trap against Tab (#4846 follow-up)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -221,22 +222,42 @@ fun WorkspaceShell(
 
 /**
  * Makes the content this modifies inert to keyboard and screen-reader focus while [active] is true,
- * for the workspace behind a full-window overlay (issue #4846). Removing the subtree from the focus
- * tree ([focusProperties] `canFocus = false` on a [focusGroup]) keeps a Tab from landing on the
- * dimmed controls behind the scrim, and [clearAndSetSemantics] drops the whole subtree from the
- * accessibility tree so assistive tech can't traverse behind the overlay either. A no-op when
- * [active] is false, so the un-overlaid workspace keeps its normal focus order and semantics.
+ * for the workspace behind a full-window overlay (issue #4846). Three cooperating parts form a real
+ * modal focus trap:
+ * - `onEnter = { cancelFocusChange() }` on a [focusGroup] seals the subtree against Tab traversal.
+ *   `canFocus = false` alone is not enough: a deactivated focus group is skipped for focus
+ *   *itself*, but its independently-focusable descendants stay reachable, so a Tab would still land
+ *   on a dimmed control behind the scrim. Cancelling the focus change at the group boundary blocks
+ *   entry into the whole subtree.
+ * - Clearing focus when [active] flips true drops any focus a background control was *already*
+ *   holding when the overlay opened, so it can't keep receiving key input behind the scrim (the
+ *   trap above only blocks *entering* — it does not evict focus already inside).
+ * - [clearAndSetSemantics] drops the whole subtree from the accessibility tree so assistive tech
+ *   can't traverse behind the overlay either.
  *
- * Public (not private) so the app root can apply the same isolation to the whole [WorkspaceShell]
- * when it hosts a sibling overlay of its own (the ⌘K command palette), keeping every workspace
- * overlay modal through one mechanism.
+ * A no-op when [active] is false, so the un-overlaid workspace keeps its normal focus order and
+ * semantics. `@Composable` (and public) so the app root can apply the same trap — focus clearing
+ * included — to the whole [WorkspaceShell] when it hosts a sibling overlay of its own (the ⌘K
+ * command palette), keeping every workspace overlay modal through one mechanism.
  */
-fun Modifier.isolatedBehindOverlay(active: Boolean): Modifier =
-  if (active) {
-    focusProperties { canFocus = false }.focusGroup().clearAndSetSemantics {}
+@Composable
+fun Modifier.isolatedBehindOverlay(active: Boolean): Modifier {
+  val focusManager = LocalFocusManager.current
+  LaunchedEffect(active) {
+    // force = true so a control that captured focus is released too, not just plainly-focused ones.
+    if (active) focusManager.clearFocus(force = true)
+  }
+  return if (active) {
+    focusProperties {
+      canFocus = false
+      onEnter = { cancelFocusChange() }
+    }
+      .focusGroup()
+      .clearAndSetSemantics {}
   } else {
     this
   }
+}
 
 /**
  * Pick the two device columns to compare: the focused column plus the first other observed column.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -1,13 +1,30 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
@@ -15,6 +32,7 @@ import dev.jasonpearson.automobile.desktop.core.update.ReleaseAsset
 import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import java.util.Base64
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -822,5 +840,78 @@ class WorkspaceShellUiTest {
     onNodeWithText("compare-body").assertExists()
     // Pane controls behind the compare scrim have left the accessibility tree.
     onNodeWithContentDescription("Close Pixel").assertDoesNotExist()
+  }
+
+  // #4846: the modal trap must block *keyboard* focus too, not only accessibility. Removing the
+  // background from the semantics tree (clearAndSetSemantics) hides it from screen readers but a
+  // deactivated focusGroup still leaves its descendants Tab-reachable — so these two tests pin the
+  // keyboard half of the trap the accessibility-only tests above cannot observe. The isolated
+  // background is intentionally absent from the queryable a11y tree, so focus is read through an
+  // onFocusChanged log rather than a semantics query.
+
+  @Test
+  fun `an open overlay traps Tab so it cannot reach the isolated background`() = runComposeUiTest {
+    val overlayFocus = FocusRequester()
+    val backgroundEverFocused = mutableListOf<Boolean>()
+    setContent {
+      MaterialTheme {
+        Box {
+          Column(Modifier.isolatedBehindOverlay(active = true)) {
+            BasicText(
+              "background",
+              Modifier.onFocusChanged { backgroundEverFocused.add(it.isFocused) }.focusable(),
+            )
+          }
+          // Stand-in overlay content: a focusable sibling outside the isolated subtree.
+          BasicText(
+            "overlay",
+            Modifier.testTag("overlay").focusRequester(overlayFocus).focusable(),
+          )
+        }
+      }
+    }
+    runOnIdle { overlayFocus.requestFocus() }
+    onNodeWithTag("overlay").assertIsFocused()
+    // Two Tab presses would wrap through every focusable if the trap leaked at the group boundary.
+    onRoot().performKeyInput { pressKey(Key.Tab) }
+    onRoot().performKeyInput { pressKey(Key.Tab) }
+    assertFalse(
+      "Tab reached a control behind the overlay: $backgroundEverFocused",
+      backgroundEverFocused.any { it },
+    )
+  }
+
+  @Test
+  fun `opening an overlay releases focus a background control already held`() = runComposeUiTest {
+    val backgroundFocus = FocusRequester()
+    var overlayOpen by mutableStateOf(false)
+    val backgroundFocusLog = mutableListOf<Boolean>()
+    setContent {
+      MaterialTheme {
+        Box {
+          Column(Modifier.isolatedBehindOverlay(active = overlayOpen)) {
+            BasicText(
+              "background",
+              Modifier.focusRequester(backgroundFocus)
+                .onFocusChanged { backgroundFocusLog.add(it.isFocused) }
+                .focusable(),
+            )
+          }
+        }
+      }
+    }
+    runOnIdle { backgroundFocus.requestFocus() }
+    runOnIdle {}
+    assertTrue(
+      "precondition: background should hold focus",
+      backgroundFocusLog.lastOrNull() == true,
+    )
+    // Opening the overlay must drop the focus the background was already holding.
+    overlayOpen = true
+    runOnIdle {}
+    assertFalse(
+      "background kept focus behind the overlay: $backgroundFocusLog",
+      backgroundFocusLog.lastOrNull() == true,
+    )
   }
 }


### PR DESCRIPTION
## What

Follow-up to the merged #4846 work ([#6020](https://github.com/kaeawc/auto-mobile/pull/6020)). A Codex review on that PR found — correctly — that the overlay isolation was **accessibility-only**: `Modifier.focusProperties { canFocus = false }.focusGroup()` deactivates the *group node* itself but not its descendants ([Android focus docs](https://developer.android.com/develop/ui/compose/touch-input/focus/change-focus-behavior) confirm `canFocus` does not propagate to children). So `clearAndSetSemantics {}` genuinely removed the dimmed workspace from the a11y tree, but **Tab could still land on a control behind the scrim**, and a background control that already held focus kept it. The a11y-only regression tests passed precisely because they only observed semantics. That PR squash-merged before this fix could land, so this seals the gap on `main`.

Both gaps were reproduced with focus tests **before** fixing.

## Fix — complete the modal focus trap

`Modifier.isolatedBehindOverlay` now:

- **`onEnter = { cancelFocusChange() }`** on the background `focusGroup()` — cancels the focus change at the group boundary, sealing the *whole subtree* against Tab traversal (deactivation alone left focusable descendants reachable).
- **Clears focus (`force = true`) when an overlay opens** — releases any focus a background control was already holding, so it can't keep receiving key input behind the scrim (the trap only blocks *entering*; it does not evict focus already inside). This makes the modifier `@Composable`; both call sites (the three shell panels + the app-root ⌘K palette) are composable context, so the single-mechanism design is preserved.
- Keeps the existing `clearAndSetSemantics {}` for the accessibility half.

## Tests

Two regression tests observe **real keyboard focus** via `onFocusChanged` (the isolated background is intentionally absent from the queryable a11y tree, so a semantics query can't see it):

- `an open overlay traps Tab so it cannot reach the isolated background` — red on the old impl (`[false, true, false]`: background got focused), green now.
- `opening an overlay releases focus a background control already held` — red on the old impl (`focusedAfter=true`), green now.

## Validation

- `:desktop-core:test` (48) + `:desktop-core:detekt` + `:desktop-app:compileKotlin` green
- ktfmt clean / idempotent (touched files)

## Notes

- `needs-human`, auto-merge **off** — runtime behavior change in `android/`.
- References #4846 (already closed by #6020); does not re-close it.