### PR TITLE
ci(ios): cut macOS wall time via CircleCI path-filtering + build sharding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,28 @@ workflows:
     jobs:
       # Runs on a small Linux executor. Computes the changed-file set vs main
       # (merge-base) and sets the `run-ios` pipeline parameter, then continues to
-      # continue_config.yml. On main itself the diff is empty, so run-ios stays
-      # false and no macOS job runs — matching the old "halt on base branch".
+      # continue_config.yml.
+      #
+      # `branches: ignore: main` excludes post-merge main builds entirely. On the
+      # base branch the orb's merge-base equals HEAD, and path-filtering's
+      # `same-base-run` default (true) then falls back to diffing HEAD~1..HEAD —
+      # which would re-run every merged iOS change on macOS after the PR already
+      # validated it. Skipping main restores the old "halt on base branch" and
+      # protects the limited macOS budget.
+      #
+      # The mapping mirrors GitHub's filter-ios paths (ios/**, scripts/ios/**,
+      # .swiftformat, .swiftlint.yml) plus .circleci/** so a config change also
+      # revalidates. Keep it in sync with `filter-ios` in pull_request.yml.
       - path-filtering/filter:
           name: detect-ios-changes
           base-revision: main
           config-path: .circleci/continue_config.yml
+          filters:
+            branches:
+              ignore: main
           mapping: |
             ios/.* run-ios true
             scripts/ios/.* run-ios true
+            \.swiftformat run-ios true
+            \.swiftlint\.yml run-ios true
             \.circleci/.* run-ios true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,148 +6,47 @@ version: 2.1
 # GitHub Actions, where it runs free and fast on Linux. CircleCI exists here for
 # one reason: AutoMobile is a public repo, so GitHub-hosted macOS minutes are
 # free but capped at 5 CONCURRENT macOS jobs, and the per-PR iOS matrix competes
-# for that cap. Running the iOS build/test on CircleCI's macOS executor adds a
-# parallel lane. (CircleCI's auto-generated Linux node/java/python jobs were
-# intentionally discarded — importing free-on-GitHub Linux work buys nothing.)
+# for that cap. Running iOS build/test on CircleCI's macOS executor adds
+# parallel lanes.
 #
-# Scope: the two jobs below mirror `ios-swift-packages` and `ios-xcode-build`
-# in .github/workflows/pull_request.yml — the ones that feed the required
-# "iOS Build" gate. They call the SAME repo scripts, so build logic stays
-# single-sourced. The heavier simulator TESTS (Playground / XCTestRunner) are
-# left on GitHub Actions: they need a booted simulator, they cost more macOS
-# minutes, and they feed only the non-required "iOS" gate.
+# DYNAMIC CONFIG (setup workflow): this file is a cheap Linux "setup" pipeline.
+# The path-filtering job diffs the branch against main and continues to
+# .circleci/continue_config.yml ONLY when iOS sources changed — so a non-iOS
+# push never spins up (or checks out on) a macOS executor at all. This replaces
+# the old `halt_if_no_ios_changes`, which ran AFTER a full macOS checkout and
+# therefore still billed macOS minutes for every push. The heavier macOS jobs
+# live in continue_config.yml.
+#
+# ── REQUIRED ONE-TIME PROJECT SETTING ────────────────────────────────────────
+# CircleCI → Project Settings → Advanced → "Enable dynamic config using setup
+# workflows" MUST be ON, or CircleCI rejects this `setup: true` config. There is
+# no config-file equivalent; it is a dashboard toggle.
+# ─────────────────────────────────────────────────────────────────────────────
 #
 # Budget: CircleCI's open-source plan includes ~30,000 macOS credits/month
 # (~150 macOS minutes at ~200 credits/min); paid overflow is ~$0.12-0.24/min.
-# Every job halts early unless ios/**, scripts/ios/**, or this config changed, so non-iOS
-# commits cost nothing. To trim spend further, drop `ios-xcode-build` from the
-# workflow and keep only `ios-swift-packages`.
-#
-# Signing: the scripts only sign when IOS_SIGNING_ENABLED / MACOS_SIGNING_ENABLED
-# are "true" (derived from cert-secret presence). No secrets are configured on
-# CircleCI, so these build unsigned — correct for a simulator build+test lane.
+# With path filtering, only pushes that touch ios/**, scripts/ios/**, or
+# .circleci/** reach the macOS lanes; everything else costs a few Linux seconds.
 
