### PR TITLE
fix(observe): flag focused SystemUI overlay in activeWindow (#6078)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4710,6 +4710,9 @@
             },
             "type": {
               "type": "string"
+            },
+            "systemOverlay": {
+              "type": "boolean"
             }
           },
           "additionalProperties": {}
@@ -10090,6 +10093,9 @@
                     },
                     "type": {
                       "type": "string"
+                    },
+                    "systemOverlay": {
+                      "type": "boolean"
                     }
                   },
                   "additionalProperties": {}
@@ -10228,6 +10234,9 @@
                     },
                     "type": {
                       "type": "string"
+                    },
+                    "systemOverlay": {
+                      "type": "boolean"
                     }
                   },
                   "additionalProperties": {}
@@ -10312,6 +10321,9 @@
                     },
                     "type": {
                       "type": "string"
+                    },
+                    "systemOverlay": {
+                      "type": "boolean"
                     }
                   },
                   "additionalProperties": {}

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -108,6 +108,33 @@ function isSystemUiSurfaceWindow(window: ViewHierarchyWindowInfo): boolean {
 }
 
 /**
+ * Whether a SystemUI window is large enough to be an occluding surface (an
+ * expanded shade, quick settings, or keyguard) rather than the ever-present
+ * thin status bar / navigation bar. Only used to decide whether the topmost
+ * window is worth an adb `mCurrentFocus` confirmation, so a normal app screen —
+ * where the status bar can be the topmost SystemUI window when no focus flag is
+ * populated — never triggers a per-observe adb read. A window covering more than
+ * half the screen height is a shade-class surface; the status bar is a small
+ * fraction of it.
+ */
+function isOccludingSystemUiWindow(
+  window: ViewHierarchyWindowInfo,
+  screenHeight: number | undefined,
+): boolean {
+  const bounds = window.bounds;
+  if (!bounds) {
+    return false;
+  }
+  const height = bounds.bottom - bounds.top;
+  if (screenHeight && screenHeight > 0) {
+    return height > screenHeight / 2;
+  }
+  // No screen dimension to normalize against: fall back to an absolute floor
+  // that a status/navigation bar never reaches but a shade always exceeds.
+  return height > 400;
+}
+
+/**
  * Classify what the captured `windows[]` list says about a focused SystemUI
  * surface (issue #6078), the free (no-adb) primary signal:
  *
@@ -115,11 +142,12 @@ function isSystemUiSurfaceWindow(window: ViewHierarchyWindowInfo): boolean {
  *   surface. This mirrors `mCurrentFocus` directly; no adb read is needed.
  *   A focused non-SystemUI (ordinary app) window returns `none`.
  * - `topmost-suspect` — no window reports focus, but the topmost window (by
- *   `windowLayer`) is a SystemUI surface. Focus is unconfirmed on this API
- *   level, so the caller confirms with a `dumpsys window` `mCurrentFocus` read.
- * - `none` — no `windows[]`, a focused app window, or a topmost app window.
- *   The status bar always exists but is not focused and is not topmost over an
- *   expanded shade, so an ordinary app screen never lands here as a suspect.
+ *   `windowLayer`) is a large SystemUI surface (shade/quick-settings/keyguard,
+ *   not the thin status bar). Focus is unconfirmed on this API level, so the
+ *   caller confirms with a `dumpsys window` `mCurrentFocus` read.
+ * - `none` — no `windows[]`, a focused app window, or a topmost app / status-bar
+ *   window. An ordinary app screen never lands here as a suspect, so it never
+ *   pays for the adb confirmation.
  */
 function classifyFocusedSystemUiWindow(
   hierarchy: ObserveResult["viewHierarchy"],
@@ -135,7 +163,10 @@ function classifyFocusedSystemUiWindow(
   const topmost = windows.reduce((current, candidate) =>
     (candidate.windowLayer ?? 0) > (current.windowLayer ?? 0) ? candidate : current,
   );
-  return isSystemUiSurfaceWindow(topmost) ? "topmost-suspect" : "none";
+  return isSystemUiSurfaceWindow(topmost) &&
+    isOccludingSystemUiWindow(topmost, hierarchy?.screenHeight)
+    ? "topmost-suspect"
+    : "none";
 }
 
 interface PostCaptureForegroundIdentity {
@@ -1062,6 +1093,13 @@ export class RealObserveScreen implements ObserveScreen {
     result: ObserveResult,
     signal?: AbortSignal,
   ): Promise<boolean> {
+    // Android-only: `com.android.systemui`, the notification shade, and the
+    // `dumpsys window` fallback are Android concepts. iOS reuses the same
+    // `windows[]` shape, so without this guard an iOS window carrying
+    // `type === TYPE_SYSTEM` could stamp an Android package onto an iOS result.
+    if (this.device.platform !== "android") {
+      return false;
+    }
     const activeWindow = result.activeWindow;
     if (activeWindow === undefined || !(await this.detectFocusedSystemUiOverlay(result, signal))) {
       return false;

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../utils/logger";
 import { throwIfAborted } from "../../utils/toolUtils";
-import { BootedDevice, ObserveResult, ScreenIdentity } from "../../models";
+import { BootedDevice, ObserveResult, ScreenIdentity, ViewHierarchyWindowInfo } from "../../models";
 import { ViewHierarchy } from "./ViewHierarchy";
 import { Window } from "./Window";
 import { TakeScreenshot } from "./TakeScreenshot";
@@ -89,6 +89,54 @@ function boundCachedLayoutWarnings(result: ObserveResult | undefined): ObserveRe
  * misreporting an expanded shade as a stale wrong-window capture.
  */
 const SYSTEM_UI_WINDOW_PACKAGES = new Set<string>(["com.android.systemui"]);
+
+const SYSTEM_UI_PACKAGE = "com.android.systemui";
+
+/**
+ * AccessibilityWindowInfo.TYPE_SYSTEM — the window type CtrlProxy reports for
+ * framework surfaces (notification shade, quick settings, keyguard, status bar).
+ * Same constant `androidSystemUiAnr.ts` keys the ANR dialog off.
+ */
+const ACCESSIBILITY_WINDOW_TYPE_SYSTEM = 3;
+
+type FocusedSystemUiSignal = "focused" | "topmost-suspect" | "none";
+
+function isSystemUiSurfaceWindow(window: ViewHierarchyWindowInfo): boolean {
+  return (
+    window.packageName === SYSTEM_UI_PACKAGE || window.type === ACCESSIBILITY_WINDOW_TYPE_SYSTEM
+  );
+}
+
+/**
+ * Classify what the captured `windows[]` list says about a focused SystemUI
+ * surface (issue #6078), the free (no-adb) primary signal:
+ *
+ * - `focused` — a window carries `isFocused === true` and it is a SystemUI
+ *   surface. This mirrors `mCurrentFocus` directly; no adb read is needed.
+ *   A focused non-SystemUI (ordinary app) window returns `none`.
+ * - `topmost-suspect` — no window reports focus, but the topmost window (by
+ *   `windowLayer`) is a SystemUI surface. Focus is unconfirmed on this API
+ *   level, so the caller confirms with a `dumpsys window` `mCurrentFocus` read.
+ * - `none` — no `windows[]`, a focused app window, or a topmost app window.
+ *   The status bar always exists but is not focused and is not topmost over an
+ *   expanded shade, so an ordinary app screen never lands here as a suspect.
+ */
+function classifyFocusedSystemUiWindow(
+  hierarchy: ObserveResult["viewHierarchy"],
+): FocusedSystemUiSignal {
+  const windows = hierarchy?.windows;
+  if (!windows || windows.length === 0) {
+    return "none";
+  }
+  const focused = windows.find((window) => window.isFocused === true);
+  if (focused) {
+    return isSystemUiSurfaceWindow(focused) ? "focused" : "none";
+  }
+  const topmost = windows.reduce((current, candidate) =>
+    (candidate.windowLayer ?? 0) > (current.windowLayer ?? 0) ? candidate : current,
+  );
+  return isSystemUiSurfaceWindow(topmost) ? "topmost-suspect" : "none";
+}
 
 interface PostCaptureForegroundIdentity {
   sampled: boolean;
@@ -910,8 +958,20 @@ export class RealObserveScreen implements ObserveScreen {
     result: ObserveResult,
     signal?: AbortSignal,
   ): Promise<PostCaptureForegroundIdentity> {
-    const observed = result.viewHierarchy?.packageName;
     const activeWindow = result.activeWindow;
+
+    // A focused SystemUI surface (notification shade, quick settings, keyguard,
+    // status bar owning focus) occludes the app behind it while CtrlProxy's
+    // `foregroundActivity` and `adb getForegroundApp` both still name that
+    // occluded app — neither reads `mCurrentFocus`. Mirror the SystemUI identity
+    // into `activeWindow` so `waitFor.activeWindow.appId == <app>` fails closed
+    // and one object never names two apps (issue #6078). This runs before the
+    // #6070 back-stack backfill and the system-UI bail below.
+    if (await this.applyFocusedSystemUiOverlay(result, signal)) {
+      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
+    }
+
+    const observed = result.viewHierarchy?.packageName;
     if (
       observed === undefined ||
       activeWindow === undefined ||
@@ -965,6 +1025,58 @@ export class RealObserveScreen implements ObserveScreen {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
     return { sampled: true, identity: confirmed, activityAttributionMismatch: false };
+  }
+
+  /**
+   * Decide whether a focused SystemUI surface currently owns input focus
+   * (issue #6078). The free primary signal is the captured accessibility
+   * `windows[]`: a window flagged `isFocused` that is a SystemUI surface
+   * confirms the overlay with no extra device round-trip. When no window on this
+   * API level carries a focus flag but the topmost window is a SystemUI surface,
+   * focus is confirmed with a single `dumpsys window` `mCurrentFocus` read (the
+   * status bar always exists but is neither focused nor topmost over an expanded
+   * shade, so an ordinary app screen never reaches the adb read).
+   */
+  private async detectFocusedSystemUiOverlay(
+    result: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const signalKind = classifyFocusedSystemUiWindow(result.viewHierarchy);
+    if (signalKind === "focused") {
+      return true;
+    }
+    if (signalKind === "topmost-suspect") {
+      return this.deviceStateCollector.collectFocusedSystemUiSurface(signal);
+    }
+    return false;
+  }
+
+  /**
+   * Mirror the SystemUI surface identity into `activeWindow` when a SystemUI
+   * surface owns focus (issue #6078). Returns `true` when the overlay was
+   * detected and applied — the caller then short-circuits the rest of
+   * attribution. A no-op (returns `false`) when there is no `activeWindow` to
+   * annotate or no focused SystemUI surface.
+   */
+  private async applyFocusedSystemUiOverlay(
+    result: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const activeWindow = result.activeWindow;
+    if (activeWindow === undefined || !(await this.detectFocusedSystemUiOverlay(result, signal))) {
+      return false;
+    }
+    const overlay = {
+      ...activeWindow,
+      appId: SYSTEM_UI_PACKAGE,
+      activityName: "",
+      systemOverlay: true,
+    };
+    // The occluded-app `type` (e.g. a notification-permission dialog) does not
+    // describe the shade that is now on top; drop it while the overlay is up.
+    delete overlay.type;
+    result.activeWindow = overlay;
+    return true;
   }
 
   private async recaptureHierarchyForBackStackAttribution(

--- a/src/features/observe/Window.ts
+++ b/src/features/observe/Window.ts
@@ -407,3 +407,37 @@ export function parseDumpsysWindowFocus(
 
   return null;
 }
+
+/**
+ * SystemUI focus-window names that carry no `package/activity` — they are
+ * windows, not ActivityRecords, so `mCurrentFocus` reports a bare token
+ * (`mCurrentFocus=Window{... u0 NotificationShade}`). Used to recognize when a
+ * SystemUI surface owns input focus from a raw `dumpsys window` read, the
+ * ground-truth fallback for issue #6078 when the accessibility windows[] list
+ * does not carry a focused-window flag on a given API level.
+ */
+const SYSTEM_UI_FOCUS_WINDOW_NAMES = new Set<string>([
+  "NotificationShade",
+  "StatusBar",
+  "QuickSettings",
+  "ShadeWindow",
+  "NavigationBar",
+  "Keyguard",
+  "KeyguardScrim",
+]);
+
+/**
+ * True when `dumpsys window` reports a package-less SystemUI surface owning
+ * input focus (`mCurrentFocus=Window{... <Name>}` with a bare token). Matches
+ * the AOSP focus-window names (shade, quick settings, keyguard, status bar) plus
+ * any `*Keyguard*` variant, case-insensitively. Returns false for an ordinary
+ * `package/activity` focus (an app owns focus, shade collapsed).
+ */
+export function isFocusedSystemUiSurface(stdout: string): boolean {
+  const match = stdout.match(/mCurrentFocus=Window\{[^}]*?\s+u\d+\s+([^\s}]+)\}/);
+  const token = match?.[1];
+  if (!token || token.includes("/")) {
+    return false;
+  }
+  return SYSTEM_UI_FOCUS_WINDOW_NAMES.has(token) || /keyguard/i.test(token);
+}

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -1,6 +1,7 @@
 import { logger } from "../../../utils/logger";
 import { NoOpPerformanceTracker, PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { appendObserveError } from "../ObserveError";
+import { isFocusedSystemUiSurface } from "../Window";
 import type { BootedDevice, ObserveResult } from "../../../models";
 import type { Window } from "../interfaces/Window";
 import type { BackStack } from "../interfaces/BackStack";
@@ -90,6 +91,35 @@ export class DeviceStateCollector {
       // the observation, only skip the comparison.
       logger.debug("Failed to get ground-truth foreground app:", error);
       return undefined;
+    }
+  }
+
+  /**
+   * Ground-truth check for a focused SystemUI surface (issue #6078). Reads
+   * `dumpsys window` and reports whether `mCurrentFocus` is a package-less
+   * SystemUI window (notification shade, quick settings, keyguard, status bar
+   * owning focus) — the one signal that `getForegroundApp` (resumed activity)
+   * and the accessibility `foregroundActivity` both miss. Best-effort: a failed
+   * read returns `false` (treat as "no overlay"), never fails the observation.
+   * Only invoked on the overlay-suspicion path, so it adds no cost to an
+   * ordinary app-foreground observe.
+   */
+  async collectFocusedSystemUiSurface(signal?: AbortSignal): Promise<boolean> {
+    const { adb } = this.opts;
+    try {
+      const { stdout } = await adb.executeCommand(
+        `shell "dumpsys window"`,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
+      return isFocusedSystemUiSurface(stdout);
+    } catch (error) {
+      // Connection/read failure must not fail observe; absence of the signal is
+      // treated as "no overlay" so attribution falls back to the normal path.
+      logger.debug("Failed to read focused window surface from dumpsys:", error);
+      return false;
     }
   }
 

--- a/src/models/ActiveWindowInfo.ts
+++ b/src/models/ActiveWindowInfo.ts
@@ -7,4 +7,12 @@ export interface ActiveWindowInfo {
   layoutSeqSum: number;
   /** Optional classification for system dialogs or non-app surfaces */
   type?: string;
+  /**
+   * True when a focused SystemUI surface (notification shade, quick settings,
+   * status bar owning focus, keyguard) is on top and owns input focus. In that
+   * state `appId` mirrors the SystemUI surface (`com.android.systemui`) rather
+   * than the app occluded behind it, so `waitFor.activeWindow.appId == <app>`
+   * fails closed instead of matching an occluded app (issue #6078).
+   */
+  systemOverlay?: boolean;
 }

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -114,6 +114,10 @@ export const activeWindowSchema = z
     activityName: z.string().optional(),
     layoutSeqSum: z.number().int().optional(),
     type: z.string().optional(),
+    // True when a focused SystemUI surface (notification shade, quick settings,
+    // keyguard) owns focus; `appId` then mirrors com.android.systemui so
+    // `waitFor.activeWindow.appId` fails closed for the occluded app (#6078).
+    systemOverlay: z.boolean().optional(),
   })
   .passthrough();
 

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1172,6 +1172,89 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
   });
 
+  test("a thin status-bar SystemUI window with no focus flags does not trigger an adb read", async () => {
+    // Perf guard: when no window carries isFocused, the ever-present status bar
+    // (SystemUI, high layer, but thin) must NOT be treated as an occluding
+    // overlay — otherwise every observe on that API level pays a dumpsys read.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const thinStatusBar = {
+      packageName: "com.android.systemui",
+      type: 3,
+      isFocused: undefined,
+      windowLayer: 300,
+      bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+    };
+    const appWindow = { ...occludedAppWindow(false), isFocused: undefined };
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(shadeHierarchy(now, [thinStatusBar, appWindow]));
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
+  });
+
+  test("iOS: a focused TYPE_SYSTEM window never stamps an Android systemui appId", async () => {
+    // iOS reuses the ViewHierarchyWindowInfo shape. The overlay branch is an
+    // Android concept and must be platform-gated so it cannot mirror
+    // com.android.systemui onto an iOS observation.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const iosDevice: BootedDevice = {
+      deviceId: "SIM-1",
+      name: "iPhone 15",
+      platform: "ios",
+    };
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 393,
+      screenHeight: 852,
+      packageName: "com.example.iosapp",
+      windows: [{ packageName: "com.example.iosapp", type: 3, isFocused: true, windowLayer: 200 }],
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 393, bottom: 852 },
+          node: [{ text: "Home" }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    const screen = new RealObserveScreen(
+      iosDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.example.iosapp");
+    expect(result.activeWindow?.appId).not.toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+  });
+
   test("a present-but-unfocused status bar does not mirror when the app owns focus", async () => {
     // The status bar (SystemUI, type 3) is always present. It must never be
     // mistaken for a focus-owning overlay when an app window is focused.

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -935,3 +935,264 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(viewHierarchy.getCallCount()).toBe(2);
   });
 });
