### PR TITLE
chore(deps): remove stale dependabot.yml swift entry for nonexistent /ios/XCTestService

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,18 +73,6 @@ updates:
         versions: ["[2.3,)"]
   # iOS Swift Package Manager dependencies
   - package-ecosystem: "swift"
-    directory: "/ios/XCTestService"
-    schedule:
-      interval: "daily"
-      time: "07:00"
-      timezone: "UTC"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "ios"
-    commit-message:
-      prefix: "chore(deps)"
-  - package-ecosystem: "swift"
     directory: "/ios/XCTestRunner"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary

Removes the stale `package-ecosystem: "swift"` block for `directory: "/ios/XCTestService"` from `.github/dependabot.yml`. That directory no longer exists in the tree, so Dependabot was scanning a dead path. The valid `/ios/XCTestRunner` swift entry — whose directory `ios/XCTestRunner` is present — is retained, along with every other ecosystem block (`bun`, `gradle`).

## Linked Issue

Closes #6062

## Changes

- Delete the 12-line stale `swift` / `/ios/XCTestService` update block.
- Keep the `/ios/XCTestRunner` swift block and all other entries untouched.

## Validation

- [x] `scripts/validate_dependabot.sh` passes — `.github/dependabot.yml` still parses as valid YAML.
- [x] Confirmed `/ios/XCTestRunner` entry retained and `/ios/XCTestService` fully removed (`grep`).
- [x] No repo test asserts the set of Dependabot ecosystems/directories; the only coverage is the YAML-parse check in `scripts/validate_dependabot.sh`, so no test update was required.

Config-only change; the full TS suite is not relevant to a dependabot-only edit.

## Follow-ups

- None.
