### PR TITLE
feat(android-sdk): add navigation-only initialization

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -42,6 +42,20 @@ for details.
 
 ## Usage
 
+### Navigation-only initialization
+
+Use navigation-only initialization when the host needs navigation event delivery but not the SDK's
+inspection, diagnostics, network, interaction, or performance integrations:
+
+```kotlin
+AutoMobileSDK.initialize(
+    NavigationConfiguration(applicationContext)
+)
+```
+
+This mode only creates the bounded navigation-delivery pipeline. Call `AutoMobileSDK.shutdown()`
+to stop delivery and release its resources before initializing the full SDK.
+
 ### Navigation3 Integration
 
 For apps using androidx.navigation3, add tracking calls in your `NavDisplay` entry providers:

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -605,6 +605,8 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityReg
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry();
   public final void markInitialized();
+  public final void markNavigationInitialized();
+  public final void markNavigationShutdown();
   public final void markLifecycleReady();
   public final void markShutdown();
   public final void setEnabled(boolean);

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -75,7 +75,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$WhenMappings {
   public static final int[] $EnumSwitchMapping$0;
 }
 Compiled from "AutoMobileSDK.kt"
-public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$1$6$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
+public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$1$7$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
   public void onStart(androidx.lifecycle.LifecycleOwner);
   public void onStop(androidx.lifecycle.LifecycleOwner);
   public void onCreate(androidx.lifecycle.LifecycleOwner);
@@ -104,6 +104,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void setLogger$auto_mobile_sdk(dev.jasonpearson.automobile.sdk.logging.SdkLogger);
   public final void initialize(android.content.Context);
   public final void initialize(android.content.Context, dev.jasonpearson.automobile.sdk.AutoMobileConfiguration);
+  public final void initialize(dev.jasonpearson.automobile.sdk.NavigationConfiguration);
   public final void addNavigationListener(dev.jasonpearson.automobile.sdk.NavigationListener);
   public final void removeNavigationListener(dev.jasonpearson.automobile.sdk.NavigationListener);
   public final void addRuntimeContextListener(dev.jasonpearson.automobile.sdk.RuntimeContextListener);
