### PR TITLE
fix(video): retain artifacts when force stop races startup

### DIFF
--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -447,12 +447,14 @@ export class VideoRecorderService {
     if (this.activeRecordings.get(active.recordingId) === active && !active.forceStopRequested) {
       this.activeRecordings.delete(active.recordingId);
     }
-    try {
-      await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
-    } catch (cleanupError) {
-      this.log.warn(
-        `[VideoRecorderService] Failed to remove aborted recording directory for ${active.recordingId}: ${String(cleanupError)}`,
-      );
+    if (!active.forceStopRequested) {
+      try {
+        await this.removeRecordingArtifacts(active.recordingId, active.outputPath);
+      } catch (cleanupError) {
+        this.log.warn(
+          `[VideoRecorderService] Failed to remove aborted recording directory for ${active.recordingId}: ${String(cleanupError)}`,
+        );
+      }
     }
     throw error;
   }

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -435,7 +435,9 @@ export class VideoRecorderService {
   private async handleStartFailure(error: unknown, active: ActiveRecordingState): Promise<never> {
     if (this.retainStartCleanupHandle(error, active)) {
       try {
-        await this.forceStopOrDiscardRecording(active.recordingId, true);
+        if (!active.forceStopRequested) {
+          await this.forceStopOrDiscardRecording(active.recordingId, true);
+        }
       } catch (cleanupError) {
         this.log.warn(
           `[VideoRecorderService] Failed to retry cleanup for ${active.recordingId}: ${String(cleanupError)}`,

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -274,6 +274,43 @@ describe("VideoRecorderService", () => {
     expect(await pathExists(outputPath)).toBe(true);
   });
 
+  test("retains partial artifacts when force stop races a cleanup-handle startup failure", async () => {
+    let failStart: (() => void) | undefined;
+    let startedConfig: Parameters<typeof backend.start>[0] | undefined;
+    let markBackendStarted: (() => void) | undefined;
+    const backendStarted = new Promise<void>((resolve) => {
+      markBackendStarted = resolve;
+    });
+    const allowStartupFailure = new Promise<void>((resolve) => {
+      failStart = resolve;
+    });
+    backend.start = async (config) => {
+      startedConfig = config;
+      await fsPromises.writeFile(config.outputPath, "partial capture");
+      markBackendStarted?.();
+      await allowStartupFailure;
+      throw new VideoCaptureStartCleanupError("startup cleanup timed out", {
+        recordingId: config.recordingId,
+        outputPath: config.outputPath,
+        startedAt: config.startedAt,
+      });
+    };
+
+    const starting = service.startRecording();
+    await backendStarted;
+    const outputPath = startedConfig!.outputPath;
+
+    const forcing = service.forceStopRecording("rec-1");
+    expect(startedConfig?.abortSignal?.aborted).toBe(true);
+    failStart?.();
+
+    await expect(starting).rejects.toThrow("startup cleanup timed out");
+    await forcing;
+
+    expect(await pathExists(path.dirname(outputPath))).toBe(true);
+    expect(await pathExists(outputPath)).toBe(true);
+  });
+
   test("allows a later graceful stop after a force-stop failure", async () => {
     const recording = await service.startRecording();
     backend.forceStop = async (handle) => {

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -236,6 +236,44 @@ describe("VideoRecorderService", () => {
     expect(service.listActiveRecordingIds()).toEqual([]);
   });
 
+  test("retains partial artifacts when a non-discard force stop races startup", async () => {
+    let resolveStart: ((handle: (typeof backend.startResults)[number]) => void) | undefined;
+    let startedConfig: Parameters<typeof backend.start>[0] | undefined;
+    let markBackendStarted: (() => void) | undefined;
+    const backendStarted = new Promise<void>((resolve) => {
+      markBackendStarted = resolve;
+    });
+    backend.start = async (config) => {
+      startedConfig = config;
+      await fsPromises.writeFile(config.outputPath, "partial capture");
+      markBackendStarted?.();
+      const handle = await new Promise<(typeof backend.startResults)[number]>((resolve) => {
+        resolveStart = resolve;
+      });
+      backend.startResults.push(handle);
+      return handle;
+    };
+
+    const starting = service.startRecording();
+    await backendStarted;
+    const outputPath = startedConfig!.outputPath;
+
+    const forcing = service.forceStopRecording("rec-1");
+    expect(startedConfig?.abortSignal?.aborted).toBe(true);
+    const handle = {
+      recordingId: "rec-1",
+      outputPath,
+      startedAt: startedConfig!.startedAt,
+    };
+    resolveStart?.(handle);
+
+    await expect(starting).rejects.toThrow("force-stopped while it was starting");
+    await forcing;
+
+    expect(await pathExists(path.dirname(outputPath))).toBe(true);
+    expect(await pathExists(outputPath)).toBe(true);
+  });
+
   test("allows a later graceful stop after a force-stop failure", async () => {
     const recording = await service.startRecording();
     backend.forceStop = async (handle) => {


### PR DESCRIPTION
## Summary

Fix the startup race where a plain `forceStopRecording` removed a partial capture's artifact directory.

`handleStartFailure` now leaves cleanup to the in-flight force-stop operation, which removes artifacts only for `discardRecording`.

## Linked Issue

Closes [#6001](https://github.com/kaeawc/auto-mobile/issues/6001)

## Bug / Regression Context

- **Observed symptom:** A non-discard force stop issued while startup was pending deleted the partial recording.
- **Repro steps / conditions:** Start capture, wait until the backend writes its output and blocks, then force-stop it before startup resolves.

## Validation

- [x] `bun test test/features/video/VideoRecorderService.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Rebased onto latest `main`, conflicts resolved