-executors:
-  ios:
-    macos:
-      # Match the Xcode pinned by pull_request.yml. Verify the exact image is
-      # offered at https://circleci.com/developer/machine/image/xcode and adjust.
-      xcode: "26.5"
-    # m4pro.medium is the ONLY macOS class available on the Free plan (all
-    # Free-plan macOS jobs run on it since 2025-11-10) and it is ~200 credits/min.
-    # Apple-silicon classes take NO `macos.` prefix (that prefix is only on the
-    # legacy m1/Intel classes, e.g. macos.m1.medium.gen1). Do NOT use m1/m2 — they
-    # reached end-of-life 2026-02-16 and are rejected as invalid resource classes.
-    resource_class: m4pro.medium
+setup: true
 
-commands:
-  halt_if_no_ios_changes:
-    description: "Save macOS credits: stop the job unless iOS sources changed."
-    steps:
-      - run:
-          name: "Halt if no iOS changes"
-          command: |
-            set -euo pipefail
-            # Diff the WHOLE branch against its base (merge-base with main), not
-            # just HEAD~1..HEAD: a multi-commit push — or a post-rebase tip that
-            # only touches docs — can leave an earlier commit's ios/** change
-            # invisible to a tip-only diff, wrongly halting a build that should
-            # run. Always fall back to RUNNING if a base can't be established, so
-            # a real iOS change is never skipped.
-            if ! git fetch --no-tags --quiet origin main 2>/dev/null; then
-              echo "Could not fetch origin/main — running to be safe."
-              exit 0
-            fi
-            BASE="$(git merge-base FETCH_HEAD HEAD 2>/dev/null || true)"
-            if [ -z "${BASE}" ]; then
-              echo "No merge-base with main — running to be safe."
-              exit 0
-            fi
-            if [ "${BASE}" = "$(git rev-parse HEAD)" ]; then
-              # HEAD is an ancestor of main (e.g. a build on main itself): no PR
-              # delta to test, and main was already validated on its PR.
-              echo "On base branch (no delta vs main) — halting to save macOS credits."
-              circleci-agent step halt
-              exit 0
-            fi
-            # --no-renames so a move OUT of ios/** (e.g. `git mv ios/a docs/a`)
-            # still reports the ios/ source path, not just the destination.
-            # Write the list to a file and grep the file — NOT `git diff | grep`
-            # (grep exits on first match while git diff is still writing, and
-            # under pipefail that SIGPIPE (141) would divert a real match into
-            # the halt branch) and NOT a shell here-string: CircleCI's config
-            # processor reads the here-string redirection operator as a
-            # parameter-tag delimiter and rejects the whole config. Keep every
-            # such double-angle sequence out of this file entirely.
-            git diff --no-renames --name-only "${BASE}" HEAD > /tmp/ios_changed.txt || true
-            if grep -qE '^(ios/|scripts/ios/|\.circleci/)' /tmp/ios_changed.txt; then
-              echo "iOS changes in this branch vs main — continuing."
-            else
-              echo "No ios/**, scripts/ios/**, or .circleci/ changes vs main — halting to save macOS credits."
-              circleci-agent step halt
-            fi
-  restore_spm_cache:
-    steps:
-      - run:
-          name: "Compute SwiftPM cache key"
-          command: cat ios/*/Package.swift > /tmp/spm-lock.txt
-      - restore_cache:
-          keys:
-            - spm-v1-{{ checksum "/tmp/spm-lock.txt" }}
-            - spm-v1-
-
-jobs:
-  ios-swift-packages:
-    executor: ios
-    steps:
-      - checkout
-      - halt_if_no_ios_changes
-      - restore_spm_cache
-      - run:
-          name: "Report toolchain"
-          command: xcodebuild -version && swift --version
-      - run:
-          name: "Build Swift packages"
-          command: ./scripts/ios/swift-build.sh
-      - run:
-          name: "Test Swift packages"
-          command: ./scripts/ios/swift-test.sh
-      - save_cache:
-          key: spm-v1-{{ checksum "/tmp/spm-lock.txt" }}
-          paths:
-            - ~/Library/Caches/org.swift.swiftpm
-            - ios/auto-mobile-sdk/.build
-            - ios/control-proxy/.build
-            - ios/screen-capture/.build
-            - ios/XCTestRunner/.build
-
-  ios-xcode-build:
-    executor: ios
-    steps:
-      - checkout
-      - halt_if_no_ios_changes
-      - run:
-          name: "Install XcodeGen"
-          # CircleCI's macOS image has a non-writable /usr/local/share, which the
-          # script's default prefix can't create. The script honors an override,
-          # so install into $HOME/.local and persist that on PATH (via CircleCI's
-          # $BASH_ENV) for the drift-check and build steps that follow.
-          command: |
-            export XCODEGEN_PREFIX="${HOME}/.local"
-            ./scripts/ios/install-xcodegen.sh
-            echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> "${BASH_ENV}"
-      - run:
-          name: "Check XcodeGen project drift"
-          command: ./scripts/ios/xcodegen-drift-check.sh --all
-      - run:
-          name: "Ensure iOS Simulator runtime"
-          command: ./scripts/ios/ensure-simulator-runtime.sh
-      - run:
-          name: "Build Xcode projects (iOS Simulator)"
-          command: ./scripts/ios/xcode-build.sh
+orbs:
+  # Latest stable at time of writing. The filter job's base-revision/config-path/
+  # mapping interface used below is unchanged across the 1.x–3.x line.
+  path-filtering: circleci/path-filtering@3.0.0
 
 workflows:
-  ios-macos:
+  detect-ios-changes:
     jobs:
-      - ios-swift-packages
-      - ios-xcode-build
+      # Runs on a small Linux executor. Computes the changed-file set vs main
+      # (merge-base) and sets the `run-ios` pipeline parameter, then continues to
+      # continue_config.yml. On main itself the diff is empty, so run-ios stays
+      # false and no macOS job runs — matching the old "halt on base branch".
+      - path-filtering/filter:
+          name: detect-ios-changes
+          base-revision: main
+          config-path: .circleci/continue_config.yml
+          mapping: |
+            ios/.* run-ios true
+            scripts/ios/.* run-ios true
+            \.circleci/.* run-ios true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,121 @@
+version: 2.1
+
+# Continuation config for the CircleCI macOS/iOS lanes. Reached from
+# .circleci/config.yml (the setup pipeline) only when the path-filtering job
+# decided iOS sources changed and set `run-ios` to true. See that file's header
+# for the why, the budget, and the REQUIRED dynamic-config project setting.
+#
+# Scope: ios-swift-packages and ios-xcode-build mirror the same-named jobs in
+# .github/workflows/pull_request.yml — the ones feeding the required "iOS Build"
+# gate. ios-playground-tests mirrors the design-system Playground tests that used
+# to run on GitHub Actions; they were moved here to free a concurrent macOS slot
+# on GitHub (throughput) and stay advisory (simulator tests must not gate merges,
+# per repo policy), so this job's CircleCI check is NOT a required status check.
+# All jobs call the SAME repo scripts, so build logic stays single-sourced.
+#
+# Signing: the scripts only sign when IOS_SIGNING_ENABLED / MACOS_SIGNING_ENABLED
+# are "true" (derived from cert-secret presence). No secrets are configured on
+# CircleCI, so these build unsigned — correct for a simulator build+test lane.
+
+parameters:
+  run-ios:
+    type: boolean
+    default: false
+
+executors:
+  ios:
+    macos:
+      # Match the Xcode pinned by pull_request.yml. Verify the exact image is
+      # offered at https://circleci.com/developer/machine/image/xcode and adjust.
+      xcode: "26.5"
+    # m4pro.medium is the ONLY macOS class available on the Free plan (all
+    # Free-plan macOS jobs run on it since 2025-11-10) and it is ~200 credits/min.
+    # Apple-silicon classes take NO `macos.` prefix (that prefix is only on the
+    # legacy m1/Intel classes, e.g. macos.m1.medium.gen1). Do NOT use m1/m2 — they
+    # reached end-of-life 2026-02-16 and are rejected as invalid resource classes.
+    resource_class: m4pro.medium
+
+commands:
+  restore_spm_cache:
+    steps:
+      - run:
+          name: "Compute SwiftPM cache key"
+          command: cat ios/*/Package.swift > /tmp/spm-lock.txt
+      - restore_cache:
+          keys:
+            - spm-v1-{{ checksum "/tmp/spm-lock.txt" }}
+            - spm-v1-
+
+jobs:
+  ios-swift-packages:
+    executor: ios
+    steps:
+      - checkout
+      - restore_spm_cache
+      - run:
+          name: "Report toolchain"
+          command: xcodebuild -version && swift --version
+      - run:
+          name: "Build Swift packages"
+          command: ./scripts/ios/swift-build.sh
+      - run:
+          name: "Test Swift packages"
+          command: ./scripts/ios/swift-test.sh
+      - save_cache:
+          key: spm-v1-{{ checksum "/tmp/spm-lock.txt" }}
+          paths:
+            - ~/Library/Caches/org.swift.swiftpm
+            - ios/auto-mobile-sdk/.build
+            - ios/control-proxy/.build
+            - ios/screen-capture/.build
+            - ios/XCTestRunner/.build
+
+  ios-xcode-build:
+    executor: ios
+    steps:
+      - checkout
+      - run:
+          name: "Install XcodeGen"
+          # CircleCI's macOS image has a non-writable /usr/local/share, which the
+          # script's default prefix can't create. The script honors an override,
+          # so install into $HOME/.local and persist that on PATH (via CircleCI's
+          # $BASH_ENV) for the drift-check and build steps that follow.
+          command: |
+            export XCODEGEN_PREFIX="${HOME}/.local"
+            ./scripts/ios/install-xcodegen.sh
+            echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> "${BASH_ENV}"
+      - run:
+          name: "Check XcodeGen project drift"
+          command: ./scripts/ios/xcodegen-drift-check.sh --all
+      - run:
+          name: "Ensure iOS Simulator runtime"
+          command: ./scripts/ios/ensure-simulator-runtime.sh
+      - run:
+          name: "Build Xcode projects (iOS Simulator)"
+          command: ./scripts/ios/xcode-build.sh
+
+  # Design-system Playground tests (colour/contrast/typography/shape, #5102),
+  # moved off GitHub Actions to free a concurrent macOS slot there. Simulator
+  # tests are advisory (must not gate merges), so this job's status check must
+  # stay OFF the branch-protection required list.
+  ios-playground-tests:
+    executor: ios
+    steps:
+      - checkout
+      - restore_spm_cache
+      - run:
+          name: "Ensure iOS Simulator runtime"
+          command: ./scripts/ios/ensure-simulator-runtime.sh
+      - run:
+          name: "Run Playground tests"
+          command: ./scripts/ios/xcode-test.sh Playground
+
+workflows:
+  ios-macos:
+    # Gate the whole workflow on the parameter path-filtering set. When false
+    # (no iOS changes) the workflow has no jobs and no macOS executor is used.
+    when: << pipeline.parameters.run-ios >>
+    jobs:
+      - ios-swift-packages
+      - ios-xcode-build
+      - ios-playground-tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1767,7 +1767,7 @@ jobs:
         run: ./scripts/ios/swift-test.sh
 
   ios-xcode-build:
