### PR TITLE
fix(dev): run desktop app under Compose Hot Reload in hot-reload.sh

### DIFF
--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -108,14 +108,16 @@ IOS_NEEDS_RESTART=false
 IOS_NEEDS_DAEMON_RELOAD_AFTER_HANDOFF=false
 
 # Desktop crash-relaunch backoff. If hotRun exits immediately (e.g. a hot-reload
-# config failure), relaunching every poll interval would hammer Gradle for the
-# whole watcher lifetime and repeatedly clobber the diagnostic log. Cap attempts
-# and back off exponentially; reset only once the app has stayed up a while.
+# config failure), relaunching every poll interval would hammer Gradle and
+# repeatedly clobber the diagnostic log. Back off exponentially up to a capped
+# delay, then keep retrying at that cap forever — never permanently give up, so a
+# subsequently-fixed error still recovers (source-change detection is gone; this
+# liveness check is the only relaunch path). Reset only once the app stays up.
 DESKTOP_RELAUNCH_ATTEMPTS=0
 DESKTOP_RELAUNCH_NEXT_TS=0
 DESKTOP_LAST_LAUNCH_TS=0
-DESKTOP_RELAUNCH_MAX=5
-DESKTOP_RELAUNCH_BACKOFF_CAP=300  # seconds
+DESKTOP_RELAUNCH_BACKOFF_CAP=300  # seconds (retry ceiling once backoff saturates)
+DESKTOP_RELAUNCH_SHIFT_CAP=16     # clamp the 2^n exponent so the shift can't overflow
 DESKTOP_RELAUNCH_STABLE_SECS=30   # uptime before a launch is deemed healthy
 
 usage() {
@@ -607,6 +609,16 @@ get_current_simulator() {
 unified_watch_loop() {
   local poll_interval="${1:-2}"
 
+  # Integer seconds base for the desktop backoff math. poll_interval may be
+  # fractional (e.g. --poll-interval 0.5, which `sleep` accepts); Bash arithmetic
+  # is integer-only and would abort the whole watcher under `set -e`. Floor to the
+  # integer part, minimum 1s.
+  local desktop_backoff_base="${poll_interval%%.*}"
+  case "${desktop_backoff_base}" in
+    '' | *[!0-9]*) desktop_backoff_base=1 ;;
+  esac
+  [[ ${desktop_backoff_base} -lt 1 ]] && desktop_backoff_base=1
+
   log_info "Starting unified watch loop (poll interval ${poll_interval}s)..."
   log_info "Watching: Desktop app=$(bool_str ${DESKTOP_APP_ENABLED}), Android=$(bool_str ${ANDROID_ENABLED}), iOS=$(bool_str ${IOS_ENABLED}), TypeScript=true"
   if [[ "${IOS_ENABLED}" == "true" ]]; then
@@ -654,7 +666,8 @@ unified_watch_loop() {
     # source change — doing so would kill the live-reload process for every keystroke
     # and reintroduce the rebuild-under-JVM NoClassDefFoundError trap. We only relaunch
     # if the app process has died (e.g. crashed or the reload daemon exited), with
-    # bounded exponential backoff so an immediately-exiting hotRun cannot spin.
+    # exponential backoff up to a capped delay — then keep retrying at that cap so a
+    # later-fixed error still recovers, rather than staying down for the session.
     if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
       local desktop_pid now_ts
       desktop_pid="$(cat "${DESKTOP_APP_PID_FILE}" 2>/dev/null || true)"
@@ -669,19 +682,15 @@ unified_watch_loop() {
           DESKTOP_RELAUNCH_ATTEMPTS=0
           DESKTOP_RELAUNCH_NEXT_TS=0
         fi
-      elif [[ ${DESKTOP_RELAUNCH_ATTEMPTS} -ge ${DESKTOP_RELAUNCH_MAX} ]]; then
-        : # Gave up after DESKTOP_RELAUNCH_MAX attempts; stay quiet until it recovers.
       elif [[ ${now_ts} -ge ${DESKTOP_RELAUNCH_NEXT_TS} ]]; then
         DESKTOP_RELAUNCH_ATTEMPTS=$(( DESKTOP_RELAUNCH_ATTEMPTS + 1 ))
-        local backoff=$(( POLL_INTERVAL * (1 << (DESKTOP_RELAUNCH_ATTEMPTS - 1)) ))
+        local backoff_shift=$(( DESKTOP_RELAUNCH_ATTEMPTS - 1 ))
+        [[ ${backoff_shift} -gt ${DESKTOP_RELAUNCH_SHIFT_CAP} ]] && backoff_shift=${DESKTOP_RELAUNCH_SHIFT_CAP}
+        local backoff=$(( desktop_backoff_base * (1 << backoff_shift) ))
         [[ ${backoff} -gt ${DESKTOP_RELAUNCH_BACKOFF_CAP} ]] && backoff=${DESKTOP_RELAUNCH_BACKOFF_CAP}
         DESKTOP_RELAUNCH_NEXT_TS=$(( now_ts + backoff ))
         DESKTOP_LAST_LAUNCH_TS=${now_ts}
-        if [[ ${DESKTOP_RELAUNCH_ATTEMPTS} -ge ${DESKTOP_RELAUNCH_MAX} ]]; then
-          log_warn "[Desktop App] Not running; final relaunch (${DESKTOP_RELAUNCH_ATTEMPTS}/${DESKTOP_RELAUNCH_MAX}). If it keeps exiting, see ${DESKTOP_APP_LOG}."
-        else
-          log_warn "[Desktop App] Process not running; relaunching (${DESKTOP_RELAUNCH_ATTEMPTS}/${DESKTOP_RELAUNCH_MAX}, next retry in >=${backoff}s)."
-        fi
+        log_warn "[Desktop App] Process not running; relaunching (attempt ${DESKTOP_RELAUNCH_ATTEMPTS}, next retry in >=${backoff}s). If it keeps exiting, see ${DESKTOP_APP_LOG}."
         # Preserve the log so a repeatedly-crashing hotRun keeps its diagnostics.
         run_desktop_app preserve_log
       fi

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -90,8 +90,10 @@ ANDROID_ENABLED=false
 IOS_ENABLED=false
 HAVE_DEVICE=false
 
-# Track last hashes for change detection. Desktop app has no hash: Compose Hot
-# Reload (hotRun --autoReload) watches and reloads its own source live.
+# Track last hashes for change detection. Desktop app SOURCE has no hash: Compose
+# Hot Reload (hotRun --autoReload) watches and reloads it live. Only the desktop
+# Gradle build scripts are hashed, since hotRun won't reconfigure on their change.
+LAST_DESKTOP_GRADLE_HASH=""
 LAST_APK_HASH=""
 LAST_VIDEO_SERVER_HASH=""
 LAST_IOS_HASH=""
@@ -612,10 +614,13 @@ unified_watch_loop() {
   # Integer seconds base for the desktop backoff math. poll_interval may be
   # fractional (e.g. --poll-interval 0.5, which `sleep` accepts); Bash arithmetic
   # is integer-only and would abort the whole watcher under `set -e`. Floor to the
-  # integer part, minimum 1s.
+  # integer part, minimum 1s. Force base-10 so a zero-padded value like `08` or
+  # `010` is not misread as (invalid or surprising) octal in later arithmetic — do
+  # the 10# conversion before any arithmetic context touches the raw string.
   local desktop_backoff_base="${poll_interval%%.*}"
   case "${desktop_backoff_base}" in
     '' | *[!0-9]*) desktop_backoff_base=1 ;;
+    *) desktop_backoff_base=$(( 10#${desktop_backoff_base} )) ;;
   esac
   [[ ${desktop_backoff_base} -lt 1 ]] && desktop_backoff_base=1
 
@@ -629,7 +634,11 @@ unified_watch_loop() {
     fi
   fi
 
-  # Initialize hashes (desktop app self-reloads via Compose Hot Reload; no hash)
+  # Initialize hashes (desktop source self-reloads via Compose Hot Reload; only the
+  # desktop Gradle build scripts are hashed).
+  if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
+    LAST_DESKTOP_GRADLE_HASH="$(hash_desktop_gradle_state)"
+  fi
   if [[ "${ANDROID_ENABLED}" == "true" ]]; then
     LAST_APK_HASH="$(hash_apk_watch_state)"
     LAST_VIDEO_SERVER_HASH="$(hash_video_server_watch_state)"
@@ -668,8 +677,24 @@ unified_watch_loop() {
     # if the app process has died (e.g. crashed or the reload daemon exited), with
     # exponential backoff up to a capped delay — then keep retrying at that cap so a
     # later-fixed error still recovers, rather than staying down for the session.
+    # The one source-driven exception is a change to a desktop build.gradle.kts:
+    # Compose Hot Reload won't reconfigure an existing Gradle model, so we fully
+    # restart the app (a clean stop+relaunch, NOT a rebuild into the live JVM, so the
+    # NoClassDefFoundError trap does not return).
     if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
-      local desktop_pid now_ts
+      local desktop_pid now_ts next_desktop_gradle_hash
+      next_desktop_gradle_hash="$(hash_desktop_gradle_state)"
+      if [[ "${next_desktop_gradle_hash}" != "${LAST_DESKTOP_GRADLE_HASH}" ]]; then
+        log_info "[Desktop App] Gradle build script changed; restarting to apply new configuration..."
+        LAST_DESKTOP_GRADLE_HASH="${next_desktop_gradle_hash}"
+        DESKTOP_RELAUNCH_ATTEMPTS=0
+        DESKTOP_RELAUNCH_NEXT_TS=0
+        DESKTOP_LAST_LAUNCH_TS=$(date +%s)
+        run_desktop_app
+        LAST_DESKTOP_GRADLE_HASH="$(hash_desktop_gradle_state)"
+      fi
+      # Liveness/backoff. After a build-script restart just above, the app is freshly
+      # alive with ATTEMPTS=0, so this is a no-op that tick.
       desktop_pid="$(cat "${DESKTOP_APP_PID_FILE}" 2>/dev/null || true)"
       now_ts=$(date +%s)
       if [[ -n "${desktop_pid}" ]] && kill -0 "${desktop_pid}" 2>/dev/null; then

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -90,8 +90,8 @@ ANDROID_ENABLED=false
 IOS_ENABLED=false
 HAVE_DEVICE=false
 
-# Track last hashes for change detection
-LAST_IDE_PLUGIN_HASH=""
+# Track last hashes for change detection. Desktop app has no hash: Compose Hot
+# Reload (hotRun --autoReload) watches and reloads its own source live.
 LAST_APK_HASH=""
 LAST_VIDEO_SERVER_HASH=""
 LAST_IOS_HASH=""
@@ -606,10 +606,7 @@ unified_watch_loop() {
     fi
   fi
 
-  # Initialize hashes
-  if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
-    LAST_IDE_PLUGIN_HASH="$(hash_ide_plugin_state)"
-  fi
+  # Initialize hashes (desktop app self-reloads via Compose Hot Reload; no hash)
   if [[ "${ANDROID_ENABLED}" == "true" ]]; then
     LAST_APK_HASH="$(hash_apk_watch_state)"
     LAST_VIDEO_SERVER_HASH="$(hash_video_server_watch_state)"
@@ -639,21 +636,19 @@ unified_watch_loop() {
       fi
     fi
 
-    # === 1. Check desktop app changes ===
+    # === 1. Desktop app ===
+    # The desktop app runs under Compose Hot Reload (`hotRun --autoReload`), which
+    # owns a Gradle daemon that recompiles desktop-core/desktop-app edits and
+    # reloads them into the SAME window. So the watcher must NOT rebuild/restart on
+    # source change — doing so would kill the live-reload process for every keystroke
+    # and reintroduce the rebuild-under-JVM NoClassDefFoundError trap. We only relaunch
+    # if the app process has died (e.g. crashed or the reload daemon exited).
     if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
-      local next_ide_hash
-      next_ide_hash="$(hash_ide_plugin_state)"
-      if [[ "${next_ide_hash}" != "${LAST_IDE_PLUGIN_HASH}" ]]; then
-        log_info "[Desktop App] Change detected. Rebuilding and restarting..."
-        LAST_IDE_PLUGIN_HASH="${next_ide_hash}"
-
-        if build_desktop_app; then
-          run_desktop_app
-        else
-          log_warn "[Desktop App] Build failed; waiting for next change."
-        fi
-
-        LAST_IDE_PLUGIN_HASH="$(hash_ide_plugin_state)"
+      local desktop_pid
+      desktop_pid="$(cat "${DESKTOP_APP_PID_FILE}" 2>/dev/null || true)"
+      if [[ -z "${desktop_pid}" ]] || ! kill -0 "${desktop_pid}" 2>/dev/null; then
+        log_warn "[Desktop App] Process not running; relaunching Compose Hot Reload..."
+        run_desktop_app
       fi
     fi
 

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -107,6 +107,17 @@ ANDROID_VIDEO_SERVER_NEEDS_DAEMON_RELOAD_AFTER_HANDOFF=false
 IOS_NEEDS_RESTART=false
 IOS_NEEDS_DAEMON_RELOAD_AFTER_HANDOFF=false
 
+# Desktop crash-relaunch backoff. If hotRun exits immediately (e.g. a hot-reload
+# config failure), relaunching every poll interval would hammer Gradle for the
+# whole watcher lifetime and repeatedly clobber the diagnostic log. Cap attempts
+# and back off exponentially; reset only once the app has stayed up a while.
+DESKTOP_RELAUNCH_ATTEMPTS=0
+DESKTOP_RELAUNCH_NEXT_TS=0
+DESKTOP_LAST_LAUNCH_TS=0
+DESKTOP_RELAUNCH_MAX=5
+DESKTOP_RELAUNCH_BACKOFF_CAP=300  # seconds
+DESKTOP_RELAUNCH_STABLE_SECS=30   # uptime before a launch is deemed healthy
+
 usage() {
   cat << EOF
 Usage: $0 [options]
@@ -642,13 +653,37 @@ unified_watch_loop() {
     # reloads them into the SAME window. So the watcher must NOT rebuild/restart on
     # source change — doing so would kill the live-reload process for every keystroke
     # and reintroduce the rebuild-under-JVM NoClassDefFoundError trap. We only relaunch
-    # if the app process has died (e.g. crashed or the reload daemon exited).
+    # if the app process has died (e.g. crashed or the reload daemon exited), with
+    # bounded exponential backoff so an immediately-exiting hotRun cannot spin.
     if [[ "${DESKTOP_APP_ENABLED}" == "true" ]]; then
-      local desktop_pid
+      local desktop_pid now_ts
       desktop_pid="$(cat "${DESKTOP_APP_PID_FILE}" 2>/dev/null || true)"
-      if [[ -z "${desktop_pid}" ]] || ! kill -0 "${desktop_pid}" 2>/dev/null; then
-        log_warn "[Desktop App] Process not running; relaunching Compose Hot Reload..."
-        run_desktop_app
+      now_ts=$(date +%s)
+      if [[ -n "${desktop_pid}" ]] && kill -0 "${desktop_pid}" 2>/dev/null; then
+        # Alive — clear backoff only once it has stayed up long enough to be healthy.
+        # A crash-looping launcher is briefly "alive" between relaunches while Gradle
+        # spins up, so resetting on the first live poll would defeat the backoff.
+        if [[ ${DESKTOP_RELAUNCH_ATTEMPTS} -gt 0 ]] &&
+          [[ $(( now_ts - DESKTOP_LAST_LAUNCH_TS )) -ge ${DESKTOP_RELAUNCH_STABLE_SECS} ]]; then
+          log_info "[Desktop App] Stable again; clearing relaunch backoff."
+          DESKTOP_RELAUNCH_ATTEMPTS=0
+          DESKTOP_RELAUNCH_NEXT_TS=0
+        fi
+      elif [[ ${DESKTOP_RELAUNCH_ATTEMPTS} -ge ${DESKTOP_RELAUNCH_MAX} ]]; then
+        : # Gave up after DESKTOP_RELAUNCH_MAX attempts; stay quiet until it recovers.
+      elif [[ ${now_ts} -ge ${DESKTOP_RELAUNCH_NEXT_TS} ]]; then
+        DESKTOP_RELAUNCH_ATTEMPTS=$(( DESKTOP_RELAUNCH_ATTEMPTS + 1 ))
+        local backoff=$(( POLL_INTERVAL * (1 << (DESKTOP_RELAUNCH_ATTEMPTS - 1)) ))
+        [[ ${backoff} -gt ${DESKTOP_RELAUNCH_BACKOFF_CAP} ]] && backoff=${DESKTOP_RELAUNCH_BACKOFF_CAP}
+        DESKTOP_RELAUNCH_NEXT_TS=$(( now_ts + backoff ))
+        DESKTOP_LAST_LAUNCH_TS=${now_ts}
+        if [[ ${DESKTOP_RELAUNCH_ATTEMPTS} -ge ${DESKTOP_RELAUNCH_MAX} ]]; then
+          log_warn "[Desktop App] Not running; final relaunch (${DESKTOP_RELAUNCH_ATTEMPTS}/${DESKTOP_RELAUNCH_MAX}). If it keeps exiting, see ${DESKTOP_APP_LOG}."
+        else
+          log_warn "[Desktop App] Process not running; relaunching (${DESKTOP_RELAUNCH_ATTEMPTS}/${DESKTOP_RELAUNCH_MAX}, next retry in >=${backoff}s)."
+        fi
+        # Preserve the log so a repeatedly-crashing hotRun keeps its diagnostics.
+        run_desktop_app preserve_log
       fi
     fi
 

--- a/scripts/local-dev/lib/ide-plugin.sh
+++ b/scripts/local-dev/lib/ide-plugin.sh
@@ -11,6 +11,7 @@
 #   build_desktop_app()               - Run gradlew :desktop-app:build -x test
 #   run_desktop_app()                 - Launch desktop-app via gradlew :desktop-app:hotRun --autoReload
 #   stop_desktop_app()                - Kill running desktop-app process (launcher + hot-reload JVM)
+#   hash_desktop_gradle_state()       - Hash of the two desktop build.gradle.kts (restart-on-config)
 
 # Desktop app paths
 ANDROID_DIR="${PROJECT_ROOT}/android"
@@ -120,7 +121,24 @@ stop_desktop_app() {
   fi
 }
 
-# Note: the desktop app no longer needs source-watch/hash helpers here. Compose
-# Hot Reload (hotRun --autoReload) watches desktop-core/desktop-app source itself
-# and reloads changes into the running window, so the unified watcher only checks
-# process liveness (see hot-reload.sh) rather than diffing file hashes.
+# Desktop app SOURCE edits are handled by Compose Hot Reload (hotRun --autoReload),
+# so the watcher does not diff source hashes. The two Gradle BUILD SCRIPTS are the
+# exception: Compose Hot Reload reloads source into the running window but does not
+# reconfigure an already-created Gradle project model, so a change to a build script
+# (new dependency, plugin, or compiler option) needs a full desktop-app restart or
+# later compilation runs against stale configuration. The watcher hashes just these
+# two files and restarts on change (see hot-reload.sh).
+DESKTOP_GRADLE_BUILD_FILES=(
+  "${ANDROID_DIR}/desktop-core/build.gradle.kts"
+  "${ANDROID_DIR}/desktop-app/build.gradle.kts"
+)
+
+# Hash of the desktop Gradle build scripts' timestamps (for restart-on-config-change)
+hash_desktop_gradle_state() {
+  local file
+  for file in "${DESKTOP_GRADLE_BUILD_FILES[@]}"; do
+    if [[ -f "${file}" ]]; then
+      stat_entry "${file}" 2>/dev/null || true
+    fi
+  done | sort | hash_stream
+}

--- a/scripts/local-dev/lib/ide-plugin.sh
+++ b/scripts/local-dev/lib/ide-plugin.sh
@@ -53,10 +53,16 @@ install_ide_plugin() {
 # desktop source changes (see hot-reload.sh). `--no-configuration-cache` is
 # required: the hot-reload tasks are not configuration-cache serializable and the
 # repo enables the configuration cache by default.
+# Pass "preserve_log" as $1 to append to the existing log instead of truncating it
+# (used by the watcher's crash-relaunch path so a hotRun that exits immediately does
+# not erase its own diagnostics on every retry).
 run_desktop_app() {
+  local preserve_log="${1:-}"
   stop_desktop_app
   mkdir -p "$(dirname "${DESKTOP_APP_LOG}")"
-  : > "${DESKTOP_APP_LOG}"
+  if [[ "${preserve_log}" != "preserve_log" ]]; then
+    : > "${DESKTOP_APP_LOG}"
+  fi
   log_info "Launching desktop app (Compose Hot Reload, --autoReload)..."
   (cd "${ANDROID_DIR}" && ./gradlew :desktop-app:hotRun --autoReload --no-configuration-cache --quiet) \
     >> "${DESKTOP_APP_LOG}" 2>&1 &
@@ -95,12 +101,19 @@ stop_desktop_app() {
   # or checkout hot-reloading under the same account has an identical bare
   # `compose.reload.argfile` / `MainKt` command line, and an unscoped pgrep would kill
   # its JVM too.
+  #
+  # `pgrep -f` treats its pattern as an extended regex, so the interpolated path must
+  # be escaped: an unescaped `.` would match any char (broadening into another
+  # checkout), and a literal `+`/`(`/`)` in the path would fail to match its own
+  # process. Escape every ERE metacharacter in ${ANDROID_DIR} to a literal.
+  local android_re
+  android_re=$(printf '%s' "${ANDROID_DIR}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')
   local pids
   pids=$(
-    pgrep -f "${ANDROID_DIR}.*:desktop-app:hotRun" 2>/dev/null
-    pgrep -f "${ANDROID_DIR}.*:desktop-app:run" 2>/dev/null
-    pgrep -f "compose.reload.argfile=${ANDROID_DIR}" 2>/dev/null
-    pgrep -f "${ANDROID_DIR}.*dev.jasonpearson.automobile.desktop.MainKt" 2>/dev/null
+    pgrep -f "${android_re}.*:desktop-app:hotRun" 2>/dev/null
+    pgrep -f "${android_re}.*:desktop-app:run" 2>/dev/null
+    pgrep -f "compose\\.reload\\.argfile=${android_re}" 2>/dev/null
+    pgrep -f "${android_re}.*dev\\.jasonpearson\\.automobile\\.desktop\\.MainKt" 2>/dev/null
   ) || true
   if [[ -n "${pids}" ]]; then
     echo "${pids}" | xargs kill 2>/dev/null || true

--- a/scripts/local-dev/lib/ide-plugin.sh
+++ b/scripts/local-dev/lib/ide-plugin.sh
@@ -9,15 +9,11 @@
 #
 # Functions:
 #   build_desktop_app()               - Run gradlew :desktop-app:build -x test
-#   run_desktop_app()                 - Launch desktop-app via gradlew :desktop-app:run
-#   stop_desktop_app()                - Kill running desktop-app process
-#   list_ide_plugin_watch_files()     - Files to watch for changes (desktop-core + desktop-app)
-#   hash_ide_plugin_state()           - Hash of watched file timestamps
+#   run_desktop_app()                 - Launch desktop-app via gradlew :desktop-app:hotRun --autoReload
+#   stop_desktop_app()                - Kill running desktop-app process (launcher + hot-reload JVM)
 
 # Desktop app paths
 ANDROID_DIR="${PROJECT_ROOT}/android"
-DESKTOP_CORE_DIR="${ANDROID_DIR}/desktop-core"
-DESKTOP_APP_DIR="${ANDROID_DIR}/desktop-app"
 
 # Runtime state
 DESKTOP_APP_PID=""
@@ -46,17 +42,28 @@ install_ide_plugin() {
   return 0
 }
 
-# Launch the desktop app in the background, logging to a file
+# Launch the desktop app in the background via Compose Hot Reload, logging to a file.
+#
+# `hotRun --autoReload` launches a separate Gradle daemon that continuously
+# recompiles and reloads desktop-core/desktop-app source into the SAME running
+# window — no rebuild-and-restart cycle. This avoids the plain `:desktop-app:run`
+# trap where a rebuild overwrites the running JVM's exploded classes and the next
+# lazy class load throws NoClassDefFoundError. Because Compose Hot Reload owns
+# desktop reloading, the unified watcher must NOT also rebuild/restart the app on
+# desktop source changes (see hot-reload.sh). `--no-configuration-cache` is
+# required: the hot-reload tasks are not configuration-cache serializable and the
+# repo enables the configuration cache by default.
 run_desktop_app() {
   stop_desktop_app
   mkdir -p "$(dirname "${DESKTOP_APP_LOG}")"
   : > "${DESKTOP_APP_LOG}"
-  log_info "Launching desktop app..."
-  (cd "${ANDROID_DIR}" && ./gradlew :desktop-app:run --quiet) >> "${DESKTOP_APP_LOG}" 2>&1 &
+  log_info "Launching desktop app (Compose Hot Reload, --autoReload)..."
+  (cd "${ANDROID_DIR}" && ./gradlew :desktop-app:hotRun --autoReload --no-configuration-cache --quiet) \
+    >> "${DESKTOP_APP_LOG}" 2>&1 &
   DESKTOP_APP_PID=$!
   echo "${DESKTOP_APP_PID}" > "${DESKTOP_APP_PID_FILE}"
   disown "${DESKTOP_APP_PID}"
-  log_info "Desktop app running (PID ${DESKTOP_APP_PID})."
+  log_info "Desktop app running (PID ${DESKTOP_APP_PID}); source edits reload live."
   log_info "Desktop app logs: tail -f ${DESKTOP_APP_LOG}"
 }
 
@@ -80,44 +87,17 @@ stop_desktop_app() {
     DESKTOP_APP_PID=""
   fi
   rm -f "${DESKTOP_APP_PID_FILE}"
-  # Also kill any orphaned desktop-app Gradle run processes
+  # Also kill any orphaned desktop-app Gradle processes: the launcher (hotRun/run),
+  # the Compose Hot Reload JVM (identified by its -Dcompose.reload.argfile), and the
+  # app main class.
   local pids
-  pids=$(pgrep -f "desktop-app:run" 2>/dev/null; pgrep -f "dev.jasonpearson.automobile.desktop.MainKt" 2>/dev/null) || true
+  pids=$(pgrep -f "desktop-app:hotRun" 2>/dev/null; pgrep -f "desktop-app:run" 2>/dev/null; pgrep -f "compose.reload.argfile" 2>/dev/null; pgrep -f "dev.jasonpearson.automobile.desktop.MainKt" 2>/dev/null) || true
   if [[ -n "${pids}" ]]; then
     echo "${pids}" | xargs kill 2>/dev/null || true
   fi
 }
 
-# List all files to watch for changes (desktop-core + desktop-app source)
-list_ide_plugin_watch_files() {
-  local watch_dirs=(
-    "${DESKTOP_CORE_DIR}/src"
-    "${DESKTOP_APP_DIR}/src"
-  )
-  local extra_files=(
-    "${DESKTOP_CORE_DIR}/build.gradle.kts"
-    "${DESKTOP_APP_DIR}/build.gradle.kts"
-  )
-
-  # Use ripgrep if available, otherwise find
-  if command -v rg >/dev/null 2>&1; then
-    rg --files "${watch_dirs[@]}" -g '!**/build/**' 2>/dev/null || true
-  else
-    find "${watch_dirs[@]}" -type f ! -path "*/build/*" 2>/dev/null || true
-  fi
-
-  for file in "${extra_files[@]}"; do
-    if [[ -f "${file}" ]]; then
-      echo "${file}"
-    fi
-  done
-}
-
-# Compute hash of all watched file timestamps
-hash_ide_plugin_state() {
-  list_ide_plugin_watch_files | while read -r file; do
-    if [[ -f "${file}" ]]; then
-      stat_entry "${file}" 2>/dev/null || true
-    fi
-  done | sort | hash_stream
-}
+# Note: the desktop app no longer needs source-watch/hash helpers here. Compose
+# Hot Reload (hotRun --autoReload) watches desktop-core/desktop-app source itself
+# and reloads changes into the running window, so the unified watcher only checks
+# process liveness (see hot-reload.sh) rather than diffing file hashes.

--- a/scripts/local-dev/lib/ide-plugin.sh
+++ b/scripts/local-dev/lib/ide-plugin.sh
@@ -89,9 +89,19 @@ stop_desktop_app() {
   rm -f "${DESKTOP_APP_PID_FILE}"
   # Also kill any orphaned desktop-app Gradle processes: the launcher (hotRun/run),
   # the Compose Hot Reload JVM (identified by its -Dcompose.reload.argfile), and the
-  # app main class.
+  # app main class. Every one of these carries THIS checkout's ${ANDROID_DIR} in its
+  # argv (Gradle wrapper classpath, the reload argfile path, or the app classpath), so
+  # every pattern is scoped to that path. Never match machine-wide: another workspace
+  # or checkout hot-reloading under the same account has an identical bare
+  # `compose.reload.argfile` / `MainKt` command line, and an unscoped pgrep would kill
+  # its JVM too.
   local pids
-  pids=$(pgrep -f "desktop-app:hotRun" 2>/dev/null; pgrep -f "desktop-app:run" 2>/dev/null; pgrep -f "compose.reload.argfile" 2>/dev/null; pgrep -f "dev.jasonpearson.automobile.desktop.MainKt" 2>/dev/null) || true
+  pids=$(
+    pgrep -f "${ANDROID_DIR}.*:desktop-app:hotRun" 2>/dev/null
+    pgrep -f "${ANDROID_DIR}.*:desktop-app:run" 2>/dev/null
+    pgrep -f "compose.reload.argfile=${ANDROID_DIR}" 2>/dev/null
+    pgrep -f "${ANDROID_DIR}.*dev.jasonpearson.automobile.desktop.MainKt" 2>/dev/null
+  ) || true
   if [[ -n "${pids}" ]]; then
     echo "${pids}" | xargs kill 2>/dev/null || true
   fi


### PR DESCRIPTION
## Summary

The unified dev workflow (`scripts/local-dev/hot-reload.sh`) launched the desktop app with plain `:desktop-app:run` and, on every desktop source change, ran `:desktop-app:build` — recompiling into the running JVM's exploded `build/classes` — then killed and relaunched the app. During that rebuild window the still-running app would fail the first lazy load of a freshly-overwritten class with a bare `NoClassDefFoundError` (e.g. `DevicePickerViewModel$observeDevice$1`, hit on the first device-card click), the classloader-poisoning trap the app's own error dialog already describes.

This switches the desktop leg to `:desktop-app:hotRun --autoReload --no-configuration-cache`, the purpose-built Compose Hot Reload task the `desktop-app` build already documents. It runs its own Gradle daemon that recompiles `desktop-core`/`desktop-app` edits and reloads them into the same window — no rebuild-under-JVM cycle to poison, and no restart on every keystroke.

Changes:
- `run_desktop_app()` launches `hotRun --autoReload` instead of `run`.
- `stop_desktop_app()` also reaps the Compose Hot Reload JVM (`-Dcompose.reload.argfile`) and the `hotRun` launcher.
- The watcher's desktop rebuild/restart-on-change block is removed (Compose Hot Reload owns live reloading); it now only relaunches if the app process has died (crash recovery). Removed the now-unused desktop watch/hash helpers and their vars.

Android, iOS, and TypeScript legs are unchanged.

## Linked Issue

<!-- no tracking issue -->

## Bug / Regression Context

- **Observed symptom:** clicking into a device card in the dev desktop app crashed with `NoClassDefFoundError: .../DevicePickerViewModel$observeDevice$1` (surfaced first on an iOS card, but the path is platform-agnostic).
- **Repro steps / conditions:** run the desktop app via the hot-reload script, trigger a background rebuild, then click a booted device card before the restart completes — the first lazy class load fails.
- **Root cause:** `:desktop-app:run` binds the JVM to exploded `build/classes`; a concurrent `:desktop-app:build` overwrites those files under the live JVM.

## Validation

- [x] `shellcheck -x scripts/local-dev/hot-reload.sh scripts/local-dev/lib/ide-plugin.sh` clean
- [x] Verified live: script now launches the desktop app under Compose Hot Reload (`--autoReload`); Android/iOS/TS legs and daemon restart still work
- [ ] No TypeScript/Kotlin source touched (shell-only change)

## Device Verification

- [x] Ran the full workflow against the local Android emulator + iOS simulator fleet; desktop app comes up under hotRun and reloads source edits live.

## Follow-ups

- [ ] None.