+
+/**
+ * Issue #6078: while the notification shade (or another focused SystemUI
+ * surface) is open, `observe` returns the shade's hierarchy but composes
+ * `activeWindow` from the accessibility `foregroundActivity` / `getForegroundApp`
+ * — both of which name the app occluded *behind* the shade, never the focused
+ * surface. `waitFor.activeWindow.appId == <occluded app>` therefore
+ * false-positives while the shade fully covers the app, and on API 29 the single
+ * object even names two different apps.
+ *
+ * The fix reconciles against the focused window: when a SystemUI surface owns
+ * focus, `activeWindow.appId` mirrors `com.android.systemui`, `activityName` is
+ * cleared, and `systemOverlay: true` is set so callers can fail closed.
+ */
+describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () => {
+  afterEach(() => {
+    resetObserveCacheStore();
+  });
+
+  const OCCLUDED_APP = "com.google.android.settings.intelligence";
+  const OCCLUDED_ACTIVITY = `${OCCLUDED_APP}/${OCCLUDED_APP}.modules.search.SearchActivity`;
+
+  /**
+   * A full-screen expanded-shade capture: the returned hierarchy is the shade's
+   * (quick-settings tiles), while CtrlProxy still reports the occluded app in
+   * `foregroundActivity` and `packageName` — the exact incoherence #6078 hits on
+   * API 31/34/35. `windows` describes what the accessibility window list carries.
+   */
+  function shadeHierarchy(
+    now: number,
+    windows: any[],
+    overrides: { packageName?: string; foregroundActivity?: string } = {},
+  ): any {
+    return {
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: overrides.packageName ?? OCCLUDED_APP,
+      foregroundActivity: overrides.foregroundActivity ?? OCCLUDED_ACTIVITY,
+      windows,
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [
+            { text: "Silent", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+            { text: "Clear all", bounds: { left: 0, top: 200, right: 200, bottom: 260 } },
+          ],
+        },
+      },
+    };
+  }
+
+  const focusedShadeWindow = () => ({
+    packageName: "com.android.systemui",
+    type: 3,
+    isFocused: true,
+    windowLayer: 200,
+    bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+  });
+
+  const occludedAppWindow = (isFocused: boolean) => ({
+    packageName: OCCLUDED_APP,
+    type: 1,
+    isFocused,
+    windowLayer: 10,
+    bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+  });
+
+  // The status bar always exists as a SystemUI window but does not own focus
+  // when the shade is collapsed — the reviewer edge the fix must not mis-mirror.
+  const statusBarWindow = () => ({
+    packageName: "com.android.systemui",
+    type: 3,
+    isFocused: false,
+    windowLayer: 150,
+    bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+  });
+
+  function makeOverlayScreen(
+    viewHierarchy: FakeViewHierarchy,
+    fakeAdb: FakeAdbExecutor,
+    timer: FakeTimer,
+  ): RealObserveScreen {
+    return new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+  }
+
+  for (const api of [31, 34, 35]) {
+    test(`API ${api}: focused shade window mirrors com.android.systemui and sets systemOverlay`, async () => {
+      const now = 1_700_000_000_000;
+      const timer = new FakeTimer();
+      timer.setCurrentTime(now);
+
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy(
+        shadeHierarchy(now, [focusedShadeWindow(), occludedAppWindow(false)]),
+      );
+
+      const fakeAdb = new FakeAdbExecutor();
+      // dumpsys resumed/focused activity still names the occluded app.
+      fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+      const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+      const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+      // waitFor.activeWindow.appId == <occluded app> must fail closed.
+      expect(result.activeWindow?.appId).toBe("com.android.systemui");
+      expect(result.activeWindow?.appId).not.toBe(OCCLUDED_APP);
+      expect(result.activeWindow?.systemOverlay).toBe(true);
+      expect(result.activeWindow?.activityName).toBe("");
+      // The shade capture is genuine — freshness stays verified.
+      expect(result.freshness?.verified).toBe(true);
+      expect(result.freshness?.isFresh).toBe(true);
+    });
+  }
+
+  test("API 29: single activeWindow no longer names two different apps", async () => {
+    // On API 29 CtrlProxy reports foregroundActivity with the systemui package
+    // but the resumed activity behind it, so appId=systemui while activityName
+    // names Settings — one object, two apps.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(
+      shadeHierarchy(now, [focusedShadeWindow(), occludedAppWindow(false)], {
+        packageName: "com.android.systemui",
+        foregroundActivity:
+          "com.android.systemui/com.android.settings.homepage.SettingsHomepageActivity",
+      }),
+    );
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+    // Must NOT publish the occluded app's activity — no two-app object.
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.activeWindow?.activityName).not.toContain("com.android.settings");
+  });
+
+  test("adb mCurrentFocus fallback confirms overlay when windows[] carries no focus flag", async () => {
+    // Some API levels do not populate isFocused on the accessibility window list.
+    // The topmost window is SystemUI, so a dumpsys window read confirms the shade
+    // owns focus.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+    );
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: "  mCurrentFocus=Window{8ddaeb2 u0 NotificationShade}\n",
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+    expect(result.activeWindow?.activityName).toBe("");
+  });
+
+  test("adb fallback: a package/activity mCurrentFocus (shade collapsed) is NOT an overlay", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+    );
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: `  mCurrentFocus=Window{1a2b3c u0 ${OCCLUDED_ACTIVITY}}\n`,
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    // The app owns focus — normal attribution, no overlay flag.
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+  });
+
+  test("shade closed: a focused app window keeps normal attribution and no overlay flag", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(
+      shadeHierarchy(now, [occludedAppWindow(true), statusBarWindow()]),
+    );
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    // A focused app window must not trigger the adb ground-truth read.
+    expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
+  });
+
+  test("a present-but-unfocused status bar does not mirror when the app owns focus", async () => {
+    // The status bar (SystemUI, type 3) is always present. It must never be
+    // mistaken for a focus-owning overlay when an app window is focused.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(
+      // Status bar has the higher layer but the app window carries focus.
+      shadeHierarchy(now, [statusBarWindow(), occludedAppWindow(true)]),
+    );
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
+  });
+});

