### PR TITLE
fix(rotate): report achieved orientation as currentOrientation on Android (#6057)

### DIFF
--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -201,7 +201,10 @@ export class Rotate extends BaseVisualChange {
             success: true,
             orientation,
             value,
-            currentOrientation,
+            // waitForRotation(value) above already confirmed the device reached the
+            // requested orientation, so report the achieved orientation here. The local
+            // `currentOrientation` remains the legitimate prior value (see #6057).
+            currentOrientation: orientation,
             previousOrientation: currentOrientation,
             rotationPerformed: true,
             orientationLockHandled: orientationUnlocked,

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -202,6 +202,57 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(false);
     });
 
+    test("should report achieved orientation as currentOrientation for landscape->portrait (#6057)", async () => {
+      // Device starts in landscape (user_rotation 1), rotates to portrait.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // currentOrientation must be the ACHIEVED orientation, not the stale prior value.
+      expect(result.currentOrientation).toBe("portrait");
+      // previousOrientation is legitimately the prior value.
+      expect(result.previousOrientation).toBe("landscape");
+      // The two fields must not duplicate on a performed rotation.
+      expect(result.currentOrientation).not.toBe(result.previousOrientation);
+      expect(result.message || "").toContain("Successfully rotated from landscape to portrait");
+    });
+
+    test("should report achieved orientation as currentOrientation for portrait->landscape (#6057)", async () => {
+      // Device starts in portrait (user_rotation 0), rotates to landscape.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+
+      const result = await rotate.execute("landscape");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.previousOrientation).toBe("portrait");
+      expect(result.currentOrientation).not.toBe(result.previousOrientation);
+      expect(result.message || "").toContain("Successfully rotated from portrait to landscape");
+    });
+
+    test("should coincide currentOrientation and previousOrientation when already in orientation (#6057)", async () => {
+      // Device already in portrait: no rotation performed, fields legitimately coincide.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.rotationPerformed).toBe(false);
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.previousOrientation).toBe("portrait");
+      expect(result.currentOrientation).toBe(result.previousOrientation);
+    });
+
     test("should get current orientation and lock status before rotation", async () => {
       // Setup: device starts in portrait, needs to rotate to landscape
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));


### PR DESCRIPTION
## Summary

Fixes [#6057](https://github.com/kaeawc/auto-mobile/issues/6057): on Android, `rotate` returned the pre-rotation value as `currentOrientation` on a successful performed rotation, duplicating `previousOrientation`.

In `executeAndroidRotation` (`src/features/action/Rotate.ts`), the `rotationPerformed: true` success return reused the stale pre-rotation local `currentOrientation` for **both** the `currentOrientation` and `previousOrientation` fields. By that point `waitForRotation(value)` has already confirmed the device reached the requested orientation, so the achieved orientation should be reported.

## Fix (one field)

- `currentOrientation` now reports the achieved orientation (`currentOrientation: orientation`).
- `previousOrientation: currentOrientation` is unchanged — the stale local is legitimately the prior value.
- The message `Successfully rotated from ${currentOrientation} to ${orientation}` is unchanged — there the local is the correct "from" value.
- The early-return already-in-orientation branch (`rotationPerformed: false`, where the two fields legitimately coincide) is untouched.
- No iOS rotate paths or `ios/control-proxy/` files touched.

## Tests

Extended `test/features/action/Rotate.test.ts` (fully unit-tested with existing fakes — `FakeAdbExecutor`, `FakeAwaitIdle`, no real device or DB):

- `landscape->portrait`: asserts `currentOrientation === "portrait"`, `previousOrientation === "landscape"`, `rotationPerformed === true`, and the two fields differ.
- `portrait->landscape`: symmetric case.
- already-in-orientation: asserts the two fields coincide with `rotationPerformed === false`.

The two performed-rotation tests **fail without the fix** (report the prior orientation for both fields) and **pass with it**. Full suite: 22 pass / 0 fail in ~550ms.

## Validation

- `bun test test/features/action/Rotate.test.ts` — 22 pass
- `bun run lint` — no new ratchet violations
- `bun run build` — success
- `bun run typecheck` — no new type errors
