### PR TITLE
feat(desktop): use the installed AutoMobile (or install it), plus live-session bug fixes

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -157,14 +157,17 @@ fun AutoMobileDesktopApp(
   val pickerState by pickerViewModel.state.collectAsState()
   var pickerOpen by remember { mutableStateOf(false) }
 
-  // Daemon bootstrap as a first-class startup step: detect the current AutoMobile daemon, or
-  // install Bun + start the pinned package when none is reachable — instead of leaving that work
-  // to happen invisibly inside the picker's first resource read. The bootstrap shares its
-  // lifecycle with the daemon client (see ApplicationModule), so whichever trigger wins the
-  // lifecycle lock, its progress lands in bootstrapState for the launch surfaces to narrate.
+  // Observable daemon-bootstrap progress for the launch surfaces. The startup lifecycle pass —
+  // detect the current AutoMobile daemon, or install Bun + start the pinned package when none is
+  // reachable — is triggered exactly ONCE, by the picker view model's init load through the daemon
+  // client's request preflight; the bootstrap shares that client's lifecycle (see
+  // ApplicationModule), so its phases land here regardless of the trigger. Deliberately NO second
+  // explicit ensureReady() pass at startup: the lifecycle lock would only serialize it behind the
+  // picker's, and after a FAILED first pass (offline Bun install, dead npm fetch) the queued
+  // duplicate would repeat the whole failed pipeline for a second full startup timeout before the
+  // user ever sees a stable Retry.
   val daemonBootstrap = graph.daemonBootstrap
   val bootstrapState by daemonBootstrap.state.collectAsState()
-  LaunchedEffect(daemonBootstrap) { withContext(Dispatchers.IO) { daemonBootstrap.ensureReady() } }
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
@@ -436,8 +439,10 @@ fun AutoMobileDesktopApp(
     if (!cameUp) return@LaunchedEffect
     // Short settle so the freshly (re)started daemon finishes binding its resources.
     delay(GRID_REFRESH_POLL_MS)
-    // Re-read the CURRENT picker state after the settle: only a still-failed picker reloads.
-    if (pickerState is DevicePickerUiState.Error) {
+    // Read the live state flow after the settle — explicitly, not through the composition's
+    // delegated property — so only a picker that is STILL failed reloads; a Retry the user
+    // pressed during the settle (now Loading/Content) is never overlapped by a second refresh.
+    if (pickerViewModel.state.value is DevicePickerUiState.Error) {
       pickerViewModel.onAction(DevicePickerAction.Refresh)
     }
   }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -422,15 +422,22 @@ fun AutoMobileDesktopApp(
       pickerViewModel.onAction(DevicePickerAction.SilentRefresh)
     }
   }
-  // A failed first load is otherwise a dead end (SilentRefresh only polls from Content): once the
-  // health poll sees the daemon reachable while the picker sits on Error, retry the load after a
-  // short settle. Gated on the daemon being up so a bootstrap failure (no daemon, install failed)
-  // is NOT hammered with repeated install attempts — that path stays on the explicit Retry button.
+  // A failed first load is otherwise a dead end (SilentRefresh only polls from Content): retry it
+  // automatically ONCE per disconnected -> connected transition of the daemon health poll — the
+  // "daemon was down, now it's back" recovery. Latching on the transition (not on the Error state)
+  // means a read that keeps failing WHILE the daemon stays connected (e.g. a malformed payload) is
+  // not retried in a Loading/Error flash loop every few seconds; that persistent case stays on the
+  // explicit Retry button, as does a bootstrap failure with no daemon at all.
   val daemonUp = daemonConnectionState is ConnectionState.Connected
-  val pickerFailed = pickerState is DevicePickerUiState.Error
-  LaunchedEffect(pickerViewModel, daemonUp, pickerFailed) {
-    if (daemonUp && pickerFailed) {
-      delay(GRID_REFRESH_POLL_MS)
+  var wasDaemonUp by remember(pickerViewModel) { mutableStateOf(daemonUp) }
+  LaunchedEffect(pickerViewModel, daemonUp) {
+    val cameUp = daemonUp && !wasDaemonUp
+    wasDaemonUp = daemonUp
+    if (!cameUp) return@LaunchedEffect
+    // Short settle so the freshly (re)started daemon finishes binding its resources.
+    delay(GRID_REFRESH_POLL_MS)
+    // Re-read the CURRENT picker state after the settle: only a still-failed picker reloads.
+    if (pickerState is DevicePickerUiState.Error) {
       pickerViewModel.onAction(DevicePickerAction.Refresh)
     }
   }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -68,6 +68,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.parseDeviceLockStates
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.RealDeviceBootController
 import dev.jasonpearson.automobile.desktop.core.workspace.rememberWorkspaceDeviceControl
@@ -155,6 +156,15 @@ fun AutoMobileDesktopApp(
     }
   val pickerState by pickerViewModel.state.collectAsState()
   var pickerOpen by remember { mutableStateOf(false) }
+
+  // Daemon bootstrap as a first-class startup step: detect the current AutoMobile daemon, or
+  // install Bun + start the pinned package when none is reachable — instead of leaving that work
+  // to happen invisibly inside the picker's first resource read. The bootstrap shares its
+  // lifecycle with the daemon client (see ApplicationModule), so whichever trigger wins the
+  // lifecycle lock, its progress lands in bootstrapState for the launch surfaces to narrate.
+  val daemonBootstrap = graph.daemonBootstrap
+  val bootstrapState by daemonBootstrap.state.collectAsState()
+  LaunchedEffect(daemonBootstrap) { withContext(Dispatchers.IO) { daemonBootstrap.ensureReady() } }
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
@@ -412,6 +422,18 @@ fun AutoMobileDesktopApp(
       pickerViewModel.onAction(DevicePickerAction.SilentRefresh)
     }
   }
+  // A failed first load is otherwise a dead end (SilentRefresh only polls from Content): once the
+  // health poll sees the daemon reachable while the picker sits on Error, retry the load after a
+  // short settle. Gated on the daemon being up so a bootstrap failure (no daemon, install failed)
+  // is NOT hammered with repeated install attempts — that path stays on the explicit Retry button.
+  val daemonUp = daemonConnectionState is ConnectionState.Connected
+  val pickerFailed = pickerState is DevicePickerUiState.Error
+  LaunchedEffect(pickerViewModel, daemonUp, pickerFailed) {
+    if (daemonUp && pickerFailed) {
+      delay(GRID_REFRESH_POLL_MS)
+      pickerViewModel.onAction(DevicePickerAction.Refresh)
+    }
+  }
 
   AutoMobileTheme(themeMode = settings.themeMode) {
     Surface(
@@ -447,6 +469,7 @@ fun AutoMobileDesktopApp(
               onClose = { pickerOpen = false },
               // Only offer Close when there is an observed workspace to return to.
               canClose = workspaceState is WorkspaceUiState.Content,
+              bootstrapState = bootstrapState,
             )
           else ->
             Box(Modifier.fillMaxSize()) {

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.KeyShortcut
@@ -16,8 +17,11 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.LocalWindowExceptionHandlerFactory
 import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowExceptionHandler
+import androidx.compose.ui.window.WindowExceptionHandlerFactory
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
@@ -25,6 +29,7 @@ import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.connection.DaemonConnectionMonitor
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.platform.uncaughtUiErrorMessage
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
@@ -32,6 +37,7 @@ import dev.zacsweers.metro.createGraphFactory
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
 import java.nio.file.Path
+import javax.swing.JOptionPane
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -70,6 +76,7 @@ private fun acquireSingleInstanceLock(): Boolean {
   }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 fun main() {
   // Must run before any AWT toolkit initialization so the app name is picked up.
   System.setProperty("apple.awt.application.name", "AutoMobile")
@@ -139,97 +146,122 @@ fun main() {
     // not a Boolean, so repeat presses each register even while the palette is already open.
     var openPaletteRequest by remember { mutableStateOf(0) }
 
-    Window(
-      onCloseRequest = { isWindowVisible = false },
-      title = "AutoMobile",
-      state = windowState,
-      visible = isWindowVisible,
-      onPreviewKeyEvent = { event ->
-        if (
-          event.type == KeyEventType.KeyDown &&
-            isCommandPaletteShortcut(event.key, event.isMetaPressed, event.isCtrlPressed)
-        ) {
-          openPaletteRequest++
-          true
-        } else {
-          false
+    // Last-resort handler for uncaught exceptions on the UI thread. Compose Desktop's default
+    // shows a bare Swing dialog containing only the throwable's toString() (a NoClassDefFoundError
+    // renders as an unreadable slash-form class path) and logs nothing. Ours logs the full stack
+    // and shows a readable message with a restart hint for the rebuilt-jar case. The dialog stays
+    // native (JOptionPane) on purpose: this surface exists precisely for "composition is broken",
+    // so it must not depend on Compose rendering. See uncaughtUiErrorMessage.
+    val uiExceptionHandlerFactory = remember {
+      WindowExceptionHandlerFactory { window ->
+        WindowExceptionHandler { throwable ->
+          LOG.error("Uncaught UI exception: ${throwable.message}", throwable)
+          JOptionPane.showMessageDialog(
+            window,
+            uncaughtUiErrorMessage(throwable),
+            "AutoMobile",
+            JOptionPane.ERROR_MESSAGE,
+          )
         }
-      },
+      }
+    }
+
+    CompositionLocalProvider(
+      LocalWindowExceptionHandlerFactory provides uiExceptionHandlerFactory
     ) {
-      CompositionLocalProvider(LocalAutoMobileGraph provides graph) {
-        MenuBar {
-          Menu("File", mnemonic = 'F') {
-            Item(
-              "Settings",
-              onClick = { menuBarActions.showSettings = true },
-              shortcut = platformShortcut(Key.Comma),
-            )
-            Separator()
-            Item(
-              "Quit",
-              onClick = { exitApplication() },
-              shortcut = platformShortcut(Key.Q),
-            )
+      Window(
+        onCloseRequest = { isWindowVisible = false },
+        title = "AutoMobile",
+        state = windowState,
+        visible = isWindowVisible,
+        onPreviewKeyEvent = { event ->
+          if (
+            event.type == KeyEventType.KeyDown &&
+              isCommandPaletteShortcut(event.key, event.isMetaPressed, event.isCtrlPressed)
+          ) {
+            openPaletteRequest++
+            true
+          } else {
+            false
           }
-          Menu("View", mnemonic = 'V') {
-            Item(
-              "Toggle Left Pane",
-              onClick = { menuBarActions.showLeftPane = !menuBarActions.showLeftPane },
-              shortcut = platformShortcut(Key.Zero),
-            )
-            Item(
-              "Toggle Right Pane",
-              onClick = { menuBarActions.showRightPane = !menuBarActions.showRightPane },
-              shortcut = platformShortcut(Key.Zero, shift = true),
-            )
-            Item(
-              "Toggle Bottom Pane",
-              onClick = { menuBarActions.showBottomPane = !menuBarActions.showBottomPane },
-              shortcut = platformShortcut(Key.Y, shift = true),
-            )
+        },
+      ) {
+        CompositionLocalProvider(LocalAutoMobileGraph provides graph) {
+          MenuBar {
+            Menu("File", mnemonic = 'F') {
+              Item(
+                "Settings",
+                onClick = { menuBarActions.showSettings = true },
+                shortcut = platformShortcut(Key.Comma),
+              )
+              Separator()
+              Item(
+                "Quit",
+                onClick = { exitApplication() },
+                shortcut = platformShortcut(Key.Q),
+              )
+            }
+            Menu("View", mnemonic = 'V') {
+              Item(
+                "Toggle Left Pane",
+                onClick = { menuBarActions.showLeftPane = !menuBarActions.showLeftPane },
+                shortcut = platformShortcut(Key.Zero),
+              )
+              Item(
+                "Toggle Right Pane",
+                onClick = { menuBarActions.showRightPane = !menuBarActions.showRightPane },
+                shortcut = platformShortcut(Key.Zero, shift = true),
+              )
+              Item(
+                "Toggle Bottom Pane",
+                onClick = { menuBarActions.showBottomPane = !menuBarActions.showBottomPane },
+                shortcut = platformShortcut(Key.Y, shift = true),
+              )
+            }
+            Menu("Tools", mnemonic = 'T') {
+              Item(
+                "Command Palette",
+                onClick = { menuBarActions.showCommandPalette = true },
+                shortcut = platformShortcut(Key.P, shift = true),
+              )
+              Item(
+                "Global Search",
+                onClick = { menuBarActions.showGlobalSearch = true },
+                shortcut = platformShortcut(Key.F, shift = true),
+              )
+              Item(
+                // ⌘K/Ctrl+K is handled by the window-level onPreviewKeyEvent below (opens the
+                // command
+                // palette). No shortcut here — a duplicate Key.K accelerator on this (currently
+                // inert)
+                // item would race the window handler. Re-wiring this menu item + restoring its
+                // shortcut is tracked in #4670.
+                "Quick Jump",
+                onClick = { menuBarActions.showQuickJump = true },
+              )
+              Separator()
+              Item(
+                "Take Screenshot",
+                onClick = { menuBarActions.onTakeScreenshot?.invoke() },
+                shortcut = platformShortcut(Key.S, shift = true),
+              )
+            }
+            Menu("Help", mnemonic = 'H') {
+              Item(
+                "Keyboard Shortcuts",
+                onClick = { menuBarActions.showCheatSheet = true },
+                shortcut = platformShortcut(Key.Slash),
+              )
+              Separator()
+              Item("About AutoMobile", onClick = { /* TODO: show about dialog */ })
+            }
           }
-          Menu("Tools", mnemonic = 'T') {
-            Item(
-              "Command Palette",
-              onClick = { menuBarActions.showCommandPalette = true },
-              shortcut = platformShortcut(Key.P, shift = true),
-            )
-            Item(
-              "Global Search",
-              onClick = { menuBarActions.showGlobalSearch = true },
-              shortcut = platformShortcut(Key.F, shift = true),
-            )
-            Item(
-              // ⌘K/Ctrl+K is handled by the window-level onPreviewKeyEvent below (opens the command
-              // palette). No shortcut here — a duplicate Key.K accelerator on this (currently
-              // inert)
-              // item would race the window handler. Re-wiring this menu item + restoring its
-              // shortcut is tracked in #4670.
-              "Quick Jump",
-              onClick = { menuBarActions.showQuickJump = true },
-            )
-            Separator()
-            Item(
-              "Take Screenshot",
-              onClick = { menuBarActions.onTakeScreenshot?.invoke() },
-              shortcut = platformShortcut(Key.S, shift = true),
-            )
-          }
-          Menu("Help", mnemonic = 'H') {
-            Item(
-              "Keyboard Shortcuts",
-              onClick = { menuBarActions.showCheatSheet = true },
-              shortcut = platformShortcut(Key.Slash),
-            )
-            Separator()
-            Item("About AutoMobile", onClick = { /* TODO: show about dialog */ })
-          }
+          AutoMobileDesktopApp(
+            menuBarActions = menuBarActions,
+            openPaletteRequest = openPaletteRequest,
+            daemonConnectionState = daemonState,
+          )
         }
-        AutoMobileDesktopApp(
-          menuBarActions = menuBarActions,
-          openPaletteRequest = openPaletteRequest,
-          daemonConnectionState = daemonState,
-        )
       }
     }
   }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.di
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.di.AppScope
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
@@ -22,6 +23,9 @@ interface AutoMobileGraph : AutoMobileGraphProvider {
 
   /** The MCP client for communicating with the AutoMobile daemon. */
   override val autoMobileClient: AutoMobileClient
+
+  /** Observable install/start progress of the shared daemon (drives the launch surfaces). */
+  override val daemonBootstrap: DaemonBootstrap
 
   /** Application settings provider. */
   override val settingsProvider: SettingsProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
@@ -1,0 +1,87 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Observable daemon-bootstrap state for the launch surfaces. A projection of every
+ * [DaemonLifecyclePhase] the shared [DesktopDaemonLifecycle] reports — whether the pass was
+ * triggered by the explicit startup bootstrap or by a per-request preflight — so the UI always
+ * reflects the pass that is actually holding the lifecycle lock.
+ */
+sealed interface DaemonBootstrapState {
+  /**
+   * Bootstrap does not apply: the app talks to an HTTP/STDIO transport it neither installs nor
+   * launches.
+   */
+  data object Inactive : DaemonBootstrapState
+
+  /** No lifecycle pass has reported yet (app just launched). */
+  data object Unknown : DaemonBootstrapState
+
+  /** A lifecycle pass is in flight; [phase] narrates what it is doing. */
+  data class Working(val phase: DaemonLifecyclePhase) : DaemonBootstrapState
+
+  /** The last pass resolved with a ready daemon. */
+  data class Ready(val restarted: Boolean) : DaemonBootstrapState
+
+  /** The last pass resolved without a usable daemon. */
+  data class Failed(val message: String) : DaemonBootstrapState
+}
+
+/**
+ * Owns the app-wide [DesktopDaemonLifecycle] and exposes its progress as [state]. One instance
+ * lives on the DI graph: the same lifecycle is attached to the shared [McpDaemonClient] (so
+ * per-request preflights report through it) and run once at startup via [ensureReady] (so the first
+ * launch installs/starts the daemon before the user has to trigger a request).
+ */
+class DaemonBootstrap
+internal constructor(lifecycleFactory: ((DaemonLifecyclePhase) -> Unit) -> DaemonLifecycleEnsurer) {
+  private val _state = MutableStateFlow<DaemonBootstrapState>(DaemonBootstrapState.Unknown)
+  val state: StateFlow<DaemonBootstrapState> = _state.asStateFlow()
+
+  internal val lifecycle: DaemonLifecycleEnsurer = lifecycleFactory(::onPhase)
+
+  private fun onPhase(phase: DaemonLifecyclePhase) {
+    _state.value =
+      when (phase) {
+        is DaemonLifecyclePhase.Completed -> DaemonBootstrapState.Ready(phase.restarted)
+        is DaemonLifecyclePhase.Failed -> DaemonBootstrapState.Failed(phase.message)
+        else -> DaemonBootstrapState.Working(phase)
+      }
+  }
+
+  /**
+   * Runs one lifecycle pass — detect the current daemon, or install Bun and start the pinned
+   * package when none is reachable. Blocking (up to the daemon-startup budget); call on an IO
+   * dispatcher. Progress and the terminal outcome land in [state] via the phase listener. Safe to
+   * call again to retry a failure.
+   */
+  fun ensureReady() {
+    lifecycle.ensureVersionMatchedDaemon()
+  }
+
+  /** Marks bootstrap as not applicable for this run (non-daemon transport). */
+  internal fun markInactive() {
+    _state.value = DaemonBootstrapState.Inactive
+  }
+
+  companion object {
+    fun create(): DaemonBootstrap = DaemonBootstrap { listener ->
+      DesktopDaemonLifecycle(phaseListener = listener)
+    }
+
+    /**
+     * An inert instance whose lifecycle never touches the system — for test graphs and non-daemon
+     * transports. Its state is permanently [DaemonBootstrapState.Inactive].
+     */
+    fun inactive(): DaemonBootstrap = DaemonBootstrap {
+      object : DaemonLifecycleEnsurer {
+        override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
+          DaemonLifecycleResult.Failure("Daemon bootstrap is inactive.")
+      }
+    }
+      .apply { markInactive() }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
@@ -32,9 +32,12 @@ sealed interface DaemonBootstrapState {
 
 /**
  * Owns the app-wide [DesktopDaemonLifecycle] and exposes its progress as [state]. One instance
- * lives on the DI graph: the same lifecycle is attached to the shared [McpDaemonClient] (so
- * per-request preflights report through it) and run once at startup via [ensureReady] (so the first
- * launch installs/starts the daemon before the user has to trigger a request).
+ * lives on the DI graph, and the same lifecycle is attached to the shared [McpDaemonClient], so
+ * per-request preflights report through it — the picker's first load is what runs the startup
+ * install/start pass. [ensureReady] exists for explicit triggers (e.g. a future recovery
+ * affordance); the app deliberately does NOT also call it at startup, since a second queued pass
+ * behind the lifecycle lock would repeat a failed install/start pipeline for another full startup
+ * timeout.
  */
 class DaemonBootstrap
 internal constructor(lifecycleFactory: ((DaemonLifecyclePhase) -> Unit) -> DaemonLifecycleEnsurer) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
@@ -43,7 +43,14 @@ internal constructor(lifecycleFactory: ((DaemonLifecyclePhase) -> Unit) -> Daemo
 
   internal val lifecycle: DaemonLifecycleEnsurer = lifecycleFactory(::onPhase)
 
+  // Latched by markInactive: a configured non-daemon transport (HTTP/STDIO) neither installs nor
+  // launches the local daemon, so ensureReady must be a no-op — otherwise the app-startup effect
+  // would run the real lifecycle anyway, installing Bun and starting/restarting an unused Unix
+  // daemon, and its phases would overwrite the Inactive state.
+  @Volatile private var inactive = false
+
   private fun onPhase(phase: DaemonLifecyclePhase) {
+    if (inactive) return
     _state.value =
       when (phase) {
         is DaemonLifecyclePhase.Completed -> DaemonBootstrapState.Ready(phase.restarted)
@@ -56,14 +63,17 @@ internal constructor(lifecycleFactory: ((DaemonLifecyclePhase) -> Unit) -> Daemo
    * Runs one lifecycle pass — detect the current daemon, or install Bun and start the pinned
    * package when none is reachable. Blocking (up to the daemon-startup budget); call on an IO
    * dispatcher. Progress and the terminal outcome land in [state] via the phase listener. Safe to
-   * call again to retry a failure.
+   * call again to retry a failure. A no-op for an [markInactive]-marked bootstrap (non-daemon
+   * transport) — the app must never install/start a local daemon it is not connected to.
    */
   fun ensureReady() {
+    if (inactive) return
     lifecycle.ensureVersionMatchedDaemon()
   }
 
   /** Marks bootstrap as not applicable for this run (non-daemon transport). */
   internal fun markInactive() {
+    inactive = true
     _state.value = DaemonBootstrapState.Inactive
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -454,6 +454,33 @@ internal sealed interface DaemonLifecycleResult {
   data class Failure(val message: String) : DaemonLifecycleResult
 }
 
+/**
+ * Coarse progress phases of a daemon lifecycle pass, reported through the lifecycle's
+ * `phaseListener` so the UI can narrate a slow first launch (installing Bun, fetching the daemon
+ * package) instead of sitting on a generic spinner. Terminal phases mirror [DaemonLifecycleResult];
+ * the listener sees every pass, including per-request preflights that resolve instantly to
+ * [Completed].
+ */
+sealed interface DaemonLifecyclePhase {
+  /** Reading the pid file and probing the daemon socket. */
+  data object Probing : DaemonLifecyclePhase
+
+  /** Downloading and running the Bun installer (first launch on a machine without Bun). */
+  data object InstallingRuntime : DaemonLifecyclePhase
+
+  /** Running `bunx @kaeawc/auto-mobile@<version> --daemon <action>` (fetches the package). */
+  data class LaunchingDaemon(val action: String, val version: String) : DaemonLifecyclePhase
+
+  /** Daemon command succeeded; polling the socket until it serves the expected version. */
+  data object Verifying : DaemonLifecyclePhase
+
+  /** The pass resolved with a ready daemon. */
+  data class Completed(val restarted: Boolean) : DaemonLifecyclePhase
+
+  /** The pass resolved without a usable daemon. */
+  data class Failed(val message: String) : DaemonLifecyclePhase
+}
+
 internal interface DaemonLifecycleEnsurer {
   fun ensureVersionMatchedDaemon(): DaemonLifecycleResult
 }
@@ -473,118 +500,138 @@ internal class DesktopDaemonLifecycle(
     SystemDaemonPackageRunnerResolver(),
   private val bunInstaller: DesktopBunInstaller = SystemDesktopBunInstaller(),
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
+  /**
+   * Observes [DaemonLifecyclePhase] transitions of every pass. Invoked under [lifecycleLock], so
+   * implementations must be non-blocking (e.g. a `StateFlow.value` write).
+   */
+  private val phaseListener: (DaemonLifecyclePhase) -> Unit = {},
 ) : DaemonLifecycleEnsurer {
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
     synchronized(lifecycleLock) {
-      val expectedVersion =
-        expectedVersionProvider()
-          ?: return DaemonLifecycleResult.Failure(
-            "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
-              "Rebuild or reinstall the desktop application, then try again."
-          )
-      val currentDaemon =
-        when (val readResult = readPidStateWithRetry()) {
-          is DaemonPidReadResult.Present -> readResult.state
-          DaemonPidReadResult.Absent -> null
-          DaemonPidReadResult.Unreadable ->
-            return DaemonLifecycleResult.Failure(
-              "Could not read the AutoMobile daemon state. Wait a moment for startup to finish, then retry."
-            )
+      phaseListener(DaemonLifecyclePhase.Probing)
+      val result = ensureLocked()
+      phaseListener(
+        when (result) {
+          is DaemonLifecycleResult.Ready -> DaemonLifecyclePhase.Completed(result.restarted)
+          is DaemonLifecycleResult.Failure -> DaemonLifecyclePhase.Failed(result.message)
         }
-      val currentVersion = currentDaemon?.version
-      val daemonAvailable = socketIsReady(currentVersion, expectedVersion)
-      if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
-        return DaemonLifecycleResult.Ready(restarted = false)
-      }
+      )
+      result
+    }
 
-      if (declaresFullVersion(expectedVersion)) {
-        return DaemonLifecycleResult.Failure(
-          "AutoMobile desktop source build $expectedVersion cannot start a matching published daemon. " +
-            "Start the daemon from the same checkout, then try again."
+  private fun ensureLocked(): DaemonLifecycleResult {
+    val expectedVersion =
+      expectedVersionProvider()
+        ?: return DaemonLifecycleResult.Failure(
+          "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
+            "Rebuild or reinstall the desktop application, then try again."
         )
+    val currentDaemon =
+      when (val readResult = readPidStateWithRetry()) {
+        is DaemonPidReadResult.Present -> readResult.state
+        DaemonPidReadResult.Absent -> null
+        DaemonPidReadResult.Unreadable ->
+          return DaemonLifecycleResult.Failure(
+            "Could not read the AutoMobile daemon state. Wait a moment for startup to finish, then retry."
+          )
       }
+    val currentVersion = currentDaemon?.version
+    val daemonAvailable = socketIsReady(currentVersion, expectedVersion)
+    if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
+      return DaemonLifecycleResult.Ready(restarted = false)
+    }
 
-      val action = if (daemonAvailable) "restart" else "start"
-      val osName = System.getProperty("os.name", "")
-      var runner = packageRunnerResolver.resolve(osName)
-      if (runner == null) {
-        val installResult = bunInstaller.install(osName)
-        if (installResult.cancelled) {
-          return DaemonLifecycleResult.Failure("Bun installation was cancelled.")
-        }
-        if (installResult.timedOut) {
-          return DaemonLifecycleResult.Failure(
-            "Timed out while installing Bun. Check your network connection and retry."
-          )
-        }
-        if (installResult.exitCode != 0) {
-          val detail = installResult.output.trim().takeIf { it.isNotEmpty() }
-          return DaemonLifecycleResult.Failure(
-            buildString {
-              append("Could not install Bun automatically")
-              detail?.let { append(": $it") }
-              append(". Install Bun manually, then try again.")
-            }
-          )
-        }
-        runner = packageRunnerResolver.resolve(osName)
-        if (runner == null) {
-          return DaemonLifecycleResult.Failure(
-            "Bun installed, but bunx could not be found. Restart AutoMobile and try again."
-          )
-        }
-      }
-      val commandResult =
-        try {
-          val command =
-            packageDaemonCommand(
-              runner,
-              expectedVersion,
-              action,
-              currentDaemon?.launchArguments.orEmpty(),
-              osName,
-            )
-          commandExecutor.execute(command)
-        } catch (error: Exception) {
-          return DaemonLifecycleResult.Failure(
-            "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
-              "Install Bun so bunx is available, then try again."
-          )
-        }
-      if (commandResult.cancelled) {
-        return DaemonLifecycleResult.Failure("AutoMobile daemon startup was cancelled.")
-      }
-      if (commandResult.exitCode != 0) {
-        if (commandResult.timedOut) {
-          return DaemonLifecycleResult.Failure(
-            "Timed out while trying to $action AutoMobile $expectedVersion. " +
-              "Check the daemon logs and retry."
-          )
-        }
-        val detail =
-          commandResult.output.trim().takeIf { it.isNotEmpty() }
-            ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."
-        return DaemonLifecycleResult.Failure(
-          "Could not $action AutoMobile $expectedVersion (exit code ${commandResult.exitCode}). $detail"
-        )
-      }
-
-      var actualVersion: String? = null
-      repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
-        actualVersion = (pidFileReader.read() as? DaemonPidReadResult.Present)?.state?.version
-        if (socketChecker.isReady() && versionsMatch(actualVersion, expectedVersion)) {
-          return DaemonLifecycleResult.Ready(restarted = true)
-        }
-        if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
-          timer.sleep(VERIFICATION_RETRY_DELAY_MS)
-        }
-      }
+    if (declaresFullVersion(expectedVersion)) {
       return DaemonLifecycleResult.Failure(
-        "AutoMobile daemon version mismatch: desktop requires $expectedVersion, but the daemon " +
-          "reports ${actualVersion ?: "no version"}. Stop the existing daemon and retry so " +
-          "@kaeawc/auto-mobile@$expectedVersion can start."
+        "AutoMobile desktop source build $expectedVersion cannot start a matching published daemon. " +
+          "Start the daemon from the same checkout, then try again."
       )
     }
+
+    val action = if (daemonAvailable) "restart" else "start"
+    val osName = System.getProperty("os.name", "")
+    var runner = packageRunnerResolver.resolve(osName)
+    if (runner == null) {
+      phaseListener(DaemonLifecyclePhase.InstallingRuntime)
+      val installResult = bunInstaller.install(osName)
+      if (installResult.cancelled) {
+        return DaemonLifecycleResult.Failure("Bun installation was cancelled.")
+      }
+      if (installResult.timedOut) {
+        return DaemonLifecycleResult.Failure(
+          "Timed out while installing Bun. Check your network connection and retry."
+        )
+      }
+      if (installResult.exitCode != 0) {
+        val detail = installResult.output.trim().takeIf { it.isNotEmpty() }
+        return DaemonLifecycleResult.Failure(
+          buildString {
+            append("Could not install Bun automatically")
+            detail?.let { append(": $it") }
+            append(". Install Bun manually, then try again.")
+          }
+        )
+      }
+      runner = packageRunnerResolver.resolve(osName)
+      if (runner == null) {
+        return DaemonLifecycleResult.Failure(
+          "Bun installed, but bunx could not be found. Restart AutoMobile and try again."
+        )
+      }
+    }
+    phaseListener(DaemonLifecyclePhase.LaunchingDaemon(action, expectedVersion))
+    val commandResult =
+      try {
+        val command =
+          packageDaemonCommand(
+            runner,
+            expectedVersion,
+            action,
+            currentDaemon?.launchArguments.orEmpty(),
+            osName,
+          )
+        commandExecutor.execute(command)
+      } catch (error: Exception) {
+        return DaemonLifecycleResult.Failure(
+          "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
+            "Install Bun so bunx is available, then try again."
+        )
+      }
+    if (commandResult.cancelled) {
+      return DaemonLifecycleResult.Failure("AutoMobile daemon startup was cancelled.")
+    }
+    if (commandResult.exitCode != 0) {
+      if (commandResult.timedOut) {
+        return DaemonLifecycleResult.Failure(
+          "Timed out while trying to $action AutoMobile $expectedVersion. " +
+            "Check the daemon logs and retry."
+        )
+      }
+      val detail =
+        commandResult.output.trim().takeIf { it.isNotEmpty() }
+          ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."
+      return DaemonLifecycleResult.Failure(
+        "Could not $action AutoMobile $expectedVersion (exit code ${commandResult.exitCode}). $detail"
+      )
+    }
+
+    phaseListener(DaemonLifecyclePhase.Verifying)
+    var actualVersion: String? = null
+    repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
+      actualVersion = (pidFileReader.read() as? DaemonPidReadResult.Present)?.state?.version
+      if (socketChecker.isReady() && versionsMatch(actualVersion, expectedVersion)) {
+        return DaemonLifecycleResult.Ready(restarted = true)
+      }
+      if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
+        timer.sleep(VERIFICATION_RETRY_DELAY_MS)
+      }
+    }
+    return DaemonLifecycleResult.Failure(
+      "AutoMobile daemon version mismatch: desktop requires $expectedVersion, but the daemon " +
+        "reports ${actualVersion ?: "no version"}. Stop the existing daemon and retry so " +
+        "@kaeawc/auto-mobile@$expectedVersion can start."
+    )
+  }
 
   private fun packageDaemonCommand(
     runner: String,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpClientFactory.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpClientFactory.kt
@@ -25,18 +25,29 @@ object McpClientFactory {
     }
   }
 
-  fun createPreferred(): AutoMobileClient {
+  /**
+   * Creates the app's preferred client. When [bootstrap] is provided and the Unix-socket daemon is
+   * selected, the client shares the bootstrap's lifecycle so its per-request preflights report
+   * their progress to the launch surfaces; non-daemon transports mark the bootstrap inactive.
+   */
+  fun createPreferred(bootstrap: DaemonBootstrap? = null): AutoMobileClient {
     val configuredHttp = createConfiguredHttp()
     if (configuredHttp != null) {
+      bootstrap?.markInactive()
       return configuredHttp
     }
 
     val configuredStdio = createConfiguredStdio()
     if (configuredStdio != null) {
+      bootstrap?.markInactive()
       return configuredStdio
     }
 
-    return McpDaemonClient()
+    return if (bootstrap != null) {
+      McpDaemonClient(DaemonSocketPaths.socketPath(), bootstrap.lifecycle)
+    } else {
+      McpDaemonClient()
+    }
   }
 
   fun createConfiguredHttp(): McpHttpClient? {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -1142,8 +1142,23 @@ object DaemonSocketPaths {
     if (trimmed.isEmpty() || ignoredVersions.contains(trimmed.lowercase())) {
       return null
     }
+    // A Gradle dev build stamps `<release>-SNAPSHOT` (e.g. `0.0.67-SNAPSHOT`). The daemon's
+    // handshake gate compares release strings, and `-SNAPSHOT` is a semver prerelease — not `+`
+    // build metadata — so an unstripped SNAPSHOT can never match the published daemon it tracks
+    // (`0.0.67-SNAPSHOT` != `0.0.67`), and `bunx @kaeawc/auto-mobile@0.0.67-SNAPSHOT` names a
+    // package that does not exist on npm. Declare the base release instead so a dev-run desktop
+    // connects to the current installed daemon, and can install the real package when none runs.
+    val snapshotBase =
+      trimmed
+        .takeIf { it.endsWith(SNAPSHOT_SUFFIX, ignoreCase = true) }
+        ?.dropLast(SNAPSHOT_SUFFIX.length)
+    if (snapshotBase != null) {
+      return snapshotBase.takeIf { it.isNotEmpty() }
+    }
     return trimmed
   }
+
+  private const val SNAPSHOT_SUFFIX = "-SNAPSHOT"
 
   internal fun releaseVersion(version: String): String = version.substringBefore('+')
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.di
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
 import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
@@ -23,8 +24,16 @@ interface ApplicationModule {
 
     @Provides
     @SingleIn(AppScope::class)
-    fun provideAutoMobileClient(): AutoMobileClient {
-      return McpClientFactory.createPreferred()
+    fun provideDaemonBootstrap(): DaemonBootstrap {
+      return DaemonBootstrap.create()
+    }
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideAutoMobileClient(daemonBootstrap: DaemonBootstrap): AutoMobileClient {
+      // Shares the bootstrap's lifecycle with the daemon client so install/start progress from any
+      // trigger (startup bootstrap or a request preflight) reaches the launch surfaces.
+      return McpClientFactory.createPreferred(daemonBootstrap)
     }
 
     @Provides

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AutoMobileGraphProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AutoMobileGraphProvider.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.di
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
@@ -15,6 +16,9 @@ import dev.jasonpearson.automobile.desktop.core.update.UpdateController
 interface AutoMobileGraphProvider {
   /** The default MCP client for communicating with the AutoMobile daemon. */
   val autoMobileClient: AutoMobileClient
+
+  /** Observable install/start progress of the shared daemon (drives the launch surfaces). */
+  val daemonBootstrap: DaemonBootstrap
 
   /** Application settings provider. */
   val settingsProvider: SettingsProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.di
 
 import androidx.compose.runtime.staticCompositionLocalOf
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
@@ -19,10 +20,12 @@ import dev.jasonpearson.automobile.desktop.core.update.RealUpdateController
  */
 val LocalAutoMobileGraph =
   staticCompositionLocalOf<AutoMobileGraphProvider> {
-    val client = McpClientFactory.createPreferred()
+    val bootstrap = DaemonBootstrap.create()
+    val client = McpClientFactory.createPreferred(bootstrap)
     val versionProvider = RuntimeAppVersionProvider(PackagedVersionSource())
     object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = bootstrap
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val appVersionProvider = versionProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/UncaughtUiError.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/UncaughtUiError.kt
@@ -1,0 +1,27 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+/**
+ * Human-readable message for the app's last-resort uncaught-UI-exception dialog.
+ *
+ * Compose Desktop's default handler shows a bare Swing dialog whose only content is the throwable's
+ * `toString()` — for a [NoClassDefFoundError] that is just a slash-form class path
+ * (`dev/jasonpearson/.../DaemonPidReadResult$Absent`), which reads as gibberish. The app installs
+ * its own handler (see Main.kt) that logs the full stack and shows this message instead. The dialog
+ * itself stays native (Swing) ON PURPOSE: the one situation this surface exists for is "composition
+ * is broken" — e.g. the jar was rebuilt under the running JVM and Compose classes may no longer
+ * load — so the error UI must not depend on Compose rendering.
+ */
+fun uncaughtUiErrorMessage(throwable: Throwable): String {
+  val summary = "${throwable.javaClass.simpleName}: ${throwable.message ?: "no further detail"}"
+  val hint =
+    if (throwable is NoClassDefFoundError || throwable is ClassNotFoundException) {
+      // The classic dev-loop trap: a jar rebuilt while this JVM is running poisons its
+      // classloader; the first lazy class load afterwards fails. Nothing is wrong with the
+      // source — restarting the app on the fresh build fixes it.
+      "\n\nThe app's code on disk changed after launch (a rebuild while the app was " +
+        "running). Restart AutoMobile to load the current build."
+    } else {
+      "\n\nDetails were written to the application log."
+    }
+  return "AutoMobile hit an unexpected error.\n\n$summary$hint"
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -168,6 +168,20 @@ fun DeviceStreamView(
       // NOT be reconnected; the first-frame deadline still catches a never-first-frame wedge.
       stallReconnectMs = if (column.platform == Platform.Android) LIVE_STALL_RECONNECT_MS else null,
     )
+  // Retain the newest frame ACROSS source swaps, keyed on the device. rememberLiveVideoFrame
+  // retains frames across relay drops WITHIN one source, but arming the pane (fps 10→30), a manual
+  // preset pick, or an auto-adjust step recreates the source — resetting that per-source state to
+  // null and flashing "Connecting to live mirror…" mid-interaction. The mirror keeps rendering this
+  // retained frame until the new subscription decodes its first frame, so a re-subscribe is
+  // seamless. Keyed on deviceId so one device never shows another device's last frame; control
+  // arming still requires a CURRENT frame + Streaming state (below), so stale pixels are never
+  // clickable.
+  var retainedFrame by remember(column.deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
+  LaunchedEffect(liveFrame) {
+    if (liveFrame != null) {
+      retainedFrame = liveFrame
+    }
+  }
   val state by source.state.collectAsState()
   val droppedFrames by source.droppedFrames.collectAsState(initial = null)
   val controlSnapshot = control?.interactionSnapshot
@@ -190,6 +204,7 @@ fun DeviceStreamView(
       column = column,
       state = state,
       liveFrame = liveFrame,
+      retainedFrame = retainedFrame,
       control = control,
       controlSnapshot = controlSnapshot,
       enableDeviceControl = enableDeviceControl,
@@ -242,6 +257,10 @@ private fun DeviceStreamContent(
   column: DeviceColumn,
   state: VideoStreamState,
   liveFrame: LiveVideoFrame?,
+  // The last frame any PREVIOUS source for this device decoded — rendered by the plain mirror
+  // while a recreated source (arming / quality change) is still connecting, never by the armed
+  // control surface.
+  retainedFrame: LiveVideoFrame?,
   control: WorkspaceDeviceControlState?,
   controlSnapshot: DeviceFrameSnapshot?,
   enableDeviceControl: Boolean,
@@ -325,7 +344,7 @@ private fun DeviceStreamContent(
     )
   } else {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      val bitmap = liveFrame?.bitmap
+      val bitmap = (liveFrame ?: retainedFrame)?.bitmap
       if (bitmap != null) {
         Image(
           bitmap = bitmap,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -38,6 +38,7 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
+import kotlinx.coroutines.delay
 
 /**
  * Live device mirror for a workspace pane's stream area: subscribes to the daemon's video-stream
@@ -70,6 +71,14 @@ import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 // subscriber's hint fixes the shared per-device encode.
 private const val CONTROL_PANE_FPS = 30
 private const val MIRROR_PANE_FPS = 10
+
+/**
+ * How long the armed control surface survives on retained pixels while the stream is between
+ * Streaming states (re-subscribe, brief drop). Long enough to cover a quality-step reconnect, short
+ * enough that a genuinely dead relay disarms before the on-screen UI can meaningfully drift from
+ * the device.
+ */
+private const val ARMED_FRAME_RETENTION_MS = 3_000L
 
 /** Test tag on the armed interactive-video surface, so tests can pin which branch rendered. */
 internal const val DEVICE_CONTROL_SURFACE_TEST_TAG = "device-control-surface"
@@ -107,6 +116,9 @@ fun DeviceStreamView(
     },
   screenRecordingSettingsLauncher: ScreenRecordingSettingsLauncher =
     MacScreenRecordingSettingsLauncher(),
+  // How long the armed control surface may keep running on the newest frame while the stream is
+  // not currently reporting Streaming (see the freshness gate below). Injectable for tests.
+  armedFrameRetentionMs: Long = ARMED_FRAME_RETENTION_MS,
 ) {
   // The pane's fixed per-mode preset when there's no controller: an armed (user-driven) pane wants
   // the sharpest High stream; unfocused farm mirrors stay on the cheap Low preset.
@@ -183,6 +195,24 @@ fun DeviceStreamView(
     }
   }
   val state by source.state.collectAsState()
+  val newestFrame = liveFrame ?: retainedFrame
+  // Freshness gate for CONTROL across transient non-Streaming windows (a quality-step
+  // re-subscribe, a brief relay drop before auto-reconnect): the armed surface may keep using the
+  // newest frame until it goes [armedFrameRetentionMs] without a successor, at which point control
+  // disarms — preserving "stale pixels are never clickable" (#5255) while no longer flickering the
+  // interactive surface (and its Tap Targets bar) away on every re-subscribe. The effect restarts
+  // on every decoded frame, so a healthy feed never expires. While the source itself reports
+  // Streaming the gate is bypassed below: an idle iOS capture emits no frames on a static screen,
+  // and that is healthy, not stale.
+  var armedFrameExpired by remember(column.deviceId) { mutableStateOf(false) }
+  LaunchedEffect(newestFrame) {
+    if (newestFrame == null) return@LaunchedEffect
+    armedFrameExpired = false
+    delay(armedFrameRetentionMs)
+    armedFrameExpired = true
+  }
+  val armedFrame =
+    if (state is VideoStreamState.Streaming || !armedFrameExpired) newestFrame else null
   val droppedFrames by source.droppedFrames.collectAsState(initial = null)
   val controlSnapshot = control?.interactionSnapshot
   var settingsLaunchFailure by remember(column.deviceId) { mutableStateOf(false) }
@@ -203,8 +233,8 @@ fun DeviceStreamView(
     DeviceStreamContent(
       column = column,
       state = state,
-      liveFrame = liveFrame,
-      retainedFrame = retainedFrame,
+      displayFrame = newestFrame,
+      armedFrame = armedFrame,
       control = control,
       controlSnapshot = controlSnapshot,
       enableDeviceControl = enableDeviceControl,
@@ -225,7 +255,6 @@ fun DeviceStreamView(
       StreamQualityControls(
         currentQuality = currentQuality,
         actualFps = actualFps,
-        targetFps = qualityController.targetFps,
         autoAdjustEnabled = autoAdjust,
         expanded = overlayExpanded,
         onToggleExpanded = { overlayExpanded = !overlayExpanded },
@@ -256,11 +285,12 @@ fun DeviceStreamView(
 private fun DeviceStreamContent(
   column: DeviceColumn,
   state: VideoStreamState,
-  liveFrame: LiveVideoFrame?,
-  // The last frame any PREVIOUS source for this device decoded — rendered by the plain mirror
-  // while a recreated source (arming / quality change) is still connecting, never by the armed
-  // control surface.
-  retainedFrame: LiveVideoFrame?,
+  // The newest frame ANY source for this device decoded — what the plain mirror renders, so a
+  // re-subscribing source never blanks the pane back to a connect hint.
+  displayFrame: LiveVideoFrame?,
+  // [displayFrame] gated by the control-freshness rule (Streaming, or within the retention
+  // window): the only pixels the armed interactive surface may run on. Null disarms control.
+  armedFrame: LiveVideoFrame?,
   control: WorkspaceDeviceControlState?,
   controlSnapshot: DeviceFrameSnapshot?,
   enableDeviceControl: Boolean,
@@ -288,17 +318,15 @@ private fun DeviceStreamContent(
       },
     )
   } else if (
-    enableDeviceControl &&
-      control != null &&
-      controlSnapshot != null &&
-      liveFrame != null &&
-      state is VideoStreamState.Streaming
+    enableDeviceControl && control != null && controlSnapshot != null && armedFrame != null
   ) {
     // Armed WITH live video: the pane's pixels are ALWAYS the live H.264 mirror — never the
-    // observation screenshot. The armed surface requires a decoded frame AND a currently-Streaming
-    // relay: before the first frame the pane shows the status hint, and once the relay drops the
-    // last frame is still RENDERED (mirror branch below) but control DISARMS — a retained-but-stale
-    // frame must not stay clickable while untagged taps land on a device whose UI may have moved.
+    // observation screenshot. The armed surface requires [armedFrame]: a decoded frame from a
+    // Streaming relay, or a retained frame within the control-freshness window (so a quality-step
+    // re-subscribe or a momentary drop does not flicker the interactive surface away). Once the
+    // window lapses with no frame, control DISARMS while the mirror below keeps the last pixels —
+    // a genuinely-stale frame must not stay clickable while untagged taps land on a device whose
+    // UI may have moved (#5255).
     // Clicks map through the in-memory observation snapshot (its real device dimensions);
     // video and observation cover the same screen at the same aspect ratio, so a click normalized
     // against the displayed video maps to the same device pixel. DeviceScreenView already renders
@@ -310,7 +338,7 @@ private fun DeviceStreamContent(
       // Passing them here is what made the pane visibly "switch over to screenshots" whenever the
       // relay dropped a frame source; the retained live frame now covers those windows.
       screenshotData = null,
-      liveFrame = liveFrame.bitmap,
+      liveFrame = armedFrame.bitmap,
       screenWidth = renderSnapshot?.deviceWidth ?: 0,
       screenHeight = renderSnapshot?.deviceHeight ?: 0,
       rotation = renderSnapshot?.rotation ?: 0,
@@ -344,7 +372,7 @@ private fun DeviceStreamContent(
     )
   } else {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      val bitmap = (liveFrame ?: retainedFrame)?.bitmap
+      val bitmap = displayFrame?.bitmap
       if (bitmap != null) {
         Image(
           bitmap = bitmap,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -203,11 +203,14 @@ fun DeviceStreamView(
   // immediately and recreate the Tap Targets flicker this gate exists to prevent. While Streaming
   // the window is continuously reset; once Streaming is lost the armed surface may keep using the
   // newest frame for [armedFrameRetentionMs], then control disarms — preserving "stale pixels are
-  // never clickable" (#5255). A recreated source resets the collected state itself, so the swap
-  // lands here as a plain Streaming -> non-Streaming transition.
+  // never clickable" (#5255). Keyed on [source] as well: a swap while the OLD source was already
+  // mid-grace (same non-Streaming boolean, so no transition) restarts the window for the fresh
+  // connection attempt rather than letting the old source's clock expire it. The restart cannot
+  // re-arm already-expired pixels — the effect body only CLEARS the flag under Streaming, so an
+  // expired verdict carries across the swap until the new source actually streams.
   var armedGraceExpired by remember(column.deviceId) { mutableStateOf(false) }
   val streamingNow = state is VideoStreamState.Streaming
-  LaunchedEffect(streamingNow) {
+  LaunchedEffect(source, streamingNow) {
     if (streamingNow) {
       armedGraceExpired = false
     } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -196,23 +196,26 @@ fun DeviceStreamView(
   }
   val state by source.state.collectAsState()
   val newestFrame = liveFrame ?: retainedFrame
-  // Freshness gate for CONTROL across transient non-Streaming windows (a quality-step
-  // re-subscribe, a brief relay drop before auto-reconnect): the armed surface may keep using the
-  // newest frame until it goes [armedFrameRetentionMs] without a successor, at which point control
-  // disarms — preserving "stale pixels are never clickable" (#5255) while no longer flickering the
-  // interactive surface (and its Tap Targets bar) away on every re-subscribe. The effect restarts
-  // on every decoded frame, so a healthy feed never expires. While the source itself reports
-  // Streaming the gate is bypassed below: an idle iOS capture emits no frames on a static screen,
-  // and that is healthy, not stale.
-  var armedFrameExpired by remember(column.deviceId) { mutableStateOf(false) }
-  LaunchedEffect(newestFrame) {
-    if (newestFrame == null) return@LaunchedEffect
-    armedFrameExpired = false
-    delay(armedFrameRetentionMs)
-    armedFrameExpired = true
+  // Grace window for CONTROL across transient non-Streaming windows (a quality-step re-subscribe,
+  // a brief relay drop before auto-reconnect): the clock starts when the stream LEAVES Streaming
+  // — not from the last frame's age. Aging frames would pre-expire on a healthy static iOS screen
+  // (its capture emits no frames while idle), so the very first source swap would disarm
+  // immediately and recreate the Tap Targets flicker this gate exists to prevent. While Streaming
+  // the window is continuously reset; once Streaming is lost the armed surface may keep using the
+  // newest frame for [armedFrameRetentionMs], then control disarms — preserving "stale pixels are
+  // never clickable" (#5255). A recreated source resets the collected state itself, so the swap
+  // lands here as a plain Streaming -> non-Streaming transition.
+  var armedGraceExpired by remember(column.deviceId) { mutableStateOf(false) }
+  val streamingNow = state is VideoStreamState.Streaming
+  LaunchedEffect(streamingNow) {
+    if (streamingNow) {
+      armedGraceExpired = false
+    } else {
+      delay(armedFrameRetentionMs)
+      armedGraceExpired = true
+    }
   }
-  val armedFrame =
-    if (state is VideoStreamState.Streaming || !armedFrameExpired) newestFrame else null
+  val armedFrame = if (streamingNow || !armedGraceExpired) newestFrame else null
   val droppedFrames by source.droppedFrames.collectAsState(initial = null)
   val controlSnapshot = control?.interactionSnapshot
   var settingsLaunchFailure by remember(column.deviceId) { mutableStateOf(false) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -116,9 +116,12 @@ fun DeviceStreamView(
     },
   screenRecordingSettingsLauncher: ScreenRecordingSettingsLauncher =
     MacScreenRecordingSettingsLauncher(),
-  // How long the armed control surface may keep running on the newest frame while the stream is
-  // not currently reporting Streaming (see the freshness gate below). Injectable for tests.
-  armedFrameRetentionMs: Long = ARMED_FRAME_RETENTION_MS,
+  // The grace period the armed control surface may keep running on the newest frame while the
+  // stream is not currently reporting Streaming (see the grace gate below). A suspend seam —
+  // mirroring NavigationFacet's resolveTimeout — so tests drive expiry, cancellation, and
+  // restart-on-source-swap ordering deterministically (e.g. awaiting a CompletableDeferred) with
+  // zero wall time. Production waits the real retention window.
+  armedFrameGraceWait: suspend () -> Unit = { delay(ARMED_FRAME_RETENTION_MS) },
 ) {
   // The pane's fixed per-mode preset when there's no controller: an armed (user-driven) pane wants
   // the sharpest High stream; unfocused farm mirrors stay on the cheap Low preset.
@@ -202,7 +205,8 @@ fun DeviceStreamView(
   // (its capture emits no frames while idle), so the very first source swap would disarm
   // immediately and recreate the Tap Targets flicker this gate exists to prevent. While Streaming
   // the window is continuously reset; once Streaming is lost the armed surface may keep using the
-  // newest frame for [armedFrameRetentionMs], then control disarms — preserving "stale pixels are
+  // newest frame until [armedFrameGraceWait] completes, then control disarms — preserving "stale
+  // pixels are
   // never clickable" (#5255). Keyed on [source] as well: a swap while the OLD source was already
   // mid-grace (same non-Streaming boolean, so no transition) restarts the window for the fresh
   // connection attempt rather than letting the old source's clock expire it. The restart cannot
@@ -214,7 +218,7 @@ fun DeviceStreamView(
     if (streamingNow) {
       armedGraceExpired = false
     } else {
-      delay(armedFrameRetentionMs)
+      armedFrameGraceWait()
       armedGraceExpired = true
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
@@ -28,14 +28,13 @@ import kotlin.math.roundToInt
  * callbacks are hoisted, so the pane owns the [QualityController] and persistence and this view
  * stays testable.
  *
- * @param actualFps the live rate from the controller; rendered rounded next to [targetFps].
+ * @param actualFps the live rate from the controller, rendered rounded.
  * @param expanded whether the selector/toggle row is shown beneath the readout.
  */
 @Composable
 fun StreamQualityControls(
   currentQuality: VideoStreamQuality,
   actualFps: Float,
-  targetFps: Int,
   autoAdjustEnabled: Boolean,
   expanded: Boolean,
   onToggleExpanded: () -> Unit,
@@ -51,7 +50,10 @@ fun StreamQualityControls(
     verticalArrangement = Arrangement.spacedBy(4.dp),
   ) {
     Text(
-      "${currentQuality.name} · ${actualFps.roundToInt()} / $targetFps fps",
+      // Measured rate only — no "/ target" suffix. The measured rate can legitimately exceed the
+      // requested rate (decoder catch-up bursts after a stall), so rendering it against the target
+      // read as a broken limit rather than live throughput.
+      "${currentQuality.name} · ${actualFps.roundToInt()} fps",
       fontSize = 10.sp,
       color = Color.White.copy(alpha = 0.9f),
       modifier = Modifier.clickable(onClick = onToggleExpanded).pointerHoverIcon(PointerIcon.Hand),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -18,10 +18,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -40,6 +40,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrapState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonLifecyclePhase
 import dev.jasonpearson.automobile.desktop.core.theme.PlatformIcons
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 
@@ -58,38 +60,86 @@ fun DevicePicker(
   // Whether the "Close" affordance is offered. False when the grid is the app's home surface (no
   // observed workspace to return to); true when opened over an existing workspace ("Devices +").
   canClose: Boolean = true,
+  // Install/start progress of the shared daemon. The picker's first load can silently install Bun
+  // and start the daemon (up to the daemon-startup budget), so the Loading state narrates that
+  // work instead of sitting on "Loading devices…", and the Error state surfaces the bootstrap
+  // failure with its actionable message.
+  bootstrapState: DaemonBootstrapState = DaemonBootstrapState.Inactive,
   // The per-card device thumbnail. Hoisted (default = the screenshot [DeviceThumbnail]) so a test
   // can stub it and never open an observation socket while composing the grid. Thumbnails are
   // stills by design — a per-card live-video subscription would put a standing capture/decode cost
   // on every booted tile of a potentially huge grid.
   thumbnail: @Composable (device: PickerDevice, booting: Boolean) -> Unit = { device, booting ->
+    // Width-only sizing: the thumbnail derives its own height from the device's aspect ratio
+    // (screenshot ratio once captured, a portrait stand-in until then), which the staggered grid
+    // below packs masonry-style.
     DeviceThumbnail(
       device = device,
       booting = booting,
-      modifier = Modifier.fillMaxWidth().height(DeviceThumbnailHeight),
+      modifier = Modifier.fillMaxWidth(),
     )
   },
 ) {
   Column(modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
     when (state) {
-      is DevicePickerUiState.Loading -> Centered("Loading devices…")
-      is DevicePickerUiState.Error ->
-        Centered("Couldn't load devices: ${state.message}") {
+      is DevicePickerUiState.Loading -> Centered(loadingMessage(bootstrapState))
+      is DevicePickerUiState.Error -> {
+        val bootstrapFailure = (bootstrapState as? DaemonBootstrapState.Failed)?.message
+        Centered(
+          message =
+            if (bootstrapFailure != null) "AutoMobile daemon isn't available"
+            else "Couldn't load devices",
+          detail = bootstrapFailure ?: state.message,
+        ) {
+          // Retry re-runs the whole chain: the load's preflight re-detects the daemon and, when
+          // none is reachable, re-attempts the install/start pipeline before reading devices.
           Button(onClick = { onAction(DevicePickerAction.Refresh) }) { Text("Retry") }
         }
+      }
       is DevicePickerUiState.Content -> Content(state, onAction, onClose, canClose, thumbnail)
     }
   }
 }
 
+/**
+ * Maps the daemon-bootstrap phase behind a Loading state to what the user is actually waiting on. A
+ * first launch on a machine without AutoMobile can spend most of a minute installing Bun and
+ * fetching the daemon package; that must read as setup progress, not a hung device list.
+ */
+internal fun loadingMessage(bootstrap: DaemonBootstrapState): String =
+  when (bootstrap) {
+    is DaemonBootstrapState.Working ->
+      when (val phase = bootstrap.phase) {
+        DaemonLifecyclePhase.InstallingRuntime -> "Installing the Bun runtime (one-time setup)…"
+        is DaemonLifecyclePhase.LaunchingDaemon ->
+          if (phase.action == "restart") "Updating the AutoMobile daemon to ${phase.version}…"
+          else "Starting AutoMobile ${phase.version}…"
+        DaemonLifecyclePhase.Verifying -> "Waiting for the AutoMobile daemon…"
+        else -> "Loading devices…"
+      }
+    else -> "Loading devices…"
+  }
+
 @Composable
-private fun Centered(message: String, extra: @Composable (() -> Unit)? = null) {
+private fun Centered(
+  message: String,
+  detail: String? = null,
+  extra: @Composable (() -> Unit)? = null,
+) {
   Column(
-    Modifier.fillMaxSize(),
+    Modifier.fillMaxSize().padding(horizontal = 48.dp),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Text(message, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    if (detail != null) {
+      Spacer(Modifier.height(8.dp))
+      Text(
+        detail,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall,
+      )
+    }
     if (extra != null) {
       Spacer(Modifier.height(12.dp))
       extra()
@@ -259,11 +309,14 @@ private fun DeviceGrid(
   thumbnail: @Composable (PickerDevice, Boolean) -> Unit,
 ) {
   val devices = filteredDevices(content.devices, content.filters)
-  LazyVerticalGrid(
-    columns = GridCells.Adaptive(220.dp),
+  // Masonry (Pinterest-style) packing: every card is column-width, but each card's HEIGHT follows
+  // its own device's aspect ratio, so the staggered grid packs disjoint heights instead of forcing
+  // one uniform row height.
+  LazyVerticalStaggeredGrid(
+    columns = StaggeredGridCells.Adaptive(220.dp),
     modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
     horizontalArrangement = Arrangement.spacedBy(12.dp),
-    verticalArrangement = Arrangement.spacedBy(12.dp),
+    verticalItemSpacing = 12.dp,
   ) {
     items(devices, key = { it.id }) { device ->
       DeviceCard(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnail.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnail.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace.picker
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import java.util.Base64
 import kotlinx.coroutines.CancellationException
@@ -40,8 +42,13 @@ import org.jetbrains.skia.Image as SkiaImage
 
 private val LOG = LoggerFactory.getLogger("DeviceThumbnail")
 
-/** Height of a grid device thumbnail; the frame is aspect-fit centered on black inside it. */
-private val THUMBNAIL_HEIGHT = 132.dp
+/**
+ * Width:height ratio of a thumbnail with no screenshot yet (shut-down, booting, or capture still
+ * pending): a portrait-phone-ish stand-in so the staggered grid's placeholder cards stay compact.
+ * Once a screenshot decodes, the card adopts that bitmap's true ratio — a landscape tablet goes
+ * wide, a foldable goes square-ish — which is what gives the grid its masonry variety.
+ */
+internal const val PLACEHOLDER_THUMBNAIL_ASPECT = 0.62f
 
 // Backoff bounds for the screenshot capture retry (see captureScreenshotWithRetry).
 private const val SCREENSHOT_RETRY_INITIAL_MS = 1_000L
@@ -87,6 +94,16 @@ internal fun thumbnailPlaceholder(state: DeviceState, booting: Boolean): String?
     else -> null
   }
 
+/**
+ * Whether a stream frame is THIS card's thumbnail. The observation socket can deliver frames for
+ * other subscribed devices (and a `replay = 1` stream can hand a new collector another device's
+ * last frame), so a capture that accepts "any non-empty screenshot" attributes the fastest device's
+ * frame to whichever card asked — an Android home screen on an iPhone card. Only a frame stamped
+ * with this device's id qualifies; an unstamped frame is ambiguous and is skipped.
+ */
+internal fun isThumbnailFrameFor(deviceId: String, update: ScreenshotStreamUpdate): Boolean =
+  update.deviceId == deviceId && !update.screenshotBase64.isNullOrEmpty()
+
 /** A last-known screenshot for a device, rendered as the grid thumbnail. */
 interface DeviceThumbnailScreenshotSource {
   /** The most recent screenshot for [deviceId], or null when none can be captured. */
@@ -111,59 +128,61 @@ fun DeviceThumbnail(
   modifier: Modifier = Modifier,
   screenshotSource: DeviceThumbnailScreenshotSource? = ObservationScreenshotSource,
 ) {
-  Box(
-    modifier =
-      modifier.clip(RoundedCornerShape(4.dp)).background(Color.Black).semantics {
-        contentDescription = "Thumbnail ${device.name}"
-      },
-    contentAlignment = Alignment.Center,
-  ) {
-    val placeholder = thumbnailPlaceholder(device.state, booting)
+  val placeholder = thumbnailPlaceholder(device.state, booting)
+  // One still per boot, retried with backoff until the observation service yields one. The state
+  // is hoisted here (not in a screenshot-only child) because the CARD's aspect ratio derives from
+  // it; the placeholder reset below reproduces the old unmount-through-placeholder semantics, so a
+  // rebooted device captures a fresh still rather than keeping the previous boot's screen.
+  var screenshot by remember(device.id) { mutableStateOf<ImageBitmap?>(null) }
+  LaunchedEffect(placeholder) {
     if (placeholder != null) {
-      Text(placeholder, color = Color.White.copy(alpha = 0.6f), fontSize = 12.sp)
-    } else {
-      ScreenshotThumbnail(device.id, device.name, screenshotSource)
+      screenshot = null
     }
   }
-}
-
-@Composable
-private fun ScreenshotThumbnail(
-  deviceId: String,
-  deviceName: String,
-  screenshotSource: DeviceThumbnailScreenshotSource?,
-) {
-  // One still per card mount, retried with backoff until the observation service yields one. Keyed
-  // on deviceId: a rebooted device unmounts through the "Shutdown"/"Booting" placeholder, so a
-  // fresh boot captures a fresh still rather than showing the previous boot's screen.
-  var screenshot by remember(deviceId) { mutableStateOf<ImageBitmap?>(null) }
-  LaunchedEffect(deviceId, screenshotSource) {
-    if (screenshotSource != null && screenshot == null) {
-      screenshot = captureScreenshotWithRetry(deviceId, screenshotSource)
+  LaunchedEffect(device.id, screenshotSource, placeholder) {
+    if (placeholder == null && screenshotSource != null && screenshot == null) {
+      screenshot = captureScreenshotWithRetry(device.id, screenshotSource)
     }
   }
 
   val still = screenshot
-  if (still != null) {
-    Image(
-      bitmap = still,
-      contentDescription = "Screenshot of $deviceName",
-      modifier = Modifier.fillMaxSize(),
-      contentScale = ContentScale.Fit,
-    )
-  } else {
-    Text(
-      "No preview yet",
-      color = Color.White.copy(alpha = 0.5f),
-      fontSize = 11.sp,
-      textAlign = TextAlign.Center,
-      modifier = Modifier.padding(8.dp),
-    )
+  // Each card fits its own device: the decoded screenshot's ratio once available, a portrait
+  // stand-in until then. This is what lets the staggered grid pack disjoint card heights.
+  val aspect =
+    if (still != null && still.height > 0) still.width.toFloat() / still.height
+    else PLACEHOLDER_THUMBNAIL_ASPECT
+  Box(
+    modifier =
+      modifier
+        .aspectRatio(aspect)
+        .clip(RoundedCornerShape(4.dp))
+        .background(Color.Black)
+        .semantics {
+          contentDescription = "Thumbnail ${device.name}"
+        },
+    contentAlignment = Alignment.Center,
+  ) {
+    when {
+      placeholder != null ->
+        Text(placeholder, color = Color.White.copy(alpha = 0.6f), fontSize = 12.sp)
+      still != null ->
+        Image(
+          bitmap = still,
+          contentDescription = "Screenshot of ${device.name}",
+          modifier = Modifier.fillMaxSize(),
+          contentScale = ContentScale.Fit,
+        )
+      else ->
+        Text(
+          "No preview yet",
+          color = Color.White.copy(alpha = 0.5f),
+          fontSize = 11.sp,
+          textAlign = TextAlign.Center,
+          modifier = Modifier.padding(8.dp),
+        )
+    }
   }
 }
-
-/** Fixed thumbnail height, exposed so the card lays out the row above/below it consistently. */
-internal val DeviceThumbnailHeight = THUMBNAIL_HEIGHT
 
 /**
  * Thumbnail still backed by a one-shot [ObservationStream] observation. Deliberately does NOT cache
@@ -186,7 +205,7 @@ object ObservationScreenshotSource : DeviceThumbnailScreenshotSource {
           stream.connect(deviceId)
           stream.requestObservation(deviceId)
           withTimeoutOrNull(CAPTURE_TIMEOUT_MS) {
-            stream.screenshotUpdates.first { !it.screenshotBase64.isNullOrEmpty() }.screenshotBase64
+            stream.screenshotUpdates.first { isThumbnailFrameFor(deviceId, it) }.screenshotBase64
           }
         }
       base64?.let {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
@@ -94,6 +94,25 @@ class DaemonBootstrapTest {
   }
 
   @Test
+  fun `a marked-inactive bootstrap never runs its lifecycle`() {
+    // A configured non-daemon transport (HTTP/STDIO) marks the bootstrap inactive while the real
+    // lifecycle stays installed; ensureReady must then be a no-op — never install Bun or
+    // start/restart a local daemon the app is not connected to — and Inactive must not be
+    // overwritten by phases.
+    val lifecycle =
+      ScriptedLifecycle(
+        listOf(DaemonLifecyclePhase.Probing, DaemonLifecyclePhase.Completed(restarted = false))
+      )
+    val bootstrap = bootstrapOf(lifecycle)
+
+    bootstrap.markInactive()
+    bootstrap.ensureReady()
+
+    assertEquals(0, lifecycle.passes)
+    assertEquals(DaemonBootstrapState.Inactive, bootstrap.state.value)
+  }
+
+  @Test
   fun `inactive bootstrap stays inactive and never touches the system`() {
     val bootstrap = DaemonBootstrap.inactive()
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
@@ -1,0 +1,104 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DaemonBootstrapTest {
+
+  /** Captures the bootstrap's phase listener and replays a scripted phase sequence on demand. */
+  private class ScriptedLifecycle(
+    private val phases: List<DaemonLifecyclePhase>,
+    private val result: DaemonLifecycleResult = DaemonLifecycleResult.Ready(restarted = false),
+  ) : DaemonLifecycleEnsurer {
+    lateinit var listener: (DaemonLifecyclePhase) -> Unit
+    var passes = 0
+
+    override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult {
+      passes++
+      phases.forEach(listener)
+      return result
+    }
+  }
+
+  private fun bootstrapOf(lifecycle: ScriptedLifecycle): DaemonBootstrap =
+    DaemonBootstrap { listener ->
+      lifecycle.also { it.listener = listener }
+    }
+
+  @Test
+  fun `starts unknown before any lifecycle pass reports`() {
+    val bootstrap = bootstrapOf(ScriptedLifecycle(emptyList()))
+    assertEquals(DaemonBootstrapState.Unknown, bootstrap.state.value)
+  }
+
+  @Test
+  fun `projects working phases and the ready terminal`() {
+    val lifecycle =
+      ScriptedLifecycle(
+        listOf(
+          DaemonLifecyclePhase.Probing,
+          DaemonLifecyclePhase.InstallingRuntime,
+          DaemonLifecyclePhase.Completed(restarted = true),
+        )
+      )
+    val bootstrap = bootstrapOf(lifecycle)
+
+    bootstrap.ensureReady()
+
+    assertEquals(1, lifecycle.passes)
+    assertEquals(DaemonBootstrapState.Ready(restarted = true), bootstrap.state.value)
+  }
+
+  @Test
+  fun `projects a failed terminal with its message`() {
+    val bootstrap =
+      bootstrapOf(
+        ScriptedLifecycle(
+          listOf(DaemonLifecyclePhase.Probing, DaemonLifecyclePhase.Failed("no daemon"))
+        )
+      )
+
+    bootstrap.ensureReady()
+
+    assertEquals(DaemonBootstrapState.Failed("no daemon"), bootstrap.state.value)
+  }
+
+  @Test
+  fun `retains the last working phase while a pass is in flight`() {
+    val lifecycle = ScriptedLifecycle(emptyList())
+    val bootstrap = bootstrapOf(lifecycle)
+
+    lifecycle.listener(DaemonLifecyclePhase.LaunchingDaemon(action = "start", version = "0.0.40"))
+
+    assertEquals(
+      DaemonBootstrapState.Working(
+        DaemonLifecyclePhase.LaunchingDaemon(action = "start", version = "0.0.40")
+      ),
+      bootstrap.state.value,
+    )
+  }
+
+  @Test
+  fun `a retried pass reports again after a failure`() {
+    val lifecycle =
+      ScriptedLifecycle(
+        listOf(DaemonLifecyclePhase.Probing, DaemonLifecyclePhase.Completed(restarted = false))
+      )
+    val bootstrap = bootstrapOf(lifecycle)
+
+    bootstrap.ensureReady()
+    bootstrap.ensureReady()
+
+    assertEquals(2, lifecycle.passes)
+    assertEquals(DaemonBootstrapState.Ready(restarted = false), bootstrap.state.value)
+  }
+
+  @Test
+  fun `inactive bootstrap stays inactive and never touches the system`() {
+    val bootstrap = DaemonBootstrap.inactive()
+
+    assertEquals(DaemonBootstrapState.Inactive, bootstrap.state.value)
+    bootstrap.ensureReady()
+    assertEquals(DaemonBootstrapState.Inactive, bootstrap.state.value)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -626,6 +626,79 @@ class DesktopDaemonLifecycleTest {
     )
   }
 
+  @Test
+  fun `reports probing and completed phases when reusing a running daemon`() {
+    val phases = mutableListOf<DaemonLifecyclePhase>()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40")),
+        commandExecutor = FakeDaemonCommandExecutor(),
+        timer = FakeDaemonRetryTimer(),
+        phaseListener = phases::add,
+      )
+
+    lifecycle.ensureVersionMatchedDaemon()
+
+    assertEquals(
+      listOf(DaemonLifecyclePhase.Probing, DaemonLifecyclePhase.Completed(restarted = false)),
+      phases,
+    )
+  }
+
+  @Test
+  fun `reports install launch and verify phases across a cold start`() {
+    val phases = mutableListOf<DaemonLifecyclePhase>()
+    val installer = FakeDesktopBunInstaller()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false, false, false, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40")),
+        commandExecutor = FakeDaemonCommandExecutor(),
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver(listOf(null, "bunx")),
+        bunInstaller = installer,
+        phaseListener = phases::add,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertEquals(1, installer.installCalls)
+    assertEquals(
+      listOf(
+        DaemonLifecyclePhase.Probing,
+        DaemonLifecyclePhase.InstallingRuntime,
+        DaemonLifecyclePhase.LaunchingDaemon(action = "start", version = "0.0.40"),
+        DaemonLifecyclePhase.Verifying,
+        DaemonLifecyclePhase.Completed(restarted = true),
+      ),
+      phases,
+    )
+  }
+
+  @Test
+  fun `reports a terminal failed phase with the failure message`() {
+    val phases = mutableListOf<DaemonLifecyclePhase>()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { null },
+        socketChecker = FakeDaemonSocketChecker(listOf(false)),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null)),
+        commandExecutor = FakeDaemonCommandExecutor(),
+        timer = FakeDaemonRetryTimer(),
+        phaseListener = phases::add,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertEquals(DaemonLifecyclePhase.Probing, phases.first())
+    assertEquals(DaemonLifecyclePhase.Failed(result.message), phases.last())
+  }
+
   private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {
     private var reads = 0
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
@@ -23,6 +23,18 @@ class McpDaemonClientHandshakeTest {
   }
 
   @Test
+  fun `normalizeClientVersion declares the base release for a Gradle SNAPSHOT dev build`() {
+    // A dev-run desktop stamps `<release>-SNAPSHOT`; the daemon gate compares releases and npm has
+    // no SNAPSHOT packages, so the base release is what can both match and be installed.
+    assertEquals("0.0.67", DaemonSocketPaths.normalizeClientVersion("0.0.67-SNAPSHOT"))
+    assertEquals("0.0.67", DaemonSocketPaths.normalizeClientVersion(" 0.0.67-snapshot "))
+    // A bare snapshot marker with no release is not a declarable version.
+    assertNull(DaemonSocketPaths.normalizeClientVersion("-SNAPSHOT"))
+    // Non-SNAPSHOT prereleases stay exact — they may exist as published packages.
+    assertEquals("0.0.68-rc.1", DaemonSocketPaths.normalizeClientVersion("0.0.68-rc.1"))
+  }
+
+  @Test
   fun `resolveClientVersion falls back after an unpinnable environment alias`() {
     assertEquals(
       "0.0.40",

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationProvenanceUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationProvenanceUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
@@ -37,6 +38,7 @@ class NavigationProvenanceUiTest {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = DaemonBootstrap.inactive()
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val updateController = FakeUpdateController()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/UncaughtUiErrorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/UncaughtUiErrorTest.kt
@@ -1,0 +1,38 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class UncaughtUiErrorTest {
+
+  @Test
+  fun `a rebuilt-jar class-load failure gets the restart hint, not a raw class path`() {
+    val message =
+      uncaughtUiErrorMessage(
+        NoClassDefFoundError(
+          "dev/jasonpearson/automobile/desktop/core/daemon/DaemonPidReadResult\$Absent"
+        )
+      )
+
+    assertContains(message, "NoClassDefFoundError")
+    assertContains(message, "Restart AutoMobile")
+    assertContains(message, "rebuild while the app was running")
+  }
+
+  @Test
+  fun `an ordinary exception points at the application log`() {
+    val message = uncaughtUiErrorMessage(IllegalStateException("boom"))
+
+    assertContains(message, "IllegalStateException: boom")
+    assertContains(message, "application log")
+    assertFalse(message.contains("Restart AutoMobile"))
+  }
+
+  @Test
+  fun `a message-less throwable still reads as a sentence`() {
+    val message = uncaughtUiErrorMessage(RuntimeException())
+
+    assertContains(message, "RuntimeException: no further detail")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(ExperimentalTestApi::class)
@@ -91,6 +92,34 @@ class DeviceStreamViewTest {
       onAllNodesWithContentDescription("Live stream of Pixel 8").fetchSemanticsNodes().isNotEmpty()
     }
     onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `keeps the last frame on screen while a recreated source reconnects`() = runComposeUiTest {
+    // Arming the pane changes the source's remember keys (fps/preset), recreating the source. The
+    // fresh source has no frame yet — the pane must keep rendering the retained frame instead of
+    // flashing "Connecting to live mirror…" mid-interaction.
+    val sources = mutableListOf<FakeVideoStreamSource>()
+    val armed = androidx.compose.runtime.mutableStateOf(false)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          enableDeviceControl = armed.value,
+          sourceFactory = { _, _ -> FakeVideoStreamSource().also { sources += it } },
+        )
+      }
+    }
+    waitUntil { sources.size == 1 && sources[0].connectedDeviceId != null }
+    sources[0].emitFrame(width = 1, height = 1)
+    waitUntil {
+      onAllNodesWithContentDescription("Live stream of Pixel 8").fetchSemanticsNodes().isNotEmpty()
+    }
+    armed.value = true
+    waitUntil { sources.size == 2 }
+    onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
+    assertTrue(onAllNodesWithText("Connecting to live mirror…").fetchSemanticsNodes().isEmpty())
+    assertTrue(onAllNodesWithText("Waiting for the first frame…").fetchSemanticsNodes().isEmpty())
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -252,6 +252,9 @@ class DeviceStreamViewTest {
             enableDeviceControl = true,
             control = armedControlState(scope),
             sourceFactory = { _, _ -> source },
+            // Zero retention: disarm the moment the relay leaves Streaming, so this test pins the
+            // disarm rule itself rather than the transient-tolerance window.
+            armedFrameRetentionMs = 0L,
           )
         }
       }
@@ -269,6 +272,35 @@ class DeviceStreamViewTest {
       onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
       scope.cancel()
     }
+
+  @Test
+  fun `armed control survives a transient drop within the retention window`() = runComposeUiTest {
+    // A quality-step re-subscribe or momentary relay drop leaves Streaming briefly; while the
+    // newest frame is within the retention window the interactive surface (and its Tap Targets
+    // affordance) must stay mounted instead of flickering to the plain mirror and back.
+    val source =
+      FakeVideoStreamSource(refuseWith = "dropped", nowMs = { System.nanoTime() / 1_000_000L })
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          enableDeviceControl = true,
+          control = armedControlState(scope),
+          sourceFactory = { _, _ -> source },
+          armedFrameRetentionMs = 600_000L, // effectively never expires within this test
+        )
+      }
+    }
+    runOnUiThread { source.becomeStreaming() }
+    source.emitFrame()
+    waitUntilExactlyOneExists(hasTestTag(DEVICE_CONTROL_SURFACE_TEST_TAG))
+
+    runOnUiThread { source.becomeUnavailable("dropped") }
+    waitForIdle()
+    onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).assertCountEquals(1)
+    scope.cancel()
+  }
 
   @Test
   fun `an armed iOS pane still surfaces Screen Recording approval over the control view`() =
@@ -367,7 +399,7 @@ class DeviceStreamViewTest {
     }
     // Collapsed readout: persisted preset + live-vs-target fps (control pane targets 30fps). The
     // selector chips stay hidden so they cannot intercept a tap on the interactive surface.
-    onNodeWithText("Medium · 0 / 30 fps").assertIsDisplayed()
+    onNodeWithText("Medium · 0 fps").assertIsDisplayed()
     onAllNodesWithText("Auto").assertCountEquals(0)
   }
 
@@ -420,7 +452,7 @@ class DeviceStreamViewTest {
       val medium = sources.getValue(VideoStreamQuality.Medium)
 
       // Expand the collapsed overlay, then pick High.
-      onNodeWithText("Medium · 0 / 30 fps").performClick()
+      onNodeWithText("Medium · 0 fps").performClick()
       onNodeWithText("High").performClick()
 
       // A distinct High source is created and connects, the old Medium source is disposed, and the

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -303,6 +303,42 @@ class DeviceStreamViewTest {
   }
 
   @Test
+  fun `a source swap does not leave control disarmed once the new source streams`() =
+    runComposeUiTest {
+      // Recreating the source (arming, quality step) must not strand the pane disarmed: the fresh
+      // source reports Streaming before its first frame decodes, and the armed surface may run on
+      // the retained frame under that Streaming state. Guards the grace effect's keying across
+      // source swaps (CodeRabbit).
+      val sources = mutableListOf<FakeVideoStreamSource>()
+      val scope = CoroutineScope(Dispatchers.Unconfined)
+      val armed = mutableStateOf(false)
+      setContent {
+        MaterialTheme {
+          DeviceStreamView(
+            col(),
+            enableDeviceControl = armed.value,
+            control = armedControlState(scope),
+            sourceFactory = { _, _ -> FakeVideoStreamSource().also { sources += it } },
+            armedFrameRetentionMs = 0L, // any grace comes from Streaming state, never the window
+          )
+        }
+      }
+      waitUntil { sources.size == 1 && sources[0].connectedDeviceId != null }
+      sources[0].emitFrame(width = 1, height = 1)
+      waitUntil {
+        onAllNodesWithContentDescription("Live stream of Pixel 8")
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+
+      // Arming swaps the source; the new fake connects straight to Streaming with no frame yet.
+      armed.value = true
+      waitUntil { sources.size == 2 && sources[1].connectedDeviceId != null }
+      waitUntilExactlyOneExists(hasTestTag(DEVICE_CONTROL_SURFACE_TEST_TAG))
+      scope.cancel()
+    }
+
+  @Test
   fun `an armed iOS pane still surfaces Screen Recording approval over the control view`() =
     runComposeUiTest {
       // Regression: a refused iOS relay (PermissionRequired) must win even when device control is

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -20,8 +20,10 @@ import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -252,9 +254,9 @@ class DeviceStreamViewTest {
             enableDeviceControl = true,
             control = armedControlState(scope),
             sourceFactory = { _, _ -> source },
-            // Zero retention: disarm the moment the relay leaves Streaming, so this test pins the
-            // disarm rule itself rather than the transient-tolerance window.
-            armedFrameRetentionMs = 0L,
+            // Immediate expiry: disarm the moment the relay leaves Streaming, so this test pins
+            // the disarm rule itself rather than the transient-tolerance window.
+            armedFrameGraceWait = {},
           )
         }
       }
@@ -288,7 +290,7 @@ class DeviceStreamViewTest {
           enableDeviceControl = true,
           control = armedControlState(scope),
           sourceFactory = { _, _ -> source },
-          armedFrameRetentionMs = 600_000L, // effectively never expires within this test
+          armedFrameGraceWait = { awaitCancellation() }, // grace never expires on its own
         )
       }
     }
@@ -299,6 +301,72 @@ class DeviceStreamViewTest {
     runOnUiThread { source.becomeUnavailable("dropped") }
     waitForIdle()
     onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).assertCountEquals(1)
+    scope.cancel()
+  }
+
+  @Test
+  fun `grace expiry and source-swap restart are driven deterministically`() = runComposeUiTest {
+    // Drives the shipped grace window through the injected suspend seam (no wall time, no 0/huge
+    // extremes): each grace pass awaits its own gate, so the test controls exactly when a window
+    // expires and proves a source swap CANCELS the old source's window and starts a fresh one.
+    val gates = mutableListOf<CompletableDeferred<Unit>>()
+    val sources = mutableListOf<FakeVideoStreamSource>()
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    val armed = mutableStateOf(false)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          enableDeviceControl = armed.value,
+          control = armedControlState(scope),
+          sourceFactory = { _, _ ->
+            FakeVideoStreamSource(nowMs = { System.nanoTime() / 1_000_000L }).also { sources += it }
+          },
+          armedFrameGraceWait = { CompletableDeferred<Unit>().also { gates += it }.await() },
+        )
+      }
+    }
+    // Mirror-mode source streams a frame; arming swaps to a fresh source. The initial non-Streaming
+    // states open early gates; note how many exist before the drop we care about.
+    waitUntil { sources.size == 1 && sources[0].connectedDeviceId != null }
+    sources[0].emitFrame(width = 1, height = 1)
+    // Wait for the frame to be collected (it becomes the retained frame) before swapping sources.
+    waitUntil {
+      onAllNodesWithContentDescription("Live stream of Pixel 8").fetchSemanticsNodes().isNotEmpty()
+    }
+    armed.value = true
+    waitUntil { sources.size == 2 && sources[1].connectedDeviceId != null }
+    waitUntilExactlyOneExists(hasTestTag(DEVICE_CONTROL_SURFACE_TEST_TAG))
+    val gatesBeforeDrop = gates.size
+
+    // Drop the stream: a grace window opens (new gate) and control stays armed while it runs.
+    runOnUiThread { sources[1].becomeUnavailable("dropped") }
+    waitUntil { gates.size == gatesBeforeDrop + 1 }
+    onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).assertCountEquals(1)
+    val droppedSourceGate = gates.last()
+
+    // Swap sources mid-grace (disarm/rearm recreates it): the old window's gate is cancelled and a
+    // fresh one opens for the new source's non-Streaming state.
+    armed.value = false
+    waitUntil { sources.size == 3 }
+    runOnUiThread { sources[2].becomeUnavailable("still down") }
+    armed.value = true
+    waitUntil { sources.size == 4 }
+    runOnUiThread { sources[3].becomeUnavailable("still down") }
+    waitUntil { gates.size > gatesBeforeDrop + 1 }
+
+    // The old window's waiter died with the swap: completing ITS gate must not disarm anything.
+    droppedSourceGate.complete(Unit)
+    waitForIdle()
+    onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).assertCountEquals(1)
+
+    // Completing the CURRENT window's gate is what disarms — deterministic boundary crossing.
+    val currentGate = gates.last()
+    currentGate.complete(Unit)
+    waitUntil {
+      onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).fetchSemanticsNodes().isEmpty()
+    }
+    onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
     scope.cancel()
   }
 
@@ -319,7 +387,7 @@ class DeviceStreamViewTest {
             enableDeviceControl = armed.value,
             control = armedControlState(scope),
             sourceFactory = { _, _ -> FakeVideoStreamSource().also { sources += it } },
-            armedFrameRetentionMs = 0L, // any grace comes from Streaming state, never the window
+            armedFrameGraceWait = {}, // any grace comes from Streaming state, never the window
           )
         }
       }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
@@ -51,6 +52,7 @@ class NavigationFacetTest {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = DaemonBootstrap.inactive()
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val updateController = FakeUpdateController()
@@ -842,6 +844,7 @@ class NavigationFacetTest {
     val graphProvider =
       object : AutoMobileGraphProvider {
         override val autoMobileClient = client
+        override val daemonBootstrap = DaemonBootstrap.inactive()
         override val settingsProvider = settings
         override val dataSourceFactory = DefaultDataSourceFactory(client)
         override val updateController = FakeUpdateController()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationAppSummary
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
@@ -34,6 +35,7 @@ class OfflineNavigationBrowserTest {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = DaemonBootstrap.inactive()
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val updateController = FakeUpdateController()
@@ -315,6 +317,7 @@ class OfflineNavigationBrowserTest {
     val graphProvider =
       object : AutoMobileGraphProvider {
         override val autoMobileClient = client
+        override val daemonBootstrap = DaemonBootstrap.inactive()
         override val settingsProvider = FakeSettingsProvider()
         override val dataSourceFactory = DefaultDataSourceFactory(client)
         override val updateController = FakeUpdateController()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
@@ -35,6 +36,7 @@ class PerformanceFacetTest {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = DaemonBootstrap.inactive()
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val updateController = FakeUpdateController()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
@@ -42,6 +43,7 @@ class StorageFacetTest {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
+      override val daemonBootstrap = DaemonBootstrap.inactive()
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val updateController = FakeUpdateController()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
@@ -22,7 +22,6 @@ class StreamQualityControlsTest {
         StreamQualityControls(
           currentQuality = VideoStreamQuality.Medium,
           actualFps = 23.6f,
-          targetFps = 30,
           autoAdjustEnabled = true,
           expanded = false,
           onToggleExpanded = {},
@@ -33,7 +32,7 @@ class StreamQualityControlsTest {
     }
     // Readout: current preset + rounded actual over target. Selector chips are hidden until
     // expanded.
-    onNodeWithText("Medium · 24 / 30 fps").assertIsDisplayed()
+    onNodeWithText("Medium · 24 fps").assertIsDisplayed()
     onAllNodesWithText("Low").assertCountEquals(0)
     onAllNodesWithText("Auto").assertCountEquals(0)
   }
@@ -46,7 +45,6 @@ class StreamQualityControlsTest {
         StreamQualityControls(
           currentQuality = VideoStreamQuality.Medium,
           actualFps = 30f,
-          targetFps = 30,
           autoAdjustEnabled = true,
           expanded = false,
           onToggleExpanded = { toggled++ },
@@ -55,7 +53,7 @@ class StreamQualityControlsTest {
         )
       }
     }
-    onNodeWithText("Medium · 30 / 30 fps").performClick()
+    onNodeWithText("Medium · 30 fps").performClick()
     assertEquals(1, toggled)
   }
 
@@ -67,7 +65,6 @@ class StreamQualityControlsTest {
         StreamQualityControls(
           currentQuality = VideoStreamQuality.Medium,
           actualFps = 30f,
-          targetFps = 30,
           autoAdjustEnabled = true,
           expanded = true,
           onToggleExpanded = {},
@@ -90,7 +87,6 @@ class StreamQualityControlsTest {
         StreamQualityControls(
           currentQuality = VideoStreamQuality.Low,
           actualFps = 10f,
-          targetFps = 30,
           autoAdjustEnabled = true,
           expanded = true,
           onToggleExpanded = {},

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerBootstrapMessageTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerBootstrapMessageTest.kt
@@ -1,0 +1,48 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrapState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonLifecyclePhase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DevicePickerBootstrapMessageTest {
+
+  @Test
+  fun `narrates the slow bootstrap phases behind the loading state`() {
+    assertEquals(
+      "Installing the Bun runtime (one-time setup)…",
+      loadingMessage(DaemonBootstrapState.Working(DaemonLifecyclePhase.InstallingRuntime)),
+    )
+    assertEquals(
+      "Starting AutoMobile 0.0.67…",
+      loadingMessage(
+        DaemonBootstrapState.Working(
+          DaemonLifecyclePhase.LaunchingDaemon(action = "start", version = "0.0.67")
+        )
+      ),
+    )
+    assertEquals(
+      "Updating the AutoMobile daemon to 0.0.67…",
+      loadingMessage(
+        DaemonBootstrapState.Working(
+          DaemonLifecyclePhase.LaunchingDaemon(action = "restart", version = "0.0.67")
+        )
+      ),
+    )
+    assertEquals(
+      "Waiting for the AutoMobile daemon…",
+      loadingMessage(DaemonBootstrapState.Working(DaemonLifecyclePhase.Verifying)),
+    )
+  }
+
+  @Test
+  fun `fast or inapplicable states keep the plain device loading message`() {
+    assertEquals("Loading devices…", loadingMessage(DaemonBootstrapState.Inactive))
+    assertEquals("Loading devices…", loadingMessage(DaemonBootstrapState.Unknown))
+    assertEquals("Loading devices…", loadingMessage(DaemonBootstrapState.Ready(restarted = false)))
+    assertEquals(
+      "Loading devices…",
+      loadingMessage(DaemonBootstrapState.Working(DaemonLifecyclePhase.Probing)),
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnailFrameFilterTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnailFrameFilterTest.kt
@@ -1,0 +1,35 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DeviceThumbnailFrameFilterTest {
+
+  private fun frame(deviceId: String?, screenshotBase64: String? = "aGk=") =
+    ScreenshotStreamUpdate(
+      deviceId = deviceId,
+      timestamp = 1L,
+      screenshotBase64 = screenshotBase64,
+      screenWidth = 1080,
+      screenHeight = 2340,
+    )
+
+  @Test
+  fun `accepts only a non-empty frame stamped with this device's id`() {
+    assertTrue(isThumbnailFrameFor("iphone-17", frame("iphone-17")))
+  }
+
+  @Test
+  fun `rejects another device's frame so a fast android frame never fills an ios card`() {
+    assertFalse(isThumbnailFrameFor("iphone-17", frame("am-api34-ga-arm64")))
+  }
+
+  @Test
+  fun `rejects unstamped and empty frames`() {
+    assertFalse(isThumbnailFrameFor("iphone-17", frame(null)))
+    assertFalse(isThumbnailFrameFor("iphone-17", frame("iphone-17", screenshotBase64 = null)))
+    assertFalse(isThumbnailFrameFor("iphone-17", frame("iphone-17", screenshotBase64 = "")))
+  }
+}

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -2030,9 +2030,16 @@ export class NavigationGraphManager implements NavigationGraphService {
   public setGraphUpdateListener(listener: (() => void | Promise<void>) | null): void {
     if (listener === null) {
       this.graphUpdateListeners = [];
-    } else {
+    } else if (!this.graphUpdateListeners.includes(listener)) {
+      // Idempotent add: a subsystem re-registering the same callback (e.g. the
+      // resource layer re-attaching on provider swap) must not double-notify.
       this.graphUpdateListeners.push(listener);
     }
+  }
+
+  /** Remove exactly one listener, leaving other subsystems' listeners attached. */
+  public removeGraphUpdateListener(listener: () => void | Promise<void>): void {
+    this.graphUpdateListeners = this.graphUpdateListeners.filter((entry) => entry !== listener);
   }
 
   /**

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -100,8 +100,17 @@ function scheduleNavigationGraphUpdate(): void {
 }
 
 function attachGraphUpdateListener(provider: NavigationGraphSummaryProvider): void {
-  if (updateListenerProvider?.setGraphUpdateListener) {
-    updateListenerProvider.setGraphUpdateListener(null);
+  // Detach only OUR callback from the previous provider. `setGraphUpdateListener(null)`
+  // removes every listener on the provider — on the global NavigationGraphManager that
+  // also wiped the daemon's stream-push listener, so live graph changes stopped emitting
+  // `navigation_update` frames and stream-driven clients (the desktop Navigation pane)
+  // never saw the device navigate. Fall back to clear-all only for legacy providers that
+  // predate removeGraphUpdateListener (their listener list is exclusively ours).
+  const previous = updateListenerProvider;
+  if (previous?.removeGraphUpdateListener) {
+    previous.removeGraphUpdateListener(scheduleNavigationGraphUpdate);
+  } else if (previous?.setGraphUpdateListener) {
+    previous.setGraphUpdateListener(null);
   }
 
   updateListenerProvider = provider;

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -327,6 +327,14 @@ export interface NavigationGraphSummaryProvider {
   exportGraphSummary(): Promise<NavigationGraphSummary>;
   exportGraphSummaryForApp?(appId: string | null): Promise<NavigationGraphSummary>;
   setGraphUpdateListener?(listener: (() => void) | null): void;
+  /**
+   * Remove exactly one previously registered listener. Callers that co-own a
+   * provider with other subsystems MUST use this rather than
+   * `setGraphUpdateListener(null)`, which removes EVERY listener — including
+   * other subsystems' (the daemon's stream-push listener was silently wiped
+   * this way, killing live `navigation_update` frames to desktop panes).
+   */
+  removeGraphUpdateListener?(listener: () => void): void;
 }
 
 /**

--- a/test/fakes/FakeNavigationGraphManager.ts
+++ b/test/fakes/FakeNavigationGraphManager.ts
@@ -394,9 +394,15 @@ export class FakeNavigationGraphManager
   setGraphUpdateListener(listener: (() => void) | null): void {
     if (listener === null) {
       this.graphUpdateListeners = [];
-    } else {
+    } else if (!this.graphUpdateListeners.includes(listener)) {
+      // Mirrors NavigationGraphManager: idempotent add.
       this.graphUpdateListeners.push(listener);
     }
+  }
+
+  // Mirrors NavigationGraphManager: remove exactly one listener.
+  removeGraphUpdateListener(listener: () => void): void {
+    this.graphUpdateListeners = this.graphUpdateListeners.filter((entry) => entry !== listener);
   }
 
   private emitGraphUpdated(): void {

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -37,6 +37,22 @@ describe("MCP Navigation Graph Resource", () => {
     }
   });
 
+  test("re-registering the provider preserves other subsystems' graph listeners", () => {
+    // The daemon attaches its own stream-push listener to the same manager the resource
+    // layer listens on. A provider re-registration must detach only the resource layer's
+    // callback — clear-all here silently killed live navigation_update stream frames.
+    let daemonPushes = 0;
+    fakeGraph.setGraphUpdateListener(() => {
+      daemonPushes++;
+    });
+
+    // Re-register the same provider (what MCP server re-initialization does).
+    setNavigationGraphProvider(fakeGraph);
+
+    fakeGraph.setCurrentApp("com.example.app");
+    expect(daemonPushes).toBe(1);
+  });
+
   test("should include navigation graph resource in list", async () => {
     const { client } = fixture.getContext();
 


### PR DESCRIPTION
## Summary

Desktop-app usability iteration: make the app connect to whatever AutoMobile is currently installed (or install it visibly when nothing is), and fix four live-session bugs found while driving it against a real daemon + device farm.

**Launch / bootstrap (desktop-core + desktop-app):**
- Normalize Gradle `-SNAPSHOT` desktop versions to their base release in `DaemonSocketPaths.normalizeClientVersion`. A dev-run desktop declared `0.0.67-SNAPSHOT`, which can never match a published daemon at the handshake gate and names a nonexistent npm package — so `:desktop-app:run` could neither connect to the installed daemon nor auto-start one. It now connects to the current install, and `bunx @kaeawc/auto-mobile@<release>` works when nothing is running.
- First-class daemon bootstrap: a shared `DesktopDaemonLifecycle` reports `DaemonLifecyclePhase`s through a new `DaemonBootstrap` on the DI graph (same lifecycle instance is attached to the `McpDaemonClient`, so per-request preflights report too). The device picker narrates the slow paths ("Installing the Bun runtime (one-time setup)…", "Starting AutoMobile 0.0.67…") instead of a generic spinner, surfaces bootstrap failures with the actionable message + Retry, and auto-retries a failed load once the daemon health poll sees the daemon reachable.

**Bug fixes:**
- **Cross-device thumbnails:** the picker's screenshot capture accepted any non-empty frame from the observation socket, so a fast Android frame filled an iOS card. Frames are now matched to the card's `deviceId`.
- **"Connecting to live mirror…" flashes mid-interaction:** arming a pane or an auto-adjust quality step recreates the video source, which reset the per-source frame state to null. The pane now retains the newest frame across source swaps (keyed per device) and renders it until the new subscription decodes.
- **Armed control surface (Tap Targets) flicker:** the interactive surface required video state to be exactly `Streaming`; every re-subscribe bounced it to the plain mirror and back. Control now stays armed while the newest frame is within a 3s freshness window (`Streaming` bypasses the gate so idle iOS captures stay armed); a sustained drought still disarms — the #5255 "stale pixels are never clickable" rule is preserved and pinned by tests at retention=0.
- **Navigation pane never auto-updated (daemon, TypeScript):** `navigationResources.attachGraphUpdateListener` cleared listeners with `setGraphUpdateListener(null)` — which removes *every* listener — silently wiping the daemon's stream-push listener from the global `NavigationGraphManager`. Live graph changes then fired with only the resource callback attached ("1 listeners" in the daemon log) and no `navigation_update` frame was ever pushed, so stream-driven clients never saw the device navigate. Added `removeGraphUpdateListener` (targeted detach), made registration idempotent, and the resource layer now detaches only its own callback.

**UX:**
- Device grid is now a masonry (`LazyVerticalStaggeredGrid`) layout; each card derives its height from its own screenshot's aspect ratio (portrait stand-in until captured).
- Stream overlay shows the measured rate only (`High · 24 fps`); decoder catch-up bursts can legitimately exceed the requested rate, so rendering it against the target read as a broken limit.

## Bug / Regression Context

- **Observed symptoms:** dev desktop build fails with "Could not start AutoMobile 0.0.67-SNAPSHOT"; iPhone picker card showing an Android home screen; "Connecting to live mirror…" text replacing video while tapping/swiping; Tap Targets bar appearing/disappearing; Navigation facet static while the device navigates (daemon log: `notifyGraphUpdated called, 1 listeners`, zero `Pushed navigation graph update`).
- **Repro steps / conditions:** run `./gradlew -p android :desktop-app:run` against a bunx-installed daemon; observe a device pane and interact while auto-adjust steps the quality preset; navigate an app on-device with the Navigation facet open.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — 35/35
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: `scripts/ktfmt/apply_ktfmt.sh` + `:desktop-core:test :desktop-app:compileKotlin :desktop-core:detektMain :desktop-app:detektMain` green (new tests: lifecycle phases, `DaemonBootstrap`, SNAPSHOT normalization, thumbnail frame filter, bootstrap loading messages, stream frame retention, armed-control retention window)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses the standard library or an existing project helper; no new dependencies
- [x] Rebased onto latest `main`, conflicts resolved

## Kotlin Reuse Check

- [x] Checked Kotlin stdlib/JDK/AndroidX, existing module dependencies, and dependency-compatible AutoMobile modules before adding helpers, wrappers, `*Util` files, or dependencies

## Device Verification

- [x] Verified live against a real daemon (npm 0.0.67) + Android emulator + iOS simulator: dev desktop now connects and loads the 70-device grid; interaction no longer flashes the connect hint. The navigation-listener fix is daemon-side and takes effect once a daemon runs from this branch (the published 0.0.67 daemon still carries the wipe bug).

## Follow-ups

- [ ] Auto-restart/recovery affordance on the workspace red status dot (legacy `McpProcessesPanel` has the only "Start daemon" button; the picker surfaces recovery, the workspace dot does not yet)
- [ ] Server-side reconfigure of a live shared capture so quality/fps changes need no re-subscribe at all (existing known limitation noted in `DeviceStreamView`)
