### PR TITLE
fix(doctor): force-kill timed-out host checks

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -371,7 +371,10 @@ export function createIosObserveRoundTripInspector(
 const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   platform: () => process.platform,
   execFile: (file, args) =>
-    hostCommandExecutor.executeCommand(file, args, { timeoutMs: DOCTOR_EXEC_TIMEOUT_MS }),
+    hostCommandExecutor.executeCommand(file, args, {
+      timeoutMs: DOCTOR_EXEC_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    }),
   xcodebuild: new XcodebuildClient(),
   fileExists: existsSync,
   readDir: async (path) => fs.readdir(path),

--- a/src/utils/ExecSeam.ts
+++ b/src/utils/ExecSeam.ts
@@ -12,6 +12,7 @@ export interface ExecSeamOptions {
   maxBuffer?: number;
   cwd?: string;
   signal?: AbortSignal;
+  killSignal?: NodeJS.Signals;
 }
 
 /** Raw stdout/stderr an exec seam resolves with, before Buffer coercion. */
@@ -29,6 +30,7 @@ export interface ExecRequestOptions {
   maxBuffer?: number;
   cwd?: string;
   signal?: AbortSignal;
+  killSignal?: NodeJS.Signals;
 }
 
 /** Behavior toggles for {@link runExecSeam} that do not map to node exec options. */
@@ -64,6 +66,7 @@ export async function runExecSeam(
       maxBuffer: options.maxBuffer,
       cwd: options.cwd,
       signal: options.signal,
+      killSignal: options.killSignal,
     });
     return createExecResult(stdout, stderr);
   } catch (error) {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -239,11 +239,17 @@ describe("iOS doctor checks", () => {
         "executeCommand",
       ).mockResolvedValue(createExecResult(""));
       try {
-        await expect(checkXcrunAvailable()).resolves.toMatchObject({ status: "pass" });
-        expect(executeCommand).toHaveBeenCalledWith("xcrun", ["--version"], {
-          timeoutMs: 5000,
-          killSignal: "SIGKILL",
-        });
+        const result = await checkXcrunAvailable();
+        if (process.platform === "darwin") {
+          expect(result.status).toBe("pass");
+          expect(executeCommand).toHaveBeenCalledWith("xcrun", ["--version"], {
+            timeoutMs: 5000,
+            killSignal: "SIGKILL",
+          });
+        } else {
+          expect(result.status).toBe("skip");
+          expect(executeCommand).not.toHaveBeenCalled();
+        }
       } finally {
         executeCommand.mockRestore();
       }

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { IosDoctorDependencies } from "../../src/doctor/checks/ios";
 import {
   checkAppleDeveloperAccount,
@@ -26,6 +26,7 @@ import type {
   IosRunnerInspectorHooks,
 } from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
+import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import type { SecurityClient } from "../../src/utils/ios-cmdline-tools/SecurityClient";
 import { FakeLogger } from "../fakes/FakeLogger";
 
@@ -230,6 +231,22 @@ describe("iOS doctor checks", () => {
 
       expect(result.status).toBe("fail");
       expect(result.message).toContain("xcrun not functional");
+    });
+
+    test("force-kills a wedged xcrun process when using default dependencies", async () => {
+      const executeCommand = spyOn(
+        DefaultHostCommandExecutor.prototype,
+        "executeCommand",
+      ).mockResolvedValue(createExecResult(""));
+      try {
+        await expect(checkXcrunAvailable()).resolves.toMatchObject({ status: "pass" });
+        expect(executeCommand).toHaveBeenCalledWith("xcrun", ["--version"], {
+          timeoutMs: 5000,
+          killSignal: "SIGKILL",
+        });
+      } finally {
+        executeCommand.mockRestore();
+      }
     });
 
     test("skips when not on darwin", async () => {

--- a/test/utils/ExecSeam.test.ts
+++ b/test/utils/ExecSeam.test.ts
@@ -60,10 +60,16 @@ describe("runExecSeam", function () {
       };
       await runExecSeam(
         invoke,
-        { timeoutMs: 1234, maxBuffer: 42, cwd: "/tmp" },
+        { timeoutMs: 1234, maxBuffer: 42, cwd: "/tmp", killSignal: "SIGKILL" },
         { command: "cmd" },
       );
-      expect(seen).toEqual({ timeout: 1234, maxBuffer: 42, cwd: "/tmp" });
+      expect(seen).toEqual({
+        timeout: 1234,
+        maxBuffer: 42,
+        cwd: "/tmp",
+        signal: undefined,
+        killSignal: "SIGKILL",
+      });
     },
     FAST_TEST_TIMEOUT_MS,
   );
@@ -169,6 +175,28 @@ describe("argv exec seam", function () {
   );
 
   test(
+    "force-kills a child that ignores SIGTERM within the timeout budget",
+    async function () {
+      const ignoresSigterm: ExecFileAsync = async (_file, _args, options) => {
+        if (options?.killSignal === "SIGKILL") {
+          throw new Error("child process was force-killed");
+        }
+        throw new Error("child ignored SIGTERM and remained running");
+      };
+
+      const startedAt = performance.now();
+      await expect(
+        new DefaultHostCommandExecutor(ignoresSigterm).executeCommand("wedged-tool", [], {
+          timeoutMs: 5,
+          killSignal: "SIGKILL",
+        }),
+      ).rejects.toThrow("child process was force-killed");
+      expect(performance.now() - startedAt).toBeLessThan(FAST_TEST_TIMEOUT_MS);
+    },
+    FAST_TEST_TIMEOUT_MS,
+  );
+
+  test(
     "trackable command execution shares option mapping and result coercion",
     async function () {
       const child = { kill: () => true } as ChildProcess;
@@ -185,7 +213,13 @@ describe("argv exec seam", function () {
       ).executeCommandWithChild("adb", ["shell", "true"], { timeoutMs: 1234, maxBuffer: 42 });
 
       expect(started.child).toBe(child);
-      expect(seen).toEqual({ timeout: 1234, maxBuffer: 42, cwd: undefined, signal: undefined });
+      expect(seen).toEqual({
+        timeout: 1234,
+        maxBuffer: 42,
+        cwd: undefined,
+        signal: undefined,
+        killSignal: undefined,
+      });
       await expect(started.result).resolves.toMatchObject({
         stdout: "tracked-out",
         stderr: "tracked-err",


### PR DESCRIPTION
## Summary

- Forward the Node `execFile` force-kill signal through the shared host-command seam.
- Request `SIGKILL` for iOS doctor host diagnostics, preserving their bounded timeout behavior when a tool ignores `SIGTERM`.
- Cover option forwarding, a simulated SIGTERM-ignoring child, and the default doctor dependency.

## Linked Issue

Closes [#6018](https://github.com/kaeawc/auto-mobile/issues/6018)

## Bug / Regression Context

- **Prior attempts:** [#5997](https://github.com/kaeawc/auto-mobile/pull/5997) moved doctor host commands to the shared executor but did not preserve its force-kill behavior.
- **Observed symptom:** a diagnostic process that ignores `SIGTERM` can leave doctor blocked past `DOCTOR_EXEC_TIMEOUT_MS`.
- **Repro steps / conditions:** run a macOS doctor host check against a wedged command that traps or ignores `SIGTERM`.

## Validation

- [x] `bun test test/utils/ExecSeam.test.ts`
- [x] `bun test test/doctor/ios.test.ts`
- [x] `bun run test:changed` — 6,248 tests passed
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate` — 1,356 tests passed
- [x] New coverage uses the existing executor interface and fake seam; every new unit test completes in under 100ms.
- [x] No generic helper or dependency added.
- [x] Based on current `main` (`d6a248e6c6b9`).
