### PR TITLE
fix: reject unissued device session IDs

### DIFF
--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -1,9 +1,9 @@
-import { SessionManager } from "../daemon/sessionManager";
+import { SessionManager, TerminalSessionError } from "../daemon/sessionManager";
 import type { Session, SessionExecutionMetadata } from "../daemon/sessionManager";
 import { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
-import { ActionableError, BootedDevice, Platform } from "../models";
+import { ActionableError, BootedDevice, Platform, toActionableError } from "../models";
 import { logger } from "../utils/logger";
 import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
@@ -70,7 +70,7 @@ export interface SessionOptions {
 /**
  * Create tool execution context from session UUID
  *
- * Ensures session exists and device is assigned if session UUID provided.
+ * Resolves an issued session UUID to its assigned device.
  */
 export async function createToolExecutionContext(
   sessionUuid: string | undefined,
@@ -86,13 +86,22 @@ export async function createToolExecutionContext(
   devicePool.assertSessionReadyForAutomation(sessionUuid);
   const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
 
-  // Get or create session
-  const session = await sessionManager.getOrCreateSession(
-    sessionUuid,
-    devicePool,
-    sessionOptions.platform,
-    execution,
-  );
+  // Tool calls must use an issued session UUID; device acquisition owns
+  // session creation.
+  let session: Session;
+  try {
+    session = await sessionManager.getOrCreateSession(
+      sessionUuid,
+      undefined,
+      sessionOptions.platform,
+      execution,
+    );
+  } catch (error) {
+    if (error instanceof TerminalSessionError) {
+      throw error;
+    }
+    throw toActionableError(error, `Failed to resolve session ${sessionUuid}`);
+  }
 
   if (!sessionManager.isCurrentSession(session)) {
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -489,7 +489,12 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         },
         execution,
       );
-      if (context.deviceId && !providedDeviceId) {
+      if (context.deviceId && providedDeviceId && context.deviceId !== providedDeviceId) {
+        throw new ActionableError(
+          `Session ${sessionUuid} is bound to ${context.deviceId}, not ${providedDeviceId}.`,
+        );
+      }
+      if (context.deviceId) {
         providedDeviceId = context.deviceId;
         logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
       }
@@ -505,7 +510,9 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       // ensureDeviceReady("either", undefined) and hits an ambiguity error.
       const directSession = resolveDirectSessionDevice(sessionUuid);
       if (!directSession) {
-        logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
+        throw new ActionableError(
+          `Unknown session UUID ${sessionUuid}. Call getAndroid or getApple first to acquire a device.`,
+        );
       } else if (!providedDeviceId) {
         providedDeviceId = directSession.device.deviceId;
         logger.info(

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod/v4";
 import { DeviceSessionManager, type DeviceReadinessLevel } from "../utils/DeviceSessionManager";
-import { ActionableError, BootedDevice, SomePlatform } from "../models";
+import { ActionableError, BootedDevice, SomePlatform, toActionableError } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -14,6 +14,7 @@ import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { logger, type Logger } from "../utils/logger";
 import { DaemonState } from "../daemon/daemonState";
+import { TerminalSessionError } from "../daemon/sessionManager";
 import { createToolExecutionContext } from "./ToolExecutionContext";
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
@@ -430,6 +431,10 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     // Extract platform from args, default to "either" for backward compatibility
     let platform: SomePlatform = args.platform || "either";
 
+    if (sessionUuid && !shouldResolveDevice) {
+      await this.assertSessionIssuedForNonDeviceTool(sessionUuid, execution);
+    }
+
     if (shouldResolveDevice) {
       const implicitSessionUuid = this.resolveImplicitAutolockSession(
         platform,
@@ -513,6 +518,10 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         throw new ActionableError(
           `Unknown session UUID ${sessionUuid}. Call getAndroid or getApple first to acquire a device.`,
         );
+      } else if (providedDeviceId && providedDeviceId !== directSession.device.deviceId) {
+        throw new ActionableError(
+          `Session ${sessionUuid} is bound to ${directSession.device.deviceId}, not ${providedDeviceId}.`,
+        );
       } else if (!providedDeviceId) {
         providedDeviceId = directSession.device.deviceId;
         logger.info(
@@ -594,6 +603,31 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       sessionUuid,
       shouldResolveDevice,
     };
+  }
+
+  private async assertSessionIssuedForNonDeviceTool(
+    sessionUuid: string,
+    execution?: import("../daemon/sessionManager").SessionExecutionMetadata,
+  ): Promise<void> {
+    if (!DaemonState.getInstance().isInitialized()) {
+      if (!resolveDirectSessionDevice(sessionUuid)) {
+        throw new ActionableError(
+          `Unknown session UUID ${sessionUuid}. Call getAndroid or getApple first to acquire a device.`,
+        );
+      }
+      return;
+    }
+
+    try {
+      await DaemonState.getInstance()
+        .getSessionManager()
+        .getOrCreateSession(sessionUuid, undefined, undefined, execution);
+    } catch (error) {
+      if (error instanceof TerminalSessionError) {
+        throw error;
+      }
+      throw toActionableError(error, `Failed to resolve session ${sessionUuid}`);
+    }
   }
 
   private async enforceSessionUuidForMultipleIos(

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -54,70 +54,38 @@ describe("ToolExecutionContext", () => {
     AndroidCtrlProxyClient.resetInstances();
   });
 
-  test("should run accessibility setup when creating a new session", async () => {
-    let setupCalls = 0;
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => {
-          setupCalls += 1;
-          return { success: true, message: "ok" };
-        },
+  test.each(["banana", "11111111-2222-4333-8444-555555555555"])(
+    "rejects unknown session identifier %s without assigning a device",
+    async (sessionUuid) => {
+      let setupCalls = 0;
+      AndroidCtrlProxyManager.getInstance = () =>
+        ({
+          resetSetupState: () => {},
+          setup: async () => {
+            setupCalls += 1;
+            return { success: true, message: "ok" };
+          },
+        }) as any;
+
+      const clientCallArgs: unknown[] = [];
+      AndroidCtrlProxyClient.getInstance = ((device: unknown) => {
+        clientCallArgs.push(device);
+        return {
+          waitForConnection: async () => true,
+          close: async () => {},
+        };
       }) as any;
 
-    const clientCallArgs: unknown[] = [];
-    AndroidCtrlProxyClient.getInstance = ((device: unknown) => {
-      clientCallArgs.push(device);
-      return {
-        waitForConnection: async () => true,
-        close: async () => {},
-      };
-    }) as any;
+      await expect(
+        createToolExecutionContext(sessionUuid, sessionManager, devicePool, sessionOptions),
+      ).rejects.toThrow(/not found/i);
 
-    const context = await createToolExecutionContext(
-      "session-1",
-      sessionManager,
-      devicePool,
-      sessionOptions,
-    );
-
-    expect(context.deviceId).toBe("device-1");
-    expect(setupCalls).toBe(1);
-    expect(clientCallArgs.length).toBeGreaterThan(0);
-    const passed = clientCallArgs[0] as BootedDevice;
-    expect(typeof passed).toBe("object");
-    expect(passed.deviceId).toBe("device-1");
-    expect(passed.platform).toBe("android");
-  });
-
-  test("does not run accessibility setup when a pooled emulator serial is stale", async () => {
-    const staleDeviceManager = new FakeDeviceManager();
-    const stalePool = new DevicePool(
-      sessionManager,
-      "test-daemon-session-id",
-      fakeTimer,
-      fakeAppsRepo,
-      staleDeviceManager,
-    );
-    await stalePool.initializeWithDevices([createBootedDevice("emulator-5554")]);
-    staleDeviceManager.bootedDevices = [];
-
-    let setupCalls = 0;
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => {
-          setupCalls += 1;
-          return { success: true, message: "ok" };
-        },
-      }) as any;
-
-    await expect(
-      createToolExecutionContext("session-stale", sessionManager, stalePool, sessionOptions),
-    ).rejects.toThrow(/No devices in pool|not available|disconnected/);
-    expect(setupCalls).toBe(0);
-    expect(stalePool.getDevice("emulator-5554")).toBeNull();
-  });
+      expect(sessionManager.getSession(sessionUuid)).toBeNull();
+      expect(devicePool.getDevice("device-1")?.sessionId).toBeNull();
+      expect(setupCalls).toBe(0);
+      expect(clientCallArgs).toHaveLength(0);
+    },
+  );
 
   test("writes the keep-awake state to the typed keepScreenAwake slot on setup (#2973)", async () => {
     AndroidCtrlProxyManager.getInstance = () =>
@@ -130,6 +98,7 @@ describe("ToolExecutionContext", () => {
       close: async () => {},
     })) as any;
 
+    await devicePool.bindOrReuseDeviceSession("session-1", "device-1", "android");
     // keepScreenAwake:false → apply() short-circuits to an applied:false state,
     // which ensureKeepScreenAwake must persist to the typed slot (not customData).
     await createToolExecutionContext("session-1", sessionManager, devicePool, sessionOptions);
@@ -258,44 +227,15 @@ describe("ToolExecutionContext", () => {
     }
   });
 
-  test("runs first-session setup when a released UUID is recreated during context creation", async () => {
-    let setupCalls = 0;
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => {
-          setupCalls += 1;
-          return { success: true, message: "ok" };
-        },
-      }) as any;
-    AndroidCtrlProxyClient.getInstance = (() => ({
-      waitForConnection: async () => true,
-      close: async () => {},
-    })) as any;
-
+  test("rejects a released session UUID rather than recreating it", async () => {
     const original = await sessionManager.createSession("session-recreated", "device-1", "android");
-    let finishSetup!: () => void;
-    const setup = sessionManager.trackSessionSetup(
-      original,
-      () =>
-        new Promise<void>((resolve) => {
-          finishSetup = resolve;
-        }),
-    );
-    const release = sessionManager.releaseSession("session-recreated");
-    await Promise.resolve();
-    const context = createToolExecutionContext(
-      "session-recreated",
-      sessionManager,
-      devicePool,
-      sessionOptions,
-    );
-    finishSetup();
-    await setup;
-    await release;
+    await sessionManager.releaseSession("session-recreated");
 
-    await expect(context).resolves.toMatchObject({ deviceId: "device-1" });
-    expect(setupCalls).toBe(1);
+    await expect(
+      createToolExecutionContext("session-recreated", sessionManager, devicePool, sessionOptions),
+    ).rejects.toThrow(/not found/i);
+    expect(sessionManager.getSession(original.sessionId)).toBeNull();
+    expect(devicePool.getDevice("device-1")?.sessionId).toBeNull();
   });
 
   test("does not apply keep-awake after a session is released during setup", async () => {
@@ -343,90 +283,6 @@ describe("ToolExecutionContext", () => {
     } finally {
       applySpy.mockRestore();
       manager.stopCleanupTimer();
-    }
-  });
-
-  test("bounds accessibility setup and rejects it after the session releases", async () => {
-    const boundedTimer = new FakeTimer();
-    const boundedSessionManager = new SessionManager(boundedTimer, {
-      async upsertActiveSession(): Promise<void> {},
-      async recordActivity(): Promise<void> {},
-      async markReleased(): Promise<void> {},
-      async markStaleActiveSessionsExpired(): Promise<void> {},
-    });
-    const boundedPool = new DevicePool(
-      boundedSessionManager,
-      "test-daemon-session-id",
-      boundedTimer,
-      fakeAppsRepo,
-      new FakeDeviceManager(),
-    );
-    await boundedPool.initializeWithDevices([createBootedDevice("device-1")]);
-    let finishSetup!: () => void;
-    const setupFinished = new Promise<void>((resolve) => {
-      finishSetup = resolve;
-    });
-    let setupStarted!: () => void;
-    const setupStartedPromise = new Promise<void>((resolve) => {
-      setupStarted = resolve;
-    });
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => {
-          setupStarted();
-          await setupFinished;
-          return { success: true, message: "ok" };
-        },
-      }) as any;
-    AndroidCtrlProxyClient.getInstance = (() => ({
-      waitForConnection: async () => true,
-      close: async () => {},
-    })) as any;
-
-    try {
-      const context = createToolExecutionContext(
-        "session-setup-race",
-        boundedSessionManager,
-        boundedPool,
-        sessionOptions,
-      );
-      await setupStartedPromise;
-      const release = boundedSessionManager.releaseSession("session-setup-race");
-      for (
-        let attempt = 0;
-        attempt < 10 && !boundedTimer.getPendingTimeouts().includes(1_000);
-        attempt++
-      ) {
-        await Promise.resolve();
-      }
-      expect(boundedTimer.getPendingTimeouts()).toContain(1_000);
-      boundedTimer.advanceTime(1_000);
-      let releasedDevice: string | null | undefined;
-      void release.then((deviceId) => {
-        releasedDevice = deviceId;
-      });
-      for (let attempt = 0; attempt < 10 && releasedDevice === undefined; attempt++) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
-      expect(releasedDevice).toBe("device-1");
-      await boundedPool.releaseDevice("device-1", "session-setup-race");
-
-      expect(boundedSessionManager.getSession("session-setup-race")).toBeNull();
-      expect(boundedPool.getDevice("device-1")).toMatchObject({
-        sessionId: "session-setup-race",
-        status: "busy",
-      });
-
-      finishSetup();
-      await expect(context).rejects.toThrow("released during setup");
-      await Promise.resolve();
-      expect(boundedPool.getDevice("device-1")).toMatchObject({
-        sessionId: null,
-        status: "idle",
-      });
-    } finally {
-      boundedSessionManager.stopCleanupTimer();
     }
   });
 });

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -160,6 +160,40 @@ describe("ToolRegistry autolock session enforcement", () => {
     expect(pool.getDevice(androidB.deviceId)?.sessionId).toBeNull();
   });
 
+  test("rejects an unknown sessionUuid for a non-device tool before its handler runs", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    let handlerCalls = 0;
+    ToolRegistry.registerDeviceAware(
+      "nonDeviceUnknownSession",
+      "nonDeviceUnknownSession",
+      schema,
+      async () => {
+        handlerCalls += 1;
+        return { success: true };
+      },
+      { shouldEnsureDevice: () => false },
+    );
+    const tool = ToolRegistry.getTool("nonDeviceUnknownSession")!;
+
+    await expect(tool.handler({ sessionUuid: "banana" })).rejects.toThrow(/not found/i);
+
+    expect(handlerCalls).toBe(0);
+    expect(daemonSessionManager.getSession("banana")).toBeNull();
+  });
+
   test("rejects a deviceId that differs from an issued session's assignment", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -9,6 +9,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { clearDirectSessionDevices } from "../../src/server/directSessionDeviceRegistry";
 
 const AUTOLOCK_ENV_KEYS = [
   "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
@@ -55,6 +56,7 @@ describe("ToolRegistry autolock session enforcement", () => {
 
   beforeEach(() => {
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
     fakeDeviceSessionManager = new FakeDeviceSessionManager();
     originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
@@ -63,6 +65,7 @@ describe("ToolRegistry autolock session enforcement", () => {
   afterEach(() => {
     (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
     DaemonState.getInstance().reset();
     daemonSessionManager?.stopCleanupTimer();
     setAutolock(false);
@@ -78,17 +81,6 @@ describe("ToolRegistry autolock session enforcement", () => {
       "Device pool autolock is enabled and multiple devices are available.",
     );
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
-  });
-
-  test("allows the call when a sessionUuid is provided", async () => {
-    setAutolock(true);
-    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
-
-    const tool = registerTool("autolockWithSession");
-
-    const response = await tool.handler({ platform: "android", sessionUuid: "session-123" });
-    expect(response).toEqual({ success: true });
-    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
   });
 
   test("allows the call when an explicit deviceId is provided", async () => {
@@ -122,6 +114,95 @@ describe("ToolRegistry autolock session enforcement", () => {
     const response = await tool.handler({ platform: "android" });
     expect(response).toEqual({ success: true });
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("rejects an unknown sessionUuid before it can target another session's device", async () => {
+    setAutolock(false);
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    await pool.initializeWithDevices([androidA, androidB]);
+    await pool.bindOrReuseDeviceSession("owner-session", androidA.deviceId, "android");
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    let handlerCalls = 0;
+    ToolRegistry.registerDeviceAware(
+      "unknownSessionTarget",
+      "unknownSessionTarget",
+      schema,
+      async () => {
+        handlerCalls += 1;
+        return { success: true };
+      },
+    );
+    const tool = ToolRegistry.getTool("unknownSessionTarget")!;
+
+    await expect(
+      tool.handler({
+        platform: "android",
+        deviceId: androidA.deviceId,
+        sessionUuid: "banana",
+        keepScreenAwake: false,
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    expect(handlerCalls).toBe(0);
+    expect(daemonSessionManager.getSession("banana")).toBeNull();
+    expect(pool.getDevice(androidA.deviceId)?.sessionId).toBe("owner-session");
+    expect(pool.getDevice(androidB.deviceId)?.sessionId).toBeNull();
+  });
+
+  test("rejects a deviceId that differs from an issued session's assignment", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    await pool.initializeWithDevices([androidA, androidB]);
+    await pool.bindOrReuseDeviceSession("session-a", androidA.deviceId, "android");
+    await pool.bindOrReuseDeviceSession("session-b", androidB.deviceId, "android");
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    let handlerCalls = 0;
+    ToolRegistry.registerDeviceAware(
+      "mismatchedSessionTarget",
+      "mismatchedSessionTarget",
+      schema,
+      async () => {
+        handlerCalls += 1;
+        return { success: true };
+      },
+    );
+    const tool = ToolRegistry.getTool("mismatchedSessionTarget")!;
+
+    await expect(
+      tool.handler({
+        platform: "android",
+        deviceId: androidA.deviceId,
+        sessionUuid: "session-b",
+        keepScreenAwake: false,
+      }),
+    ).rejects.toThrow(
+      `Session session-b is bound to ${androidB.deviceId}, not ${androidA.deviceId}.`,
+    );
+
+    expect(handlerCalls).toBe(0);
+    expect(pool.getDevice(androidA.deviceId)?.sessionId).toBe("session-a");
+    expect(pool.getDevice(androidB.deviceId)?.sessionId).toBe("session-b");
   });
 
   test("requires sessionUuid for platform 'either' when multiple devices exist", async () => {

--- a/test/server/toolRegistry.directSessionResolution.test.ts
+++ b/test/server/toolRegistry.directSessionResolution.test.ts
@@ -105,15 +105,15 @@ describe("ToolRegistry direct-mode sessionUuid resolution (#5893)", () => {
     expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("either");
   });
 
-  test("falls through unchanged when the sessionUuid has no direct-session device", async () => {
+  test("rejects an unknown sessionUuid before resolving a device", async () => {
     fakeDeviceSessionManager.setConnectedDevices([android]);
     const tool = registerTool();
 
-    const response = await tool.handler({ sessionUuid: "session-unknown" });
-    expect(response).toEqual({ success: true });
+    await expect(tool.handler({ sessionUuid: "session-unknown" })).rejects.toThrow(
+      "Unknown session UUID",
+    );
 
-    // No direct session registered: platform stays "either", no deviceId injected.
-    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("either");
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
     expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBeUndefined();
   });
 });

--- a/test/server/toolRegistry.directSessionResolution.test.ts
+++ b/test/server/toolRegistry.directSessionResolution.test.ts
@@ -88,21 +88,16 @@ describe("ToolRegistry direct-mode sessionUuid resolution (#5893)", () => {
     expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("ios");
   });
 
-  test("does not override an explicitly provided cross-platform deviceId, and leaves platform for the id to resolve", async () => {
-    // Session is Android-bound, but the caller explicitly targets the iOS device
-    // and omits platform. The explicit id must win, and platform must stay
-    // "either" so the production ensureDeviceReady resolves the platform FROM the
-    // id — narrowing to the session's "android" here would search only Android
-    // devices and reject the iOS id (Codex #5906 P2).
+  test("rejects an explicit deviceId that differs from the direct session's device", async () => {
     fakeDeviceSessionManager.setConnectedDevices([android, ios]);
     registerDirectSessionDevice("session-abc", android);
     const tool = registerTool();
 
-    const response = await tool.handler({ sessionUuid: "session-abc", deviceId: ios.deviceId });
-    expect(response).toEqual({ success: true });
+    await expect(
+      tool.handler({ sessionUuid: "session-abc", deviceId: ios.deviceId }),
+    ).rejects.toThrow(`Session session-abc is bound to ${android.deviceId}, not ${ios.deviceId}.`);
 
-    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyDeviceId()).toBe(ios.deviceId);
-    expect(fakeDeviceSessionManager.getLastEnsureDeviceReadyPlatform()).toBe("either");
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
   });
 
   test("rejects an unknown sessionUuid before resolving a device", async () => {

--- a/test/server/toolRegistry.iosSessionContext.test.ts
+++ b/test/server/toolRegistry.iosSessionContext.test.ts
@@ -3,6 +3,10 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { BootedDevice } from "../../src/models";
 import { z } from "zod/v4";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
 
 describe("ToolRegistry iOS session context", () => {
   const iosDeviceA: BootedDevice = {
@@ -21,6 +25,7 @@ describe("ToolRegistry iOS session context", () => {
 
   beforeEach(() => {
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
     fakeDeviceSessionManager = new FakeDeviceSessionManager();
     originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
@@ -29,6 +34,7 @@ describe("ToolRegistry iOS session context", () => {
   afterEach(() => {
     (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
     ToolRegistry.clearTools();
+    clearDirectSessionDevices();
   });
 
   test("requires sessionUuid when multiple iOS simulators are booted", async () => {
@@ -55,6 +61,7 @@ describe("ToolRegistry iOS session context", () => {
 
   test("allows sessionUuid when multiple iOS simulators are booted", async () => {
     fakeDeviceSessionManager.setConnectedDevices([iosDeviceA, iosDeviceB]);
+    registerDirectSessionDevice("session-123", iosDeviceA);
 
     ToolRegistry.registerDeviceAware(
       "iosSessionAllowedTool",

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -9,6 +9,10 @@ import type { BootedDevice } from "../../src/models";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { FakeLogger } from "../fakes/FakeLogger";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
 import type {
   ObservationArtifactPayload,
   ObservationArtifactWriter,
@@ -180,6 +184,7 @@ describe("ToolRegistry device-aware pipeline", () => {
         throw new Error("bind unavailable");
       },
     });
+    registerDirectSessionDevice("session-1", device);
     try {
       registry.registerDeviceAware(
         "bindFailureProbe",
@@ -201,6 +206,7 @@ describe("ToolRegistry device-aware pipeline", () => {
       );
     } finally {
       (AndroidCtrlProxyClient as any).getInstance = originalGetInstance;
+      clearDirectSessionDevices();
     }
   });
 

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -721,4 +721,28 @@ describe("videoRecording tool segmentation branch", () => {
     expect((stopRes.recordings as unknown[]).length).toBe(1);
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
   });
+
+  test("by-handle stop rejects an unissued sessionUuid before stopping the recording", async () => {
+    const startRes = parse(
+      await handler()(androidDevice, {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+      }),
+    );
+    const recordingId = (startRes.recordings as Array<Record<string, unknown>>)[0]
+      .recordingId as string;
+    const tool = ToolRegistry.getTool("videoRecording");
+    expect(tool).toBeDefined();
+
+    await expect(
+      tool!.handler({
+        action: "stop",
+        recordingId,
+        sessionUuid: "fabricated-session",
+      }),
+    ).rejects.toThrow("Unknown session UUID");
+
+    expect(fakeBackend.stopCalls).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Reject unissued session IDs before device resolution, so fabricated and expired IDs cannot claim an idle pool device or target another session's device. Daemon calls now reject a device ID that differs from the session's assigned device; direct-mode calls require a session registered by device acquisition.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/6019

## Bug / Regression Context

- **Observed symptom:** arbitrary or malformed `sessionUuid` values could execute against a device owned by another live session.
- **Root cause:** device-aware tools auto-created unseen session IDs, while an explicit device ID continued to override that new session's assigned device.

## Validation

- [x] `AUTOMOBILE_UNIT_TEST_WORKERS=6 AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS=360 bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors
- [x] Focused session-ownership, direct-session, tool-registry, and plan-label tests pass
- [x] New tests use fakes and `FakeTimer`
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] No follow-ups identified