@@ -215,6 +216,12 @@ public final class dev.jasonpearson.automobile.sdk.InspectorRegistration {
 Compiled from "InspectorRegistration.kt"
 public final class dev.jasonpearson.automobile.sdk.InspectorRegistrationKt {
   public static final <V> boolean removeIfIdentical(java.util.concurrent.ConcurrentHashMap<java.lang.String, V>, java.lang.String, V);
+}
+Compiled from "NavigationConfiguration.kt"
+public final class dev.jasonpearson.automobile.sdk.NavigationConfiguration {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.NavigationConfiguration(android.content.Context);
+  public final android.content.Context getContext$auto_mobile_sdk();
 }
 Compiled from "NavigationEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.NavigationEvent {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -99,8 +99,9 @@ object AutoMobileSDK {
   @Volatile private var dropCounter: DropCounter? = null
   private val capabilityRegistry = SdkCapabilityRegistry()
   private val lifecycleLock = Any()
+  @Volatile private var navigationOnlyMode = false
   private var mainThreadTeardownPending = false
-  private var pendingInitialization: Pair<Context, AutoMobileConfiguration>? = null
+  private var pendingInitialization: (() -> Unit)? = null
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -137,15 +138,17 @@ object AutoMobileSDK {
   fun initialize(context: Context, configuration: AutoMobileConfiguration) {
     synchronized(lifecycleLock) {
       if (mainThreadTeardownPending) {
-        pendingInitialization = context.applicationContext to configuration
+        val appContext = context.applicationContext
+        pendingInitialization = { initialize(appContext, configuration) }
         return
       }
       try {
-        if (this.context != null) {
+        if (this.context != null || navigationOnlyMode) {
           logger.d(TAG) { "AutoMobileSDK already initialized" }
           return
         }
 
+        navigationOnlyMode = false
         this.context = context.applicationContext
         this.configuration = configuration
         capabilityRegistry.markInitialized()
@@ -268,6 +271,55 @@ object AutoMobileSDK {
   }
 
   /**
+   * Initializes navigation event delivery without activating the broad SDK integrations.
+   *
+   * This mode does not initialize SDK inspection, diagnostics, network, interaction, or performance
+   * subsystems. Calling it while either SDK mode is active is a no-op; call [shutdown] before
+   * switching modes.
+   */
+  fun initialize(configuration: NavigationConfiguration) {
+    synchronized(lifecycleLock) {
+      if (mainThreadTeardownPending) {
+        pendingInitialization = { initialize(configuration) }
+        return
+      }
+      if (context != null || navigationOnlyMode) {
+        logger.d(TAG) { "AutoMobileSDK already initialized" }
+        return
+      }
+
+      initializeNavigationOnly(configuration)
+    }
+  }
+
+  private fun initializeNavigationOnly(configuration: NavigationConfiguration) {
+    try {
+      navigationOnlyMode = true
+      val appContext = configuration.context.applicationContext
+      context = appContext
+
+      val counter = DefaultDropCounter()
+      dropCounter = counter
+      SdkEventBroadcaster.dropCounter = counter
+
+      eventBuffer =
+        SdkEventBuffer(
+            onFlush = { events -> SdkEventBroadcaster.broadcastBatch(appContext, events) },
+            dropCounter = counter,
+          )
+          .also {
+            it.isEnabled = _isEnabled
+            it.start()
+          }
+    } catch (error: Exception) {
+      logger.e(TAG, error) {
+        "Navigation-only initialization failed; disabling navigation delivery"
+      }
+      shutdown()
+    }
+  }
+
+  /**
    * Adds a navigation listener to receive navigation events.
    *
    * @param listener The listener to add
@@ -322,25 +374,26 @@ object AutoMobileSDK {
       }
     }
 
-    addBreadcrumb(event.destination, BreadcrumbCategory.NAVIGATION, event.metadata)
-
     // Route navigation events through the shared event buffer so they are
     // batched and broadcast on the buffer's background thread instead of
     // blocking the caller (which is often the main thread).
-    val buf = eventBuffer ?: return
-    val ctx = context ?: return
-    val timestamp = System.currentTimeMillis()
-
-    buf.add(
-      SdkNavigationEvent(
-        timestamp = timestamp,
-        applicationId = ctx.packageName,
-        destination = event.destination,
-        source = event.source.toProtocolType(),
-        arguments = event.arguments.mapValues { it.value?.toString() ?: "null" },
-        metadata = event.metadata,
+    try {
+      addBreadcrumb(event.destination, BreadcrumbCategory.NAVIGATION, event.metadata)
+      val buf = eventBuffer ?: return
+      val ctx = context ?: return
+      buf.add(
+        SdkNavigationEvent(
+          timestamp = System.currentTimeMillis(),
+          applicationId = ctx.packageName,
+          destination = event.destination,
+          source = event.source.toProtocolType(),
+          arguments = event.arguments.mapValues { it.value?.toString() ?: "null" },
+          metadata = event.metadata,
+        )
       )
-    )
+    } catch (error: Exception) {
+      logger.e(TAG, error) { "Failed to dispatch navigation event" }
+    }
   }
 
   /** Convert SDK NavigationSource to protocol NavigationSourceType. */
@@ -365,9 +418,11 @@ object AutoMobileSDK {
   fun setEnabled(enabled: Boolean) {
     _isEnabled = enabled
     eventBuffer?.isEnabled = enabled
-    RecompositionTracker.setEnabled(enabled)
-    FrameMetricsCollector.setEnabled(enabled)
-    capabilityRegistry.setEnabled(enabled)
+    if (context != null && !navigationOnlyMode) {
+      RecompositionTracker.setEnabled(enabled)
+      FrameMetricsCollector.setEnabled(enabled)
+      capabilityRegistry.setEnabled(enabled)
+    }
   }
 
   /** Returns the versioned capability and policy snapshot for this SDK integration. */
@@ -430,7 +485,9 @@ object AutoMobileSDK {
   /** Sets the current screen or route used by future diagnostics and lifecycle events. */
   fun setCurrentScreen(screen: String?) {
     sdkContext?.currentScreen = screen?.take(MAX_CONTEXT_VALUE_LENGTH)
-    AutoMobileCrashes.currentScreenProvider = { sdkContext?.snapshot()?.currentScreen }
+    if (context != null && !navigationOnlyMode) {
+      AutoMobileCrashes.currentScreenProvider = { sdkContext?.snapshot()?.currentScreen }
+    }
     notifyRuntimeContextChanged(if (screen == null) "screen_cleared" else "screen_changed")
   }
 
@@ -446,7 +503,7 @@ object AutoMobileSDK {
     schemaVersion: String = "1",
     fields: Map<String, String> = emptyMap(),
   ) {
-    if (!_isEnabled || name.isBlank()) return
+    if (!_isEnabled || name.isBlank() || context == null || navigationOnlyMode) return
     val buf = eventBuffer ?: return
     val ctx = context ?: return
     val snapshot = sdkContext?.snapshot()
@@ -533,6 +590,11 @@ object AutoMobileSDK {
    */
   fun shutdown() {
     synchronized(lifecycleLock) {
+      if (navigationOnlyMode) {
+        shutdownNavigationOnly()
+        return
+      }
+
       pendingInitialization = null
       // Cancel any pending main-thread init work so a fast init→shutdown
       // sequence doesn't re-register hooks after shutdown completes.
@@ -598,7 +660,20 @@ object AutoMobileSDK {
       capabilityRegistry.markShutdown()
       configuration = null
       context = null
+      navigationOnlyMode = false
     }
+  }
+
+  private fun shutdownNavigationOnly() {
+    eventBuffer?.shutdown()
+    eventBuffer = null
+    dropCounter = null
+    SdkEventBroadcaster.reset()
+    listeners.clear()
+    runtimeContextListeners.clear()
+    _isEnabled = true
+    context = null
+    navigationOnlyMode = false
   }
 
   private fun completeMainThreadTeardown() {
@@ -606,7 +681,7 @@ object AutoMobileSDK {
       mainThreadTeardownPending = false
       val nextInitialization = pendingInitialization ?: return
       pendingInitialization = null
-      initialize(nextInitialization.first, nextInitialization.second)
+      nextInitialization()
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -297,6 +297,7 @@ object AutoMobileSDK {
       navigationOnlyMode = true
       val appContext = configuration.context.applicationContext
       context = appContext
+      capabilityRegistry.markNavigationInitialized()
 
       val counter = DefaultDropCounter()
       dropCounter = counter
@@ -672,6 +673,7 @@ object AutoMobileSDK {
     listeners.clear()
     runtimeContextListeners.clear()
     _isEnabled = true
+    capabilityRegistry.markNavigationShutdown()
     context = null
     navigationOnlyMode = false
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -419,10 +419,10 @@ object AutoMobileSDK {
   fun setEnabled(enabled: Boolean) {
     _isEnabled = enabled
     eventBuffer?.isEnabled = enabled
+    capabilityRegistry.setEnabled(enabled)
     if (context != null && !navigationOnlyMode) {
       RecompositionTracker.setEnabled(enabled)
       FrameMetricsCollector.setEnabled(enabled)
-      capabilityRegistry.setEnabled(enabled)
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NavigationConfiguration.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NavigationConfiguration.kt
@@ -1,0 +1,11 @@
+package dev.jasonpearson.automobile.sdk
+
+import android.content.Context
+
+/**
+ * Configuration for navigation-only SDK initialization.
+ *
+ * This mode provides navigation event delivery without installing the broad SDK's inspection,
+ * diagnostics, interaction, network, or performance integrations.
+ */
+class NavigationConfiguration(internal val context: Context)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -11,6 +11,7 @@ import com.slack.circuitx.navigation.intercepting.NavigationEventListener
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import dev.jasonpearson.automobile.sdk.NavigationSource
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Adapter for Circuit navigation library by Slack.
@@ -28,17 +29,17 @@ import dev.jasonpearson.automobile.sdk.NavigationSource
  * ```
  */
 object CircuitAdapter : NavigationFrameworkAdapter {
-  private var isActive = false
+  private val active = AtomicBoolean(false)
 
   override fun start() {
-    isActive = true
+    active.set(true)
   }
 
   override fun stop() {
-    isActive = false
+    active.set(false)
   }
 
-  override fun isActive(): Boolean = isActive
+  override fun isActive(): Boolean = active.get()
 
   /**
    * Creates a listener for CircuitX
@@ -60,7 +61,7 @@ object CircuitAdapter : NavigationFrameworkAdapter {
     val currentExtractMetadata = rememberUpdatedState(extractMetadata)
 
     return remember {
-      if (!isActive) start()
+      start()
 
       CircuitNavigationEventListener(currentExtractArguments, currentExtractMetadata)
     }
@@ -75,11 +76,17 @@ object CircuitAdapter : NavigationFrameworkAdapter {
       navigationContext: NavigationContext,
     ) {
       val screen = navStack?.active ?: return
-      CircuitAdapter.trackScreen(
-        screen = screen,
-        arguments = extractArguments.value(screen),
-        metadata = extractMetadata.value(screen),
-      )
+      try {
+        CircuitAdapter.trackScreen(
+          screen = screen,
+          arguments = extractArguments.value(screen),
+          metadata = extractMetadata.value(screen),
+        )
+      } catch (error: Exception) {
+        AutoMobileSDK.logger.e("CircuitAdapter", error) {
+          "Failed to extract or dispatch Circuit navigation event"
+        }
+      }
     }
   }
 
@@ -114,7 +121,7 @@ object CircuitAdapter : NavigationFrameworkAdapter {
     arguments: Map<String, Any?> = emptyMap(),
     metadata: Map<String, String> = emptyMap(),
   ) {
-    if (!isActive) return
+    if (!active.get()) return
 
     AutoMobileSDK.notifyNavigationEvent(
       NavigationEvent(

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -52,6 +52,8 @@ internal class SdkCapabilityRegistry {
   private var initialized = false
   private var navigationOnly = false
   private var enabled = true
+  private var initializedBeforeNavigation = false
+  private var enabledBeforeNavigation = true
   private var policy = SdkCapturePolicy()
 
   init {
@@ -68,6 +70,8 @@ internal class SdkCapabilityRegistry {
   /** Marks only navigation event delivery as active. */
   fun markNavigationInitialized() {
     synchronized(lock) {
+      initializedBeforeNavigation = initialized
+      enabledBeforeNavigation = enabled
       initialized = true
       navigationOnly = true
     }
@@ -76,8 +80,9 @@ internal class SdkCapabilityRegistry {
   /** Restores the pre-navigation initialization state without clearing host registrations. */
   fun markNavigationShutdown() {
     synchronized(lock) {
-      initialized = false
+      initialized = initializedBeforeNavigation
       navigationOnly = false
+      enabled = enabledBeforeNavigation
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -50,6 +50,7 @@ internal class SdkCapabilityRegistry {
   private val lock = Any()
   private val descriptors = LinkedHashMap<String, SdkCapabilityDescriptor>()
   private var initialized = false
+  private var navigationOnly = false
   private var enabled = true
   private var policy = SdkCapturePolicy()
 
@@ -58,7 +59,26 @@ internal class SdkCapabilityRegistry {
   }
 
   fun markInitialized() {
-    synchronized(lock) { initialized = true }
+    synchronized(lock) {
+      initialized = true
+      navigationOnly = false
+    }
+  }
+
+  /** Marks only navigation event delivery as active. */
+  fun markNavigationInitialized() {
+    synchronized(lock) {
+      initialized = true
+      navigationOnly = true
+    }
+  }
+
+  /** Restores the pre-navigation initialization state without clearing host registrations. */
+  fun markNavigationShutdown() {
+    synchronized(lock) {
+      initialized = false
+      navigationOnly = false
+    }
   }
 
   fun markLifecycleReady() {
@@ -71,6 +91,7 @@ internal class SdkCapabilityRegistry {
   fun markShutdown() {
     synchronized(lock) {
       initialized = false
+      navigationOnly = false
       enabled = true
       policy = SdkCapturePolicy()
       descriptors.clear()
@@ -124,6 +145,11 @@ internal class SdkCapabilityRegistry {
       val visible =
         descriptors.values.map { descriptor ->
           when {
+            navigationOnly && descriptor.id != "events.navigation" ->
+              descriptor.copy(
+                state = SdkCapabilityState.UNSUPPORTED,
+                reason = "Unavailable in navigation-only mode",
+              )
             !initialized && descriptor.state != SdkCapabilityState.UNSUPPORTED ->
               descriptor.copy(
                 state = SdkCapabilityState.NOT_INITIALIZED,
@@ -145,7 +171,10 @@ internal class SdkCapabilityRegistry {
 
   private fun isSupported(id: String): Boolean {
     val descriptor = descriptors[id]
-    return initialized && enabled && descriptor?.state == SdkCapabilityState.SUPPORTED
+    return (initialized &&
+      enabled &&
+      (!navigationOnly || id == "events.navigation") &&
+      descriptor?.state == SdkCapabilityState.SUPPORTED)
   }
 
   fun isCapabilitySupported(id: String): Boolean = synchronized(lock) { isSupported(id) }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -53,7 +53,6 @@ internal class SdkCapabilityRegistry {
   private var navigationOnly = false
   private var enabled = true
   private var initializedBeforeNavigation = false
-  private var enabledBeforeNavigation = true
   private var policy = SdkCapturePolicy()
 
   init {
@@ -71,7 +70,6 @@ internal class SdkCapabilityRegistry {
   fun markNavigationInitialized() {
     synchronized(lock) {
       initializedBeforeNavigation = initialized
-      enabledBeforeNavigation = enabled
       initialized = true
       navigationOnly = true
     }
@@ -82,7 +80,7 @@ internal class SdkCapabilityRegistry {
     synchronized(lock) {
       initialized = initializedBeforeNavigation
       navigationOnly = false
-      enabled = enabledBeforeNavigation
+      enabled = true
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
@@ -9,6 +9,7 @@ import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 import dev.jasonpearson.automobile.sdk.SdkConstants
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Broadcasts batched SDK events via Intent for cross-process communication.
@@ -25,9 +26,11 @@ object SdkEventBroadcaster {
   internal var retryPolicy: RetryPolicy = RetryPolicy()
   internal var retryHandler: Handler = Handler(Looper.getMainLooper())
   internal var dropCounter: DropCounter? = null
+  private val deliveryGeneration = AtomicLong()
 
   /** Reset mutable state. Called by [AutoMobileSDK.shutdown]. */
   internal fun reset() {
+    deliveryGeneration.incrementAndGet()
     retryHandler.removeCallbacksAndMessages(null)
     retryPolicy = RetryPolicy()
     retryHandler = Handler(Looper.getMainLooper())
@@ -43,12 +46,13 @@ object SdkEventBroadcaster {
   internal fun broadcastBatch(context: Context, events: List<SdkEvent>) {
     if (events.isEmpty()) return
 
+    val generation = deliveryGeneration.get()
     val batches = splitIntoBatches(events, context.packageName)
     val eventCount = events.size
     val perBatch = if (batches.size > 1) eventCount / batches.size else eventCount
     for ((i, json) in batches.withIndex()) {
       val count = if (i == batches.lastIndex) eventCount - perBatch * i else perBatch
-      sendBatchIntent(context, json, count)
+      sendBatchIntent(context, json, count, generation = generation)
     }
   }
 
@@ -99,7 +103,10 @@ object SdkEventBroadcaster {
     batchJson: String,
     eventCount: Int = 1,
     attempt: Int = 0,
+    generation: Long,
   ) {
+    if (generation != deliveryGeneration.get()) return
+
     try {
       val intent =
         Intent(SdkEventSerializer.ACTION_SDK_EVENT_BATCH).apply {
@@ -112,13 +119,22 @@ object SdkEventBroadcaster {
         }
       context.sendBroadcast(intent)
     } catch (_: Exception) {
+      if (generation != deliveryGeneration.get()) return
       if (attempt < retryPolicy.maxRetries) {
         val delayMs = retryPolicy.delayForAttempt(attempt)
         retryHandler.postDelayed(
-          { sendBatchIntent(context, batchJson, eventCount, attempt + 1) },
+          {
+            sendBatchIntent(
+              context,
+              batchJson,
+              eventCount,
+              attempt + 1,
+              generation = generation,
+            )
+          },
           delayMs,
         )
-      } else {
+      } else if (generation == deliveryGeneration.get()) {
         dropCounter?.increment(DropReason.DELIVERY_FAILED, eventCount)
       }
     }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
@@ -1,0 +1,169 @@
+package dev.jasonpearson.automobile.sdk
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
+import dev.jasonpearson.automobile.sdk.database.DatabaseError
+import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
+import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError
+import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileSDKNavigationInitializationTest {
+  private val context = RuntimeEnvironment.getApplication()
+  private lateinit var originalHandler: Thread.UncaughtExceptionHandler
+
+  @Before
+  fun setUp() {
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    AutoMobileCrashes.uninstall()
+    DatabaseInspector.reset()
+    SharedPreferencesInspector.reset()
+    originalHandler = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+  }
+
+  @After
+  fun tearDown() {
+    AutoMobileSDK.shutdown()
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+  }
+
+  @Test
+  fun `navigation initialization creates delivery without broad SDK subsystems`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(context))
+
+    assertNotNull(AutoMobileSDK.getEventBuffer())
+    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+    assertFalse(AutoMobileCrashes.isInitialized())
+    try {
+      DatabaseInspector.getDriver()
+      fail("DatabaseInspector should not be initialized")
+    } catch (_: DatabaseError.NotInitialized) {
+      // Expected: navigation-only initialization must not initialize inspection.
+    }
+    try {
+      SharedPreferencesInspector.getDriver()
+      fail("SharedPreferencesInspector should not be initialized")
+    } catch (_: SharedPreferencesError.NotInitialized) {
+      // Expected: navigation-only initialization must not initialize inspection.
+    }
+  }
+
+  @Test
+  fun `navigation initialization is idempotent and shutdown releases delivery`() {
+    val configuration = NavigationConfiguration(context)
+
+    AutoMobileSDK.initialize(configuration)
+    val firstBuffer = AutoMobileSDK.getEventBuffer()
+    AutoMobileSDK.initialize(configuration)
+
+    assertSame(firstBuffer, AutoMobileSDK.getEventBuffer())
+
+    AutoMobileSDK.shutdown()
+
+    assertNull(AutoMobileSDK.getEventBuffer())
+    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `concurrent navigation initialization creates one delivery runtime`() {
+    val configuration = NavigationConfiguration(context)
+    val start = CountDownLatch(1)
+    val complete = CountDownLatch(2)
+
+    val first = Thread {
+      start.await()
+      AutoMobileSDK.initialize(configuration)
+      complete.countDown()
+    }
+    val second = Thread {
+      start.await()
+      AutoMobileSDK.initialize(configuration)
+      complete.countDown()
+    }
+    first.start()
+    second.start()
+    start.countDown()
+    assertTrue(complete.await(5, TimeUnit.SECONDS))
+
+    assertNotNull(AutoMobileSDK.getEventBuffer())
+    assertFalse(AutoMobileCrashes.isInitialized())
+  }
+
+  @Test
+  fun `broad initialization does not replace an active navigation-only runtime`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(context))
+    val navigationBuffer = AutoMobileSDK.getEventBuffer()
+
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertSame(navigationBuffer, AutoMobileSDK.getEventBuffer())
+    assertFalse(AutoMobileCrashes.isInitialized())
+  }
+
+  @Test
+  fun `broad initialization can start after navigation-only shutdown`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(context))
+    AutoMobileSDK.shutdown()
+
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertTrue(AutoMobileCrashes.isInitialized())
+  }
+
+  @Test
+  fun `navigation initialization failure is contained and releases partial state`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(ThrowingApplicationContext(context)))
+
+    assertNull(AutoMobileSDK.getEventBuffer())
+    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+  }
+
+  @Test
+  fun `navigation dispatch failure is contained`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(ThrowingBroadcastContext(context)))
+
+    AutoMobileSDK.notifyNavigationEvent(
+      NavigationEvent(
+        destination = "Profile",
+        source = NavigationSource.CIRCUIT,
+      )
+    )
+    AutoMobileSDK.shutdown()
+
+    assertNull(AutoMobileSDK.getEventBuffer())
+  }
+
+  private class ThrowingApplicationContext(base: Context) : ContextWrapper(base) {
+    override fun getApplicationContext(): Context = error("Application context unavailable")
+  }
+
+  private class ThrowingBroadcastContext(base: Context) : ContextWrapper(base) {
+    override fun getApplicationContext(): Context = this
+
+    override fun sendBroadcast(intent: Intent) {
+      error("Broadcast unavailable")
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
@@ -157,6 +157,16 @@ class AutoMobileSDKNavigationInitializationTest {
   }
 
   @Test
+  fun `disabling navigation-only tracking updates its capability state`() {
+    AutoMobileSDK.initialize(NavigationConfiguration(context))
+
+    AutoMobileSDK.setEnabled(false)
+
+    val capabilities = AutoMobileSDK.capabilities.capabilities.associateBy { it.id }
+    assertEquals(SdkCapabilityState.DISABLED, capabilities.getValue("events.navigation").state)
+  }
+
+  @Test
   fun `navigation initialization failure is contained and releases partial state`() {
     AutoMobileSDK.initialize(NavigationConfiguration(ThrowingApplicationContext(context)))
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
@@ -3,14 +3,19 @@ package dev.jasonpearson.automobile.sdk
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
 import dev.jasonpearson.automobile.sdk.database.DatabaseError
 import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
+import dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter
+import dev.jasonpearson.automobile.sdk.storage.DataStoreEntry
+import dev.jasonpearson.automobile.sdk.storage.DataStoreInspector
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -35,6 +40,7 @@ class AutoMobileSDKNavigationInitializationTest {
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     AutoMobileCrashes.uninstall()
     DatabaseInspector.reset()
+    DataStoreInspector.reset()
     SharedPreferencesInspector.reset()
     originalHandler = Thread.UncaughtExceptionHandler { _, _ -> }
     Thread.setDefaultUncaughtExceptionHandler(originalHandler)
@@ -44,6 +50,7 @@ class AutoMobileSDKNavigationInitializationTest {
   fun tearDown() {
     AutoMobileSDK.shutdown()
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    DataStoreInspector.reset()
     Thread.setDefaultUncaughtExceptionHandler(originalHandler)
   }
 
@@ -54,6 +61,9 @@ class AutoMobileSDKNavigationInitializationTest {
     assertNotNull(AutoMobileSDK.getEventBuffer())
     assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
     assertFalse(AutoMobileCrashes.isInitialized())
+    val capabilities = AutoMobileSDK.capabilities.capabilities.associateBy { it.id }
+    assertEquals(SdkCapabilityState.SUPPORTED, capabilities.getValue("events.navigation").state)
+    assertEquals(SdkCapabilityState.UNSUPPORTED, capabilities.getValue("network.capture").state)
     try {
       DatabaseInspector.getDriver()
       fail("DatabaseInspector should not be initialized")
@@ -133,6 +143,20 @@ class AutoMobileSDKNavigationInitializationTest {
   }
 
   @Test
+  fun `navigation shutdown preserves host-owned DataStore registrations`() {
+    val registration = DataStoreInspector.registerAdapter("host", EmptyDataStoreAdapter)
+
+    try {
+      AutoMobileSDK.initialize(NavigationConfiguration(context))
+      AutoMobileSDK.shutdown()
+
+      assertEquals(setOf("host"), DataStoreInspector.registeredAdapterNames())
+    } finally {
+      registration.unregister()
+    }
+  }
+
+  @Test
   fun `navigation initialization failure is contained and releases partial state`() {
     AutoMobileSDK.initialize(NavigationConfiguration(ThrowingApplicationContext(context)))
 
@@ -165,5 +189,11 @@ class AutoMobileSDKNavigationInitializationTest {
     override fun sendBroadcast(intent: Intent) {
       error("Broadcast unavailable")
     }
+  }
+
+  private object EmptyDataStoreAdapter : DataStoreAdapter {
+    override suspend fun storeNames(): List<String> = emptyList()
+
+    override suspend fun read(storeName: String): List<DataStoreEntry> = emptyList()
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
@@ -32,18 +32,20 @@ import org.robolectric.shadows.ShadowLooper
 @RunWith(RobolectricTestRunner::class)
 class AutoMobileSDKNavigationInitializationTest {
   private val context = RuntimeEnvironment.getApplication()
-  private lateinit var originalHandler: Thread.UncaughtExceptionHandler
+  private var preTestHandler: Thread.UncaughtExceptionHandler? = null
+  private lateinit var assertionHandler: Thread.UncaughtExceptionHandler
 
   @Before
   fun setUp() {
+    preTestHandler = Thread.getDefaultUncaughtExceptionHandler()
     AutoMobileSDK.shutdown()
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     AutoMobileCrashes.uninstall()
     DatabaseInspector.reset()
     DataStoreInspector.reset()
     SharedPreferencesInspector.reset()
-    originalHandler = Thread.UncaughtExceptionHandler { _, _ -> }
-    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+    assertionHandler = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(assertionHandler)
   }
 
   @After
@@ -51,7 +53,7 @@ class AutoMobileSDKNavigationInitializationTest {
     AutoMobileSDK.shutdown()
     ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     DataStoreInspector.reset()
-    Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+    Thread.setDefaultUncaughtExceptionHandler(preTestHandler)
   }
 
   @Test
@@ -59,7 +61,7 @@ class AutoMobileSDKNavigationInitializationTest {
     AutoMobileSDK.initialize(NavigationConfiguration(context))
 
     assertNotNull(AutoMobileSDK.getEventBuffer())
-    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+    assertSame(assertionHandler, Thread.getDefaultUncaughtExceptionHandler())
     assertFalse(AutoMobileCrashes.isInitialized())
     val capabilities = AutoMobileSDK.capabilities.capabilities.associateBy { it.id }
     assertEquals(SdkCapabilityState.SUPPORTED, capabilities.getValue("events.navigation").state)
@@ -91,7 +93,7 @@ class AutoMobileSDKNavigationInitializationTest {
     AutoMobileSDK.shutdown()
 
     assertNull(AutoMobileSDK.getEventBuffer())
-    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+    assertSame(assertionHandler, Thread.getDefaultUncaughtExceptionHandler())
   }
 
   @Test
@@ -183,7 +185,7 @@ class AutoMobileSDKNavigationInitializationTest {
     AutoMobileSDK.initialize(NavigationConfiguration(ThrowingApplicationContext(context)))
 
     assertNull(AutoMobileSDK.getEventBuffer())
-    assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+    assertSame(assertionHandler, Thread.getDefaultUncaughtExceptionHandler())
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKNavigationInitializationTest.kt
@@ -167,6 +167,18 @@ class AutoMobileSDKNavigationInitializationTest {
   }
 
   @Test
+  fun `navigation shutdown restores enabled capability state`() {
+    AutoMobileSDK.setEnabled(false)
+    AutoMobileSDK.initialize(NavigationConfiguration(context))
+
+    AutoMobileSDK.shutdown()
+    AutoMobileSDK.initialize(context)
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    assertTrue(AutoMobileSDK.isCapabilitySupported("events.navigation"))
+  }
+
+  @Test
   fun `navigation initialization failure is contained and releases partial state`() {
     AutoMobileSDK.initialize(NavigationConfiguration(ThrowingApplicationContext(context)))
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
@@ -91,6 +91,7 @@ class CircuitNavigationEventListenerTest {
         ),
         events.map(NavigationEvent::destination),
       )
+      assertTrue(events.all { it.arguments.isEmpty() && it.metadata.isEmpty() })
     } finally {
       composition.dispose()
     }
@@ -229,6 +230,37 @@ class CircuitNavigationEventListenerTest {
       assertSame(initialListener, listener)
       assertEquals("updated", events.last().arguments["extractor"])
       assertEquals("updated", events.last().metadata["metadata"])
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `listener contains extractor failures`() = runTest {
+    val events = collectEvents()
+    val delegate = fakeNavigator(HomeScreen)
+    lateinit var navigator: Navigator
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val listener =
+          CircuitAdapter.rememberCircuitNavigationEventListener(
+            extractArguments = { error("extractor failure") }
+          )
+        navigator =
+          rememberInterceptingNavigator(
+            navigator = delegate,
+            eventListeners = listOf(listener),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      navigator.goTo(DetailScreen("ignored"))
+      composition.awaitIdle()
+
+      assertTrue(events.isEmpty())
     } finally {
       composition.dispose()
     }


### PR DESCRIPTION
## Summary

- add `AutoMobileSDK.initialize(NavigationConfiguration(...))` for navigation-only delivery in the existing SDK artifact
- serialize full and navigation-only lifecycles, with failure containment and reversible navigation teardown
- harden Circuit dispatch and broadcaster retry cancellation; retain existing debug manifest components without initializing their SDK subsystems

## Validation

- `./gradlew --no-daemon -Dorg.gradle.jvmargs='-XX:+UseG1GC -Xmx5g -Xms512m -Dfile.encoding=UTF-8' :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:lintDebug`
- `./gradlew --no-daemon --no-configuration-cache -Dorg.gradle.jvmargs='-XX:+UseG1GC -Xmx5g -Xms512m -Dfile.encoding=UTF-8' :auto-mobile-sdk:apiCheck`
- `scripts/all_fast_validate_checks.sh --only ktfmt,xml,stdlib-first,dependency-decisions,debug-tags`

## Risk

The navigation-only path shares the established event wire format and is mutually exclusive with the full SDK until shutdown. Existing full initialization remains unchanged.

Closes #6052