--- a/test/features/observe/Window.test.ts
+++ b/test/features/observe/Window.test.ts
@@ -4,6 +4,7 @@ import {
   parseActiveWindowModern,
   parseActiveWindowLegacy,
   parseDumpsysWindowFocus,
+  isFocusedSystemUiSurface,
 } from "../../../src/features/observe/Window";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
@@ -946,6 +947,38 @@ describe("Window", () => {
         appId: "com.example.app",
         activityName: "com.example.app.SomeActivity",
       });
+    });
+  });
+
+  // Issue #6078: recognize a package-less SystemUI focus window (the shade owns
+  // focus while the app behind it is only the resumed activity).
+  describe("isFocusedSystemUiSurface", () => {
+    test("true for a NotificationShade focus window", () => {
+      expect(isFocusedSystemUiSurface("mCurrentFocus=Window{8ddaeb2 u0 NotificationShade}")).toBe(
+        true,
+      );
+    });
+
+    test("true for StatusBar, QuickSettings, and keyguard variants", () => {
+      expect(isFocusedSystemUiSurface("mCurrentFocus=Window{1 u0 StatusBar}")).toBe(true);
+      expect(isFocusedSystemUiSurface("mCurrentFocus=Window{2 u0 QuickSettings}")).toBe(true);
+      expect(isFocusedSystemUiSurface("mCurrentFocus=Window{3 u0 Keyguard}")).toBe(true);
+      expect(
+        isFocusedSystemUiSurface("mCurrentFocus=Window{4 u0 StatusBarKeyguardViewManager}"),
+      ).toBe(true);
+    });
+
+    test("false when an app package/activity owns focus (shade collapsed)", () => {
+      expect(
+        isFocusedSystemUiSurface(
+          "mCurrentFocus=Window{41e2a458 u0 com.example.app/com.example.app.SomeActivity}",
+        ),
+      ).toBe(false);
+    });
+
+    test("false for empty output or no mCurrentFocus", () => {
+      expect(isFocusedSystemUiSurface("")).toBe(false);
+      expect(isFocusedSystemUiSurface("mFocusedApp=AppWindowToken{...}")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

While the Android notification shade is open, `observe` returns the **shade's**
hierarchy but composes `activeWindow` from the accessibility `foregroundActivity`
/ `getForegroundApp` — both of which name the app occluded *behind* the shade,
never the focused surface. `mCurrentFocus` (adb ground truth) is a package-less
`NotificationShade`. So `waitFor.activeWindow.appId == <occluded app>`
false-positives while the shade fully covers the app (the next `tapOn` then hits
shade rows), and on API 29 a single `activeWindow` even names two different apps
(`appId=com.android.systemui`, `activityName=` the resumed activity behind it).

This reconciles `activeWindow` against the focused window: when a SystemUI
surface owns focus, `appId` mirrors `com.android.systemui`, `activityName` is
cleared, and a new **`systemOverlay: true`** flag is set. `waitFor.activeWindow`
now **fails closed** for the occluded app, one object never names two apps, and
opening/closing the shade becomes a real `appId` transition so the observe diff
reports it as an effect. `systemTray` gains an explicit "shade is up" signal.

This is the **read half** of the same field pair as #6070 (the empty/stale half,
merged in #6087) and the inverse of #5981.

## Linked Issue

Closes #6078

## Bug / Regression Context

- **Prior attempts:** #6070 / #6087 fixed the empty/stale `activityName` half of
  the same field pair; this PR fixes the shade-occlusion attribution half.
- **Observed symptom:** shade open, `mCurrentFocus=NotificationShade`, but
  `activeWindow` names the occluded app (API 31/34/35), or names two different
  apps in one object (API 29).
- **Repro:** `adb shell cmd statusbar expand-notifications`, then
  `getAndroid` -> `observe` over one MCP session.

## How it works

- **Primary signal (free, no adb):** the captured accessibility `windows[]`.
  A window flagged `isFocused` that is a SystemUI surface
  (`com.android.systemui` or `TYPE_SYSTEM` = 3) mirrors `mCurrentFocus` directly.
  Reuses the topmost/type pattern already in `src/utils/androidSystemUiAnr.ts`.
- **Fallback (ground truth, one adb read):** when no window on a given API level
  carries a focus flag but the topmost window *is* a SystemUI surface, a single
  `dumpsys window` `mCurrentFocus` read confirms focus. New
  `isFocusedSystemUiSurface` parser recognizes package-less shade / quick-settings
  / keyguard / status-bar-owning-focus tokens.
- The status bar always exists as a SystemUI window but is never focused nor
  topmost over an expanded shade, so an ordinary app screen never reaches the adb
  read and is never mis-mirrored (the reviewer edge from the #6070 review).

Which focused-window signal (`windows[].isFocused` vs the adb `mCurrentFocus`
fallback) is populated per API level (29/31/34/35, shade open) is what a
manual-test hardware pass will confirm; the logic ships and is covered TS-side.

## Changes

- `systemOverlay?: boolean` added to `ActiveWindowInfo` and `activeWindowSchema`
  (a `.passthrough()` output schema; additive and validation-safe), tool
  definitions regenerated via `scripts/update-tool-definitions.sh`.
- `reconcileActiveWindowAttribution` gains a focused-SystemUI overlay branch that
  precedes the #6070 back-stack backfill and the existing systemui bail.
- New `isFocusedSystemUiSurface` in `Window.ts`; new
  `DeviceStateCollector.collectFocusedSystemUiSurface` (best-effort adb read).
- Invariants preserved: #5867 window-identity mismatch, #5981 status-bar-only
  retraction (overlay keys off *focus*, not systemui *presence*), #6070 backfill.
  Helps #6048 by failing closed on shade-open.

## Validation

- [x] `bun run lint` — clean, no new oxlint ratchet violations
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bunx turbo run build` — green
- [x] Full `bun test` green except one pre-existing, unrelated failure in
      `test/integration/webrtcDeviceCaptureLoad.integration.test.ts` (a bun-1.3.14
      skip-label output-format mismatch; fails identically on the base with these
      changes stashed)
- [x] `bun run format:check` — clean
- [x] Full observe + diff suites (`test/features/observe/**`,
      `output/diffObserveResult.test.ts`) green with no golden/snapshot churn

## Device Verification

- [ ] Pending manual-test hardware pass (API 29/31/34/35, shade open) to confirm
      which focused-window signal is populated per level. Fixture-driven unit
      tests cover the logic in the meantime.

## Test coverage

- Per-API-level matrix (29/31/34/35): occluded app in `foregroundActivity` /
  `getForegroundApp` + focused `windows[]` systemui entry ->
  `activeWindow.appId === "com.android.systemui"`, `systemOverlay === true`,
  `activityName === ""`, and a `waitFor` for the occluded app would fail.
- API 29 two-app case -> the single `activeWindow` no longer names two apps.
- adb `mCurrentFocus` fallback: positive (`NotificationShade`) and negative
  (`package/activity` focus, shade collapsed).
- Shade-closed (focused app window) -> `systemOverlay` absent, no adb read.
- Present-but-unfocused status bar -> no mirror, no adb read.
- `isFocusedSystemUiSurface` parser unit tests.

## Follow-ups

- [ ] Manual-test hardware confirmation of the per-API focused-window signal.
