### PR TITLE
docs: surface Homebrew install in README and docs Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ You can use our interactive installer to step through all host platform requirem
 curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/refs/heads/main/scripts/install.sh | bash
 ```
 
-or follow the [installation guide](docs/index.md#install).
+Prefer Homebrew for the CLI:
+
+```bash title="Homebrew (click to copy)"
+brew install kaeawc/tap/auto-mobile
+```
+
+or follow the [installation guide](docs/index.md#install) — including the [Homebrew guide](docs/install/homebrew.md).
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,21 @@ global configuration. Restart your MCP client when it finishes.
 </details>
 
 <details markdown>
+<summary>Homebrew (CLI)</summary>
+
+```bash
+brew tap kaeawc/tap
+brew install kaeawc/tap/auto-mobile
+```
+
+Installs the `auto-mobile` command-line tool and keeps it current through
+`brew upgrade`. On recent Homebrew, run `brew trust kaeawc/tap` first if the
+tap is reported untrusted. See the [Homebrew guide](install/homebrew.md) for
+upgrade, uninstall, and details.
+
+</details>
+
+<details markdown>
 <summary>Manual MCP configuration</summary>
 
 ```json


### PR DESCRIPTION
The Homebrew guide (`docs/install/homebrew.md`) shipped with the tap pipeline (#5989) but was only reachable via the mkdocs nav. Now that the tap is seeded and `brew install kaeawc/tap/auto-mobile` works end-to-end, make it discoverable:

- **docs/index.md** — add a "Homebrew (CLI)" option to the Install section (collapsible, alongside one-line install / manual MCP config), linking to the full Homebrew guide.
- **README.md** — add a `brew install kaeawc/tap/auto-mobile` one-liner and a link to the guide.

Docs-only. mkdocs-nav validation passes; link target exists.