-    name: "Build Xcode Projects (${{ matrix.config.name }})"
+    name: "Build Xcode Projects (${{ matrix.config.name }}, ${{ matrix.project }})"
     runs-on: ${{ matrix.config.runner }}
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
@@ -1781,6 +1781,16 @@ jobs:
         # PR runs only the primary Xcode toolchain; full sweep runs on nightly.yml.
         config:
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
+        # Shard the two Xcode projects across two runners so they build in
+        # parallel, halving this required leg's wall time. The "iOS Build" gate
+        # reads needs.ios-xcode-build.result, which aggregates the whole matrix
+        # (green only if every shard is green), so the gate needs no change. Costs
+        # one extra concurrent macOS slot per PR — offset by moving the Playground
+        # tests to CircleCI (see .circleci/continue_config.yml). Names must match
+        # the generated <name>.xcodeproj basenames passed to xcode-build.sh.
+        project:
+          - Playground
+          - CtrlProxy
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1802,41 +1812,14 @@ jobs:
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Build Xcode Projects"
-        run: ./scripts/ios/xcode-build.sh
+        run: ./scripts/ios/xcode-build.sh ${{ matrix.project }}
 
-  # Runs the Playground PlaygroundTests target (design-system colour/contrast/
-  # typography/shape tests, #5102) via xcode-test.sh, scoped to "Playground" so
-  # the heavier CtrlProxy tests (covered by ios-xctest-runner-simulator-tests)
-  # are not double-run. Simulator-based, so it feeds the non-required "iOS" gate
-  # (not the deterministic "iOS Build" gate) — matching the repo policy that
-  # simulator tests must not gate merges.
-  ios-playground-tests:
-    name: "iOS Playground Tests (${{ matrix.config.name }})"
-    runs-on: ${{ matrix.config.runner }}
-    needs: detect-changes
-    if: needs.detect-changes.outputs.ios_should_run == 'true'
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
-    steps:
-      - name: "Git Checkout"
-        uses: actions/checkout@v6
-        with:
-          lfs: false
-
-      - name: "Select Xcode ${{ matrix.config.xcode }}"
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.config.xcode }}
-
-      - name: "Ensure iOS Simulator runtime"
-        uses: ./.github/actions/ensure-ios-simulator-runtime
-
-      - name: "Run Playground Tests"
-        run: ./scripts/ios/xcode-test.sh Playground
+  # The Playground design-system tests (colour/contrast/typography/shape, #5102)
+  # ran here on macOS as "iOS Playground Tests". They were moved to CircleCI
+  # (.circleci/continue_config.yml → ios-playground-tests) to free a concurrent
+  # GitHub macOS slot for the sharded build lanes above. They remain advisory —
+  # simulator tests must not gate merges — so the CircleCI check stays off the
+  # required-status list, and this gate no longer references them.
 
   ios-xctest-runner-simulator-tests:
     name: "XCTestRunner Simulator Tests"
