### PR TITLE
fix(test): isolate targeted test lanes

### DIFF
--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -97,6 +97,18 @@ lane_for_test_path() {
   esac
 }
 
+normalize_test_target() {
+  local target="${1#./}"
+  printf '%s\n' "${target#"$ROOT/"}"
+}
+
+has_glob_pattern() {
+  case "$1" in
+    *"?"* | *"*"* | *"["*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 add_test_path_to_lane() {
   local path="$1"
   case "$(lane_for_test_path "$path")" in
@@ -107,27 +119,41 @@ add_test_path_to_lane() {
 }
 
 add_test_target() {
-  local target="${1#./}"
-  local test_path
+  local target
+  local test_path match
   local found=0
+  local matched_paths=()
 
-  if [[ -f "$target" ]]; then
-    if [[ "$target" != *.test.ts ]]; then
-      echo "Test target is not a Bun test file: $1" >&2
-      exit 2
-    fi
-    add_test_path_to_lane "$target"
-    return
+  target="$(normalize_test_target "$1")"
+
+  if has_glob_pattern "$target"; then
+    while IFS= read -r match; do
+      matched_paths+=("$match")
+    done < <(compgen -G "$target" || true)
+  else
+    matched_paths=("$target")
   fi
 
-  if [[ -d "$target" ]]; then
-    while IFS= read -r test_path; do
+  for match in "${matched_paths[@]}"; do
+    if [[ -f "$match" ]]; then
+      if [[ "$match" != *.test.ts ]]; then
+        continue
+      fi
       found=1
-      add_test_path_to_lane "$test_path"
-    done < <(find "$target" -type f -name '*.test.ts' -print | sort)
-    if [[ "$found" -eq 1 ]]; then
-      return
+      add_test_path_to_lane "$match"
+      continue
     fi
+
+    if [[ -d "$match" ]]; then
+      while IFS= read -r test_path; do
+        found=1
+        add_test_path_to_lane "$test_path"
+      done < <(find "$match" -type f -name '*.test.ts' -print | sort)
+    fi
+  done
+
+  if [[ "$found" -eq 1 ]]; then
+    return
   fi
 
   echo "No test files found for target: $1" >&2
@@ -135,8 +161,9 @@ add_test_target() {
 }
 
 is_test_target() {
-  local target="${1#./}"
-  [[ "$target" == "test" || "$target" == test/* || "$target" == *.test.ts ]]
+  local target
+  target="$(normalize_test_target "$1")"
+  [[ "$target" == "test" || "$target" == test/* || "$target" == *.test.ts ]] || has_glob_pattern "$target"
 }
 
 test_option_takes_value() {

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -88,6 +88,89 @@ run_test_command() {
   "$@"
 }
 
+lane_for_test_path() {
+  local path="$1"
+  case "$path" in
+    test/stress/*) printf '%s\n' "stress" ;;
+    *.integration.test.ts) printf '%s\n' "integration" ;;
+    *) printf '%s\n' "unit" ;;
+  esac
+}
+
+add_test_path_to_lane() {
+  local path="$1"
+  case "$(lane_for_test_path "$path")" in
+    unit) unit_test_paths+=("$path") ;;
+    integration) integration_test_paths+=("$path") ;;
+    stress) stress_test_paths+=("$path") ;;
+  esac
+}
+
+add_test_target() {
+  local target="${1#./}"
+  local test_path
+  local found=0
+
+  if [[ -f "$target" ]]; then
+    if [[ "$target" != *.test.ts ]]; then
+      echo "Test target is not a Bun test file: $1" >&2
+      exit 2
+    fi
+    add_test_path_to_lane "$target"
+    return
+  fi
+
+  if [[ -d "$target" ]]; then
+    while IFS= read -r test_path; do
+      found=1
+      add_test_path_to_lane "$test_path"
+    done < <(find "$target" -type f -name '*.test.ts' -print | sort)
+    if [[ "$found" -eq 1 ]]; then
+      return
+    fi
+  fi
+
+  echo "No test files found for target: $1" >&2
+  exit 2
+}
+
+is_test_target() {
+  local target="${1#./}"
+  [[ "$target" == "test" || "$target" == test/* || "$target" == *.test.ts ]]
+}
+
+test_option_takes_value() {
+  case "$1" in
+    --timeout | --rerun-each | --retry | --seed | --coverage-reporter | --coverage-dir | --test-name-pattern | -t | --reporter | --reporter-outfile | --max-concurrency | --path-ignore-patterns | --changed | --parallel | --parallel-delay | --shard)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+unit_test_paths=()
+integration_test_paths=()
+stress_test_paths=()
+passthrough_args=()
+has_test_targets=0
+expect_option_value=0
+for arg in "$@"; do
+  if [[ "$expect_option_value" -eq 1 ]]; then
+    passthrough_args+=("$arg")
+    expect_option_value=0
+  elif test_option_takes_value "$arg"; then
+    passthrough_args+=("$arg")
+    expect_option_value=1
+  elif is_test_target "$arg"; then
+    has_test_targets=1
+    add_test_target "$arg"
+  else
+    passthrough_args+=("$arg")
+  fi
+done
+
 run_unit_shards() {
   local shard_root="$ROOT/scratch/test-ts-unit-shards"
   local file index shard worker_count rc pid
@@ -199,13 +282,23 @@ fi
 
 case "$mode" in
   unit)
-    if [[ "$#" -eq 0 && "$runner_os" != "Windows" ]]; then
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    elif [[ "${#unit_test_paths[@]}" -eq 0 && "${#passthrough_args[@]}" -eq 0 && "$runner_os" != "Windows" ]]; then
       run_unit_shards
     else
-      run_test_command "${unit_args[@]}" "$@"
+      run_test_command \
+        "${unit_args[@]}" \
+        "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+        "${passthrough_args[@]+"${passthrough_args[@]}"}"
     fi
     ;;
   changed)
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    fi
     changed_ref="${AUTOMOBILE_UNIT_TEST_BASE_REF:-origin/main}"
     changed_args=("${unit_args[@]}")
     if [[ -n "${AUTOMOBILE_UNIT_JUNIT_DIR:-}" ]]; then
@@ -216,30 +309,23 @@ case "$mode" in
         --reporter-outfile "$AUTOMOBILE_UNIT_JUNIT_DIR/changed.xml"
       )
     fi
-    run_test_command "${changed_args[@]}" "--changed=${changed_ref}" "$@"
+    run_test_command \
+      "${changed_args[@]}" \
+      "--changed=${changed_ref}" \
+      "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+      "${passthrough_args[@]+"${passthrough_args[@]}"}"
     ;;
   integration)
     integration_args=(bun test --timeout "$per_test_timeout_ms")
     if [[ "$runner_os" != "Windows" ]]; then
       integration_args+=(--no-orphans "--parallel=${integration_workers}")
     fi
-    requested_paths=()
-    passthrough_args=()
-    for arg in "$@"; do
-      if [[ "$arg" == *.test.ts ]]; then
-        if [[ "$arg" == *.integration.test.ts ]]; then
-          requested_paths+=("$arg")
-        fi
-      else
-        passthrough_args+=("$arg")
-      fi
-    done
-    if [[ "${#requested_paths[@]}" -gt 0 ]]; then
+    if [[ "${#integration_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         "${integration_args[@]}" \
-        "${requested_paths[@]+"${requested_paths[@]}"}" \
+        "${integration_test_paths[@]+"${integration_test_paths[@]}"}" \
         "${passthrough_args[@]+"${passthrough_args[@]}"}"
-    elif [[ "$#" -eq 0 || "${#passthrough_args[@]}" -eq "$#" ]]; then
+    elif [[ "$has_test_targets" -eq 0 ]]; then
       run_test_command \
         "${integration_args[@]}" \
         ".integration.test.ts" \
@@ -250,23 +336,12 @@ case "$mode" in
     fi
     ;;
   stress)
-    requested_paths=()
-    passthrough_args=()
-    for arg in "$@"; do
-      if [[ "$arg" == *.test.ts ]]; then
-        if [[ "$arg" == test/stress/* ]]; then
-          requested_paths+=("$arg")
-        fi
-      else
-        passthrough_args+=("$arg")
-      fi
-    done
-    if [[ "${#requested_paths[@]}" -gt 0 ]]; then
+    if [[ "${#stress_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         bun test --timeout "$per_test_timeout_ms" \
-        "${requested_paths[@]+"${requested_paths[@]}"}" \
+        "${stress_test_paths[@]+"${stress_test_paths[@]}"}" \
         "${passthrough_args[@]+"${passthrough_args[@]}"}"
-    elif [[ "$#" -eq 0 || "${#passthrough_args[@]}" -eq "$#" ]]; then
+    elif [[ "$has_test_targets" -eq 0 ]]; then
       run_test_command \
         bun test --timeout "$per_test_timeout_ms" \
         test/stress \
@@ -277,17 +352,28 @@ case "$mode" in
     fi
     ;;
   coverage)
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    fi
     run_test_command \
       "${unit_args[@]}" \
       --coverage \
       --coverage-reporter=lcov \
       --coverage-dir=coverage \
-      "$@"
+      "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+      "${passthrough_args[@]+"${passthrough_args[@]}"}"
     ;;
   all)
-    "$0" unit "$@"
-    "$0" integration "$@"
-    "$0" stress "$@"
+    if [[ "$has_test_targets" -eq 0 || "${#unit_test_paths[@]}" -gt 0 ]]; then
+      "$0" unit "${unit_test_paths[@]+"${unit_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
+    if [[ "$has_test_targets" -eq 0 || "${#integration_test_paths[@]}" -gt 0 ]]; then
+      "$0" integration "${integration_test_paths[@]+"${integration_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
+    if [[ "$has_test_targets" -eq 0 || "${#stress_test_paths[@]}" -gt 0 ]]; then
+      "$0" stress "${stress_test_paths[@]+"${stress_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
     ;;
   *)
     echo "Usage: scripts/test-ts.sh {unit|changed|integration|stress|coverage|all} [bun-test-args...]" >&2

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -138,6 +138,22 @@ run_lane() {
   [ "$(grep -c '^bun test' <<< "$output")" -eq 3 ]
 }
 
+@test "absolute test paths use their canonical lane" {
+  repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  run_lane all "$repo_root/test/stress/memory-leak.stress.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/stress/memory-leak.stress.test.ts"* ]]
+  [[ "$output" != *"path-ignore-patterns"* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 1 ]
+}
+
+@test "quoted glob test targets expand and retain their lane" {
+  run_lane integration 'test/contracts/*.integration.test.ts'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/contracts/runAll.integration.test.ts"* ]]
+  [[ "$output" != *"*.integration.test.ts"* ]]
+}
+
 @test "a Bun option value is not classified as a test target" {
   run_lane integration --test-name-pattern test/scripts
   [ "$status" -eq 0 ]

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -99,16 +99,58 @@ run_lane() {
 }
 
 @test "integration lane targets only requested integration paths" {
-  run_lane integration test/example.integration.test.ts
+  run_lane integration test/contracts/runAll.integration.test.ts
   [ "$status" -eq 0 ]
-  [[ "$output" == *"test/example.integration.test.ts"* ]]
+  [[ "$output" == *"test/contracts/runAll.integration.test.ts"* ]]
   [[ "$output" != *" .integration.test.ts "* ]]
 }
 
 @test "integration lane rejects a requested unit-test path" {
-  run_lane integration test/example.test.ts
+  run_lane integration test/scripts/testLaneClassification.test.ts
   [ "$status" -eq 2 ]
   [[ "$output" == *"No integration test paths were selected."* ]]
+}
+
+@test "unit lanes reject cross-lane test targets" {
+  for target in test/contracts/runAll.integration.test.ts test/stress/memory-leak.stress.test.ts; do
+    for lane in unit changed coverage; do
+      run_lane "$lane" "$target"
+      [ "$status" -eq 2 ]
+      [[ "$output" == *"No unit test paths were selected."* ]]
+    done
+  done
+}
+
+@test "all partitions a targeted test path and skips empty lanes" {
+  run_lane all test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+  [[ "$output" != *"No integration test paths were selected."* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 1 ]
+}
+
+@test "all partitions targeted directories into their matching lane" {
+  run_lane all test/scripts test/stress
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+  [[ "$output" == *"test/scripts/xcodegenDriftCheck.integration.test.ts"* ]]
+  [[ "$output" == *"test/stress/memory-leak.stress.test.ts"* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 3 ]
+}
+
+@test "a Bun option value is not classified as a test target" {
+  run_lane integration --test-name-pattern test/scripts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--test-name-pattern test/scripts"* ]]
+  [[ "$output" == *" .integration.test.ts "* ]]
+  [[ "$output" != *"xcodegenDriftCheck.integration.test.ts"* ]]
+}
+
+@test "targeting a stale test path fails before invoking Bun" {
+  run_lane unit test/scripts/removed-test.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No test files found for target"* ]]
+  [ ! -s "$BUN_ARGS_FILE" ]
 }
 
 @test "stress lane is explicit" {

--- a/test/lint/oxlintConfigScoping.integration.test.ts
+++ b/test/lint/oxlintConfigScoping.integration.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+// The custom rules' file-scoping used to be enforced (and tested) through
+// eslint.config.mjs's `files:` globs. Under oxlint that scoping lives in
+// .oxlintrc.json's `overrides`, so the "does not apply outside <glob>"
+// guarantees that bareExpectRule / accumulatorForEachRule / stressExplicitTimeout
+// used to assert are now asserted here.
+//
+// Rather than parse .oxlintrc.json ourselves (it is JSONC — comments would break
+// a naive JSON.parse), we read oxlint's OWN resolved configuration via
+// `oxlint --print-config`, which emits strict JSON. That is the tool's typed
+// configuration contract and reflects exactly what oxlint will enforce.
+
+const ROOT = join(import.meta.dir, "..", "..");
+// `oxlint --print-config` normally completes in milliseconds, but it can be
+// delayed by concurrent test processes on a two-core CI host.
+const CONFIG_READ_HOOK_TIMEOUT_MS = 20_000;
+
+interface ResolvedOverride {
+  files: string[];
+  rules?: Record<string, unknown>;
+}
+interface ResolvedConfig {
+  overrides: ResolvedOverride[];
+}
+
+let config: ResolvedConfig;
+
+beforeAll(() => {
+  const result = Bun.spawnSync({
+    cmd: [join(ROOT, "node_modules", ".bin", "oxlint"), "--print-config"],
+    cwd: ROOT,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`oxlint --print-config failed: ${result.stderr.toString()}`);
+  }
+  config = JSON.parse(result.stdout.toString()) as ResolvedConfig;
+}, CONFIG_READ_HOOK_TIMEOUT_MS);
+
+// Return the `files` of the SINGLE override that gates `rule`, asserting the
+// rule resolves through exactly one override. Using the first match alone would
+// miss a later, broader override that also enables the rule (widening its
+// scope), so uniqueness is part of the guarantee.
+function filesScopingRule(rule: string): string[] | undefined {
+  const matches = config.overrides.filter((override) =>
+    override.rules ? Object.prototype.hasOwnProperty.call(override.rules, rule) : false,
+  );
+  expect(matches.length, `${rule} must be gated by exactly one override`).toBe(1);
+  return matches[0]?.files;
+}
+
+describe(".oxlintrc.json rule scoping (via oxlint --print-config)", () => {
+  test("catch-convention and no-unknown-cast are scoped to src/**", () => {
+    for (const rule of ["auto-mobile/catch-convention", "auto-mobile/no-unknown-cast"]) {
+      expect(filesScopingRule(rule)).toEqual(["src/**/*.ts"]);
+    }
+  });
+
+  test("no-accumulator-foreach is scoped to src/** (not the whole tree)", () => {
+    expect(filesScopingRule("auto-mobile/no-accumulator-foreach")).toEqual(["src/**/*.ts"]);
+  });
+
+  test("stress-explicit-timeout is scoped to test/stress/**", () => {
+    expect(filesScopingRule("auto-mobile/stress-explicit-timeout")).toEqual([
+      "test/stress/**/*.ts",
+    ]);
+  });
+
+  test("no-bare-expect is scoped to test/**", () => {
+    expect(filesScopingRule("auto-mobile/no-bare-expect")).toEqual(["test/**/*.ts"]);
+  });
+
+  test("no-explicit-any is scoped to the two correctness-sensitive navigation files", () => {
+    expect(filesScopingRule("typescript/no-explicit-any")).toEqual([
+      "src/features/navigation/ScreenFingerprint.ts",
+      "src/features/navigation/ExploreElementExtraction.ts",
+    ]);
+  });
+
+  test("the raw-timer guard applies globally, with SystemTimer.ts exempted", () => {
+    // no-raw-timer is enabled at the top level (so tests/scripts are covered) and
+    // only turned OFF in the SystemTimer.ts override — that override is the sole
+    // place it appears in the resolved overrides.
+    expect(filesScopingRule("auto-mobile/no-raw-timer")).toEqual(["**/SystemTimer.ts"]);
+  });
+});


### PR DESCRIPTION
## Summary

Classify explicit test paths before invoking Bun so unit, changed, and coverage cannot run integration or stress tests outside their lane. `all` now partitions targets and skips unmatched lanes; stale or empty targets fail before Bun runs. Restore the resolved oxlint configuration-scoping guard as an integration test.

## Linked Issue

Closes [#6036](https://github.com/kaeawc/auto-mobile/issues/6036)

## Bug / Regression Context

- **Prior attempts:** The test-lane split in [PR #6024](https://github.com/kaeawc/auto-mobile/pull/6024) forwarded positional paths without uniform classification.
- **Observed symptom:** Explicit integration/stress paths bypassed the unit-lane excludes; `all` sent lane-specific paths to every lane and failed.
- **Repro steps / conditions:** Run `bash scripts/test-ts.sh unit test/contracts/runAll.integration.test.ts` or target a single lane through `all`.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `bats test/bats/test-ts.bats`
- [x] `shellcheck scripts/test-ts.sh`
- [x] `bash scripts/test-ts.sh integration test/lint/oxlintConfigScoping.integration.test.ts`
- [x] `bun run format:check`
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] No follow-up issue required for this focused fix.
