### PR TITLE
docs: remove dead Homebrew guide link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Prefer Homebrew for the CLI:
 brew install kaeawc/tap/auto-mobile
 ```
 
-or follow the [installation guide](docs/index.md#install) — including the [Homebrew guide](docs/install/homebrew.md).
+or follow the [installation guide](docs/index.md#install).
 
 ## Documentation
 


### PR DESCRIPTION
## What changed

Removed the broken `[Homebrew guide](docs/install/homebrew.md)` reference from the README.

## Why

`docs/install/homebrew.md` was deleted in #6065 ("docs: remove Homebrew install guide page"), which left a dead link in the README.

## Notes for reviewers

- Homebrew install is still covered — the README keeps the `brew install kaeawc/tap/auto-mobile` block just above, and the linked [installation guide](docs/index.md#install) still documents Homebrew.
- Verified every other link in the README resolves: all 16 remaining local link/image targets exist, and the anchors `docs/index.md#install` and `docs/using/ui-tests.md#ios--swift-package-manager` are valid.