### PR TITLE
fix(pinchOn): report failure message on failed gestures, mirroring swipeOn (#6056)

### DIFF
--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -25,6 +25,7 @@ import {
   BootedDevice,
   ClipboardResult,
   OpenURLResult,
+  PinchOnResult,
   SendTextResult,
   SwipeOnToolPayload,
   type TapOnSelectedElement,
@@ -824,6 +825,19 @@ export function formatSwipeOnMessage(
     : `Swiped ${direction}`;
 }
 
+export function formatPinchOnMessage(
+  result: Pick<PinchOnResult, "success" | "error">,
+  direction: string,
+): string {
+  if (!result.success) {
+    // `||` not `??`: an empty-string error (`error: ""`) must still yield the
+    // non-empty fallback, mirroring formatSwipeOnMessage (#4183 P4). Without this
+    // a validation failure (e.g. scale:0) reported a success-shaped message (#6056).
+    return result.error || `Pinch ${direction} failed`;
+  }
+  return `Pinched ${direction}`;
+}
+
 export function buildInputTextResultMessage(
   result: Pick<SendTextResult, "success" | "error" | "matchedId" | "matchedText">,
 ): string {
@@ -1353,7 +1367,7 @@ export function registerInteractionTools() {
     );
 
     return createJSONToolResponse({
-      message: `Pinched ${args.direction}`,
+      message: formatPinchOnMessage(result, args.direction),
       observation: result.observation,
       ...result,
     });

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -838,6 +838,51 @@ export function formatPinchOnMessage(
   return `Pinched ${direction}`;
 }
 
+// Injection seam for the pinchOn handler (mirrors the systemTray factory seam in
+// this file). Lets a unit test exercise the registered handler wiring with a fake
+// PinchOn whose execute() returns a failure, so a revert of the handler message
+// wiring is caught by a test — not just the formatter (#6056).
+export type PinchOnLike = Pick<PinchOn, "execute">;
+
+let pinchOnFactory: (device: BootedDevice) => PinchOnLike = (device) => new PinchOn(device);
+
+export function setPinchOnFactory(factory: (device: BootedDevice) => PinchOnLike): void {
+  pinchOnFactory = factory;
+}
+
+export function resetPinchOnFactory(): void {
+  pinchOnFactory = (device) => new PinchOn(device);
+}
+
+export async function pinchOnHandler(
+  device: BootedDevice,
+  args: PinchOnArgs,
+  progress?: ProgressCallback,
+) {
+  RecompositionTracker.getInstance().recordInteraction();
+  const pinchOn = pinchOnFactory(device);
+  const result = await pinchOn.execute(
+    {
+      direction: args.direction,
+      distanceStart: args.distanceStart,
+      distanceEnd: args.distanceEnd,
+      scale: args.scale,
+      duration: args.duration,
+      rotationDegrees: args.rotationDegrees,
+      includeSystemInsets: args.includeSystemInsets,
+      container: args.container,
+      autoTarget: args.autoTarget,
+    },
+    progress,
+  );
+
+  return createJSONToolResponse({
+    message: formatPinchOnMessage(result, args.direction),
+    observation: result.observation,
+    ...result,
+  });
+}
+
 export function buildInputTextResultMessage(
   result: Pick<SendTextResult, "success" | "error" | "matchedId" | "matchedText">,
 ): string {
@@ -1344,34 +1389,8 @@ export function registerInteractionTools() {
   };
 
   // Pinch on handler
-  const pinchOnHandler = async (
-    device: BootedDevice,
-    args: PinchOnArgs,
-    progress?: ProgressCallback,
-  ) => {
-    RecompositionTracker.getInstance().recordInteraction();
-    const pinchOn = new PinchOn(device);
-    const result = await pinchOn.execute(
-      {
-        direction: args.direction,
-        distanceStart: args.distanceStart,
-        distanceEnd: args.distanceEnd,
-        scale: args.scale,
-        duration: args.duration,
-        rotationDegrees: args.rotationDegrees,
-        includeSystemInsets: args.includeSystemInsets,
-        container: args.container,
-        autoTarget: args.autoTarget,
-      },
-      progress,
-    );
-
-    return createJSONToolResponse({
-      message: formatPinchOnMessage(result, args.direction),
-      observation: result.observation,
-      ...result,
-    });
-  };
+  // pinchOn handler is defined at module scope (with an injectable PinchOn
+  // factory) so a unit test can exercise the registered handler wiring (#6056).
 
   // Input text handler
   const inputTextHandler = async (

--- a/test/server/interactionTools.pinchOn.test.ts
+++ b/test/server/interactionTools.pinchOn.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from "bun:test";
-import { formatPinchOnMessage } from "../../src/server/interactionTools";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  formatPinchOnMessage,
+  pinchOnHandler,
+  resetPinchOnFactory,
+  setPinchOnFactory,
+} from "../../src/server/interactionTools";
+import type { PinchOnArgs } from "../../src/server/interactionToolTypes";
+import type { BootedDevice } from "../../src/models";
+import type { PinchOnResult } from "../../src/models";
 
 // Mirrors interactionTools.swipeOn.test.ts for the pinchOn message fix (#6056).
 // Before the fix, pinchOnHandler hardcoded `Pinched ${direction}` regardless of
@@ -43,5 +51,54 @@ describe("formatPinchOnMessage", () => {
     [{ success: true as const }, "out", "Pinched out"],
   ])("success %o yields %p", (result, direction, expected) => {
     expect(formatPinchOnMessage(result, direction)).toBe(expected);
+  });
+});
+
+// Handler-level coverage: exercise the REGISTERED pinchOn handler path (not just
+// the formatter) with an injected fake PinchOn, and assert the serialized
+// response's message. This is the test that would fail if the handler wiring
+// reverted to the hard-coded `Pinched ${direction}` (#6056; AGENTS.md L22-24).
+describe("pinchOnHandler (registered handler wiring)", () => {
+  const fakeDevice = { deviceId: "fake", platform: "android" } as unknown as BootedDevice;
+  const args: PinchOnArgs = { direction: "in", platform: "android" };
+
+  afterEach(() => {
+    resetPinchOnFactory();
+  });
+
+  const parseMessage = (response: { content: Array<{ type: string; text: string }> }): string => {
+    const payload = JSON.parse(response.content[0].text) as { message: string };
+    return payload.message;
+  };
+
+  const fakeResult = (overrides: Partial<PinchOnResult>): PinchOnResult =>
+    ({
+      success: false,
+      direction: "in",
+      distanceStart: 0,
+      distanceEnd: 0,
+      duration: 0,
+      centerX: 0,
+      centerY: 0,
+      targetType: "screen",
+      ...overrides,
+    }) as PinchOnResult;
+
+  test("serialized response carries the failure error, not a success message", async () => {
+    setPinchOnFactory(() => ({
+      execute: async () => fakeResult({ success: false, error: "scale must be greater than 0" }),
+    }));
+
+    const message = parseMessage(await pinchOnHandler(fakeDevice, args));
+    expect(message).toBe("scale must be greater than 0");
+    expect(message).not.toBe("Pinched in");
+  });
+
+  test("serialized response reports a success message on a successful pinch", async () => {
+    setPinchOnFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    expect(parseMessage(await pinchOnHandler(fakeDevice, args))).toBe("Pinched in");
   });
 });

--- a/test/server/interactionTools.pinchOn.test.ts
+++ b/test/server/interactionTools.pinchOn.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { formatPinchOnMessage } from "../../src/server/interactionTools";
+
+// Mirrors interactionTools.swipeOn.test.ts for the pinchOn message fix (#6056).
+// Before the fix, pinchOnHandler hardcoded `Pinched ${direction}` regardless of
+// outcome, so a validation failure (e.g. scale:0 -> success:false, error:"scale
+// must be greater than 0") still reported a success-shaped message. The helper
+// did not exist; these failure assertions could not have passed against the old
+// hardcoded behavior.
+describe("formatPinchOnMessage", () => {
+  test("reports the failure error instead of a completed pinch", () => {
+    const message = formatPinchOnMessage(
+      {
+        success: false,
+        error: "scale must be greater than 0",
+      },
+      "in",
+    );
+    expect(message).toBe("scale must be greater than 0");
+    expect(message).not.toBe("Pinched in");
+  });
+
+  test("preserves the successful pinch message", () => {
+    expect(formatPinchOnMessage({ success: true }, "out")).toBe("Pinched out");
+  });
+
+  // Table is the spec: the failure branch must always produce a non-empty
+  // message. The `error: ""` row is the `||`-not-`??` case — `??` would let an
+  // empty string through, returning a blank tool message (#4183 P4).
+  test.each([
+    [{ success: false as const, error: "boom" }, "in", "boom"],
+    [{ success: false as const }, "in", "Pinch in failed"],
+    [{ success: false as const, error: "" }, "out", "Pinch out failed"],
+    [{ success: false as const, error: undefined }, "out", "Pinch out failed"],
+  ])("failure %o yields %p", (result, direction, expected) => {
+    const message = formatPinchOnMessage(result, direction);
+    expect(message).toBe(expected);
+    expect(message.length).toBeGreaterThan(0);
+  });
+
+  test.each([
+    [{ success: true as const }, "in", "Pinched in"],
+    [{ success: true as const }, "out", "Pinched out"],
+  ])("success %o yields %p", (result, direction, expected) => {
+    expect(formatPinchOnMessage(result, direction)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Problem

`pinchOnHandler` in `src/server/interactionTools.ts` hardcoded `message: \`Pinched ${args.direction}\`` regardless of outcome. A validation failure — e.g. `scale: 0`, which yields `success: false, error: "scale must be greater than 0"` — still reported a success-shaped message (`"Pinched in"`), misleading callers into thinking the gesture ran.

This is the same class of bug [#4183](https://github.com/kaeawc/auto-mobile/issues/4183) fixed for `swipeOn`, where the sibling `swipeOnHandler` now routes its message through `formatSwipeOnMessage(result, direction)`.

## Fix (mirror of [#4183](https://github.com/kaeawc/auto-mobile/issues/4183), message-only)

1. Add an exported `formatPinchOnMessage(result, direction)` helper next to `formatSwipeOnMessage`. On `!result.success` it returns `result.error || \`Pinch ${direction} failed\`` — **`||` not `??`**, so an empty-string error (`error: ""`) still yields the non-empty fallback (the [#4183](https://github.com/kaeawc/auto-mobile/issues/4183) P4 nuance). On success it returns `\`Pinched ${direction}\``. Its `result` param is typed `Pick<PinchOnResult, "success" | "error">`.
2. `pinchOnHandler` now sets `message: formatPinchOnMessage(result, args.direction)`, keeping `createJSONToolResponse` and the `...result` spread as-is.

### Scope discipline

Deliberately message-only, matching [#4183](https://github.com/kaeawc/auto-mobile/issues/4183)'s mirror. The MCP `isError` envelope flag is left unchanged, and no iOS paths or anything under `ios/control-proxy/` were touched.

## Tests

New `test/server/interactionTools.pinchOn.test.ts` parallels the existing `interactionTools.swipeOn.test.ts`, asserting:

- failure with error → returns the error string (`"scale must be greater than 0"`), **not** `"Pinched in"`.
- failure with empty-string error (`error: ""`) → returns the fallback `Pinch <direction> failed` (the `||`-not-`??` case, asserted explicitly).
- success → returns `Pinched <direction>`.

The helper did not exist before this change, so the failure assertions could not have passed against the old hardcoded behavior.

## Validation

`turbo run lint build test` green in the worktree: lint ratchet no new violations, typecheck gate no new type errors (165 baseline), build clean, and the 16 pinchOn+swipeOn message tests pass in ~250ms.

Closes #6056