@@ -3255,11 +3238,12 @@ jobs:
     timeout-minutes: 10
     name: "iOS"
     if: always() && needs.detect-changes.outputs.auto_chore != 'true'
+    # ios-playground-tests moved to CircleCI (advisory), so it is intentionally
+    # not part of this roll-up any more.
     needs:
       - detect-changes
       - ios-build-gate
       - ios-xctest-runner-simulator-tests
-      - ios-playground-tests
       - ios-spm-root-package-build
     runs-on: ubuntu-latest
     steps:
@@ -3269,7 +3253,6 @@ jobs:
             "${{ needs.detect-changes.result }}" \
             "${{ needs.ios-build-gate.result }}" \
             "${{ needs.ios-xctest-runner-simulator-tests.result }}" \
-            "${{ needs.ios-playground-tests.result }}" \
             "${{ needs.ios-spm-root-package-build.result }}" \
           )
           for r in "${results[@]}"; do

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1815,11 +1815,41 @@ jobs:
         run: ./scripts/ios/xcode-build.sh ${{ matrix.project }}
 
   # The Playground design-system tests (colour/contrast/typography/shape, #5102)
-  # ran here on macOS as "iOS Playground Tests". They were moved to CircleCI
-  # (.circleci/continue_config.yml → ios-playground-tests) to free a concurrent
-  # GitHub macOS slot for the sharded build lanes above. They remain advisory —
-  # simulator tests must not gate merges — so the CircleCI check stays off the
-  # required-status list, and this gate no longer references them.
+  # normally run on CircleCI (.circleci/continue_config.yml → ios-playground-tests),
+  # which frees a concurrent GitHub macOS slot for the sharded build lanes above.
+  # CircleCI derives its run-ios parameter from changed PATHS only, so it cannot
+  # see the run-ios / run-native LABEL force. This GHA job is the fallback for that
+  # one case: a label-forced run whose diff touches no iOS path (ios_should_run is
+  # true only via the label, ios_changed is false). On a normal iOS-path PR
+  # ios_changed is true and this job is skipped — CircleCI runs Playground instead,
+  # so there is no double-run. Advisory, like the other simulator tests.
+  ios-playground-tests:
+    name: "iOS Playground Tests (${{ matrix.config.name }})"
+    runs-on: ${{ matrix.config.runner }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ios_should_run == 'true' && needs.detect-changes.outputs.ios_changed != 'true'
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Select Xcode ${{ matrix.config.xcode }}"
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.config.xcode }}
+
+      - name: "Ensure iOS Simulator runtime"
+        uses: ./.github/actions/ensure-ios-simulator-runtime
+
+      - name: "Run Playground Tests"
+        run: ./scripts/ios/xcode-test.sh Playground
 
   ios-xctest-runner-simulator-tests:
     name: "XCTestRunner Simulator Tests"
