### PR TITLE
fix(doctor): treat slow xcodebuild probe as warn, not Xcode-missing fail

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -458,6 +458,24 @@ export async function checkXcodeInstallation(
     };
   } catch (error) {
     dependencies.logger.warn(`Xcode installation check failed: ${errorMessage(error)}`, error);
+
+    // A slow `xcodebuild -version` probe (issue #6003) must be diagnosed
+    // distinctly from a missing/unusable Xcode: it should not force a nonzero
+    // doctor verdict that blocks readiness-gate callers. Only a genuine
+    // timeout maps to `warn`; every other failure stays a `fail`.
+    if (isTimeoutError(error)) {
+      return {
+        name: "Xcode",
+        status: "warn",
+        message:
+          `Xcode availability probe timed out after ${DOCTOR_EXEC_TIMEOUT_MS}ms ` +
+          `(xcodebuild -version); Command Line Tools and simulator automation may still be usable`,
+        recommendation:
+          "A slow probe is not a missing install — re-run doctor. If it keeps timing out, " +
+          "raise AUTOMOBILE_DOCTOR_TIMEOUT_MS to give xcodebuild more time.",
+      };
+    }
+
     return {
       name: "Xcode",
       status: "fail",
@@ -465,6 +483,16 @@ export async function checkXcodeInstallation(
       recommendation: `Install Xcode ${minimumVersion}+ from the App Store.`,
     };
   }
+}
+
+/**
+ * A timed-out probe is distinct from a missing/unusable install (issue #6003).
+ * There is no typed timeout error at this seam, so match the message the way
+ * the rest of the repo does (e.g. CtrlProxyManager's `errorLower.includes`).
+ */
+function isTimeoutError(error: unknown): boolean {
+  const message = errorMessage(error).toLowerCase();
+  return message.includes("timed out") || message.includes("timeout");
 }
 
 /**

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -135,19 +135,38 @@ describe("iOS doctor checks", () => {
       expect(result.message).toContain("requires macOS");
     });
 
-    test("fails when xcodebuild throws", async () => {
+    test("warns (does not fail) when the xcodebuild probe times out", async () => {
+      // A slow `xcodebuild -version` probe must be diagnosed distinctly from a
+      // missing Xcode and must not force a nonzero doctor verdict (issue #6003).
       const result = await checkXcodeInstallation("15.0", {
         ...baseDependencies,
         xcodebuild: {
           executeCommand: async () => {
-            throw new Error("xcodebuild not found");
+            throw new Error("Command timed out after 5000ms: xcodebuild -version");
+          },
+        },
+      });
+
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("timed out");
+      expect(result.message).toContain("5000ms");
+      expect(result.message).not.toContain("Xcode not detected");
+      expect(result.recommendation).toContain("AUTOMOBILE_DOCTOR_TIMEOUT_MS");
+    });
+
+    test("fails when xcodebuild throws a non-timeout error", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        xcodebuild: {
+          executeCommand: async () => {
+            throw new Error("spawn xcodebuild ENOENT");
           },
         },
       });
 
       expect(result.status).toBe("fail");
       expect(result.message).toContain("Xcode not detected");
-      expect(result.message).toContain("xcodebuild not found");
+      expect(result.message).toContain("spawn xcodebuild ENOENT");
     });
   });
 

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -148,8 +148,11 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("warn");
-      expect(result.message).toContain("timed out");
-      expect(result.message).toContain("5000ms");
+      // Assert the duration shape, not a literal value: DOCTOR_EXEC_TIMEOUT_MS
+      // is read from AUTOMOBILE_DOCTOR_TIMEOUT_MS at module load, so hard-coding
+      // 5000ms would go red in any env that overrides it (issue #6003 review).
+      expect(result.message).toMatch(/timed out after \d+ms/);
+      expect(result.message).toContain("xcodebuild -version");
       expect(result.message).not.toContain("Xcode not detected");
       expect(result.recommendation).toContain("AUTOMOBILE_DOCTOR_TIMEOUT_MS");
     });


### PR DESCRIPTION
## Summary

On macOS, `doctor --ios` reported `Xcode not detected: Command timed out after 5000ms: xcodebuild -version` with status **fail** even when Command Line Tools, xcrun, simctl, and a real simulator automation round trip all succeeded. A slow `xcodebuild -version` probe was indistinguishable from a genuinely missing Xcode, and because the CLI exits nonzero on `summary.failed > 0`, that slow probe blocked readiness-gate callers.

This narrows the catch block in `checkXcodeInstallation` (`src/doctor/checks/ios.ts`) so a **timeout** is diagnosed distinctly from a missing/unusable install:

- **Timeout → `warn`** (not `fail`). A `warn` does not increment `summary.failed`, so it no longer gates the CLI exit. The message retains the timeout as diagnostic evidence and signals that Command Line Tools and simulator automation may still be usable, with a recommendation to re-run doctor or raise `AUTOMOBILE_DOCTOR_TIMEOUT_MS`.
- **Non-timeout errors → unchanged**: still `status: "fail"` with `Xcode not detected: <error>` and the same recommendation, so a genuinely missing Xcode is still detected. Detection is not weakened.

Timeout classification uses the repo's established message-match approach (`errorLower.includes("timed out")`, as in CtrlProxyManager) via a small local `isTimeoutError(error)` helper — there is no typed timeout error at this seam. The success/parse/version-compare branches and simctl wiring are untouched.

## Linked Issue

Closes #6003

## Bug / Regression Context

- **Observed symptom:** `doctor --ios` returns a fail verdict (`Xcode not detected: Command timed out after 5000ms: xcodebuild -version`) despite a fully functional iOS toolchain, blocking readiness gates.
- **Repro steps / conditions:** any environment where `xcodebuild -version` takes longer than `AUTOMOBILE_DOCTOR_TIMEOUT_MS` (default 5000ms) to respond while Xcode/CLT are actually installed and usable.

## Validation

- [x] `bun run lint` passes (oxlint ratchet: no new violations; boundary-checks pass)
- [x] `bun run typecheck` reports no new errors (baseline gate: 165 known)
- [x] `bun run build` succeeds
- [x] `bun test test/doctor/` green (188 pass), including the new timeout/non-timeout cases
- [x] New tests use the injectable `dependencies` fake (no real device/DB); unit tests run in <100ms
- [x] Red-first proven: the timeout test fails against the pre-fix source (`"warn"` expected, got `"fail"`) and passes with the fix

## Tests

In `test/doctor/ios.test.ts`, the single generic "fails when xcodebuild throws" case was split into two contract tests:

- `warns (does not fail) when the xcodebuild probe times out` — fake throws `Command timed out after 5000ms: xcodebuild -version`; asserts `status === "warn"`, message contains the timeout detail (and `5000ms`), message does **not** contain `Xcode not detected`, and the recommendation mentions `AUTOMOBILE_DOCTOR_TIMEOUT_MS`.
- `fails when xcodebuild throws a non-timeout error` — fake throws `spawn xcodebuild ENOENT`; asserts `status === "fail"` and message contains `Xcode not detected`.
