### PR TITLE
fix(test): guard optional test runner flags

### DIFF
--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -174,14 +174,24 @@ has_test_targets=0
 args=("$@")
 for ((arg_index = 0; arg_index < ${#args[@]}; arg_index += 1)); do
   arg="${args[$arg_index]}"
-  if [[ "$arg" == --bail ]]; then
+  if [[ "$arg" == --cwd || "$arg" == --cwd=* ]]; then
+    echo "--cwd is not supported because test lanes are resolved from the repository root." >&2
+    exit 2
+  elif [[ "$arg" == --bail || "$arg" == --parallel ]]; then
     passthrough_args+=("$arg")
     next_arg="${args[$((arg_index + 1))]:-}"
     if [[ "$next_arg" =~ ^[0-9]+$ ]]; then
       passthrough_args+=("$next_arg")
       arg_index=$((arg_index + 1))
     fi
-  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --changed || "$arg" == --parallel || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" || "$arg" == --import || "$arg" == --inspect || "$arg" == --inspect-wait || "$arg" == --inspect-brk || "$arg" == --cpu-prof-name || "$arg" == --cpu-prof-dir || "$arg" == --cpu-prof-interval || "$arg" == --heap-prof-name || "$arg" == --heap-prof-dir || "$arg" == --install || "$arg" == "--eval" || "$arg" == "-e" || "$arg" == --print || "$arg" == "-p" || "$arg" == --port || "$arg" == --conditions || "$arg" == --fetch-preconnect || "$arg" == --max-http-header-size || "$arg" == --dns-result-order || "$arg" == --unhandled-rejections || "$arg" == --console-depth || "$arg" == --user-agent || "$arg" == --cron-title || "$arg" == --cron-period || "$arg" == --elide-lines || "$arg" == "--filter" || "$arg" == "-F" || "$arg" == --shell || "$arg" == --env-file || "$arg" == --cwd || "$arg" == --config || "$arg" == "-c" ]]; then
+  elif [[ "$arg" == --changed || "$arg" == --inspect || "$arg" == --inspect-wait || "$arg" == --inspect-brk ]]; then
+    passthrough_args+=("$arg")
+    next_arg="${args[$((arg_index + 1))]:-}"
+    if [[ -n "$next_arg" && "$next_arg" != -* && "$next_arg" != test/* && "$next_arg" != "$ROOT"/test/* ]]; then
+      passthrough_args+=("$next_arg")
+      arg_index=$((arg_index + 1))
+    fi
+  elif [[ "$arg" == --timeout || "$arg" == --rerun-each || "$arg" == --retry || "$arg" == --seed || "$arg" == --coverage-reporter || "$arg" == --coverage-dir || "$arg" == --test-name-pattern || "$arg" == "-t" || "$arg" == --reporter || "$arg" == --reporter-outfile || "$arg" == --max-concurrency || "$arg" == --path-ignore-patterns || "$arg" == --parallel-delay || "$arg" == --shard || "$arg" == --preload || "$arg" == --require || "$arg" == "-r" || "$arg" == --import || "$arg" == --cpu-prof-name || "$arg" == --cpu-prof-dir || "$arg" == --cpu-prof-interval || "$arg" == --heap-prof-name || "$arg" == --heap-prof-dir || "$arg" == --install || "$arg" == "--eval" || "$arg" == "-e" || "$arg" == --print || "$arg" == "-p" || "$arg" == --port || "$arg" == --conditions || "$arg" == --fetch-preconnect || "$arg" == --max-http-header-size || "$arg" == --dns-result-order || "$arg" == --unhandled-rejections || "$arg" == --console-depth || "$arg" == --user-agent || "$arg" == --cron-title || "$arg" == --cron-period || "$arg" == --elide-lines || "$arg" == "--filter" || "$arg" == "-F" || "$arg" == --shell || "$arg" == --env-file || "$arg" == --config || "$arg" == "-c" ]]; then
     passthrough_args+=("$arg")
     if [[ "$arg_index" -lt $((${#args[@]} - 1)) ]]; then
       arg_index=$((arg_index + 1))

--- a/scripts/test-ts.sh
+++ b/scripts/test-ts.sh
@@ -106,9 +106,49 @@ add_test_path_to_lane() {
   esac
 }
 
-add_test_target() {
+canonical_file_target() {
+  local target="$1"
+  local target_directory
+  local link_target
+
+  target="$(cd "$(dirname "$target")" && pwd -P)/$(basename "$target")"
+  while [[ -L "$target" ]]; do
+    target_directory="$(cd "$(dirname "$target")" && pwd -P)"
+    link_target="$(readlink "$target")"
+    if [[ "$link_target" == /* ]]; then
+      target="$link_target"
+    else
+      target="$target_directory/$link_target"
+    fi
+    target="$(cd "$(dirname "$target")" && pwd -P)/$(basename "$target")"
+  done
+  printf '%s\n' "$target"
+}
+
+canonical_test_target() {
   local requested_target="$1"
   local absolute_target
+
+  if [[ -f "$requested_target" ]]; then
+    absolute_target="$(canonical_file_target "$requested_target")"
+  elif [[ -d "$requested_target" ]]; then
+    absolute_target="$(cd "$requested_target" && pwd -P)"
+  else
+    printf '%s\n' "__missing__"
+    return
+  fi
+
+  if [[ "$absolute_target" == "$ROOT/test" ]]; then
+    printf '%s\n' "test"
+  elif [[ "$absolute_target" == "$ROOT/test/"* ]]; then
+    printf '%s\n' "${absolute_target#"$ROOT"/}"
+  else
+    printf '%s\n' "__outside_test__"
+  fi
+}
+
+add_test_target() {
+  local requested_target="$1"
   local target
   local test_path
   local found=0
@@ -116,34 +156,19 @@ add_test_target() {
 
   if [[ -f "$requested_target" ]]; then
     is_file_target=1
-    absolute_target="$(cd "$(dirname "$requested_target")" && pwd -P)/$(basename "$requested_target")"
-    while [[ -L "$absolute_target" ]]; do
-      local target_directory
-      local link_target
-      target_directory="$(cd "$(dirname "$absolute_target")" && pwd -P)"
-      link_target="$(readlink "$absolute_target")"
-      if [[ "$link_target" == /* ]]; then
-        absolute_target="$link_target"
-      else
-        absolute_target="$target_directory/$link_target"
-      fi
-      absolute_target="$(cd "$(dirname "$absolute_target")" && pwd -P)/$(basename "$absolute_target")"
-    done
-  elif [[ -d "$requested_target" ]]; then
-    absolute_target="$(cd "$requested_target" && pwd -P)"
-  else
-    echo "No test files found for target: $requested_target" >&2
-    exit 2
   fi
 
-  if [[ "$absolute_target" == "$ROOT/test" ]]; then
-    target="test"
-  elif [[ "$absolute_target" == "$ROOT/test/"* ]]; then
-    target="${absolute_target#"$ROOT"/}"
-  else
-    echo "Test target must be inside test/: $requested_target" >&2
-    exit 2
-  fi
+  target="$(canonical_test_target "$requested_target")"
+  case "$target" in
+    __missing__)
+      echo "No test files found for target: $requested_target" >&2
+      exit 2
+      ;;
+    __outside_test__)
+      echo "Test target must be inside test/: $requested_target" >&2
+      exit 2
+      ;;
+  esac
 
   if [[ "$is_file_target" -eq 1 ]]; then
     if [[ "$target" != *.test.ts ]]; then
@@ -187,7 +212,10 @@ for ((arg_index = 0; arg_index < ${#args[@]}; arg_index += 1)); do
   elif [[ "$arg" == --changed || "$arg" == --inspect || "$arg" == --inspect-wait || "$arg" == --inspect-brk ]]; then
     passthrough_args+=("$arg")
     next_arg="${args[$((arg_index + 1))]:-}"
-    if [[ -n "$next_arg" && "$next_arg" != -* && "$next_arg" != test/* && "$next_arg" != "$ROOT"/test/* ]]; then
+    next_target="$(canonical_test_target "$next_arg")"
+    if [[ "$next_target" == "test" || "$next_target" == test/* || ( "$next_target" == "__missing__" && ( "$next_arg" == test || "$next_arg" == test/* || "$next_arg" == ./test || "$next_arg" == ./test/* || "$next_arg" == "$ROOT"/test || "$next_arg" == "$ROOT"/test/* ) ) ]]; then
+      :
+    elif [[ -n "$next_arg" && "$next_arg" != -* ]]; then
       passthrough_args+=("$next_arg")
       arg_index=$((arg_index + 1))
     fi

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -178,12 +178,32 @@ run_lane() {
 }
 
 @test "Bun runtime option values are not classified as positional test targets" {
-  for option in --config --env-file --cwd; do
+  for option in --config --env-file; do
     run_lane unit "$option" bunfig.toml test/scripts/testLaneClassification.test.ts
     [ "$status" -eq 0 ]
     [[ "$output" == *"$option bunfig.toml"* ]]
     [[ "$output" == *"test/scripts/testLaneClassification.test.ts"* ]]
   done
+}
+
+@test "optional Bun flags do not consume following test targets" {
+  for option in --parallel --changed --inspect; do
+    run_lane unit "$option" test/contracts/runAll.integration.test.ts
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"No unit test paths were selected."* ]]
+  done
+}
+
+@test "optional Bun flags preserve unambiguous split values" {
+  run_lane unit --parallel 2 test/scripts/testLaneClassification.test.ts
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel 2"* ]]
+}
+
+@test "rejects a cwd override that would invalidate lane classification" {
+  run_lane unit --cwd test scripts/testLaneClassification.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--cwd is not supported"* ]]
 }
 
 @test "rejects an unclassified positional Bun pattern" {

--- a/test/bats/test-ts.bats
+++ b/test/bats/test-ts.bats
@@ -194,6 +194,25 @@ run_lane() {
   done
 }
 
+@test "optional Bun flags classify normalized test target spellings" {
+  run_lane unit --changed ./test/contracts/runAll.integration.test.ts
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No unit test paths were selected."* ]]
+
+  run_lane unit --changed test
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Unit test targets cannot include other lanes."* ]]
+
+  link="$BATS_TEST_TMPDIR/auto-mobile-link"
+  ln -s "$PWD" "$link"
+  run env \
+    PATH="$STUB_BIN:$PATH" \
+    TEST_TS_PRINT_CMD=1 \
+    bash "$link/$SCRIPT" unit --changed "$link/test/contracts/runAll.integration.test.ts"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No unit test paths were selected."* ]]
+}
+
 @test "optional Bun flags preserve unambiguous split values" {
   run_lane unit --parallel 2 test/scripts/testLaneClassification.test.ts
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Follow-up to [#6055](https://github.com/kaeawc/auto-mobile/pull/6055), which merged while final review fixes were being validated.

- Preserve positional test-target classification after bare optional Bun flags.
- Reject `--cwd`, which conflicts with repository-root lane classification.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `bats test/bats/test-ts.bats`