@@ -3238,12 +3268,15 @@ jobs:
     timeout-minutes: 10
     name: "iOS"
     if: always() && needs.detect-changes.outputs.auto_chore != 'true'
-    # ios-playground-tests moved to CircleCI (advisory), so it is intentionally
-    # not part of this roll-up any more.
+    # ios-playground-tests normally runs on CircleCI; the GHA job stays in this
+    # roll-up for the label-forced-without-iOS-paths fallback, where it runs here.
+    # In the common iOS-path case it is skipped (result 'skipped'), which this
+    # gate treats as non-failing.
     needs:
       - detect-changes
       - ios-build-gate
       - ios-xctest-runner-simulator-tests
+      - ios-playground-tests
       - ios-spm-root-package-build
     runs-on: ubuntu-latest
     steps:
@@ -3253,6 +3286,7 @@ jobs:
             "${{ needs.detect-changes.result }}" \
             "${{ needs.ios-build-gate.result }}" \
             "${{ needs.ios-xctest-runner-simulator-tests.result }}" \
+            "${{ needs.ios-playground-tests.result }}" \
             "${{ needs.ios-spm-root-package-build.result }}" \
           )
           for r in "${results[@]}"; do

--- a/scripts/ios/xcode-build.sh
+++ b/scripts/ios/xcode-build.sh
@@ -8,12 +8,20 @@ set -e
 
 # Options
 DRY_RUN=false
+# Optional positional args restrict which Xcode projects get built, by name
+# (without the .xcodeproj suffix), mirroring xcode-test.sh's filter (#5102) so CI
+# can shard the build one project per runner. With no names, every project under
+# ios/ is built (legacy behavior).
+REQUESTED_PROJECTS=()
 for arg in "$@"; do
     case "$arg" in
         --dry-run)
             DRY_RUN=true
             ;;
+        --*)
+            ;;
         *)
+            REQUESTED_PROJECTS+=("$arg")
             ;;
     esac
 done
@@ -33,7 +41,8 @@ source "${SCRIPT_DIR}/xcodegen_version.sh"
 # shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
 source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-IOS_DIR="${PROJECT_ROOT}/ios"
