### PR TITLE
fix(android-sdk): fail open network observation

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
 
@@ -333,6 +334,8 @@ object AutoMobileNetwork {
         } else {
           try {
             candidate.allow(type, size)
+          } catch (error: CancellationException) {
+            throw error
           } catch (error: Exception) {
             logObservationFailure(error)
             true

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.UUID
@@ -149,6 +150,7 @@ private constructor(
  * OkHttp is a `compileOnly` dependency -- consumers must include OkHttp themselves.
  */
 object AutoMobileNetwork {
+  private const val TAG = "AutoMobileNetwork"
 
   @Volatile private var buffer: SdkEventBuffer? = null
   @Volatile private var applicationId: String? = null
@@ -224,40 +226,47 @@ object AutoMobileNetwork {
     captureBodies: Boolean = false,
   ) {
     val buf = buffer ?: return
-    val policy = capturePolicyProvider?.invoke()
-    val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
-    val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
-    val parsedUrl =
-      if (record.host == null || record.path == null) {
-        try {
-          java.net.URL(record.url)
-        } catch (_: Exception) {
-          null
-        }
-      } else null
-    val host = record.host ?: parsedUrl?.host
-    val path = record.path ?: parsedUrl?.path
-    buf.add(
-      SdkNetworkRequestEvent(
-        timestamp = System.currentTimeMillis(),
-        applicationId = applicationId,
-        url = record.url,
-        method = record.method,
-        statusCode = record.statusCode,
-        durationMs = record.durationMs,
-        protocol = record.protocol,
-        requestBodySize = record.requestBodySize,
-        responseBodySize = record.responseBodySize,
-        host = host,
-        path = path,
-        error = record.error,
-        requestHeaders = if (headersEnabled) record.requestHeaders else null,
-        responseHeaders = if (headersEnabled) record.responseHeaders else null,
-        requestBody = if (bodiesEnabled) record.requestBody else null,
-        responseBody = if (bodiesEnabled) record.responseBody else null,
-        contentType = record.contentType,
+    try {
+      val policy = capturePolicyProvider?.invoke()
+      val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
+      val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
+      val parsedUrl =
+        if (record.host == null || record.path == null) {
+          try {
+            java.net.URL(record.url)
+          } catch (_: Exception) {
+            null
+          }
+        } else null
+      val host = record.host ?: parsedUrl?.host
+      val path = record.path ?: parsedUrl?.path
+      buf.add(
+        SdkNetworkRequestEvent(
+          timestamp = System.currentTimeMillis(),
+          applicationId = applicationId,
+          url = record.url,
+          method = record.method,
+          statusCode = record.statusCode,
+          durationMs = record.durationMs,
+          protocol = record.protocol,
+          requestBodySize = record.requestBodySize,
+          responseBodySize = record.responseBodySize,
+          host = host,
+          path = path,
+          error = record.error,
+          requestHeaders = if (headersEnabled) record.requestHeaders else null,
+          responseHeaders = if (headersEnabled) record.responseHeaders else null,
+          requestBody = if (bodiesEnabled) record.requestBody else null,
+          responseBody = if (bodiesEnabled) record.responseBody else null,
+          contentType = record.contentType,
+        )
       )
-    )
+    } catch (error: Exception) {
+      // Custom loggers are user supplied, so logging must not break host transport behavior either.
+      runCatching {
+        AutoMobileSDK.logger.w(TAG, error) { "Network observation failed; dropping event" }
+      }
+    }
   }
 
   /**
@@ -317,7 +326,37 @@ object AutoMobileNetwork {
     connectionId: String = UUID.randomUUID().toString().take(8),
   ): okhttp3.WebSocket {
     val buf = buffer ?: return webSocket
-    return AutoMobileWebSocket(webSocket, url, buf, applicationId, controller, connectionId)
+    val gatedController = controller?.let { candidate ->
+      WebSocketSendController { type, size ->
+        if (!networkControlMutationsEnabled()) {
+          true
+        } else {
+          try {
+            candidate.allow(type, size)
+          } catch (error: Exception) {
+            logObservationFailure(error)
+            true
+          }
+        }
+      }
+    }
+    return AutoMobileWebSocket(webSocket, url, buf, applicationId, gatedController, connectionId)
+  }
+
+  private fun networkControlMutationsEnabled(): Boolean =
+    try {
+      capturePolicyProvider?.invoke()?.allowMutations == true &&
+        networkControlProvider?.invoke() == true
+    } catch (error: Exception) {
+      logObservationFailure(error)
+      false
+    }
+
+  private fun logObservationFailure(error: Exception) {
+    // Custom loggers are user supplied, so logging must not break host transport behavior either.
+    runCatching {
+      AutoMobileSDK.logger.w(TAG, error) { "Network observation failed; continuing host transport" }
+    }
   }
 
   /** Reset internal state. Visible for testing only. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -71,8 +71,9 @@ internal class AutoMobileNetworkInterceptor(
     val request = chain.request()
     val startMs = System.currentTimeMillis()
     val policy = policyProvider?.let { observeOrNull { it() } }
-    val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
-    val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
+    val policyUnavailable = policyProvider != null && policy == null
+    val headersEnabled = captureHeaders && !policyUnavailable && (policy?.captureHeaders ?: true)
+    val bodiesEnabled = captureBodies && !policyUnavailable && (policy?.captureBodies ?: true)
     val mutationsEnabled = policy?.allowMutations == true
     val networkControlEnabled =
       mutationsEnabled && observeOrNull { networkControlProvider?.invoke() } == true
@@ -100,31 +101,31 @@ internal class AutoMobileNetworkInterceptor(
       } else null
     if (mockRule != null) {
       val durationMs = System.currentTimeMillis() - startMs
-      observe {
-        buffer.add(
-          SdkNetworkRequestEvent(
-            timestamp = startMs,
-            applicationId = applicationId,
-            url = request.url.toString(),
-            method = request.method,
-            statusCode = mockRule.statusCode,
-            durationMs = durationMs,
-            requestBodySize = request.body?.contentLength() ?: -1,
-            responseBodySize = mockRule.responseBody.length.toLong(),
-            host = request.url.host,
-            path = request.url.encodedPath,
-            error = "mocked:${mockRule.mockId}",
-            requestHeaders = reqHeaders,
-            requestBody = reqBody,
-            responseBody = if (bodiesEnabled) mockRule.responseBody else null,
-            contentType = mockRule.contentType,
+      val mockedResponse = observeOrNull { buildMockResponse(request, mockRule) }
+      if (mockedResponse != null) {
+        observe {
+          buffer.add(
+            SdkNetworkRequestEvent(
+              timestamp = startMs,
+              applicationId = applicationId,
+              url = request.url.toString(),
+              method = request.method,
+              statusCode = mockRule.statusCode,
+              durationMs = durationMs,
+              requestBodySize = request.body?.contentLength() ?: -1,
+              responseBodySize = mockRule.responseBody.length.toLong(),
+              host = request.url.host,
+              path = request.url.encodedPath,
+              error = "mocked:${mockRule.mockId}",
+              requestHeaders = reqHeaders,
+              requestBody = reqBody,
+              responseBody = if (bodiesEnabled) mockRule.responseBody else null,
+              contentType = mockRule.contentType,
+            )
           )
-        )
-      }
-      observeOrNull { buildMockResponse(request, mockRule) }
-        ?.let {
-          return it
         }
+        return mockedResponse
+      }
     }
 
     // --- Error simulation enforcement ---

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.net.ConnectException
@@ -44,6 +45,8 @@ internal class AutoMobileNetworkInterceptor(
 ) : Interceptor {
 
   companion object {
+    private const val TAG = "AutoMobileNetwork"
+
     /** Default max body capture size: 32KB */
     const val MAX_BODY_BYTES = 32L * 1024
 
@@ -67,60 +70,68 @@ internal class AutoMobileNetworkInterceptor(
   override fun intercept(chain: Interceptor.Chain): Response {
     val request = chain.request()
     val startMs = System.currentTimeMillis()
-    val policy = policyProvider?.invoke()
+    val policy = policyProvider?.let { observeOrNull { it() } }
     val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
     val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
-    val mutationsEnabled = policy?.allowMutations ?: true
+    val mutationsEnabled = policy?.allowMutations == true
     val networkControlEnabled =
-      if (policy == null) true else networkControlProvider?.invoke() == true
+      mutationsEnabled && observeOrNull { networkControlProvider?.invoke() } == true
 
     // Capture request headers — include OkHttp defaults that will be added later
-    val reqHeaders =
-      if (headersEnabled) {
-        val headers = request.headers.toHeaderMap().toMutableMap()
-        if ("Host" !in headers) headers["Host"] = request.url.host
-        if ("User-Agent" !in headers) headers["User-Agent"] = "okhttp/${okhttp3.OkHttp.VERSION}"
-        headers
-      } else null
+    val reqHeaders = observeOrNull {
+      if (!headersEnabled) return@observeOrNull null
+      val headers = request.headers.toHeaderMap().toMutableMap()
+      if ("Host" !in headers) headers["Host"] = request.url.host
+      if ("User-Agent" !in headers) headers["User-Agent"] = "okhttp/${okhttp3.OkHttp.VERSION}"
+      headers
+    }
 
     // Capture request body
-    val reqBody =
-      if (bodiesEnabled && request.body != null) {
-        captureRequestBody(request)
-      } else null
+    val reqBody = observeOrNull {
+      if (bodiesEnabled && request.body != null) captureRequestBody(request) else null
+    }
 
     // --- Mock rule enforcement ---
     val mockRule =
       if (mutationsEnabled && networkControlEnabled) {
-        ruleStore?.findMatchingRule(request.url.host, request.url.encodedPath, request.method)
+        observeOrNull {
+          ruleStore?.findMatchingRule(request.url.host, request.url.encodedPath, request.method)
+        }
       } else null
     if (mockRule != null) {
       val durationMs = System.currentTimeMillis() - startMs
-      buffer.add(
-        SdkNetworkRequestEvent(
-          timestamp = startMs,
-          applicationId = applicationId,
-          url = request.url.toString(),
-          method = request.method,
-          statusCode = mockRule.statusCode,
-          durationMs = durationMs,
-          requestBodySize = request.body?.contentLength() ?: -1,
-          responseBodySize = mockRule.responseBody.length.toLong(),
-          host = request.url.host,
-          path = request.url.encodedPath,
-          error = "mocked:${mockRule.mockId}",
-          requestHeaders = reqHeaders,
-          requestBody = reqBody,
-          responseBody = if (bodiesEnabled) mockRule.responseBody else null,
-          contentType = mockRule.contentType,
+      observe {
+        buffer.add(
+          SdkNetworkRequestEvent(
+            timestamp = startMs,
+            applicationId = applicationId,
+            url = request.url.toString(),
+            method = request.method,
+            statusCode = mockRule.statusCode,
+            durationMs = durationMs,
+            requestBodySize = request.body?.contentLength() ?: -1,
+            responseBodySize = mockRule.responseBody.length.toLong(),
+            host = request.url.host,
+            path = request.url.encodedPath,
+            error = "mocked:${mockRule.mockId}",
+            requestHeaders = reqHeaders,
+            requestBody = reqBody,
+            responseBody = if (bodiesEnabled) mockRule.responseBody else null,
+            contentType = mockRule.contentType,
+          )
         )
-      )
-      return buildMockResponse(request, mockRule)
+      }
+      observeOrNull { buildMockResponse(request, mockRule) }
+        ?.let {
+          return it
+        }
     }
 
     // --- Error simulation enforcement ---
     val errorSim =
-      if (mutationsEnabled && networkControlEnabled) ruleStore?.getErrorSimulation() else null
+      if (mutationsEnabled && networkControlEnabled) {
+        observeOrNull { ruleStore?.getErrorSimulation() }
+      } else null
     if (errorSim != null) {
       val durationMs = System.currentTimeMillis() - startMs
       return handleErrorSimulation(request, errorSim, startMs, durationMs, reqHeaders, reqBody)
@@ -132,68 +143,60 @@ internal class AutoMobileNetworkInterceptor(
       response = chain.proceed(request)
     } catch (e: Exception) {
       val durationMs = System.currentTimeMillis() - startMs
+      observe {
+        buffer.add(
+          SdkNetworkRequestEvent(
+            timestamp = startMs,
+            applicationId = applicationId,
+            url = request.url.toString(),
+            method = request.method,
+            statusCode = 0,
+            durationMs = durationMs,
+            requestBodySize = request.body?.contentLength() ?: -1,
+            responseBodySize = -1,
+            host = request.url.host,
+            path = request.url.encodedPath,
+            error = e.message,
+            requestHeaders = reqHeaders,
+            requestBody = reqBody,
+          )
+        )
+      }
+      throw e
+    }
+
+    observe {
+      val durationMs = System.currentTimeMillis() - startMs
+      val responseContentType = response.header("Content-Type")
+      val finalReqHeaders =
+        if (headersEnabled) response.request.headers.toHeaderMap() else reqHeaders
+      val respHeaders = if (headersEnabled) response.headers.toHeaderMap() else null
+      val respBody =
+        if (bodiesEnabled && isTextContentType(responseContentType)) {
+          response.peekBody(maxBodyBytes).string()
+        } else null
+
       buffer.add(
         SdkNetworkRequestEvent(
           timestamp = startMs,
           applicationId = applicationId,
           url = request.url.toString(),
           method = request.method,
-          statusCode = 0,
+          statusCode = response.code,
           durationMs = durationMs,
           requestBodySize = request.body?.contentLength() ?: -1,
-          responseBodySize = -1,
+          responseBodySize = response.body?.contentLength() ?: -1,
+          protocol = response.protocol.toString(),
           host = request.url.host,
           path = request.url.encodedPath,
-          error = e.message,
-          requestHeaders = reqHeaders,
+          requestHeaders = finalReqHeaders,
+          responseHeaders = respHeaders,
           requestBody = reqBody,
+          responseBody = respBody,
+          contentType = responseContentType,
         )
       )
-      throw e
     }
-
-    val durationMs = System.currentTimeMillis() - startMs
-    val responseContentType = response.header("Content-Type")
-
-    val finalReqHeaders =
-      if (headersEnabled) {
-        response.request.headers.toHeaderMap()
-      } else reqHeaders
-
-    val respHeaders =
-      if (headersEnabled) {
-        response.headers.toHeaderMap()
-      } else null
-
-    val respBody =
-      if (bodiesEnabled && isTextContentType(responseContentType)) {
-        try {
-          response.peekBody(maxBodyBytes).string()
-        } catch (_: Exception) {
-          null
-        }
-      } else null
-
-    buffer.add(
-      SdkNetworkRequestEvent(
-        timestamp = startMs,
-        applicationId = applicationId,
-        url = request.url.toString(),
-        method = request.method,
-        statusCode = response.code,
-        durationMs = durationMs,
-        requestBodySize = request.body?.contentLength() ?: -1,
-        responseBodySize = response.body?.contentLength() ?: -1,
-        protocol = response.protocol.toString(),
-        host = request.url.host,
-        path = request.url.encodedPath,
-        requestHeaders = finalReqHeaders,
-        responseHeaders = respHeaders,
-        requestBody = reqBody,
-        responseBody = respBody,
-        contentType = responseContentType,
-      )
-    )
 
     return response
   }
@@ -233,23 +236,25 @@ internal class AutoMobileNetworkInterceptor(
     val errorMsg = "simulated:${sim.errorType}"
     when (sim.errorType) {
       "http500" -> {
-        buffer.add(
-          SdkNetworkRequestEvent(
-            timestamp = startMs,
-            applicationId = applicationId,
-            url = request.url.toString(),
-            method = request.method,
-            statusCode = 500,
-            durationMs = durationMs,
-            requestBodySize = request.body?.contentLength() ?: -1,
-            responseBodySize = 0,
-            host = request.url.host,
-            path = request.url.encodedPath,
-            error = errorMsg,
-            requestHeaders = reqHeaders,
-            requestBody = reqBody,
+        observe {
+          buffer.add(
+            SdkNetworkRequestEvent(
+              timestamp = startMs,
+              applicationId = applicationId,
+              url = request.url.toString(),
+              method = request.method,
+              statusCode = 500,
+              durationMs = durationMs,
+              requestBodySize = request.body?.contentLength() ?: -1,
+              responseBodySize = 0,
+              host = request.url.host,
+              path = request.url.encodedPath,
+              error = errorMsg,
+              requestHeaders = reqHeaders,
+              requestBody = reqBody,
+            )
           )
-        )
+        }
         return Response.Builder()
           .request(request)
           .protocol(Protocol.HTTP_1_1)
@@ -259,23 +264,25 @@ internal class AutoMobileNetworkInterceptor(
           .build()
       }
       else -> {
-        buffer.add(
-          SdkNetworkRequestEvent(
-            timestamp = startMs,
-            applicationId = applicationId,
-            url = request.url.toString(),
-            method = request.method,
-            statusCode = 0,
-            durationMs = durationMs,
-            requestBodySize = request.body?.contentLength() ?: -1,
-            responseBodySize = -1,
-            host = request.url.host,
-            path = request.url.encodedPath,
-            error = errorMsg,
-            requestHeaders = reqHeaders,
-            requestBody = reqBody,
+        observe {
+          buffer.add(
+            SdkNetworkRequestEvent(
+              timestamp = startMs,
+              applicationId = applicationId,
+              url = request.url.toString(),
+              method = request.method,
+              statusCode = 0,
+              durationMs = durationMs,
+              requestBodySize = request.body?.contentLength() ?: -1,
+              responseBodySize = -1,
+              host = request.url.host,
+              path = request.url.encodedPath,
+              error = errorMsg,
+              requestHeaders = reqHeaders,
+              requestBody = reqBody,
+            )
           )
-        )
+        }
         throw when (sim.errorType) {
           "timeout" -> SocketTimeoutException("Simulated timeout (AutoMobile)")
           "connectionRefused" -> ConnectException("Simulated connection refused (AutoMobile)")
@@ -298,6 +305,29 @@ internal class AutoMobileNetworkInterceptor(
       buffer.readUtf8(bytes)
     } catch (_: Exception) {
       null
+    }
+  }
+
+  private fun observe(block: () -> Unit) {
+    try {
+      block()
+    } catch (error: Exception) {
+      logObservationFailure(error)
+    }
+  }
+
+  private fun <T> observeOrNull(block: () -> T): T? =
+    try {
+      block()
+    } catch (error: Exception) {
+      logObservationFailure(error)
+      null
+    }
+
+  private fun logObservationFailure(error: Exception) {
+    // Custom loggers are user supplied, so logging must not break host transport behavior either.
+    runCatching {
+      AutoMobileSDK.logger.w(TAG, error) { "Network observation failed; continuing host transport" }
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk.network
 import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
 import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.UUID
 import okhttp3.Request
@@ -15,9 +16,20 @@ internal class AutoMobileWebSocket(
   private val url: String,
   private val buffer: SdkEventBuffer,
   private val applicationId: String?,
-  private val controller: WebSocketSendController?,
+  controller: WebSocketSendController?,
   private val connectionId: String = UUID.randomUUID().toString().take(8),
 ) : WebSocket {
+  private val controller = controller?.let { delegate ->
+    WebSocketSendController { type, size ->
+      try {
+        delegate.allow(type, size)
+      } catch (error: Exception) {
+        logObservationFailure(error)
+        true
+      }
+    }
+  }
+
   override fun request(): Request = delegate.request()
 
   override fun queueSize(): Long = delegate.queueSize()
@@ -46,9 +58,13 @@ internal class AutoMobileWebSocket(
   override fun cancel() = delegate.cancel()
 
   private fun send(type: WebSocketFrameType, size: Long, action: () -> Boolean): Boolean {
-    val success = controller?.allow(type, size) != false && action()
+    val success = controllerAllows(type, size) && action()
     recordFrame(WebSocketFrameDirection.SENT, type, size, success)
     return success
+  }
+
+  private fun controllerAllows(type: WebSocketFrameType, size: Long): Boolean {
+    return controller?.allow(type, size) ?: true
   }
 
   private fun recordFrame(
@@ -57,17 +73,36 @@ internal class AutoMobileWebSocket(
     size: Long,
     success: Boolean,
   ) {
-    buffer.add(
-      SdkWebSocketFrameEvent(
-        timestamp = System.currentTimeMillis(),
-        applicationId = applicationId,
-        connectionId = connectionId,
-        url = url,
-        direction = direction,
-        frameType = type,
-        payloadSize = size,
-        success = success,
+    observe {
+      buffer.add(
+        SdkWebSocketFrameEvent(
+          timestamp = System.currentTimeMillis(),
+          applicationId = applicationId,
+          connectionId = connectionId,
+          url = url,
+          direction = direction,
+          frameType = type,
+          payloadSize = size,
+          success = success,
+        )
       )
-    )
+    }
+  }
+
+  private fun observe(block: () -> Unit) {
+    try {
+      block()
+    } catch (error: Exception) {
+      logObservationFailure(error)
+    }
+  }
+
+  private fun logObservationFailure(error: Exception) {
+    // Custom loggers are user supplied, so logging must not break host transport behavior either.
+    runCatching {
+      AutoMobileSDK.logger.w("AutoMobileWebSocket", error) {
+        "WebSocket observation failed; continuing transport"
+      }
+    }
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.protocol.WebSocketFrameType
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import okhttp3.Request
 import okhttp3.WebSocket
 import okio.ByteString
@@ -23,6 +24,8 @@ internal class AutoMobileWebSocket(
     WebSocketSendController { type, size ->
       try {
         delegate.allow(type, size)
+      } catch (error: CancellationException) {
+        throw error
       } catch (error: Exception) {
         logObservationFailure(error)
         true

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListener.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListener.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk.network
 import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
 import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.UUID
 import okhttp3.Response
@@ -62,17 +63,26 @@ internal class AutoMobileWebSocketListener(
     type: WebSocketFrameType,
     size: Long,
   ) {
-    buffer.add(
-      SdkWebSocketFrameEvent(
-        timestamp = System.currentTimeMillis(),
-        applicationId = applicationId,
-        connectionId = connectionId,
-        url = url,
-        direction = direction,
-        frameType = type,
-        payloadSize = size,
-        success = true,
+    try {
+      buffer.add(
+        SdkWebSocketFrameEvent(
+          timestamp = System.currentTimeMillis(),
+          applicationId = applicationId,
+          connectionId = connectionId,
+          url = url,
+          direction = direction,
+          frameType = type,
+          payloadSize = size,
+          success = true,
+        )
       )
-    )
+    } catch (error: Exception) {
+      // Custom loggers are user supplied, so logging must not break host callbacks either.
+      runCatching {
+        AutoMobileSDK.logger.w("AutoMobileWebSocketListener", error) {
+          "WebSocket observation failed; continuing host callback"
+        }
+      }
+    }
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
@@ -2,6 +2,9 @@ package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
+import dev.jasonpearson.automobile.sdk.events.DropCounter
+import dev.jasonpearson.automobile.sdk.events.DropReason
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.io.IOException
 import java.net.Proxy
@@ -17,6 +20,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import okhttp3.Authenticator
 import okhttp3.Cache
@@ -61,6 +65,24 @@ class AutoMobileNetworkInterceptorTest {
 
   private fun drainDelivery() {
     bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
+  }
+
+  private fun throwingBuffer(): SdkEventBuffer {
+    val buffer =
+      SdkEventBuffer(
+        onFlush = {},
+        dropCounter =
+          object : DropCounter {
+            override fun increment(reason: DropReason, count: Int): Nothing =
+              throw IllegalStateException("recording failed")
+
+            override fun snapshot(): Map<DropReason, Long> = emptyMap()
+
+            override fun reset() = Unit
+          },
+      )
+    buffer.shutdown()
+    return buffer
   }
 
   private fun fakeChain(
@@ -486,6 +508,17 @@ class AutoMobileNetworkInterceptorTest {
     }
   }
 
+  private fun mutationEnabledInterceptor(
+    buffer: SdkEventBuffer,
+    ruleStore: NetworkMockRuleStore.RuleMatcher,
+  ) =
+    AutoMobileNetworkInterceptor(
+      buffer,
+      ruleStore = ruleStore,
+      policyProvider = { SdkCapturePolicy(allowMutations = true) },
+      networkControlProvider = { true },
+    )
+
   @Test
   fun `mock rule returns synthetic response without calling chain`() {
     val (buffer, flushed) = collectingBuffer()
@@ -505,8 +538,7 @@ class AutoMobileNetworkInterceptorTest {
         responseBody = """{"error":"service unavailable"}""",
         contentType = "application/json",
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(matchResult = mockRule))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(matchResult = mockRule))
 
     val response = interceptor.intercept(chain)
 
@@ -543,8 +575,7 @@ class AutoMobileNetworkInterceptorTest {
         remaining = null,
         expiresAtEpochMs = 99999L,
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(errorSim = sim))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(errorSim = sim))
 
     val response = interceptor.intercept(fakeChain())
 
@@ -565,8 +596,7 @@ class AutoMobileNetworkInterceptorTest {
         remaining = null,
         expiresAtEpochMs = 99999L,
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(errorSim = sim))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(errorSim = sim))
 
     assertFailsWith<java.net.SocketTimeoutException> {
       interceptor.intercept(fakeChain())
@@ -587,8 +617,7 @@ class AutoMobileNetworkInterceptorTest {
         remaining = null,
         expiresAtEpochMs = 99999L,
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(errorSim = sim))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(errorSim = sim))
 
     assertFailsWith<java.net.ConnectException> {
       interceptor.intercept(fakeChain())
@@ -605,8 +634,7 @@ class AutoMobileNetworkInterceptorTest {
         remaining = null,
         expiresAtEpochMs = 99999L,
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(errorSim = sim))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(errorSim = sim))
 
     assertFailsWith<java.net.UnknownHostException> {
       interceptor.intercept(fakeChain())
@@ -623,8 +651,7 @@ class AutoMobileNetworkInterceptorTest {
         remaining = null,
         expiresAtEpochMs = 99999L,
       )
-    val interceptor =
-      AutoMobileNetworkInterceptor(buffer, ruleStore = fakeRuleMatcher(errorSim = sim))
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(errorSim = sim))
 
     assertFailsWith<javax.net.ssl.SSLException> {
       interceptor.intercept(fakeChain())
@@ -650,9 +677,9 @@ class AutoMobileNetworkInterceptorTest {
         expiresAtEpochMs = 99999L,
       )
     val interceptor =
-      AutoMobileNetworkInterceptor(
+      mutationEnabledInterceptor(
         buffer,
-        ruleStore = fakeRuleMatcher(matchResult = mockRule, errorSim = sim),
+        fakeRuleMatcher(matchResult = mockRule, errorSim = sim),
       )
 
     val response = interceptor.intercept(fakeChain())
@@ -672,6 +699,85 @@ class AutoMobileNetworkInterceptorTest {
     val response = interceptor.intercept(fakeChain(responseCode = 200))
 
     assertEquals(200, response.code)
+  }
+
+  @Test
+  fun `observation failures leave a successful host request unchanged`() {
+    val buffer = throwingBuffer()
+    var proceedCalls = 0
+    val interceptor =
+      AutoMobileNetworkInterceptor(
+        buffer,
+        ruleStore =
+          object : NetworkMockRuleStore.RuleMatcher {
+            override fun findMatchingRule(host: String, path: String, method: String): Nothing =
+              throw IllegalStateException("rule matching failed")
+
+            override fun getErrorSimulation(): NetworkMockRuleStore.ErrorSimulationConfig? = null
+          },
+        policyProvider = { SdkCapturePolicy(allowMutations = true) },
+        networkControlProvider = { true },
+      )
+
+    val response =
+      interceptor.intercept(
+        FakeInterceptorChain(responseCode = 202, onProceed = { proceedCalls++ })
+      )
+
+    assertEquals(1, proceedCalls)
+    assertEquals(202, response.code)
+  }
+
+  @Test
+  fun `observation failures leave a failed host request unchanged`() {
+    val buffer = throwingBuffer()
+    val hostFailure = IOException("host failure")
+    var proceedCalls = 0
+    val interceptor =
+      AutoMobileNetworkInterceptor(
+        buffer,
+        policyProvider = { throw IllegalStateException("policy failed") },
+      )
+
+    val thrown =
+      assertFailsWith<IOException> {
+        interceptor.intercept(
+          FakeInterceptorChain(
+            throwOnProceed = hostFailure,
+            onProceed = { proceedCalls++ },
+          )
+        )
+      }
+
+    assertEquals(1, proceedCalls)
+    assertSame(hostFailure, thrown)
+  }
+
+  @Test
+  fun `mock rules require an explicitly enabled network control policy`() {
+    val (buffer, _) = collectingBuffer()
+    val mockRule =
+      NetworkMockRuleStore.MatchedMockRule(
+        mockId = "mock-1",
+        statusCode = 503,
+        responseHeaders = emptyMap(),
+        responseBody = "mocked",
+        contentType = "text/plain",
+      )
+    var proceedCalls = 0
+    val interceptor =
+      AutoMobileNetworkInterceptor(
+        buffer,
+        ruleStore = fakeRuleMatcher(matchResult = mockRule),
+      )
+
+    val response =
+      interceptor.intercept(
+        FakeInterceptorChain(responseCode = 204, onProceed = { proceedCalls++ })
+      )
+
+    assertEquals(1, proceedCalls)
+    assertEquals(204, response.code)
   }
 
   // --- Default behavior tests ---

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
@@ -780,6 +780,59 @@ class AutoMobileNetworkInterceptorTest {
     assertEquals(204, response.code)
   }
 
+  @Test
+  fun `policy lookup failure disables sensitive capture`() {
+    val (buffer, flushed) = collectingBuffer()
+    val request =
+      Request.Builder()
+        .url("https://api.example.com/users")
+        .header("Authorization", "Bearer token")
+        .post("secret".toRequestBody("text/plain".toMediaType()))
+        .build()
+    val interceptor =
+      AutoMobileNetworkInterceptor(
+        buffer,
+        captureHeaders = true,
+        captureBodies = true,
+        policyProvider = { throw IllegalStateException("policy failed") },
+      )
+
+    interceptor.intercept(fakeChain(request = request))
+    drainDelivery()
+
+    val event = flushed.single().single() as SdkNetworkRequestEvent
+    assertNull(event.requestHeaders)
+    assertNull(event.responseHeaders)
+    assertNull(event.requestBody)
+    assertNull(event.responseBody)
+  }
+
+  @Test
+  fun `invalid mock response falls through without recording a mock event`() {
+    val (buffer, flushed) = collectingBuffer()
+    var proceedCalls = 0
+    val mockRule =
+      NetworkMockRuleStore.MatchedMockRule(
+        mockId = "mock-1",
+        statusCode = 503,
+        responseHeaders = mapOf("X-Invalid" to "line\nbreak"),
+        responseBody = "mocked",
+        contentType = "text/plain",
+      )
+    val interceptor = mutationEnabledInterceptor(buffer, fakeRuleMatcher(matchResult = mockRule))
+
+    val response =
+      interceptor.intercept(
+        FakeInterceptorChain(responseCode = 204, onProceed = { proceedCalls++ })
+      )
+    drainDelivery()
+
+    assertEquals(1, proceedCalls)
+    assertEquals(204, response.code)
+    assertEquals(1, flushed.flatten().size)
+    assertNull((flushed.single().single() as SdkNetworkRequestEvent).error)
+  }
+
   // --- Default behavior tests ---
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -8,7 +8,12 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.Request
+import okhttp3.WebSocket
+import okio.ByteString
 import org.junit.After
 import org.junit.Test
 
@@ -173,6 +178,64 @@ class AutoMobileNetworkTest {
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertNull(event.requestHeaders)
     assertNull(event.requestBody)
+  }
+
+  @Test
+  fun `recordRequest swallows capture policy failures`() {
+    val (buffer, flushed) = collectingBuffer()
+    AutoMobileNetwork.initialize("com.example", buffer)
+    AutoMobileNetwork.setCapturePolicyProvider { throw IllegalStateException("policy failed") }
+
+    AutoMobileNetwork.recordRequest(
+      NetworkRequestRecord(
+        url = "https://api.example.com/users",
+        method = "GET",
+      )
+    )
+
+    assertEquals(emptyList(), flushed)
+  }
+
+  @Test
+  fun `WebSocket controller requires an enabled network control policy`() {
+    val (buffer, _) = collectingBuffer()
+    var sends = 0
+    val delegate =
+      object : WebSocket {
+        override fun request(): Request = Request.Builder().url("https://example.com").build()
+
+        override fun queueSize(): Long = 0
+
+        override fun send(text: String): Boolean {
+          sends++
+          return true
+        }
+
+        override fun send(bytes: ByteString): Boolean {
+          sends++
+          return true
+        }
+
+        override fun close(code: Int, reason: String?): Boolean = true
+
+        override fun cancel() = Unit
+      }
+    val controller = WebSocketSendController { _, _ -> false }
+    AutoMobileNetwork.initialize("com.example", buffer)
+    AutoMobileNetwork.setCapturePolicyProvider { SdkCapturePolicy() }
+    AutoMobileNetwork.setNetworkControlProvider { true }
+
+    assertTrue(
+      AutoMobileNetwork.wrapWebSocket(delegate, "wss://example.com", controller).send("one")
+    )
+    assertEquals(1, sends)
+
+    AutoMobileNetwork.setCapturePolicyProvider { SdkCapturePolicy(allowMutations = true) }
+
+    assertFalse(
+      AutoMobileNetwork.wrapWebSocket(delegate, "wss://example.com", controller).send("two")
+    )
+    assertEquals(1, sends)
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -4,12 +4,15 @@ import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import okhttp3.Request
 import okhttp3.WebSocket
@@ -235,6 +238,20 @@ class AutoMobileNetworkTest {
     assertFalse(
       AutoMobileNetwork.wrapWebSocket(delegate, "wss://example.com", controller).send("two")
     )
+    assertEquals(1, sends)
+
+    val cancellation = CancellationException("controller cancelled")
+    val thrown =
+      assertFailsWith<CancellationException> {
+        AutoMobileNetwork.wrapWebSocket(
+            delegate,
+            "wss://example.com",
+            WebSocketSendController { _, _ -> throw cancellation },
+          )
+          .send("three")
+      }
+
+    assertSame(cancellation, thrown)
     assertEquals(1, sends)
   }
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListenerTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListenerTest.kt
@@ -4,11 +4,16 @@ import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
 import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.events.DropCounter
+import dev.jasonpearson.automobile.sdk.events.DropReason
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
@@ -40,6 +45,24 @@ class AutoMobileWebSocketListenerTest {
 
   private fun drainDelivery() {
     bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
+  }
+
+  private fun throwingBuffer(): SdkEventBuffer {
+    val buffer =
+      SdkEventBuffer(
+        onFlush = {},
+        dropCounter =
+          object : DropCounter {
+            override fun increment(reason: DropReason, count: Int): Nothing =
+              throw IllegalStateException("recording failed")
+
+            override fun snapshot(): Map<DropReason, Long> = emptyMap()
+
+            override fun reset() = Unit
+          },
+      )
+    buffer.shutdown()
+    return buffer
   }
 
   /** Minimal no-op WebSocket for testing callbacks */
@@ -184,13 +207,75 @@ class AutoMobileWebSocketListenerTest {
     assertEquals("com.example.app", event.applicationId)
   }
 
+  @Test
+  fun `recording failures do not skip any delegate callback`() {
+    val buffer = throwingBuffer()
+    val delegate = RecordingDelegate()
+    val listener =
+      AutoMobileWebSocketListener(
+        delegate,
+        "wss://x",
+        buffer,
+      )
+    val response =
+      Response.Builder()
+        .request(fakeWebSocket.request())
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .build()
+    val failure = IllegalStateException("host failure")
+
+    listener.onOpen(fakeWebSocket, response)
+    listener.onMessage(fakeWebSocket, "text")
+    listener.onMessage(fakeWebSocket, "binary".encodeUtf8())
+    listener.onClosing(fakeWebSocket, 1000, "bye")
+    listener.onClosed(fakeWebSocket, 1000, "bye")
+    listener.onFailure(fakeWebSocket, failure, response)
+
+    assertEquals(1, delegate.openCalls)
+    assertEquals(listOf("text"), delegate.textMessages)
+    assertEquals(listOf("binary".encodeUtf8()), delegate.binaryMessages)
+    assertEquals(listOf(1000 to "bye"), delegate.closingCalls)
+    assertEquals(listOf(1000 to "bye"), delegate.closedCalls)
+    assertSame(failure, delegate.failures.single())
+  }
+
+  @Test
+  fun `delegate failures remain unchanged when recording fails`() {
+    val buffer = throwingBuffer()
+    val delegateFailure = IllegalStateException("delegate failed")
+    val listener =
+      AutoMobileWebSocketListener(
+        object : WebSocketListener() {
+          override fun onMessage(webSocket: WebSocket, text: String) {
+            throw delegateFailure
+          }
+        },
+        "wss://x",
+        buffer,
+      )
+
+    val thrown =
+      assertFailsWith<IllegalStateException> {
+        listener.onMessage(fakeWebSocket, "text")
+      }
+
+    assertSame(delegateFailure, thrown)
+  }
+
   /** Recording delegate that tracks all callback invocations */
   private class RecordingDelegate : WebSocketListener() {
+    var openCalls = 0
     val textMessages = mutableListOf<String>()
     val binaryMessages = mutableListOf<okio.ByteString>()
     val closingCalls = mutableListOf<Pair<Int, String>>()
     val closedCalls = mutableListOf<Pair<Int, String>>()
     val failures = mutableListOf<Throwable>()
+
+    override fun onOpen(webSocket: WebSocket, response: Response) {
+      openCalls++
+    }
 
     override fun onMessage(webSocket: WebSocket, text: String) {
       textMessages.add(text)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
@@ -7,6 +7,7 @@ import dev.jasonpearson.automobile.protocol.WebSocketFrameType
 import dev.jasonpearson.automobile.sdk.events.DropCounter
 import dev.jasonpearson.automobile.sdk.events.DropReason
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -216,6 +217,25 @@ class AutoMobileWebSocketTest {
 
     assertTrue(webSocket.send("sent"))
     assertEquals(listOf("sent"), delegate.textSends)
+  }
+
+  @Test
+  fun `controller cancellation leaves send uninvoked`() {
+    val (buffer, _) = collectingBuffer()
+    val cancellation = CancellationException("controller cancelled")
+    val delegate = FakeWebSocket(sendResult = true)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = WebSocketSendController { _, _ -> throw cancellation },
+        connectionId = "c1",
+      )
+
+    assertSame(cancellation, assertFailsWith<CancellationException> { webSocket.send("sent") })
+    assertTrue(delegate.textSends.isEmpty())
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
@@ -4,12 +4,16 @@ import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
 import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
 import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.events.DropCounter
+import dev.jasonpearson.automobile.sdk.events.DropReason
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import okhttp3.Request
 import okhttp3.WebSocket
@@ -42,6 +46,24 @@ class AutoMobileWebSocketTest {
 
   private fun drainDelivery() {
     bufferExecutor!!.submit {}.get(1, TimeUnit.SECONDS)
+  }
+
+  private fun throwingBuffer(): SdkEventBuffer {
+    val buffer =
+      SdkEventBuffer(
+        onFlush = {},
+        dropCounter =
+          object : DropCounter {
+            override fun increment(reason: DropReason, count: Int): Nothing =
+              throw IllegalStateException("recording failed")
+
+            override fun snapshot(): Map<DropReason, Long> = emptyMap()
+
+            override fun reset() = Unit
+          },
+      )
+    buffer.shutdown()
+    return buffer
   }
 
   @Test
@@ -177,20 +199,97 @@ class AutoMobileWebSocketTest {
     )
   }
 
+  @Test
+  fun `controller failure leaves send delegated exactly once`() {
+    val (buffer, _) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = true)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller =
+          WebSocketSendController { _, _ -> throw IllegalStateException("control failed") },
+        connectionId = "c1",
+      )
+
+    assertTrue(webSocket.send("sent"))
+    assertEquals(listOf("sent"), delegate.textSends)
+  }
+
+  @Test
+  fun `recording failures preserve successful send and close results`() {
+    val buffer = throwingBuffer()
+    val delegate = FakeWebSocket(sendResult = true, closeResult = true)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = null,
+        connectionId = "c1",
+      )
+
+    assertTrue(webSocket.send("text"))
+    assertTrue(webSocket.send("binary".encodeUtf8()))
+    assertTrue(webSocket.close(1000, "bye"))
+    assertEquals(listOf("text"), delegate.textSends)
+    assertEquals(listOf("binary".encodeUtf8()), delegate.binarySends)
+    assertEquals(listOf(1000 to ("bye" as String?)), delegate.closeCalls)
+  }
+
+  @Test
+  fun `host WebSocket failures remain unchanged`() {
+    val (buffer, _) = collectingBuffer()
+    val failure = IllegalStateException("host failure")
+    val delegate =
+      FakeWebSocket(
+        sendResult = true,
+        sendFailure = failure,
+        closeFailure = failure,
+        cancelFailure = failure,
+      )
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = null,
+        connectionId = "c1",
+      )
+
+    assertSame(failure, assertFailsWith<IllegalStateException> { webSocket.send("text") })
+    assertSame(failure, assertFailsWith<IllegalStateException> { webSocket.close(1000, "bye") })
+    assertSame(failure, assertFailsWith<IllegalStateException> { webSocket.cancel() })
+    assertEquals(1, delegate.textSendCalls)
+    assertEquals(1, delegate.closeCalls.size)
+    assertEquals(1, delegate.cancelCalls)
+  }
+
   private class FakeWebSocket(
     private val sendResult: Boolean,
     private val closeResult: Boolean = false,
+    private val sendFailure: Exception? = null,
+    private val closeFailure: Exception? = null,
+    private val cancelFailure: Exception? = null,
   ) : WebSocket {
     val textSends = mutableListOf<String>()
     val binarySends = mutableListOf<ByteString>()
     val closeCalls = mutableListOf<Pair<Int, String?>>()
+    var textSendCalls = 0
+    var cancelCalls = 0
 
     override fun request(): Request = Request.Builder().url("https://fake").build()
 
     override fun queueSize(): Long = 0
 
     override fun send(text: String): Boolean {
+      textSendCalls++
       textSends.add(text)
+      sendFailure?.let { throw it }
       return sendResult
     }
 
@@ -201,9 +300,13 @@ class AutoMobileWebSocketTest {
 
     override fun close(code: Int, reason: String?): Boolean {
       closeCalls.add(code to reason)
+      closeFailure?.let { throw it }
       return closeResult
     }
 
-    override fun cancel() {}
+    override fun cancel() {
+      cancelCalls++
+      cancelFailure?.let { throw it }
+    }
   }
 }

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -31,7 +31,10 @@ android {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
-  buildFeatures { compose = true }
+  buildFeatures {
+    compose = true
+    buildConfig = true
+  }
 }
 
 dependencies {

--- a/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
+++ b/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
@@ -14,6 +14,9 @@ import dev.jasonpearson.automobile.playground.navigation.AppNavigation
 import dev.jasonpearson.automobile.playground.navigation.DeepLinkManager
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.EnableComposeObservableApi
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import dev.jasonpearson.automobile.storage.AnalyticsTracker
@@ -37,6 +40,11 @@ class MainActivity : ComponentActivity() {
 
     // Initialize AutoMobile SDK for navigation tracking
     AutoMobileSDK.initialize(applicationContext)
+    // The playground installs the SDK network-control receiver, so opt in to its debug mocks.
+    AutoMobileSDK.registerCapability(
+      SdkCapabilityDescriptor("network.control", SdkCapabilityState.SUPPORTED)
+    )
+    AutoMobileSDK.updateCapturePolicy(SdkCapturePolicy(allowMutations = true))
     // Enable storage and database inspection in debug builds
     SharedPreferencesInspector.setEnabled(true)
     DatabaseInspector.setEnabled(true)

--- a/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
+++ b/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
@@ -40,11 +40,13 @@ class MainActivity : ComponentActivity() {
 
     // Initialize AutoMobile SDK for navigation tracking
     AutoMobileSDK.initialize(applicationContext)
-    // The playground installs the SDK network-control receiver, so opt in to its debug mocks.
-    AutoMobileSDK.registerCapability(
-      SdkCapabilityDescriptor("network.control", SdkCapabilityState.SUPPORTED)
-    )
-    AutoMobileSDK.updateCapturePolicy(SdkCapturePolicy(allowMutations = true))
+    if (BuildConfig.DEBUG) {
+      // The playground installs the SDK network-control receiver, so opt in to its debug mocks.
+      AutoMobileSDK.registerCapability(
+        SdkCapabilityDescriptor("network.control", SdkCapabilityState.SUPPORTED)
+      )
+      AutoMobileSDK.updateCapturePolicy(SdkCapturePolicy(allowMutations = true))
+    }
     // Enable storage and database inspection in debug builds
     SharedPreferencesInspector.setEnabled(true)
     DatabaseInspector.setEnabled(true)

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { validateHeaderName, validateHeaderValue } from "node:http";
 import { ToolRegistry } from "./toolRegistry";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
@@ -14,6 +15,7 @@ import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { BootedDevice } from "../utils/deviceUtils";
 import { logger } from "../utils/logger";
+import { errorMessage } from "../utils/describeUnknownError";
 import {
   LATEST_RELEASE_VERSION,
   RELEASE_CHECKSUM_REGISTRY,
@@ -81,6 +83,19 @@ const mockNetworkSchema = addDeviceTargetingToSchema(
 );
 
 type MockNetworkArgs = z.infer<typeof mockNetworkSchema>;
+
+function assertValidResponseHeaders(responseHeaders: Record<string, string> | undefined): void {
+  if (responseHeaders === undefined) {return;}
+
+  for (const [name, value] of Object.entries(responseHeaders)) {
+    try {
+      validateHeaderName(name);
+      validateHeaderValue(name, value);
+    } catch (error) {
+      throw new ActionableError(`Invalid mock response header '${name}': ${errorMessage(error)}`);
+    }
+  }
+}
 
 // --- clearMockNetwork tool ---
 
@@ -341,6 +356,7 @@ export function registerNetworkTools(): void {
       } catch {
         throw new ActionableError(`Invalid path regex: ${args.path}`);
       }
+      assertValidResponseHeaders(args.responseHeaders);
 
       const mock = state.addMock({
         host: args.host,

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { validateHeaderName, validateHeaderValue } from "node:http";
+import { validateHeaderName } from "node:http";
 import { ToolRegistry } from "./toolRegistry";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
@@ -92,9 +92,11 @@ function assertValidResponseHeaders(responseHeaders: Record<string, string> | un
   for (const [name, value] of Object.entries(responseHeaders)) {
     try {
       validateHeaderName(name);
-      validateHeaderValue(name, value);
     } catch (error) {
       throw new ActionableError(`Invalid mock response header '${name}': ${errorMessage(error)}`);
+    }
+    if (!/^[\t\x20-\x7e]*$/.test(value)) {
+      throw new ActionableError(`Invalid mock response header '${name}': value must be ASCII`);
     }
   }
 }

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -85,7 +85,9 @@ const mockNetworkSchema = addDeviceTargetingToSchema(
 type MockNetworkArgs = z.infer<typeof mockNetworkSchema>;
 
 function assertValidResponseHeaders(responseHeaders: Record<string, string> | undefined): void {
-  if (responseHeaders === undefined) {return;}
+  if (responseHeaders === undefined) {
+    return;
+  }
 
   for (const [name, value] of Object.entries(responseHeaders)) {
     try {

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -543,6 +543,21 @@ describe("network tool schema", () => {
     expect(JSON.parse(androidMessages[0]).type).toBe("set_network_mock_rules");
   });
 
+  test("mockNetwork rejects invalid response headers before changing state", async () => {
+    const tool = ToolRegistry.getTool("mockNetwork");
+
+    await expect(
+      tool!.deviceAwareHandler!(androidDevice, {
+        host: "api\\.example\\.com",
+        path: "/users",
+        responseHeaders: { "X-Invalid": "line\nbreak" },
+      }),
+    ).rejects.toThrow("Invalid mock response header");
+
+    expect(NetworkState.getInstance().getMockSummary()).toEqual({});
+    expect(androidMessages).toHaveLength(0);
+  });
+
   test("clearMockNetwork supports iOS and re-syncs remaining rules", async () => {
     const mockTool = ToolRegistry.getTool("mockNetwork");
     const clearTool = ToolRegistry.getTool("clearMockNetwork");

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -543,16 +543,20 @@ describe("network tool schema", () => {
     expect(JSON.parse(androidMessages[0]).type).toBe("set_network_mock_rules");
   });
 
-  test("mockNetwork rejects invalid response headers before changing state", async () => {
+  test("mockNetwork rejects invalid response header values before changing state", async () => {
     const tool = ToolRegistry.getTool("mockNetwork");
 
-    await expect(
-      tool!.deviceAwareHandler!(androidDevice, {
-        host: "api\\.example\\.com",
-        path: "/users",
-        responseHeaders: { "X-Invalid": "line\nbreak" },
+    await Promise.all(
+      [{ "X-Invalid": "line\nbreak" }, { "X-Invalid": "café" }].map(async (responseHeaders) => {
+        await expect(
+          tool!.deviceAwareHandler!(androidDevice, {
+            host: "api\\.example\\.com",
+            path: "/users",
+            responseHeaders,
+          }),
+        ).rejects.toThrow("Invalid mock response header");
       }),
-    ).rejects.toThrow("Invalid mock response header");
+    );
 
     expect(NetworkState.getInstance().getMockSummary()).toEqual({});
     expect(androidMessages).toHaveLength(0);


### PR DESCRIPTION
## Summary
- make Android HTTP and WebSocket observation fail open when policy, matching, controller, or event recording fails
- require an explicitly enabled `allowMutations` policy and `network.control` capability before mocks, error simulation, or WebSocket send blocking can alter host transport
- add deterministic coverage for host return values, host exceptions, every WebSocket callback, and failure-injection paths

## Root cause
Observation code ran inline with host transport operations, allowing instrumentation exceptions to prevent callbacks, mask successful operations, or replace host failures.

## Validation
- `./gradlew :auto-mobile-sdk:testDebugUnitTest --tests 'dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptorTest' --tests 'dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocketListenerTest' --tests 'dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocketTest' --tests 'dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkTest' --no-daemon -Dorg.gradle.jvmargs=`
- `./scripts/all_fast_validate_checks.sh`
- `./gradlew :auto-mobile-sdk:apiCheck --no-daemon --no-configuration-cache -Dorg.gradle.jvmargs=`

Closes [#6027](https://github.com/kaeawc/auto-mobile/issues/6027).
