### PR TITLE
fix: return failure exit codes for MCP tool errors

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -538,11 +538,7 @@ async function handleDoctorResult(result: any, jsonOutput: boolean): Promise<voi
   }
 }
 
-function handleToolResult(result: any, toolName: string): void {
-  console.log(JSON.stringify(result, null, 2));
-
-  // Check if the result indicates failure and exit with code 1
-  // Handle both direct result format and MCP content format
+function cliToolResultPayload(result: any): any {
   let actualResult = result;
   if (
     result &&
@@ -560,8 +556,21 @@ function handleToolResult(result: any, toolName: string): void {
       }
     }
   }
+  return actualResult;
+}
 
-  if (actualResult && typeof actualResult === "object" && actualResult.success === false) {
+export function isCliToolFailure(result: any): boolean {
+  return result?.isError === true || cliToolResultPayload(result)?.success === false;
+}
+
+function handleToolResult(result: any, toolName: string): void {
+  console.log(JSON.stringify(result, null, 2));
+
+  // MCP tool errors use the top-level `isError` flag, while older daemon
+  // responses encode their failure in the JSON payload.
+  const actualResult = cliToolResultPayload(result);
+
+  if (isCliToolFailure(result)) {
     // Write error message to STDERR
     if (actualResult.error) {
       console.error(actualResult.error);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -574,10 +574,20 @@ function handleToolResult(result: any, toolName: string): void {
     // Write error message to STDERR
     if (actualResult.error) {
       console.error(actualResult.error);
+    } else if (
+      result?.isError === true &&
+      Array.isArray(result.content) &&
+      result.content[0]?.type === "text"
+    ) {
+      console.error(result.content[0].text);
     }
 
-    // Special handling for executePlan tool
-    if (toolName === "executePlan") {
+    // Plan progress is only available in structured executePlan failures.
+    if (
+      toolName === "executePlan" &&
+      typeof actualResult.executedSteps === "number" &&
+      typeof actualResult.totalSteps === "number"
+    ) {
       console.error(`Executed ${actualResult.executedSteps} of ${actualResult.totalSteps} steps`);
       if (actualResult.failedStep) {
         console.error(

--- a/test/cli/toolResultFailure.test.ts
+++ b/test/cli/toolResultFailure.test.ts
@@ -8,9 +8,11 @@ import {
 
 describe("isCliToolFailure (issue #6017)", () => {
   const originalProcessExit = process.exit;
+  const originalConsoleError = console.error;
 
   afterEach(() => {
     process.exit = originalProcessExit;
+    console.error = originalConsoleError;
     resetDaemonProxyFactoryForTesting();
   });
 
@@ -58,11 +60,15 @@ describe("isCliToolFailure (issue #6017)", () => {
     ).toBe(true);
   });
 
-  test("exits non-zero for an MCP error response", async () => {
+  test("prints an MCP error without executePlan diagnostics and exits non-zero", async () => {
     const exitCodes: number[] = [];
+    const errorMessages: unknown[][] = [];
     process.exit = ((code?: number) => {
       exitCodes.push(code ?? 0);
     }) as typeof process.exit;
+    console.error = ((...args: unknown[]) => {
+      errorMessages.push(args);
+    }) as typeof console.error;
     setDaemonProxyFactoryForTesting((): any => ({
       callTool: async () => ({
         content: [{ type: "text", text: "MCP error -32001: Request timed out" }],
@@ -73,8 +79,9 @@ describe("isCliToolFailure (issue #6017)", () => {
       },
     }));
 
-    await runCliCommand(["observe"]);
+    await runCliCommand(["executePlan"]);
 
     expect(exitCodes).toEqual([1]);
+    expect(errorMessages).toEqual([["MCP error -32001: Request timed out"]]);
   });
 });

--- a/test/cli/toolResultFailure.test.ts
+++ b/test/cli/toolResultFailure.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  isCliToolFailure,
+  resetDaemonProxyFactoryForTesting,
+  runCliCommand,
+  setDaemonProxyFactoryForTesting,
+} from "../../src/cli";
+
+describe("isCliToolFailure (issue #6017)", () => {
+  const originalProcessExit = process.exit;
+
+  afterEach(() => {
+    process.exit = originalProcessExit;
+    resetDaemonProxyFactoryForTesting();
+  });
+
+  test("recognizes an in-band session ownership error envelope", () => {
+    expect(
+      isCliToolFailure({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                code: "session_ownership_lost",
+                message: "Session ownership lost for session-123: heartbeat-timeout",
+              },
+            }),
+          },
+        ],
+        isError: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("recognizes an MCP protocol error response", () => {
+    expect(
+      isCliToolFailure({
+        content: [{ type: "text", text: "MCP error -32001: Request timed out" }],
+        isError: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps successful responses successful", () => {
+    expect(
+      isCliToolFailure({
+        content: [{ type: "text", text: JSON.stringify({ success: true }) }],
+      }),
+    ).toBe(false);
+  });
+
+  test("preserves legacy success false response detection", () => {
+    expect(
+      isCliToolFailure({
+        content: [{ type: "text", text: JSON.stringify({ success: false }) }],
+      }),
+    ).toBe(true);
+  });
+
+  test("exits non-zero for an MCP error response", async () => {
+    const exitCodes: number[] = [];
+    process.exit = ((code?: number) => {
+      exitCodes.push(code ?? 0);
+    }) as typeof process.exit;
+    setDaemonProxyFactoryForTesting((): any => ({
+      callTool: async () => ({
+        content: [{ type: "text", text: "MCP error -32001: Request timed out" }],
+        isError: true,
+      }),
+      close: async (): Promise<void> => {
+        // no-op fake
+      },
+    }));
+
+    await runCliCommand(["observe"]);
+
+    expect(exitCodes).toEqual([1]);
+  });
+});

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -20,7 +20,7 @@ import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { getAbortSignal, runWithAbortSignal } from "../../src/utils/AbortContext";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
-import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
 import { executionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";


### PR DESCRIPTION
## Summary

Treat MCP tool responses marked `isError: true` as failed CLI commands, so scripted calls no longer report success for session-ownership or protocol-timeout errors. Existing legacy `success: false` payload handling remains intact.

Also correct a pre-existing filename-case mismatch in a Linux unit test, which caused an `ENOENT` error and blocked this PR’s Ubuntu test lane.

## Linked Issues

Closes [#6017](https://github.com/kaeawc/auto-mobile/issues/6017)

Closes [#6051](https://github.com/kaeawc/auto-mobile/issues/6051)

## Bug / Regression Context

- **Observed symptom:** `--cli` exited 0 after receiving an in-band `session_ownership_lost` envelope or an MCP timeout response.
- **Root cause:** CLI failure detection only inspected the decoded payload's `success` field and ignored MCP's top-level `isError` flag.
- **CI root cause:** a test import’s case did not match the tracked source filename on Linux.

## Validation

- [x] `bun test test/cli`
- [x] `bun test test/utils/GitMetadataClient.test.ts`
- [x] `bun test test/server/deviceTools.killDevice.test.ts`
- [x] `bun run typecheck`
- [x] `AUTOMOBILE_UNIT_TEST_WORKERS=1 AUTOMOBILE_TEST_WALL_TIMEOUT_SECONDS=600 bun run turbo:validate`
