### PR TITLE
fix(test): classify targeted test lanes

### DIFF
--- a/scripts/shellcheck/sete-baseline.txt
+++ b/scripts/shellcheck/sete-baseline.txt
@@ -334,7 +334,6 @@ scripts/local-dev/hot-reload.sh: note: This function is invoked in an 'if' condi
 scripts/local-dev/hot-reload.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
 scripts/local-dev/hot-reload.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
 scripts/local-dev/hot-reload.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
-scripts/local-dev/hot-reload.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
 scripts/local-dev/probe-android-locale.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
 scripts/local-dev/probe-android-locale.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]
 scripts/local-dev/probe-android-locale.sh: note: This function is invoked in an 'if' condition so set -e will be disabled. Invoke separately if failures should cause the script to exit. [SC2310]

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -112,9 +112,23 @@ add_test_target() {
   local target
   local test_path
   local found=0
+  local is_file_target=0
 
   if [[ -f "$requested_target" ]]; then
+    is_file_target=1
     absolute_target="$(cd "$(dirname "$requested_target")" && pwd -P)/$(basename "$requested_target")"
+    while [[ -L "$absolute_target" ]]; do
+      local target_directory
+      local link_target
+      target_directory="$(cd "$(dirname "$absolute_target")" && pwd -P)"
+      link_target="$(readlink "$absolute_target")"
+      if [[ "$link_target" == /* ]]; then
+        absolute_target="$link_target"
+      else
+        absolute_target="$target_directory/$link_target"
+      fi
+      absolute_target="$(cd "$(dirname "$absolute_target")" && pwd -P)/$(basename "$absolute_target")"
+    done
   elif [[ -d "$requested_target" ]]; then
     absolute_target="$(cd "$requested_target" && pwd -P)"
   else
@@ -131,7 +145,7 @@ add_test_target() {
     exit 2
   fi
 
-  if [[ -f "$requested_target" ]]; then
+  if [[ "$is_file_target" -eq 1 ]]; then
     if [[ "$target" != *.test.ts ]]; then
       echo "Test target is not a Bun test file: $requested_target" >&2
       exit 2
@@ -157,29 +171,22 @@ integration_test_paths=()
 stress_test_paths=()
 passthrough_args=()
 has_test_targets=0
-expect_option_value=0
-expect_bail_count=0
-for arg in "$@"; do
-  if [[ "$expect_bail_count" -eq 1 && "$arg" =~ ^[0-9]+$ ]]; then
+args=("$@")
+for ((arg_index = 0; arg_index < ${#args[@]}; arg_index += 1)); do
+  arg="${args[$arg_index]}"
+  if [[ "$arg" == --bail ]]; then
     passthrough_args+=("$arg")
-    expect_bail_count=0
-  elif [[ "$expect_option_value" -eq 1 ]]; then
-    passthrough_args+=("$arg")
-    expect_option_value=0
-  elif [[ "$expect_bail_count" -eq 1 ]]; then
-    expect_bail_count=0
-    if [[ "$arg" == -* ]]; then
-      passthrough_args+=("$arg")
-    else
-      has_test_targets=1
-      add_test_target "$arg"
+    next_arg="${args[$((arg_index + 1))]:-}"
+    if [[ "$next_arg" =~ ^[0-9]+$ ]]; then
+      passthrough_args+=("$next_arg")
+      arg_index=$((arg_index + 1))
     fi
-  elif [[ "$arg" == --bail ]]; then
+  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" || "$arg" == --import || "$arg" == --inspect || "$arg" == --inspect-wait || "$arg" == --inspect-brk || "$arg" == --cpu-prof-name || "$arg" == --cpu-prof-dir || "$arg" == --cpu-prof-interval || "$arg" == --heap-prof-name || "$arg" == --heap-prof-dir || "$arg" == --install || "$arg" == "--eval" || "$arg" == "-e" || "$arg" == --print || "$arg" == "-p" || "$arg" == --port || "$arg" == --conditions || "$arg" == --fetch-preconnect || "$arg" == --max-http-header-size || "$arg" == --dns-result-order || "$arg" == --unhandled-rejections || "$arg" == --console-depth || "$arg" == --user-agent || "$arg" == --cron-title || "$arg" == --cron-period || "$arg" == --elide-lines || "$arg" == "--filter" || "$arg" == "-F" || "$arg" == --shell || "$arg" == --env-file || "$arg" == --cwd || "$arg" == --config || "$arg" == "-c" ]]; then
     passthrough_args+=("$arg")
-    expect_bail_count=1
-  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" ]]; then
-    passthrough_args+=("$arg")
-    expect_option_value=1
+    if [[ "$arg_index" -lt $((${#args[@]} - 1)) ]]; then
+      arg_index=$((arg_index + 1))
+      passthrough_args+=("${args[$arg_index]}")
+    fi
   elif [[ "$arg" == -* ]]; then
     passthrough_args+=("$arg")
   else
@@ -299,7 +306,10 @@ fi
 
 case "$mode" in
   unit)
-    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+    if [[ "${#unit_test_paths[@]}" -gt 0 && ( "${#integration_test_paths[@]}" -gt 0 || "${#stress_test_paths[@]}" -gt 0 ) ]]; then
+      echo "Unit test targets cannot include other lanes." >&2
+      exit 2
+    elif [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
       echo "No unit test paths were selected." >&2
       exit 2
     elif [[ "${#unit_test_paths[@]}" -eq 0 && "${#passthrough_args[@]}" -eq 0 && "$runner_os" != "Windows" ]]; then
@@ -312,7 +322,10 @@ case "$mode" in
     fi
     ;;
   changed)
-    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+    if [[ "${#unit_test_paths[@]}" -gt 0 && ( "${#integration_test_paths[@]}" -gt 0 || "${#stress_test_paths[@]}" -gt 0 ) ]]; then
+      echo "Unit test targets cannot include other lanes." >&2
+      exit 2
+    elif [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
       echo "No unit test paths were selected." >&2
       exit 2
     fi
@@ -337,7 +350,10 @@ case "$mode" in
     if [[ "$runner_os" != "Windows" ]]; then
       integration_args+=(--no-orphans "--parallel=${integration_workers}")
     fi
-    if [[ "${#integration_test_paths[@]}" -gt 0 ]]; then
+    if [[ "${#integration_test_paths[@]}" -gt 0 && ( "${#unit_test_paths[@]}" -gt 0 || "${#stress_test_paths[@]}" -gt 0 ) ]]; then
+      echo "Integration test targets cannot include other lanes." >&2
+      exit 2
+    elif [[ "${#integration_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         "${integration_args[@]}" \
         "${integration_test_paths[@]+"${integration_test_paths[@]}"}" \
@@ -353,7 +369,10 @@ case "$mode" in
     fi
     ;;
   stress)
-    if [[ "${#stress_test_paths[@]}" -gt 0 ]]; then
+    if [[ "${#stress_test_paths[@]}" -gt 0 && ( "${#unit_test_paths[@]}" -gt 0 || "${#integration_test_paths[@]}" -gt 0 ) ]]; then
+      echo "Stress test targets cannot include other lanes." >&2
+      exit 2
+    elif [[ "${#stress_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         bun test --timeout "$per_test_timeout_ms" \
         "${stress_test_paths[@]+"${stress_test_paths[@]}"}" \
@@ -369,7 +388,10 @@ case "$mode" in
     fi
     ;;
   coverage)
-    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+    if [[ "${#unit_test_paths[@]}" -gt 0 && ( "${#integration_test_paths[@]}" -gt 0 || "${#stress_test_paths[@]}" -gt 0 ) ]]; then
+      echo "Unit test targets cannot include other lanes." >&2
+      exit 2
+    elif [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
       echo "No unit test paths were selected." >&2
       exit 2
     fi

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -158,10 +158,25 @@ stress_test_paths=()
 passthrough_args=()
 has_test_targets=0
 expect_option_value=0
+expect_bail_count=0
 for arg in "$@"; do
-  if [[ "$expect_option_value" -eq 1 ]]; then
+  if [[ "$expect_bail_count" -eq 1 && "$arg" =~ ^[0-9]+$ ]]; then
+    passthrough_args+=("$arg")
+    expect_bail_count=0
+  elif [[ "$expect_option_value" -eq 1 ]]; then
     passthrough_args+=("$arg")
     expect_option_value=0
+  elif [[ "$expect_bail_count" -eq 1 ]]; then
+    expect_bail_count=0
+    if [[ "$arg" == -* ]]; then
+      passthrough_args+=("$arg")
+    else
+      has_test_targets=1
+      add_test_target "$arg"
+    fi
+  elif [[ "$arg" == --bail ]]; then
+    passthrough_args+=("$arg")
+    expect_bail_count=1
   elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" ]]; then
     passthrough_args+=("$arg")
     expect_option_value=1

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -13,7 +13,7 @@
 # their dedicated package scripts and workflows.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$ROOT"
 
 mode="${1:-unit}"
@@ -162,7 +162,7 @@ for arg in "$@"; do
   if [[ "$expect_option_value" -eq 1 ]]; then
     passthrough_args+=("$arg")
     expect_option_value=0
-  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard ]]; then
+  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" ]]; then
     passthrough_args+=("$arg")
     expect_option_value=1
   elif [[ "$arg" == -* ]]; then

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -107,30 +107,48 @@ add_test_path_to_lane() {
 }
 
 add_test_target() {
-  local target="${1#./}"
+  local requested_target="$1"
+  local absolute_target
+  local target
   local test_path
   local found=0
 
-  if [[ -f "$target" ]]; then
+  if [[ -f "$requested_target" ]]; then
+    absolute_target="$(cd "$(dirname "$requested_target")" && pwd -P)/$(basename "$requested_target")"
+  elif [[ -d "$requested_target" ]]; then
+    absolute_target="$(cd "$requested_target" && pwd -P)"
+  else
+    echo "No test files found for target: $requested_target" >&2
+    exit 2
+  fi
+
+  if [[ "$absolute_target" == "$ROOT/test" ]]; then
+    target="test"
+  elif [[ "$absolute_target" == "$ROOT/test/"* ]]; then
+    target="${absolute_target#"$ROOT"/}"
+  else
+    echo "Test target must be inside test/: $requested_target" >&2
+    exit 2
+  fi
+
+  if [[ -f "$requested_target" ]]; then
     if [[ "$target" != *.test.ts ]]; then
-      echo "Test target is not a Bun test file: $1" >&2
+      echo "Test target is not a Bun test file: $requested_target" >&2
       exit 2
     fi
     add_test_path_to_lane "$target"
     return
   fi
 
-  if [[ -d "$target" ]]; then
-    while IFS= read -r test_path; do
-      found=1
-      add_test_path_to_lane "$test_path"
-    done < <(find "$target" -type f -name '*.test.ts' -print | sort)
-    if [[ "$found" -eq 1 ]]; then
-      return
-    fi
+  while IFS= read -r test_path; do
+    found=1
+    add_test_path_to_lane "$test_path"
+  done < <(find "$target" -type f -name '*.test.ts' -print | sort)
+  if [[ "$found" -eq 1 ]]; then
+    return
   fi
 
-  echo "No test files found for target: $1" >&2
+  echo "No test files found for target: $requested_target" >&2
   exit 2
 }
 
@@ -147,11 +165,11 @@ for arg in "$@"; do
   elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard ]]; then
     passthrough_args+=("$arg")
     expect_option_value=1
-  elif [[ "${arg#./}" == "test" || "${arg#./}" == test/* || "$arg" == *.test.ts ]]; then
+  elif [[ "$arg" == -* ]]; then
+    passthrough_args+=("$arg")
+  else
     has_test_targets=1
     add_test_target "$arg"
-  else
-    passthrough_args+=("$arg")
   fi
 done
 

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -88,6 +88,73 @@ run_test_command() {
   "$@"
 }
 
+lane_for_test_path() {
+  local path="$1"
+  case "$path" in
+    test/stress/*) printf '%s\n' "stress" ;;
+    *.integration.test.ts) printf '%s\n' "integration" ;;
+    *) printf '%s\n' "unit" ;;
+  esac
+}
+
+add_test_path_to_lane() {
+  local path="$1"
+  case "$(lane_for_test_path "$path")" in
+    unit) unit_test_paths+=("$path") ;;
+    integration) integration_test_paths+=("$path") ;;
+    stress) stress_test_paths+=("$path") ;;
+  esac
+}
+
+add_test_target() {
+  local target="${1#./}"
+  local test_path
+  local found=0
+
+  if [[ -f "$target" ]]; then
+    if [[ "$target" != *.test.ts ]]; then
+      echo "Test target is not a Bun test file: $1" >&2
+      exit 2
+    fi
+    add_test_path_to_lane "$target"
+    return
+  fi
+
+  if [[ -d "$target" ]]; then
+    while IFS= read -r test_path; do
+      found=1
+      add_test_path_to_lane "$test_path"
+    done < <(find "$target" -type f -name '*.test.ts' -print | sort)
+    if [[ "$found" -eq 1 ]]; then
+      return
+    fi
+  fi
+
+  echo "No test files found for target: $1" >&2
+  exit 2
+}
+
+unit_test_paths=()
+integration_test_paths=()
+stress_test_paths=()
+passthrough_args=()
+has_test_targets=0
+expect_option_value=0
+for arg in "$@"; do
+  if [[ "$expect_option_value" -eq 1 ]]; then
+    passthrough_args+=("$arg")
+    expect_option_value=0
+  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard ]]; then
+    passthrough_args+=("$arg")
+    expect_option_value=1
+  elif [[ "${arg#./}" == "test" || "${arg#./}" == test/* || "$arg" == *.test.ts ]]; then
+    has_test_targets=1
+    add_test_target "$arg"
+  else
+    passthrough_args+=("$arg")
+  fi
+done
+
 run_unit_shards() {
   local shard_root="$ROOT/scratch/test-ts-unit-shards"
   local file index shard worker_count rc pid
@@ -199,13 +266,23 @@ fi
 
 case "$mode" in
   unit)
-    if [[ "$#" -eq 0 && "$runner_os" != "Windows" ]]; then
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    elif [[ "${#unit_test_paths[@]}" -eq 0 && "${#passthrough_args[@]}" -eq 0 && "$runner_os" != "Windows" ]]; then
       run_unit_shards
     else
-      run_test_command "${unit_args[@]}" "$@"
+      run_test_command \
+        "${unit_args[@]}" \
+        "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+        "${passthrough_args[@]+"${passthrough_args[@]}"}"
     fi
     ;;
   changed)
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    fi
     changed_ref="${AUTOMOBILE_UNIT_TEST_BASE_REF:-origin/main}"
     changed_args=("${unit_args[@]}")
     if [[ -n "${AUTOMOBILE_UNIT_JUNIT_DIR:-}" ]]; then
@@ -216,30 +293,23 @@ case "$mode" in
         --reporter-outfile "$AUTOMOBILE_UNIT_JUNIT_DIR/changed.xml"
       )
     fi
-    run_test_command "${changed_args[@]}" "--changed=${changed_ref}" "$@"
+    run_test_command \
+      "${changed_args[@]}" \
+      "--changed=${changed_ref}" \
+      "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+      "${passthrough_args[@]+"${passthrough_args[@]}"}"
     ;;
   integration)
     integration_args=(bun test --timeout "$per_test_timeout_ms")
     if [[ "$runner_os" != "Windows" ]]; then
       integration_args+=(--no-orphans "--parallel=${integration_workers}")
     fi
-    requested_paths=()
-    passthrough_args=()
-    for arg in "$@"; do
-      if [[ "$arg" == *.test.ts ]]; then
-        if [[ "$arg" == *.integration.test.ts ]]; then
-          requested_paths+=("$arg")
-        fi
-      else
-        passthrough_args+=("$arg")
-      fi
-    done
-    if [[ "${#requested_paths[@]}" -gt 0 ]]; then
+    if [[ "${#integration_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         "${integration_args[@]}" \
-        "${requested_paths[@]+"${requested_paths[@]}"}" \
+        "${integration_test_paths[@]+"${integration_test_paths[@]}"}" \
         "${passthrough_args[@]+"${passthrough_args[@]}"}"
-    elif [[ "$#" -eq 0 || "${#passthrough_args[@]}" -eq "$#" ]]; then
+    elif [[ "$has_test_targets" -eq 0 ]]; then
       run_test_command \
         "${integration_args[@]}" \
         ".integration.test.ts" \
@@ -250,23 +320,12 @@ case "$mode" in
     fi
     ;;
   stress)
-    requested_paths=()
-    passthrough_args=()
-    for arg in "$@"; do
-      if [[ "$arg" == *.test.ts ]]; then
-        if [[ "$arg" == test/stress/* ]]; then
-          requested_paths+=("$arg")
-        fi
-      else
-        passthrough_args+=("$arg")
-      fi
-    done
-    if [[ "${#requested_paths[@]}" -gt 0 ]]; then
+    if [[ "${#stress_test_paths[@]}" -gt 0 ]]; then
       run_test_command \
         bun test --timeout "$per_test_timeout_ms" \
-        "${requested_paths[@]+"${requested_paths[@]}"}" \
+        "${stress_test_paths[@]+"${stress_test_paths[@]}"}" \
         "${passthrough_args[@]+"${passthrough_args[@]}"}"
-    elif [[ "$#" -eq 0 || "${#passthrough_args[@]}" -eq "$#" ]]; then
+    elif [[ "$has_test_targets" -eq 0 ]]; then
       run_test_command \
         bun test --timeout "$per_test_timeout_ms" \
         test/stress \
@@ -277,17 +336,28 @@ case "$mode" in
     fi
     ;;
   coverage)
+    if [[ "${#unit_test_paths[@]}" -eq 0 && "$has_test_targets" -eq 1 ]]; then
+      echo "No unit test paths were selected." >&2
+      exit 2
+    fi
     run_test_command \
       "${unit_args[@]}" \
       --coverage \
       --coverage-reporter=lcov \
       --coverage-dir=coverage \
-      "$@"
+      "${unit_test_paths[@]+"${unit_test_paths[@]}"}" \
+      "${passthrough_args[@]+"${passthrough_args[@]}"}"
     ;;
   all)
-    "$0" unit "$@"
-    "$0" integration "$@"
-    "$0" stress "$@"
+    if [[ "$has_test_targets" -eq 0 || "${#unit_test_paths[@]}" -gt 0 ]]; then
+      "$0" unit "${unit_test_paths[@]+"${unit_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
+    if [[ "$has_test_targets" -eq 0 || "${#integration_test_paths[@]}" -gt 0 ]]; then
+      "$0" integration "${integration_test_paths[@]+"${integration_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
+    if [[ "$has_test_targets" -eq 0 || "${#stress_test_paths[@]}" -gt 0 ]]; then
+      "$0" stress "${stress_test_paths[@]+"${stress_test_paths[@]}"}" "${passthrough_args[@]+"${passthrough_args[@]}"}"
+    fi
     ;;
   *)
     echo "Usage: scripts/test-ts.sh {unit|changed|integration|stress|coverage|all} [bun-test-args...]" >&2

--- a/test/bats/test-fast.bats
+++ b/test/bats/test-fast.bats
@@ -49,11 +49,11 @@ _mock_nproc() {
 @test "passes through extra arguments to bun test" {
   local dir
   dir="$(_mock_nproc 8)"
-  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT" test/features/foo.test.ts
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT" test/scripts/testLaneClassification.test.ts
   rm -rf "$dir"
   [ "$status" -eq 0 ]
   [[ "$output" == *"--parallel=6"* ]]
-  [[ "$output" == *"test/features/foo.test.ts"* ]]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
 }
 
 @test "falls back to sysctl when nproc is unavailable" {

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -170,6 +170,22 @@ run_lane() {
   [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
 }
 
+@test "bare bail reprocesses a following value-bearing option" {
+  run_lane unit --bail --test-name-pattern "lane classification" test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--test-name-pattern lane\\ classification"* ]]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+}
+
+@test "Bun runtime option values are not classified as positional test targets" {
+  for option in --config --env-file --cwd; do
+    run_lane unit "$option" bunfig.toml test/scripts/testLaneClassification.test.ts
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$option bunfig.toml"* ]]
+    [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+  done
+}
+
 @test "rejects an unclassified positional Bun pattern" {
   run_lane unit oxlintConfigScoping
   [ "$status" -eq 2 ]
@@ -192,6 +208,29 @@ run_lane() {
     bash "$link/$SCRIPT" unit "$link/test/scripts/testLaneClassification.test.ts"
   [ "$status" -eq 0 ]
   [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+}
+
+@test "classifies a symlinked test file by its resolved target" {
+  link="test/.lane-classification-${BATS_TEST_NUMBER}.test.ts"
+  ln -s "stress/memory-leak.stress.test.ts" "$link"
+  run_lane unit "$link"
+  rm -f "$link"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No unit test paths were selected."* ]]
+}
+
+@test "single-lane modes reject a mixed-lane target list" {
+  run_lane unit test/scripts/testLaneClassification.test.ts test/contracts/runAll.integration.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Unit test targets cannot include other lanes."* ]]
+
+  run_lane integration test/contracts/runAll.integration.test.ts test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Integration test targets cannot include other lanes."* ]]
+
+  run_lane stress test/stress/memory-leak.stress.test.ts test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Stress test targets cannot include other lanes."* ]]
 }
 
 @test "targeting a stale test path fails before invoking Bun" {

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -99,16 +99,54 @@ run_lane() {
 }
 
 @test "integration lane targets only requested integration paths" {
-  run_lane integration test/example.integration.test.ts
+  run_lane integration test/contracts/runAll.integration.test.ts
   [ "$status" -eq 0 ]
-  [[ "$output" == *"test/example.integration.test.ts"* ]]
+  [[ "$output" == *"test/contracts/runAll.integration.test.ts"* ]]
   [[ "$output" != *" .integration.test.ts "* ]]
 }
 
 @test "integration lane rejects a requested unit-test path" {
-  run_lane integration test/example.test.ts
+  run_lane integration test/scripts/testLaneClassification.test.ts
   [ "$status" -eq 2 ]
   [[ "$output" == *"No integration test paths were selected."* ]]
+}
+
+@test "unit lanes reject cross-lane test targets" {
+  for lane in unit changed coverage; do
+    run_lane "$lane" test/contracts/runAll.integration.test.ts
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"No unit test paths were selected."* ]]
+  done
+}
+
+@test "all partitions a targeted test path and skips empty lanes" {
+  run_lane all test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+  [[ "$output" != *"No integration test paths were selected."* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 1 ]
+}
+
+@test "all partitions targeted directories into their matching lane" {
+  run_lane all test/scripts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+  [[ "$output" == *"test/scripts/xcodegenDriftCheck.integration.test.ts"* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 2 ]
+}
+
+@test "test-option values are not classified as positional test targets" {
+  run_lane all --test-name-pattern test/scripts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--test-name-pattern test/scripts"* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 3 ]
+}
+
+@test "targeting a stale test path fails before invoking Bun" {
+  run_lane unit test/scripts/removed-test.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No test files found for target"* ]]
+  [ ! -s "$BUN_ARGS_FILE" ]
 }
 
 @test "stress lane is explicit" {

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -156,6 +156,20 @@ run_lane() {
   done
 }
 
+@test "split-form bail counts are not classified as positional test targets" {
+  run_lane unit --bail 2 test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--bail 2"* ]]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+}
+
+@test "bare bail does not consume a positional test target" {
+  run_lane unit --bail test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--bail"* ]]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
+}
+
 @test "rejects an unclassified positional Bun pattern" {
   run_lane unit oxlintConfigScoping
   [ "$status" -eq 2 ]

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -142,6 +142,25 @@ run_lane() {
   [ "$(grep -c '^bun test' <<< "$output")" -eq 3 ]
 }
 
+@test "equals-form options are not classified as positional test targets" {
+  run_lane unit --test-name-pattern=integration.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--test-name-pattern=integration.test.ts"* ]]
+}
+
+@test "rejects an unclassified positional Bun pattern" {
+  run_lane unit oxlintConfigScoping
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No test files found for target"* ]]
+}
+
+@test "canonicalizes absolute test paths before assigning their lane" {
+  run_lane all "$BATS_TEST_DIRNAME/../stress/memory-leak.stress.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/stress/memory-leak.stress.test.ts"* ]]
+  [ "$(grep -c '^bun test' <<< "$output")" -eq 1 ]
+}
+
 @test "targeting a stale test path fails before invoking Bun" {
   run_lane unit test/scripts/removed-test.test.ts
   [ "$status" -eq 2 ]

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -148,6 +148,14 @@ run_lane() {
   [[ "$output" == *"--test-name-pattern=integration.test.ts"* ]]
 }
 
+@test "preload option values are not classified as positional test targets" {
+  for option in --preload --require -r; do
+    run_lane unit "$option" test/fakes/FakeTimer.ts
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$option test/fakes/FakeTimer.ts"* ]]
+  done
+}
+
 @test "rejects an unclassified positional Bun pattern" {
   run_lane unit oxlintConfigScoping
   [ "$status" -eq 2 ]
@@ -159,6 +167,17 @@ run_lane() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"test/stress/memory-leak.stress.test.ts"* ]]
   [ "$(grep -c '^bun test' <<< "$output")" -eq 1 ]
+}
+
+@test "accepts explicit targets when invoked through a symlinked checkout path" {
+  link="$BATS_TEST_TMPDIR/auto-mobile-link"
+  ln -s "$PWD" "$link"
+  run env \
+    PATH="$STUB_BIN:$PATH" \
+    TEST_TS_PRINT_CMD=1 \
+    bash "$link/$SCRIPT" unit "$link/test/scripts/testLaneClassification.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
 }
 
 @test "targeting a stale test path fails before invoking Bun" {

--- a/test/lint/oxlintConfigScoping.integration.test.ts
+++ b/test/lint/oxlintConfigScoping.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // The custom rules' file-scoping used to be enforced (and tested) through
 // eslint.config.mjs's `files:` globs. Under oxlint that scoping lives in
@@ -11,8 +11,9 @@ import { join } from "node:path";
 //
 // Rather than parse .oxlintrc.json ourselves (it is JSONC — comments would break
 // a naive JSON.parse), we read oxlint's OWN resolved configuration via
-// `oxlint --print-config`, which emits strict JSON. That is the tool's typed
-// configuration contract and reflects exactly what oxlint will enforce.
+// `oxlint --print-config`, which emits strict JSON. That checks the declared
+// override ownership and severities; fixture linting below proves the globs are
+// applied to files in each configured scope.
 
 const ROOT = join(import.meta.dir, "..", "..");
 // `oxlint --print-config` normally completes in milliseconds, but it can be
@@ -58,6 +59,13 @@ function expectScopedRule(rule: string, files: string[], severity: string): void
   expect(override?.rules?.[rule]).toBe(severity);
 }
 
+function lintFixture(path: string) {
+  return Bun.spawnSync({
+    cmd: [join(ROOT, "node_modules", ".bin", "oxlint"), "--config", ".oxlintrc.json", path],
+    cwd: ROOT,
+  });
+}
+
 describe(".oxlintrc.json rule scoping (via oxlint --print-config)", () => {
   test("catch-convention and no-unknown-cast are scoped to src/**", () => {
     for (const rule of ["auto-mobile/catch-convention", "auto-mobile/no-unknown-cast"]) {
@@ -86,6 +94,71 @@ describe(".oxlintrc.json rule scoping (via oxlint --print-config)", () => {
       ],
       "deny",
     );
+  });
+
+  test("configured globs apply to linted src, test, and stress fixtures", async () => {
+    const sourceDirectory = await mkdtemp(join(ROOT, "src/oxlint-scoping-"));
+    const testDirectory = await mkdtemp(join(ROOT, "test/oxlint-scoping-"));
+    const stressDirectory = await mkdtemp(join(ROOT, "test/stress/oxlint-scoping-"));
+    const sourceAccumulator = join(sourceDirectory, "accumulator.ts");
+    const testAccumulator = join(testDirectory, "accumulator.ts");
+    const sourceBareExpect = join(sourceDirectory, "bare-expect.ts");
+    const testBareExpect = join(testDirectory, "bare-expect.ts");
+    const regularTimeout = join(testDirectory, "timeout.test.ts");
+    const stressTimeout = join(stressDirectory, "timeout.test.ts");
+    const accumulator = `const output: string[] = [];
+["item"].forEach((item) => {
+  output.push(item);
+});
+`;
+    const bareExpect = "expect(true);\n";
+    const missingTimeout = `import { test } from "bun:test";
+test("fixture", async () => {
+  await Promise.resolve();
+});
+`;
+
+    try {
+      await Promise.all([
+        writeFile(sourceAccumulator, accumulator),
+        writeFile(testAccumulator, accumulator),
+        writeFile(sourceBareExpect, bareExpect),
+        writeFile(testBareExpect, bareExpect),
+        writeFile(regularTimeout, missingTimeout),
+        writeFile(stressTimeout, missingTimeout),
+      ]);
+
+      const sourceAccumulatorResult = lintFixture(relative(ROOT, sourceAccumulator));
+      expect(sourceAccumulatorResult.exitCode).toBe(1);
+      expect(sourceAccumulatorResult.stdout.toString()).toContain(
+        "auto-mobile(no-accumulator-foreach)",
+      );
+
+      const testAccumulatorResult = lintFixture(relative(ROOT, testAccumulator));
+      expect(testAccumulatorResult.exitCode).toBe(0);
+
+      const sourceBareExpectResult = lintFixture(relative(ROOT, sourceBareExpect));
+      expect(sourceBareExpectResult.exitCode).toBe(0);
+
+      const testBareExpectResult = lintFixture(relative(ROOT, testBareExpect));
+      expect(testBareExpectResult.exitCode).toBe(1);
+      expect(testBareExpectResult.stdout.toString()).toContain("auto-mobile(no-bare-expect)");
+
+      const regularTimeoutResult = lintFixture(relative(ROOT, regularTimeout));
+      expect(regularTimeoutResult.exitCode).toBe(0);
+
+      const stressTimeoutResult = lintFixture(relative(ROOT, stressTimeout));
+      expect(stressTimeoutResult.exitCode).toBe(1);
+      expect(stressTimeoutResult.stdout.toString()).toContain(
+        "auto-mobile(stress-explicit-timeout)",
+      );
+    } finally {
+      await Promise.all([
+        rm(sourceDirectory, { recursive: true, force: true }),
+        rm(testDirectory, { recursive: true, force: true }),
+        rm(stressDirectory, { recursive: true, force: true }),
+      ]);
+    }
   });
 
   test("the raw-timer guard applies globally, with SystemTimer.ts exempted", () => {

--- a/test/lint/oxlintConfigScoping.integration.test.ts
+++ b/test/lint/oxlintConfigScoping.integration.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+// The custom rules' file-scoping used to be enforced (and tested) through
+// eslint.config.mjs's `files:` globs. Under oxlint that scoping lives in
+// .oxlintrc.json's `overrides`, so the "does not apply outside <glob>"
+// guarantees that bareExpectRule / accumulatorForEachRule / stressExplicitTimeout
+// used to assert are now asserted here.
+//
+// Rather than parse .oxlintrc.json ourselves (it is JSONC — comments would break
+// a naive JSON.parse), we read oxlint's OWN resolved configuration via
+// `oxlint --print-config`, which emits strict JSON. That is the tool's typed
+// configuration contract and reflects exactly what oxlint will enforce.
+
+const ROOT = join(import.meta.dir, "..", "..");
+// `oxlint --print-config` normally completes in milliseconds, but it can be
+// delayed by concurrent test processes on a two-core CI host.
+const CONFIG_READ_HOOK_TIMEOUT_MS = 20_000;
+
+interface ResolvedOverride {
+  files: string[];
+  rules?: Record<string, unknown>;
+}
+interface ResolvedConfig {
+  overrides: ResolvedOverride[];
+}
+
+let config: ResolvedConfig;
+
+beforeAll(() => {
+  const result = Bun.spawnSync({
+    cmd: [join(ROOT, "node_modules", ".bin", "oxlint"), "--print-config"],
+    cwd: ROOT,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`oxlint --print-config failed: ${result.stderr.toString()}`);
+  }
+  config = JSON.parse(result.stdout.toString()) as ResolvedConfig;
+}, CONFIG_READ_HOOK_TIMEOUT_MS);
+
+// Return the `files` of the SINGLE override that gates `rule`, asserting the
+// rule resolves through exactly one override. Using the first match alone would
+// miss a later, broader override that also enables the rule (widening its
+// scope), so uniqueness is part of the guarantee.
+function filesScopingRule(rule: string): string[] | undefined {
+  const matches = config.overrides.filter((override) =>
+    override.rules ? Object.prototype.hasOwnProperty.call(override.rules, rule) : false,
+  );
+  expect(matches.length, `${rule} must be gated by exactly one override`).toBe(1);
+  return matches[0]?.files;
+}
+
+describe(".oxlintrc.json rule scoping (via oxlint --print-config)", () => {
+  test("catch-convention and no-unknown-cast are scoped to src/**", () => {
+    for (const rule of ["auto-mobile/catch-convention", "auto-mobile/no-unknown-cast"]) {
+      expect(filesScopingRule(rule)).toEqual(["src/**/*.ts"]);
+    }
+  });
+
+  test("no-accumulator-foreach is scoped to src/** (not the whole tree)", () => {
+    expect(filesScopingRule("auto-mobile/no-accumulator-foreach")).toEqual(["src/**/*.ts"]);
+  });
+
+  test("stress-explicit-timeout is scoped to test/stress/**", () => {
+    expect(filesScopingRule("auto-mobile/stress-explicit-timeout")).toEqual([
+      "test/stress/**/*.ts",
+    ]);
+  });
+
+  test("no-bare-expect is scoped to test/**", () => {
+    expect(filesScopingRule("auto-mobile/no-bare-expect")).toEqual(["test/**/*.ts"]);
+  });
+
+  test("no-explicit-any is scoped to the two correctness-sensitive navigation files", () => {
+    expect(filesScopingRule("typescript/no-explicit-any")).toEqual([
+      "src/features/navigation/ScreenFingerprint.ts",
+      "src/features/navigation/ExploreElementExtraction.ts",
+    ]);
+  });
+
+  test("the raw-timer guard applies globally, with SystemTimer.ts exempted", () => {
+    // no-raw-timer is enabled at the top level (so tests/scripts are covered) and
+    // only turned OFF in the SystemTimer.ts override — that override is the sole
+    // place it appears in the resolved overrides.
+    expect(filesScopingRule("auto-mobile/no-raw-timer")).toEqual(["**/SystemTimer.ts"]);
+  });
+});

