### PR TITLE
fix(android-sdk): restore hooks on shutdown

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -235,6 +235,10 @@ AutoMobileSDK.updateCapturePolicy(
 )
 ```
 
+`setEnabled(false)` stops SDK capture and tracking but retains installed runtime hooks. Call
+`AutoMobileSDK.shutdown()` to detach all SDK instrumentation and restore its pre-initialization
+state.
+
 Capability snapshots are versioned and distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`,
 `PERMISSION_DENIED`, `SUPPORTED`, and `UNKNOWN`. Removing an optional capability restores its unsupported
 descriptor and revokes any policy field that depends on it. Older clients should ignore unknown

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -65,6 +65,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileNotifications {
   public static final java.lang.String EXTRA_NOTIFICATION_ID;
   public static final int $stable;
   public final void initialize(android.content.Context);
+  public final void reset$auto_mobile_sdk();
   public final boolean post(java.lang.String, java.lang.String, dev.jasonpearson.automobile.sdk.NotificationStyle, java.lang.String, java.util.List<dev.jasonpearson.automobile.sdk.NotificationAction>, java.lang.String);
   public static boolean post$default(dev.jasonpearson.automobile.sdk.AutoMobileNotifications, java.lang.String, java.lang.String, dev.jasonpearson.automobile.sdk.NotificationStyle, java.lang.String, java.util.List, java.lang.String, int, java.lang.Object);
   public final boolean postWithContext$auto_mobile_sdk(android.content.Context, java.lang.String, java.lang.String, dev.jasonpearson.automobile.sdk.NotificationStyle, java.lang.String, java.util.List<dev.jasonpearson.automobile.sdk.NotificationAction>, java.lang.String);
@@ -74,7 +75,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$WhenMappings {
   public static final int[] $EnumSwitchMapping$0;
 }
 Compiled from "AutoMobileSDK.kt"
-public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$5$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
+public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$6$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
   public void onStart(androidx.lifecycle.LifecycleOwner);
   public void onStop(androidx.lifecycle.LifecycleOwner);
   public void onCreate(androidx.lifecycle.LifecycleOwner);
@@ -414,6 +415,7 @@ public final class dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr {
   public static final int $stable;
   public final void initialize(android.content.Context);
   public final boolean isAvailable();
+  public final void reset$auto_mobile_sdk();
 }
 Compiled from "AutoMobileBiometrics.kt"
 final class dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics$PendingOverride {
@@ -1024,6 +1026,7 @@ public final class dev.jasonpearson.automobile.sdk.failures.AutoMobileFailures {
   public final java.util.List<dev.jasonpearson.automobile.sdk.failures.HandledExceptionEvent> getRecentEvents();
   public final void clearEvents();
   public final int getEventCount();
+  public final void reset$auto_mobile_sdk();
 }
 Compiled from "HandledExceptionEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.failures.DeviceInfo {
@@ -1575,6 +1578,12 @@ public interface dev.jasonpearson.automobile.sdk.session.SessionTracking {
   public abstract void onForeground();
   public abstract void onBackground();
   public abstract void shutdown();
+}
+Compiled from "SharedPreferencesDriverImpl.kt"
+final class dev.jasonpearson.automobile.sdk.storage.BoundedPreferenceChangeQueue {
+  public dev.jasonpearson.automobile.sdk.storage.BoundedPreferenceChangeQueue(int);
+  public final synchronized void add(dev.jasonpearson.automobile.sdk.storage.PreferenceChange);
+  public final synchronized java.util.List<dev.jasonpearson.automobile.sdk.storage.PreferenceChange> drainAfter(long);
 }
 Compiled from "DataStoreAdapter.kt"
 public interface dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter {

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -75,7 +75,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$WhenMappings {
   public static final int[] $EnumSwitchMapping$0;
 }
 Compiled from "AutoMobileSDK.kt"
-public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$6$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
+public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$1$6$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
   public void onStart(androidx.lifecycle.LifecycleOwner);
   public void onStop(androidx.lifecycle.LifecycleOwner);
   public void onCreate(androidx.lifecycle.LifecycleOwner);

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -733,8 +733,8 @@ public final class dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes {
   public final void initialize(android.content.Context);
   public final boolean isInitialized();
   public final void uninstall();
-  public static final void access$broadcastCrash(dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes, java.lang.Thread, java.lang.Throwable);
   public static final java.lang.Thread$UncaughtExceptionHandler access$getOriginalHandler$p();
+  public static final void access$broadcastCrash(dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes, java.lang.Thread, java.lang.Throwable);
 }
 Compiled from "DatabaseDriver.kt"
 public final class dev.jasonpearson.automobile.sdk.database.ColumnInfo {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileNotifications.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileNotifications.kt
@@ -75,6 +75,11 @@ object AutoMobileNotifications {
     this.context = context.applicationContext
   }
 
+  /** Clears the application context retained by SDK-managed notification helpers. */
+  internal fun reset() {
+    context = null
+  }
+
   /**
    * Post a notification to the system notification tray.
    *

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -360,7 +360,7 @@ object AutoMobileSDK {
    *
    * Call [shutdown] to detach all hooks and return the SDK to its pre-initialization state.
    *
-   * @param enabled Whether navigation tracking should be enabled
+   * @param enabled Whether event capture and tracking should be enabled
    */
   fun setEnabled(enabled: Boolean) {
     _isEnabled = enabled

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -98,6 +98,9 @@ object AutoMobileSDK {
   @Volatile private var breadcrumbTrail: BreadcrumbTrail? = null
   @Volatile private var dropCounter: DropCounter? = null
   private val capabilityRegistry = SdkCapabilityRegistry()
+  private val lifecycleLock = Any()
+  private var mainThreadTeardownPending = false
+  private var pendingInitialization: Pair<Context, AutoMobileConfiguration>? = null
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -132,128 +135,135 @@ object AutoMobileSDK {
    */
   @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
   fun initialize(context: Context, configuration: AutoMobileConfiguration) {
-    try {
-      if (this.context != null) {
-        logger.d(TAG) { "AutoMobileSDK already initialized" }
+    synchronized(lifecycleLock) {
+      if (mainThreadTeardownPending) {
+        pendingInitialization = context.applicationContext to configuration
         return
       }
-
-      this.context = context.applicationContext
-      this.configuration = configuration
-      capabilityRegistry.markInitialized()
-      AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
-      AutoMobileNetwork.setNetworkControlProvider {
-        capabilityRegistry.isCapabilitySupported("network.control")
-      }
-      val appContext = this.context!!
-
-      // Create disk persistence for events
-      val eventPersistence = FileEventPersistence(File(appContext.cacheDir, "automobile_events"))
-      persistence = eventPersistence
-
-      // Create drop counter for tracking event drops across the pipeline
-      val counter = DefaultDropCounter()
-      dropCounter = counter
-      SdkEventBroadcaster.dropCounter = counter
-
-      // Create shared event buffer with broadcast flush callback and disk persistence
-      val buffer =
-        SdkEventBuffer(
-          maxBufferSize = configuration.bufferSize,
-          flushIntervalMs = configuration.flushIntervalMs,
-          onFlush = { events -> SdkEventBroadcaster.broadcastBatch(appContext, events) },
-          persistence = eventPersistence,
-          dropCounter = counter,
-          processors = configuration.eventProcessors,
-          maxPendingEvents = configuration.maxPendingEvents,
-          backPressureStrategy = configuration.backPressureStrategy,
-        )
-      buffer.isEnabled = _isEnabled
-      buffer.start()
-      eventBuffer = buffer
-
-      // Initialize SDK context with app version from PackageManager
-      val ctx = SdkContext()
       try {
-        ctx.appVersion =
-          appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
-      } catch (_: Exception) {
-        // PackageManager lookup may fail in test environments
-      }
-      sdkContext = ctx
-      // Replay pending batches and clean up old ones on the buffer's executor
-      // to avoid blocking the calling thread with disk I/O.
-      buffer.execute {
-        replayPendingBatches(appContext, eventPersistence)
-        eventPersistence.cleanup()
-      }
-
-      // Thread-safe subsystems — can initialize from any thread
-      NetworkMockRuleStore.initialize(appContext)
-      AutoMobileNetwork.initialize(
-        appContext.packageName,
-        buffer,
-        NetworkMockRuleStore.getInstance().ruleMatcher,
-      )
-      AutoMobileLog.initialize()
-      AutoMobileBroadcastInterceptor.initialize(appContext, buffer)
-
-      DatabaseInspector.initialize(appContext)
-      SharedPreferencesInspector.initialize(appContext)
-      AutoMobileFailures.initialize(appContext)
-
-      AutoMobileCrashes.initialize(appContext)
-      val trail = BreadcrumbTrail()
-      breadcrumbTrail = trail
-      AutoMobileCrashes.breadcrumbTrail = trail
-
-      AutoMobileAnr.initialize(appContext)
-      AutoMobileBiometrics.initialize(appContext)
-
-      val tracker = SessionTracker()
-      sessionTracker = tracker
-
-      // Subsystems that register lifecycle observers or activity callbacks must run on main thread
-      val handler = Handler(Looper.getMainLooper())
-      mainHandler = handler
-      handler.post {
-        try {
-          // Guard: if shutdown() was called before this posted block runs, no-op.
-          if (this@AutoMobileSDK.context == null) return@post
-          AutoMobileOsEvents.initialize(appContext, buffer) { kind ->
-            notifyRuntimeContextChanged(kind)
-          }
-
-          // Register session tracker with process lifecycle
-          val observer =
-            object : DefaultLifecycleObserver {
-              override fun onStart(owner: LifecycleOwner) {
-                tracker.onForeground()
-              }
-
-              override fun onStop(owner: LifecycleOwner) {
-                tracker.onBackground()
-              }
-            }
-          sessionLifecycleObserver = observer
-          ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
-          capabilityRegistry.markLifecycleReady()
-          RecompositionTracker.initialize(appContext)
-          RecompositionTracker.setEnabled(_isEnabled)
-          FrameMetricsCollector.initialize(appContext)
-          FrameMetricsCollector.setEnabled(_isEnabled)
-          AutoMobileNotifications.initialize(appContext)
-          if (appContext is Application) {
-            AutoMobileClickTracker.initialize(appContext, appContext.packageName)
-          }
-        } catch (error: Exception) {
-          logger.e(TAG, error) { "AutoMobileSDK main-thread initialization failed; rolling back" }
-          shutdown()
+        if (this.context != null) {
+          logger.d(TAG) { "AutoMobileSDK already initialized" }
+          return
         }
+
+        this.context = context.applicationContext
+        this.configuration = configuration
+        capabilityRegistry.markInitialized()
+        AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
+        AutoMobileNetwork.setNetworkControlProvider {
+          capabilityRegistry.isCapabilitySupported("network.control")
+        }
+        val appContext = this.context!!
+
+        // Create disk persistence for events
+        val eventPersistence = FileEventPersistence(File(appContext.cacheDir, "automobile_events"))
+        persistence = eventPersistence
+
+        // Create drop counter for tracking event drops across the pipeline
+        val counter = DefaultDropCounter()
+        dropCounter = counter
+        SdkEventBroadcaster.dropCounter = counter
+
+        // Create shared event buffer with broadcast flush callback and disk persistence
+        val buffer =
+          SdkEventBuffer(
+            maxBufferSize = configuration.bufferSize,
+            flushIntervalMs = configuration.flushIntervalMs,
+            onFlush = { events -> SdkEventBroadcaster.broadcastBatch(appContext, events) },
+            persistence = eventPersistence,
+            dropCounter = counter,
+            processors = configuration.eventProcessors,
+            maxPendingEvents = configuration.maxPendingEvents,
+            backPressureStrategy = configuration.backPressureStrategy,
+          )
+        buffer.isEnabled = _isEnabled
+        buffer.start()
+        eventBuffer = buffer
+
+        // Initialize SDK context with app version from PackageManager
+        val ctx = SdkContext()
+        try {
+          ctx.appVersion =
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+        } catch (_: Exception) {
+          // PackageManager lookup may fail in test environments
+        }
+        sdkContext = ctx
+        // Replay pending batches and clean up old ones on the buffer's executor
+        // to avoid blocking the calling thread with disk I/O.
+        buffer.execute {
+          replayPendingBatches(appContext, eventPersistence)
+          eventPersistence.cleanup()
+        }
+
+        // Thread-safe subsystems — can initialize from any thread
+        NetworkMockRuleStore.initialize(appContext)
+        AutoMobileNetwork.initialize(
+          appContext.packageName,
+          buffer,
+          NetworkMockRuleStore.getInstance().ruleMatcher,
+        )
+        AutoMobileLog.initialize()
+        AutoMobileBroadcastInterceptor.initialize(appContext, buffer)
+
+        DatabaseInspector.initialize(appContext)
+        SharedPreferencesInspector.initialize(appContext)
+        AutoMobileFailures.initialize(appContext)
+
+        AutoMobileCrashes.initialize(appContext)
+        val trail = BreadcrumbTrail()
+        breadcrumbTrail = trail
+        AutoMobileCrashes.breadcrumbTrail = trail
+
+        AutoMobileAnr.initialize(appContext)
+        AutoMobileBiometrics.initialize(appContext)
+
+        val tracker = SessionTracker()
+        sessionTracker = tracker
+
+        // Subsystems that register lifecycle observers or activity callbacks must run on main
+        // thread
+        val handler = Handler(Looper.getMainLooper())
+        mainHandler = handler
+        handler.post {
+          try {
+            // Guard: if shutdown() was called before this posted block runs, no-op.
+            if (this@AutoMobileSDK.context == null) return@post
+            AutoMobileOsEvents.initialize(appContext, buffer) { kind ->
+              notifyRuntimeContextChanged(kind)
+            }
+
+            // Register session tracker with process lifecycle
+            val observer =
+              object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                  tracker.onForeground()
+                }
+
+                override fun onStop(owner: LifecycleOwner) {
+                  tracker.onBackground()
+                }
+              }
+            sessionLifecycleObserver = observer
+            ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+            capabilityRegistry.markLifecycleReady()
+            RecompositionTracker.initialize(appContext)
+            RecompositionTracker.setEnabled(_isEnabled)
+            FrameMetricsCollector.initialize(appContext)
+            FrameMetricsCollector.setEnabled(_isEnabled)
+            AutoMobileNotifications.initialize(appContext)
+            if (appContext is Application) {
+              AutoMobileClickTracker.initialize(appContext, appContext.packageName)
+            }
+          } catch (error: Exception) {
+            logger.e(TAG, error) { "AutoMobileSDK main-thread initialization failed; rolling back" }
+            shutdown()
+          }
+        }
+      } catch (error: Exception) {
+        shutdown()
+        throw error
       }
-    } catch (error: Exception) {
-      shutdown()
-      throw error
     }
   }
 
@@ -522,68 +532,82 @@ object AutoMobileSDK {
    * called again to restart the SDK.
    */
   fun shutdown() {
-    // Cancel any pending main-thread init work so a fast init→shutdown
-    // sequence doesn't re-register hooks after shutdown completes.
-    mainHandler?.removeCallbacksAndMessages(null)
-    mainHandler = null
+    synchronized(lifecycleLock) {
+      pendingInitialization = null
+      // Cancel any pending main-thread init work so a fast init→shutdown
+      // sequence doesn't re-register hooks after shutdown completes.
+      mainHandler?.removeCallbacksAndMessages(null)
+      mainHandler = null
 
-    // Tear down subsystem hooks. Lifecycle observer removal and click
-    // tracker unregistration must happen on the main thread.
-    // Read sessionLifecycleObserver inside the Runnable so we see the
-    // value assigned by a concurrent init handler, not a stale snapshot.
-    val ctx = context
-    if (ctx != null) {
-      val teardown = Runnable {
-        AutoMobileOsEvents.shutdown(ctx)
-        AutoMobileBroadcastInterceptor.shutdown(ctx)
-        AutoMobileClickTracker.shutdown(ctx)
-        NetworkMockRuleStore.shutdown(ctx)
-        sessionLifecycleObserver?.let {
-          ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
+      // Tear down subsystem hooks. Lifecycle observer removal and click
+      // tracker unregistration must happen on the main thread.
+      // Read sessionLifecycleObserver inside the Runnable so we see the
+      // value assigned by a concurrent init handler, not a stale snapshot.
+      val ctx = context
+      if (ctx != null) {
+        val teardown = Runnable {
+          AutoMobileOsEvents.shutdown(ctx)
+          AutoMobileBroadcastInterceptor.shutdown(ctx)
+          AutoMobileClickTracker.shutdown(ctx)
+          NetworkMockRuleStore.shutdown(ctx)
+          sessionLifecycleObserver?.let {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
+          }
+          sessionLifecycleObserver = null
+          completeMainThreadTeardown()
         }
-        sessionLifecycleObserver = null
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+          teardown.run()
+        } else {
+          mainThreadTeardownPending = true
+          Handler(Looper.getMainLooper()).post(teardown)
+        }
       }
-      if (Looper.myLooper() == Looper.getMainLooper()) {
-        teardown.run()
-      } else {
-        Handler(Looper.getMainLooper()).post(teardown)
-      }
+
+      // Clear application-provided DataStore adapters so shutdown does not retain host references
+      // (issue #5192).
+      DataStoreInspector.reset()
+      DatabaseInspector.reset()
+      SharedPreferencesInspector.reset()
+      AutoMobileCrashes.uninstall()
+      AutoMobileAnr.reset()
+      AutoMobileBiometrics.shutdown()
+      AutoMobileFailures.reset()
+      AutoMobileNotifications.reset()
+
+      sessionTracker?.shutdown()
+      sessionTracker = null
+
+      eventBuffer?.shutdown()
+      eventBuffer = null
+      sdkContext?.reset()
+      sdkContext = null
+      breadcrumbTrail?.clear()
+      breadcrumbTrail = null
+      dropCounter = null
+      SdkEventBroadcaster.reset()
+      persistence = null
+      RecompositionTracker.reset()
+      FrameMetricsCollector.reset()
+      listeners.clear()
+      runtimeContextListeners.clear()
+      _isEnabled = true
+      AutoMobileNetwork.setCapturePolicyProvider(null)
+      AutoMobileNetwork.setNetworkControlProvider(null)
+      AutoMobileNetwork.reset()
+      capabilityRegistry.markShutdown()
+      configuration = null
+      context = null
     }
+  }
 
-    // Clear application-provided DataStore adapters so shutdown does not retain host references
-    // (issue #5192).
-    DataStoreInspector.reset()
-    DatabaseInspector.reset()
-    SharedPreferencesInspector.reset()
-    AutoMobileCrashes.uninstall()
-    AutoMobileAnr.reset()
-    AutoMobileBiometrics.shutdown()
-    AutoMobileFailures.reset()
-    AutoMobileNotifications.reset()
-
-    sessionTracker?.shutdown()
-    sessionTracker = null
-
-    eventBuffer?.shutdown()
-    eventBuffer = null
-    sdkContext?.reset()
-    sdkContext = null
-    breadcrumbTrail?.clear()
-    breadcrumbTrail = null
-    dropCounter = null
-    SdkEventBroadcaster.reset()
-    persistence = null
-    RecompositionTracker.reset()
-    FrameMetricsCollector.reset()
-    listeners.clear()
-    runtimeContextListeners.clear()
-    _isEnabled = true
-    AutoMobileNetwork.setCapturePolicyProvider(null)
-    AutoMobileNetwork.setNetworkControlProvider(null)
-    AutoMobileNetwork.reset()
-    capabilityRegistry.markShutdown()
-    configuration = null
-    context = null
+  private fun completeMainThreadTeardown() {
+    synchronized(lifecycleLock) {
+      mainThreadTeardownPending = false
+      val nextInitialization = pendingInitialization ?: return
+      pendingInitialization = null
+      initialize(nextInitialization.first, nextInitialization.second)
+    }
   }
 
   /** Returns the current configuration, or null if not initialized. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -132,110 +132,128 @@ object AutoMobileSDK {
    */
   @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
   fun initialize(context: Context, configuration: AutoMobileConfiguration) {
-    this.context = context.applicationContext
-    this.configuration = configuration
-    capabilityRegistry.markInitialized()
-    AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
-    AutoMobileNetwork.setNetworkControlProvider {
-      capabilityRegistry.isCapabilitySupported("network.control")
-    }
-    val appContext = this.context!!
-
-    // Create disk persistence for events
-    val eventPersistence = FileEventPersistence(File(appContext.cacheDir, "automobile_events"))
-    persistence = eventPersistence
-
-    // Create drop counter for tracking event drops across the pipeline
-    val counter = DefaultDropCounter()
-    dropCounter = counter
-    SdkEventBroadcaster.dropCounter = counter
-
-    // Create shared event buffer with broadcast flush callback and disk persistence
-    val buffer =
-      SdkEventBuffer(
-        maxBufferSize = configuration.bufferSize,
-        flushIntervalMs = configuration.flushIntervalMs,
-        onFlush = { events -> SdkEventBroadcaster.broadcastBatch(appContext, events) },
-        persistence = eventPersistence,
-        dropCounter = counter,
-        processors = configuration.eventProcessors,
-        maxPendingEvents = configuration.maxPendingEvents,
-        backPressureStrategy = configuration.backPressureStrategy,
-      )
-    buffer.isEnabled = _isEnabled
-    buffer.start()
-    eventBuffer = buffer
-
-    // Initialize SDK context with app version from PackageManager
-    val ctx = SdkContext()
     try {
-      ctx.appVersion =
-        appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
-    } catch (_: Exception) {
-      // PackageManager lookup may fail in test environments
-    }
-    sdkContext = ctx
-    // Replay pending batches and clean up old ones on the buffer's executor
-    // to avoid blocking the calling thread with disk I/O.
-    buffer.execute {
-      replayPendingBatches(appContext, eventPersistence)
-      eventPersistence.cleanup()
-    }
-
-    // Thread-safe subsystems — can initialize from any thread
-    NetworkMockRuleStore.initialize(appContext)
-    AutoMobileNetwork.initialize(
-      appContext.packageName,
-      buffer,
-      NetworkMockRuleStore.getInstance().ruleMatcher,
-    )
-    AutoMobileLog.initialize()
-    AutoMobileBroadcastInterceptor.initialize(appContext, buffer)
-    DatabaseInspector.initialize(appContext)
-    SharedPreferencesInspector.initialize(appContext)
-    AutoMobileFailures.initialize(appContext)
-    AutoMobileCrashes.initialize(appContext)
-    val trail = BreadcrumbTrail()
-    breadcrumbTrail = trail
-    AutoMobileCrashes.breadcrumbTrail = trail
-    AutoMobileAnr.initialize(appContext)
-    AutoMobileBiometrics.initialize(appContext)
-
-    val tracker = SessionTracker()
-    sessionTracker = tracker
-
-    // Subsystems that register lifecycle observers or activity callbacks must run on main thread
-    val handler = Handler(Looper.getMainLooper())
-    mainHandler = handler
-    handler.post {
-      // Guard: if shutdown() was called before this posted block runs, no-op.
-      if (this@AutoMobileSDK.context == null) return@post
-      AutoMobileOsEvents.initialize(appContext, buffer) { kind ->
-        notifyRuntimeContextChanged(kind)
+      if (this.context != null) {
+        logger.d(TAG) { "AutoMobileSDK already initialized" }
+        return
       }
 
-      // Register session tracker with process lifecycle
-      val observer =
-        object : DefaultLifecycleObserver {
-          override fun onStart(owner: LifecycleOwner) {
-            tracker.onForeground()
+      this.context = context.applicationContext
+      this.configuration = configuration
+      capabilityRegistry.markInitialized()
+      AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
+      AutoMobileNetwork.setNetworkControlProvider {
+        capabilityRegistry.isCapabilitySupported("network.control")
+      }
+      val appContext = this.context!!
+
+      // Create disk persistence for events
+      val eventPersistence = FileEventPersistence(File(appContext.cacheDir, "automobile_events"))
+      persistence = eventPersistence
+
+      // Create drop counter for tracking event drops across the pipeline
+      val counter = DefaultDropCounter()
+      dropCounter = counter
+      SdkEventBroadcaster.dropCounter = counter
+
+      // Create shared event buffer with broadcast flush callback and disk persistence
+      val buffer =
+        SdkEventBuffer(
+          maxBufferSize = configuration.bufferSize,
+          flushIntervalMs = configuration.flushIntervalMs,
+          onFlush = { events -> SdkEventBroadcaster.broadcastBatch(appContext, events) },
+          persistence = eventPersistence,
+          dropCounter = counter,
+          processors = configuration.eventProcessors,
+          maxPendingEvents = configuration.maxPendingEvents,
+          backPressureStrategy = configuration.backPressureStrategy,
+        )
+      buffer.isEnabled = _isEnabled
+      buffer.start()
+      eventBuffer = buffer
+
+      // Initialize SDK context with app version from PackageManager
+      val ctx = SdkContext()
+      try {
+        ctx.appVersion =
+          appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+      } catch (_: Exception) {
+        // PackageManager lookup may fail in test environments
+      }
+      sdkContext = ctx
+      // Replay pending batches and clean up old ones on the buffer's executor
+      // to avoid blocking the calling thread with disk I/O.
+      buffer.execute {
+        replayPendingBatches(appContext, eventPersistence)
+        eventPersistence.cleanup()
+      }
+
+      // Thread-safe subsystems — can initialize from any thread
+      NetworkMockRuleStore.initialize(appContext)
+      AutoMobileNetwork.initialize(
+        appContext.packageName,
+        buffer,
+        NetworkMockRuleStore.getInstance().ruleMatcher,
+      )
+      AutoMobileLog.initialize()
+      AutoMobileBroadcastInterceptor.initialize(appContext, buffer)
+
+      DatabaseInspector.initialize(appContext)
+      SharedPreferencesInspector.initialize(appContext)
+      AutoMobileFailures.initialize(appContext)
+
+      AutoMobileCrashes.initialize(appContext)
+      val trail = BreadcrumbTrail()
+      breadcrumbTrail = trail
+      AutoMobileCrashes.breadcrumbTrail = trail
+
+      AutoMobileAnr.initialize(appContext)
+      AutoMobileBiometrics.initialize(appContext)
+
+      val tracker = SessionTracker()
+      sessionTracker = tracker
+
+      // Subsystems that register lifecycle observers or activity callbacks must run on main thread
+      val handler = Handler(Looper.getMainLooper())
+      mainHandler = handler
+      handler.post {
+        try {
+          // Guard: if shutdown() was called before this posted block runs, no-op.
+          if (this@AutoMobileSDK.context == null) return@post
+          AutoMobileOsEvents.initialize(appContext, buffer) { kind ->
+            notifyRuntimeContextChanged(kind)
           }
 
-          override fun onStop(owner: LifecycleOwner) {
-            tracker.onBackground()
+          // Register session tracker with process lifecycle
+          val observer =
+            object : DefaultLifecycleObserver {
+              override fun onStart(owner: LifecycleOwner) {
+                tracker.onForeground()
+              }
+
+              override fun onStop(owner: LifecycleOwner) {
+                tracker.onBackground()
+              }
+            }
+          sessionLifecycleObserver = observer
+          ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+          capabilityRegistry.markLifecycleReady()
+          RecompositionTracker.initialize(appContext)
+          RecompositionTracker.setEnabled(_isEnabled)
+          FrameMetricsCollector.initialize(appContext)
+          FrameMetricsCollector.setEnabled(_isEnabled)
+          AutoMobileNotifications.initialize(appContext)
+          if (appContext is Application) {
+            AutoMobileClickTracker.initialize(appContext, appContext.packageName)
           }
+        } catch (error: Exception) {
+          logger.e(TAG, error) { "AutoMobileSDK main-thread initialization failed; rolling back" }
+          shutdown()
         }
-      sessionLifecycleObserver = observer
-      ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
-      capabilityRegistry.markLifecycleReady()
-      RecompositionTracker.initialize(appContext)
-      RecompositionTracker.setEnabled(_isEnabled)
-      FrameMetricsCollector.initialize(appContext)
-      FrameMetricsCollector.setEnabled(_isEnabled)
-      AutoMobileNotifications.initialize(appContext)
-      if (appContext is Application) {
-        AutoMobileClickTracker.initialize(appContext, appContext.packageName)
       }
+    } catch (error: Exception) {
+      shutdown()
+      throw error
     }
   }
 
@@ -328,7 +346,9 @@ object AutoMobileSDK {
   }
 
   /**
-   * Enables or disables navigation event tracking.
+   * Enables or disables capture and tracking while leaving installed runtime hooks in place.
+   *
+   * Call [shutdown] to detach all hooks and return the SDK to its pre-initialization state.
    *
    * @param enabled Whether navigation tracking should be enabled
    */
@@ -518,7 +538,6 @@ object AutoMobileSDK {
         AutoMobileBroadcastInterceptor.shutdown(ctx)
         AutoMobileClickTracker.shutdown(ctx)
         NetworkMockRuleStore.shutdown(ctx)
-        AutoMobileBiometrics.shutdown()
         sessionLifecycleObserver?.let {
           ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
         }
@@ -534,6 +553,13 @@ object AutoMobileSDK {
     // Clear application-provided DataStore adapters so shutdown does not retain host references
     // (issue #5192).
     DataStoreInspector.reset()
+    DatabaseInspector.reset()
+    SharedPreferencesInspector.reset()
+    AutoMobileCrashes.uninstall()
+    AutoMobileAnr.reset()
+    AutoMobileBiometrics.shutdown()
+    AutoMobileFailures.reset()
+    AutoMobileNotifications.reset()
 
     sessionTracker?.shutdown()
     sessionTracker = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnr.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnr.kt
@@ -73,6 +73,11 @@ object AutoMobileAnr {
   /** Check if ANR detection is available on this device. */
   fun isAvailable(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 
+  /** Clears the retained application context during SDK shutdown or a failed initialization. */
+  internal fun reset() {
+    context = null
+  }
+
   @RequiresApi(Build.VERSION_CODES.R)
   private fun checkForPreviousAnrs() {
     val ctx = context ?: return

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
@@ -202,13 +202,16 @@ object AutoMobileBiometrics {
   /** Unregister the override receiver so it doesn't leak across init/shutdown cycles (#3599). */
   @Synchronized
   fun shutdown() {
-    if (!receiverRegistered) return
-    context?.let {
-      try {
-        it.unregisterReceiver(broadcastReceiver)
-      } catch (_: Exception) {}
+    if (receiverRegistered) {
+      context?.let {
+        try {
+          it.unregisterReceiver(broadcastReceiver)
+        } catch (_: Exception) {}
+      }
     }
     receiverRegistered = false
+    context = null
+    pendingOverride.set(null)
   }
 
   /**

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
@@ -84,10 +84,10 @@ object AutoMobileCrashes {
 
     this.context = context.applicationContext
 
-    // Save the original handler
-    originalHandler = Thread.getDefaultUncaughtExceptionHandler()
-
-    // Install our handler
+    // Capture the predecessor in the installed handler. It must remain available after uninstall
+    // because a later crash reporter may retain this handler as its delegate.
+    val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+    this.originalHandler = originalHandler
     Thread.setDefaultUncaughtExceptionHandler(AutoMobileExceptionHandler())
 
     AutoMobileSDK.logger.d(TAG) { "AutoMobileCrashes initialized - crash detection enabled" }
@@ -113,12 +113,16 @@ object AutoMobileCrashes {
   }
 
   private class AutoMobileExceptionHandler : Thread.UncaughtExceptionHandler {
+    private val originalHandler = AutoMobileCrashes.originalHandler
+
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
-      try {
-        // Broadcast the crash before the app terminates
-        broadcastCrash(thread, throwable)
-      } catch (e: Exception) {
-        AutoMobileSDK.logger.e(TAG, e) { "Failed to broadcast crash" }
+      if (AutoMobileSDK.isTrackingEnabled) {
+        try {
+          // Broadcast the crash before the app terminates
+          broadcastCrash(thread, throwable)
+        } catch (e: Exception) {
+          AutoMobileSDK.logger.e(TAG, e) { "Failed to broadcast crash" }
+        }
       }
 
       // Call the original handler to preserve default crash behavior

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
@@ -95,6 +95,8 @@ object AutoMobileFailures {
     message: String? = null,
     currentScreen: String? = null,
   ) {
+    if (!AutoMobileSDK.isTrackingEnabled) return
+
     val ctx = context
     if (ctx == null) {
       AutoMobileSDK.logger.w(TAG) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
@@ -138,6 +138,12 @@ object AutoMobileFailures {
     }
   }
 
+  /** Clears process-wide failure reporting state during SDK shutdown. */
+  internal fun reset() {
+    context = null
+    clearEvents()
+  }
+
   private fun createEvent(
     context: Context,
     throwable: Throwable,

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/interaction/AutoMobileClickTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/interaction/AutoMobileClickTracker.kt
@@ -161,7 +161,7 @@ internal object AutoMobileClickTracker {
     }
 
     private fun emitTapEvent(x: Float, y: Float, durationMs: Long) {
-      if (!isInitialized) return
+      if (!isInitialized || !AutoMobileSDK.isTrackingEnabled) return
       val now = System.currentTimeMillis()
       if (now - lastTapProcessedAt < TAP_DEBOUNCE_MS) return
       lastTapProcessedAt = now

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
@@ -41,7 +41,10 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     }
 
     fun shutdown(context: Context) {
-      getInstance().unregisterReceiver(context)
+      getInstance().apply {
+        unregisterReceiver(context)
+        clear()
+      }
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptor.kt
@@ -110,5 +110,6 @@ internal object AutoMobileBroadcastInterceptor {
     }
     receiver = null
     buffer = null
+    applicationId = null
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileOsEvents.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileOsEvents.kt
@@ -65,7 +65,10 @@ internal object AutoMobileOsEvents {
     unregisterScreenReceiver(context)
     unregisterLifecycleObserver()
     buffer = null
+    applicationId = null
     onLifecycleEvent = {}
+    lastBatteryPct = null
+    lastBatteryCharging = null
   }
 
   private fun postEvent(kind: String, details: Map<String, String>? = null) {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKShutdownTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKShutdownTest.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -69,6 +70,24 @@ class AutoMobileSDKShutdownTest {
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
     assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `reinitialization waits for pending main thread teardown`() {
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    val shutdownThread = Thread { AutoMobileSDK.shutdown() }
+    shutdownThread.start()
+    shutdownThread.join()
+    AutoMobileSDK.initialize(context)
+
+    assertNull(AutoMobileSDK.getEventBuffer())
+
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertTrue(AutoMobileCrashes.isInitialized())
+    assertTrue(AutoMobileSDK.getEventBuffer() != null)
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKShutdownTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKShutdownTest.kt
@@ -1,0 +1,84 @@
+package dev.jasonpearson.automobile.sdk
+
+import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
+import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
+import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileSDKShutdownTest {
+  private val context = RuntimeEnvironment.getApplication()
+  private lateinit var originalHandler: Thread.UncaughtExceptionHandler
+
+  @Before
+  fun setUp() {
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    AutoMobileCrashes.uninstall()
+    DatabaseInspector.reset()
+    SharedPreferencesInspector.reset()
+    originalHandler = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+  }
+
+  @After
+  fun tearDown() {
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+  }
+
+  @Test
+  fun `shutdown restores crash handling and inspector state`() {
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    DatabaseInspector.setEnabled(true)
+    SharedPreferencesInspector.setEnabled(true)
+
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+    assertFalse(AutoMobileCrashes.isInitialized())
+    assertFalse(DatabaseInspector.isEnabled())
+    assertFalse(SharedPreferencesInspector.isEnabled())
+  }
+
+  @Test
+  fun `a shutdown cycle reinitializes without retaining crash handler state`() {
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertTrue(AutoMobileCrashes.isInitialized())
+
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `setEnabled disables capture without uninstalling runtime hooks`() {
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    AutoMobileSDK.setEnabled(false)
+
+    assertFalse(AutoMobileSDK.isTrackingEnabled)
+    assertTrue(AutoMobileCrashes.isInitialized())
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashesTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashesTest.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.sdk.crashes
 
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -103,5 +105,24 @@ class AutoMobileCrashesTest {
       foreign,
       Thread.getDefaultUncaughtExceptionHandler(),
     )
+  }
+
+  @Test
+  fun `uninstalled handler retained by a later reporter forwards to its original handler`() {
+    val originalCalls = AtomicInteger()
+    val original = Thread.UncaughtExceptionHandler { _, _ -> originalCalls.incrementAndGet() }
+    Thread.setDefaultUncaughtExceptionHandler(original)
+    AutoMobileCrashes.initialize(context)
+    val autoMobileHandler = Thread.getDefaultUncaughtExceptionHandler()
+    val foreign = Thread.UncaughtExceptionHandler { thread, throwable ->
+      autoMobileHandler?.uncaughtException(thread, throwable)
+    }
+    Thread.setDefaultUncaughtExceptionHandler(foreign)
+
+    AutoMobileCrashes.uninstall()
+    foreign.uncaughtException(Thread.currentThread(), RuntimeException("test crash"))
+
+    assertSame(foreign, Thread.getDefaultUncaughtExceptionHandler())
+    assertEquals("a retained handler must forward to its predecessor", 1, originalCalls.get())
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailuresTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailuresTest.kt
@@ -1,25 +1,27 @@
 package dev.jasonpearson.automobile.sdk.failures
 
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AutoMobileFailuresTest {
 
   @Before
   fun setup() {
-    // Clear events before each test
-    AutoMobileFailures.clearEvents()
+    AutoMobileFailures.reset()
+    AutoMobileSDK.setEnabled(true)
   }
 
   @After
   fun tearDown() {
-    // Clean up after each test
-    AutoMobileFailures.clearEvents()
+    AutoMobileFailures.reset()
+    AutoMobileSDK.setEnabled(true)
   }
 
   @Test
@@ -61,6 +63,16 @@ class AutoMobileFailuresTest {
   fun `recordHandledException with screen should not crash when context not initialized`() {
     val exception = RuntimeException("Test exception")
     AutoMobileFailures.recordHandledException(exception, "Custom message", "TestScreen")
+
+    assertEquals(0, AutoMobileFailures.getEventCount())
+  }
+
+  @Test
+  fun `recordHandledException does not capture while the SDK is disabled`() {
+    AutoMobileFailures.initialize(RuntimeEnvironment.getApplication())
+    AutoMobileSDK.setEnabled(false)
+
+    AutoMobileFailures.recordHandledException(RuntimeException("Test exception"))
 
     assertEquals(0, AutoMobileFailures.getEventCount())
   }


### PR DESCRIPTION
## Summary

Makes Android SDK lifecycle instrumentation reversible: initialization now rolls back through
`shutdown()` on synchronous or main-thread setup failures, and shutdown clears every SDK-owned
hook and retained application state.

Clarifies that `setEnabled(false)` disables capture only; `shutdown()` is the complete detach
operation.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/6025

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Shutdown retained the crash exception handler and inspector state, so an
  optional SDK initialization could not be safely rolled back.
- **Repro steps / conditions:** Initialize the SDK, enable either inspector, then call shutdown.

## Validation

- [x] `./gradlew --no-daemon --no-configuration-cache -Dorg.gradle.jvmargs='-Xmx4g -Dfile.encoding=UTF-8' :auto-mobile-sdk:test :auto-mobile-sdk:apiCheck`
- [x] `INSTALL_KTFMT_WHEN_MISSING=true ONLY_TOUCHED_FILES=true bash scripts/ktfmt/validate_ktfmt.sh`
- [x] `bun run lint`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `scripts/all_fast_validate_checks.sh --skip lychee --max-parallel 4`
- [ ] Device verification (not applicable: lifecycle cleanup covered by Robolectric unit tests)

## Follow-ups

- [ ] None.
