### PR TITLE
hardening: reject never-issued session UUIDs at the pooled-mint primitive (#6069)

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -497,6 +497,20 @@ export class SessionManager {
     return persisted ? this.terminalReleaseFromPersisted(sessionId, persisted) : undefined;
   }
 
+  /**
+   * #6069: True when a persisted, non-terminal session row exists for this id —
+   * i.e. an identity this daemon issued that survived a restart and may be
+   * re-materialized with a pooled device (live-during-restart recovery). Mirrors
+   * the persisted-recovery admission in {@link admitIssuedSessionForAutomation}.
+   */
+  private async hasRecoverablePersistedSession(sessionId: string): Promise<boolean> {
+    const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
+    return Boolean(
+      persisted &&
+        (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason)),
+    );
+  }
+
   private terminalReleaseFromPersisted(
     sessionId: string,
     persisted: DeviceSession,
@@ -608,11 +622,24 @@ export class SessionManager {
     devicePool?: SessionDeviceAssigner,
     platform?: Platform,
     execution?: SessionExecutionMetadata,
+    // #6069: when true, a NEW session (no live in-memory session) may only be
+    // minted for an id this daemon already issued — i.e. a persisted, non-terminal
+    // row (live-during-restart recovery). This is set on the device-tool path so a
+    // fabricated/never-issued sessionUuid can never be auto-assigned a pooled
+    // device just because a device pool is in scope. Internal fresh mints
+    // (device-label derived sessions) leave it false and keep minting.
+    requireIssuedSession = false,
   ): Promise<Session> {
     const pendingRebind = this.pendingSessionRebinds.get(sessionId);
     if (pendingRebind) {
       await pendingRebind.promise;
-      return await this.getOrCreateSession(sessionId, devicePool, platform, execution);
+      return await this.getOrCreateSession(
+        sessionId,
+        devicePool,
+        platform,
+        execution,
+        requireIssuedSession,
+      );
     }
 
     const existing = this.getSessionForNewExecution(sessionId, execution);
@@ -620,7 +647,13 @@ export class SessionManager {
       const inFlightRelease = this.releasePromises.get(sessionId);
       if (this.releasingSessions.has(existing) && inFlightRelease?.session === existing) {
         await inFlightRelease.promise;
-        return await this.getOrCreateSession(sessionId, devicePool, platform);
+        return await this.getOrCreateSession(
+          sessionId,
+          devicePool,
+          platform,
+          undefined,
+          requireIssuedSession,
+        );
       }
       logger.info(
         `[SessionManager] Found existing session ${sessionId} with device ${existing.assignedDevice}`,
@@ -652,9 +685,34 @@ export class SessionManager {
       (currentSession === undefined || inFlightRelease.session === currentSession)
     ) {
       await inFlightRelease.promise;
-      return await this.getOrCreateSession(sessionId, devicePool, platform);
+      return await this.getOrCreateSession(
+        sessionId,
+        devicePool,
+        platform,
+        undefined,
+        requireIssuedSession,
+      );
     }
 
+    return await this.startOrJoinUnseenAssignment(
+      sessionId,
+      devicePool,
+      platform,
+      requireIssuedSession,
+    );
+  }
+
+  /**
+   * Join an in-flight assignment/creation for this id, or start a new one via
+   * {@link createUnseenSession}. Split out of getOrCreateSession to keep that
+   * method's branch count under the complexity ceiling.
+   */
+  private async startOrJoinUnseenAssignment(
+    sessionId: string,
+    devicePool: SessionDeviceAssigner | undefined,
+    platform: Platform | undefined,
+    requireIssuedSession: boolean,
+  ): Promise<Session> {
     const pendingAssignment = this.pendingSessionAssignments.get(sessionId);
     if (pendingAssignment) {
       return await pendingAssignment;
@@ -665,7 +723,12 @@ export class SessionManager {
       return await pendingCreation.promise;
     }
 
-    const assignment = this.createUnseenSession(sessionId, devicePool, platform).finally(() => {
+    const assignment = this.createUnseenSession(
+      sessionId,
+      devicePool,
+      platform,
+      requireIssuedSession,
+    ).finally(() => {
       if (this.pendingSessionAssignments.get(sessionId) === assignment) {
         this.pendingSessionAssignments.delete(sessionId);
       }
@@ -709,12 +772,31 @@ export class SessionManager {
     sessionId: string,
     devicePool: SessionDeviceAssigner | undefined,
     platform: Platform | undefined,
+    requireIssuedSession = false,
   ): Promise<Session> {
     const persistedTerminalRelease = await this.getPersistedTerminalRelease(sessionId);
     if (persistedTerminalRelease) {
       this.terminalReleaseSnapshots.set(sessionId, persistedTerminalRelease);
       throw new TerminalSessionError(sessionId, persistedTerminalRelease);
     }
+
+    // #6069: On the device-tool path (requireIssuedSession), admission is decided
+    // from the session registry — NOT from whether a device pool happens to be in
+    // scope. A live in-memory session is already resolved by getOrCreateSession
+    // before reaching here, so the only admissible new-session case is
+    // live-during-restart recovery: a persisted, non-terminal row. Without this,
+    // the `admittedSession ?? getOrCreateSession(uuid, realPool)` fallback in
+    // ToolExecutionContext auto-assigned a pooled device to a fabricated,
+    // never-issued sessionUuid (e.g. "kumquat-D") whenever the #6045 admit guard
+    // was bypassed by the call path — the ownership bypass this closes. The
+    // pool-less `if (!devicePool)` throw below stays as a secondary safety net.
+    if (requireIssuedSession && !(await this.hasRecoverablePersistedSession(sessionId))) {
+      throw new UnissuedSessionError(
+        `Session ${sessionId} is not an active daemon session (not found). ` +
+          "Acquire a device with getAndroid or getApple before using its sessionUuid.",
+      );
+    }
+
     logger.info(
       `[SessionManager] Creating new session ${sessionId}, calling devicePool.assignDeviceToSession()`,
     );

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -507,7 +507,7 @@ export class SessionManager {
   private isRecoverablePersistedSession(persisted: DeviceSession | undefined): boolean {
     return Boolean(
       persisted &&
-        (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason)),
+      (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason)),
     );
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -498,13 +498,13 @@ export class SessionManager {
   }
 
   /**
-   * #6069: True when a persisted, non-terminal session row exists for this id —
-   * i.e. an identity this daemon issued that survived a restart and may be
-   * re-materialized with a pooled device (live-during-restart recovery). Mirrors
-   * the persisted-recovery admission in {@link admitIssuedSessionForAutomation}.
+   * #6069: True when this persisted row is a non-terminal identity this daemon
+   * issued that survived a restart and may be re-materialized with a pooled
+   * device (live-during-restart recovery). Mirrors the persisted-recovery
+   * admission in {@link admitIssuedSessionForAutomation}. A missing row (never
+   * issued) is not recoverable.
    */
-  private async hasRecoverablePersistedSession(sessionId: string): Promise<boolean> {
-    const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
+  private isRecoverablePersistedSession(persisted: DeviceSession | undefined): boolean {
     return Boolean(
       persisted &&
         (!persisted.release_reason || !isTerminalReleaseReason(persisted.release_reason)),
@@ -774,7 +774,10 @@ export class SessionManager {
     platform: Platform | undefined,
     requireIssuedSession = false,
   ): Promise<Session> {
-    const persistedTerminalRelease = await this.getPersistedTerminalRelease(sessionId);
+    const persisted = await this.deviceSessionRepository.getSession?.(sessionId);
+    const persistedTerminalRelease = persisted
+      ? this.terminalReleaseFromPersisted(sessionId, persisted)
+      : undefined;
     if (persistedTerminalRelease) {
       this.terminalReleaseSnapshots.set(sessionId, persistedTerminalRelease);
       throw new TerminalSessionError(sessionId, persistedTerminalRelease);
@@ -790,7 +793,7 @@ export class SessionManager {
     // never-issued sessionUuid (e.g. "kumquat-D") whenever the #6045 admit guard
     // was bypassed by the call path — the ownership bypass this closes. The
     // pool-less `if (!devicePool)` throw below stays as a secondary safety net.
-    if (requireIssuedSession && !(await this.hasRecoverablePersistedSession(sessionId))) {
+    if (requireIssuedSession && !this.isRecoverablePersistedSession(persisted)) {
       throw new UnissuedSessionError(
         `Session ${sessionId} is not an active daemon session (not found). ` +
           "Acquire a device with getAndroid or getApple before using its sessionUuid.",

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -79,6 +79,12 @@ export async function createToolExecutionContext(
   sessionOptions: SessionOptions = {},
   execution?: SessionExecutionMetadata,
   admittedSession?: Session,
+  // #6069: set by the device-tool path so the getOrCreateSession fallback below
+  // cannot mint a brand-new pooled session for a never-issued sessionUuid. Only a
+  // live session (resolved via admittedSession / getSessionForNewExecution) or a
+  // persisted, non-terminal row (restart recovery) is admissible. Internal callers
+  // that intentionally mint fresh derived sessions (device labels) leave it false.
+  requireIssuedSession = false,
 ): Promise<ToolExecutionContext> {
   if (!sessionUuid) {
     return {};
@@ -99,6 +105,7 @@ export async function createToolExecutionContext(
       devicePool,
       sessionOptions.platform,
       execution,
+      requireIssuedSession,
     ));
 
   if (!sessionManager.isAdmittedForAutomation(session)) {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -496,6 +496,13 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         },
         execution,
         admittedSession,
+        // #6069: this is a caller-provided sessionUuid on a device tool. Require it
+        // to have been issued by this daemon (live, or persisted non-terminal for
+        // restart recovery). admitIssuedSessionForAutomation above already rejects
+        // a never-issued id on the no-active-session path; requiring issuance here
+        // closes the residual bypass where the connection already held an active
+        // session and a fabricated id reached the pool-minting fallback.
+        true,
       );
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -496,12 +496,17 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         },
         execution,
         admittedSession,
-        // #6069: this is a caller-provided sessionUuid on a device tool. Require it
-        // to have been issued by this daemon (live, or persisted non-terminal for
-        // restart recovery). admitIssuedSessionForAutomation above already rejects
-        // a never-issued id on the no-active-session path; requiring issuance here
-        // closes the residual bypass where the connection already held an active
-        // session and a fabricated id reached the pool-minting fallback.
+        // #6069: defense-in-depth. On this path `admitIssuedSessionForAutomation`
+        // above already partitions every state (throws for a never-issued id,
+        // returns a live session so the fallback is skipped, returns undefined
+        // only for a persisted non-terminal row — restart recovery — which the
+        // createUnseenSession guard also admits), so this flag rejects nothing
+        // admit does not already reject HERE. It exists so the pool-minting
+        // primitive itself refuses to mint a never-issued id: if a future route
+        // reaches createToolExecutionContext for a caller-provided sessionUuid
+        // without going through admit, issuance is still enforced. See the PR
+        // discussion for why the reported #6069 bound-connection bypass could not
+        // be reproduced through any current public route in-harness.
         true,
       );
       if (context.deviceId && !providedDeviceId) {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -351,6 +351,135 @@ describe("SessionManager", () => {
       }
     });
 
+    // #6069: with requireIssuedSession, a never-issued id must NOT be minted a
+    // pooled device just because a live device pool is in scope. Admission is
+    // decided from the registry, not from pool presence.
+    test("requireIssuedSession rejects a never-issued id instead of minting a pooled device", async () => {
+      const assignedSessionIds: string[] = [];
+      const devicePool: SessionDeviceAssigner = {
+        assignDeviceToSession: async (sessionId: string): Promise<string> => {
+          assignedSessionIds.push(sessionId);
+          const session = await sessionManager.createSession(sessionId, "device-x", "android");
+          return session.assignedDevice;
+        },
+      };
+
+      await expect(
+        sessionManager.getOrCreateSession("kumquat-D", devicePool, "android", undefined, true),
+      ).rejects.toThrow(/not an active daemon session/);
+      expect(assignedSessionIds).toEqual([]);
+      expect(sessionManager.getSession("kumquat-D")).toBeNull();
+    });
+
+    // Regression: requireIssuedSession must NOT block minting for a NEW id when
+    // requireIssuedSession is false (device-label / internal derived sessions).
+    test("still mints a fresh id when requireIssuedSession is false (default)", async () => {
+      const devicePool: SessionDeviceAssigner = {
+        assignDeviceToSession: async (sessionId: string): Promise<string> => {
+          const session = await sessionManager.createSession(sessionId, "device-y", "android");
+          return session.assignedDevice;
+        },
+      };
+
+      const session = await sessionManager.getOrCreateSession("base:B", devicePool, "android");
+      expect(session.assignedDevice).toBe("device-y");
+    });
+
+    // Regression: live-during-restart recovery — a persisted, non-terminal row is
+    // an issued identity, so requireIssuedSession still recovers it.
+    test("requireIssuedSession still recovers a persisted, non-terminal session", async () => {
+      const persisted: DeviceSession = {
+        session_uuid: "restarted-session",
+        device_id: "emulator-5560",
+        platform: "android",
+        status: "active",
+        source: null,
+        autolock_enabled: 0,
+        mcp_session_id: null,
+        daemon_session_id: "old-daemon",
+        created_at_ms: 1,
+        last_used_at_ms: 20,
+        expires_at_ms: 30,
+        released_at_ms: 25,
+        release_reason: "daemon-restart",
+        session_timeout_ms: 10,
+        heartbeat_timeout_ms: 5,
+        has_received_heartbeat: 1,
+        created_at: "2026-09-03T00:00:00.000Z",
+        updated_at: "2026-09-03T00:00:00.000Z",
+      };
+      const persistence: DeviceSessionPersistence = {
+        async getSession() {
+          return persisted;
+        },
+        async upsertActiveSession() {},
+        async recordActivity() {},
+        async markReleased() {},
+      };
+      const restarted = new SessionManager(fakeTimer, persistence);
+      const devicePool: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId: string): Promise<string> {
+          await restarted.createSession(sessionId, "emulator-5560", "android");
+          return "emulator-5560";
+        },
+      };
+      try {
+        await expect(
+          restarted.getOrCreateSession("restarted-session", devicePool, "android", undefined, true),
+        ).resolves.toMatchObject({ assignedDevice: "emulator-5560" });
+      } finally {
+        restarted.stopCleanupTimer();
+      }
+    });
+
+    // Regression: a terminal persisted row keeps yielding TerminalSessionError,
+    // never a pooled assignment, under requireIssuedSession.
+    test("requireIssuedSession preserves TerminalSessionError for a terminal persisted row", async () => {
+      const persisted: DeviceSession = {
+        session_uuid: "lost-session",
+        device_id: "emulator-5554",
+        platform: "android",
+        status: "released",
+        source: null,
+        autolock_enabled: 0,
+        mcp_session_id: null,
+        daemon_session_id: "old-daemon",
+        created_at_ms: 1,
+        last_used_at_ms: 20,
+        expires_at_ms: 30,
+        released_at_ms: 25,
+        release_reason: "device-disconnected:emulator-5554;incident=emulator-loss-1",
+        session_timeout_ms: 10,
+        heartbeat_timeout_ms: 5,
+        has_received_heartbeat: 1,
+        created_at: "2026-09-03T00:00:00.000Z",
+        updated_at: "2026-09-03T00:00:00.000Z",
+      };
+      const restarted = new SessionManager(fakeTimer, {
+        async getSession() {
+          return persisted;
+        },
+        async upsertActiveSession() {},
+        async recordActivity() {},
+        async markReleased() {},
+      });
+      const assignedSessionIds: string[] = [];
+      const devicePool: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId: string): Promise<string> {
+          assignedSessionIds.push(sessionId);
+          return "emulator-5560";
+        },
+      };
+      try {
+        await expect(
+          restarted.getOrCreateSession("lost-session", devicePool, "android", undefined, true),
+        ).rejects.toThrow("terminal");
+        expect(assignedSessionIds).toEqual([]);
+      } finally {
+        restarted.stopCleanupTimer();
+      }
+    });
+
     test("allows distinct unseen session IDs to begin assignment independently", async () => {
       const assignedSessionIds: string[] = [];
       let releaseAssignments!: () => void;

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -10,6 +10,7 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
+import type { DeviceSession } from "../../src/db/types";
 
 describe("ToolExecutionContext", () => {
   let sessionManager: SessionManager;
@@ -499,5 +500,172 @@ describe("ToolExecutionContext", () => {
     } finally {
       boundedSessionManager.stopCleanupTimer();
     }
+  });
+
+  // #6069: A never-issued sessionUuid reaching the device-tool path must be
+  // rejected even when the caller's connection already holds a live session —
+  // the residual of #6019 that #6045 left open. `requireIssuedSession` is the
+  // flag toolRegistry sets for exactly this (caller-provided) path.
+  describe("rejects an unissued sessionUuid on the device-tool path (#6069)", () => {
+    const nonTerminalPersisted = (sessionUuid: string, deviceId: string): DeviceSession => ({
+      session_uuid: sessionUuid,
+      device_id: deviceId,
+      platform: "android",
+      status: "active",
+      source: null,
+      autolock_enabled: 0,
+      mcp_session_id: null,
+      daemon_session_id: "old-daemon",
+      created_at_ms: 1,
+      last_used_at_ms: 20,
+      expires_at_ms: 30,
+      released_at_ms: 25,
+      release_reason: "daemon-restart",
+      session_timeout_ms: 10,
+      heartbeat_timeout_ms: 5,
+      has_received_heartbeat: 1,
+      created_at: "2026-09-03T00:00:00.000Z",
+      updated_at: "2026-09-03T00:00:00.000Z",
+    });
+
+    test("rejects a fabricated UUID and never assigns a pooled device while a session is active", async () => {
+      let setupCalls = 0;
+      AndroidCtrlProxyManager.getInstance = () =>
+        ({
+          resetSetupState: () => {},
+          setup: async () => {
+            setupCalls += 1;
+            return { success: true, message: "ok" };
+          },
+        }) as any;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        waitForConnection: async () => true,
+        close: async () => {},
+      })) as any;
+
+      // The connection already holds a live, issued session on device-1.
+      await devicePool.assignDeviceToSession("issued-session", "android");
+      expect(sessionManager.getSession("issued-session")?.assignedDevice).toBe("device-1");
+
+      const assignSpy = spyOn(devicePool, "assignDeviceToSession");
+
+      await expect(
+        createToolExecutionContext(
+          "kumquat-D",
+          sessionManager,
+          devicePool,
+          sessionOptions,
+          undefined,
+          undefined,
+          true, // requireIssuedSession — the device-tool boundary
+        ),
+      ).rejects.toThrow(/not an active daemon session/);
+
+      // No pooled device was minted for the fabricated id, and the caller's own
+      // live session is untouched.
+      expect(assignSpy).not.toHaveBeenCalled();
+      expect(sessionManager.getSession("kumquat-D")).toBeNull();
+      expect(sessionManager.getSession("issued-session")?.assignedDevice).toBe("device-1");
+      expect(setupCalls).toBe(0);
+      assignSpy.mockRestore();
+    });
+
+    test("still recovers a persisted, non-terminal session (live-during-restart)", async () => {
+      AndroidCtrlProxyManager.getInstance = () =>
+        ({
+          resetSetupState: () => {},
+          setup: async () => ({ success: true, message: "ok" }),
+        }) as any;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        waitForConnection: async () => true,
+        close: async () => {},
+      })) as any;
+
+      const persisted = nonTerminalPersisted("restarted-session", "device-1");
+      const recoveryManager = new SessionManager(fakeTimer, {
+        async getSession() {
+          return persisted;
+        },
+        async upsertActiveSession() {},
+        async recordActivity() {},
+        async markReleased() {},
+      });
+      const recoveryPool = new DevicePool(
+        recoveryManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+      );
+      await recoveryPool.initializeWithDevices([createBootedDevice("device-1")]);
+
+      try {
+        const context = await createToolExecutionContext(
+          "restarted-session",
+          recoveryManager,
+          recoveryPool,
+          sessionOptions,
+          undefined,
+          undefined,
+          true, // requireIssuedSession must NOT block restart recovery
+        );
+        expect(context.deviceId).toBe("device-1");
+        expect(recoveryManager.getSession("restarted-session")?.assignedDevice).toBe("device-1");
+      } finally {
+        recoveryManager.stopCleanupTimer();
+      }
+    });
+
+    test("the caller's own issued session still resolves without a new assignment", async () => {
+      AndroidCtrlProxyManager.getInstance = () =>
+        ({
+          resetSetupState: () => {},
+          setup: async () => ({ success: true, message: "ok" }),
+        }) as any;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        waitForConnection: async () => true,
+        close: async () => {},
+      })) as any;
+
+      await sessionManager.createSession("mine", "device-1", "android");
+      const assignSpy = spyOn(devicePool, "assignDeviceToSession");
+
+      const context = await createToolExecutionContext(
+        "mine",
+        sessionManager,
+        devicePool,
+        sessionOptions,
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(context.deviceId).toBe("device-1");
+      expect(assignSpy).not.toHaveBeenCalled();
+      assignSpy.mockRestore();
+    });
+
+    test("device-label / internal fresh mint is unaffected (requireIssuedSession defaults false)", async () => {
+      AndroidCtrlProxyManager.getInstance = () =>
+        ({
+          resetSetupState: () => {},
+          setup: async () => ({ success: true, message: "ok" }),
+        }) as any;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        waitForConnection: async () => true,
+        close: async () => {},
+      })) as any;
+
+      // Mirrors deviceLabelMapping.registerDeviceLabelMap, which mints a fresh
+      // derived session without passing requireIssuedSession.
+      const context = await createToolExecutionContext(
+        "base:B",
+        sessionManager,
+        devicePool,
+        sessionOptions,
+      );
+      expect(context.deviceId).toBe("device-1");
+      expect(sessionManager.getSession("base:B")?.assignedDevice).toBe("device-1");
+    });
   });
 });

--- a/test/server/unissuedSessionBoundConnection.integration.test.ts
+++ b/test/server/unissuedSessionBoundConnection.integration.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import type { BootedDevice } from "../../src/models";
+
+/**
+ * #6069 — public-path guard for the residual ownership bypass.
+ *
+ * The connection already holds a live, issued device session (either an explicit
+ * SessionToolBinding or an active autolock session); a device tool is then called
+ * with a fabricated `sessionUuid` on the SAME connection. This drives the real
+ * MCP server (src/server/index.ts) through the daemon-mode handler + ToolRegistry
+ * device-aware pipeline — the actual public entry point — and asserts the
+ * fabricated id is rejected rather than auto-assigned a pooled device.
+ *
+ * NOTE: this passes on origin/main as well: #6045's admitIssuedSessionForAutomation
+ * (toolRegistry, immediately before createToolExecutionContext) already rejects a
+ * never-issued id on both of these routes. It is a REGRESSION GUARD against that
+ * admission being weakened, not a red→green reproduction — the bound-connection
+ * bypass reported on hardware in #6069 could not be reproduced through any current
+ * public route in this harness (see the PR discussion). It documents that the two
+ * most likely routing preconditions ("active binding" and "active autolock") do
+ * NOT let a fabricated id reach the pool-minting fallback.
+ */
+describe("unissued sessionUuid on a bound connection (#6069)", () => {
+  let fixture: McpTestFixture | undefined;
+  let sessionManager: SessionManager;
+  let pool: DevicePool;
+  let timer: FakeTimer;
+  let origMgr: typeof AndroidCtrlProxyManager.getInstance;
+  let origClient: typeof AndroidCtrlProxyClient.getInstance;
+
+  const devices: BootedDevice[] = [
+    { name: "Pixel A", platform: "android", deviceId: "emulator-5554" },
+    { name: "Pixel B", platform: "android", deviceId: "emulator-5556" },
+  ];
+  let handlerDevices: string[] = [];
+
+  beforeEach(async () => {
+    timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", devices);
+    pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices(devices);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+
+    origMgr = AndroidCtrlProxyManager.getInstance;
+    origClient = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({ resetSetupState: () => {}, setup: async () => ({ success: true, message: "ok" }) }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+    AndroidCtrlProxyClient.resetInstances();
+
+    handlerDevices = [];
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "observeProbe",
+      "observeProbe",
+      z.object({ sessionUuid: z.string().optional(), platform: z.string().optional() }).strict(),
+      async (device: BootedDevice) => {
+        handlerDevices.push(device.deviceId);
+        return {
+          content: [{ type: "text" as const, text: device.deviceId }],
+          structuredContent: { deviceId: device.deviceId },
+        };
+      },
+    );
+
+    fixture = new McpTestFixture({ daemonMode: true, sessionContext: { sessionId: "conn-1" } });
+    await fixture.setup();
+  });
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.teardown();
+      fixture = undefined;
+    }
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+    sessionManager.stopCleanupTimer();
+    AndroidCtrlProxyManager.getInstance = origMgr;
+    AndroidCtrlProxyClient.getInstance = origClient;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  test("rejects a fabricated sessionUuid and never assigns a second pooled device", async () => {
+    const { client } = fixture!.getContext();
+
+    // 1) Acquire a real, issued session S1 on emulator-5554 and use it once so
+    // the connection binds to it (index.ts SessionToolBinding). This is the
+    // "connection already holds an active session" precondition.
+    await sessionManager.createSession("S1", "emulator-5554", "android");
+    const first = (await client.request(
+      { method: "tools/call", params: { name: "observeProbe", arguments: { sessionUuid: "S1" } } },
+      z.any(),
+    )) as { isError?: boolean };
+    expect(first.isError ?? false).toBe(false);
+    expect(handlerDevices).toEqual(["emulator-5554"]); // ran on the caller's device
+
+    const assignedBefore = pool.getDevice("emulator-5556")?.sessionId ?? null;
+    expect(assignedBefore).toBeNull(); // the other pooled device is still idle
+
+    // 2) On the SAME connection, call the device tool with a never-issued id.
+    let rejected = false;
+    let result: { isError?: boolean } | undefined;
+    try {
+      result = (await client.request(
+        {
+          method: "tools/call",
+          params: { name: "observeProbe", arguments: { sessionUuid: "kumquat-D" } },
+        },
+        z.any(),
+      )) as { isError?: boolean };
+    } catch {
+      rejected = true;
+    }
+
+    // The fabricated id must NOT have been minted a pooled device...
+    expect(sessionManager.getSession("kumquat-D")).toBeNull();
+    expect(pool.getDevice("emulator-5556")?.sessionId ?? null).toBeNull();
+    // ...the handler must NOT have run on a second, foreign device...
+    expect(handlerDevices).toEqual(["emulator-5554"]);
+    // ...and the call surfaced the guard error rather than a foreign screen.
+    expect(rejected || result?.isError === true).toBe(true);
+
+    // The caller's own session is untouched.
+    expect(sessionManager.getSession("S1")?.assignedDevice).toBe("emulator-5554");
+  });
+
+  test("rejects a fabricated sessionUuid while an autolock session is active on the connection", async () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    try {
+      const { client } = fixture!.getContext();
+
+      // An autolock session is the connection's active session (implicit binding
+      // via the mcp session id), not an explicit SessionToolBinding.
+      const autolockSessionId = await pool.autolockDevice("emulator-5554", "android", "conn-1");
+      expect(sessionManager.getSession(autolockSessionId)?.assignedDevice).toBe("emulator-5554");
+
+      let rejected = false;
+      let result: { isError?: boolean } | undefined;
+      try {
+        result = (await client.request(
+          {
+            method: "tools/call",
+            params: {
+              name: "observeProbe",
+              arguments: { sessionUuid: "kumquat-D", __mcpSessionId: "conn-1" },
+            },
+          },
+          z.any(),
+        )) as { isError?: boolean };
+      } catch {
+        rejected = true;
+      }
+
+      expect(sessionManager.getSession("kumquat-D")).toBeNull();
+      expect(pool.getDevice("emulator-5556")?.sessionId ?? null).toBeNull();
+      expect(handlerDevices).not.toContain("emulator-5556");
+      expect(rejected || result?.isError === true).toBe(true);
+    } finally {
+      delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    }
+  });
+});


### PR DESCRIPTION
## Defense-in-depth: reject never-issued session UUIDs at the pooled-mint primitive (#6069 hardening)

**This PR does NOT close #6069.** An honest investigation could not reproduce the reported ownership bypass through any public route in the daemon test harness — see below — so #6069 stays open pending a hardware/integration repro. What this PR lands is a genuine safety-net invariant plus public regression coverage.

### What this adds

1. **A last-line-of-defense guard at the pool-minting primitive.** `SessionManager.createUnseenSession` previously rejected only when no device pool was in scope (`if (!devicePool) throw`) — i.e. it keyed admission on *how it was called*, not on *whether the id was ever issued*. This threads a `requireIssuedSession` flag from the device-tool boundary (`toolRegistry` → `createToolExecutionContext` → `getOrCreateSession` → `createUnseenSession`) so that, on the caller-provided-sessionUuid path, a brand-new pooled session can be minted only for an id this daemon actually issued: a live in-memory session (resolved earlier) or a persisted, non-terminal row (live-during-restart recovery). A fabricated/never-issued id throws `UnissuedSessionError`. Internal callers that intentionally mint fresh derived sessions (device-label mapping) leave the flag `false` and are unaffected.

2. **Public integration regression tests** (`test/server/unissuedSessionBoundConnection.integration.test.ts`) that drive a bound connection with an active session (both SessionToolBinding and autolock preconditions) through the real `server/index.ts` + ToolRegistry device-aware pipeline and assert a fabricated `sessionUuid` is rejected with no second pooled device minted. These guard #6045's admission invariant at the public boundary (previously only direct-seam unit tested).

### Why it does not claim to fix #6069

For any id with no live in-memory session and no persisted non-terminal row, `admitIssuedSessionForAutomation` (called just above the guarded path in `toolRegistry`) already throws `UnissuedSessionError` via its own pool-less `getOrCreateSession` — regardless of active-session / binding / autolock state. So on every route reproducible in-harness the new flag is redundant with the existing #6045 admission (the integration tests pass on `origin/main` too). The Codex P1 review correctly identified this redundancy.

The issue's hardware repro shows a single `Creating new session kumquat-D` line and a real pooled assignment with **no** `Entering session-based device assignment` log — consistent only with `admit` not reaching its own mint attempt, which does not occur in-harness for a genuinely-never-issued id on a fresh daemon. The most plausible real-world trigger is **fleet / persisted-DB state** (e.g. a leftover persisted non-terminal row for the id from earlier fleet activity, which `admit` would legitimately treat as recovery) — which cannot be reconstructed in the unit/integration harness and needs a hardware capture to pin.

### Value regardless of #6069

The primitive-level guard is a real security invariant: `admit` is currently the *only* thing standing between a caller-supplied string and a pooled-device mint. If any future refactor introduces a route that reaches `createUnseenSession` without going through `admit`, this guard fails closed. The regression tests lock in #6045's public behavior.

Relates to #6069 (kept open), #6019, #6045.
