### PR TITLE
refactor(ios/screen-capture): Swift-6 strict concurrency + per-frame copy elimination

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -418,14 +418,12 @@ jobs:
       MACOS_SIGNING_ENABLED: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 != '' }}
     strategy:
       fail-fast: false
-      # Swift-package floor is Xcode 26.5 (Swift 6.3). The root, XCTestRunner, and
-      # screen-capture manifests declare swift-tools-version 6.3 for strict
-      # concurrency; Swift 5.10 (Xcode 15.4) and Swift 6.2 (Xcode 26.0) cannot even
-      # parse a 6.3 manifest, so those legs are pruned here (PR #6014 established the
-      # 26.5 floor for the root build). The Xcode-project sweep below still covers
-      # 15.4 for the packages that support it.
+      # The SDK still supports older Swift toolchains. Keep its SwiftPM tests on
+      # Xcode 26.0; the other packages require Swift 6.3 / Xcode 26.5 or newer.
+      # Xcode 15.4 / macos-14 runners were retired separately in #6312.
       matrix:
         config:
+          - { name: "Xcode 26 (SDK)", runner: "macos-26", xcode: "26.0" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
           - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
     steps:
@@ -456,6 +454,7 @@ jobs:
         run: ./scripts/ios/setup-signing-keychain.sh
 
       - name: "Build Swift Packages"
+        if: matrix.config.xcode != '26.0'
         env:
           MACOS_SIGNING_ENABLED: ${{ env.MACOS_SIGNING_ENABLED }}
           MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
@@ -468,7 +467,15 @@ jobs:
         run: ./scripts/ios/swift-build.sh
 
       - name: "Test Swift Packages"
+        if: matrix.config.xcode != '26.0'
         run: ./scripts/ios/swift-test.sh
+
+      - name: "Build and test SDK on older Swift"
+        if: matrix.config.xcode == '26.0'
+        working-directory: ios/auto-mobile-sdk
+        run: |
+          swift build -Xswiftc -warnings-as-errors
+          swift test -Xswiftc -warnings-as-errors
 
   ios-xcode-build-sweep:
     name: "Build Xcode Projects Sweep (${{ matrix.config.name }})"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -418,9 +418,14 @@ jobs:
       MACOS_SIGNING_ENABLED: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 != '' }}
     strategy:
       fail-fast: false
+      # Swift-package floor is Xcode 26.5 (Swift 6.3). The root, XCTestRunner, and
+      # screen-capture manifests declare swift-tools-version 6.3 for strict
+      # concurrency; Swift 5.10 (Xcode 15.4) and Swift 6.2 (Xcode 26.0) cannot even
+      # parse a 6.3 manifest, so those legs are pruned here (PR #6014 established the
+      # 26.5 floor for the root build). The Xcode-project sweep below still covers
+      # 15.4 for the packages that support it.
       matrix:
         config:
-          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
           - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
     steps:

--- a/ios/screen-capture/Benchmarks/.gitignore
+++ b/ios/screen-capture/Benchmarks/.gitignore
@@ -1,0 +1,8 @@
+# SwiftPM build products and resolved graph (machine-specific; the repo does not
+# commit Package.resolved for its Swift packages).
+.build/
+Package.resolved
+
+# package-benchmark stores saved baselines here; they are machine-specific run data,
+# not source.
+.benchmarkBaselines/

--- a/ios/screen-capture/Benchmarks/Benchmarks/ScreenCaptureCoreBenchmarks/ScreenCaptureCoreBenchmarks.swift
+++ b/ios/screen-capture/Benchmarks/Benchmarks/ScreenCaptureCoreBenchmarks/ScreenCaptureCoreBenchmarks.swift
@@ -1,0 +1,150 @@
+import Benchmark
+import Foundation
+import ScreenCaptureCore
+
+// Per-frame byte-transform benchmarks for the ScreenCaptureCore hot path (the pure,
+// device-free layer where the encoded path's copies live). These quantify the
+// allocation/CPU cost the Swift-6 + performance pass targets: the avcC -> Annex-B
+// access-unit assembly, the frame header build, and the audio PCM conversion.
+//
+// `.mallocCountTotal` is the headline metric — it is the count of heap allocations
+// per iteration, which directly demonstrates the copy/alloc reduction (e.g. a keyframe
+// access unit going from three heap buffers to one).
+
+// A length-prefixed (avcC) sample: each NAL is a 4-byte big-endian length + payload.
+// Payload content is irrelevant to the copy path, so a deterministic fill is used.
+private func avccSample(nalSizes: [Int]) -> Data {
+    var data = Data()
+    for size in nalSizes {
+        var length = UInt32(size).bigEndian
+        withUnsafeBytes(of: &length) { data.append(contentsOf: $0) }
+        data.append(Data(repeating: 0xAB, count: size))
+    }
+    return data
+}
+
+// Representative compressed frames. A delta frame is a few NALs (~28 KB total); a
+// keyframe is a single larger slice (~60 KB) that also carries SPS/PPS.
+private let deltaSample = avccSample(nalSizes: [15_000, 8_000, 5_000])
+private let keyframeSample = avccSample(nalSizes: [60_000])
+private let parameterSets: [Data] = [
+    Data(repeating: 0x67, count: 25),  // SPS
+    Data(repeating: 0x68, count: 6),   // PPS
+]
+private let float32Audio = Data(repeating: 0x00, count: 320 * MemoryLayout<Float>.size)
+
+// A raw buffer standing in for a VideoToolbox CMBlockBuffer's data pointer, used to
+// compare the encoder's copy-out-then-assemble flow with the zero-extra-copy
+// `Data(bytesNoCopy:)` flow that this pass adopts.
+// `nonisolated(unsafe)`: a process-lifetime, write-once benchmark fixture read only
+// from the benchmark closures; the raw buffer is not itself Sendable.
+nonisolated(unsafe) private let blockBufferBytes: UnsafeMutableRawBufferPointer = {
+    let buffer = UnsafeMutableRawBufferPointer.allocate(
+        byteCount: deltaSample.count, alignment: 16
+    )
+    deltaSample.copyBytes(to: buffer)
+    return buffer
+}()
+
+// A 1080p BGRA frame (1920x1080x4 ≈ 8.3 MB) standing in for the RAW path's per-frame
+// payload — the largest per-frame slab in the system and where the copy cost is real
+// (hundreds of µs, unlike the compressed path). The device capture (CVPixelBuffer lock /
+// ScreenCaptureKit delivery) is not headless-testable, but the copy itself takes a raw
+// pointer, so the pooled-vs-unpooled allocation cost around the same memcpy is.
+private let rawFrameByteCount = 1920 * 1080 * 4
+nonisolated(unsafe) private let rawFrame: UnsafeMutableRawBufferPointer = {
+    let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: rawFrameByteCount, alignment: 16)
+    buffer.initializeMemory(as: UInt8.self, repeating: 0xCD)
+    return buffer
+}()
+nonisolated(unsafe) private let rawFramePool = FrameBufferPool()
+
+let benchmarks: @Sendable () -> Void = {
+    Benchmark.defaultConfiguration = .init(
+        metrics: [.mallocCountTotal, .cpuTotal, .wallClock, .throughput],
+        maxDuration: .seconds(2),
+        maxIterations: 100_000
+    )
+
+    Benchmark("AnnexB assembleAccessUnit — delta (2 copies today)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(
+                try AnnexBConverter.assembleAccessUnit(
+                    fromAvcc: deltaSample, nalUnitHeaderLength: 4,
+                    parameterSets: [], isKeyframe: false
+                )
+            )
+        }
+    }
+
+    Benchmark("AnnexB assembleAccessUnit — keyframe + SPS/PPS (3 copies today)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(
+                try AnnexBConverter.assembleAccessUnit(
+                    fromAvcc: keyframeSample, nalUnitHeaderLength: 4,
+                    parameterSets: parameterSets, isKeyframe: true
+                )
+            )
+        }
+    }
+
+    // Isolates copy #1 (the encoder's copy-out of the CMBlockBuffer). The real encoder
+    // path is device-only; these two siblings model its before/after in one run.
+    Benchmark("encoder copy-out — Data(bytes:) + assemble (copy #1 present)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            let copied = Data(bytes: blockBufferBytes.baseAddress!, count: blockBufferBytes.count)
+            blackHole(
+                try AnnexBConverter.assembleAccessUnit(
+                    fromAvcc: copied, nalUnitHeaderLength: 4,
+                    parameterSets: [], isKeyframe: false
+                )
+            )
+        }
+    }
+
+    Benchmark("encoder copy-out — Data(bytesNoCopy:) + assemble (copy #1 elided)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            let wrapped = Data(
+                bytesNoCopy: blockBufferBytes.baseAddress!,
+                count: blockBufferBytes.count, deallocator: .none
+            )
+            blackHole(
+                try AnnexBConverter.assembleAccessUnit(
+                    fromAvcc: wrapped, nalUnitHeaderLength: 4,
+                    parameterSets: [], isKeyframe: false
+                )
+            )
+        }
+    }
+
+    Benchmark("FrameProtocol.encodeEncodedVideoHeader") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(
+                FrameProtocol.encodeEncodedVideoHeader(
+                    payloadLength: 28_000, isKeyframe: false, presentationTimestampMs: 1234
+                )
+            )
+        }
+    }
+
+    Benchmark("AudioPcm16Encoder.encodeFloat32LE") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(AudioPcm16Encoder.encodeFloat32LE(float32Audio))
+        }
+    }
+
+    // Raw path: same ~8.3 MB memcpy either way — the delta is malloc + first-touch page
+    // faulting of a fresh slab (unpooled) vs recycling one (pooled). CPU/wall is the
+    // story here, not allocation count.
+    Benchmark("raw frame copy — 1080p BGRA via FrameBufferPool (pooled)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(rawFramePool.makeData(copyingFrom: rawFrame.baseAddress!, count: rawFrame.count))
+        }
+    }
+
+    Benchmark("raw frame copy — 1080p BGRA via Data(bytes:) (unpooled)") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(Data(bytes: rawFrame.baseAddress!, count: rawFrame.count))
+        }
+    }
+}

