### PR TITLE
fix: reconcile Android activity attribution after taps

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -43,6 +43,7 @@ interface ObservedChangeOptions {
   observationTimestampProvider?: () => number | undefined;
   overrideMinTimestamp?: number;
   signal?: AbortSignal;
+  deferPredictionOutcome?: boolean;
   predictionContext?: {
     toolName: string;
     toolArgs: Record<string, any>;
@@ -57,6 +58,10 @@ export class BaseVisualChange {
   observeScreen: ObserveScreen;
   window: Window;
   private predictionAnalyzer: PredictionAnalyzer;
+  private deferredPredictionOutcomes = new WeakMap<
+    object,
+    (observation: ObserveResult) => Promise<void>
+  >();
   protected timer: Timer;
 
   /**
@@ -254,9 +259,18 @@ export class BaseVisualChange {
       gfxMetrics,
       perf,
       actionStartTime: options.overrideMinTimestamp ?? observationStartTime,
-      predictionContext,
+      predictionContext: options.deferPredictionOutcome ? undefined : predictionContext,
       signal: options.signal,
     });
+    if (options.deferPredictionOutcome && predictionContext && typeof observed === "object") {
+      this.deferredPredictionOutcomes.set(observed, async (finalObservation) => {
+        await this.predictionAnalyzer.recordOutcomeForAction(
+          previousObserveResult,
+          finalObservation,
+          predictionContext,
+        );
+      });
+    }
     this.annotateDeviceLock(observed, previousObserveResult);
     return observed;
   }
@@ -281,6 +295,25 @@ export class BaseVisualChange {
     result.deviceLock = lock;
     result.deviceLockWarning = BaseVisualChange.buildDeviceLockWarning(lock);
     logger.warn(`[BaseVisualChange] ${result.deviceLockWarning}`);
+  }
+
+  /**
+   * Record a deferred prediction outcome after a subclass replaces the initial
+   * post-action observation with a later, more representative observation.
+   */
+  protected async recordDeferredPredictionOutcome(
+    result: unknown,
+    finalObservation: ObserveResult,
+  ): Promise<void> {
+    if (!result || typeof result !== "object") {
+      return;
+    }
+    const recordOutcome = this.deferredPredictionOutcomes.get(result);
+    if (!recordOutcome) {
+      return;
+    }
+    this.deferredPredictionOutcomes.delete(result);
+    await recordOutcome(finalObservation);
   }
 
   private static buildDeviceLockWarning(lock: DeviceLockState): string {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -594,7 +594,7 @@ export class TapOnElement extends BaseVisualChange {
       },
     );
     const effect = this.deriveTapEffect(previousObservation, effectObservation.observation);
-    if (!effectObservation.matched) {
+    if (!effectObservation.matched && effect?.screenChanged !== true) {
       return { effect, observation: currentObservation };
     }
     return {
@@ -1721,6 +1721,7 @@ export class TapOnElement extends BaseVisualChange {
           progress,
           perf,
           signal,
+          deferPredictionOutcome: true,
           predictionContext: {
             toolName: "tapOn",
             toolArgs: {
@@ -1750,6 +1751,7 @@ export class TapOnElement extends BaseVisualChange {
         // The observation that established the effect must be returned and become
         // the caller's diff baseline, rather than the earlier source capture.
         result.observation = postTap.observation;
+        await this.recordDeferredPredictionOutcome(result, result.observation);
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,
           selectionState: selectionCapture,

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -570,14 +570,14 @@ export class TapOnElement extends BaseVisualChange {
     previousObservation: ObserveResult | null,
     currentObservation: ObserveResult,
     signal?: AbortSignal,
-  ): Promise<TapOnElementResult["effect"]> {
+  ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
     const immediateEffect = this.deriveTapEffect(previousObservation, currentObservation);
     if (
       this.device.platform !== "android" ||
       !previousObservation ||
       immediateEffect?.screenChanged === true
     ) {
-      return immediateEffect;
+      return { effect: immediateEffect, observation: currentObservation };
     }
 
     // A stable source tree can arrive before Android begins the activity
@@ -593,7 +593,18 @@ export class TapOnElement extends BaseVisualChange {
         signal,
       },
     );
-    return this.deriveTapEffect(previousObservation, effectObservation.observation);
+    const effect = this.deriveTapEffect(previousObservation, effectObservation.observation);
+    if (!effectObservation.matched) {
+      return { effect, observation: currentObservation };
+    }
+    return {
+      effect,
+      observation: {
+        ...effectObservation.observation,
+        gfxMetrics: effectObservation.observation.gfxMetrics ?? currentObservation.gfxMetrics,
+        perfTiming: effectObservation.observation.perfTiming ?? currentObservation.perfTiming,
+      },
+    };
   }
 
   private isElementTapTargetOffScreen(
@@ -1730,11 +1741,15 @@ export class TapOnElement extends BaseVisualChange {
       );
 
       if (result.success && result.observation && result.element) {
-        result.effect = await this.deriveTapEffectAfterPostTapObservation(
+        const postTap = await this.deriveTapEffectAfterPostTapObservation(
           previousObserveResult,
           result.observation,
           signal,
         );
+        result.effect = postTap.effect;
+        // The observation that established the effect must be returned and become
+        // the caller's diff baseline, rather than the earlier source capture.
+        result.observation = postTap.observation;
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,
           selectionState: selectionCapture,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -995,7 +995,7 @@ export class RealObserveScreen implements ObserveScreen {
       source: "unavailable",
       units: "unknown",
     };
-    result.wakefulness = hierarchy.wakefulness;
+    result.wakefulness = hierarchy.wakefulness ?? result.wakefulness;
     result.intentChooserDetected = hierarchy.intentChooserDetected;
     result.notificationPermissionDetected = hierarchy.notificationPermissionDetected;
     result.focusedElement = this.viewHierarchy.findFocusedElement(hierarchy) ?? undefined;

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -93,6 +93,7 @@ const SYSTEM_UI_WINDOW_PACKAGES = new Set<string>(["com.android.systemui"]);
 interface PostCaptureForegroundIdentity {
   sampled: boolean;
   identity: string | undefined;
+  activityAttributionMismatch: boolean;
 }
 
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
@@ -101,6 +102,43 @@ function isAccessibilityViewClass(foregroundActivity: string): boolean {
     activityName.startsWith("android.widget.") ||
     activityName.startsWith("android.view.") ||
     activityName.endsWith("DecorView")
+  );
+}
+
+function isActivityInPackage(activityName: string, packageName: string): boolean {
+  return activityName === packageName || activityName.startsWith(`${packageName}.`);
+}
+
+function resolveBackStackActivityAttribution(
+  result: ObserveResult,
+): { packageName: string; activityName: string } | undefined {
+  const packageName = result.viewHierarchy?.packageName;
+  const backStack = result.backStack;
+  if (!packageName || backStack?.source !== "adb") {
+    return undefined;
+  }
+  const activityName = backStack.currentActivity?.name;
+  if (!activityName) {
+    return undefined;
+  }
+  if (isActivityInPackage(activityName, packageName)) {
+    return { packageName, activityName };
+  }
+
+  const currentTaskId = backStack.currentActivity?.taskId;
+  const ownedByPackage =
+    backStack.tasks.some(
+      (task) => task.id === currentTaskId && task.packageName === packageName,
+    ) === true;
+  return ownedByPackage ? { packageName, activityName } : undefined;
+}
+
+function hasUsableHierarchy(hierarchy: ObserveResult["viewHierarchy"]): boolean {
+  return (
+    hierarchy?.hierarchy !== undefined &&
+    typeof hierarchy.hierarchy === "object" &&
+    hierarchy.hierarchy !== null &&
+    !("error" in hierarchy.hierarchy)
   );
 }
 
@@ -449,6 +487,7 @@ export class RealObserveScreen implements ObserveScreen {
           postCaptureForeground,
           signal,
         ),
+        activityAttributionMismatch: postCaptureForeground.activityAttributionMismatch,
       });
 
       // Cache the result for future use
@@ -828,17 +867,140 @@ export class RealObserveScreen implements ObserveScreen {
     if (
       observed === undefined ||
       activeWindow === undefined ||
-      activeWindow.appId === observed ||
       SYSTEM_UI_WINDOW_PACKAGES.has(observed)
     ) {
-      return { sampled: false, identity: undefined };
+      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
+    }
+
+    const backStackAttribution = resolveBackStackActivityAttribution(result);
+    if (backStackAttribution && activeWindow.activityName !== backStackAttribution.activityName) {
+      const recaptured = await this.recaptureHierarchyForBackStackAttribution(
+        result,
+        backStackAttribution,
+        signal,
+      );
+      if (!recaptured) {
+        return { sampled: false, identity: undefined, activityAttributionMismatch: true };
+      }
+      // Do not pair an adb activity from a later navigation with an earlier
+      // hierarchy. The forced recapture and repeated back-stack read establish
+      // that both sources still describe the same destination (#5992).
+      const reconciled = {
+        ...activeWindow,
+        appId: backStackAttribution.packageName,
+        activityName: backStackAttribution.activityName,
+      };
+      if (result.notificationPermissionDetected) {
+        reconciled.type = "notification_permission_dialog";
+      } else {
+        delete reconciled.type;
+      }
+      result.activeWindow = reconciled;
+      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
+    }
+
+    if (activeWindow.appId === observed) {
+      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
     }
 
     const confirmed = await this.deviceStateCollector.collectForegroundIdentity(signal);
     if (confirmed === observed) {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
-    return { sampled: true, identity: confirmed };
+    return { sampled: true, identity: confirmed, activityAttributionMismatch: false };
+  }
+
+  private async recaptureHierarchyForBackStackAttribution(
+    result: ObserveResult,
+    expected: { packageName: string; activityName: string },
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const initialTimestamp = this.resolveObservationTimestampMs(result);
+    const minTimestamp = (initialTimestamp ?? this.timer.now()) + 1;
+    let hierarchy: ObserveResult["viewHierarchy"];
+    try {
+      hierarchy = await this.viewHierarchy.getViewHierarchy(
+        undefined,
+        new NoOpPerformanceTracker(),
+        false,
+        minTimestamp,
+        signal,
+      );
+    } catch (error) {
+      logger.debug(
+        `[OBSERVE] Attribution recapture failed; preserving original hierarchy: ${error}`,
+      );
+      return false;
+    }
+    if (!this.isUsableAttributionRecapture(hierarchy, expected)) {
+      return false;
+    }
+
+    // A failed back-stack query is represented as a partial result rather than
+    // thrown. Keep it isolated from the original capture so a stale first read
+    // cannot be mistaken for confirmation of this fresh hierarchy.
+    const recapturedState: ObserveResult = { ...result, backStack: undefined, errors: undefined };
+    await this.deviceStateCollector.collectBackStack(
+      recapturedState,
+      new NoOpPerformanceTracker(),
+      signal,
+    );
+    const confirmed = resolveBackStackActivityAttribution(recapturedState);
+    if (!this.matchesExpectedBackStackAttribution(confirmed, expected)) {
+      return false;
+    }
+
+    this.applyRecapturedHierarchy(result, hierarchy);
+    result.backStack = recapturedState.backStack;
+    return true;
+  }
+
+  private isUsableAttributionRecapture(
+    hierarchy: ObserveResult["viewHierarchy"],
+    expected: { packageName: string; activityName: string },
+  ): hierarchy is NonNullable<ObserveResult["viewHierarchy"]> {
+    if (!hierarchy) {
+      return false;
+    }
+    return (
+      hasUsableHierarchy(hierarchy) &&
+      hierarchy.fresh === true &&
+      hierarchy.packageName === expected.packageName &&
+      this.platformValidator.validate(this.device.platform, hierarchy).valid
+    );
+  }
+
+  private matchesExpectedBackStackAttribution(
+    actual: { packageName: string; activityName: string } | undefined,
+    expected: { packageName: string; activityName: string },
+  ): boolean {
+    return (
+      actual?.packageName === expected.packageName && actual.activityName === expected.activityName
+    );
+  }
+
+  private applyRecapturedHierarchy(
+    result: ObserveResult,
+    hierarchy: NonNullable<ObserveResult["viewHierarchy"]>,
+  ): void {
+    result.viewHierarchy = hierarchy;
+    result.updatedAt = hierarchy.updatedAt ?? result.updatedAt;
+    if (hierarchy.screenWidth && hierarchy.screenHeight) {
+      result.screenSize = { width: hierarchy.screenWidth, height: hierarchy.screenHeight };
+    }
+    result.rotation = hierarchy.rotation;
+    result.systemInsets = hierarchy.systemInsets ?? { top: 0, right: 0, bottom: 0, left: 0 };
+    result.insets = hierarchy.insets ?? {
+      available: false,
+      source: "unavailable",
+      units: "unknown",
+    };
+    result.wakefulness = hierarchy.wakefulness;
+    result.intentChooserDetected = hierarchy.intentChooserDetected;
+    result.notificationPermissionDetected = hierarchy.notificationPermissionDetected;
+    result.focusedElement = this.viewHierarchy.findFocusedElement(hierarchy) ?? undefined;
+    result.accessibilityFocusedElement =
+      this.viewHierarchy.findAccessibilityFocusedElement(hierarchy) ?? undefined;
   }
 
   /**

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -77,6 +77,11 @@ export interface FreshnessInputs {
    * never verified against the foreground app no matter how recently captured.
    */
   windowIdentityMismatch?: { observed: string; foreground: string };
+  /**
+   * ADB and CtrlProxy disagree about the current activity within the same
+   * application, and a forced recapture could not safely reconcile them.
+   */
+  activityAttributionMismatch?: boolean;
   /** Age budget; defaults to {@link maxObservationAgeMs}. */
   maxAgeMs?: number;
 }
@@ -153,6 +158,36 @@ function resolveAgeMs(
   return ageBasis !== undefined ? Math.max(0, now - ageBasis) : undefined;
 }
 
+function resolveIdentityMismatch(
+  inputs: FreshnessInputs,
+  ageMs: number | undefined,
+): FreshnessVerdict | undefined {
+  const { requestedAfter, actualTimestamp } = inputs;
+  if (inputs.windowIdentityMismatch) {
+    const { observed, foreground } = inputs.windowIdentityMismatch;
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning: `Observed hierarchy is from ${observed}, but the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+    };
+  }
+  if (inputs.activityAttributionMismatch) {
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning:
+        "CtrlProxy and adb disagree about the current activity, and a fresh hierarchy could not reconcile them. The observation was not verified against the current activity; call observe again.",
+    };
+  }
+  return undefined;
+}
+
 /**
  * Compute the freshness verdict.
  *
@@ -162,7 +197,6 @@ function resolveAgeMs(
  */
 export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
   const { requestedAfter, actualTimestamp, hostAgeBasisMs, now, verified, unavailable } = inputs;
-  const windowIdentityMismatch = inputs.windowIdentityMismatch;
   const maxAgeMs = inputs.maxAgeMs ?? maxObservationAgeMs();
 
   const ageMs = resolveAgeMs(hostAgeBasisMs, actualTimestamp, now);
@@ -178,19 +212,12 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
     };
   }
 
-  // The tree belongs to a different app than the one currently resumed on the
-  // device (issue #5867). This dominates every other signal — a wrong-window
-  // capture is unfresh at any age, and `verified` is retracted to false so a
-  // consumer reading that field alone is not green-lit onto a phantom.
-  if (windowIdentityMismatch) {
-    return {
-      requestedAfter,
-      actualTimestamp,
-      ageMs,
-      verified: false,
-      isFresh: false,
-      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
-    };
+  // An app- or activity-level identity split dominates every other signal: a
+  // client must not treat the tree as verified while its attribution is known
+  // to be inconsistent (issues #5867 and #5992).
+  const identityMismatch = resolveIdentityMismatch(inputs, ageMs);
+  if (identityMismatch) {
+    return identityMismatch;
   }
 
   // Caller supplied an explicit constraint: answer exactly that question.

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -452,10 +452,13 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         } else if (
           shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))
         ) {
-          observationOut = diffObserveResult(baseline, sanitized);
+          const diff = diffObserveResult(baseline, sanitized);
+          const screenChangedWithEmptyDiff =
+            hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
+          observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;
           observationDiff = {
-            mode: "diff",
-            reason: "diff_emitted",
+            mode: screenChangedWithEmptyDiff ? "full" : "diff",
+            reason: screenChangedWithEmptyDiff ? "screen_changed" : "diff_emitted",
             fromScreen: observationScreenIdentity(baseline),
             toScreen: observationScreenIdentity(sanitized),
           };
@@ -808,6 +811,24 @@ function isObserveResult(value: unknown): value is ObserveResult {
 
 function hasRenderableHierarchy(observation: ObserveResult): boolean {
   return !!observation.viewHierarchy?.hierarchy;
+}
+
+function hasScreenChangedEffect(payload: Record<string, unknown>): boolean {
+  const effect = payload.effect;
+  return (
+    effect !== null &&
+    typeof effect === "object" &&
+    (effect as Record<string, unknown>).screenChanged === true
+  );
+}
+
+function isEmptyObserveDiff(diff: ReturnType<typeof diffObserveResult>): boolean {
+  return (
+    diff.added.length === 0 &&
+    diff.removed.length === 0 &&
+    diff.changed.length === 0 &&
+    diff.fields === undefined
+  );
 }
 
 function observationScreenIdentity(observation: ObserveResult): ObservationDiffScreenIdentity {

--- a/test/fakes/FakeViewHierarchy.ts
+++ b/test/fakes/FakeViewHierarchy.ts
@@ -8,6 +8,7 @@ import type { Element, ScreenIdentity, ViewHierarchyResult } from "../../src/mod
 export class FakeViewHierarchy implements ViewHierarchy {
   private calls: { skipWaitForFresh?: boolean; minTimestamp?: number }[] = [];
   private configuredHierarchy: ViewHierarchyResult = { hierarchy: {} };
+  private configuredHierarchySequence: ViewHierarchyResult[] = [];
   private configuredFocusedElement: Element | null = null;
   private configuredAccessibilityFocusedElement: Element | null = null;
   private configuredScreenIdentity: ScreenIdentity | undefined;
@@ -29,7 +30,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
     }
 
     this.calls.push({ skipWaitForFresh, minTimestamp });
-    return { ...this.configuredHierarchy };
+    return { ...(this.configuredHierarchySequence.shift() ?? this.configuredHierarchy) };
   }
 
   /**
@@ -93,6 +94,12 @@ export class FakeViewHierarchy implements ViewHierarchy {
     this.configuredHierarchy = hierarchy;
   }
 
+  /** Configure consecutive hierarchy reads, then fall back to the final configured value. */
+  configureHierarchySequence(hierarchies: ViewHierarchyResult[]): void {
+    this.configuredHierarchy = hierarchies.at(-1) ?? this.configuredHierarchy;
+    this.configuredHierarchySequence = [...hierarchies];
+  }
+
   /**
    * Configure the focused element to return.
    */
@@ -135,6 +142,10 @@ export class FakeViewHierarchy implements ViewHierarchy {
     return this.calls.length;
   }
 
+  getCalls(): ReadonlyArray<{ skipWaitForFresh?: boolean; minTimestamp?: number }> {
+    return this.calls;
+  }
+
   /**
    * Check if getViewHierarchy() was called.
    */
@@ -148,6 +159,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
   reset(): void {
     this.calls = [];
     this.configuredHierarchy = { hierarchy: {} };
+    this.configuredHierarchySequence = [];
     this.configuredFocusedElement = null;
     this.configuredAccessibilityFocusedElement = null;
     this.configuredScreenIdentity = undefined;

--- a/test/features/action/BaseVisualChange.postActionObservation.test.ts
+++ b/test/features/action/BaseVisualChange.postActionObservation.test.ts
@@ -125,4 +125,35 @@ describe("BaseVisualChange post-action observation", () => {
     expect(fakeObserveScreen.getGetMostRecentCachedObserveResultCallCount()).toBe(1);
     expect(fakeObserveScreen.getExecuteCallCount()).toBe(1);
   });
+
+  test("records a deferred prediction outcome against the final observation once", async () => {
+    const instance = createVisualChange("ios");
+    const initialObservation = makeObserve({ updatedAt: 1 });
+    const finalObservation = makeObserve({ updatedAt: 2 });
+    const recordedObservations: ObserveResult[] = [];
+    fakeObserveScreen.setObserveResult(initialObservation);
+    (instance as any).buildPredictionContext = () => ({
+      appId: "com.example.app",
+      fromScreen: "Home",
+      toolName: "tapOn",
+      toolArgs: { text: "Continue" },
+    });
+    (instance as any).predictionAnalyzer = {
+      recordOutcomeForAction: async (_previous: ObserveResult | null, actual: ObserveResult) => {
+        recordedObservations.push(actual);
+      },
+    };
+
+    const result = await instance.observedInteraction(async () => ({ success: true }), {
+      changeExpected: false,
+      skipPreviousObserve: true,
+      deferPredictionOutcome: true,
+      predictionContext: { toolName: "tapOn", toolArgs: { text: "Continue" } },
+    });
+
+    expect(recordedObservations).toEqual([]);
+    await (instance as any).recordDeferredPredictionOutcome(result, finalObservation);
+    await (instance as any).recordDeferredPredictionOutcome(result, initialObservation);
+    expect(recordedObservations).toEqual([finalObservation]);
+  });
 });

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -246,13 +246,14 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("android", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
 
     expect(waitCalls).toBe(1);
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: true,
       basis: "activeWindow changed",
     });
+    expect(postTap.observation).toEqual(destination);
   });
 
   test("does not wait when the initial Android observation shows a change", async () => {
@@ -286,12 +287,13 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("android", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, destination);
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, destination);
 
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: true,
       basis: "activeWindow changed",
     });
+    expect(postTap.observation).toBe(destination);
     expect(waitCalls).toBe(0);
   });
 
@@ -319,15 +321,16 @@ describe("deriveTapEffect", () => {
     };
     const { tap } = createTapOnElement("ios", waitForCondition);
 
-    const effect = await (tap as any).deriveTapEffectAfterPostTapObservation(
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(
       observation,
       observation,
     );
 
-    expect(effect).toEqual({
+    expect(postTap.effect).toEqual({
       screenChanged: false,
       basis: "activeWindow unchanged",
     });
+    expect(postTap.observation).toBe(observation);
     expect(waitCalls).toBe(0);
   });
 });

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -256,6 +256,42 @@ describe("deriveTapEffect", () => {
     expect(postTap.observation).toEqual(destination);
   });
 
+  test("keeps a changed observation when Android polling ends unmatched", async () => {
+    const stale = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SettingsHomepageActivity",
+        layoutSeqSum: 0,
+      },
+    });
+    const destination = makeObservation({
+      activeWindow: {
+        appId: "com.android.settings",
+        activityName: ".SubSettings",
+        layoutSeqSum: 0,
+      },
+    });
+    const waitForCondition: WaitForCondition = {
+      execute: async () => ({
+        matched: false,
+        candidates: [],
+        observation: destination,
+        polls: 2,
+        waitMs: 200,
+        timedOut: false,
+      }),
+    };
+    const { tap } = createTapOnElement("android", waitForCondition);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(stale, stale);
+
+    expect(postTap.effect).toEqual({
+      screenChanged: true,
+      basis: "activeWindow changed",
+    });
+    expect(postTap.observation).toEqual(destination);
+  });
+
   test("does not wait when the initial Android observation shows a change", async () => {
     const stale = makeObservation({
       activeWindow: {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -294,6 +294,157 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toBeUndefined();
   });
 
+  test("recaptures before replacing stale same-app activity attribution", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+        hierarchy: { node: { node: [{ text: "Settings home" }] } },
+      },
+      {
+        ...calendarHierarchy(now + 1),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.SubSettings",
+        hierarchy: { node: { node: [{ text: "Connected devices" }] } },
+      },
+    ] as any);
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(viewHierarchy.getCalls()[1]?.minTimestamp).toBe(now + 1);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Connected devices");
+  });
+
+  test("uses the adb task owner for an activity outside its package namespace", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.google.android.contacts",
+        foregroundActivity: "com.google.android.contacts/.ContactsActivity",
+      },
+      {
+        ...calendarHierarchy(now + 1),
+        packageName: "com.google.android.contacts",
+        foregroundActivity: "com.google.android.apps.contacts.activities.OnboardingSignInActivity",
+      },
+    ] as any);
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.contacts", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [{ id: 7, packageName: "com.google.android.contacts" }],
+            currentActivity: {
+              name: "com.google.android.apps.contacts.activities.OnboardingSignInActivity",
+              taskId: 7,
+            },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe(
+      "com.google.android.apps.contacts.activities.OnboardingSignInActivity",
+    );
+  });
+
+  test("keeps the original observation when a forced attribution recapture is unusable", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      {
+        ...calendarHierarchy(now),
+        packageName: "com.android.settings",
+        foregroundActivity: "com.android.settings/.homepage.SettingsHomepageActivity",
+        hierarchy: { node: { node: [{ text: "Settings home" }] } },
+      },
+      { hierarchy: { error: "CtrlProxy timed out" }, fresh: false },
+    ] as any);
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 7 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe(
+      "com.android.settings.homepage.SettingsHomepageActivity",
+    );
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Settings home");
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("disagree about the current activity");
+  });
+
   test("an expanded system-UI shade is not flagged as a wrong-window capture", async () => {
     // When the notification shade / quick settings takes accessibility focus,
     // the observed window is com.android.systemui while the resumed activity

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -343,6 +343,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(viewHierarchy.getCalls()[1]?.minTimestamp).toBe(now + 1);
     expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
     expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Connected devices");
+    expect(result.wakefulness).toBe("Awake");
   });
 
   test("uses the adb task owner for an activity outside its package namespace", async () => {

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -221,6 +221,18 @@ describe("computeFreshness", () => {
       expect(v.isFresh).toBe(false);
     });
 
+    test("an unresolved same-app activity disagreement is NOT verified or fresh", () => {
+      const v = computeFreshness({
+        actualTimestamp: NOW - 100,
+        now: NOW,
+        verified: true,
+        activityAttributionMismatch: true,
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("disagree about the current activity");
+    });
+
     test("a hierarchy that could not be retrieved still reports unavailable, not a mismatch", () => {
       // No hierarchy means no window to compare — unavailable dominates.
       const v = computeFreshness({

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -856,6 +856,29 @@ describe("finalizeToolResponse", () => {
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 
+    test("returns a full observation when a reported screen change would emit an empty diff", () => {
+      const { store } = makeStore();
+      finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({
+          success: true,
+          effect: { screenChanged: true, basis: "viewHierarchy changed" },
+          observation: sameScreenObserve(),
+        }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store, args: { project: "full" } },
+      );
+
+      const observation = (finalized.structuredContent as any).observation;
+      expect(observation.isDiff).toBeUndefined();
+      expect(observation.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+    });
+
     test("hierarchy-less action observations emit full sanitized payloads, not empty diffs", () => {
       const { store, map } = makeStore();
       const baseline = sameScreenObserve();


### PR DESCRIPTION
## Summary
- Reconcile stale Android `activeWindow.activityName` only after a fresh hierarchy recapture and repeated adb back-stack confirmation.
- Return the same delayed post-tap observation used to determine the effect, preserving telemetry, and fall back to a full observation when a reported screen change has an empty diff.
- Add deterministic coverage for stale same-app attribution, task-owned external activity names, unsafe recapture rejection, freshness honesty, and the empty-diff fallback.

Closes [#5992](https://github.com/kaeawc/auto-mobile/issues/5992)

## Test plan
- [x] `bun test test/features/observe/ObserveScreenWindowIdentity.test.ts test/features/observe/observationFreshness.test.ts test/features/action/TapOnElement.retryIfNoChange.test.ts test/server/finalizeToolResponse.test.ts`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate` attempted twice; parallel full-suite runs encountered unrelated intermittent failures in `GitMetadataClient` and `ExecSeam`, each passing in isolation.

Made with [Cursor](https://cursor.com)