--- a/test/lint/oxlintConfigScoping.integration.test.ts
+++ b/test/lint/oxlintConfigScoping.integration.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // The custom rules' file-scoping used to be enforced (and tested) through
@@ -38,50 +40,78 @@ beforeAll(() => {
   config = JSON.parse(result.stdout.toString()) as ResolvedConfig;
 }, CONFIG_READ_HOOK_TIMEOUT_MS);
 
-// Return the `files` of the SINGLE override that gates `rule`, asserting the
+// Return the SINGLE override that gates `rule`, asserting the
 // rule resolves through exactly one override. Using the first match alone would
 // miss a later, broader override that also enables the rule (widening its
 // scope), so uniqueness is part of the guarantee.
-function filesScopingRule(rule: string): string[] | undefined {
+function scopedRuleOverride(rule: string): ResolvedOverride | undefined {
   const matches = config.overrides.filter((override) =>
     override.rules ? Object.prototype.hasOwnProperty.call(override.rules, rule) : false,
   );
   expect(matches.length, `${rule} must be gated by exactly one override`).toBe(1);
-  return matches[0]?.files;
+  return matches[0];
+}
+
+function expectScopedRule(rule: string, files: string[], severity: string): void {
+  const override = scopedRuleOverride(rule);
+  expect(override?.files).toEqual(files);
+  expect(override?.rules?.[rule]).toBe(severity);
 }
 
 describe(".oxlintrc.json rule scoping (via oxlint --print-config)", () => {
   test("catch-convention and no-unknown-cast are scoped to src/**", () => {
     for (const rule of ["auto-mobile/catch-convention", "auto-mobile/no-unknown-cast"]) {
-      expect(filesScopingRule(rule)).toEqual(["src/**/*.ts"]);
+      expectScopedRule(rule, ["src/**/*.ts"], "warn");
     }
   });
 
   test("no-accumulator-foreach is scoped to src/** (not the whole tree)", () => {
-    expect(filesScopingRule("auto-mobile/no-accumulator-foreach")).toEqual(["src/**/*.ts"]);
+    expectScopedRule("auto-mobile/no-accumulator-foreach", ["src/**/*.ts"], "deny");
   });
 
   test("stress-explicit-timeout is scoped to test/stress/**", () => {
-    expect(filesScopingRule("auto-mobile/stress-explicit-timeout")).toEqual([
-      "test/stress/**/*.ts",
-    ]);
+    expectScopedRule("auto-mobile/stress-explicit-timeout", ["test/stress/**/*.ts"], "deny");
   });
 
   test("no-bare-expect is scoped to test/**", () => {
-    expect(filesScopingRule("auto-mobile/no-bare-expect")).toEqual(["test/**/*.ts"]);
+    expectScopedRule("auto-mobile/no-bare-expect", ["test/**/*.ts"], "deny");
   });
 
   test("no-explicit-any is scoped to the two correctness-sensitive navigation files", () => {
-    expect(filesScopingRule("typescript/no-explicit-any")).toEqual([
-      "src/features/navigation/ScreenFingerprint.ts",
-      "src/features/navigation/ExploreElementExtraction.ts",
-    ]);
+    expectScopedRule(
+      "typescript/no-explicit-any",
+      [
+        "src/features/navigation/ScreenFingerprint.ts",
+        "src/features/navigation/ExploreElementExtraction.ts",
+      ],
+      "deny",
+    );
   });
 
   test("the raw-timer guard applies globally, with SystemTimer.ts exempted", () => {
-    // no-raw-timer is enabled at the top level (so tests/scripts are covered) and
-    // only turned OFF in the SystemTimer.ts override — that override is the sole
-    // place it appears in the resolved overrides.
-    expect(filesScopingRule("auto-mobile/no-raw-timer")).toEqual(["**/SystemTimer.ts"]);
+    // `--print-config` omits top-level JavaScript-plugin rules, so run oxlint
+    // against a temporary source file to prove the global rule is active.
+    expectScopedRule("auto-mobile/no-raw-timer", ["**/SystemTimer.ts"], "allow");
+  });
+
+  test("the raw-timer guard is active outside its SystemTimer.ts exemption", async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "auto-mobile-oxlint-"));
+    const sourcePath = join(temporaryDirectory, "raw-timer.ts");
+    try {
+      await writeFile(sourcePath, "setTimeout(() => {}, 1);\n");
+      const result = Bun.spawnSync({
+        cmd: [
+          join(ROOT, "node_modules", ".bin", "oxlint"),
+          "--config",
+          ".oxlintrc.json",
+          sourcePath,
+        ],
+        cwd: ROOT,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout.toString()).toContain("auto-mobile(no-raw-timer)");
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/test/lint/turboTestInputsCoverNativeSources.integration.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.integration.test.ts
@@ -407,11 +407,17 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
     }
   });
 
-  test("integration caching includes scripts and workflows its tests read from disk", () => {
+  test("integration caching includes scripts, lint config, and workflows its tests read from disk", () => {
     const inputs = loadTurbo().tasks["test:integration"]?.inputs ?? [];
 
     expect(inputs).toEqual(
-      expect.arrayContaining(["scripts/**", ".github/workflows/**", "turbo.json"]),
+      expect.arrayContaining([
+        "scripts/**",
+        ".oxlintrc.json",
+        "oxlint-plugins/**",
+        ".github/workflows/**",
+        "turbo.json",
+      ]),
     );
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -118,6 +118,8 @@
         "scripts/**",
         "package.json",
         "bunfig.toml",
+        ".oxlintrc.json",
+        "oxlint-plugins/**",
         ".github/workflows/**",
         "turbo.json",
         "android/auto-mobile-sdk/src/main/kotlin/**",


### PR DESCRIPTION
## Summary

Classify positional test targets once, expand directories into canonical lane-specific test files, and only invoke matching lanes in `all` mode. This prevents unit, changed, and coverage runs from executing integration or stress tests under their fast-lane policy and makes stale targets fail before Bun runs.

Restore the resolved oxlint configuration-scoping test as integration coverage because it starts the oxlint binary.

## Linked Issue

Closes [#6036](https://github.com/kaeawc/auto-mobile/issues/6036)

## Bug / Regression Context

- **Prior attempt:** [#6024](https://github.com/kaeawc/auto-mobile/pull/6024) separated test lanes.
- **Observed symptom:** Explicit paths bypassed unit-lane ignore patterns and one lane-specific target made `all` fail in the other lanes.
- **Repro:** `bash scripts/test-ts.sh unit test/contracts/runAll.integration.test.ts`

## Validation

- [x] `bats test/bats/test-ts.bats`
- [x] `shellcheck scripts/test-ts.sh`
- [x] `bash scripts/test-ts.sh integration test/lint/oxlintConfigScoping.integration.test.ts`
- [x] `bun run turbo:validate`
- [x] `scripts/all_fast_validate_checks.sh`
- [x] `bun run typecheck`
- [x] `bun run format:check`
