### PR TITLE
fix(android-sdk): dispatch capacity event batches asynchronously

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -40,7 +40,9 @@ internal class SdkEventBuffer(
 ) {
   private val lock = ReentrantLock()
   private val buffer = mutableListOf<SdkEvent>()
+  private val pendingBatches = ArrayDeque<MutableList<SdkEvent>>()
   private var flushTask: ScheduledFuture<*>? = null
+  private var isDeliveryScheduled = false
   @Volatile private var isShutdown = false
   @Volatile var isEnabled: Boolean = true
 
@@ -94,10 +96,10 @@ internal class SdkEventBuffer(
         return
       }
 
-      if (buffer.size >= maxPendingEvents) {
+      while (pendingEventCount() >= maxPendingEvents) {
         when (backPressureStrategy) {
           BackPressureStrategy.DROP_OLDEST -> {
-            buffer.removeFirst()
+            dropOldestPendingEvent()
             dropCounter?.increment(DropReason.BUFFER_OVERFLOW)
           }
           BackPressureStrategy.IGNORE_NEWEST -> {
@@ -111,7 +113,7 @@ internal class SdkEventBuffer(
       if (buffer.size >= maxBufferSize) {
         val snapshot = ArrayList(buffer)
         buffer.clear()
-        submitDelivery(snapshot)
+        enqueueDelivery(snapshot)
       }
     }
   }
@@ -147,7 +149,7 @@ internal class SdkEventBuffer(
       if (buffer.isNotEmpty()) {
         val snapshot = ArrayList(buffer)
         buffer.clear()
-        submitDelivery(snapshot)
+        enqueueDelivery(snapshot)
       }
     }
     executor.shutdown()
@@ -159,13 +161,47 @@ internal class SdkEventBuffer(
       if (isShutdown || buffer.isEmpty()) return
       val snapshot = ArrayList(buffer)
       buffer.clear()
-      submitDelivery(snapshot)
+      enqueueDelivery(snapshot)
     }
   }
 
-  /** Queue delivery while holding [lock] to preserve snapshot submission order. */
-  private fun submitDelivery(events: List<SdkEvent>) {
-    executor.execute { deliverBatch(events) }
+  /** Queue delivery while holding [lock] to preserve snapshot submission order and backpressure. */
+  private fun enqueueDelivery(events: MutableList<SdkEvent>) {
+    pendingBatches.addLast(events)
+    if (!isDeliveryScheduled) {
+      isDeliveryScheduled = true
+      executor.execute { drainDeliveries() }
+    }
+  }
+
+  private fun drainDeliveries() {
+    while (true) {
+      val events = lock.withLock {
+        if (pendingBatches.isEmpty()) {
+          isDeliveryScheduled = false
+          return
+        }
+        pendingBatches.removeFirst()
+      }
+      deliverBatch(events)
+    }
+  }
+
+  /** Must be called while holding [lock]. Delivery in progress is no longer pending. */
+  private fun pendingEventCount(): Int = buffer.size + pendingBatches.sumOf { it.size }
+
+  /** Must be called while holding [lock]. */
+  private fun dropOldestPendingEvent() {
+    val oldestBatch = pendingBatches.firstOrNull()
+    if (oldestBatch == null) {
+      buffer.removeFirst()
+      return
+    }
+
+    oldestBatch.removeFirst()
+    if (oldestBatch.isEmpty()) {
+      pendingBatches.removeFirst()
+    }
   }
 
   private fun deliverBatch(events: List<SdkEvent>) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -194,11 +194,11 @@ internal class SdkEventBuffer(
   private fun dropOldestPendingEvent() {
     val oldestBatch = pendingBatches.firstOrNull()
     if (oldestBatch == null) {
-      buffer.removeFirst()
+      buffer.removeAt(0)
       return
     }
 
-    oldestBatch.removeFirst()
+    oldestBatch.removeAt(0)
     if (oldestBatch.isEmpty()) {
       pendingBatches.removeFirst()
     }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -53,7 +53,7 @@ internal class SdkEventBuffer(
             // Backstop: any exception escaping the periodic task cancels all future
             // runs (the scheduleAtFixedRate contract). Per-batch errors are already
             // accounted inside deliverBatch; swallow here so the timer survives (#3605).
-            { runCatching { flush() } },
+            { runCatching { enqueueFlush() } },
             flushIntervalMs,
             flushIntervalMs,
             TimeUnit.MILLISECONDS,
@@ -88,10 +88,12 @@ internal class SdkEventBuffer(
       }
     }
 
-    val shouldFlush: Boolean
-    val snapshot: List<SdkEvent>
-
     lock.withLock {
+      if (isShutdown) {
+        dropCounter?.increment(DropReason.SHUTDOWN)
+        return
+      }
+
       if (buffer.size >= maxPendingEvents) {
         when (backPressureStrategy) {
           BackPressureStrategy.DROP_OLDEST -> {
@@ -107,17 +109,10 @@ internal class SdkEventBuffer(
 
       buffer.add(current)
       if (buffer.size >= maxBufferSize) {
-        snapshot = ArrayList(buffer)
+        val snapshot = ArrayList(buffer)
         buffer.clear()
-        shouldFlush = true
-      } else {
-        snapshot = emptyList()
-        shouldFlush = false
+        submitDelivery(snapshot)
       }
-    }
-
-    if (shouldFlush) {
-      deliverBatch(snapshot)
     }
   }
 
@@ -136,17 +131,41 @@ internal class SdkEventBuffer(
 
   /** Submit a task to run on the buffer's background executor. */
   fun execute(task: Runnable) {
-    if (!isShutdown) {
-      executor.execute(task)
+    lock.withLock {
+      if (!isShutdown) {
+        executor.execute(task)
+      }
     }
   }
 
   /** Shutdown the buffer, flushing remaining events. */
   fun shutdown() {
-    isShutdown = true
-    flushTask?.cancel(false)
-    flush()
+    lock.withLock {
+      if (isShutdown) return
+      isShutdown = true
+      flushTask?.cancel(false)
+      if (buffer.isNotEmpty()) {
+        val snapshot = ArrayList(buffer)
+        buffer.clear()
+        submitDelivery(snapshot)
+      }
+    }
     executor.shutdown()
+  }
+
+  /** Snapshot and queue pending events from the periodic executor. */
+  private fun enqueueFlush() {
+    lock.withLock {
+      if (isShutdown || buffer.isEmpty()) return
+      val snapshot = ArrayList(buffer)
+      buffer.clear()
+      submitDelivery(snapshot)
+    }
+  }
+
+  /** Queue delivery while holding [lock] to preserve snapshot submission order. */
+  private fun submitDelivery(events: List<SdkEvent>) {
+    executor.execute { deliverBatch(events) }
   }
 
   private fun deliverBatch(events: List<SdkEvent>) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -153,6 +153,7 @@ internal class SdkEventBuffer(
       }
     }
     executor.shutdown()
+    awaitExecutorTermination()
   }
 
   /** Snapshot and queue pending events from the periodic executor. */
@@ -201,6 +202,21 @@ internal class SdkEventBuffer(
     oldestBatch.removeAt(0)
     if (oldestBatch.isEmpty()) {
       pendingBatches.removeFirst()
+    }
+  }
+
+  /** Preserve shutdown delivery completion without running delivery on the caller thread. */
+  private fun awaitExecutorTermination() {
+    var wasInterrupted = false
+    while (true) {
+      try {
+        if (executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)) break
+      } catch (_: InterruptedException) {
+        wasInterrupted = true
+      }
+    }
+    if (wasInterrupted) {
+      Thread.currentThread().interrupt()
     }
   }
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -7,9 +7,12 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class SdkEventBufferTest {
@@ -23,6 +26,34 @@ class SdkEventBufferTest {
   /** Wait for any pending tasks on the executor to complete. */
   private fun drainExecutor(executor: ScheduledExecutorService) {
     executor.submit {}.get(1, TimeUnit.SECONDS)
+  }
+
+  private class TimerGatedExecutor : ScheduledThreadPoolExecutor(1) {
+    private val timerStarted = CountDownLatch(1)
+    private val allowTimer = CountDownLatch(1)
+
+    override fun scheduleAtFixedRate(
+      command: Runnable,
+      initialDelay: Long,
+      period: Long,
+      unit: TimeUnit,
+    ) =
+      super.scheduleAtFixedRate(
+        {
+          timerStarted.countDown()
+          allowTimer.await()
+          command.run()
+        },
+        initialDelay,
+        period,
+        unit,
+      )
+
+    fun awaitTimerStart(): Boolean = timerStarted.await(1, TimeUnit.SECONDS)
+
+    fun releaseTimer() {
+      allowTimer.countDown()
+    }
   }
 
   @Test
@@ -45,6 +76,85 @@ class SdkEventBufferTest {
     drainExecutor(executor) // capacity flush is async
     assertEquals(1, flushed.size, "Should flush at capacity")
     assertEquals(3, flushed[0].size)
+  }
+
+  @Test
+  fun `capacity delivery runs on executor without blocking caller`() {
+    val executorThreadName = "SdkEventBuffer-test-executor"
+    val executor = Executors.newSingleThreadScheduledExecutor { runnable ->
+      Thread(runnable, executorThreadName)
+    }
+    val deliveryStarted = CountDownLatch(1)
+    val releaseDelivery = CountDownLatch(1)
+    val addReturned = CountDownLatch(1)
+    val flushThread = AtomicReference<String>()
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 1,
+        flushIntervalMs = 60_000,
+        onFlush = {
+          flushThread.set(Thread.currentThread().name)
+          deliveryStarted.countDown()
+          releaseDelivery.await()
+        },
+        executor = executor,
+      )
+    val caller =
+      Thread(
+        {
+          buffer.add(makeEvent(1))
+          addReturned.countDown()
+        },
+        "SDK host caller",
+      )
+
+    try {
+      caller.start()
+      assertTrue(deliveryStarted.await(1, TimeUnit.SECONDS), "Delivery should begin")
+      assertTrue(
+        addReturned.await(100, TimeUnit.MILLISECONDS),
+        "add() should not wait for delivery",
+      )
+      assertEquals(executorThreadName, flushThread.get())
+    } finally {
+      releaseDelivery.countDown()
+      caller.join(1_000)
+      executor.shutdownNow()
+    }
+  }
+
+  @Test
+  fun `capacity and timer delivery retain event order and ownership`() {
+    val executor = TimerGatedExecutor()
+    val deliveries = CopyOnWriteArrayList<List<SdkEvent>>()
+    val delivered = CountDownLatch(2)
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 2,
+        flushIntervalMs = 1,
+        onFlush = {
+          deliveries.add(ArrayList(it))
+          delivered.countDown()
+        },
+        executor = executor,
+      )
+
+    try {
+      buffer.start()
+      assertTrue(executor.awaitTimerStart(), "Timer task should be pending")
+
+      buffer.add(makeEvent(1))
+      buffer.add(makeEvent(2))
+      buffer.add(makeEvent(3))
+      executor.releaseTimer()
+
+      assertTrue(delivered.await(1, TimeUnit.SECONDS), "Both batches should be delivered")
+      assertEquals(listOf(1L, 2L, 3L), deliveries.flatten().map { it.timestamp })
+    } finally {
+      executor.releaseTimer()
+      buffer.shutdown()
+      executor.shutdownNow()
+    }
   }
 
   @Test
@@ -84,20 +194,79 @@ class SdkEventBufferTest {
   @Test
   fun `shutdown flushes remaining events`() {
     val flushed = mutableListOf<List<SdkEvent>>()
+    val executorThreadName = "SdkEventBuffer-shutdown-executor"
+    val executor = Executors.newSingleThreadScheduledExecutor { runnable ->
+      Thread(runnable, executorThreadName)
+    }
+    val flushThread = AtomicReference<String>()
     val buffer =
       SdkEventBuffer(
         maxBufferSize = 100,
         flushIntervalMs = 60_000,
-        onFlush = { flushed.add(it) },
-        executor = Executors.newSingleThreadScheduledExecutor(),
+        onFlush = {
+          flushThread.set(Thread.currentThread().name)
+          flushed.add(it)
+        },
+        executor = executor,
       )
 
     buffer.add(makeEvent(1))
     buffer.add(makeEvent(2))
     buffer.shutdown()
 
+    assertTrue(
+      executor.awaitTermination(1, TimeUnit.SECONDS),
+      "Shutdown should drain queued delivery",
+    )
     assertEquals(1, flushed.size)
     assertEquals(2, flushed[0].size)
+    assertEquals(executorThreadName, flushThread.get())
+  }
+
+  @Test
+  fun `shutdown drains queued capacity and pending batches on executor`() {
+    val executorThreadName = "SdkEventBuffer-shutdown-drain-executor"
+    val executor = Executors.newSingleThreadScheduledExecutor { runnable ->
+      Thread(runnable, executorThreadName)
+    }
+    val deliveryStarted = CountDownLatch(1)
+    val releaseDelivery = CountDownLatch(1)
+    val deliveries = CopyOnWriteArrayList<List<SdkEvent>>()
+    val deliveryThreads = CopyOnWriteArrayList<String>()
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 2,
+        flushIntervalMs = 60_000,
+        onFlush = { events ->
+          deliveries.add(ArrayList(events))
+          deliveryThreads.add(Thread.currentThread().name)
+          if (events.first().timestamp == 1L) {
+            deliveryStarted.countDown()
+            releaseDelivery.await()
+          }
+        },
+        executor = executor,
+      )
+
+    try {
+      buffer.add(makeEvent(1))
+      buffer.add(makeEvent(2))
+      assertTrue(deliveryStarted.await(1, TimeUnit.SECONDS), "Capacity delivery should be queued")
+
+      buffer.add(makeEvent(3))
+      buffer.shutdown()
+      releaseDelivery.countDown()
+
+      assertTrue(
+        executor.awaitTermination(1, TimeUnit.SECONDS),
+        "Shutdown should drain both batches",
+      )
+      assertEquals(listOf(1L, 2L, 3L), deliveries.flatten().map { it.timestamp })
+      assertEquals(listOf(executorThreadName, executorThreadName), deliveryThreads)
+    } finally {
+      releaseDelivery.countDown()
+      executor.shutdownNow()
+    }
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -270,6 +270,52 @@ class SdkEventBufferTest {
   }
 
   @Test
+  fun `queued batches participate in pending event cap`() {
+    val executor = Executors.newSingleThreadScheduledExecutor()
+    val deliveryStarted = CountDownLatch(1)
+    val releaseDelivery = CountDownLatch(1)
+    val deliveries = CopyOnWriteArrayList<List<SdkEvent>>()
+    val counter = DefaultDropCounter()
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 1,
+        flushIntervalMs = 60_000,
+        onFlush = { events ->
+          deliveries.add(ArrayList(events))
+          if (events.first().timestamp == 1L) {
+            deliveryStarted.countDown()
+            releaseDelivery.await()
+          }
+        },
+        executor = executor,
+        dropCounter = counter,
+        maxPendingEvents = 3,
+      )
+
+    try {
+      buffer.add(makeEvent(1))
+      assertTrue(deliveryStarted.await(1, TimeUnit.SECONDS), "First delivery should block")
+
+      buffer.add(makeEvent(2))
+      buffer.add(makeEvent(3))
+      buffer.add(makeEvent(4))
+      buffer.add(makeEvent(5))
+      releaseDelivery.countDown()
+      buffer.shutdown()
+
+      assertTrue(
+        executor.awaitTermination(1, TimeUnit.SECONDS),
+        "Shutdown should drain queued batches",
+      )
+      assertEquals(listOf(1L, 3L, 4L, 5L), deliveries.flatten().map { it.timestamp })
+      assertEquals(1L, counter.snapshot()[DropReason.BUFFER_OVERFLOW])
+    } finally {
+      releaseDelivery.countDown()
+      executor.shutdownNow()
+    }
+  }
+
+  @Test
   fun `add after shutdown is ignored`() {
     val flushed = mutableListOf<List<SdkEvent>>()
     val buffer =

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Test
 
@@ -254,9 +255,27 @@ class SdkEventBufferTest {
       assertTrue(deliveryStarted.await(1, TimeUnit.SECONDS), "Capacity delivery should be queued")
 
       buffer.add(makeEvent(3))
-      buffer.shutdown()
+      val shutdownReturned = CountDownLatch(1)
+      val shutdownCaller =
+        Thread(
+          {
+            buffer.shutdown()
+            shutdownReturned.countDown()
+          },
+          "SDK host shutdown",
+        )
+      shutdownCaller.start()
+      assertFalse(
+        shutdownReturned.await(100, TimeUnit.MILLISECONDS),
+        "Shutdown should wait for queued delivery",
+      )
       releaseDelivery.countDown()
 
+      assertTrue(
+        shutdownReturned.await(1, TimeUnit.SECONDS),
+        "Shutdown should complete after delivery",
+      )
+      shutdownCaller.join(1_000)
       assertTrue(
         executor.awaitTermination(1, TimeUnit.SECONDS),
         "Shutdown should drain both batches",

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -38,7 +39,7 @@ class SdkEventBufferTest {
       initialDelay: Long,
       period: Long,
       unit: TimeUnit,
-    ) =
+    ): ScheduledFuture<*> =
       super.scheduleAtFixedRate(
         {
           timerStarted.countDown()

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
@@ -7,6 +7,7 @@ import java.io.IOException
 import java.net.Proxy
 import java.net.ProxySelector
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
@@ -33,20 +34,33 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
 import org.junit.Test
 
 class AutoMobileNetworkInterceptorTest {
+  private var bufferExecutor: ScheduledExecutorService? = null
+
+  @After
+  fun tearDown() {
+    bufferExecutor?.shutdownNow()
+  }
 
   private fun collectingBuffer(): Pair<SdkEventBuffer, MutableList<List<SdkEvent>>> {
     val flushed = mutableListOf<List<SdkEvent>>()
+    val executor = Executors.newSingleThreadScheduledExecutor()
     val buffer =
       SdkEventBuffer(
         maxBufferSize = 1,
         flushIntervalMs = 60_000,
         onFlush = { flushed.add(it) },
-        executor = Executors.newSingleThreadScheduledExecutor(),
+        executor = executor,
       )
+    bufferExecutor = executor
     return buffer to flushed
+  }
+
+  private fun drainDelivery() {
+    bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
   }
 
   private fun fakeChain(
@@ -175,7 +189,7 @@ class AutoMobileNetworkInterceptorTest {
     val request = Request.Builder().url("https://api.example.com/users?page=1").get().build()
 
     interceptor.intercept(fakeChain(request = request, responseCode = 200))
-    buffer.flush()
+    drainDelivery()
 
     assertEquals(1, flushed.size)
     val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -195,7 +209,7 @@ class AutoMobileNetworkInterceptorTest {
     val body = "x".repeat(1024)
 
     interceptor.intercept(fakeChain(responseBody = body))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals(1024L, event.responseBodySize)
@@ -207,7 +221,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer)
 
     interceptor.intercept(fakeChain(protocol = Protocol.HTTP_2))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("h2", event.protocol)
@@ -221,7 +235,7 @@ class AutoMobileNetworkInterceptorTest {
     assertFailsWith<IOException> {
       interceptor.intercept(fakeChain(throwOnProceed = IOException("Connection refused")))
     }
-    buffer.flush()
+    drainDelivery()
 
     assertEquals(1, flushed.size)
     val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -251,7 +265,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request, responseCode = 201))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("POST", event.method)
@@ -265,7 +279,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer)
 
     interceptor.intercept(fakeChain())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertTrue(event.durationMs >= 0, "Duration should be non-negative")
@@ -285,7 +299,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNotNull(event.requestHeaders)
@@ -309,7 +323,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("first, second, third", event.requestHeaders!!["X-Trace"])
@@ -329,7 +343,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("lower", event.requestHeaders!!["X-Case"])
@@ -342,7 +356,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = true)
 
     interceptor.intercept(fakeChain())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNotNull(event.responseHeaders)
@@ -356,7 +370,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = false)
 
     interceptor.intercept(fakeChain())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestHeaders)
@@ -376,7 +390,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request, responseCode = 201))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("""{"name":"test"}""", event.requestBody)
@@ -388,7 +402,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer, captureBodies = true)
 
     interceptor.intercept(fakeChain(responseBody = """{"ok":true}"""))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("""{"ok":true}""", event.responseBody)
@@ -405,7 +419,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestBody)
@@ -423,7 +437,7 @@ class AutoMobileNetworkInterceptorTest {
         .build()
 
     interceptor.intercept(fakeChain(request = request))
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestBody) // image/png is not a text type
@@ -435,7 +449,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer)
 
     interceptor.intercept(fakeChain())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("application/json", event.contentType)
@@ -451,7 +465,7 @@ class AutoMobileNetworkInterceptorTest {
     assertFailsWith<IOException> {
       interceptor.intercept(fakeChain(request = request, throwOnProceed = IOException("timeout")))
     }
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNotNull(event.requestHeaders)
@@ -499,7 +513,7 @@ class AutoMobileNetworkInterceptorTest {
     assertEquals(false, chainCalled)
     assertEquals(503, response.code)
     assertEquals("""{"error":"service unavailable"}""", response.body.string())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals(503, event.statusCode)
@@ -514,7 +528,7 @@ class AutoMobileNetworkInterceptorTest {
     val response = interceptor.intercept(fakeChain(responseCode = 200))
 
     assertEquals(200, response.code)
-    buffer.flush()
+    drainDelivery()
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.error)
   }
@@ -535,7 +549,7 @@ class AutoMobileNetworkInterceptorTest {
     val response = interceptor.intercept(fakeChain())
 
     assertEquals(500, response.code)
-    buffer.flush()
+    drainDelivery()
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals(500, event.statusCode)
     assertEquals("simulated:http500", event.error)
@@ -557,7 +571,7 @@ class AutoMobileNetworkInterceptorTest {
     assertFailsWith<java.net.SocketTimeoutException> {
       interceptor.intercept(fakeChain())
     }
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("simulated:timeout", event.error)
@@ -668,7 +682,7 @@ class AutoMobileNetworkInterceptorTest {
     val interceptor = AutoMobileNetworkInterceptor(buffer)
 
     interceptor.intercept(fakeChain())
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestHeaders)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -5,28 +5,38 @@ import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.junit.After
 import org.junit.Test
 
 class AutoMobileNetworkTest {
+  private var bufferExecutor: ScheduledExecutorService? = null
 
   @After
   fun tearDown() {
     AutoMobileNetwork.reset()
+    bufferExecutor?.shutdownNow()
   }
 
   private fun collectingBuffer(): Pair<SdkEventBuffer, MutableList<List<SdkEvent>>> {
     val flushed = mutableListOf<List<SdkEvent>>()
+    val executor = Executors.newSingleThreadScheduledExecutor()
     val buffer =
       SdkEventBuffer(
         maxBufferSize = 1,
         flushIntervalMs = 60_000,
         onFlush = { flushed.add(it) },
-        executor = Executors.newSingleThreadScheduledExecutor(),
+        executor = executor,
       )
+    bufferExecutor = executor
     return buffer to flushed
+  }
+
+  private fun drainDelivery() {
+    bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
   }
 
   @Test
@@ -46,7 +56,7 @@ class AutoMobileNetworkTest {
         path = "/users",
       )
     )
-    buffer.flush()
+    drainDelivery()
 
     assertEquals(1, flushed.size)
     val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -73,7 +83,7 @@ class AutoMobileNetworkTest {
         method = "POST",
       )
     )
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("api.example.com", event.host)
@@ -108,7 +118,7 @@ class AutoMobileNetworkTest {
 
     // Without capture flags, headers and bodies should be null
     AutoMobileNetwork.recordRequest(record)
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestHeaders)
@@ -133,7 +143,7 @@ class AutoMobileNetworkTest {
       )
 
     AutoMobileNetwork.recordRequest(record, captureHeaders = true, captureBodies = true)
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals(mapOf("Authorization" to "Bearer token"), event.requestHeaders)
@@ -158,7 +168,7 @@ class AutoMobileNetworkTest {
       captureHeaders = true,
       captureBodies = true,
     )
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestHeaders)
@@ -197,7 +207,7 @@ class AutoMobileNetworkTest {
     session.complete(statusCode = 200, durationMs = 12)
     session.fail(IllegalStateException("late failure"))
     session.cancel()
-    buffer.flush()
+    drainDelivery()
 
     assertEquals(1, flushed.size)
     val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -224,7 +234,7 @@ class AutoMobileNetworkTest {
       responseHeaders = mapOf("X-Request-Id" to "abc"),
       responseBody = "{\"ok\":true}",
     )
-    buffer.flush()
+    drainDelivery()
 
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals(mapOf("Authorization" to "secret"), event.requestHeaders)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListenerTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListenerTest.kt
@@ -6,25 +6,40 @@ import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString.Companion.encodeUtf8
+import org.junit.After
 import org.junit.Test
 
 class AutoMobileWebSocketListenerTest {
+  private var bufferExecutor: ScheduledExecutorService? = null
+
+  @After
+  fun tearDown() {
+    bufferExecutor?.shutdownNow()
+  }
 
   private fun collectingBuffer(): Pair<SdkEventBuffer, MutableList<SdkEvent>> {
     val events = mutableListOf<SdkEvent>()
+    val executor = Executors.newSingleThreadScheduledExecutor()
     val buffer =
       SdkEventBuffer(
         maxBufferSize = 1,
         flushIntervalMs = 60_000,
         onFlush = { events.addAll(it) },
-        executor = Executors.newSingleThreadScheduledExecutor(),
+        executor = executor,
       )
+    bufferExecutor = executor
     return buffer to events
+  }
+
+  private fun drainDelivery() {
+    bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
   }
 
   /** Minimal no-op WebSocket for testing callbacks */
@@ -57,6 +72,7 @@ class AutoMobileWebSocketListenerTest {
 
     listener.onMessage(fakeWebSocket, "hello world")
 
+    drainDelivery()
     assertEquals(1, events.size)
     val event = events[0] as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.RECEIVED, event.direction)
@@ -75,6 +91,7 @@ class AutoMobileWebSocketListenerTest {
     val bytes = "binary data".encodeUtf8()
     listener.onMessage(fakeWebSocket, bytes)
 
+    drainDelivery()
     val event = events[0] as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.RECEIVED, event.direction)
     assertEquals(WebSocketFrameType.BINARY, event.frameType)
@@ -89,6 +106,7 @@ class AutoMobileWebSocketListenerTest {
 
     listener.onClosing(fakeWebSocket, 1000, "goodbye")
 
+    drainDelivery()
     val event = events[0] as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.RECEIVED, event.direction)
     assertEquals(WebSocketFrameType.CLOSE, event.frameType)
@@ -161,6 +179,7 @@ class AutoMobileWebSocketListenerTest {
 
     listener.onMessage(fakeWebSocket, "msg")
 
+    drainDelivery()
     val event = events[0] as SdkWebSocketFrameEvent
     assertEquals("com.example.app", event.applicationId)
   }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
@@ -6,6 +6,8 @@ import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -13,20 +15,33 @@ import okhttp3.Request
 import okhttp3.WebSocket
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
+import org.junit.After
 import org.junit.Test
 
 class AutoMobileWebSocketTest {
+  private var bufferExecutor: ScheduledExecutorService? = null
+
+  @After
+  fun tearDown() {
+    bufferExecutor?.shutdownNow()
+  }
 
   private fun collectingBuffer(): Pair<SdkEventBuffer, MutableList<SdkEvent>> {
     val events = mutableListOf<SdkEvent>()
+    val executor = Executors.newSingleThreadScheduledExecutor()
     val buffer =
       SdkEventBuffer(
         maxBufferSize = 1,
         flushIntervalMs = 60_000,
         onFlush = { events.addAll(it) },
-        executor = Executors.newSingleThreadScheduledExecutor(),
+        executor = executor,
       )
+    bufferExecutor = executor
     return buffer to events
+  }
+
+  private fun drainDelivery() {
+    bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
   }
 
   @Test
@@ -45,6 +60,7 @@ class AutoMobileWebSocketTest {
 
     assertTrue(webSocket.send("hé"))
 
+    drainDelivery()
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.SENT, event.direction)
     assertEquals(WebSocketFrameType.TEXT, event.frameType)
@@ -72,6 +88,7 @@ class AutoMobileWebSocketTest {
 
     assertFalse(webSocket.send(bytes))
 
+    drainDelivery()
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameType.BINARY, event.frameType)
     assertEquals(bytes.size.toLong(), event.payloadSize)
@@ -97,6 +114,7 @@ class AutoMobileWebSocketTest {
     assertFalse(webSocket.send("blocked"))
 
     assertTrue(delegate.textSends.isEmpty())
+    drainDelivery()
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.SENT, event.direction)
     assertEquals(WebSocketFrameType.TEXT, event.frameType)
@@ -120,6 +138,7 @@ class AutoMobileWebSocketTest {
     assertTrue(webSocket.close(1000, "adiós"))
 
     assertEquals(1000 to "adiós", delegate.closeCalls.single())
+    drainDelivery()
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameType.CLOSE, event.frameType)
     assertEquals(6L, event.payloadSize)
@@ -151,6 +170,7 @@ class AutoMobileWebSocketTest {
     listener.onMessage(delegate, "received")
     webSocket.send("sent")
 
+    drainDelivery()
     assertEquals(
       listOf(connectionId, connectionId),
       events.map { (it as SdkWebSocketFrameEvent).connectionId },

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -20,7 +20,7 @@ import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { getAbortSignal, runWithAbortSignal } from "../../src/utils/AbortContext";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
-import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
 import { executionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";


### PR DESCRIPTION
## Summary

Capacity-triggered SDK event batches now enqueue onto the SDK executor instead of delivering on the producer thread. A single ordered delivery queue preserves timer/capacity ordering, drains on shutdown, and keeps queued batches within the configured pending-event backpressure cap.

Producer tests now explicitly drain injected executors, and buffer tests cover executor affinity, non-blocking recording, timer/capacity ownership, shutdown draining, and queued-batch overflow eviction.

## Linked Issue

Closes [#6026](https://github.com/kaeawc/auto-mobile/issues/6026)

## Bug / Regression Context

- **Observed symptom:** Reaching SDK buffer capacity broadcast events and performed failure persistence inline on host UI and transport threads.
- **Repro steps / conditions:** Record an event that fills `SdkEventBuffer`.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — external documentation-link validation stalled locally.
- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors
- [x] `android/gradlew :auto-mobile-sdk:check :auto-mobile-sdk:createDebugUnitTestCoverageReport`
- [x] New executor behavior is covered by deterministic unit tests
- [x] Rebased onto latest `main`, conflicts resolved
