### PR TITLE
fix(observe): backfill empty/stale activeWindow.activityName from backStack (#6070)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -922,6 +922,10 @@ export class RealObserveScreen implements ObserveScreen {
 
     const backStackAttribution = resolveBackStackActivityAttribution(result);
     if (backStackAttribution && activeWindow.activityName !== backStackAttribution.activityName) {
+      if (!activeWindow.activityName) {
+        this.backfillEmptyActivityFromBackStack(result, backStackAttribution);
+        return { sampled: false, identity: undefined, activityAttributionMismatch: false };
+      }
       const recaptured = await this.recaptureHierarchyForBackStackAttribution(
         result,
         backStackAttribution,
@@ -956,6 +960,34 @@ export class RealObserveScreen implements ObserveScreen {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
     return { sampled: true, identity: confirmed, activityAttributionMismatch: false };
+  }
+
+  /**
+   * Backfill an empty `activeWindow.activityName` from the adb-sourced
+   * `backStack`. An empty/missing activityName is not a real reading — it is the
+   * bootstrap `Window.getActive()` (or last-resort package) path publishing a
+   * blank, sometimes served from a stale cache with a frozen `layoutSeqSum`
+   * (e.g. 3478) across a genuine navigation. `backStack` never drifts and is
+   * already confirmed in-package, so this backfills directly — no expensive
+   * hierarchy recapture, which the non-empty stale-name case (#5992) still
+   * requires to avoid pairing a later activity with an earlier tree.
+   * `layoutSeqSum` is reset to the unknown sentinel (0, the value the
+   * accessibility path uses) so a stale sequence is never published beside the
+   * corrected activity (#6070).
+   */
+  private backfillEmptyActivityFromBackStack(
+    result: ObserveResult,
+    backStackAttribution: { packageName: string; activityName: string },
+  ): void {
+    const backfilled = {
+      appId: backStackAttribution.packageName,
+      activityName: backStackAttribution.activityName,
+      layoutSeqSum: 0,
+    } as NonNullable<ObserveResult["activeWindow"]>;
+    if (result.notificationPermissionDetected) {
+      backfilled.type = "notification_permission_dialog";
+    }
+    result.activeWindow = backfilled;
   }
 
   private async recaptureHierarchyForBackStackAttribution(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -923,13 +923,14 @@ export class RealObserveScreen implements ObserveScreen {
     const backStackAttribution = resolveBackStackActivityAttribution(result);
     if (backStackAttribution && activeWindow.activityName !== backStackAttribution.activityName) {
       // An empty `activityName` (the bootstrap `Window.getActive()` / last-resort
-      // package path, sometimes a stale cache with a frozen `layoutSeqSum`) is
-      // reconciled through the SAME temporal confirmation as a stale non-empty
-      // name (#5992): the recapture re-reads the hierarchy so the adb activity is
-      // paired with a *fresh* tree, never blindly stamped onto the earlier
-      // capture. A same-app mid-flight navigation between capture and back-stack
-      // read is therefore surfaced as a mismatch/unknown rather than a
-      // confidently-wrong name (#6070).
+      // package path) is reconciled through the SAME temporal confirmation as a
+      // stale non-empty name (#5992), never a blind backfill: the recapture
+      // re-reads the hierarchy so the adb activity is paired with a *fresh* tree.
+      // A same-app mid-flight navigation between capture and back-stack read is
+      // therefore surfaced as a mismatch/unknown rather than a confidently-wrong
+      // name, and the confirmed window keeps its correlated `layoutSeqSum` (the
+      // freshness of which is guaranteed by the `getActive(true)` bootstrap read)
+      // so tap-effect detection is not blinded by a zero sentinel (#6070).
       const recaptured = await this.recaptureHierarchyForBackStackAttribution(
         result,
         backStackAttribution,
@@ -946,14 +947,6 @@ export class RealObserveScreen implements ObserveScreen {
         appId: backStackAttribution.packageName,
         activityName: backStackAttribution.activityName,
       };
-      // An empty original name carried no trustworthy `layoutSeqSum` (it came
-      // from the bootstrap window / possibly-stale cache), so reset it to the
-      // unknown sentinel (0, the value the accessibility path uses) once the
-      // recapture has confirmed the activity — a stale sequence must never be
-      // published beside the corrected activity (#6070).
-      if (!activeWindow.activityName) {
-        reconciled.layoutSeqSum = 0;
-      }
       if (result.notificationPermissionDetected) {
         reconciled.type = "notification_permission_dialog";
       } else {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -922,10 +922,14 @@ export class RealObserveScreen implements ObserveScreen {
 
     const backStackAttribution = resolveBackStackActivityAttribution(result);
     if (backStackAttribution && activeWindow.activityName !== backStackAttribution.activityName) {
-      if (!activeWindow.activityName) {
-        this.backfillEmptyActivityFromBackStack(result, backStackAttribution);
-        return { sampled: false, identity: undefined, activityAttributionMismatch: false };
-      }
+      // An empty `activityName` (the bootstrap `Window.getActive()` / last-resort
+      // package path, sometimes a stale cache with a frozen `layoutSeqSum`) is
+      // reconciled through the SAME temporal confirmation as a stale non-empty
+      // name (#5992): the recapture re-reads the hierarchy so the adb activity is
+      // paired with a *fresh* tree, never blindly stamped onto the earlier
+      // capture. A same-app mid-flight navigation between capture and back-stack
+      // read is therefore surfaced as a mismatch/unknown rather than a
+      // confidently-wrong name (#6070).
       const recaptured = await this.recaptureHierarchyForBackStackAttribution(
         result,
         backStackAttribution,
@@ -942,6 +946,14 @@ export class RealObserveScreen implements ObserveScreen {
         appId: backStackAttribution.packageName,
         activityName: backStackAttribution.activityName,
       };
+      // An empty original name carried no trustworthy `layoutSeqSum` (it came
+      // from the bootstrap window / possibly-stale cache), so reset it to the
+      // unknown sentinel (0, the value the accessibility path uses) once the
+      // recapture has confirmed the activity — a stale sequence must never be
+      // published beside the corrected activity (#6070).
+      if (!activeWindow.activityName) {
+        reconciled.layoutSeqSum = 0;
+      }
       if (result.notificationPermissionDetected) {
         reconciled.type = "notification_permission_dialog";
       } else {
@@ -960,34 +972,6 @@ export class RealObserveScreen implements ObserveScreen {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
     return { sampled: true, identity: confirmed, activityAttributionMismatch: false };
-  }
-
-  /**
-   * Backfill an empty `activeWindow.activityName` from the adb-sourced
-   * `backStack`. An empty/missing activityName is not a real reading — it is the
-   * bootstrap `Window.getActive()` (or last-resort package) path publishing a
-   * blank, sometimes served from a stale cache with a frozen `layoutSeqSum`
-   * (e.g. 3478) across a genuine navigation. `backStack` never drifts and is
-   * already confirmed in-package, so this backfills directly — no expensive
-   * hierarchy recapture, which the non-empty stale-name case (#5992) still
-   * requires to avoid pairing a later activity with an earlier tree.
-   * `layoutSeqSum` is reset to the unknown sentinel (0, the value the
-   * accessibility path uses) so a stale sequence is never published beside the
-   * corrected activity (#6070).
-   */
-  private backfillEmptyActivityFromBackStack(
-    result: ObserveResult,
-    backStackAttribution: { packageName: string; activityName: string },
-  ): void {
-    const backfilled = {
-      appId: backStackAttribution.packageName,
-      activityName: backStackAttribution.activityName,
-      layoutSeqSum: 0,
-    } as NonNullable<ObserveResult["activeWindow"]>;
-    if (result.notificationPermissionDetected) {
-      backfilled.type = "notification_permission_dialog";
-    }
-    result.activeWindow = backfilled;
   }
 
   private async recaptureHierarchyForBackStackAttribution(

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -97,7 +97,14 @@ export class DeviceStateCollector {
     const { window, timer } = this.opts;
     try {
       const startedAt = timer.now();
-      const activeWindow = await window.getActive();
+      // Force a fresh read on the bootstrap path. The Window memory/disk cache
+      // has no expiry, so a `getActive()` (non-forced) read can serve a frozen
+      // record — an empty activityName with a stale `layoutSeqSum` — across a
+      // real navigation, which the observe layer would then publish. This path
+      // only runs during the lazy-CtrlProxy bootstrap interval (rare), so the
+      // extra dumpsys is cheap; the cache must never win over current window
+      // state (#6070).
+      const activeWindow = await window.getActive(true);
       logger.debug(`Bootstrap active window retrieval took ${timer.now() - startedAt}ms`);
       if (activeWindow) {
         result.activeWindow = activeWindow;

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -764,9 +764,13 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
   // Issue #6070: on the bootstrap Window.getActive() path (used when the
   // accessibility service supplies no usable foregroundActivity), a blank/stale
   // active-window record can be published with an empty activityName and a
-  // frozen layoutSeqSum. The adb-sourced backStack never drifts, so an empty
-  // activityName must be backfilled directly from backStack — without requiring
-  // an expensive hierarchy recapture — and the stale layoutSeqSum must not ride
+  // frozen layoutSeqSum. An empty activityName is reconciled from the adb-sourced
+  // backStack, but through the SAME temporal confirmation (hierarchy recapture)
+  // the stale non-empty case uses (#5992): the adb activity is only accepted once
+  // a fresh recapture agrees, never blindly stamped onto the earlier hierarchy.
+  // When the recapture cannot confirm (e.g. a same-app mid-flight navigation
+  // between capture and back-stack read), the name resolves to unknown/mismatch
+  // rather than a confidently-wrong value. The stale layoutSeqSum must not ride
   // along. System UI (#6078) is out of scope here.
   const emptyBootstrapWindow = (activeWindow: {
     appId: string;
@@ -781,14 +785,16 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       clearCache: async () => undefined,
     }) as any;
 
-  test("backfills an empty activeWindow activityName from backStack without a recapture (#6070)", async () => {
+  test("backfills an empty activeWindow activityName from a temporally-confirmed backStack (#6070)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();
     timer.setCurrentTime(now);
 
     const viewHierarchy = new FakeViewHierarchy();
     // No usable foregroundActivity -> the accessibility path does not set
-    // activeWindow, so the bootstrap Window.getActive() fallback runs.
+    // activeWindow, so the bootstrap Window.getActive() fallback runs. The device
+    // is stable: the recapture re-reads the same (fresh) hierarchy and the same
+    // backStack, so the adb activity is confirmed and backfilled.
     viewHierarchy.configureHierarchy({
       updatedAt: now,
       receivedAt: now,
@@ -841,20 +847,23 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     // The stale frozen layoutSeqSum must not be published alongside the
     // corrected activity (it is reset to the unknown sentinel 0).
     expect(result.activeWindow?.layoutSeqSum).toBe(0);
-    // No hierarchy recapture is required to backfill an empty name.
-    expect(viewHierarchy.getCallCount()).toBe(1);
+    // Temporal confirmation ran: the initial capture plus one recapture.
+    expect(viewHierarchy.getCallCount()).toBe(2);
     expect(result.freshness?.verified).toBe(true);
   });
 
-  test("backfills an empty activeWindow activityName even when a recapture is unavailable (#6070)", async () => {
+  test("does not stamp a later same-app backStack activity onto an earlier hierarchy when a recapture cannot confirm it (#6070)", async () => {
+    // Temporal-skew guard: the hierarchy is captured for activity A
+    // (SettingsHomepageActivity), but the back-stack read that follows reports a
+    // *later* same-app activity B (SubSettings). Package equality cannot tell A
+    // and B apart, so a blind backfill would confidently pair B onto A's tree. A
+    // recapture that cannot confirm B (the fresh read is unusable) must leave the
+    // name unknown and flag the mismatch, never publish B against A's hierarchy.
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();
     timer.setCurrentTime(now);
 
     const viewHierarchy = new FakeViewHierarchy();
-    // First read is the (usable) captured hierarchy; a second read (which the
-    // pre-#6070 recapture path would attempt) fails. The empty-name backfill
-    // must still succeed off backStack alone.
     viewHierarchy.configureHierarchySequence([
       {
         updatedAt: now,
@@ -866,7 +875,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
         hierarchy: {
           node: {
             bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
-            node: [{ text: "Settings", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+            node: [{ text: "Settings home", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
           },
         },
       },
@@ -891,7 +900,8 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
             depth: 1,
             activities: [],
             tasks: [],
-            currentActivity: { name: "com.android.settings.Settings", taskId: 14 },
+            // The later same-app activity, read after the A hierarchy was captured.
+            currentActivity: { name: "com.android.settings.SubSettings", taskId: 14 },
             source: "adb",
           }),
         } as any,
@@ -905,11 +915,16 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     const result = await screen.execute({ skipScreenshot: true });
 
-    // On pre-#6070 code the empty name stays "" because the recapture is
-    // unusable; with the fix it is backfilled from backStack.
-    expect(result.activeWindow?.activityName).toBe("com.android.settings.Settings");
-    expect(result.activeWindow?.layoutSeqSum).toBe(0);
-    // Only the initial capture is read; no recapture round-trip is made.
-    expect(viewHierarchy.getCallCount()).toBe(1);
+    // The later activity B must NOT be stamped onto A's hierarchy; the name
+    // stays unknown ("") and the divergence is surfaced as a mismatch.
+    expect(result.activeWindow?.activityName).not.toBe("com.android.settings.SubSettings");
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("disagree about the current activity");
+    // The original A hierarchy is preserved (not replaced by an unusable recapture).
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Settings home");
+    // Temporal confirmation was attempted: initial capture plus the recapture read.
+    expect(viewHierarchy.getCallCount()).toBe(2);
   });
 });

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -763,15 +763,18 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
   // Issue #6070: on the bootstrap Window.getActive() path (used when the
   // accessibility service supplies no usable foregroundActivity), a blank/stale
-  // active-window record can be published with an empty activityName and a
-  // frozen layoutSeqSum. An empty activityName is reconciled from the adb-sourced
-  // backStack, but through the SAME temporal confirmation (hierarchy recapture)
-  // the stale non-empty case uses (#5992): the adb activity is only accepted once
-  // a fresh recapture agrees, never blindly stamped onto the earlier hierarchy.
-  // When the recapture cannot confirm (e.g. a same-app mid-flight navigation
-  // between capture and back-stack read), the name resolves to unknown/mismatch
-  // rather than a confidently-wrong value. The stale layoutSeqSum must not ride
-  // along. System UI (#6078) is out of scope here.
+  // active-window record can be published with an empty activityName. An empty
+  // activityName is reconciled from the adb-sourced backStack, but through the
+  // SAME temporal confirmation (hierarchy recapture) the stale non-empty case
+  // uses (#5992): the adb activity is only accepted once a fresh recapture
+  // agrees, never blindly stamped onto the earlier hierarchy. When the recapture
+  // cannot confirm (e.g. a same-app mid-flight navigation between capture and
+  // back-stack read), the name resolves to unknown/mismatch rather than a
+  // confidently-wrong value. The confirmed window keeps its correlated
+  // layoutSeqSum (kept fresh by the getActive(true) bootstrap read), never a
+  // zero sentinel that would blind tap-effect detection. The frozen-cache source
+  // of the stale layoutSeqSum is eliminated at the collector (see
+  // DeviceStateCollector force-refresh). System UI (#6078) is out of scope here.
   const emptyBootstrapWindow = (activeWindow: {
     appId: string;
     activityName: string;
@@ -821,7 +824,8 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
         window: emptyBootstrapWindow({
           appId: "com.android.settings",
           activityName: "",
-          layoutSeqSum: 3478,
+          // The current (force-refreshed) window layout sequence.
+          layoutSeqSum: 5120,
         }),
         backStack: {
           execute: async () => ({
@@ -844,9 +848,10 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     expect(result.activeWindow?.activityName).toBe("com.android.settings.Settings");
     expect(result.activeWindow?.appId).toBe("com.android.settings");
-    // The stale frozen layoutSeqSum must not be published alongside the
-    // corrected activity (it is reset to the unknown sentinel 0).
-    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+    // The correlated layoutSeqSum is preserved, NOT reset to the 0 sentinel: a
+    // zero would make TapOnElement.compareActiveWindow treat a same-activity
+    // content change as "unchanged" and mask it.
+    expect(result.activeWindow?.layoutSeqSum).toBe(5120);
     // Temporal confirmation ran: the initial capture plus one recapture.
     expect(viewHierarchy.getCallCount()).toBe(2);
     expect(result.freshness?.verified).toBe(true);

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -875,7 +875,9 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
         hierarchy: {
           node: {
             bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
-            node: [{ text: "Settings home", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+            node: [
+              { text: "Settings home", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+            ],
           },
         },
       },

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -760,4 +760,156 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.isFresh).toBe(true);
     expect(result.freshness?.verified).toBe(true);
   });
+
+  // Issue #6070: on the bootstrap Window.getActive() path (used when the
+  // accessibility service supplies no usable foregroundActivity), a blank/stale
+  // active-window record can be published with an empty activityName and a
+  // frozen layoutSeqSum. The adb-sourced backStack never drifts, so an empty
+  // activityName must be backfilled directly from backStack — without requiring
+  // an expensive hierarchy recapture — and the stale layoutSeqSum must not ride
+  // along. System UI (#6078) is out of scope here.
+  const emptyBootstrapWindow = (activeWindow: {
+    appId: string;
+    activityName: string;
+    layoutSeqSum: number;
+  }) =>
+    ({
+      getActive: async () => activeWindow,
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    }) as any;
+
+  test("backfills an empty activeWindow activityName from backStack without a recapture (#6070)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // No usable foregroundActivity -> the accessibility path does not set
+    // activeWindow, so the bootstrap Window.getActive() fallback runs.
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.android.settings",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Settings", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "",
+          layoutSeqSum: 3478,
+        }),
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.Settings", taskId: 14 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.Settings");
+    expect(result.activeWindow?.appId).toBe("com.android.settings");
+    // The stale frozen layoutSeqSum must not be published alongside the
+    // corrected activity (it is reset to the unknown sentinel 0).
+    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+    // No hierarchy recapture is required to backfill an empty name.
+    expect(viewHierarchy.getCallCount()).toBe(1);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("backfills an empty activeWindow activityName even when a recapture is unavailable (#6070)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // First read is the (usable) captured hierarchy; a second read (which the
+    // pre-#6070 recapture path would attempt) fails. The empty-name backfill
+    // must still succeed off backStack alone.
+    viewHierarchy.configureHierarchySequence([
+      {
+        updatedAt: now,
+        receivedAt: now,
+        fresh: true,
+        screenWidth: 1080,
+        screenHeight: 2400,
+        packageName: "com.android.settings",
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+            node: [{ text: "Settings", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+          },
+        },
+      },
+      { hierarchy: { error: "CtrlProxy timed out" }, fresh: false },
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "",
+          layoutSeqSum: 3478,
+        }),
+        backStack: {
+          execute: async () => ({
+            depth: 1,
+            activities: [],
+            tasks: [],
+            currentActivity: { name: "com.android.settings.Settings", taskId: 14 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    // On pre-#6070 code the empty name stays "" because the recapture is
+    // unusable; with the fix it is backfilled from backStack.
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.Settings");
+    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+    // Only the initial capture is read; no recapture round-trip is made.
+    expect(viewHierarchy.getCallCount()).toBe(1);
+  });
 });

--- a/test/features/observe/collectors/DeviceStateCollector.test.ts
+++ b/test/features/observe/collectors/DeviceStateCollector.test.ts
@@ -146,5 +146,30 @@ describe("DeviceStateCollector", () => {
         layoutSeqSum: 1,
       });
     });
+
+    test("forces a fresh window read so a stale cached record cannot be published across a navigation (#6070)", async () => {
+      // A frozen memory/disk cache record (empty activityName + stale
+      // layoutSeqSum) must not win over the device's current window state.
+      fakeWindow.configureCachedActiveWindow({
+        appId: "com.android.settings",
+        activityName: "",
+        layoutSeqSum: 3478,
+      });
+      fakeWindow.configureActiveWindow({
+        appId: "com.android.settings",
+        activityName: "com.android.settings.SubSettings",
+        layoutSeqSum: 5000,
+      });
+      const result = makeResult();
+
+      await collector.collectActiveWindow(result);
+
+      expect(fakeWindow.getGetActiveForceRefreshes()).toEqual([true]);
+      expect(result.activeWindow).toEqual({
+        appId: "com.android.settings",
+        activityName: "com.android.settings.SubSettings",
+        layoutSeqSum: 5000,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the **deterministic** half of [#6070](https://github.com/kaeawc/auto-mobile/issues/6070) (residual of [#5992](https://github.com/kaeawc/auto-mobile/issues/5992)): on the observe bootstrap path, a frozen `Window.getActive()` cache could publish `activeWindow` with an empty `activityName` and a stale `layoutSeqSum` (e.g. `3478`) across a genuine navigation, while `backStack.currentActivity` and adb ground truth agreed. `backStack` is adb-sourced and never drifts, so when `activeWindow` disagrees it is the value that is wrong.

Scoped strictly to the frozen-cache / empty-as-unknown case. The notification-shade / `systemOverlay` half is a deliberate separate follow-up ([#6078](https://github.com/kaeawc/auto-mobile/issues/6078)); the `com.android.systemui` bail in `reconcileActiveWindowAttribution` is intentionally left untouched.

## Changes

**1. Force-refresh the bootstrap window read** (`src/features/observe/collectors/DeviceStateCollector.ts`) — the substantive fix.

The `Window` memory/disk cache has no expiry, so a non-forced `getActive()` read can serve a frozen record — an empty `activityName` with a stale `layoutSeqSum` — across a real navigation, which the observe layer then publishes. `collectActiveWindow` now calls `getActive(true)`. This path runs only during the lazy-CtrlProxy bootstrap interval (rare; once CtrlProxy supplies the hierarchy package it is not hit at all), so the extra `dumpsys` is cheap and the stale cache can no longer win over current window state.

**2. Defensive documentation on the empty-name reconcile** (`src/features/observe/ObserveScreen.ts`) — comment-only vs `main`.

An empty `activeWindow.activityName` is already reconciled from the adb-sourced `backStack` through the **existing temporal confirmation** (`recaptureHierarchyForBackStackAttribution`, [#5992](https://github.com/kaeawc/auto-mobile/issues/5992)): the recapture re-reads the hierarchy so the adb activity is paired with a *fresh* tree, never blindly stamped onto the earlier capture. A comment now documents that the empty case must **not** be "optimized" into a blind backfill — doing so reintroduces a same-app A→B temporal-skew hole (assigning the later activity onto the earlier hierarchy and reporting `verified: true`). No logic change: this file is comment-only vs `main`.

**Not done, deliberately:** an earlier revision reset the reconciled window's `layoutSeqSum` to the `0` sentinel. That was dropped — it made `TapOnElement.compareActiveWindow` treat a same-activity content change as `unchanged` (the observation diff embeds the full `activeWindow`, and `0 == 0` masks a real change). The correlated sequence is preserved; its freshness is guaranteed by the `getActive(true)` read.

## Testing

Fixture-driven, no hardware; new tests run in < 1 ms each.

- `test/features/observe/collectors/DeviceStateCollector.test.ts` — a stale cached record (empty name, `layoutSeqSum: 3478`) does **not** win: `collectActiveWindow` force-refreshes and publishes the device's current window. Red on `origin/main` (served the stale cache with `forceRefresh: false`), green with the fix.
- `test/features/observe/ObserveScreenWindowIdentity.test.ts` — two regression guards on the reconcile:
  - empty `activityName` + a temporally-confirmed in-package `backStack` → backfilled, correlated `layoutSeqSum` **preserved** (not the `0` sentinel).
  - a later same-app `backStack` activity (B) is **not** stamped onto an earlier hierarchy (A) when a recapture cannot confirm it → the name resolves to unknown (`""`) and the divergence is surfaced as a mismatch (`verified: false`), never a confidently-wrong value. (Red against a blind-backfill implementation; guards [#5992](https://github.com/kaeawc/auto-mobile/issues/5992)/[#6088](https://github.com/kaeawc/auto-mobile/issues/6088)'s skew class.)

**Invariants preserved (regression-checked):** the `#5867` window-identity mismatch, `#5981` status-bar-only retraction, `#6048` launch-refusal behavior, the `#5992` non-empty recapture path, and the `com.android.systemui` shade bail ([#6078](https://github.com/kaeawc/auto-mobile/issues/6078) territory). Full `test/features/observe/**` (incl. `output/diffObserveResult.test.ts`, which consumes `activeWindow` via `effect.basis`) and `test/features/action/**` pass with **no golden/diff churn**. `bun run build`, `bun run lint` (no new ratchet violations), `bun run typecheck` (no new baseline errors), and `bun run format:check` are green.

## Scope of the fix

- **Fixes the deterministic frozen-cache symptom** of [#6070](https://github.com/kaeawc/auto-mobile/issues/6070): a stale `Window.getActive()` record (empty `activityName` + frozen `layoutSeqSum`) can no longer be served across a navigation.
- **The genuinely-intermittent API-35 timing residue** (daemon/session-state dependent) needs a **manual-test hardware pass** to confirm — it is not unit-reproducible.
- **A narrow same-app A→B attribution skew on the bootstrap path** is tracked as follow-up [#6088](https://github.com/kaeawc/auto-mobile/issues/6088): it pre-exists on `origin/main` (cache-miss path), and force-refresh widens its frequency slightly; the deterministic frozen-cache fix outweighs it.

Closes #6070 (the reproducible defect is fixed; residue tracked as follow-ups + a manual-test confirmation).