+# IOS_DIR is overridable (tests point it at a fixture dir); defaults to ios/.
+IOS_DIR="${IOS_DIR:-${PROJECT_ROOT}/ios}"
 
 # On a local arm64 host, build only the arch the simulator runs and skip the
 # index store; empty in CI / on Intel so those keep building universal (#5024).
@@ -46,6 +55,40 @@ echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Xcode Project Build${NC}"
 echo -e "${CYAN}========================================${NC}"
 echo ""
+
+# Discover Xcode projects up front and apply the optional project-name filter, so
+# a dry run (XCODE_BUILD_DRY_RUN=1) can list the selection without Xcode — that is
+# what test/bats/xcode-build-project-filter.bats pins. Mirrors xcode-test.sh's
+# selection logic (#5102); fail closed on a filter that matches nothing so a
+# sharded CI leg can't silently build zero projects.
+SELECTED_XCODEPROJ_DIRS=()
+while IFS= read -r _xcodeproj; do
+    [ -z "${_xcodeproj}" ] && continue
+    _name="$(basename "${_xcodeproj}" .xcodeproj)"
+    _match=0
+    if [ ${#REQUESTED_PROJECTS[@]} -eq 0 ]; then
+        _match=1
+    else
+        for _want in "${REQUESTED_PROJECTS[@]}"; do
+            [ "${_want}" = "${_name}" ] && _match=1
+        done
+    fi
+    [ "${_match}" -eq 1 ] && SELECTED_XCODEPROJ_DIRS+=("${_xcodeproj}")
+done < <(find "${IOS_DIR}" -name "*.xcodeproj" -type d 2>/dev/null | sort || true)
+
+# An explicit filter that matches nothing is a misconfiguration (e.g. a renamed
+# project), not a reason to pass a gating job with zero projects built.
+if [ ${#REQUESTED_PROJECTS[@]} -ne 0 ] && [ ${#SELECTED_XCODEPROJ_DIRS[@]} -eq 0 ]; then
+    echo "Error: no Xcode project under ${IOS_DIR} matched: ${REQUESTED_PROJECTS[*]}" >&2
+    exit 1
+fi
+
+if [ "${XCODE_BUILD_DRY_RUN:-0}" = "1" ]; then
+    for _xcodeproj in "${SELECTED_XCODEPROJ_DIRS[@]}"; do
+        basename "${_xcodeproj}" .xcodeproj
+    done
+    exit 0
+fi
 
 # Track overall status
 OVERALL_STATUS=0
@@ -159,19 +202,13 @@ elif command -v xcodegen &> /dev/null; then
     echo ""
 fi
 
-# Find all xcodeproj directories using glob (faster than find)
-echo -e "${BLUE}Searching for Xcode projects...${NC}"
-shopt -s nullglob
-XCODEPROJ_ARRAY=("${IOS_DIR}"/*/*.xcodeproj "${IOS_DIR}"/*.xcodeproj)
-shopt -u nullglob
-
-if [ ${#XCODEPROJ_ARRAY[@]} -eq 0 ]; then
+# Build the selected projects (discovery + filtering happened up front).
+if [ ${#SELECTED_XCODEPROJ_DIRS[@]} -eq 0 ]; then
     echo -e "${YELLOW}No Xcode projects found in ${IOS_DIR}${NC}"
     exit 0
 fi
 
-# Build each project
-for xcodeproj in "${XCODEPROJ_ARRAY[@]}"; do
+for xcodeproj in "${SELECTED_XCODEPROJ_DIRS[@]}"; do
     PROJECT_NAME=$(basename "${xcodeproj}" .xcodeproj)
 
     echo -e "  Building ${PROJECT_NAME}..."

--- a/scripts/ios/xcode-build.sh
+++ b/scripts/ios/xcode-build.sh
@@ -58,29 +58,48 @@ echo ""
 
 # Discover Xcode projects up front and apply the optional project-name filter, so
 # a dry run (XCODE_BUILD_DRY_RUN=1) can list the selection without Xcode — that is
-# what test/bats/xcode-build-project-filter.bats pins. Mirrors xcode-test.sh's
-# selection logic (#5102); fail closed on a filter that matches nothing so a
-# sharded CI leg can't silently build zero projects.
-SELECTED_XCODEPROJ_DIRS=()
+# what test/bats/xcode-build-project-filter.bats pins.
+#
+# -maxdepth 2 preserves the original glob's reach (ios/*.xcodeproj and
+# ios/*/*.xcodeproj) so a recursive descent can't sweep in nested .xcodeproj from
+# SwiftPM checkouts or generated build trees (e.g. */.build/checkouts/.../*.xcodeproj)
+# and try to build vendored/sample schemes.
+ALL_XCODEPROJ_DIRS=()
 while IFS= read -r _xcodeproj; do
     [ -z "${_xcodeproj}" ] && continue
-    _name="$(basename "${_xcodeproj}" .xcodeproj)"
-    _match=0
-    if [ ${#REQUESTED_PROJECTS[@]} -eq 0 ]; then
-        _match=1
-    else
-        for _want in "${REQUESTED_PROJECTS[@]}"; do
-            [ "${_want}" = "${_name}" ] && _match=1
-        done
-    fi
-    [ "${_match}" -eq 1 ] && SELECTED_XCODEPROJ_DIRS+=("${_xcodeproj}")
-done < <(find "${IOS_DIR}" -name "*.xcodeproj" -type d 2>/dev/null | sort || true)
+    ALL_XCODEPROJ_DIRS+=("${_xcodeproj}")
+done < <(find "${IOS_DIR}" -maxdepth 2 -name "*.xcodeproj" -type d 2>/dev/null | sort || true)
 
-# An explicit filter that matches nothing is a misconfiguration (e.g. a renamed
-# project), not a reason to pass a gating job with zero projects built.
-if [ ${#REQUESTED_PROJECTS[@]} -ne 0 ] && [ ${#SELECTED_XCODEPROJ_DIRS[@]} -eq 0 ]; then
-    echo "Error: no Xcode project under ${IOS_DIR} matched: ${REQUESTED_PROJECTS[*]}" >&2
-    exit 1
+SELECTED_XCODEPROJ_DIRS=()
+if [ ${#REQUESTED_PROJECTS[@]} -eq 0 ]; then
+    SELECTED_XCODEPROJ_DIRS=(${ALL_XCODEPROJ_DIRS[@]+"${ALL_XCODEPROJ_DIRS[@]}"})
+else
+    # Fail closed on EVERY requested name that matches no project, not merely when
+    # the whole selection ends up empty: `xcode-build.sh Playground Typo` must not
+    # silently build just Playground and swallow the typo. Track which requests
+    # matched, then reject any that did not.
+    MATCHED_REQUESTS=()
+    for _xcodeproj in ${ALL_XCODEPROJ_DIRS[@]+"${ALL_XCODEPROJ_DIRS[@]}"}; do
+        _name="$(basename "${_xcodeproj}" .xcodeproj)"
+        for _want in "${REQUESTED_PROJECTS[@]}"; do
+            if [ "${_want}" = "${_name}" ]; then
+                SELECTED_XCODEPROJ_DIRS+=("${_xcodeproj}")
+                MATCHED_REQUESTS+=("${_want}")
+            fi
+        done
+    done
+    UNMATCHED_REQUESTS=()
+    for _want in "${REQUESTED_PROJECTS[@]}"; do
+        _seen=0
+        for _matched in ${MATCHED_REQUESTS[@]+"${MATCHED_REQUESTS[@]}"}; do
+            [ "${_matched}" = "${_want}" ] && _seen=1
+        done
+        [ "${_seen}" -eq 0 ] && UNMATCHED_REQUESTS+=("${_want}")
+    done
+    if [ ${#UNMATCHED_REQUESTS[@]} -ne 0 ]; then
+        echo "Error: no Xcode project under ${IOS_DIR} matched: ${UNMATCHED_REQUESTS[*]}" >&2
+        exit 1
+    fi
 fi
 
 if [ "${XCODE_BUILD_DRY_RUN:-0}" = "1" ]; then

--- a/test/bats/xcode-build-project-filter.bats
+++ b/test/bats/xcode-build-project-filter.bats
@@ -44,3 +44,20 @@ teardown() {
   [[ "$output" == *"no Xcode project"* ]]
   [[ "$output" == *"Nonexistent"* ]]
 }
+
+@test "a valid + invalid name pair fails closed and names only the unmatched" {
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script" Playground Typo
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Typo"* ]]
+  # The error must list the unmatched request, not the valid one.
+  [[ "$output" != *"matched: Playground"* ]]
+}
+
+@test "nested .xcodeproj below depth 2 (SwiftPM checkouts, build trees) is ignored" {
+  mkdir -p "$ios_dir/XCTestRunner/.build/checkouts/Vendor/Sample.xcodeproj"
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Playground"* ]]
+  [[ "$output" == *"CtrlProxy"* ]]
+  [[ "$output" != *"Sample"* ]]
+}

--- a/test/bats/xcode-build-project-filter.bats
+++ b/test/bats/xcode-build-project-filter.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+#
+# Pins the optional project-name filter of scripts/ios/xcode-build.sh, which lets
+# CI shard the two Xcode projects (Playground, CtrlProxy) one per macOS runner so
+# the required "iOS Build" leg builds them in parallel. The dry-run path
+# (XCODE_BUILD_DRY_RUN=1) prints the selected projects without invoking xcodebuild,
+# so this runs on any host — no Xcode required. Mirrors xcode-test-project-filter.bats.
+
+setup() {
+  ios_dir="$(mktemp -d)"
+  mkdir -p "$ios_dir/Playground/Playground.xcodeproj"
+  mkdir -p "$ios_dir/control-proxy/CtrlProxy.xcodeproj"
+  script="$BATS_TEST_DIRNAME/../../scripts/ios/xcode-build.sh"
+}
+
+teardown() {
+  rm -rf "$ios_dir"
+}
+
+@test "no args selects every xcodeproj" {
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Playground"* ]]
+  [[ "$output" == *"CtrlProxy"* ]]
+}
+
+@test "a project-name arg restricts the selection to that project" {
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script" CtrlProxy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CtrlProxy"* ]]
+  [[ "$output" != *"Playground"* ]]
+}
+
+@test "the --dry-run flag is not treated as a project name" {
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script" --dry-run Playground
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Playground"* ]]
+  [[ "$output" != *"CtrlProxy"* ]]
+}
+
+@test "an unknown project-name arg fails closed (non-zero, no silent no-op)" {
+  run env IOS_DIR="$ios_dir" XCODE_BUILD_DRY_RUN=1 bash "$script" Nonexistent
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no Xcode project"* ]]
+  [[ "$output" == *"Nonexistent"* ]]
+}


### PR DESCRIPTION
## Summary

Cuts iOS CI wall time two ways at once: **lower single-PR latency** (parallelize the Xcode build) and **higher concurrent-PR throughput** (stop wasting GitHub's 5-concurrent-macOS slots and CircleCI's tiny free macOS budget). Three coordinated changes:

**1. CircleCI dynamic config — stop billing macOS for non-iOS pushes.**
`.circleci/config.yml` becomes a `setup: true` pipeline that runs `circleci/path-filtering@3.0.0` on a cheap Linux executor and continues to the new `.circleci/continue_config.yml` **only** when `ios/**`, `scripts/ios/**`, or `.circleci/**` changed. This replaces `halt_if_no_ios_changes`, which ran *after* a full macOS checkout and therefore still charged macOS minutes for every push. Non-iOS pushes now never spin up a macOS executor.

**2. Shard `ios-xcode-build` by project — faster single-PR latency.**
There are exactly two Xcode projects (`Playground`, `CtrlProxy`), previously built sequentially in one job. `scripts/ios/xcode-build.sh` gains a positional project-name filter (mirroring the already-tested `xcode-test.sh` filter; `XCODE_BUILD_DRY_RUN=1` lists the selection with no Xcode, pinned by a new bats suite), and the GHA job gets a `project: [Playground, CtrlProxy]` matrix so the two build in parallel. The required **"iOS Build"** gate reads `needs.ios-xcode-build.result`, which aggregates the whole matrix (green only if every shard is green), so **the gate is unchanged**. Costs one extra concurrent macOS slot per PR — returned by change 3.

**3. Move `ios-playground-tests` from GitHub Actions to CircleCI — return the slot.**
The Playground design-system tests move to a CircleCI job, freeing a GitHub macOS slot. They stay **advisory** (simulator tests must not gate merges, per repo policy): the CircleCI check is intentionally **not** added to required status checks, and the non-required "iOS" gate no longer references the job.

## Linked Issue

<!-- No tracked issue; part of the macOS-runner-constraints work. -->

## Reviewer notes

- **One-time manual step before CircleCI works:** enable **Project Settings → Advanced → "Enable dynamic config using setup workflows"**. There is no config-file equivalent; until it is on, CircleCI rejects the `setup: true` config. This is the only hard gate on the change.
- **Gate integrity:** `ios-build-gate` ("iOS Build", required) is untouched and still aggregates the sharded matrix; `ios-gate` ("iOS", advisory) drops only the moved Playground job.
- **Concurrency trade-off is deliberate:** sharding uses +1 macOS slot/PR (change 2) and moving Playground returns 1 (change 3), so per-PR GitHub slot usage is net-neutral while build latency drops.
- **Orb pin:** `path-filtering@3.0.0` is the current stable; the `base-revision`/`config-path`/`mapping` interface used here is unchanged across the 1.x–3.x line (verified against the orb source).
- Kept the moved Playground job advisory rather than required, to avoid coupling merges to CircleCI budget/uptime. Promoting it later is a one-line branch-protection add.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` (shellcheck leg green; full suite run locally)
- [x] Both bats filter suites pass (`xcode-build-project-filter.bats` + existing `xcode-test-project-filter.bats`, 7 tests)
- [x] `shellcheck scripts/ios/xcode-build.sh`
- [x] YAML structural load of all three configs; real-`ios/` dry-run resolves exactly `Playground` + `CtrlProxy`
- [ ] CircleCI semantics (orb + setup-workflow toggle) — only exercisable once the branch runs on CircleCI

## Device Verification

N/A — CI configuration and a build-script filter; no on-device behavior changes.
