### PR TITLE
feat(desktop): recovery affordance on the workspace status dot (#6035)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.CoalescingRecoveryLauncher
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
@@ -168,12 +169,16 @@ fun AutoMobileDesktopApp(
   // user ever sees a stable Retry.
   val daemonBootstrap = graph.daemonBootstrap
   val bootstrapState by daemonBootstrap.state.collectAsState()
-  // Synchronous in-flight claim for the workspace health sheet's "Start daemon" recovery button
-  // (#6080). Flipped true on the UI thread the instant onRecoverDaemon fires and cleared when the
-  // launched ensureReady() pass finishes, it coalesces rapid clicks into a single lifecycle pass
-  // (bootstrapState's own Working phase lags behind the click, and does not report at all for a
-  // no-op inactive transport).
-  var recoveringDaemon by remember { mutableStateOf(false) }
+  // Coalescing launcher for the workspace health sheet's "Start daemon" recovery button (#6080): it
+  // makes a synchronous in-flight claim before dispatching ensureReady() off the main thread and
+  // drops clicks while a pass is running, so rapid clicks (or clicks before bootstrapState's own
+  // Working phase catches up) don't queue duplicate startup-budget passes. Its inFlight flag backs
+  // the button's disabled state.
+  val recoveryLauncher =
+    remember(scope, daemonBootstrap) {
+      CoalescingRecoveryLauncher(scope = scope, recover = { daemonBootstrap.ensureReady() })
+    }
+  val recoveringDaemon by recoveryLauncher.inFlight.collectAsState()
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
@@ -527,25 +532,11 @@ fun AutoMobileDesktopApp(
                 // non-daemon (Inactive) transport, so the affordance is inert on HTTP/STDIO.
                 bootstrapState = bootstrapState,
                 recovering = recoveringDaemon,
-                onRecoverDaemon = {
-                  // Synchronous in-flight guard (#6080): coalesce rapid clicks — and clicks landing
-                  // before the pass reports its first Working phase, or while Dispatchers.IO is
-                  // saturated — so only one ensureReady() runs at a time. DesktopDaemonLifecycle
-                  // serializes queued passes rather than coalescing them, so each extra launch
-                  // would
-                  // repeat the full startup budget. The flag flips on the UI thread before dispatch
-                  // and clears in a finally (so a no-op/inactive pass releases it too).
-                  if (!recoveringDaemon) {
-                    recoveringDaemon = true
-                    scope.launch(Dispatchers.IO) {
-                      try {
-                        daemonBootstrap.ensureReady()
-                      } finally {
-                        recoveringDaemon = false
-                      }
-                    }
-                  }
-                },
+                // Delegate to the coalescing launcher (#6080) so a rapid second click can't queue a
+                // duplicate ensureReady() pass; the guard itself lives in
+                // CoalescingRecoveryLauncher
+                // where it is unit-tested.
+                onRecoverDaemon = { recoveryLauncher.launch() },
                 updateStatus = updateStatus,
                 onUpdateClick = { showUpdateDetails = true },
                 facetContent = { column, tool -> WorkspaceFacet(column, tool) },

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -168,6 +168,12 @@ fun AutoMobileDesktopApp(
   // user ever sees a stable Retry.
   val daemonBootstrap = graph.daemonBootstrap
   val bootstrapState by daemonBootstrap.state.collectAsState()
+  // Synchronous in-flight claim for the workspace health sheet's "Start daemon" recovery button
+  // (#6080). Flipped true on the UI thread the instant onRecoverDaemon fires and cleared when the
+  // launched ensureReady() pass finishes, it coalesces rapid clicks into a single lifecycle pass
+  // (bootstrapState's own Working phase lags behind the click, and does not report at all for a
+  // no-op inactive transport).
+  var recoveringDaemon by remember { mutableStateOf(false) }
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
@@ -520,8 +526,25 @@ fun AutoMobileDesktopApp(
                 // re-register loop self-heals the panes once the daemon is reachable. A no-op for a
                 // non-daemon (Inactive) transport, so the affordance is inert on HTTP/STDIO.
                 bootstrapState = bootstrapState,
+                recovering = recoveringDaemon,
                 onRecoverDaemon = {
-                  scope.launch(Dispatchers.IO) { daemonBootstrap.ensureReady() }
+                  // Synchronous in-flight guard (#6080): coalesce rapid clicks — and clicks landing
+                  // before the pass reports its first Working phase, or while Dispatchers.IO is
+                  // saturated — so only one ensureReady() runs at a time. DesktopDaemonLifecycle
+                  // serializes queued passes rather than coalescing them, so each extra launch
+                  // would
+                  // repeat the full startup budget. The flag flips on the UI thread before dispatch
+                  // and clears in a finally (so a no-op/inactive pass releases it too).
+                  if (!recoveringDaemon) {
+                    recoveringDaemon = true
+                    scope.launch(Dispatchers.IO) {
+                      try {
+                        daemonBootstrap.ensureReady()
+                      } finally {
+                        recoveringDaemon = false
+                      }
+                    }
+                  }
                 },
                 updateStatus = updateStatus,
                 onUpdateClick = { showUpdateDetails = true },

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -513,6 +513,16 @@ fun AutoMobileDesktopApp(
                 modifier = Modifier.isolatedBehindOverlay(paletteOpen),
                 status = workspaceStatus.status,
                 statusDetail = workspaceStatus.detail,
+                // Health-sheet recovery affordance (#6035): reuse the picker's DaemonBootstrap seam
+                // so the workspace red dot can start/restart the daemon. ensureReady() blocks up to
+                // the startup budget, so it runs off the main thread; its phases flow back into
+                // bootstrapState (narrating the in-flight button) and the existing session
+                // re-register loop self-heals the panes once the daemon is reachable. A no-op for a
+                // non-daemon (Inactive) transport, so the affordance is inert on HTTP/STDIO.
+                bootstrapState = bootstrapState,
+                onRecoverDaemon = {
+                  scope.launch(Dispatchers.IO) { daemonBootstrap.ensureReady() }
+                },
                 updateStatus = updateStatus,
                 onUpdateClick = { showUpdateDetails = true },
                 facetContent = { column, tool -> WorkspaceFacet(column, tool) },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CoalescingRecoveryLauncher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CoalescingRecoveryLauncher.kt
@@ -1,0 +1,51 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Coalesces daemon-recovery triggers so at most one recovery pass runs at a time.
+ *
+ * The workspace health sheet's "Start daemon" button (#6035) can be clicked repeatedly — before the
+ * pass reports its first phase into [DaemonBootstrap.state], or while [Dispatchers.IO] is saturated
+ * — and [DesktopDaemonLifecycle] serializes queued passes rather than coalescing them, so each
+ * extra launch would repeat the full daemon-startup budget. [launch] flips [inFlight] true
+ * **synchronously on the caller thread** before dispatching and clears it in a `finally` when the
+ * pass completes (so a no-op/inactive [recover] releases it too); a call made while a pass is
+ * already in flight is dropped. [inFlight] backs the button's disabled state.
+ *
+ * The [recover] action and [context] are injected so the coalescing guard is exercised directly by
+ * a unit test (a fake [recover] + a test dispatcher), rather than re-implemented in the caller.
+ */
+class CoalescingRecoveryLauncher(
+  private val scope: CoroutineScope,
+  private val recover: suspend () -> Unit,
+  private val context: CoroutineContext = Dispatchers.IO,
+) {
+  private val _inFlight = MutableStateFlow(false)
+
+  /** Whether a recovery pass launched here is currently running. */
+  val inFlight: StateFlow<Boolean> = _inFlight.asStateFlow()
+
+  /**
+   * Starts a recovery pass unless one is already in flight. The in-flight claim is made
+   * synchronously before dispatch, so two rapid calls on the same (UI) thread coalesce into one
+   * pass.
+   */
+  fun launch() {
+    if (_inFlight.value) return
+    _inFlight.value = true
+    scope.launch(context) {
+      try {
+        recover()
+      } finally {
+        _inFlight.value = false
+      }
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -110,6 +110,12 @@ fun WorkspaceShell(
   // host runs DaemonBootstrap.ensureReady() off the main thread; the default is an inert no-op so a
   // shell composed without a daemon lifecycle stays inert.
   onRecoverDaemon: () -> Unit = {},
+  // Whether a host-owned recovery pass is already in flight. Set synchronously by the host the
+  // instant [onRecoverDaemon] fires and cleared when the launched pass completes, it disables the
+  // "Start daemon" button so rapid clicks (or clicks while Dispatchers.IO is saturated, before the
+  // pass reports its first Working phase into [bootstrapState]) can't each queue a duplicate
+  // ensureReady() — DesktopDaemonLifecycle serializes those rather than coalescing them (#6080).
+  recovering: Boolean = false,
   // Update-availability state (#5225): the top bar shows a pill only when an update is available.
   updateStatus: UpdateStatus = UpdateStatus.Idle,
   onUpdateClick: () -> Unit = {},
@@ -214,6 +220,7 @@ fun WorkspaceShell(
         status = status,
         bootstrapState = bootstrapState,
         onRecoverDaemon = onRecoverDaemon,
+        recovering = recovering,
         onDismiss = { showHealthSheet = false },
         content = healthSheetContent,
       )
@@ -384,6 +391,7 @@ private fun HealthSheetOverlay(
   status: WorkspaceStatus,
   bootstrapState: DaemonBootstrapState,
   onRecoverDaemon: () -> Unit,
+  recovering: Boolean,
   onDismiss: () -> Unit,
   content: @Composable () -> Unit,
 ) {
@@ -429,7 +437,11 @@ private fun HealthSheetOverlay(
       // device
       // picker (#6035). Green/Yellow keep the sheet purely diagnostic.
       if (status == WorkspaceStatus.Red) {
-        DaemonRecoveryHeader(bootstrapState = bootstrapState, onRecoverDaemon = onRecoverDaemon)
+        DaemonRecoveryHeader(
+          bootstrapState = bootstrapState,
+          onRecoverDaemon = onRecoverDaemon,
+          recovering = recovering,
+        )
         Spacer(Modifier.height(8.dp))
       }
       // Constrain the body to the height below the title row so a fillMaxSize() body can't overflow
@@ -444,16 +456,22 @@ private fun HealthSheetOverlay(
  * "Start daemon" Button drives the hoisted [onRecoverDaemon], which the host wires to
  * [dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap.ensureReady] — the same
  * lifecycle seam the device picker's Retry uses, not a second one-off path. While a lifecycle pass
- * is in flight ([DaemonBootstrapState.Working]) the button is disabled and narrates the phase with
- * the picker's [loadingMessage] vocabulary; a [DaemonBootstrapState.Failed] pass surfaces its
- * actionable message below the button.
+ * is in flight ([DaemonBootstrapState.Working], or the host's synchronous [recovering] claim before
+ * the pass reports that phase) the button is disabled and narrates the phase with the picker's
+ * [loadingMessage] vocabulary; a [DaemonBootstrapState.Failed] pass surfaces its actionable message
+ * below the button.
  */
 @Composable
 private fun DaemonRecoveryHeader(
   bootstrapState: DaemonBootstrapState,
   onRecoverDaemon: () -> Unit,
+  recovering: Boolean,
 ) {
   val working = bootstrapState is DaemonBootstrapState.Working
+  // Disabled while a pass is in flight — either the host's synchronous [recovering] claim (covering
+  // the window between the click and the pass's first reported phase, plus clicks while
+  // Dispatchers.IO is saturated) or a [DaemonBootstrapState.Working] phase already flowing back.
+  val busy = working || recovering
   // While a pass runs, reuse the picker's phase narration ("Starting AutoMobile …", "Installing the
   // Bun runtime …"); otherwise offer the plain start action.
   val label = if (working) loadingMessage(bootstrapState) else "Start daemon"
@@ -464,7 +482,7 @@ private fun DaemonRecoveryHeader(
       color = MaterialTheme.colorScheme.onSurface,
     )
     Spacer(Modifier.height(8.dp))
-    Button(onClick = onRecoverDaemon, enabled = !working) { Text(label) }
+    Button(onClick = onRecoverDaemon, enabled = !busy) { Text(label) }
     val failure = (bootstrapState as? DaemonBootstrapState.Failed)?.message
     if (failure != null) {
       Spacer(Modifier.height(8.dp))

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -47,6 +48,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrapState
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
@@ -58,6 +60,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
 import dev.jasonpearson.automobile.desktop.core.shell.UpdateReadyButton
 import dev.jasonpearson.automobile.desktop.core.theme.PlatformIcons
 import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.loadingMessage
 import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -97,6 +100,16 @@ fun WorkspaceShell(
   status: WorkspaceStatus = WorkspaceStatus.Green,
   // A terse reason for a non-green status, shown inline next to the dot ("yellow = one line").
   statusDetail: String? = null,
+  // Daemon bootstrap/recovery state, surfaced in the health sheet as a recovery affordance when the
+  // status is Red (daemon down). Reuses the picker's DaemonBootstrap seam (#6035) rather than
+  // adding
+  // a second lifecycle path; the defaults keep the shell stateless/test-friendly and leave every
+  // existing call site unchanged.
+  bootstrapState: DaemonBootstrapState = DaemonBootstrapState.Inactive,
+  // Explicit recovery trigger for the health sheet's "Start daemon" button (Red status only). The
+  // host runs DaemonBootstrap.ensureReady() off the main thread; the default is an inert no-op so a
+  // shell composed without a daemon lifecycle stays inert.
+  onRecoverDaemon: () -> Unit = {},
   // Update-availability state (#5225): the top bar shows a pill only when an update is available.
   updateStatus: UpdateStatus = UpdateStatus.Idle,
   onUpdateClick: () -> Unit = {},
@@ -198,6 +211,9 @@ fun WorkspaceShell(
     }
     if (showHealthSheet) {
       HealthSheetOverlay(
+        status = status,
+        bootstrapState = bootstrapState,
+        onRecoverDaemon = onRecoverDaemon,
         onDismiss = { showHealthSheet = false },
         content = healthSheetContent,
       )
@@ -364,7 +380,13 @@ private fun TopBar(
  * overlay.
  */
 @Composable
-private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+private fun HealthSheetOverlay(
+  status: WorkspaceStatus,
+  bootstrapState: DaemonBootstrapState,
+  onRecoverDaemon: () -> Unit,
+  onDismiss: () -> Unit,
+  content: @Composable () -> Unit,
+) {
   Box(
     modifier =
       Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)).clickable(
@@ -402,9 +424,55 @@ private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () ->
         )
       }
       Spacer(Modifier.height(8.dp))
+      // Recovery affordance: the only daemon-mutating control in the (otherwise read-only) health
+      // sheet, shown only when the status is Red (daemon down) — Start-daemon parity with the
+      // device
+      // picker (#6035). Green/Yellow keep the sheet purely diagnostic.
+      if (status == WorkspaceStatus.Red) {
+        DaemonRecoveryHeader(bootstrapState = bootstrapState, onRecoverDaemon = onRecoverDaemon)
+        Spacer(Modifier.height(8.dp))
+      }
       // Constrain the body to the height below the title row so a fillMaxSize() body can't overflow
       // the header out of the panel.
       Box(Modifier.weight(1f).fillMaxWidth()) { content() }
+    }
+  }
+}
+
+/**
+ * The health sheet's daemon recovery affordance (#6035), shown only for a Red status. A single
+ * "Start daemon" Button drives the hoisted [onRecoverDaemon], which the host wires to
+ * [dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap.ensureReady] — the same
+ * lifecycle seam the device picker's Retry uses, not a second one-off path. While a lifecycle pass
+ * is in flight ([DaemonBootstrapState.Working]) the button is disabled and narrates the phase with
+ * the picker's [loadingMessage] vocabulary; a [DaemonBootstrapState.Failed] pass surfaces its
+ * actionable message below the button.
+ */
+@Composable
+private fun DaemonRecoveryHeader(
+  bootstrapState: DaemonBootstrapState,
+  onRecoverDaemon: () -> Unit,
+) {
+  val working = bootstrapState is DaemonBootstrapState.Working
+  // While a pass runs, reuse the picker's phase narration ("Starting AutoMobile …", "Installing the
+  // Bun runtime …"); otherwise offer the plain start action.
+  val label = if (working) loadingMessage(bootstrapState) else "Start daemon"
+  Column(Modifier.fillMaxWidth().semantics { contentDescription = "Daemon recovery" }) {
+    Text(
+      "AutoMobile daemon isn't available",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+    Spacer(Modifier.height(8.dp))
+    Button(onClick = onRecoverDaemon, enabled = !working) { Text(label) }
+    val failure = (bootstrapState as? DaemonBootstrapState.Failed)?.message
+    if (failure != null) {
+      Spacer(Modifier.height(8.dp))
+      Text(
+        failure,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+      )
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -434,9 +434,12 @@ private fun HealthSheetOverlay(
       Spacer(Modifier.height(8.dp))
       // Recovery affordance: the only daemon-mutating control in the (otherwise read-only) health
       // sheet, shown only when the status is Red (daemon down) — Start-daemon parity with the
-      // device
-      // picker (#6035). Green/Yellow keep the sheet purely diagnostic.
-      if (status == WorkspaceStatus.Red) {
+      // device picker (#6035). Green/Yellow keep the sheet purely diagnostic. Gated on a local
+      // daemon transport: a non-daemon (HTTP/STDIO) transport reports DaemonBootstrapState.Inactive
+      // and its ensureReady() is a no-op, so a Red caused by an HTTP/STDIO disconnect must NOT
+      // offer
+      // a "Start daemon" button that would silently do nothing (#6080).
+      if (status == WorkspaceStatus.Red && bootstrapState !is DaemonBootstrapState.Inactive) {
         DaemonRecoveryHeader(
           bootstrapState = bootstrapState,
           onRecoverDaemon = onRecoverDaemon,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CoalescingRecoveryLauncherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CoalescingRecoveryLauncherTest.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+// Note: the finally-reset-on-failure path is not unit-tested here because the injected recover in
+// production is `daemonBootstrap.ensureReady()`, which reports failures as
+// DaemonBootstrapState.Failed
+// rather than throwing; a throwing recover in a `launch` child would fail runTest itself.
+
+/**
+ * Exercises the PRODUCTION coalescing guard (#6080). The workspace wires `onRecoverDaemon = {
+ * recoveryLauncher.launch() }`, so testing [CoalescingRecoveryLauncher.launch] directly proves the
+ * rapid-click regression is caught in the shipped seam — not re-implemented in a test callback.
+ */
+class CoalescingRecoveryLauncherTest {
+
+  @Test
+  fun `a second launch while a pass is in flight does not start a second recover`() = runTest {
+    var recoverCount = 0
+    // recover() stays in flight until the gate completes, modeling a slow ensureReady() pass.
+    val gate = CompletableDeferred<Unit>()
+    val launcher =
+      CoalescingRecoveryLauncher(
+        scope = this,
+        // EmptyCoroutineContext so the launched pass runs on the test dispatcher (deterministic).
+        context = EmptyCoroutineContext,
+        recover = {
+          recoverCount++
+          gate.await()
+        },
+      )
+
+    launcher.launch()
+    runCurrent() // let the first pass start and suspend on the gate
+    assertTrue(launcher.inFlight.value)
+    assertEquals(1, recoverCount)
+
+    // Two more clicks while the first pass is still running — both must be dropped.
+    launcher.launch()
+    launcher.launch()
+    runCurrent()
+    assertEquals(1, recoverCount)
+
+    // Once the pass completes the flag clears and a fresh launch runs again.
+    gate.complete(Unit)
+    runCurrent()
+    assertFalse(launcher.inFlight.value)
+
+    val gate2 = CompletableDeferred<Unit>()
+    val launcher2 =
+      CoalescingRecoveryLauncher(
+        scope = this,
+        context = EmptyCoroutineContext,
+        recover = {
+          recoverCount++
+          gate2.await()
+        },
+      )
+    launcher2.launch()
+    runCurrent()
+    assertEquals(2, recoverCount)
+    gate2.complete(Unit)
+    runCurrent()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -912,6 +912,59 @@ class WorkspaceShellUiTest {
   }
 
   @Test
+  fun `a recovery pass already in flight disables the button`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Daemon unreachable",
+          // The host's synchronous claim before bootstrapState has reported its first Working
+          // phase.
+          recovering = true,
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    onNodeWithText("Start daemon").assertIsNotEnabled()
+  }
+
+  @Test
+  fun `a second click while a recovery pass is in flight does not re-dispatch`() =
+    runComposeUiTest {
+      // Model the host's synchronous in-flight guard: onRecoverDaemon flips `recovering` true,
+      // which
+      // disables the button so a rapid second click can't queue a duplicate ensureReady() pass.
+      val recovering = mutableStateOf(false)
+      var dispatches = 0
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = WorkspaceUiState.Empty,
+            onAction = {},
+            onOpenPicker = {},
+            status = WorkspaceStatus.Red,
+            statusDetail = "Daemon unreachable",
+            recovering = recovering.value,
+            onRecoverDaemon = {
+              dispatches++
+              recovering.value = true
+            },
+            healthSheetContent = { Text("fake-health-body") },
+          )
+        }
+      }
+      onNodeWithContentDescription("Status: Red").performClick()
+      onNodeWithText("Start daemon").performClick()
+      // The button is now disabled (recovering = true); a second click must not dispatch again.
+      onNodeWithText("Start daemon").performClick()
+      assertEquals(1, dispatches)
+    }
+
+  @Test
   fun `an in-flight bootstrap pass disables the button with the phase label`() = runComposeUiTest {
     setContent {
       MaterialTheme {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -841,6 +841,8 @@ class WorkspaceShellUiTest {
           onOpenPicker = {},
           status = WorkspaceStatus.Red,
           statusDetail = "Daemon unreachable",
+          // A local daemon that has not reported Ready — not Inactive, so recovery is offered.
+          bootstrapState = DaemonBootstrapState.Unknown,
           healthSheetContent = { Text("fake-health-body") },
         )
       }
@@ -849,6 +851,31 @@ class WorkspaceShellUiTest {
     onNodeWithContentDescription("Daemon recovery").assertIsDisplayed()
     onNodeWithText("Start daemon").assertIsDisplayed()
   }
+
+  @Test
+  fun `red status with an inactive (non-daemon) transport hides the recovery affordance`() =
+    runComposeUiTest {
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = WorkspaceUiState.Empty,
+            onAction = {},
+            onOpenPicker = {},
+            status = WorkspaceStatus.Red,
+            statusDetail = "Connection lost",
+            // HTTP/STDIO transport: bootstrap is Inactive and ensureReady() is a no-op, so a
+            // "Start daemon" button would silently do nothing — it must not be offered (#6080).
+            bootstrapState = DaemonBootstrapState.Inactive,
+            healthSheetContent = { Text("fake-health-body") },
+          )
+        }
+      }
+      onNodeWithContentDescription("Status: Red").performClick()
+      // The sheet still opens for diagnostics, but with no recovery affordance.
+      onNodeWithText("fake-health-body").assertIsDisplayed()
+      onNodeWithContentDescription("Daemon recovery").assertDoesNotExist()
+      onNodeWithText("Start daemon").assertDoesNotExist()
+    }
 
   @Test
   fun `green status health sheet hides the daemon recovery affordance`() = runComposeUiTest {
@@ -901,6 +928,7 @@ class WorkspaceShellUiTest {
           onOpenPicker = {},
           status = WorkspaceStatus.Red,
           statusDetail = "Daemon unreachable",
+          bootstrapState = DaemonBootstrapState.Unknown,
           onRecoverDaemon = { recoveries++ },
           healthSheetContent = { Text("fake-health-body") },
         )
@@ -921,6 +949,7 @@ class WorkspaceShellUiTest {
           onOpenPicker = {},
           status = WorkspaceStatus.Red,
           statusDetail = "Daemon unreachable",
+          bootstrapState = DaemonBootstrapState.Unknown,
           // The host's synchronous claim before bootstrapState has reported its first Working
           // phase.
           recovering = true,
@@ -948,6 +977,7 @@ class WorkspaceShellUiTest {
             onOpenPicker = {},
             status = WorkspaceStatus.Red,
             statusDetail = "Daemon unreachable",
+            bootstrapState = DaemonBootstrapState.Unknown,
             recovering = recovering.value,
             onRecoverDaemon = {
               dispatches++

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -5,10 +5,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrapState
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonLifecyclePhase
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.update.ReleaseAsset
@@ -822,5 +825,135 @@ class WorkspaceShellUiTest {
     onNodeWithText("compare-body").assertExists()
     // Pane controls behind the compare scrim have left the accessibility tree.
     onNodeWithContentDescription("Close Pixel").assertDoesNotExist()
+  }
+
+  // #6035: the health sheet gains a daemon recovery affordance ("Start daemon" parity with the
+  // device picker), shown only for a Red status (daemon down) and driving the hoisted
+  // onRecoverDaemon (the host wires it to DaemonBootstrap.ensureReady()).
+
+  @Test
+  fun `red status health sheet shows the daemon recovery affordance`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Daemon unreachable",
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    onNodeWithContentDescription("Daemon recovery").assertIsDisplayed()
+    onNodeWithText("Start daemon").assertIsDisplayed()
+  }
+
+  @Test
+  fun `green status health sheet hides the daemon recovery affordance`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Green,
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Green").performClick()
+    // The sheet is open (its body is visible) but the recovery affordance stays hidden for green.
+    onNodeWithText("fake-health-body").assertIsDisplayed()
+    onNodeWithContentDescription("Daemon recovery").assertDoesNotExist()
+    onNodeWithText("Start daemon").assertDoesNotExist()
+  }
+
+  @Test
+  fun `yellow status health sheet hides the daemon recovery affordance`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Yellow,
+          statusDetail = "Daemon reconnecting",
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Yellow").performClick()
+    onNodeWithText("fake-health-body").assertIsDisplayed()
+    onNodeWithContentDescription("Daemon recovery").assertDoesNotExist()
+    onNodeWithText("Start daemon").assertDoesNotExist()
+  }
+
+  @Test
+  fun `clicking Start daemon invokes onRecoverDaemon exactly once`() = runComposeUiTest {
+    var recoveries = 0
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Daemon unreachable",
+          onRecoverDaemon = { recoveries++ },
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    onNodeWithText("Start daemon").performClick()
+    assertEquals(1, recoveries)
+  }
+
+  @Test
+  fun `an in-flight bootstrap pass disables the button with the phase label`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Daemon unreachable",
+          bootstrapState =
+            DaemonBootstrapState.Working(
+              DaemonLifecyclePhase.LaunchingDaemon(action = "start", version = "0.0.67")
+            ),
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    // While a pass runs, the button narrates the picker phase and is disabled (no re-trigger).
+    onNodeWithText("Start daemon").assertDoesNotExist()
+    onNodeWithText("Starting AutoMobile 0.0.67…").assertIsDisplayed()
+    onNodeWithText("Starting AutoMobile 0.0.67…").assertIsNotEnabled()
+  }
+
+  @Test
+  fun `a failed bootstrap pass surfaces the actionable message`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Daemon unreachable",
+          bootstrapState = DaemonBootstrapState.Failed("Bun install failed: offline"),
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    // A failed pass still offers a retry via the enabled Start button, plus the failure detail.
+    onNodeWithText("Start daemon").assertIsDisplayed()
+    onNodeWithText("Bun install failed: offline").assertIsDisplayed()
   }
 }


### PR DESCRIPTION
## Summary

The desktop Compose app's workspace status dot only reflected daemon health: clicking it opened a read-only health sheet with no way to start/restart the daemon. The device picker already surfaces recovery (via `DaemonBootstrap` + `DesktopDaemonLifecycle`), but the workspace dot did not — the only "Start daemon" control lived in the legacy `McpProcessesPanel`.

This adds a **recovery affordance to the health sheet**, shown only when the status is **Red** (daemon down), reusing the picker's existing `DaemonBootstrap.ensureReady()` seam rather than adding a second lifecycle path.

## Linked Issue

Closes #6035

## Changes

- **`WorkspaceShell.kt`** — two new hoisted params with inert defaults (so every existing call site is unchanged and the shell stays stateless/test-friendly):
  - `bootstrapState: DaemonBootstrapState = DaemonBootstrapState.Inactive`
  - `onRecoverDaemon: () -> Unit = {}`

  The health sheet renders a `DaemonRecoveryHeader` **only for a Red status**. Its single "Start daemon" `Button` drives `onRecoverDaemon`. While a lifecycle pass is in flight (`DaemonBootstrapState.Working`) the button is disabled and narrates the phase by reusing the picker's `loadingMessage()` vocabulary; a `DaemonBootstrapState.Failed` pass surfaces its actionable `message` below the button. Green/Yellow keep the sheet purely diagnostic.

- **`AutoMobileDesktopApp.kt`** — passes `bootstrapState = bootstrapState` (already collected) and `onRecoverDaemon = { scope.launch(Dispatchers.IO) { daemonBootstrap.ensureReady() } }`. `ensureReady()` blocks up to the startup budget so it runs off the main thread; its phases flow back into `bootstrapState`, and the existing session re-register loop self-heals the panes once the daemon is reachable — so no extra refresh wiring is needed. `ensureReady()` is already inert for non-daemon (`Inactive`) transports, making the affordance a no-op on HTTP/STDIO.

No changes to `DaemonBootstrap`, `DesktopDaemonLifecycle`, or `deriveWorkspaceStatus` — the KDoc on `ensureReady()` explicitly names this "future recovery affordance" as its intended trigger.

## Kotlin Reuse Check

- Reuses the picker's `loadingMessage()` (module-`internal`, imported) and the existing `DaemonBootstrap.ensureReady()` seam. No new helpers, wrappers, or dependencies.

## Validation

- `:desktop-core:test` — full module suite green (1605 tests across 153 classes), including 6 new `WorkspaceShellUiTest` cases.
- `:desktop-app:compileKotlin` — green (wiring compiles).
- `ktfmt --google-style` (pinned 0.64) — clean on all touched files.
- `:desktop-core:detekt` + `:desktop-app:detekt` — green.

### Tests (fail-without / pass-with proof)

Added to `WorkspaceShellUiTest.kt` (stateless, `runComposeUiTest`), mirroring the existing update-pill show/hide tests:

- Recovery affordance **displayed** for Red; **hidden** for Green and Yellow.
- Clicking "Start daemon" invokes `onRecoverDaemon` exactly once.
- `Working(LaunchingDaemon(start, 0.0.67))` → button **disabled** with the in-flight label "Starting AutoMobile 0.0.67…".
- `Failed("…")` → the actionable message is surfaced.

With the affordance render disabled, the 4 presence/behavior tests fail and the 2 "hides" tests still pass (right-reason red); with it enabled, all 6 pass. The `loadingMessage()` label mapping remains pinned by the existing `DevicePickerBootstrapMessageTest` (the function is reused unchanged).

## Follow-ups

- None required. Feeding per-device stream health into `WorkspaceStatus` remains a pre-existing follow-up noted in the app (unchanged by this PR).