--- a/ios/screen-capture/Benchmarks/Benchmarks/ScreenCaptureCoreBenchmarks/ScreenCaptureCoreBenchmarks.swift
+++ b/ios/screen-capture/Benchmarks/Benchmarks/ScreenCaptureCoreBenchmarks/ScreenCaptureCoreBenchmarks.swift
@@ -91,8 +91,11 @@ let benchmarks: @Sendable () -> Void = {
     // Isolates copy #1 (the encoder's copy-out of the CMBlockBuffer). The real encoder
     // path is device-only; these two siblings model its before/after in one run.
     Benchmark("encoder copy-out — Data(bytes:) + assemble (copy #1 present)") { benchmark in
+        guard let baseAddress = blockBufferBytes.baseAddress else {
+            preconditionFailure("Compressed benchmark fixture must be non-empty")
+        }
         for _ in benchmark.scaledIterations {
-            let copied = Data(bytes: blockBufferBytes.baseAddress!, count: blockBufferBytes.count)
+            let copied = Data(bytes: baseAddress, count: blockBufferBytes.count)
             blackHole(
                 try AnnexBConverter.assembleAccessUnit(
                     fromAvcc: copied, nalUnitHeaderLength: 4,
@@ -103,9 +106,12 @@ let benchmarks: @Sendable () -> Void = {
     }
 
     Benchmark("encoder copy-out — Data(bytesNoCopy:) + assemble (copy #1 elided)") { benchmark in
+        guard let baseAddress = blockBufferBytes.baseAddress else {
+            preconditionFailure("Compressed benchmark fixture must be non-empty")
+        }
         for _ in benchmark.scaledIterations {
             let wrapped = Data(
-                bytesNoCopy: blockBufferBytes.baseAddress!,
+                bytesNoCopy: baseAddress,
                 count: blockBufferBytes.count, deallocator: .none
             )
             blackHole(
@@ -137,14 +143,20 @@ let benchmarks: @Sendable () -> Void = {
     // faulting of a fresh slab (unpooled) vs recycling one (pooled). CPU/wall is the
     // story here, not allocation count.
     Benchmark("raw frame copy — 1080p BGRA via FrameBufferPool (pooled)") { benchmark in
+        guard let baseAddress = rawFrame.baseAddress else {
+            preconditionFailure("Raw benchmark fixture must be non-empty")
+        }
         for _ in benchmark.scaledIterations {
-            blackHole(rawFramePool.makeData(copyingFrom: rawFrame.baseAddress!, count: rawFrame.count))
+            blackHole(rawFramePool.makeData(copyingFrom: baseAddress, count: rawFrame.count))
         }
     }
 
     Benchmark("raw frame copy — 1080p BGRA via Data(bytes:) (unpooled)") { benchmark in
+        guard let baseAddress = rawFrame.baseAddress else {
+            preconditionFailure("Raw benchmark fixture must be non-empty")
+        }
         for _ in benchmark.scaledIterations {
-            blackHole(Data(bytes: rawFrame.baseAddress!, count: rawFrame.count))
+            blackHole(Data(bytes: baseAddress, count: rawFrame.count))
         }
     }
 }

--- a/ios/screen-capture/Benchmarks/Package.swift
+++ b/ios/screen-capture/Benchmarks/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.3
+import PackageDescription
+
+// Standalone benchmark package for ScreenCaptureCore's per-frame byte transforms.
+//
+// Deliberately SEPARATE from ../Package.swift so the shipped `screen-capture` package
+// never takes a dependency on package-benchmark (and its jemalloc/pkg-config system
+// requirement): `scripts/ios/swift-build.sh` builds only the shipped package, so CI is
+// unaffected. Run locally with:
+//
+//   swift package --package-path ios/screen-capture/Benchmarks --disable-sandbox \
+//     --allow-writing-to-package-directory benchmark
+//
+// package-benchmark reports allocation counts (via jemalloc), which is the metric that
+// most directly demonstrates the per-frame copy/alloc elimination in this pass.
+let package = Package(
+    name: "ScreenCaptureBenchmarks",
+    platforms: [
+        .macOS(.v15),
+    ],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.4.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ScreenCaptureCoreBenchmarks",
+            dependencies: [
+                .product(name: "ScreenCaptureCore", package: "screen-capture"),
+                .product(name: "Benchmark", package: "benchmark"),
+            ],
+            path: "Benchmarks/ScreenCaptureCoreBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "benchmark"),
+            ]
+        ),
+    ]
+)

--- a/ios/screen-capture/Benchmarks/README.md
+++ b/ios/screen-capture/Benchmarks/README.md
@@ -1,0 +1,83 @@
+# ScreenCaptureCore benchmarks
+
+Micro-benchmarks for the per-frame byte transforms on the screen-capture hot path —
+the pure, device-free `ScreenCaptureCore` layer where the encoded path's copies live.
+They quantify the allocation/CPU cost that the Swift-6 + performance pass targets.
+
+This is a **separate** SwiftPM package (its own `Package.swift`) so the shipped
+`screen-capture` package never depends on [`ordo-one/benchmark`][pb] or its
+jemalloc/pkg-config system requirement. `scripts/ios/swift-build.sh` builds only the
+shipped package, so CI is unaffected and these run on demand, locally.
+
+## Running
+
+```bash
+# One-time system prerequisites for package-benchmark's allocation metrics:
+brew install jemalloc pkg-config
+
+# Run all benchmarks:
+swift package --package-path ios/screen-capture/Benchmarks --disable-sandbox \
+  --allow-writing-to-package-directory benchmark
+
+# Capture a baseline and compare a later run against it (how the numbers below
+# were produced):
+swift package --package-path ios/screen-capture/Benchmarks --disable-sandbox \
+  --allow-writing-to-package-directory benchmark baseline update before
+# ...make changes...
+swift package --package-path ios/screen-capture/Benchmarks --disable-sandbox \
+  --allow-writing-to-package-directory benchmark baseline compare before
+```
+
+`Malloc (total)` (heap allocations per call, via jemalloc) is the headline metric —
+it directly shows the per-frame copy/alloc reduction.
+
+## Before / after (this pass)
+
+Measured on Apple silicon, Swift 6.3.3, release build, p50 of 100k iterations.
+"before" = the pre-optimization converter/header; "after" = this pass.
+
+| Benchmark | Malloc (total) | Time (total CPU) |
+| --- | --- | --- |
+| `assembleAccessUnit` — delta frame | 4 → **2** | 2709 → **2083** ns (−23%) |
+| `assembleAccessUnit` — keyframe + SPS/PPS | 9 → **2** (−78%) | 4542 → **2416** ns (−47%) |
+| `encodeEncodedVideoHeader` (per-frame header) | 4 → **2** | 1666 → **1458** ns (−12%) |
+| encoder copy-out: `Data(bytes:)` + assemble | 6 → 4 | 3417 → 2750 ns |
+| encoder copy-out: `Data(bytesNoCopy:)` + assemble | 5 → **3** | 2834 → **1958** ns |
+| `encodeFloat32LE` (audio, unchanged control) | 2 → 2 | ~1750 ns |
+
+The last two rows isolate **copy #1** (the encoder's copy-out of the VideoToolbox
+`CMBlockBuffer`), which the real device path now elides with `Data(bytesNoCopy:)`:
+within the same build, `bytesNoCopy` + assemble is one fewer allocation and ~29% less
+CPU than `Data(bytes:)` + assemble.
+
+## Raw path (pooled vs unpooled)
+
+The raw BGRA path copies an entire uncompressed frame (~8.3 MB at 1080p) per frame —
+the largest per-frame slab in the system. The copy off the locked `CVPixelBuffer` is
+unavoidable; `FrameBufferPool` only removes the fresh-slab allocation and its
+first-touch page faults, so both variants share the same memcpy floor (the ~100 µs `p0`).
+
+| 1080p BGRA frame copy (~8.3 MB) | Time (total CPU) p50 | Throughput |
+| --- | --- | --- |
+| `Data(bytes:)` (unpooled) | 166 µs | 6.0 K/s |
+| `FrameBufferPool` (pooled) | **126 µs** (−24%) | **8.1 K/s** |
+
+At ~126 µs the raw copy is roughly **60× the compressed access-unit assembly** — this is
+where per-frame copy cost actually lives — yet still only ~0.4% of a core at 30 fps for
+the *in-helper* copy alone. The genuinely expensive raw-path costs are cross-process and
+not captured here: piping 8 MB/frame through the pipe to Node plus a separate ffmpeg
+re-encode. That is why the encoded path is the default.
+
+## Interpretation (honest scope)
+
+These are real, directionally-clear reductions — the keyframe access unit drops from
+nine heap allocations to two. **But** they run on *compressed* buffers (tens–hundreds
+of KB), so the absolute cost is only a few microseconds per frame — a fraction of a
+percent of one core at 60 fps. This pass therefore **rules out** in-helper byte-copying
+as a driver of the production CPU spikes on the encoded path; the dominant costs remain
+VideoToolbox encoding itself (especially the `-allow_sw` software fallback on shared
+runners) and, on the *raw* fallback path, the ~8 MB/frame BGRA copy plus a separate
+ffmpeg re-encode. The wins here are allocation hygiene and a cleaner, less GC-churny
+hot path, not a CPU-spike fix by themselves.
+
+[pb]: https://github.com/ordo-one/benchmark

--- a/ios/screen-capture/Package.swift
+++ b/ios/screen-capture/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.3
 import PackageDescription
 
+// ScreenCaptureHelper is a Swift-6 strict-concurrency package: language mode v6 by
+// default under swift-tools-version 6.3, matching the ios/XCTestRunner and root
+// manifests' Swift 6.3 / macOS 15 toolchain floor (PR #6014). macOS-only — it links
+// ScreenCaptureKit, AVFoundation, and VideoToolbox. Do NOT add .swiftLanguageMode
+// or warnings-as-errors here; warnings-as-errors is applied repo-wide by
+// scripts/ios/swift-build.sh and swift-test.sh (`-Xswiftc -warnings-as-errors`).
 let package = Package(
     name: "ScreenCaptureHelper",
     platforms: [
-        .macOS(.v14),
+        .macOS(.v15),
     ],
     products: [
         .executable(

--- a/ios/screen-capture/Sources/ScreenCaptureCore/AnnexBConverter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/AnnexBConverter.swift
@@ -35,6 +35,67 @@ public enum AnnexBConverter {
             throw ConversionError.invalidNalHeaderLength(nalUnitHeaderLength)
         }
         var output = Data()
+        // For the common 4-byte header the Annex-B output is exactly the input size
+        // (a 4-byte length prefix becomes a 4-byte start code), so one reservation
+        // avoids reallocating as each NAL is appended.
+        output.reserveCapacity(sample.count)
+        try appendAnnexB(fromAvcc: sample, nalUnitHeaderLength: nalUnitHeaderLength, into: &output)
+        return output
+    }
+
+    /// Concatenate parameter-set NALs (SPS then PPS) as Annex-B, each prefixed
+    /// with a start code. The NALs are passed already stripped of any length
+    /// prefix (as VideoToolbox surfaces them via
+    /// `CMVideoFormatDescriptionGetH264ParameterSetAtIndex`).
+    public static func parameterSetsAnnexB(_ parameterSets: [Data]) -> Data {
+        var output = Data()
+        output.reserveCapacity(parameterSetsAnnexBLength(parameterSets))
+        for nal in parameterSets where !nal.isEmpty {
+            output.append(startCode)
+            output.append(nal)
+        }
+        return output
+    }
+
+    /// Assemble one Annex-B access unit from an avcC sample. When `isKeyframe`
+    /// is true the parameter sets are prepended so the IDR is self-decodable
+    /// (the RTP path drops SPS/PPS otherwise). `parameterSets` are the raw
+    /// SPS/PPS NALs (no length prefix); pass an empty array for delta frames or
+    /// when they are unavailable.
+    ///
+    /// The access unit is built into ONE pre-sized `Data`: the parameter-set NALs
+    /// (keyframes only) then the sample's slices are appended in place. This replaces
+    /// the previous three-allocation path — `parameterSetsAnnexB(...)`, `annexB(...)`,
+    /// and their `+` concatenation — with a single per-frame allocation.
+    public static func assembleAccessUnit(
+        fromAvcc sample: Data,
+        nalUnitHeaderLength: Int,
+        parameterSets: [Data],
+        isKeyframe: Bool
+    ) throws -> Data {
+        guard nalUnitHeaderLength >= 1, nalUnitHeaderLength <= 4 else {
+            throw ConversionError.invalidNalHeaderLength(nalUnitHeaderLength)
+        }
+        let prependedSets = isKeyframe ? parameterSets : []
+        var output = Data()
+        output.reserveCapacity(parameterSetsAnnexBLength(prependedSets) + sample.count)
+        for nal in prependedSets where !nal.isEmpty {
+            output.append(startCode)
+            output.append(nal)
+        }
+        try appendAnnexB(fromAvcc: sample, nalUnitHeaderLength: nalUnitHeaderLength, into: &output)
+        return output
+    }
+
+    /// Appends each NAL of a length-prefixed (avcC) sample to `output` as a
+    /// start-code-prefixed Annex-B NAL. The single NAL-walking implementation shared
+    /// by `annexB` and `assembleAccessUnit`, so both build into one caller-owned
+    /// buffer. The caller validates `nalUnitHeaderLength`.
+    private static func appendAnnexB(
+        fromAvcc sample: Data,
+        nalUnitHeaderLength: Int,
+        into output: inout Data
+    ) throws {
         // Index into the sample using its own start index so this is correct even
         // for a `Data` slice whose indices do not begin at 0.
         var cursor = sample.startIndex
@@ -55,35 +116,15 @@ public enum AnnexBConverter {
             output.append(sample[nalStart..<(nalStart + nalLength)])
             cursor = nalStart + nalLength
         }
-        return output
     }
 
-    /// Concatenate parameter-set NALs (SPS then PPS) as Annex-B, each prefixed
-    /// with a start code. The NALs are passed already stripped of any length
-    /// prefix (as VideoToolbox surfaces them via
-    /// `CMVideoFormatDescriptionGetH264ParameterSetAtIndex`).
-    public static func parameterSetsAnnexB(_ parameterSets: [Data]) -> Data {
-        var output = Data()
+    /// The Annex-B byte length of `parameterSets` (start code + NAL per non-empty
+    /// set), used to size the assembly buffer exactly.
+    private static func parameterSetsAnnexBLength(_ parameterSets: [Data]) -> Int {
+        var total = 0
         for nal in parameterSets where !nal.isEmpty {
-            output.append(startCode)
-            output.append(nal)
+            total += startCode.count + nal.count
         }
-        return output
-    }
-
-    /// Assemble one Annex-B access unit from an avcC sample. When `isKeyframe`
-    /// is true the parameter sets are prepended so the IDR is self-decodable
-    /// (the RTP path drops SPS/PPS otherwise). `parameterSets` are the raw
-    /// SPS/PPS NALs (no length prefix); pass an empty array for delta frames or
-    /// when they are unavailable.
-    public static func assembleAccessUnit(
-        fromAvcc sample: Data,
-        nalUnitHeaderLength: Int,
-        parameterSets: [Data],
-        isKeyframe: Bool
-    ) throws -> Data {
-        let slices = try annexB(fromAvcc: sample, nalUnitHeaderLength: nalUnitHeaderLength)
-        guard isKeyframe, !parameterSets.isEmpty else { return slices }
-        return parameterSetsAnnexB(parameterSets) + slices
+        return total
     }
 }

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameBufferPool.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameBufferPool.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Recycles the large per-frame heap slabs the raw video path copies pixel data into,
+/// so a steady capture reuses a couple of buffers instead of malloc/free-ing (and
+/// page-faulting/zero-filling) a fresh multi-megabyte BGRA slab every frame. Only the
+/// *allocation* is pooled — copying off the locked `CVPixelBuffer` is unavoidable, so
+/// this trims allocation churn and first-touch page faults, not the memcpy itself.
+///
+/// A vended buffer returns to the pool automatically via the `Data`'s custom
+/// deallocator, which fires when the last reference is released — i.e. after a dropped
+/// frame is replaced (on the capture queue) or after the output worker finishes writing
+/// it (on the output queue). So a buffer is only reused once it is genuinely no longer
+/// in flight; the single-slot video queue means at most two slabs cycle in steady state.
+///
+/// `@unchecked Sendable`: the free list is guarded by `lock`, and the deallocator (which
+/// calls `giveBack` from either queue) only ever takes `lock` — never a `FrameWriter`
+/// lock — so there is no lock-ordering cycle with the writer's `stateLock`.
+public final class FrameBufferPool: @unchecked Sendable {
+    private struct Slab {
+        let pointer: UnsafeMutableRawPointer
+        let capacity: Int
+    }
+
+    private let lock = NSLock()
+    private var free: [Slab] = []
+    /// Upper bound on retained free buffers. The raw video queue keeps at most one
+    /// pending frame, so a small handful covers "one draining + one filling" with slack.
+    private let maxPooledBuffers: Int
+
+    public init(maxPooledBuffers: Int = 3) {
+        precondition(maxPooledBuffers > 0)
+        self.maxPooledBuffers = maxPooledBuffers
+    }
+
+    deinit {
+        for slab in free {
+            slab.pointer.deallocate()
+        }
+    }
+
+    /// A `Data` of exactly `count` bytes copied from `source`, backed by a pooled (or
+    /// freshly allocated) slab that returns to this pool when the `Data` is released.
+    /// A non-positive `count` yields an empty `Data` (nothing to pool).
+    public func makeData(copyingFrom source: UnsafeRawPointer, count: Int) -> Data {
+        guard count > 0 else { return Data() }
+        let slab = takeSlab(minimumCapacity: count)
+        slab.pointer.copyMemory(from: source, byteCount: count)
+        return Data(
+            bytesNoCopy: slab.pointer,
+            count: count,
+            deallocator: .custom { [self] _, _ in giveBack(slab) }
+        )
+    }
+
+    /// Reuse the first free slab that fits, or allocate a fresh one sized exactly to the
+    /// request. (First-fit rather than best-fit: the free list is capped at a handful,
+    /// and a steady capture's buffers are all the same frame size anyway.)
+    private func takeSlab(minimumCapacity: Int) -> Slab {
+        lock.lock()
+        if let index = free.firstIndex(where: { $0.capacity >= minimumCapacity }) {
+            let slab = free.remove(at: index)
+            lock.unlock()
+            return slab
+        }
+        lock.unlock()
+        return Slab(
+            pointer: .allocate(byteCount: minimumCapacity, alignment: 16),
+            capacity: minimumCapacity
+        )
+    }
+
+    private func giveBack(_ slab: Slab) {
+        lock.lock()
+        if free.count < maxPooledBuffers {
+            free.append(slab)
+            lock.unlock()
+        } else {
+            lock.unlock()
+            slab.pointer.deallocate()
+        }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameBufferPool.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameBufferPool.swift
@@ -41,13 +41,13 @@ public final class FrameBufferPool: @unchecked Sendable {
     /// A `Data` of exactly `count` bytes copied from `source`, backed by a pooled (or
     /// freshly allocated) slab that returns to this pool when the `Data` is released.
     /// A non-positive `count` yields an empty `Data` (nothing to pool).
-    public func makeData(copyingFrom source: UnsafeRawPointer, count: Int) -> Data {
-        guard count > 0 else { return Data() }
-        let slab = takeSlab(minimumCapacity: count)
-        slab.pointer.copyMemory(from: source, byteCount: count)
+    public func makeData(copyingFrom source: UnsafeRawPointer, count byteCount: Int) -> Data {
+        guard byteCount > 0 else { return Data() }
+        let slab = takeSlab(minimumCapacity: byteCount)
+        slab.pointer.copyMemory(from: source, byteCount: byteCount)
         return Data(
             bytesNoCopy: slab.pointer,
-            count: count,
+            count: byteCount,
             deallocator: .custom { [self] _, _ in giveBack(slab) }
         )
     }

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
@@ -86,7 +86,9 @@ public enum FrameProtocol {
             base.advanced(by: 16).storeBytes(of: header.bytesPerRow.littleEndian, as: UInt32.self)
             base.advanced(by: 20).storeBytes(of: header.timestampMs.littleEndian, as: UInt32.self)
         }
-        let checksum = crc32(data.subdata(in: fieldsOffset..<headerSize))
+        // CRC over a no-copy slice of the header's field bytes rather than a fresh
+        // `subdata` allocation — this runs once per emitted record (every frame).
+        let checksum = crc32(data[fieldsOffset..<headerSize])
         data.withUnsafeMutableBytes { ptr in
             let base = ptr.baseAddress!  // swiftlint:disable:this force_unwrapping
             base.advanced(by: 4).storeBytes(of: checksum.littleEndian, as: UInt32.self)

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -39,7 +39,12 @@ public struct FrameWriterMetrics: Codable, Equatable {
 /// Writes framed BGRA records to a `FrameSink` without blocking the capture
 /// callback. Pixel data is copied while the caller holds its CVPixelBuffer lock,
 /// then a serial output worker writes only the newest pending frame.
-public final class FrameWriter {
+///
+/// `@unchecked Sendable`: every mutable field is confined to `stateLock`, and the
+/// serial `outputQueue` is the only writer thread (it takes records under the lock
+/// and calls `sink.write` off the lock so a slow consumer never blocks producers).
+/// This matches the package's lock-confined-`Sendable` idiom (see `ForceKeyFrameLatch`).
+public final class FrameWriter: @unchecked Sendable {
     public struct Configuration {
         /// Enough for current iPhone and iPad BGRA captures, while bounding raw
         /// buffering to one frame when stdout's consumer is slow.
@@ -87,6 +92,9 @@ public final class FrameWriter {
     private let configuration: Configuration
     private let stateLock = NSLock()
     private let outputQueue = DispatchQueue(label: "automobile.screen-capture.stdout")
+    /// Recycles the large raw-frame payload slabs so a steady capture reuses buffers
+    /// instead of malloc/free-ing a multi-MB BGRA slab per frame (raw path only).
+    private let framePool = FrameBufferPool()
     private var pendingFrame: PendingRecord?
     private var pendingAudio: [PendingRecord] = []
     private var pendingAudioBytes = 0
@@ -146,9 +154,12 @@ public final class FrameWriter {
             bytesPerRow: headerBytesPerRow,
             timestampMs: captureTimestampMs
         ))
-        // The capture callback owns the pixel-buffer lock. This one copy lets it
-        // release that lock before stdout can block on a slow Node consumer.
-        let payload = Data(bytes: baseAddress, count: payloadLength)
+        // The capture callback owns the pixel-buffer lock. This one copy lets it release
+        // that lock before stdout can block on a slow Node consumer; the slab it copies
+        // into is drawn from `framePool` and returned when the record is done, so a
+        // steady capture avoids malloc/free-ing (and page-faulting) a fresh multi-MB
+        // buffer every frame.
+        let payload = framePool.makeData(copyingFrom: baseAddress, count: payloadLength)
         let record = PendingRecord(
             header: header,
             payload: payload,

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
@@ -44,8 +44,12 @@ func pcm16leAudio(sampleBuffer: CMSampleBuffer) -> Data? {
             bytesPerSample: MemoryLayout<Float>.size,
             availableBytes: availableBytes
         ) else { return nil }
+        // Wrap the retained block buffer's float samples without copying (deallocator
+        // .none): `encodeFloat32LE` reads them synchronously and returns an owned PCM16
+        // buffer, so `blockBuffer` outlives this view. Avoids a throwaway copy of the
+        // raw floats purely to adapt to the `Data` parameter.
         return AudioPcm16Encoder.encodeFloat32LE(
-            Data(bytes: input, count: count)
+            Data(bytesNoCopy: input, count: count, deallocator: .none)
         )
     }
     return nil

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/ControlChannel.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/ControlChannel.swift
@@ -9,7 +9,11 @@ import ScreenCaptureCore
 ///
 /// Only started in `--encode h264` mode, so the default raw path never touches
 /// STDIN and its output stays byte-for-byte unchanged.
-final class ControlChannel {
+///
+/// `@unchecked Sendable`: `buffer` is mutated only on the serial `queue` (via
+/// `ingest`); `handle` and `onCommand` are `let`. This lets the `@Sendable`
+/// readability handler capture `self`.
+final class ControlChannel: @unchecked Sendable {
     private let handle: FileHandle
     private let onCommand: (EncoderControlCommand) -> Void
     private let queue = DispatchQueue(label: "automobile.screen-capture.control")
@@ -32,7 +36,11 @@ final class ControlChannel {
                 handle.readabilityHandler = nil
                 return
             }
-            self?.queue.async { self?.ingest(chunk) }
+            // Bind `self` strongly once so the serial-queue hop captures a value,
+            // not the weak optional `var self` (a data race under Swift-6 strict
+            // concurrency).
+            guard let self else { return }
+            self.queue.async { self.ingest(chunk) }
         }
     }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -12,7 +12,13 @@ import ScreenCaptureCore
 /// `H264VideoEncoder` stage the Simulator path uses, emitting Annex-B
 /// encoded-video records. AVFoundation accepts 420v directly with no color
 /// conversion, so the encode input is the lowest-CPU form.
-final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+///
+/// `@unchecked Sendable`: `_pipeline` is guarded by `stateLock`, while `observers`
+/// and `stopping` are confined to the main queue (install/remove and `stop()` all
+/// run there) and every other field is `let`. This lets the AVFoundation delegate
+/// and NotificationCenter callbacks capture `self` under Swift-6 strict concurrency,
+/// matching the package's lock-confined-`Sendable` idiom (see `ForceKeyFrameLatch`).
+final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, @unchecked Sendable {
     private let session = AVCaptureSession()
     private let output = AVCaptureVideoDataOutput()
     private let writer: FrameWriter

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/H264VideoEncoder.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/H264VideoEncoder.swift
@@ -36,7 +36,12 @@ enum H264EncoderError: Error, CustomStringConvertible {
 /// and `EnableHardwareAcceleratedVideoEncoder` WITHOUT the `Require...` key so a
 /// hosted runner with no free HW encoder falls back to software (the `-allow_sw
 /// 1` semantic) rather than failing to start.
-final class H264VideoEncoder {
+///
+/// `@unchecked Sendable`: all mutable state (`session`, `inFlightFrames`,
+/// `formatParameterSets`, `nalUnitHeaderLength`) is guarded by `lock`, so the
+/// `@Sendable` VideoToolbox completion callback can capture `self`. The callback
+/// runs on VideoToolbox's own thread; `encode()`/`stop()` run on the capture queue.
+final class H264VideoEncoder: @unchecked Sendable {
     /// Target seconds between IDRs; matches the TS ffmpeg GOP
     /// (`IOS_KEYFRAME_INTERVAL_SECONDS`).
     static let keyFrameIntervalSeconds = 2
@@ -56,6 +61,11 @@ final class H264VideoEncoder {
     private var inFlightFrames = 0
     private var formatParameterSets: [Data] = []
     private var nalUnitHeaderLength = 4
+    /// Shared memory pool backing VideoToolbox's compressed-output slabs. Passing its
+    /// allocator as the `compressedDataAllocator` (the DATA allocator, distinct from the
+    /// structure allocator that builds the small session object) recycles the per-frame
+    /// compressed `CMBlockBuffer`s instead of malloc/free-ing a fresh slab every frame.
+    private let memoryPool = CMMemoryPoolCreate(options: nil)
 
     let width: Int
     let height: Int
@@ -109,7 +119,7 @@ final class H264VideoEncoder {
             codecType: kCMVideoCodecType_H264,
             encoderSpecification: encoderSpecification as CFDictionary,
             imageBufferAttributes: nil,
-            compressedDataAllocator: nil,
+            compressedDataAllocator: CMMemoryPoolGetAllocator(memoryPool),
             outputCallback: nil,
             refcon: nil,
             compressionSessionOut: &created
@@ -123,7 +133,11 @@ final class H264VideoEncoder {
             VTCompressionSessionInvalidate(session)
             throw H264EncoderError.sessionPrepareFailed(status: prepareStatus)
         }
+        // Publish `session` under the same lock `encode()`/`stop()` take, so the
+        // frame path never observes a half-assigned session.
+        lock.lock()
         self.session = session
+        lock.unlock()
     }
 
     private func applyConfiguration(to session: VTCompressionSession) {
@@ -177,9 +191,14 @@ final class H264VideoEncoder {
     /// before encode (encoder behind) so the caller can skip its bookkeeping.
     @discardableResult
     func encode(pixelBuffer: CVPixelBuffer, presentationTime: CMTime) -> Bool {
-        guard let session = session else { return false }
-
         lock.lock()
+        // Snapshot `session` under the same lock that guards the in-flight count and
+        // that `stop()` takes to nil it, so an in-flight encode can never read a
+        // session being torn down (previously `session` was read unlocked).
+        guard let session = session else {
+            lock.unlock()
+            return false
+        }
         let behind = EncoderDropPolicy.shouldDropBeforeEncode(
             inFlightFrames: inFlightFrames,
             maxInFlightFrames: H264VideoEncoder.maxInFlightFrames
@@ -263,10 +282,19 @@ final class H264VideoEncoder {
 
     /// Invalidate the session (orderly shutdown / reconfiguration teardown).
     func stop() {
+        // Take the session out under the lock so a concurrent `encode()` either
+        // sees it (and completes) or sees nil (and drops) — never a dangling session.
+        lock.lock()
+        let session = self.session
+        self.session = nil
+        lock.unlock()
         guard let session = session else { return }
         VTCompressionSessionCompleteFrames(session, untilPresentationTimeStamp: .invalid)
         VTCompressionSessionInvalidate(session)
-        self.session = nil
+        // Release the pooled compressed-output slabs now that the session that fed the
+        // pool is gone (an encoder is single-use: EncodePipeline builds a fresh one on
+        // resize).
+        CMMemoryPoolInvalidate(memoryPool)
     }
 
     // MARK: - Parameter sets
@@ -330,6 +358,12 @@ final class H264VideoEncoder {
         return true
     }
 
+    /// A NON-owning `Data` view of the sample's compressed bytes, valid only while
+    /// `sampleBuffer` is alive. `handleEncodedFrame` consumes it synchronously on the
+    /// VideoToolbox callback (building an owned Annex-B record) before returning, so the
+    /// `bytesNoCopy` view avoids copying the whole compressed frame out just to rebuild
+    /// it as Annex-B. `CMBlockBufferGetDataPointer` returns the pointer for VideoToolbox's
+    /// single contiguous compressed block (the pre-existing contiguity assumption).
     private static func contiguousData(from sampleBuffer: CMSampleBuffer) -> Data? {
         guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return nil }
         var length = 0
@@ -339,7 +373,7 @@ final class H264VideoEncoder {
             totalLengthOut: &length, dataPointerOut: &pointer
         )
         guard status == noErr, let pointer = pointer, length > 0 else { return nil }
-        return Data(bytes: pointer, count: length)
+        return Data(bytesNoCopy: UnsafeMutableRawPointer(pointer), count: length, deallocator: .none)
     }
 
     private static func presentationTimestampMs(_ sampleBuffer: CMSampleBuffer) -> UInt32 {

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -9,7 +9,7 @@ import ScreenCaptureCore
 /// exercise the session's lifecycle paths (start/stop/reconfigure/fatal-error)
 /// without a real Simulator window or Screen Recording permission (issue #4771).
 /// The signatures match `SCStream`'s exactly so it conforms without adapters.
-protocol CaptureStream: AnyObject {
+protocol CaptureStream: AnyObject, Sendable {
     func addStreamOutput(
         _ output: SCStreamOutput,
         type: SCStreamOutputType,
@@ -21,13 +21,31 @@ protocol CaptureStream: AnyObject {
     func updateConfiguration(_ configuration: SCStreamConfiguration) async throws
 }
 
+// SCStream's start/stop/updateConfiguration each hop to ScreenCaptureKit's own
+// queue and are safe to drive from the session's unstructured start/reconfigure
+// tasks, so the seam is `Sendable`. `@retroactive` because the conformance is added
+// to an SDK type this package does not own.
+extension SCStream: @retroactive @unchecked Sendable {}
 extension SCStream: CaptureStream {}
+
+// SCWindow is an immutable snapshot of window metadata (id, frame, owning app) that
+// `main.swift` resolves on the main actor and hands to the nonisolated `start`, so it
+// is safe to send. `@retroactive` because the conformance is added to an SDK type this
+// package does not own.
+extension SCWindow: @retroactive @unchecked Sendable {}
 
 /// Streams BGRA frames from a single iOS Simulator window via ScreenCaptureKit.
 /// The frame rate is configurable (5–60); 5 is the default for typical MCP
 /// automation workloads. Size changes (e.g. device rotation) trigger a stream
 /// reconfiguration so frames don't get cropped.
-final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate {
+///
+/// `@unchecked Sendable`: every mutable frame-path field (`_pipeline`, `_stream`,
+/// `_configuredPixelWidth/Height`, `_reconfiguring`) is `stateLock`-guarded, and
+/// `fps`, `audioEnabled`, `windowID`, `configuredPixelFormat`, and
+/// `startCaptureDeadlineSeconds` are set once in `start()` before frames flow, then
+/// read-only. This lets the ScreenCaptureKit callbacks and the reconfigure task
+/// capture `self` under Swift-6 strict concurrency.
+final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
     /// Builds the concrete stream for a resolved window. Injected so tests can
     /// substitute a fake `CaptureStream`; the default wires the real `SCStream`.
     typealias StreamFactory = (SCContentFilter, SCStreamConfiguration, SCStreamDelegate) -> CaptureStream

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -377,12 +377,15 @@ case .capture(let deviceID, let encode):
 // A reference box so the Task closure mutates a captured class instead of a
 // `var`. Swift 5.9 (Xcode 15) rejects `var` capture in `Task { … }` even when
 // the semaphore enforces a happens-before relationship; class capture is fine.
-private final class Box<T> {
+// `@unchecked Sendable`: the `Task` writes `value` before `semaphore.signal()` and
+// `runBlocking` reads it only after `semaphore.wait()`, so the semaphore is the
+// happens-before edge that serializes the single write and single read.
+private final class Box<T>: @unchecked Sendable {
     var value: T
     init(_ value: T) { self.value = value }
 }
 
-func runBlocking<T>(_ body: @escaping () async throws -> T) -> Result<T, Error> {
+func runBlocking<T>(_ body: @escaping @Sendable () async throws -> T) -> Result<T, Error> {
     let semaphore = DispatchSemaphore(value: 0)
     let box = Box<Result<T, Error>>(.failure(CancellationError()))
     Task {
@@ -397,7 +400,7 @@ func runBlocking<T>(_ body: @escaping () async throws -> T) -> Result<T, Error> 
     return box.value
 }
 
-func runBlocking<T>(_ body: @escaping () async -> T) -> T {
+func runBlocking<T>(_ body: @escaping @Sendable () async -> T) -> T {
     let semaphore = DispatchSemaphore(value: 0)
     let box = Box<T?>(nil)
     Task {
@@ -412,8 +415,12 @@ func runBlocking<T>(_ body: @escaping () async -> T) -> T {
 // MARK: - Signal handling
 
 // Retain signal sources beyond `installShutdownHandlers` to keep them alive
-// for the duration of the run loop.
-private var retainedSignalSources: [DispatchSourceSignal] = []
+// for the duration of the run loop. `nonisolated(unsafe)`: written exactly once by
+// `installShutdownHandlers` on the main thread before `RunLoop.main.run()`, and
+// never read afterward (it only holds the sources alive), so there is no cross-thread
+// access to race — the annotation opts this write-once global out of the top-level
+// `@MainActor` inference so the nonisolated helper can assign it.
+nonisolated(unsafe) private var retainedSignalSources: [DispatchSourceSignal] = []
 
 func installShutdownHandlers(_ handler: @escaping () -> Void) {
     let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameBufferPoolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameBufferPoolTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import XCTest
+@testable import ScreenCaptureCore
+
+final class FrameBufferPoolTests: XCTestCase {
+
+    func testCopiesBytesExactly() {
+        let pool = FrameBufferPool()
+        let source: [UInt8] = (0..<256).map { UInt8($0) }
+        let data = source.withUnsafeBytes { buffer in
+            pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
+        }
+        XCTAssertEqual(Array(data), source)
+    }
+
+    func testZeroCountReturnsEmptyData() {
+        let pool = FrameBufferPool()
+        let source: [UInt8] = [1, 2, 3]
+        let data = source.withUnsafeBytes { buffer in
+            pool.makeData(copyingFrom: buffer.baseAddress!, count: 0)
+        }
+        XCTAssertTrue(data.isEmpty)
+    }
+
+    func testReleasedSlabIsRecycledForNextSameSizeFrame() {
+        let pool = FrameBufferPool()
+        let source = [UInt8](repeating: 0xAB, count: 4096)
+
+        // Compare backing addresses (as bit patterns, never dereferenced) across a
+        // release: the second allocation should reuse the first slab.
+        let firstAddress: UInt = source.withUnsafeBytes { buffer in
+            var data: Data? = pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
+            let address = data!.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
+            data = nil  // last reference released -> custom deallocator returns the slab
+            return address
+        }
+
+        let secondAddress: UInt = source.withUnsafeBytes { buffer in
+            let data = pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
+            return data.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
+        }
+
+        XCTAssertEqual(
+            firstAddress, secondAddress,
+            "a released slab should be recycled for the next same-size frame"
+        )
+    }
+
+    func testLargerFreeSlabSatisfiesSmallerRequest() {
+        let pool = FrameBufferPool()
+        let big = [UInt8](repeating: 0x11, count: 8192)
+        let bigAddress: UInt = big.withUnsafeBytes { buffer in
+            var data: Data? = pool.makeData(copyingFrom: buffer.baseAddress!, count: big.count)
+            let address = data!.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
+            data = nil
+            return address
+        }
+
+        // A smaller frame reuses the larger freed slab (capacity fits) rather than
+        // allocating a new one; the returned Data still exposes only the smaller count.
+        let small = [UInt8](repeating: 0x22, count: 1000)
+        let (smallAddress, smallData): (UInt, Data) = small.withUnsafeBytes { buffer in
+            let data = pool.makeData(copyingFrom: buffer.baseAddress!, count: small.count)
+            return (data.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }, data)
+        }
+
+        XCTAssertEqual(bigAddress, smallAddress, "a larger free slab should satisfy a smaller request")
+        XCTAssertEqual(smallData.count, small.count)
+        XCTAssertEqual(Array(smallData), small)
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameBufferPoolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameBufferPoolTests.swift
@@ -4,39 +4,39 @@ import XCTest
 
 final class FrameBufferPoolTests: XCTestCase {
 
-    func testCopiesBytesExactly() {
+    func testCopiesBytesExactly() throws {
         let pool = FrameBufferPool()
         let source: [UInt8] = (0..<256).map { UInt8($0) }
-        let data = source.withUnsafeBytes { buffer in
-            pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
+        let data = try source.withUnsafeBytes { buffer in
+            pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: source.count)
         }
         XCTAssertEqual(Array(data), source)
     }
 
-    func testZeroCountReturnsEmptyData() {
+    func testZeroCountReturnsEmptyData() throws {
         let pool = FrameBufferPool()
         let source: [UInt8] = [1, 2, 3]
-        let data = source.withUnsafeBytes { buffer in
-            pool.makeData(copyingFrom: buffer.baseAddress!, count: 0)
+        let data = try source.withUnsafeBytes { buffer in
+            pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: 0)
         }
         XCTAssertTrue(data.isEmpty)
     }
 
-    func testReleasedSlabIsRecycledForNextSameSizeFrame() {
+    func testReleasedSlabIsRecycledForNextSameSizeFrame() throws {
         let pool = FrameBufferPool()
         let source = [UInt8](repeating: 0xAB, count: 4096)
 
         // Compare backing addresses (as bit patterns, never dereferenced) across a
         // release: the second allocation should reuse the first slab.
-        let firstAddress: UInt = source.withUnsafeBytes { buffer in
-            var data: Data? = pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
-            let address = data!.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
+        let firstAddress: UInt = try source.withUnsafeBytes { buffer in
+            var data: Data? = pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: source.count)
+            let address = try XCTUnwrap(data).withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
             data = nil  // last reference released -> custom deallocator returns the slab
             return address
         }
 
-        let secondAddress: UInt = source.withUnsafeBytes { buffer in
-            let data = pool.makeData(copyingFrom: buffer.baseAddress!, count: source.count)
+        let secondAddress: UInt = try source.withUnsafeBytes { buffer in
+            let data = pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: source.count)
             return data.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
         }
 
@@ -46,12 +46,12 @@ final class FrameBufferPoolTests: XCTestCase {
         )
     }
 
-    func testLargerFreeSlabSatisfiesSmallerRequest() {
+    func testLargerFreeSlabSatisfiesSmallerRequest() throws {
         let pool = FrameBufferPool()
         let big = [UInt8](repeating: 0x11, count: 8192)
-        let bigAddress: UInt = big.withUnsafeBytes { buffer in
-            var data: Data? = pool.makeData(copyingFrom: buffer.baseAddress!, count: big.count)
-            let address = data!.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
+        let bigAddress: UInt = try big.withUnsafeBytes { buffer in
+            var data: Data? = pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: big.count)
+            let address = try XCTUnwrap(data).withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }
             data = nil
             return address
         }
@@ -59,8 +59,8 @@ final class FrameBufferPoolTests: XCTestCase {
         // A smaller frame reuses the larger freed slab (capacity fits) rather than
         // allocating a new one; the returned Data still exposes only the smaller count.
         let small = [UInt8](repeating: 0x22, count: 1000)
-        let (smallAddress, smallData): (UInt, Data) = small.withUnsafeBytes { buffer in
-            let data = pool.makeData(copyingFrom: buffer.baseAddress!, count: small.count)
+        let (smallAddress, smallData): (UInt, Data) = try small.withUnsafeBytes { buffer in
+            let data = pool.makeData(copyingFrom: try XCTUnwrap(buffer.baseAddress), count: small.count)
             return (data.withUnsafeBytes { UInt(bitPattern: $0.baseAddress) }, data)
         }
 

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -30,8 +30,10 @@ final class SimulatorCaptureSessionTests: XCTestCase {
     }
 
     /// Fake `CaptureStream` that records calls and can be told to fail specific
-    /// operations, standing in for a real `SCStream`.
-    private final class FakeCaptureStream: CaptureStream {
+    /// operations, standing in for a real `SCStream`. `@unchecked Sendable` (as the
+    /// `Sendable` `CaptureStream` seam requires): the test drives it single-threaded,
+    /// awaiting each session call before inspecting its recorded state.
+    private final class FakeCaptureStream: CaptureStream, @unchecked Sendable {
         private(set) var addedScreenOutput = false
         private(set) var addedAudioOutput = false
         private(set) var startCaptureCallCount = 0


### PR DESCRIPTION
## Summary

A "modernize-and-robustify" pass on the `ios/screen-capture` target, following the earlier `ios/control-proxy` ([#5834](https://github.com/kaeawc/auto-mobile/pull/5834)) and `ios/XCTestRunner` ([#6014](https://github.com/kaeawc/auto-mobile/pull/6014)) work: **Swift-6 strict concurrency** on the repo's **Swift 6.3 / macOS 15 / Xcode 26.5** toolchain floor, plus a **performance** focus on the per-frame copy/allocation overhead on the H.264 encode path.

> **Stacked on [#6014](https://github.com/kaeawc/auto-mobile/pull/6014)** (inherits the 6.3 toolchain baseline). Until #6014 merges this PR's diff includes its commits — review the `ios/screen-capture/**`, `ios/screen-capture/Benchmarks/**`, and `.github/workflows/nightly.yml` changes here. Will rebase onto `main` once #6014 lands. Opened as a **draft** for that reason.

## Modernization (Swift-6 strict concurrency)

- `Package.swift` → `swift-tools-version: 6.3`, `.macOS(.v15)`, default v6 language mode (no explicit `.swiftLanguageMode`, matching XCTestRunner).
- Lock-confined `@unchecked Sendable` on the callback-bearing classes (`FrameWriter`, `DeviceCaptureSession`, `SimulatorCaptureSession`, `H264VideoEncoder`, `ControlChannel`), matching the package's existing `ForceKeyFrameLatch` idiom; a `Sendable` `CaptureStream` seam with `@retroactive @unchecked Sendable` `SCStream`/`SCWindow` conformances; `@Sendable` on the `runBlocking` bridge + `@unchecked Sendable` `Box`; `nonisolated(unsafe)` on the write-once signal-source global.
- **Fixes a real data race**: `H264VideoEncoder.session` was read in `encode()` while `start()`/`stop()` wrote it from other threads — now a lock-guarded snapshot.

## Performance (byte-identical output, pinned by the shared golden vectors)

- **`AnnexBConverter`** assembles each access unit into **one** pre-sized buffer, dropping the keyframe `+` concat and the throwaway parameter-set `Data`.
- **`FrameProtocol.encodeHeader`** CRCs a no-copy slice instead of allocating a fresh `subdata` per record.
- **`H264VideoEncoder`** wraps the `CMBlockBuffer` with `Data(bytesNoCopy:)` instead of copying the compressed frame out (copy #1 elided), and passes a `CMMemoryPool` allocator as the `compressedDataAllocator` so VideoToolbox recycles the per-frame output slabs. The audio float32 intermediate uses `bytesNoCopy` too.
- **`FrameWriter`**'s raw-BGRA payload copy draws its slab from a `deallocator`-recycled `FrameBufferPool`, so a steady raw capture reuses buffers instead of malloc/free-ing (and page-faulting) a multi-MB buffer per frame. The memcpy itself is unavoidable (must copy off the locked `CVPixelBuffer`).

### Benchmarks (before → after)

A separate `ios/screen-capture/Benchmarks` package (`ordo-one/benchmark`) captures these, kept out of the shipped package so CI never needs jemalloc. Apple silicon, Swift 6.3.3, release, p50 of 100k iterations:

| Transform | Malloc (total) | Time (total CPU) |
| --- | --- | --- |
| `assembleAccessUnit` — keyframe + SPS/PPS | **9 → 2** (−78%) | 4542 → **2416** ns (−47%) |
| `assembleAccessUnit` — delta frame | 4 → **2** | 2709 → **2083** ns (−23%) |
| `encodeEncodedVideoHeader` (per-frame) | 4 → **2** | 1666 → **1458** ns (−12%) |
| encoder copy-out: `Data(bytes:)` vs `Data(bytesNoCopy:)` | 4 → **3** | 2750 → **1958** ns (−29%) |

**Honest scope:** these run on *compressed* buffers (tens–hundreds of KB), so the absolute cost is a few µs/frame — a fraction of a percent of one core at 60fps. This pass is allocation hygiene and **rules out in-helper byte-copying as a driver of the production CPU spikes** on the encoded path; the dominant costs remain VideoToolbox itself (especially the `-allow_sw` software fallback on shared runners) and, on the raw fallback path, the ~8 MB/frame BGRA copy + a separate ffmpeg re-encode.

## CI

Pruned the sub-6.3 Xcode legs (15.4 = Swift 5.10, 26.0 = Swift 6.2) from nightly's `ios-swift-packages-sweep` — neither can parse a 6.3 manifest, which was already true for `XCTestRunner` after #6014. The merge.yml Swift jobs are already disabled and the PR `ios-swift-packages` job is already 26.5-only.

## Validation

- `swift build` / `swift test -Xswiftc -warnings-as-errors` clean under Swift-6 language mode: **141 tests, 0 failures**.
- The shared `#4787` golden vectors confirm the Annex-B + 24-byte header output is **byte-identical**.
- An adversarial memory-safety review cleared the `bytesNoCopy` lifetimes, the pool lock-ordering, and the `@unchecked Sendable` assertions.
- Fast-validation aggregator green for the `nightly.yml` change.
- The device-only paths (VideoToolbox, ScreenCaptureKit) are not headless-testable; those changes are logic-reviewed and preserve the existing behavior/contracts.

## Follow-ups (not in this PR)

- The real CPU-spike suspects the data points to — VideoToolbox software-encoder fallback and the raw + ffmpeg re-encode path — warrant a separate investigation.
- Pre-existing: `CommandLineOptions.helpText` still describes a "16-byte header"; the wire header is 24 bytes (magic + CRC-32). Surfaced for a separate doc cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
