### PR TITLE
fix(observe): reject unverified Android launch captures

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -204,6 +204,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     // Track whether the accessibility service hierarchy is incomplete
     // This happens when active windows have null roots or only system UI is accessible
     var activeWindowHasNullRoot = false
+    var primaryAppWindowHasNullRoot = false
     var hasApplicationWindow = false
 
     // Prefer the focused application window to an active system window. When the IME owns focus,
@@ -215,6 +216,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       try {
         val rootNode = window.root
         if (rootNode == null) {
+          if (window.id == primaryAppWindowId) {
+            Log.w(
+              TAG,
+              "[HIERARCHY-DEBUG] Primary application window ${window.id} has null root node - accessibility service incomplete",
+            )
+            primaryAppWindowHasNullRoot = true
+          }
           if (window.isActive) {
             Log.w(
               TAG,
@@ -321,8 +329,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       }
     }
 
-    // Fallback to activeWindowRoot if no active window found in window list
-    if (mainHierarchy == null && activeWindowRoot != null) {
+    // Fallback to activeWindowRoot when it can still recover application content. When the
+    // selected app has no root, rootInActiveWindow can be the active system status bar, which is
+    // not a substitute for application content.
+    if (
+      mainHierarchy == null &&
+        activeWindowRoot != null &&
+        (!primaryAppWindowHasNullRoot ||
+          activeWindowRoot.packageName?.toString()?.let { it != "com.android.systemui" } == true)
+    ) {
       val element =
         extractNodeInfo(
           activeWindowRoot,
@@ -426,14 +441,17 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     // Determine if the accessibility service hierarchy is incomplete
     // This happens when:
     // 1. An active window has a null root (app restricts accessibility access)
-    // 2. Only system UI windows were successfully extracted (no app windows accessible)
+    // 2. The selected application window has a null root
+    // 3. Only system UI windows were successfully extracted (no app windows accessible)
     val isSystemUiForeground = mainPackageName == "com.android.systemui"
     val ctrlProxyIncomplete =
-      activeWindowHasNullRoot || (!hasApplicationWindow && !isSystemUiForeground)
+      activeWindowHasNullRoot ||
+        primaryAppWindowHasNullRoot ||
+        (!hasApplicationWindow && !isSystemUiForeground)
     if (ctrlProxyIncomplete) {
       Log.w(
         TAG,
-        "[HIERARCHY-DEBUG] Accessibility service incomplete: activeWindowHasNullRoot=$activeWindowHasNullRoot, hasApplicationWindow=$hasApplicationWindow",
+        "[HIERARCHY-DEBUG] Accessibility service incomplete: activeWindowHasNullRoot=$activeWindowHasNullRoot, primaryAppWindowHasNullRoot=$primaryAppWindowHasNullRoot, hasApplicationWindow=$hasApplicationWindow",
       )
     }
 
@@ -677,9 +695,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
   /**
    * Selects the window id hierarchy extraction should treat as the "primary" user-facing window.
-   * Prefers a focused application window. When the IME owns focus, falls back to the topmost
-   * application window with a root. Returns null when neither condition applies so callers can
-   * retain the active-window fallback for genuine system UI.
+   * Prefers a focused application window even when its root is temporarily unavailable. When the
+   * IME owns focus, falls back to the topmost application window with a root. Returns null when
+   * neither condition applies so callers can retain the active-window fallback for genuine system
+   * UI.
    *
    * Android can mark a system window active while the foreground application is focused, and marks
    * the IME active/focused while the keyboard is showing. In either case, relying on
@@ -718,11 +737,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var topAppId: Int? = null
     var topAppLayer = Int.MIN_VALUE
     for (w in windows) {
-      if (!w.hasRoot) continue
       when (w.type) {
-        AccessibilityWindowInfo.TYPE_INPUT_METHOD -> hasIme = true
+        AccessibilityWindowInfo.TYPE_INPUT_METHOD -> if (w.hasRoot) hasIme = true
         AccessibilityWindowInfo.TYPE_APPLICATION -> {
-          if (w.layer > topAppLayer) {
+          if (w.hasRoot && w.layer > topAppLayer) {
             topAppLayer = w.layer
             topAppId = w.id
           }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -955,6 +955,29 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `pickPrimaryAppWindowId preserves focused app selection when its root is unavailable`() {
+    // Regression for #5981: do not fall back to an active status-bar window when the focused
+    // application temporarily has no accessible root.
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 10,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 5,
+          hasRoot = false,
+          isFocused = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 11,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 6,
+          hasRoot = true,
+        ),
+      )
+    assertEquals(10, extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
   fun `pickPrimaryAppWindowId leaves active-window fallback when no app is focused or IME is present`() {
     val windows =
       listOf(

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1070,6 +1070,10 @@ export class LaunchApp extends BaseVisualChange {
     observation: ObserveResult,
     expectedPackageName: string,
   ): boolean {
+    if (observation.freshness?.isFresh === false || observation.freshness?.verified === false) {
+      return false;
+    }
+
     if (this.isLaunchPermissionDialogObservation(observation)) {
       return true;
     }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -95,6 +95,48 @@ interface PostCaptureForegroundIdentity {
   identity: string | undefined;
 }
 
+function isStatusBarOnlyCandidate(
+  hierarchy: ObserveResult["viewHierarchy"],
+  foreground: string | undefined,
+): foreground is string {
+  const observed = hierarchy?.packageName;
+  return (
+    foreground !== undefined &&
+    !SYSTEM_UI_WINDOW_PACKAGES.has(foreground) &&
+    (observed === undefined
+      ? hierarchy?.ctrlProxyIncomplete === true
+      : SYSTEM_UI_WINDOW_PACKAGES.has(observed))
+  );
+}
+
+function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
+  const statusBarHeight = result.systemInsets.top;
+  const root = result.viewHierarchy?.hierarchy.node;
+  if (statusBarHeight <= 0 || !root) {
+    return false;
+  }
+
+  let hasBounds = false;
+  const nodes = Array.isArray(root) ? [...root] : [root];
+  while (nodes.length > 0) {
+    const node = nodes.pop();
+    if (!node) {
+      continue;
+    }
+    if (node.bounds) {
+      hasBounds = true;
+      if (node.bounds.bottom > statusBarHeight) {
+        return false;
+      }
+    }
+    const children = node.node;
+    if (children) {
+      nodes.push(...(Array.isArray(children) ? children : [children]));
+    }
+  }
+  return hasBounds;
+}
+
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
   const activityName = foregroundActivity.split("/")[1] ?? "";
   return (
@@ -443,6 +485,12 @@ export class RealObserveScreen implements ObserveScreen {
           !hierarchyPlatformValid ||
           result.viewHierarchy?.hierarchy === undefined ||
           result.viewHierarchy?.hierarchy?.error !== undefined,
+        statusBarOnlyHierarchy: await this.resolveStatusBarOnlyHierarchy(
+          result,
+          foregroundIdentity,
+          postCaptureForeground,
+          signal,
+        ),
         windowIdentityMismatch: await this.resolveWindowIdentityMismatch(
           result,
           foregroundIdentity,
@@ -898,6 +946,29 @@ export class RealObserveScreen implements ObserveScreen {
       return undefined;
     }
     return { observed, foreground };
+  }
+
+  private async resolveStatusBarOnlyHierarchy(
+    result: ObserveResult,
+    foregroundIdentity: Promise<string | undefined>,
+    postCaptureForeground: PostCaptureForegroundIdentity,
+    signal?: AbortSignal,
+  ): Promise<{ foreground: string } | undefined> {
+    const foreground = await foregroundIdentity;
+    const hierarchy = result.viewHierarchy;
+    if (!isStatusBarOnlyCandidate(hierarchy, foreground)) {
+      return undefined;
+    }
+    const confirmed = await this.resolvePostCaptureForegroundIdentity(
+      foreground,
+      hierarchy?.packageName ?? "",
+      postCaptureForeground,
+      signal,
+    );
+    if (confirmed !== foreground || !isStatusBarOnlyHierarchy(result)) {
+      return undefined;
+    }
+    return { foreground };
   }
 
   private async resolvePostCaptureForegroundIdentity(

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -77,6 +77,12 @@ export interface FreshnessInputs {
    * never verified against the foreground app no matter how recently captured.
    */
   windowIdentityMismatch?: { observed: string; foreground: string };
+  /**
+   * The hierarchy contains only status-bar content while a non-system app is resumed. This is a
+   * device-side wrong-window capture even when System UI would normally be a legitimate
+   * accessibility window.
+   */
+  statusBarOnlyHierarchy?: { foreground: string };
   /** Age budget; defaults to {@link maxObservationAgeMs}. */
   maxAgeMs?: number;
 }
@@ -153,6 +159,36 @@ function resolveAgeMs(
   return ageBasis !== undefined ? Math.max(0, now - ageBasis) : undefined;
 }
 
+function computeWrongWindowFreshness(
+  inputs: FreshnessInputs,
+  ageMs: number | undefined,
+): FreshnessVerdict | undefined {
+  if (inputs.windowIdentityMismatch) {
+    const { observed, foreground } = inputs.windowIdentityMismatch;
+    return {
+      requestedAfter: inputs.requestedAfter,
+      actualTimestamp: inputs.actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning: `Observed hierarchy is from ${observed}, but the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+    };
+  }
+
+  if (inputs.statusBarOnlyHierarchy) {
+    return {
+      requestedAfter: inputs.requestedAfter,
+      actualTimestamp: inputs.actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning: `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${inputs.statusBarOnlyHierarchy.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+    };
+  }
+
+  return undefined;
+}
+
 /**
  * Compute the freshness verdict.
  *
@@ -162,7 +198,6 @@ function resolveAgeMs(
  */
 export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
   const { requestedAfter, actualTimestamp, hostAgeBasisMs, now, verified, unavailable } = inputs;
-  const windowIdentityMismatch = inputs.windowIdentityMismatch;
   const maxAgeMs = inputs.maxAgeMs ?? maxObservationAgeMs();
 
   const ageMs = resolveAgeMs(hostAgeBasisMs, actualTimestamp, now);
@@ -178,19 +213,11 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
     };
   }
 
-  // The tree belongs to a different app than the one currently resumed on the
-  // device (issue #5867). This dominates every other signal — a wrong-window
-  // capture is unfresh at any age, and `verified` is retracted to false so a
+  // A wrong-window capture is unfresh at any age, and `verified` is retracted to false so a
   // consumer reading that field alone is not green-lit onto a phantom.
-  if (windowIdentityMismatch) {
-    return {
-      requestedAfter,
-      actualTimestamp,
-      ageMs,
-      verified: false,
-      isFresh: false,
-      warning: `Observed hierarchy is from ${windowIdentityMismatch.observed}, but the device's current top resumed activity is ${windowIdentityMismatch.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
-    };
+  const wrongWindowFreshness = computeWrongWindowFreshness(inputs, ageMs);
+  if (wrongWindowFreshness) {
+    return wrongWindowFreshness;
   }
 
   // Caller supplied an explicit constraint: answer exactly that question.

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -134,6 +134,18 @@ export function resetCrashAppToolDependencies(): void {
   crashAppToolDependencies = null;
 }
 
+function isVerifiedLaunchObservation(
+  appId: string,
+  observedAppId: string | undefined,
+  observation: LaunchAppResult["observation"],
+): boolean {
+  return (
+    observedAppId === appId &&
+    observation?.freshness?.isFresh !== false &&
+    observation?.freshness?.verified !== false
+  );
+}
+
 /**
  * Build the launchApp tool response from a {@link LaunchAppResult}, enforcing the
  * launch postcondition instead of reporting a flat "Launched app X" success
@@ -160,13 +172,13 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
   // the hierarchy (active window absent) still reports the observed app.
   const observedAppId =
     result.observation?.activeWindow?.appId ?? result.observation?.viewHierarchy?.packageName;
-  // Only assert verification on an exact foreground match. `LaunchApp.execute`
-  // returns `success:true` only when the foreground reconciles with the request —
-  // an exact match, an accepted surface (e.g. a notification-permission dialog
-  // whose foreground is the permission controller), or no observation at all — so
-  // a non-matching `observedAppId` here is such an accepted surface, not a failed
-  // launch. Emit `verified` as true-or-undefined; never a misleading `false`.
-  const verified = observedAppId === appId ? true : undefined;
+  // Only assert verification on an exact foreground match with a fresh, verified
+  // observation. `LaunchApp.execute` retries an unverified observation, but this
+  // response-level guard preserves the true-or-undefined contract for any direct
+  // caller that supplies one.
+  const verified = isVerifiedLaunchObservation(appId, observedAppId, result.observation)
+    ? true
+    : undefined;
 
   return {
     message: verified ? `Launched app ${appId} (foreground verified)` : `Launched app ${appId}`,

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -578,6 +578,28 @@ describe("LaunchApp", () => {
     ).toBe(true);
   });
 
+  test("re-observes when a matching launch observation is marked unverified", async () => {
+    fakeTimer.enableAutoAdvance();
+    const unverifiedObservation = {
+      ...createObserveResult(packageName),
+      freshness: {
+        isFresh: false,
+        verified: false,
+        warning: "Observed hierarchy contains only Android status-bar content",
+      },
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(unverifiedObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(false);
+    expect(result.observation).toBeUndefined();
+    expect(fakeObserveScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+
   test("treats Android notification permission dialogs as valid launch observations", async () => {
     fakeTimer.enableAutoAdvance();
     const permissionControllerPackageName = "com.google.android.permissioncontroller";

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -344,6 +344,58 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("retracts freshness for a system-UI hierarchy confined to the status bar", async () => {
+    // Regression for #5981: after in-app navigation, CtrlProxy can report the
+    // active status-bar window while Settings remains the resumed activity.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      packageName: "com.android.systemui",
+      foregroundActivity: "com.android.settings/.SubSettings",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          node: [{ text: "12:34", bounds: { left: 21, top: 0, right: 107, bottom: 63 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("status-bar");
+    expect(result.freshness?.warning).toContain("com.android.settings");
+    expect(result.freshness?.warning).toContain(
+      'pressButton { platform: "android", button: "home" }',
+    );
+  });
+
   test("a transient app transition is not flagged: the confirming read settles onto the observed app", async () => {
     // The parallel foreground sample lags the newer captured hierarchy during an
     // A→B transition: sample1 = the old app, observed hierarchy = the new app.

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -66,6 +66,26 @@ describe("buildLaunchAppResponse", () => {
     expect(payload.success).toBe(true);
   });
 
+  test("omits verification when a matching observation is marked unverified", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        ...observationForApp("com.android.settings"),
+        freshness: {
+          isFresh: false,
+          verified: false,
+          warning: "Observed hierarchy contains only Android status-bar content",
+        },
+      },
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.verified).toBeUndefined();
+    expect(payload.message).toBe("Launched app com.android.settings");
+  });
+
   // A successful launch that lands on an accepted surface (e.g. a notification
   // permission dialog, whose foreground is the permission controller) must not
   // emit a misleading verified:false — execute already returns success:false for a


### PR DESCRIPTION
## Summary

Preserves a focused Android application window when Accessibility temporarily loses its root, avoiding fallback to a status-bar-only System UI hierarchy. It retracts freshness for that wrong-window shape and prevents `launchApp` from reporting a false-green verified result.

## Linked Issue

Tracks [#5981](https://github.com/kaeawc/auto-mobile/issues/5981). This does not close the issue: the CtrlProxy behavior is fully delivered only after a release ships the rebuilt APK.

## Bug / Regression Context

- **Prior attempts:** [#5976](https://github.com/kaeawc/auto-mobile/pull/5976) selected a focused app when its root was available, but a transient null root still fell through to an active status-bar window. [#5986](https://github.com/kaeawc/auto-mobile/pull/5986) was closed without merging after accumulating unrelated CI/test-runner changes.
- **Observed symptom:** `observe` and `launchApp` could report `verified: true` for a status-bar-only hierarchy while Settings was the resumed app.
- **Repro steps / conditions:** Navigate from Settings into a sub-screen after launch; on affected devices the focused application window may briefly expose no accessibility root while the status bar is active.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` — 34/35 passed; Lychee could not reach unchanged GitHub links in `CHANGELOG.md` (connection resets/timeouts).
- [x] `bun run lint`
- [x] `bun test --bail` — 15,212 passing; 14 device-dependent tests skipped
- [x] `bun run typecheck` reports no new errors
- [x] `bun run build`
- [x] `bun run format:check`
- [x] `scripts/ktfmt/validate_ktfmt.sh`
- [x] `scripts/android/validate-kotlin-convention.sh`
- [x] `:control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest`
- [x] `:control-proxy:assembleDebug`
- [x] New behavior uses existing fakes and FakeTimer; no dependency added
- [x] Branch created from latest `main`

## Kotlin Reuse Check

- [x] Used existing `AccessibilityWindowInfo.isFocused`; no helper or dependency added.

## Device Verification

- [ ] Not run: no Android device was attached in this environment.

## Follow-ups

- [ ] No follow-up issue: keep [#5981](https://github.com/kaeawc/auto-mobile/issues/5981) open until the rebuilt CtrlProxy APK ships in a release.

Made with [Cursor](https://cursor.com)