### PR TITLE
fix: reject unissued device session UUIDs

### DIFF
--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -128,15 +128,18 @@ wait_for_ctrl_proxy_health "${ctrl_proxy_port}"
 session_result="$(auto-mobile --debug --embedded-sdk --cli getApple --deviceId "${device_id}")"
 if ! session_uuid="$(
   jq -er '
-    if .sessionUuid? then .sessionUuid
-    elif .content? then
-      .content[]
-      | select(.type == "text")
-      | .text
-      | fromjson
-      | .sessionUuid
-    else empty
-    end
+    (
+      if .sessionUuid? then .sessionUuid
+      elif .content? then
+        .content[]
+        | select(.type == "text")
+        | .text
+        | fromjson
+        | .sessionUuid
+      else empty
+      end
+    )
+    | select(type == "string" and length > 0)
   ' <<<"${session_result}"
 )"; then
   echo "error: could not acquire navigation graph session for simulator ${device_id}" >&2

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -13,7 +13,7 @@ detail_screen="Issue4460Detail"
 # Keep the runner's SDK-event consumer and the public graph query in one session. Each CLI
 # invocation otherwise receives a distinct MCP session, which can route the injected events to a
 # different session-scoped NavigationGraphManager than getNavigationGraph reads.
-session_uuid="44600000-0000-4000-8000-000000000000"
+session_uuid=""
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -122,6 +122,26 @@ wait_for_ctrl_proxy_health() {
 ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
 
 wait_for_ctrl_proxy_health "${ctrl_proxy_port}"
+
+# Acquire the booted Simulator before issuing session-scoped calls. A caller must
+# not fabricate a UUID to access a device it has not acquired.
+session_result="$(auto-mobile --debug --embedded-sdk --cli getApple --deviceId "${device_id}")"
+if ! session_uuid="$(
+  jq -er '
+    if .sessionUuid? then .sessionUuid
+    elif .content? then
+      .content[]
+      | select(.type == "text")
+      | .text
+      | fromjson
+      | .sessionUuid
+    else empty
+    end
+  ' <<<"${session_result}"
+)"; then
+  echo "error: could not acquire navigation graph session for simulator ${device_id}" >&2
+  exit 1
+fi
 
 # The graph query selects the target device's latest observed foreground app.
 # Keep the injected SDK events and the following observations scoped to the

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1433,7 +1433,7 @@ export class DaemonMcpProxy {
   }
 
   private isUnadmittedDaemonSessionError(error: unknown): boolean {
-    return errorMessage(error).includes("Unknown device session UUID");
+    return errorMessage(error).includes("is not an active daemon session");
   }
 
   private isUnknownToolError(error: unknown): boolean {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1671,6 +1671,7 @@ export class DaemonMcpProxy {
         isSessionAcquisition,
       );
       if (result?.isError) {
+        this.refreshReplayLeaseForBoundSessionResult(forwardedArgs, callReleaseEpoch);
         return result;
       }
       this.rememberToolSelectionProfile(name, args, result);
@@ -2247,6 +2248,22 @@ export class DaemonMcpProxy {
     const admittedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     if (admittedSessionUuid) {
       this.updateBoundSessionUuid(admittedSessionUuid);
+      this.startBoundSessionHeartbeat();
+    }
+  }
+
+  private refreshReplayLeaseForBoundSessionResult(
+    forwardedArgs: Record<string, unknown>,
+    callReleaseEpoch: number,
+  ): void {
+    const releaseReason = this.forwardedSessionReleaseReasonSince(forwardedArgs, callReleaseEpoch);
+    if (releaseReason) {
+      this.fenceReleasedForwardedSession(forwardedArgs, releaseReason);
+      return;
+    }
+    const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
+    if (forwardedSessionUuid && forwardedSessionUuid === this.boundSessionUuid) {
+      this.updateBoundSessionUuid(forwardedSessionUuid);
       this.startBoundSessionHeartbeat();
     }
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1433,7 +1433,7 @@ export class DaemonMcpProxy {
   }
 
   private isUnadmittedDaemonSessionError(error: unknown): boolean {
-    return errorMessage(error).includes("is not an active daemon session");
+    return errorMessage(error).includes("Unknown device session UUID");
   }
 
   private isUnknownToolError(error: unknown): boolean {
@@ -1670,6 +1670,9 @@ export class DaemonMcpProxy {
         // the result-minted session establishes a fresh binding.
         isSessionAcquisition,
       );
+      if (result?.isError) {
+        return result;
+      }
       this.rememberToolSelectionProfile(name, args, result);
       if (isSessionAcquisition) {
         await this.bindResultMintedDeviceSession(name, result);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2189,7 +2189,10 @@ export class DaemonMcpProxy {
       return;
     }
     const rememberedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
-    if (rememberedSessionUuid && this.toolAcceptsSessionUuid(name)) {
+    if (
+      rememberedSessionUuid &&
+      (rememberedSessionUuid === this.boundSessionUuid || this.toolAcceptsSessionUuid(name))
+    ) {
       this.updateBoundSessionUuid(rememberedSessionUuid);
       this.startBoundSessionHeartbeat();
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2237,6 +2237,7 @@ export class DaemonMcpProxy {
   ): void {
     if (
       name === "executePlan" ||
+      name === "setActiveDevice" ||
       name === SET_TOOL_ENABLED_TOOL_NAME ||
       this.isRecoverableDaemonSessionError(error) ||
       this.isUnadmittedDaemonSessionError(error) ||

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1432,6 +1432,10 @@ export class DaemonMcpProxy {
     return message.includes("Session not found");
   }
 
+  private isUnadmittedDaemonSessionError(error: unknown): boolean {
+    return errorMessage(error).includes("is not an active daemon session");
+  }
+
   private isUnknownToolError(error: unknown): boolean {
     const message = errorMessage(error);
     return message.includes("Unknown tool:");
@@ -2223,6 +2227,7 @@ export class DaemonMcpProxy {
       name === "executePlan" ||
       name === SET_TOOL_ENABLED_TOOL_NAME ||
       this.isRecoverableDaemonSessionError(error) ||
+      this.isUnadmittedDaemonSessionError(error) ||
       this.shouldSkipLeaseRefreshForDeviceControlTransportError(error)
     ) {
       return;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2189,10 +2189,18 @@ export class DaemonMcpProxy {
       return;
     }
     const rememberedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
-    if (rememberedSessionUuid) {
+    if (rememberedSessionUuid && this.toolAcceptsSessionUuid(name)) {
       this.updateBoundSessionUuid(rememberedSessionUuid);
       this.startBoundSessionHeartbeat();
     }
+  }
+
+  private toolAcceptsSessionUuid(name: string): boolean {
+    const tool =
+      this.cachedTools?.find((definition) => definition.name === name) ??
+      this.staticToolDefinitionsProvider().find((definition) => definition.name === name);
+    const properties = tool?.inputSchema.properties;
+    return typeof properties === "object" && properties !== null && "sessionUuid" in properties;
   }
 
   // Bind `sessionUuid`, refreshing the replay lease. A change to a different UUID

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -7,7 +7,7 @@ import {
   type DeviceSessionPersistence,
 } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
-import { toActionableError } from "../models/ActionableError";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
 import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
@@ -217,6 +217,8 @@ const EXPIRY_RELEASE_REASONS = new Set([
   "missing-first-heartbeat",
   "heartbeat-timeout",
 ]);
+
+class UnissuedSessionError extends ActionableError {}
 
 function isTerminalReleaseReason(releaseReason: string): boolean {
   return (
@@ -668,6 +670,31 @@ export class SessionManager {
     return await assignment;
   }
 
+  /**
+   * Admit an identity already issued by this daemon, or return `undefined` for
+   * an identity that was live when the daemon restarted and may be recreated.
+   */
+  async admitIssuedSessionForAutomation(
+    sessionId: string,
+    execution?: SessionExecutionMetadata,
+  ): Promise<Session | undefined> {
+    let unissuedSessionError: UnissuedSessionError | undefined;
+    try {
+      return await this.getOrCreateSession(sessionId, undefined, undefined, execution);
+    } catch (error) {
+      if (!(error instanceof UnissuedSessionError)) {
+        throw error;
+      }
+      unissuedSessionError = error;
+    }
+
+    const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
+    if (persisted?.status === "expired" && persisted.release_reason === "daemon-restart") {
+      return undefined;
+    }
+    throw unissuedSessionError;
+  }
+
   private async createUnseenSession(
     sessionId: string,
     devicePool: SessionDeviceAssigner | undefined,
@@ -684,8 +711,9 @@ export class SessionManager {
 
     // Need to create new session - assign device from pool
     if (!devicePool) {
-      throw new Error(
-        `Session ${sessionId} not found and no device pool provided for auto-assignment.`,
+      throw new UnissuedSessionError(
+        `Session ${sessionId} is not an active daemon session (not found). ` +
+          "Acquire a device with getAndroid or getApple before using its sessionUuid.",
       );
     }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -6,6 +6,7 @@ import {
   DeviceSessionRepository,
   type DeviceSessionPersistence,
 } from "../db/deviceSessionRepository";
+import type { DeviceSession } from "../db/types";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { ActionableError, toActionableError } from "../models/ActionableError";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
@@ -493,11 +494,14 @@ export class SessionManager {
     sessionId: string,
   ): Promise<SessionReleaseSnapshot | undefined> {
     const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
-    if (
-      !persisted ||
-      !persisted.release_reason ||
-      !isTerminalReleaseReason(persisted.release_reason)
-    ) {
+    return persisted ? this.terminalReleaseFromPersisted(sessionId, persisted) : undefined;
+  }
+
+  private terminalReleaseFromPersisted(
+    sessionId: string,
+    persisted: DeviceSession,
+  ): SessionReleaseSnapshot | undefined {
+    if (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason)) {
       return undefined;
     }
     const releasedAtMs = persisted.released_at_ms ?? persisted.last_used_at_ms;
@@ -686,6 +690,12 @@ export class SessionManager {
     }
 
     const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
+    const persistedTerminalRelease =
+      persisted && this.terminalReleaseFromPersisted(sessionId, persisted);
+    if (persistedTerminalRelease) {
+      this.terminalReleaseSnapshots.set(sessionId, persistedTerminalRelease);
+      throw new TerminalSessionError(sessionId, persistedTerminalRelease);
+    }
     if (
       persisted &&
       (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason))

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -670,10 +670,7 @@ export class SessionManager {
     return await assignment;
   }
 
-  /**
-   * Admit an identity already issued by this daemon, or return `undefined` for
-   * an identity that was live when the daemon restarted and may be recreated.
-   */
+  /** Admit an identity already issued by this daemon, including a nonterminal persisted one. */
   async admitIssuedSessionForAutomation(
     sessionId: string,
     execution?: SessionExecutionMetadata,
@@ -690,8 +687,8 @@ export class SessionManager {
 
     const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
     if (
-      (persisted?.status === "expired" && persisted.release_reason === "daemon-restart") ||
-      (persisted?.status === "released" && persisted.release_reason === "daemon-shutdown")
+      persisted &&
+      (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason))
     ) {
       return undefined;
     }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -934,6 +934,10 @@ export class SessionManager {
     );
   }
 
+  isAdmittedForAutomation(session: Session): boolean {
+    return this.isCurrentSession(session) && !this.releasingSessions.has(session);
+  }
+
   /** Whether this is the newest published, releasing, or finalized incarnation for its UUID. */
   isLatestSessionIdentity(
     session: Session,

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -689,7 +689,10 @@ export class SessionManager {
     }
 
     const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
-    if (persisted?.status === "expired" && persisted.release_reason === "daemon-restart") {
+    if (
+      (persisted?.status === "expired" && persisted.release_reason === "daemon-restart") ||
+      (persisted?.status === "released" && persisted.release_reason === "daemon-shutdown")
+    ) {
       return undefined;
     }
     throw unissuedSessionError;

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -7,7 +7,7 @@ import {
   type DeviceSessionPersistence,
 } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
-import { ActionableError, toActionableError } from "../models/ActionableError";
+import { toActionableError } from "../models/ActionableError";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
 import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
@@ -684,9 +684,8 @@ export class SessionManager {
 
     // Need to create new session - assign device from pool
     if (!devicePool) {
-      throw new ActionableError(
-        `Session ${sessionId} is not an active daemon session (not found). ` +
-          "Acquire a device with getAndroid or getApple before using its sessionUuid.",
+      throw new Error(
+        `Session ${sessionId} not found and no device pool provided for auto-assignment.`,
       );
     }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -7,7 +7,7 @@ import {
   type DeviceSessionPersistence,
 } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
-import { toActionableError } from "../models/ActionableError";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
 import { DeviceState, type BiometricEnrollment } from "../features/utility/DeviceState";
@@ -684,8 +684,9 @@ export class SessionManager {
 
     // Need to create new session - assign device from pool
     if (!devicePool) {
-      throw new Error(
-        `Session ${sessionId} not found and no device pool provided for auto-assignment.`,
+      throw new ActionableError(
+        `Session ${sessionId} is not an active daemon session (not found). ` +
+          "Acquire a device with getAndroid or getApple before using its sessionUuid.",
       );
     }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -84,7 +84,7 @@ export async function createToolExecutionContext(
     return {};
   }
 
-  if (admittedSession && !sessionManager.isCurrentSession(admittedSession)) {
+  if (admittedSession && !sessionManager.isAdmittedForAutomation(admittedSession)) {
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);
   }
   devicePool.assertSessionReadyForAutomation(sessionUuid);
@@ -101,7 +101,7 @@ export async function createToolExecutionContext(
       execution,
     ));
 
-  if (!sessionManager.isCurrentSession(session)) {
+  if (!sessionManager.isAdmittedForAutomation(session)) {
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);
   }
 
@@ -153,7 +153,7 @@ async function setupSession(
 }
 
 function ensureSessionIsCurrent(session: Session, sessionManager: SessionManager): void {
-  if (!sessionManager.isCurrentSession(session)) {
+  if (!sessionManager.isAdmittedForAutomation(session)) {
     throw new ActionableError(`Session ${session.sessionId} was released during setup`);
   }
 }
@@ -273,7 +273,7 @@ async function ensureKeepScreenAwake(
     state = { applied: false, skipReason: "failed" };
   }
 
-  if (!sessionManager.isCurrentSession(session)) {
+  if (!sessionManager.isAdmittedForAutomation(session)) {
     if (state.applied) {
       try {
         await manager.restore(state);

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -108,6 +108,7 @@ export async function createToolExecutionContext(
   await sessionManager.trackSessionSetup(session, () =>
     setupSession(session, existingSession === session, sessionManager, sessionOptions),
   );
+  ensureSessionIsCurrent(session, sessionManager);
 
   return {
     sessionId: sessionUuid,

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -78,28 +78,21 @@ export async function createToolExecutionContext(
   devicePool: DevicePool,
   sessionOptions: SessionOptions = {},
   execution?: SessionExecutionMetadata,
-  admittedSession?: Session,
 ): Promise<ToolExecutionContext> {
   if (!sessionUuid) {
     return {};
   }
 
-  if (admittedSession && !sessionManager.isCurrentSession(admittedSession)) {
-    throw new ActionableError(`Session ${sessionUuid} was released during setup`);
-  }
   devicePool.assertSessionReadyForAutomation(sessionUuid);
-  const existingSession =
-    admittedSession ?? sessionManager.getSessionForNewExecution(sessionUuid, execution);
+  const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
 
   // Get or create session
-  const session =
-    admittedSession ??
-    (await sessionManager.getOrCreateSession(
-      sessionUuid,
-      devicePool,
-      sessionOptions.platform,
-      execution,
-    ));
+  const session = await sessionManager.getOrCreateSession(
+    sessionUuid,
+    devicePool,
+    sessionOptions.platform,
+    execution,
+  );
 
   if (!sessionManager.isCurrentSession(session)) {
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -78,21 +78,28 @@ export async function createToolExecutionContext(
   devicePool: DevicePool,
   sessionOptions: SessionOptions = {},
   execution?: SessionExecutionMetadata,
+  admittedSession?: Session,
 ): Promise<ToolExecutionContext> {
   if (!sessionUuid) {
     return {};
   }
 
+  if (admittedSession && !sessionManager.isCurrentSession(admittedSession)) {
+    throw new ActionableError(`Session ${sessionUuid} was released during setup`);
+  }
   devicePool.assertSessionReadyForAutomation(sessionUuid);
-  const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
+  const existingSession =
+    admittedSession ?? sessionManager.getSessionForNewExecution(sessionUuid, execution);
 
   // Get or create session
-  const session = await sessionManager.getOrCreateSession(
-    sessionUuid,
-    devicePool,
-    sessionOptions.platform,
-    execution,
-  );
+  const session =
+    admittedSession ??
+    (await sessionManager.getOrCreateSession(
+      sessionUuid,
+      devicePool,
+      sessionOptions.platform,
+      execution,
+    ));
 
   if (!sessionManager.isCurrentSession(session)) {
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -684,6 +684,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       if (
         !isDeviceSessionAcquisitionTool(name) &&
         name !== SET_TOOL_ENABLED_TOOL_NAME &&
+        !result?.isError &&
         sessionToolBinding.bind(sessionId, providedSessionUuid)
       ) {
         ToolRegistry.notifyToolListChanged();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -656,6 +656,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         daemonMode &&
         providedSessionUuid &&
         !isDeviceSessionAcquisitionTool(name) &&
+        name !== "setActiveDevice" &&
         name !== SET_TOOL_ENABLED_TOOL_NAME
       ) {
         // Plain tools can strip or ignore sessionUuid themselves. Admit it here so

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -579,12 +579,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       typeof rawSessionUuid === "string" && rawSessionUuid.trim().length > 0
         ? rawSessionUuid
         : undefined;
-    if (
-      name !== SET_TOOL_ENABLED_TOOL_NAME &&
-      sessionToolBinding.bind(sessionId, providedSessionUuid)
-    ) {
-      ToolRegistry.notifyToolListChanged();
-    }
 
     // Check if tool call should be blocked due to active executePlan in this session
     const decision = planExecutionLock.evaluate({
@@ -684,6 +678,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       if (
         isDeviceSessionAcquisitionTool(name) &&
         sessionToolBinding.bind(sessionId, getDeviceSessionIdFromResult(result))
+      ) {
+        ToolRegistry.notifyToolListChanged();
+      }
+      if (
+        !isDeviceSessionAcquisitionTool(name) &&
+        name !== SET_TOOL_ENABLED_TOOL_NAME &&
+        sessionToolBinding.bind(sessionId, providedSessionUuid)
       ) {
         ToolRegistry.notifyToolListChanged();
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -690,7 +690,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         (DaemonState.getInstance().isInitialized()
           ? DaemonState.getInstance()
               .getSessionManager()
-              .getSessionForNewExecution(providedSessionUuid) !== null
+              .getSessionForNewExecution(providedSessionUuid, {
+                executionId: execution.id,
+                startTime: execution.startTime,
+              }) !== null
           : resolveDirectSessionDevice(providedSessionUuid) !== undefined) &&
         sessionToolBinding.bind(sessionId, providedSessionUuid)
       ) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,7 @@ import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanEx
 import { SessionToolBinding } from "./SessionToolBinding";
 import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
 import { TerminalSessionError } from "../daemon/sessionManager";
+import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
   DAEMON_NON_FINITE_ENCODED_PARAM,
@@ -685,6 +686,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         !isDeviceSessionAcquisitionTool(name) &&
         name !== SET_TOOL_ENABLED_TOOL_NAME &&
         !result?.isError &&
+        providedSessionUuid &&
+        (DaemonState.getInstance().isInitialized()
+          ? DaemonState.getInstance()
+              .getSessionManager()
+              .getSessionForNewExecution(providedSessionUuid) !== null
+          : resolveDirectSessionDevice(providedSessionUuid) !== undefined) &&
         sessionToolBinding.bind(sessionId, providedSessionUuid)
       ) {
         ToolRegistry.notifyToolListChanged();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -655,12 +655,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       if (
         daemonMode &&
         providedSessionUuid &&
+        !tool.requiresDevice &&
         !isDeviceSessionAcquisitionTool(name) &&
         name !== "setActiveDevice" &&
         name !== SET_TOOL_ENABLED_TOOL_NAME
       ) {
-        // Plain tools can strip or ignore sessionUuid themselves. Admit it here so
-        // an unissued UUID cannot be treated as a successful proxy binding.
+        // Plain tools can strip or ignore sessionUuid themselves. Device-aware
+        // tools carry their admitted identity into execution in ToolRegistry.
         await DaemonState.getInstance()
           .getSessionManager()
           .admitIssuedSessionForAutomation(providedSessionUuid, {
@@ -698,18 +699,25 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       ) {
         ToolRegistry.notifyToolListChanged();
       }
+      const daemonSessionManager = DaemonState.getInstance().isInitialized()
+        ? DaemonState.getInstance().getSessionManager()
+        : undefined;
+      const sessionForBinding =
+        daemonSessionManager && providedSessionUuid
+          ? daemonSessionManager.getSessionForNewExecution(providedSessionUuid, {
+              executionId: execution.id,
+              startTime: execution.startTime,
+            })
+          : undefined;
       if (
         !isDeviceSessionAcquisitionTool(name) &&
         name !== SET_TOOL_ENABLED_TOOL_NAME &&
         !result?.isError &&
         providedSessionUuid &&
-        (DaemonState.getInstance().isInitialized()
-          ? DaemonState.getInstance()
-              .getSessionManager()
-              .getSessionForNewExecution(providedSessionUuid, {
-                executionId: execution.id,
-                startTime: execution.startTime,
-              }) !== null
+        (daemonSessionManager
+          ? sessionForBinding !== null &&
+            sessionForBinding !== undefined &&
+            daemonSessionManager.isAdmittedForAutomation(sessionForBinding)
           : resolveDirectSessionDevice(providedSessionUuid) !== undefined) &&
         sessionToolBinding.bind(sessionId, providedSessionUuid)
       ) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -618,6 +618,21 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       executionSessionUuid,
       sessionId,
     );
+    if (
+      daemonMode &&
+      providedSessionUuid &&
+      !isDeviceSessionAcquisitionTool(name) &&
+      name !== SET_TOOL_ENABLED_TOOL_NAME
+    ) {
+      // Plain tools can strip or ignore sessionUuid themselves. Admit it here so
+      // an unissued UUID cannot be treated as a successful proxy binding.
+      await DaemonState.getInstance()
+        .getSessionManager()
+        .admitIssuedSessionForAutomation(providedSessionUuid, {
+          executionId: execution.id,
+          startTime: execution.startTime,
+        });
+    }
     const requestSignal = combineAbortSignals(execution.abortController.signal, extra.signal);
     const handlerParams =
       parsedParams && typeof parsedParams === "object"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -618,21 +618,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       executionSessionUuid,
       sessionId,
     );
-    if (
-      daemonMode &&
-      providedSessionUuid &&
-      !isDeviceSessionAcquisitionTool(name) &&
-      name !== SET_TOOL_ENABLED_TOOL_NAME
-    ) {
-      // Plain tools can strip or ignore sessionUuid themselves. Admit it here so
-      // an unissued UUID cannot be treated as a successful proxy binding.
-      await DaemonState.getInstance()
-        .getSessionManager()
-        .admitIssuedSessionForAutomation(providedSessionUuid, {
-          executionId: execution.id,
-          startTime: execution.startTime,
-        });
-    }
     const requestSignal = combineAbortSignals(execution.abortController.signal, extra.signal);
     const handlerParams =
       parsedParams && typeof parsedParams === "object"
@@ -667,6 +652,21 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       : undefined;
 
     try {
+      if (
+        daemonMode &&
+        providedSessionUuid &&
+        !isDeviceSessionAcquisitionTool(name) &&
+        name !== SET_TOOL_ENABLED_TOOL_NAME
+      ) {
+        // Plain tools can strip or ignore sessionUuid themselves. Admit it here so
+        // an unissued UUID cannot be treated as a successful proxy binding.
+        await DaemonState.getInstance()
+          .getSessionManager()
+          .admitIssuedSessionForAutomation(providedSessionUuid, {
+            executionId: execution.id,
+            startTime: execution.startTime,
+          });
+      }
       const result = await runWithAbortSignal(requestSignal, () =>
         runWithToolSelectionContext(
           {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -699,11 +699,17 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       ) {
         ToolRegistry.notifyToolListChanged();
       }
+      const isRecordingIdCleanup =
+        name === "videoRecording" &&
+        parsedParams &&
+        typeof parsedParams === "object" &&
+        parsedParams.action === "stop" &&
+        typeof parsedParams.recordingId === "string";
       const daemonSessionManager = DaemonState.getInstance().isInitialized()
         ? DaemonState.getInstance().getSessionManager()
         : undefined;
       const sessionForBinding =
-        daemonSessionManager && providedSessionUuid
+        daemonSessionManager && providedSessionUuid && !isRecordingIdCleanup
           ? daemonSessionManager.getSessionForNewExecution(providedSessionUuid, {
               executionId: execution.id,
               startTime: execution.startTime,
@@ -714,6 +720,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         name !== SET_TOOL_ENABLED_TOOL_NAME &&
         !result?.isError &&
         providedSessionUuid &&
+        !isRecordingIdCleanup &&
         (daemonSessionManager
           ? sessionForBinding !== null &&
             sessionForBinding !== undefined &&

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -95,7 +95,9 @@ function noActiveDeviceSessionError(error: DaemonConnectionSessionReleasedError)
   );
 }
 
-function deviceControlTransportFailureResult(error: DeviceControlTransportError): CallToolResult {
+export function deviceControlTransportFailureResult(
+  error: DeviceControlTransportError,
+): CallToolResult {
   const failure = sanitizeDeviceControlTransportFailure(error.failure);
   return {
     content: [

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -478,16 +478,18 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      // A missing assigner makes getOrCreateSession an admission-only lookup:
-      // terminal IDs retain their durable TerminalSessionError, while never-issued
-      // IDs cannot allocate a device.
-      const admittedSession = await sessionManager.getOrCreateSession(
-        sessionUuid,
-        undefined,
-        undefined,
-        execution,
-      );
       const devicePool = DaemonState.getInstance().getDevicePool();
+      const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
+      const owningSessionUuid = providedDeviceId
+        ? sessionManager.getSessionForDevice(providedDeviceId)
+        : undefined;
+      if (!existingSession && owningSessionUuid && owningSessionUuid !== sessionUuid) {
+        throw new ActionableError(
+          `Unknown device session UUID ${sessionUuid} cannot access device ${providedDeviceId}, ` +
+            `which is owned by session ${owningSessionUuid}. ` +
+            "Acquire a device with getAndroid or getApple before using its sessionUuid.",
+        );
+      }
       const context = await createToolExecutionContext(
         sessionUuid,
         sessionManager,
@@ -497,7 +499,6 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
           platform: platform === "android" || platform === "ios" ? platform : undefined,
         },
         execution,
-        admittedSession,
       );
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -478,6 +478,13 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
       const sessionManager = DaemonState.getInstance().getSessionManager();
+      const activeSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
+      if (!activeSession && !sessionManager.getTerminalReleaseSnapshot(sessionUuid)) {
+        throw new ActionableError(
+          `Session ${sessionUuid} is not an active daemon session. ` +
+            "Acquire a device with getAndroid or getApple before using its sessionUuid.",
+        );
+      }
       const devicePool = DaemonState.getInstance().getDevicePool();
       const context = await createToolExecutionContext(
         sessionUuid,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -481,7 +481,12 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       // A missing assigner makes getOrCreateSession an admission-only lookup:
       // terminal IDs retain their durable TerminalSessionError, while never-issued
       // IDs cannot allocate a device.
-      await sessionManager.getOrCreateSession(sessionUuid, undefined, undefined, execution);
+      const admittedSession = await sessionManager.getOrCreateSession(
+        sessionUuid,
+        undefined,
+        undefined,
+        execution,
+      );
       const devicePool = DaemonState.getInstance().getDevicePool();
       const context = await createToolExecutionContext(
         sessionUuid,
@@ -492,6 +497,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
           platform: platform === "android" || platform === "ios" ? platform : undefined,
         },
         execution,
+        admittedSession,
       );
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -478,13 +478,10 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      const activeSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
-      if (!activeSession && !sessionManager.getTerminalReleaseSnapshot(sessionUuid)) {
-        throw new ActionableError(
-          `Session ${sessionUuid} is not an active daemon session. ` +
-            "Acquire a device with getAndroid or getApple before using its sessionUuid.",
-        );
-      }
+      // A missing assigner makes getOrCreateSession an admission-only lookup:
+      // terminal IDs retain their durable TerminalSessionError, while never-issued
+      // IDs cannot allocate a device.
+      await sessionManager.getOrCreateSession(sessionUuid, undefined, undefined, execution);
       const devicePool = DaemonState.getInstance().getDevicePool();
       const context = await createToolExecutionContext(
         sessionUuid,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -479,17 +479,13 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
       const sessionManager = DaemonState.getInstance().getSessionManager();
       const devicePool = DaemonState.getInstance().getDevicePool();
-      const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
-      const owningSessionUuid = providedDeviceId
-        ? sessionManager.getSessionForDevice(providedDeviceId)
-        : undefined;
-      if (!existingSession && owningSessionUuid && owningSessionUuid !== sessionUuid) {
-        throw new ActionableError(
-          `Unknown device session UUID ${sessionUuid} cannot access device ${providedDeviceId}, ` +
-            `which is owned by session ${owningSessionUuid}. ` +
-            "Acquire a device with getAndroid or getApple before using its sessionUuid.",
-        );
-      }
+      // A terminal ID keeps its durable TerminalSessionError. Only an ID that
+      // was live during daemon restart can reach context creation without a
+      // live session; never-issued IDs are rejected before assignment.
+      const admittedSession = await sessionManager.admitIssuedSessionForAutomation(
+        sessionUuid,
+        execution,
+      );
       const context = await createToolExecutionContext(
         sessionUuid,
         sessionManager,
@@ -499,6 +495,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
           platform: platform === "android" || platform === "ios" ? platform : undefined,
         },
         execution,
+        admittedSession,
       );
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -5,6 +5,7 @@ SCRIPT="scripts/ios/navigation-graph-sdk-event-integration.sh"
 setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIG_PATH="$PATH"
+  export REAL_JQ="$(command -v jq)"
   export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
@@ -37,7 +38,7 @@ SCRIPT
   make_mock curl 'exit 0'
   make_mock jq '
 if [ "$1" = "-er" ] && [[ "$2" == *"sessionUuid"* ]]; then
-  exit 1
+  exec "$REAL_JQ" "$@"
 fi
 printf "8765\n"
 '
@@ -86,8 +87,7 @@ if [ "$1" = "-cn" ]; then
 fi
 if [ "$1" = "-er" ]; then
   if [[ "$2" == *"sessionUuid"* ]]; then
-    printf "44600000-0000-4000-8000-000000000000\\n"
-    exit 0
+    exec "$REAL_JQ" "$@"
   fi
   if [ -f "$POST_BIND_DOCTOR_FAILURE_FILE" ]; then
     exit 1

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -32,6 +32,32 @@ SCRIPT
   chmod +x "${MOCK_BIN}/${name}"
 }
 
+@test "rejects an empty session UUID from getApple" {
+  make_mock xcrun 'exit 0'
+  make_mock curl 'exit 0'
+  make_mock jq '
+if [ "$1" = "-er" ] && [[ "$2" == *"sessionUuid"* ]]; then
+  exit 1
+fi
+printf "8765\n"
+'
+  make_mock auto-mobile '
+if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
+  printf "{\"ios\":{\"checks\":[]}}\n"
+  exit 0
+fi
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "getApple" ]; then
+  printf "{\"sessionUuid\":\"\"}\n"
+  exit 0
+fi
+'
+
+  run env PATH="${MOCK_BIN}:${PATH}" bash "$SCRIPT" "simulator-udid"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not acquire navigation graph session"* ]]
+}
+
 @test "renews the graph session while retrying post-bind CtrlProxy health" {
   make_mock xcrun 'exit 0'
   make_mock curl '

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -59,6 +59,10 @@ if [ "$1" = "-cn" ]; then
   exit 0
 fi
 if [ "$1" = "-er" ]; then
+  if [[ "$2" == *"sessionUuid"* ]]; then
+    printf "44600000-0000-4000-8000-000000000000\\n"
+    exit 0
+  fi
   if [ -f "$POST_BIND_DOCTOR_FAILURE_FILE" ]; then
     exit 1
   fi
@@ -87,6 +91,10 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
     fi
   fi
   printf "{\"ios\":{\"checks\":[]}}\\n"
+  exit 0
+fi
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "getApple" ] && [ "$5" = "--deviceId" ] && [ "$6" = "simulator-udid" ]; then
+  printf "{\"sessionUuid\":\"44600000-0000-4000-8000-000000000000\"}\\n"
   exit 0
 fi
 if [ "$1" = "--daemon" ] && [ "$2" = "heartbeat" ] && [ "$3" = "44600000-0000-4000-8000-000000000000" ]; then

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2451,6 +2451,7 @@ describe("DaemonMcpProxy", () => {
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
         timer,
+        heartbeatIntervalMs: DAEMON_BOUND_SESSION_REPLAY_TTL_MS * 2,
       });
 
       try {
@@ -2495,6 +2496,7 @@ describe("DaemonMcpProxy", () => {
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
         timer,
+        heartbeatIntervalMs: DAEMON_BOUND_SESSION_REPLAY_TTL_MS * 2,
       });
 
       try {
@@ -2509,6 +2511,33 @@ describe("DaemonMcpProxy", () => {
         expect(client.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does not remember a UUID passed to a tool that does not accept sessions", async () => {
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("listDevices", { sessionUuid: "unissued-session" });
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "listDevices", params: { sessionUuid: "unissued-session" } },
           { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
         ]);
       } finally {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2477,6 +2477,44 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("keeps the prior binding when an unissued session UUID is rejected", async () => {
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        toolErrorByName: new Map([
+          [
+            "tapOn",
+            new ActionableError(
+              "Session session-b is not an active daemon session (not found). " +
+                "Acquire a device with getAndroid or getApple before using its sessionUuid.",
+            ),
+          ],
+        ]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await expect(
+          proxy.callTool("tapOn", { sessionUuid: "session-b", deviceId: "device-b" }),
+        ).rejects.toThrow("is not an active daemon session");
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("successful heartbeats keep the replay lease alive across a failed tool transport", async () => {
       // The failed tool request did not refresh the daemon session, but the
       // independent heartbeat keeper did. The binding therefore remains live

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2548,6 +2548,38 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("renews a bound session from an unscoped call", async () => {
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+        heartbeatIntervalMs: DAEMON_BOUND_SESSION_REPLAY_TTL_MS * 2,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("listDevices", {});
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "listDevices", params: { sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("keeps the prior binding when an unissued session UUID is rejected", async () => {
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2523,11 +2523,13 @@ describe("DaemonMcpProxy", () => {
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
       });
+      const timer = new FakeTimer();
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
       const proxy = new DaemonMcpProxy({
         clientFactory: () => client,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
+        timer,
       });
 
       try {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2484,7 +2484,8 @@ describe("DaemonMcpProxy", () => {
           [
             "tapOn",
             new ActionableError(
-              "Session session-b is not an active daemon session (not found). " +
+              "Unknown device session UUID session-b cannot access device device-b, " +
+                "which is owned by session session-a. " +
                 "Acquire a device with getAndroid or getApple before using its sessionUuid.",
             ),
           ],
@@ -2501,9 +2502,47 @@ describe("DaemonMcpProxy", () => {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
         await expect(
           proxy.callTool("tapOn", { sessionUuid: "session-b", deviceId: "device-b" }),
-        ).rejects.toThrow("is not an active daemon session");
+        ).rejects.toThrow("Unknown device session UUID");
         await proxy.callTool("observe", { deviceId: "device-a" });
 
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "tapOn", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("keeps the prior binding when an unissued session UUID returns an error result", async () => {
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const callTool = client.callTool.bind(client);
+      client.callTool = async (toolName, params) => {
+        await callTool(toolName, params);
+        return toolName === "tapOn"
+          ? { content: [{ type: "text", text: "session rejected" }], isError: true }
+          : { content: [{ type: "text", text: "ok" }] };
+      };
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        const rejected = await proxy.callTool("tapOn", {
+          sessionUuid: "session-b",
+          deviceId: "device-b",
+        });
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(rejected.isError).toBe(true);
         expect(client.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "tapOn", params: { sessionUuid: "session-b", deviceId: "device-b" } },

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2484,8 +2484,7 @@ describe("DaemonMcpProxy", () => {
           [
             "tapOn",
             new ActionableError(
-              "Unknown device session UUID session-b cannot access device device-b, " +
-                "which is owned by session session-a. " +
+              "Session session-b is not an active daemon session (not found). " +
                 "Acquire a device with getAndroid or getApple before using its sessionUuid.",
             ),
           ],
@@ -2502,7 +2501,7 @@ describe("DaemonMcpProxy", () => {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
         await expect(
           proxy.callTool("tapOn", { sessionUuid: "session-b", deviceId: "device-b" }),
-        ).rejects.toThrow("Unknown device session UUID");
+        ).rejects.toThrow("is not an active daemon session");
         await proxy.callTool("observe", { deviceId: "device-a" });
 
         expect(client.callToolCalls).toEqual([

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2477,6 +2477,46 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("refreshes the replay lease when an admitted bound call returns an error result", async () => {
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const callTool = client.callTool.bind(client);
+      client.callTool = async (toolName, params) => {
+        await callTool(toolName, params);
+        return toolName === "tapOn"
+          ? { content: [{ type: "text", text: "tap failed after admission" }], isError: true }
+          : { content: [{ type: "text", text: "ok" }] };
+      };
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).resolves.toMatchObject({
+          isError: true,
+        });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("keeps the prior binding when an unissued session UUID is rejected", async () => {
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2672,6 +2672,15 @@ describe("SessionManager", () => {
       } finally {
         gracefullyRestarted.stopCleanupTimer();
       }
+      persisted.release_reason = "explicit-release";
+      const ordinarilyReleased = new SessionManager(fakeTimer, persistence);
+      try {
+        await expect(
+          ordinarilyReleased.admitIssuedSessionForAutomation("restarted-session"),
+        ).resolves.toBeUndefined();
+      } finally {
+        ordinarilyReleased.stopCleanupTimer();
+      }
     } finally {
       restarted.stopCleanupTimer();
     }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2662,6 +2662,16 @@ describe("SessionManager", () => {
       await expect(
         restarted.getOrCreateSession("restarted-session", devicePool, "android"),
       ).resolves.toMatchObject({ assignedDevice: "emulator-5560" });
+      persisted.status = "released";
+      persisted.release_reason = "daemon-shutdown";
+      const gracefullyRestarted = new SessionManager(fakeTimer, persistence);
+      try {
+        await expect(
+          gracefullyRestarted.admitIssuedSessionForAutomation("restarted-session"),
+        ).resolves.toBeUndefined();
+      } finally {
+        gracefullyRestarted.stopCleanupTimer();
+      }
     } finally {
       restarted.stopCleanupTimer();
     }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2736,4 +2736,46 @@ describe("SessionManager", () => {
       restarted.stopCleanupTimer();
     }
   });
+
+  test("preserves a terminal release discovered while admitting an unissued UUID", async () => {
+    const persisted: DeviceSession = {
+      session_uuid: "late-terminal-session",
+      device_id: "emulator-5554",
+      platform: "android",
+      status: "released",
+      source: null,
+      autolock_enabled: 0,
+      mcp_session_id: null,
+      daemon_session_id: "old-daemon",
+      created_at_ms: 1,
+      last_used_at_ms: 20,
+      expires_at_ms: 30,
+      released_at_ms: 25,
+      release_reason: "device-killed",
+      session_timeout_ms: 10,
+      heartbeat_timeout_ms: 5,
+      has_received_heartbeat: 1,
+      created_at: "2026-08-22T00:00:00.000Z",
+      updated_at: "2026-08-22T00:00:00.000Z",
+    };
+    let readCount = 0;
+    const persistence: DeviceSessionPersistence = {
+      async getSession() {
+        readCount += 1;
+        return readCount === 1 ? undefined : persisted;
+      },
+      async upsertActiveSession() {},
+      async recordActivity() {},
+      async markReleased() {},
+    };
+    const manager = new SessionManager(fakeTimer, persistence);
+
+    try {
+      await expect(
+        manager.admitIssuedSessionForAutomation("late-terminal-session"),
+      ).rejects.toThrow("terminal");
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
 });

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2619,6 +2619,54 @@ describe("SessionManager", () => {
     }
   });
 
+  test("admits a persisted daemon-restart session for recreation", async () => {
+    const persisted: DeviceSession = {
+      session_uuid: "restarted-session",
+      device_id: "emulator-5554",
+      platform: "android",
+      status: "expired",
+      source: null,
+      autolock_enabled: 0,
+      mcp_session_id: null,
+      daemon_session_id: "old-daemon",
+      created_at_ms: 1,
+      last_used_at_ms: 20,
+      expires_at_ms: 30,
+      released_at_ms: 25,
+      release_reason: "daemon-restart",
+      session_timeout_ms: 10,
+      heartbeat_timeout_ms: 5,
+      has_received_heartbeat: 1,
+      created_at: "2026-08-22T00:00:00.000Z",
+      updated_at: "2026-08-22T00:00:00.000Z",
+    };
+    const persistence: DeviceSessionPersistence = {
+      async getSession() {
+        return persisted;
+      },
+      async upsertActiveSession() {},
+      async recordActivity() {},
+      async markReleased() {},
+    };
+    const restarted = new SessionManager(fakeTimer, persistence);
+    const devicePool: SessionDeviceAssigner = {
+      async assignDeviceToSession(sessionId: string): Promise<string> {
+        await restarted.createSession(sessionId, "emulator-5560", "android");
+        return "emulator-5560";
+      },
+    };
+    try {
+      await expect(
+        restarted.admitIssuedSessionForAutomation("restarted-session"),
+      ).resolves.toBeUndefined();
+      await expect(
+        restarted.getOrCreateSession("restarted-session", devicePool, "android"),
+      ).resolves.toMatchObject({ assignedDevice: "emulator-5560" });
+    } finally {
+      restarted.stopCleanupTimer();
+    }
+  });
+
   test("terminal device-loss UUID remains fenced after manager restart", async () => {
     const persisted: DeviceSession = {
       session_uuid: "lost-session",

--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -4,7 +4,6 @@ import { promises as fsPromises } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
-import { defaultIdGenerator } from "../../src/utils/IdGenerator";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 
 const execFileAsync = promisify(execFile);
@@ -104,6 +103,19 @@ async function runVideoRecordingCli(
   );
 }
 
+async function acquireVideoRecordingSession(deviceId: string): Promise<string> {
+  const response = await runLocalCli(["getApple", "--deviceId", deviceId]);
+  const text = response.content?.find((item) => item.type === "text")?.text;
+  if (!text) {
+    throw new Error(`getApple response did not contain text JSON: ${JSON.stringify(response)}`);
+  }
+  const session = JSON.parse(text) as { sessionUuid?: unknown };
+  if (typeof session.sessionUuid !== "string" || session.sessionUuid.length === 0) {
+    throw new Error(`getApple did not return a session UUID: ${JSON.stringify(response)}`);
+  }
+  return session.sessionUuid;
+}
+
 async function bindVideoRecordingSession(sessionUuid: string, deviceId: string): Promise<void> {
   await runLocalCli([
     "--session-uuid",
@@ -181,7 +193,7 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
         if (!deviceId) {
           throw new Error("AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID is required");
         }
-        sessionUuid = defaultIdGenerator.next();
+        sessionUuid = await acquireVideoRecordingSession(deviceId);
         await bindVideoRecordingSession(sessionUuid, deviceId);
 
         startPayload = await runVideoRecordingCli(sessionUuid, [

--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -109,8 +109,12 @@ async function acquireVideoRecordingSession(deviceId: string): Promise<string> {
   if (!text) {
     throw new Error(`getApple response did not contain text JSON: ${JSON.stringify(response)}`);
   }
-  const session = JSON.parse(text) as { sessionUuid?: unknown };
-  if (typeof session.sessionUuid !== "string" || session.sessionUuid.length === 0) {
+  const session = JSON.parse(text) as { sessionUuid?: unknown } | null;
+  if (
+    !session ||
+    typeof session.sessionUuid !== "string" ||
+    session.sessionUuid.trim().length === 0
+  ) {
     throw new Error(`getApple did not return a session UUID: ${JSON.stringify(response)}`);
   }
   return session.sessionUuid;

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -165,23 +165,6 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(0);
   });
 
-  test("does not recreate an admitted session released before setup", async () => {
-    const admittedSession = await sessionManager.createSession("session-1", "device-1", "android");
-    await sessionManager.releaseSession("session-1", "explicit-release");
-
-    await expect(
-      createToolExecutionContext(
-        "session-1",
-        sessionManager,
-        devicePool,
-        sessionOptions,
-        undefined,
-        admittedSession,
-      ),
-    ).rejects.toThrow("Session session-1 was released during setup");
-    expect(sessionManager.getSession("session-1")).toBeNull();
-  });
-
   test("quarantines preserved reset-cohort session routing until recovery settles", async () => {
     const first: BootedDevice = {
       name: "Pixel_8_API_35",

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -344,6 +344,31 @@ describe("ToolExecutionContext", () => {
     await release;
   });
 
+  test("rechecks admission after setup releases its session", async () => {
+    const session = await sessionManager.createSession("session-releasing", "device-1", "android");
+    const trackSetup = spyOn(sessionManager, "trackSessionSetup").mockImplementation(
+      async (trackedSession, setup) => {
+        await setup();
+        await sessionManager.releaseSession(trackedSession.sessionId, "explicit-release");
+      },
+    );
+
+    try {
+      await expect(
+        createToolExecutionContext(
+          "session-releasing",
+          sessionManager,
+          devicePool,
+          sessionOptions,
+          undefined,
+          session,
+        ),
+      ).rejects.toThrow("released during setup");
+    } finally {
+      trackSetup.mockRestore();
+    }
+  });
+
   test("does not apply keep-awake after a session is released during setup", async () => {
     let allowActivityWrite!: () => void;
     const activityWrite = new Promise<void>((resolve) => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -165,6 +165,23 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(0);
   });
 
+  test("does not recreate an admitted session released before setup", async () => {
+    const admittedSession = await sessionManager.createSession("session-1", "device-1", "android");
+    await sessionManager.releaseSession("session-1", "explicit-release");
+
+    await expect(
+      createToolExecutionContext(
+        "session-1",
+        sessionManager,
+        devicePool,
+        sessionOptions,
+        undefined,
+        admittedSession,
+      ),
+    ).rejects.toThrow("Session session-1 was released during setup");
+    expect(sessionManager.getSession("session-1")).toBeNull();
+  });
+
   test("quarantines preserved reset-cohort session routing until recovery settles", async () => {
     const first: BootedDevice = {
       name: "Pixel_8_API_35",

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -315,6 +315,35 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(1);
   });
 
+  test("rejects an admitted session once its release begins", async () => {
+    const session = await sessionManager.createSession("session-releasing", "device-1", "android");
+    let finishSetup!: () => void;
+    const setup = sessionManager.trackSessionSetup(
+      session,
+      () =>
+        new Promise<void>((resolve) => {
+          finishSetup = resolve;
+        }),
+    );
+    const release = sessionManager.releaseSession("session-releasing");
+    await Promise.resolve();
+
+    await expect(
+      createToolExecutionContext(
+        "session-releasing",
+        sessionManager,
+        devicePool,
+        sessionOptions,
+        undefined,
+        session,
+      ),
+    ).rejects.toThrow("released during setup");
+
+    finishSetup();
+    await setup;
+    await release;
+  });
+
   test("does not apply keep-awake after a session is released during setup", async () => {
     let allowActivityWrite!: () => void;
     const activityWrite = new Promise<void>((resolve) => {

--- a/test/server/proxyServerTransportFailure.integration.test.ts
+++ b/test/server/proxyServerTransportFailure.integration.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import {
+  DeviceControlTransportError,
+  type DeviceControlTransportFailure,
+} from "../../src/daemon/deviceControlTransportFailure";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+describe("proxy server device-control transport errors", () => {
+  test("dispatches safe machine-readable transport failure details", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const failure: DeviceControlTransportFailure = {
+      code: "device_control_transport_failure",
+      transport: "daemon_loopback_http",
+      toolName: "launchApp",
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      routingSessionUuid: "session-a",
+      sessionValid: true,
+      deviceSessionValid: true,
+      phase: "response",
+      retryable: false,
+      reconnectAttempted: true,
+      replayAttempted: false,
+    };
+    const unsafeFailure = {
+      ...failure,
+      endpoint: "https://secret.invalid?token=hidden",
+    } as DeviceControlTransportFailure;
+    const fakeClient = new FakeDaemonClient({
+      onCallTool: () => {
+        throw new DeviceControlTransportError(
+          "Device-control transport closed while handling launchApp",
+          unsafeFailure,
+        );
+      },
+    });
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = {
+      ...daemonManager.statusResult,
+      version: DAEMON_VERSION,
+    };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        initialSessionUuid: "session-a",
+        clientFactory: () => fakeClient,
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "transport-failure-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const result = await client.callTool({
+        name: "launchApp",
+        arguments: { sessionUuid: "session-a", appId: "dev.example" },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                message: "Device-control transport closed while handling launchApp",
+                ...failure,
+              },
+            }),
+          },
+        ],
+        isError: true,
+      });
+      expect(JSON.stringify(result)).not.toContain("secret.invalid");
+    } finally {
+      await client.close();
+      await server.close();
+      await proxy.close();
+    }
+  });
+});

--- a/test/server/proxyServerTransportFailure.test.ts
+++ b/test/server/proxyServerTransportFailure.test.ts
@@ -1,26 +1,12 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { DaemonClient } from "../../src/daemon/client";
-import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { describe, expect, test } from "bun:test";
 import {
   DeviceControlTransportError,
   type DeviceControlTransportFailure,
 } from "../../src/daemon/deviceControlTransportFailure";
-import { createProxyMcpServer } from "../../src/server/proxyServer";
-import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
-import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
-
-let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
-
-afterEach(() => {
-  isAvailableSpy?.mockRestore();
-  isAvailableSpy = null;
-});
+import { deviceControlTransportFailureResult } from "../../src/server/proxyServer";
 
 describe("proxy server device-control transport errors", () => {
-  test("returns safe machine-readable transport failure details", async () => {
-    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+  test("returns safe machine-readable transport failure details", () => {
     const failure: DeviceControlTransportFailure = {
       code: "device_control_transport_failure",
       transport: "daemon_loopback_http",
@@ -40,57 +26,27 @@ describe("proxy server device-control transport errors", () => {
       ...failure,
       endpoint: "https://secret.invalid?token=hidden",
     } as DeviceControlTransportFailure;
-    const fakeClient = new FakeDaemonClient({
-      onCallTool: () => {
-        throw new DeviceControlTransportError(
-          "Device-control transport closed while handling launchApp",
-          unsafeFailure,
-        );
-      },
+    const result = deviceControlTransportFailureResult(
+      new DeviceControlTransportError(
+        "Device-control transport closed while handling launchApp",
+        unsafeFailure,
+      ),
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: {
+              message: "Device-control transport closed while handling launchApp",
+              ...failure,
+            },
+          }),
+        },
+      ],
+      isError: true,
     });
-    const daemonManager = new FakeDaemonManager();
-    daemonManager.statusResult = {
-      ...daemonManager.statusResult,
-      version: DAEMON_VERSION,
-    };
-    const { server, proxy } = createProxyMcpServer({
-      proxyConfig: {
-        clientFactory: () => fakeClient,
-        daemonManager,
-        autoStartDaemon: false,
-      },
-    });
-    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    const client = new Client({ name: "transport-failure-test-client", version: "0.0.1" });
-
-    try {
-      await server.connect(serverTransport);
-      await client.connect(clientTransport);
-
-      const result = await client.callTool({
-        name: "launchApp",
-        arguments: { sessionUuid: "session-a", appId: "dev.example" },
-      });
-
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              error: {
-                message: "Device-control transport closed while handling launchApp",
-                ...failure,
-              },
-            }),
-          },
-        ],
-        isError: true,
-      });
-      expect(JSON.stringify(result)).not.toContain("secret.invalid");
-    } finally {
-      await client.close();
-      await server.close();
-      await proxy.close();
-    }
+    expect(JSON.stringify(result)).not.toContain("secret.invalid");
   });
 });

--- a/test/server/sessionToolBindingFailedCall.integration.test.ts
+++ b/test/server/sessionToolBindingFailedCall.integration.test.ts
@@ -49,4 +49,36 @@ describe("session tool binding after failed calls", () => {
       tools: expect.arrayContaining([expect.objectContaining({ name: "bindingProbe" })]),
     });
   });
+
+  test("keeps the prior binding when an explicit session UUID call returns an error result", async () => {
+    const schema = z.object({ sessionUuid: z.string().optional() });
+    ToolRegistry.register("bindingProbe", "bindingProbe", schema, async () => ({ success: true }));
+    ToolRegistry.register("rejectSession", "rejectSession", schema, async () => ({
+      content: [{ type: "text" as const, text: "session rejected" }],
+      isError: true,
+    }));
+
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-a" },
+      sessionToolSelectionService: {
+        isEnabled: async (sessionUuid, toolName, declaredDefault) =>
+          toolName === "bindingProbe" && sessionUuid === "session-b" ? false : declaredDefault,
+      },
+    });
+    await fixture.setup();
+
+    await fixture.client.callTool({
+      name: "bindingProbe",
+      arguments: { sessionUuid: "session-a" },
+    });
+    const rejected = await fixture.client.callTool({
+      name: "rejectSession",
+      arguments: { sessionUuid: "session-b" },
+    });
+
+    expect(rejected.isError).toBe(true);
+    await expect(fixture.client.listTools()).resolves.toMatchObject({
+      tools: expect.arrayContaining([expect.objectContaining({ name: "bindingProbe" })]),
+    });
+  });
 });

--- a/test/server/sessionToolBindingFailedCall.integration.test.ts
+++ b/test/server/sessionToolBindingFailedCall.integration.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { ActionableError } from "../../src/models";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+
+describe("session tool binding after failed calls", () => {
+  let fixture: McpTestFixture | undefined;
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.teardown();
+      fixture = undefined;
+    }
+    ToolRegistry.clearTools();
+  });
+
+  test("keeps the prior binding when an explicit session UUID call is rejected", async () => {
+    const schema = z.object({ sessionUuid: z.string().optional() });
+    ToolRegistry.register("bindingProbe", "bindingProbe", schema, async () => ({ success: true }));
+    ToolRegistry.register("rejectSession", "rejectSession", schema, async () => {
+      throw new ActionableError("session rejected");
+    });
+
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-a" },
+      sessionToolSelectionService: {
+        isEnabled: async (sessionUuid, toolName, declaredDefault) =>
+          toolName === "bindingProbe" && sessionUuid === "session-b" ? false : declaredDefault,
+      },
+    });
+    await fixture.setup();
+
+    await fixture.client.callTool({
+      name: "bindingProbe",
+      arguments: { sessionUuid: "session-a" },
+    });
+    await expect(
+      fixture.client.callTool({
+        name: "rejectSession",
+        arguments: { sessionUuid: "session-b" },
+      }),
+    ).rejects.toThrow("session rejected");
+    await expect(fixture.client.listTools()).resolves.toMatchObject({
+      tools: expect.arrayContaining([expect.objectContaining({ name: "bindingProbe" })]),
+    });
+  });
+});

--- a/test/server/sessionToolBindingFailedCall.integration.test.ts
+++ b/test/server/sessionToolBindingFailedCall.integration.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { ActionableError } from "../../src/models";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 
@@ -9,6 +13,12 @@ describe("session tool binding after failed calls", () => {
 
   beforeEach(() => {
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
+    registerDirectSessionDevice("session-a", {
+      deviceId: "emulator-5554",
+      name: "Pixel_9_API_36",
+      platform: "android",
+    });
   });
 
   afterEach(async () => {
@@ -17,6 +27,7 @@ describe("session tool binding after failed calls", () => {
       fixture = undefined;
     }
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
   });
 
   test("keeps the prior binding when an explicit session UUID call is rejected", async () => {
@@ -77,6 +88,36 @@ describe("session tool binding after failed calls", () => {
     });
 
     expect(rejected.isError).toBe(true);
+    await expect(fixture.client.listTools()).resolves.toMatchObject({
+      tools: expect.arrayContaining([expect.objectContaining({ name: "bindingProbe" })]),
+    });
+  });
+
+  test("does not bind an unadmitted UUID that an unscoped tool ignores", async () => {
+    const schema = z.object({ sessionUuid: z.string().optional() });
+    ToolRegistry.register("bindingProbe", "bindingProbe", schema, async () => ({ success: true }));
+    ToolRegistry.register("unscopedSuccess", "unscopedSuccess", z.object({}), async () => ({
+      success: true,
+    }));
+
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-a" },
+      sessionToolSelectionService: {
+        isEnabled: async (sessionUuid, toolName, declaredDefault) =>
+          toolName === "bindingProbe" && sessionUuid === "session-b" ? false : declaredDefault,
+      },
+    });
+    await fixture.setup();
+
+    await fixture.client.callTool({
+      name: "bindingProbe",
+      arguments: { sessionUuid: "session-a" },
+    });
+    await fixture.client.callTool({
+      name: "unscopedSuccess",
+      arguments: { sessionUuid: "session-b" },
+    });
+
     await expect(fixture.client.listTools()).resolves.toMatchObject({
       tools: expect.arrayContaining([expect.objectContaining({ name: "bindingProbe" })]),
     });

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -193,6 +193,48 @@ describe("ToolRegistry autolock session enforcement", () => {
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
   });
 
+  test("rejects an unknown session UUID before it can access an owned device", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    await pool.initializeWithDevices([androidA, androidB]);
+    await pool.bindOrReuseDeviceSession("owner-session", androidA.deviceId, "android");
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    let handlerCalls = 0;
+    ToolRegistry.registerDeviceAware(
+      "unknownSessionUuid",
+      "unknownSessionUuid",
+      schema,
+      async () => {
+        handlerCalls += 1;
+        return { success: true };
+      },
+    );
+    const tool = ToolRegistry.getTool("unknownSessionUuid")!;
+
+    for (const sessionUuid of ["banana", "00000000-0000-4000-8000-000000000000"]) {
+      await expect(
+        tool.handler({
+          platform: "android",
+          deviceId: androidA.deviceId,
+          sessionUuid,
+        }),
+      ).rejects.toThrow("not an active daemon session");
+      expect(daemonSessionManager.getSession(sessionUuid)).toBeNull();
+    }
+    expect(handlerCalls).toBe(0);
+    expect(pool.getDevice(androidA.deviceId)?.sessionId).toBe("owner-session");
+  });
+
   test("resolves the MCP autolock session when the provided deviceId belongs to it", async () => {
     setAutolock(true);
     fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -228,7 +228,7 @@ describe("ToolRegistry autolock session enforcement", () => {
           deviceId: androidA.deviceId,
           sessionUuid,
         }),
-      ).rejects.toThrow("Unknown device session UUID");
+      ).rejects.toThrow("not an active daemon session");
       expect(daemonSessionManager.getSession(sessionUuid)).toBeNull();
     }
     expect(handlerCalls).toBe(0);

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -228,7 +228,7 @@ describe("ToolRegistry autolock session enforcement", () => {
           deviceId: androidA.deviceId,
           sessionUuid,
         }),
-      ).rejects.toThrow("not an active daemon session");
+      ).rejects.toThrow("Unknown device session UUID");
       expect(daemonSessionManager.getSession(sessionUuid)).toBeNull();
     }
     expect(handlerCalls).toBe(0);


### PR DESCRIPTION
## Summary

Reject unissued `sessionUuid` values before device resolution in daemon mode. This prevents a fabricated or malformed identifier from reaching a device owned by a live session.

## Linked Issue

Closes [#6019](https://github.com/kaeawc/auto-mobile/issues/6019)

## Bug / Regression Context

- **Prior attempts:** Session-terminal handling rejected IDs that had been legitimately issued then released, but never rejected identifiers that had never been issued.
- **Observed symptom:** An unissued ID could be routed with an explicit `deviceId`, including to a device already owned by another session.
- **Repro steps / conditions:** Acquire an Android device, then invoke a device-aware tool with that device ID and either `sessionUuid: "banana"` or a fabricated UUID.

## Validation

- [x] Targeted ownership regression: `bun test test/server/toolRegistry.autolockSession.test.ts`
- [x] Full unit suite: `AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS=600 bun run test`
- [x] `bun run typecheck` reports no new errors
- [x] `AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS=600 bun run turbo:validate`
- [x] New code uses existing session manager interfaces and fakes
- [x] No new dependency or generic helper
- [x] Rebased onto latest `main`

## Follow-ups

- [x] None
