### PR TITLE
fix(recovery): redact secret plan parameters before AI recovery reaches the LLM (#6029)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -184,18 +184,18 @@ internal object AutoMobilePlanExecutor {
         )
       }
 
-      // Read the RAW plan once. Parse the declared secret keys from the raw (pre-substitution)
-      // text:
-      // a substituted value containing YAML-breaking characters could make the substituted content
-      // unparseable and silently drop the declared keys, defeating redaction (#6029). Key NAMES are
-      // literals unaffected by substitution, so the raw plan is the safe source.
+      // Read the RAW plan once. Derive the effective secret keys and the concrete strings to scrub
+      // from THIS executor's own substitution — the single source of truth for what actually landed
+      // in
+      // the plan (#6029). Key names come from the RAW plan (placeholder-tolerant, immune to
+      // substitution truncation) plus the caller config, with any `${...}` in the names resolved.
       val rawPlanContent = File(resolvedPlanPath).readText()
       val secretKeys =
-        SecretRedactor.resolveKeyNames(
-          options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(rawPlanContent),
-          parameters,
-        )
-      val secretValues = SecretRedactor.secretValues(secretKeys, parameters)
+        (options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(rawPlanContent))
+          .map { substituteParameters(it, parameters) }
+          .toSet()
+      val secretValues =
+        SecretRedactor.secretValues(resolveSecretConcreteValues(secretKeys, parameters))
 
       // Load and process the plan with parameter substitution
       val processedPlanContent = loadAndProcessPlan(rawPlanContent, parameters)
@@ -203,7 +203,12 @@ internal object AutoMobilePlanExecutor {
       if (options.debugMode) {
         println("Executing AutoMobile plan: $planPath")
         println("Parameters: ${SecretRedactor.redactParameters(parameters, secretKeys)}")
-        println("Processed plan content:\n$processedPlanContent")
+        // Redact substituted secret values out of the plan-content debug print too (#6029) —
+        // otherwise
+        // debugMode leaks them to logcat even though the LLM path is masked.
+        println(
+          "Processed plan content:\n${SecretRedactor.redact(processedPlanContent, secretValues)}"
+        )
       }
 
       // Execute the processed plan
@@ -253,15 +258,7 @@ internal object AutoMobilePlanExecutor {
   }
 
   private fun loadAndProcessPlan(planContent: String, parameters: Map<String, Any>): String {
-    // Perform parameter substitution using template syntax ${parameter_name}
-    var processedContent = planContent
-    if (parameters.isNotEmpty()) {
-      parameters.forEach { (key, value) ->
-        val placeholder = "\${$key}"
-        processedContent =
-          processedContent.replace(placeholder, SecretRedactor.parameterStringValue(value))
-      }
-    }
+    val processedContent = substituteParameters(planContent, parameters)
 
     // Validate YAML schema after parameter substitution
     val validationResult = PlanSchemaValidator.validateYaml(processedContent)
@@ -279,6 +276,49 @@ internal object AutoMobilePlanExecutor {
     }
 
     return processedContent
+  }
+
+  /**
+   * Substitute `${key}` placeholders with parameter values in a single ordered pass. Deterministic
+   * (sorted) key order so the result is reproducible — the redaction path re-runs this same
+   * function to derive exactly what landed (#6029), and a hash-ordered pass would make that mapping
+   * (and the daemon payload) non-reproducible. Kept in sync with the iOS executor's sorted
+   * substitution.
+   */
+  private fun substituteParameters(content: String, parameters: Map<String, Any>): String {
+    if (parameters.isEmpty()) return content
+    var result = content
+    for ((key, value) in parameters.entries.sortedBy { it.key }) {
+      result = result.replace("\${$key}", SecretRedactor.parameterStringValue(value))
+    }
+    return result
+  }
+
+  /**
+   * The concrete secret strings to scrub, derived entirely from THIS executor's substitution so
+   * they always equal what landed in the recovery context (#6029). For each secret key: its raw
+   * parameter value and its actual substituted value (`substituteParameters` applied to the bare
+   * `${key}`, matching the ordered single pass exactly — no independent fixpoint, so a
+   * self-referential value cannot blow up). Blank/unchanged results are dropped.
+   */
+  private fun resolveSecretConcreteValues(
+    secretKeys: Set<String>,
+    parameters: Map<String, Any>,
+  ): List<String> {
+    if (secretKeys.isEmpty()) return emptyList()
+    val values = mutableListOf<String>()
+    for (key in secretKeys) {
+      parameters[key]
+        ?.let { SecretRedactor.parameterStringValue(it) }
+        ?.takeIf { it.isNotEmpty() }
+        ?.let {
+          values.add(it)
+        }
+      val placeholder = "\${$key}"
+      val landed = substituteParameters(placeholder, parameters)
+      if (landed != placeholder && landed.isNotEmpty()) values.add(landed)
+    }
+    return values
   }
 
   // ── Plan execution with recovery ──────────────────────────────────────────

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -191,7 +191,10 @@ internal object AutoMobilePlanExecutor {
       // literals unaffected by substitution, so the raw plan is the safe source.
       val rawPlanContent = File(resolvedPlanPath).readText()
       val secretKeys =
-        options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(rawPlanContent)
+        SecretRedactor.resolveKeyNames(
+          options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(rawPlanContent),
+          parameters,
+        )
       val secretValues = SecretRedactor.secretValues(secretKeys, parameters)
 
       // Load and process the plan with parameter substitution
@@ -579,19 +582,23 @@ internal object AutoMobilePlanExecutor {
             stepObj["toolName"]?.jsonPrimitive?.content
               ?: stepObj["tool"]?.jsonPrimitive?.content
               ?: "unknown"
-          succeededSteps.add(SucceededStepSummary(stepIndex = index, tool = tool))
+          // A step's tool can be a substituted `${secret}` value, so scrub the name too (#6029).
+          succeededSteps.add(
+            SucceededStepSummary(
+              stepIndex = index,
+              tool = SecretRedactor.redact(tool, secretValues),
+            )
+          )
         }
       }
 
-      // Egress boundary (issue #6029): FailedStepContext.planContent and error are embedded
-      // verbatim
-      // into the recovery prompt sent to the LLM provider (see AutoMobileAgent.attemptAiRecovery),
-      // so
-      // mask secret values out of both here. The daemon's base64 payload above kept the real
-      // values.
+      // Egress boundary (issue #6029): FailedStepContext.planContent, error, and the (possibly
+      // substituted) tool names are embedded verbatim into the recovery prompt sent to the LLM
+      // provider (see AutoMobileAgent.attemptAiRecovery), so mask secret values out of them here.
+      // The daemon's base64 payload above kept the real values.
       return FailedStepContext(
         failedStepIndex = failedStepIndex,
-        failedTool = failedTool,
+        failedTool = SecretRedactor.redact(failedTool, secretValues),
         error = SecretRedactor.redact(error, secretValues),
         succeededSteps = succeededSteps,
         planContent = SecretRedactor.redact(planContent, secretValues),

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -184,19 +184,22 @@ internal object AutoMobilePlanExecutor {
         )
       }
 
-      // Load and process the plan with parameter substitution
-      val processedPlanContent = loadAndProcessPlan(resolvedPlanPath, parameters)
-
-      // Values to redact from any recovery context that leaves the process for the LLM provider
-      // (issue #6029). Union the plan-declared secret keys with the caller-configured ones. The
-      // processedPlanContent below keeps the real values — the daemon needs them to run the plan.
+      // Read the RAW plan once. Parse the declared secret keys from the raw (pre-substitution)
+      // text:
+      // a substituted value containing YAML-breaking characters could make the substituted content
+      // unparseable and silently drop the declared keys, defeating redaction (#6029). Key NAMES are
+      // literals unaffected by substitution, so the raw plan is the safe source.
+      val rawPlanContent = File(resolvedPlanPath).readText()
       val secretKeys =
-        options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(processedPlanContent)
+        options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(rawPlanContent)
       val secretValues = SecretRedactor.secretValues(secretKeys, parameters)
+
+      // Load and process the plan with parameter substitution
+      val processedPlanContent = loadAndProcessPlan(rawPlanContent, parameters)
 
       if (options.debugMode) {
         println("Executing AutoMobile plan: $planPath")
-        println("Parameters: $parameters")
+        println("Parameters: ${SecretRedactor.redactParameters(parameters, secretKeys)}")
         println("Processed plan content:\n$processedPlanContent")
       }
 
@@ -246,9 +249,7 @@ internal object AutoMobilePlanExecutor {
     throw IllegalArgumentException("YAML plan not found: $planPath")
   }
 
-  private fun loadAndProcessPlan(planPath: String, parameters: Map<String, Any>): String {
-    val planContent = File(planPath).readText()
-
+  private fun loadAndProcessPlan(planContent: String, parameters: Map<String, Any>): String {
     // Perform parameter substitution using template syntax ${parameter_name}
     var processedContent = planContent
     if (parameters.isNotEmpty()) {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -187,6 +187,13 @@ internal object AutoMobilePlanExecutor {
       // Load and process the plan with parameter substitution
       val processedPlanContent = loadAndProcessPlan(resolvedPlanPath, parameters)
 
+      // Values to redact from any recovery context that leaves the process for the LLM provider
+      // (issue #6029). Union the plan-declared secret keys with the caller-configured ones. The
+      // processedPlanContent below keeps the real values — the daemon needs them to run the plan.
+      val secretKeys =
+        options.secretParameterKeys + SecretRedactor.parsePlanSecretKeys(processedPlanContent)
+      val secretValues = SecretRedactor.secretValues(secretKeys, parameters)
+
       if (options.debugMode) {
         println("Executing AutoMobile plan: $planPath")
         println("Parameters: $parameters")
@@ -194,7 +201,7 @@ internal object AutoMobilePlanExecutor {
       }
 
       // Execute the processed plan
-      val result = executeProcessedPlan(processedPlanContent, options)
+      val result = executeProcessedPlan(processedPlanContent, options, secretValues)
 
       val executionTime = System.currentTimeMillis() - startTime
 
@@ -247,13 +254,8 @@ internal object AutoMobilePlanExecutor {
     if (parameters.isNotEmpty()) {
       parameters.forEach { (key, value) ->
         val placeholder = "\${$key}"
-        val stringValue =
-          when (value) {
-            is String -> value
-            is Enum<*> -> value.name
-            else -> value.toString()
-          }
-        processedContent = processedContent.replace(placeholder, stringValue)
+        processedContent =
+          processedContent.replace(placeholder, SecretRedactor.parameterStringValue(value))
       }
     }
 
@@ -280,12 +282,14 @@ internal object AutoMobilePlanExecutor {
   private fun executeProcessedPlan(
     planContent: String,
     options: AutoMobilePlanExecutionOptions,
+    secretValues: List<String>,
   ): InternalExecutionResult {
     return executePlanFromStep(
       planContent,
       options,
       startStep = 0,
       recoveryAlreadyAttempted = false,
+      secretValues = secretValues,
     )
   }
 
@@ -305,6 +309,7 @@ internal object AutoMobilePlanExecutor {
     options: AutoMobilePlanExecutionOptions,
     startStep: Int,
     recoveryAlreadyAttempted: Boolean,
+    secretValues: List<String>,
     deviceIdOverride: String? = null,
   ): InternalExecutionResult {
 
@@ -423,7 +428,8 @@ internal object AutoMobilePlanExecutor {
     }
 
     // Non-transient failure or retries exhausted — attempt recovery if allowed
-    val failedStepContext = buildFailedStepContext(response, json, planContent, options.device)
+    val failedStepContext =
+      buildFailedStepContext(response, json, planContent, options.device, secretValues)
     return handleFailure(
       result = CommandResult(1, outputPayload, response.error ?: parsed.errorMessage),
       options = options,
@@ -431,6 +437,7 @@ internal object AutoMobilePlanExecutor {
       failedStepContext = failedStepContext,
       planContent = planContent,
       recoveryAlreadyAttempted = recoveryAlreadyAttempted,
+      secretValues = secretValues,
     )
   }
 
@@ -443,6 +450,7 @@ internal object AutoMobilePlanExecutor {
     failedStepContext: FailedStepContext?,
     planContent: String,
     recoveryAlreadyAttempted: Boolean,
+    secretValues: List<String>,
   ): InternalExecutionResult {
 
     val errorMessage =
@@ -514,6 +522,7 @@ internal object AutoMobilePlanExecutor {
         options = options,
         startStep = resumeStep,
         recoveryAlreadyAttempted = true, // prevent recursive recovery
+        secretValues = secretValues,
         deviceIdOverride = failedStepContext.deviceId,
       )
 
@@ -535,6 +544,7 @@ internal object AutoMobilePlanExecutor {
     json: Json,
     planContent: String,
     deviceId: String?,
+    secretValues: List<String>,
   ): FailedStepContext? {
     try {
       val resultElement = response.result ?: return null
@@ -572,12 +582,18 @@ internal object AutoMobilePlanExecutor {
         }
       }
 
+      // Egress boundary (issue #6029): FailedStepContext.planContent and error are embedded
+      // verbatim
+      // into the recovery prompt sent to the LLM provider (see AutoMobileAgent.attemptAiRecovery),
+      // so
+      // mask secret values out of both here. The daemon's base64 payload above kept the real
+      // values.
       return FailedStepContext(
         failedStepIndex = failedStepIndex,
         failedTool = failedTool,
-        error = error,
+        error = SecretRedactor.redact(error, secretValues),
         succeededSteps = succeededSteps,
-        planContent = planContent,
+        planContent = SecretRedactor.redact(planContent, secretValues),
         deviceId = failedDevice ?: deviceId?.takeIf { it != "auto" },
       )
     } catch (e: Exception) {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanTypes.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanTypes.kt
@@ -22,6 +22,16 @@ data class AutoMobilePlanExecutionOptions(
   val aiAssistance: Boolean = true,
   val maxRetries: Int = 0,
   val debugMode: Boolean = System.getProperty("automobile.debug", "false").toBoolean(),
+  /**
+   * Parameter keys whose substituted values are sensitive (tokens, passwords, PII). Their values
+   * are masked out of any context handed to AI-assisted recovery before it reaches the third-party
+   * LLM provider (see [AutoMobilePlanExecutor.buildFailedStepContext]), while the base64
+   * `executePlan` payload to the LOCAL daemon keeps the real values so the plan can run. A plan can
+   * also declare sensitive keys via its top-level `secretParameters:` list; the two sets are
+   * unioned. Mirrors iOS's `AutoMobilePlanExecutor.Configuration.secretParameterKeys`
+   * (issue #6029).
+   */
+  val secretParameterKeys: Set<String> = emptySet(),
 )
 
 /**

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.junit
 
+import java.text.Normalizer
 import org.yaml.snakeyaml.Yaml
 
 /**
@@ -9,24 +10,40 @@ import org.yaml.snakeyaml.Yaml
  * the plan, and it is not the egress boundary.
  *
  * The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
- * substituted, a secret's value can appear in the plan YAML and in the failure error string, so
- * replacing every occurrence of each value covers those channels uniformly. Mirrors the iOS
- * `SecretRedaction`.
+ * substituted, a secret's value can appear in the plan YAML, the failure error, and a substituted
+ * tool name, so replacing every occurrence of each value covers those channels uniformly.
+ * `internal` — only [AutoMobilePlanExecutor] consumes it. Mirrors the iOS `SecretRedaction`.
  */
-object SecretRedactor {
+internal object SecretRedactor {
   const val PLACEHOLDER: String = "***REDACTED***"
 
   /**
-   * The values to scrub: the substituted value of every secret key that was actually supplied a
-   * non-blank parameter. Keys with no value contribute nothing. The value is stringified the same
-   * way parameter substitution stringifies it, so the scrubbed text matches what was substituted.
+   * Resolve `${...}` references inside declared secret key NAMES against [parameters], so a plan
+   * may parameterize the key it declares (`secretParameters: [${SECRET_KEY}]`). A literal key
+   * resolves to itself. Keeps iOS and Android agreeing on the effective key set.
    */
-  fun secretValues(keys: Set<String>, parameters: Map<String, Any>): List<String> =
-    keys
-      .mapNotNull { key -> parameters[key]?.let { parameterStringValue(it) } }
-      .filter {
-        it.isNotEmpty()
+  fun resolveKeyNames(keys: Set<String>, parameters: Map<String, Any>): Set<String> =
+    keys.map { resolve(it, parameters) }.toSet()
+
+  /**
+   * The concrete strings to scrub for the given (already key-name-resolved) secret keys. For each
+   * key we scrub BOTH its raw parameter value AND its fully-resolved value (a secret whose value
+   * embeds another `${param}` lands in the plan as the resolved form), each in its NFC and NFD
+   * Unicode forms so a decomposed on-screen/error occurrence still matches. Blank values contribute
+   * nothing. The value is stringified the same way parameter substitution stringifies it.
+   */
+  fun secretValues(keys: Set<String>, parameters: Map<String, Any>): List<String> {
+    val values = LinkedHashSet<String>()
+    for (key in keys) {
+      val raw = parameters[key]?.let { parameterStringValue(it) } ?: continue
+      if (raw.isEmpty()) continue
+      val resolved = resolve(raw, parameters)
+      for (base in listOf(raw, resolved)) {
+        if (base.isNotEmpty()) values.addAll(normalizationForms(base))
       }
+    }
+    return values.toList()
+  }
 
   /** Stringify a parameter value exactly as [AutoMobilePlanExecutor] does during substitution. */
   fun parameterStringValue(value: Any): String =
@@ -39,12 +56,14 @@ object SecretRedactor {
   /**
    * Replace every occurrence of each secret value in [text] with [PLACEHOLDER]. Longer values are
    * replaced first so a secret that contains a shorter secret as a substring is fully masked.
+   * [String.replace] matches literal code units; [secretValues] already supplies the NFC/NFD
+   * variants.
    */
   fun redact(text: String, secretValues: List<String>): String {
     if (secretValues.isEmpty()) return text
     var redacted = text
     for (value in secretValues.sortedByDescending { it.length }) {
-      redacted = redacted.replace(value, PLACEHOLDER)
+      if (value.isNotEmpty()) redacted = redacted.replace(value, PLACEHOLDER)
     }
     return redacted
   }
@@ -75,4 +94,32 @@ object SecretRedactor {
       println("Warning: failed to parse secretParameters from plan: ${e.message}")
       emptySet()
     }
+
+  /**
+   * Fully resolve `${key}` references in [value] against [parameters], iterating to a fixpoint so a
+   * value that embeds another parameter (which itself embeds another) resolves completely. Bounded
+   * by the parameter count so a reference cycle terminates instead of looping.
+   */
+  private fun resolve(value: String, parameters: Map<String, Any>): String {
+    if (!value.contains("\${")) return value
+    var current = value
+    repeat(parameters.size + 1) {
+      var next = current
+      for ((key, replacement) in parameters) {
+        next = next.replace("\${$key}", parameterStringValue(replacement))
+      }
+      if (next == current) return current
+      current = next
+    }
+    return current
+  }
+
+  /** [value] plus its canonical NFC and NFD forms (deduped). */
+  private fun normalizationForms(value: String): List<String> =
+    linkedSetOf(
+        value,
+        Normalizer.normalize(value, Normalizer.Form.NFC),
+        Normalizer.normalize(value, Normalizer.Form.NFD),
+      )
+      .toList()
 }

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -1,0 +1,69 @@
+package dev.jasonpearson.automobile.junit
+
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * Redacts sensitive plan-parameter values from any recovery context that leaves the process for a
+ * third-party LLM provider (CWE-200, issue #6029). The base64 `executePlan` payload sent to the
+ * LOCAL daemon is intentionally NOT routed through here — the daemon needs the real values to run
+ * the plan, and it is not the egress boundary.
+ *
+ * The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
+ * substituted, a secret's value can appear in the plan YAML and in the failure error string, so
+ * replacing every occurrence of each value covers those channels uniformly. Mirrors the iOS
+ * `SecretRedaction`.
+ */
+object SecretRedactor {
+  const val PLACEHOLDER: String = "***REDACTED***"
+
+  /**
+   * The values to scrub: the substituted value of every secret key that was actually supplied a
+   * non-blank parameter. Keys with no value contribute nothing. The value is stringified the same
+   * way parameter substitution stringifies it, so the scrubbed text matches what was substituted.
+   */
+  fun secretValues(keys: Set<String>, parameters: Map<String, Any>): List<String> =
+    keys
+      .mapNotNull { key -> parameters[key]?.let { parameterStringValue(it) } }
+      .filter {
+        it.isNotEmpty()
+      }
+
+  /** Stringify a parameter value exactly as [AutoMobilePlanExecutor] does during substitution. */
+  fun parameterStringValue(value: Any): String =
+    when (value) {
+      is String -> value
+      is Enum<*> -> value.name
+      else -> value.toString()
+    }
+
+  /**
+   * Replace every occurrence of each secret value in [text] with [PLACEHOLDER]. Longer values are
+   * replaced first so a secret that contains a shorter secret as a substring is fully masked.
+   */
+  fun redact(text: String, secretValues: List<String>): String {
+    if (secretValues.isEmpty()) return text
+    var redacted = text
+    for (value in secretValues.sortedByDescending { it.length }) {
+      redacted = redacted.replace(value, PLACEHOLDER)
+    }
+    return redacted
+  }
+
+  /**
+   * Parameter keys a plan declares sensitive via its top-level `secretParameters:` list. Unioned
+   * with [AutoMobilePlanExecutionOptions.secretParameterKeys] by the executor. Parsing failures
+   * yield an empty set — declaring secrets is best-effort metadata, never a hard execution
+   * dependency.
+   */
+  fun parsePlanSecretKeys(planContent: String): Set<String> =
+    try {
+      val root = Yaml().load<Any?>(planContent)
+      val list = (root as? Map<*, *>)?.get("secretParameters") as? List<*> ?: return emptySet()
+      list.mapNotNull { it?.toString()?.takeIf { key -> key.isNotBlank() } }.toSet()
+    } catch (e: Exception) {
+      // A malformed plan is caught and reported by PlanSchemaValidator on the substituted content;
+      // here we only need the secret-key hints, so swallow and fall back to the configured set.
+      println("Warning: failed to parse secretParameters from plan: ${e.message}")
+      emptySet()
+    }
+}

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -1,7 +1,6 @@
 package dev.jasonpearson.automobile.junit
 
 import java.text.Normalizer
-import org.yaml.snakeyaml.Yaml
 
 /**
  * Redacts sensitive plan-parameter values from any recovery context that leaves the process for a
@@ -9,38 +8,32 @@ import org.yaml.snakeyaml.Yaml
  * LOCAL daemon is intentionally NOT routed through here — the daemon needs the real values to run
  * the plan, and it is not the egress boundary.
  *
- * The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
- * substituted, a secret's value can appear in the plan YAML, the failure error, and a substituted
- * tool name, so replacing every occurrence of each value covers those channels uniformly.
- * `internal` — only [AutoMobilePlanExecutor] consumes it. Mirrors the iOS `SecretRedaction`.
+ * This object does NOT resolve `${...}` placeholders: substitution is owned by
+ * [AutoMobilePlanExecutor], the single source of truth for what actually landed in the plan
+ * (issue #6029 review — an independent fixpoint could mismatch the executor's single ordered pass,
+ * or blow up on a self-referential value). The executor hands over the concrete substituted secret
+ * strings; this object expands each into its Unicode NFC/NFD forms and scrubs every occurrence. It
+ * also scans the RAW plan for the declared secret key names with a placeholder-tolerant line
+ * scanner (a full YAML load chokes on `${...}` in flow collections). `internal` — its only consumer
+ * is the executor, and `SecretRedactorTest` unit-tests it. Mirrors the iOS `SecretRedaction` /
+ * `PlanMetadataParser.parseSecretParameterKeys`.
  */
 internal object SecretRedactor {
   const val PLACEHOLDER: String = "***REDACTED***"
 
   /**
-   * Resolve `${...}` references inside declared secret key NAMES against [parameters], so a plan
-   * may parameterize the key it declares (`secretParameters: [${SECRET_KEY}]`). A literal key
-   * resolves to itself. Keeps iOS and Android agreeing on the effective key set.
+   * Expand the executor-supplied concrete secret strings into the exact forms to scrub: each value
+   * in its NFC and NFD Unicode forms, so a decomposed on-screen/error occurrence still matches a
+   * composed value (and vice versa). Blank inputs are dropped; the result is deduped preserving
+   * order.
    */
-  fun resolveKeyNames(keys: Set<String>, parameters: Map<String, Any>): Set<String> =
-    keys.map { resolve(it, parameters) }.toSet()
-
-  /**
-   * The concrete strings to scrub for the given (already key-name-resolved) secret keys. For each
-   * key we scrub BOTH its raw parameter value AND its fully-resolved value (a secret whose value
-   * embeds another `${param}` lands in the plan as the resolved form), each in its NFC and NFD
-   * Unicode forms so a decomposed on-screen/error occurrence still matches. Blank values contribute
-   * nothing. The value is stringified the same way parameter substitution stringifies it.
-   */
-  fun secretValues(keys: Set<String>, parameters: Map<String, Any>): List<String> {
+  fun secretValues(concreteValues: List<String>): List<String> {
     val values = LinkedHashSet<String>()
-    for (key in keys) {
-      val raw = parameters[key]?.let { parameterStringValue(it) } ?: continue
-      if (raw.isEmpty()) continue
-      val resolved = resolve(raw, parameters)
-      for (base in listOf(raw, resolved)) {
-        if (base.isNotEmpty()) values.addAll(normalizationForms(base))
-      }
+    for (value in concreteValues) {
+      if (value.isEmpty()) continue
+      values.add(value)
+      values.add(Normalizer.normalize(value, Normalizer.Form.NFC))
+      values.add(Normalizer.normalize(value, Normalizer.Form.NFD))
     }
     return values.toList()
   }
@@ -78,48 +71,95 @@ internal object SecretRedactor {
     else parameters.mapValues { (key, value) -> if (key in secretKeys) PLACEHOLDER else value }
 
   /**
-   * Parameter keys a plan declares sensitive via its top-level `secretParameters:` list. Unioned
-   * with [AutoMobilePlanExecutionOptions.secretParameterKeys] by the executor. Parsing failures
-   * yield an empty set — declaring secrets is best-effort metadata, never a hard execution
-   * dependency.
+   * Scan a plan's top-level `secretParameters:` declaration for the sensitive key names, tolerating
+   * `${...}` placeholders anywhere (they are literal text to the scanner). MUST run on the RAW,
+   * pre-substitution plan: a substituted value can inject a newline that truncates the declaration,
+   * and a full YAML load throws on unquoted placeholders in flow collections (issue #6029 review).
+   * Non-throwing. Only the `secretParameters:` block is scanned, so unrelated `${...}` lists are
+   * ignored. Mirrors iOS `PlanMetadataParser.parseSecretParameterKeys`.
    */
-  fun parsePlanSecretKeys(planContent: String): Set<String> =
-    try {
-      val root = Yaml().load<Any?>(planContent)
-      val list = (root as? Map<*, *>)?.get("secretParameters") as? List<*> ?: return emptySet()
-      list.mapNotNull { it?.toString()?.takeIf { key -> key.isNotBlank() } }.toSet()
-    } catch (e: Exception) {
-      // A malformed plan is caught and reported by PlanSchemaValidator on the substituted content;
-      // here we only need the secret-key hints, so swallow and fall back to the configured set.
-      println("Warning: failed to parse secretParameters from plan: ${e.message}")
-      emptySet()
-    }
-
-  /**
-   * Fully resolve `${key}` references in [value] against [parameters], iterating to a fixpoint so a
-   * value that embeds another parameter (which itself embeds another) resolves completely. Bounded
-   * by the parameter count so a reference cycle terminates instead of looping.
-   */
-  private fun resolve(value: String, parameters: Map<String, Any>): String {
-    if (!value.contains("\${")) return value
-    var current = value
-    repeat(parameters.size + 1) {
-      var next = current
-      for ((key, replacement) in parameters) {
-        next = next.replace("\${$key}", parameterStringValue(replacement))
+  fun parsePlanSecretKeys(planContent: String): Set<String> {
+    val lines = planContent.split('\n')
+    val keys = LinkedHashSet<String>()
+    var index = 0
+    while (index < lines.size) {
+      val trimmed = stripComments(lines[index]).trim()
+      if (
+        indentationLevel(stripComments(lines[index])) != 0 ||
+          !trimmed.startsWith("secretParameters:")
+      ) {
+        index++
+        continue
       }
-      if (next == current) return current
-      current = next
+      val inline = trimmed.removePrefix("secretParameters:").trim()
+      if (inline.isNotEmpty()) {
+        keys.addAll(parseInlineList(inline))
+        index++
+        continue
+      }
+      index++
+      // Block sequence: `-` items at ANY indent (flush with the parent key is valid YAML) until the
+      // next non-list line, i.e. the next top-level key.
+      while (index < lines.size) {
+        val itemTrimmed = stripComments(lines[index]).trim()
+        if (itemTrimmed.isEmpty()) {
+          index++
+          continue
+        }
+        if (!itemTrimmed.startsWith("-")) break
+        val item = unquote(itemTrimmed.removePrefix("-").trim())
+        if (item.isNotEmpty()) keys.add(item)
+        index++
+      }
     }
-    return current
+    return keys
   }
 
-  /** [value] plus its canonical NFC and NFD forms (deduped). */
-  private fun normalizationForms(value: String): List<String> =
-    linkedSetOf(
-        value,
-        Normalizer.normalize(value, Normalizer.Form.NFC),
-        Normalizer.normalize(value, Normalizer.Form.NFD),
-      )
-      .toList()
+  private fun stripComments(line: String): String {
+    val hash = line.indexOf('#')
+    return if (hash >= 0) line.substring(0, hash) else line
+  }
+
+  private fun indentationLevel(line: String): Int = line.takeWhile { it == ' ' }.length
+
+  private fun unquote(value: String): String {
+    if (value.length >= 2) {
+      val first = value.first()
+      val last = value.last()
+      if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+        return value.substring(1, value.length - 1)
+      }
+    }
+    return value
+  }
+
+  /**
+   * Parse a YAML flow list of scalar keys, e.g. `[apiToken, "password"]`. A comma inside a quoted
+   * item is part of the key, not a separator, so `["API,TOKEN"]` yields the single key `API,TOKEN`.
+   */
+  private fun parseInlineList(value: String): List<String> {
+    val inner = value.removePrefix("[").removeSuffix("]")
+    val items = mutableListOf<String>()
+    val current = StringBuilder()
+    var activeQuote: Char? = null
+    for (character in inner) {
+      when {
+        activeQuote != null -> {
+          if (character == activeQuote) activeQuote = null
+          current.append(character)
+        }
+        character == '"' || character == '\'' -> {
+          activeQuote = character
+          current.append(character)
+        }
+        character == ',' -> {
+          items.add(current.toString())
+          current.clear()
+        }
+        else -> current.append(character)
+      }
+    }
+    items.add(current.toString())
+    return items.map { unquote(it.trim()) }.filter { it.isNotEmpty() }
+  }
 }

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -50,6 +50,15 @@ object SecretRedactor {
   }
 
   /**
+   * A display copy of [parameters] with the values of [secretKeys] masked. Used for debug logging
+   * so a secret value is not written to logcat in plaintext (outside #6029's strict LLM-egress
+   * scope, but consistent with it).
+   */
+  fun redactParameters(parameters: Map<String, Any>, secretKeys: Set<String>): Map<String, Any> =
+    if (secretKeys.isEmpty()) parameters
+    else parameters.mapValues { (key, value) -> if (key in secretKeys) PLACEHOLDER else value }
+
+  /**
    * Parameter keys a plan declares sensitive via its top-level `secretParameters:` list. Unioned
    * with [AutoMobilePlanExecutionOptions.secretParameterKeys] by the executor. Parsing failures
    * yield an empty set — declaring secrets is best-effort metadata, never a hard execution

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -131,6 +131,84 @@ class AutoMobilePlanRedactionTest {
     )
   }
 
+  @Test
+  fun `scrubs exactly what the executor substitution produced`() {
+    // Sorted-key single pass: ${SECRET_TOKEN} -> sec-${AA}-zeta (AA resolved before TOKEN inserts
+    // it,
+    // ZZ after) — neither the raw value nor a fully-resolved fixpoint (#6029 review 695).
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-plan.yaml",
+      mapOf("SECRET_TOKEN" to "sec-\${AA}-\${ZZ}", "AA" to "alpha", "ZZ" to "zeta"),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "the actual substituted secret must be scrubbed",
+      context.planContent.contains("sec-"),
+    )
+  }
+
+  @Test
+  fun `self referential secret terminates and is redacted`() {
+    // No fixpoint: the executor's single pass turns ${SECRET_TOKEN} into marker-${SECRET_TOKEN}
+    // once,
+    // so there is no unbounded expansion (#6029 review 701).
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-plan.yaml",
+      mapOf("SECRET_TOKEN" to "marker-\${SECRET_TOKEN}"),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "the self-referential secret must be redacted",
+      context.planContent.contains("marker-"),
+    )
+  }
+
+  @Test
+  fun `parameterized secret key name is redacted`() {
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-parameterized-key.yaml",
+      mapOf("SECRET_KEY" to "apiToken", "apiToken" to secret),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "a parameterized secret key name must resolve and redact",
+      context.planContent.contains(secret),
+    )
+  }
+
+  @Test
+  fun `debug mode does not print substituted secret values in the plan content`() {
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom")
+    val originalOut = System.out
+    val captured = java.io.ByteArrayOutputStream()
+    System.setOut(java.io.PrintStream(captured, true, "UTF-8"))
+    try {
+      AutoMobilePlanExecutor.execute(
+        "test-plans/redaction-plan.yaml",
+        mapOf("SECRET_TOKEN" to secret, "ENVIRONMENT" to visible),
+        AutoMobilePlanExecutionOptions(device = "emulator-5554", debugMode = true),
+      )
+    } finally {
+      System.setOut(originalOut)
+    }
+    assertFalse(
+      "debugMode must not emit the substituted secret to logcat",
+      captured.toString("UTF-8").contains(secret),
+    )
+  }
+
   private fun decodeDaemonPlanContent(): String? {
     val raw =
       fakeDaemonClient.executePlanArguments?.get("planContent")?.jsonPrimitive?.content

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -1,0 +1,224 @@
+package dev.jasonpearson.automobile.junit
+
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Issue #6029 (CWE-200): a secret plan parameter must never reach the third-party LLM provider
+ * during AI-assisted recovery. These tests drive the FULL executor with a real plan, capture the
+ * [FailedStepContext] handed to the recovery agent (the egress boundary — [AutoMobileAgent] embeds
+ * `planContent`/`error` verbatim into the prompt it sends to the provider), and assert the secret
+ * is absent while non-secret context is preserved. They also assert the base64 `executePlan`
+ * payload sent to the LOCAL daemon keeps the REAL secret, since the daemon is not the egress
+ * boundary.
+ */
+class AutoMobilePlanRedactionTest {
+  private val secret = "SECRET-hunter2-TOKEN"
+  private val visible = "keepme-visible-env"
+
+  private lateinit var fakeDaemonClient: CapturingDaemonToolClient
+  private lateinit var capturingAgent: CapturingAgent
+
+  @Before
+  fun setup() {
+    fakeDaemonClient = CapturingDaemonToolClient()
+    DaemonSocketClientManager.testClient = fakeDaemonClient
+    AutoMobileSharedUtils.testDeviceChecker = RedactionDeviceChecker(devicesAvailable = true)
+    DaemonHeartbeat.testController = RedactionDaemonHeartbeat()
+    capturingAgent = CapturingAgent()
+    AutoMobilePlanExecutor.testAgent = capturingAgent
+    // Recovery is skipped in CI mode; force it off so the recovery path (and its redaction) runs.
+    System.setProperty("automobile.ci.mode", "false")
+  }
+
+  @After
+  fun tearDown() {
+    DaemonSocketClientManager.testClient = null
+    AutoMobileSharedUtils.testDeviceChecker = null
+    DaemonHeartbeat.testController = null
+    AutoMobilePlanExecutor.testAgent = null
+    System.clearProperty("automobile.ci.mode")
+  }
+
+  @Test
+  fun `secret parameter is redacted from recovery context while non-secret is preserved`() {
+    // The failing step's error also carries the secret, exercising the error-scrub path.
+    fakeDaemonClient.executePlanResponse =
+      buildFailureResponse(error = "timed out entering $secret into field")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-plan.yaml",
+      mapOf("SECRET_TOKEN" to secret, "ENVIRONMENT" to visible),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured) { "recovery must receive a context" }
+
+    assertFalse(
+      "secret must not appear in the recovery plan content",
+      context.planContent.contains(secret),
+    )
+    assertFalse(
+      "secret must not appear in the recovery error string",
+      context.error.contains(secret),
+    )
+    assertTrue(
+      "the secret is replaced by the redaction placeholder",
+      context.planContent.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertTrue(
+      "non-secret substituted context is preserved",
+      context.planContent.contains(visible),
+    )
+
+    // The base64 executePlan payload sent to the LOCAL daemon must keep the REAL secret so the plan
+    // can actually run — the daemon is not the egress boundary.
+    val daemonPlan = decodeDaemonPlanContent()
+    assertNotNull("daemon must have received an executePlan payload", daemonPlan)
+    assertTrue(
+      "daemon executePlan payload must stay unredacted",
+      daemonPlan!!.contains(secret),
+    )
+  }
+
+  @Test
+  fun `secret declared only via options secretParameterKeys is redacted`() {
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
+
+    AutoMobilePlanExecutor.execute(
+      // Reuse the plan but drive the secret purely through options, not the plan's
+      // secretParameters.
+      "test-plans/redaction-plan.yaml",
+      mapOf("SECRET_TOKEN" to secret, "ENVIRONMENT" to visible),
+      AutoMobilePlanExecutionOptions(
+        device = "emulator-5554",
+        secretParameterKeys = setOf("ENVIRONMENT"),
+      ),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "an options-declared secret must also be redacted",
+      context.planContent.contains(visible),
+    )
+  }
+
+  private fun decodeDaemonPlanContent(): String? {
+    val raw =
+      fakeDaemonClient.executePlanArguments?.get("planContent")?.jsonPrimitive?.content
+        ?: return null
+    val base64 = raw.removePrefix("base64:")
+    return String(Base64.getDecoder().decode(base64))
+  }
+
+  private fun buildFailureResponse(error: String): DaemonResponse {
+    val payload =
+      JsonObject(
+        mapOf(
+          "success" to JsonPrimitive(false),
+          "executedSteps" to JsonPrimitive(1),
+          "totalSteps" to JsonPrimitive(3),
+          "failedStep" to
+            JsonObject(
+              mapOf(
+                "stepIndex" to JsonPrimitive(1),
+                "tool" to JsonPrimitive("inputText"),
+                "error" to JsonPrimitive(error),
+              )
+            ),
+        )
+      )
+    val textPayload = Json.encodeToString(JsonElement.serializer(), payload)
+    val result =
+      JsonObject(
+        mapOf(
+          "content" to
+            JsonArray(
+              listOf(
+                JsonObject(
+                  mapOf(
+                    "type" to JsonPrimitive("text"),
+                    "text" to JsonPrimitive(textPayload),
+                  )
+                )
+              )
+            )
+        )
+      )
+    return DaemonResponse(
+      id = "test",
+      type = "mcp_response",
+      success = true,
+      result = result,
+      error = null,
+    )
+  }
+}
+
+/**
+ * Captures the [FailedStepContext] the executor hands to recovery, then reports a failed outcome.
+ */
+private class CapturingAgent :
+  AutoMobileAgent(
+    recoveryConfigProvider = StaticRecoveryConfigProvider(enabled = true, maxToolCalls = 5)
+  ) {
+  var captured: FailedStepContext? = null
+
+  override fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome {
+    captured = context
+    return RecoveryOutcome(success = false, recoveryTimeMs = 0)
+  }
+}
+
+/** Fake daemon client that records the executePlan arguments and returns a scripted response. */
+private class CapturingDaemonToolClient : DaemonToolClient {
+  var executePlanResponse: DaemonResponse? = null
+  var executePlanArguments: JsonObject? = null
+  override var sessionUuid: String = "test-session"
+
+  override fun callTool(
+    toolName: String,
+    arguments: JsonObject,
+    timeoutMs: Long,
+  ): DaemonResponse {
+    return when (toolName) {
+      "setToolEnabled" -> DaemonResponse(id = "sel", type = "mcp_response", success = true)
+      "executePlan" -> {
+        executePlanArguments = arguments
+        executePlanResponse ?: throw IllegalStateException("no executePlan response configured")
+      }
+      else -> throw IllegalStateException("unexpected tool: $toolName")
+    }
+  }
+
+  override fun readResource(uri: String, timeoutMs: Long): DaemonResponse {
+    throw IllegalStateException("readResource not configured for $uri")
+  }
+}
+
+private class RedactionDeviceChecker(private val devicesAvailable: Boolean) : DeviceChecker {
+  override fun checkDeviceAvailability() = Unit
+
+  override fun areDevicesAvailable(): Boolean = devicesAvailable
+
+  override fun getDeviceCount(): Int = if (devicesAvailable) 1 else 0
+}
+
+private class RedactionDaemonHeartbeat : DaemonHeartbeatController {
+  override fun startBackground(intervalMs: Long) = java.io.Closeable {}
+
+  override fun registerSession(sessionId: String) = Unit
+
+  override fun unregisterSession(sessionId: String) = Unit
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -114,6 +114,23 @@ class AutoMobilePlanRedactionTest {
     )
   }
 
+  @Test
+  fun `secret substituted into a failing tool name is redacted`() {
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom", tool = secret)
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-plan.yaml",
+      mapOf("SECRET_TOKEN" to secret, "ENVIRONMENT" to visible),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "a secret substituted into a tool name must be redacted",
+      context.failedTool.contains(secret),
+    )
+  }
+
   private fun decodeDaemonPlanContent(): String? {
     val raw =
       fakeDaemonClient.executePlanArguments?.get("planContent")?.jsonPrimitive?.content
@@ -122,7 +139,7 @@ class AutoMobilePlanRedactionTest {
     return String(Base64.getDecoder().decode(base64))
   }
 
-  private fun buildFailureResponse(error: String): DaemonResponse {
+  private fun buildFailureResponse(error: String, tool: String = "inputText"): DaemonResponse {
     val payload =
       JsonObject(
         mapOf(
@@ -133,7 +150,7 @@ class AutoMobilePlanRedactionTest {
             JsonObject(
               mapOf(
                 "stepIndex" to JsonPrimitive(1),
-                "tool" to JsonPrimitive("inputText"),
+                "tool" to JsonPrimitive(tool),
                 "error" to JsonPrimitive(error),
               )
             ),

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -149,6 +149,15 @@ class AutoMobilePlanRedactionTest {
       "the actual substituted secret must be scrubbed",
       context.planContent.contains("sec-"),
     )
+    // Positive assertions so the test can't pass on an empty/malformed context.
+    assertTrue(
+      "the secret must be replaced by the placeholder",
+      context.planContent.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertTrue(
+      "non-secret plan structure must be preserved",
+      context.planContent.contains("launchApp"),
+    )
   }
 
   @Test
@@ -169,6 +178,14 @@ class AutoMobilePlanRedactionTest {
       "the self-referential secret must be redacted",
       context.planContent.contains("marker-"),
     )
+    assertTrue(
+      "the secret must be replaced by the placeholder",
+      context.planContent.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertTrue(
+      "non-secret plan structure must be preserved",
+      context.planContent.contains("launchApp"),
+    )
   }
 
   @Test
@@ -185,6 +202,14 @@ class AutoMobilePlanRedactionTest {
     assertFalse(
       "a parameterized secret key name must resolve and redact",
       context.planContent.contains(secret),
+    )
+    assertTrue(
+      "the secret must be replaced by the placeholder",
+      context.planContent.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertTrue(
+      "non-secret plan structure must be preserved",
+      context.planContent.contains("launchApp"),
     )
   }
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -1,0 +1,56 @@
+package dev.jasonpearson.automobile.junit
+
+import java.text.Normalizer
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Direct redaction-completeness tests for [SecretRedactor] (#6029 review): nested substitution,
+ * Unicode normalization, and parameterized secret key names. Mirrors the iOS
+ * `SecretRedactionCompletenessTests`.
+ */
+class SecretRedactorTest {
+
+  @Test
+  fun `redacts fully resolved nested secret value`() {
+    // TOKEN's value embeds ${ENV}; the resolved form is what lands in the plan and must be
+    // scrubbed.
+    val params = mapOf<String, Any>("TOKEN" to "pre-\${ENV}", "ENV" to "live")
+    val values = SecretRedactor.secretValues(setOf("TOKEN"), params)
+    assertEquals(
+      "typed ${SecretRedactor.PLACEHOLDER} into field",
+      SecretRedactor.redact("typed pre-live into field", values),
+    )
+  }
+
+  @Test
+  fun `redacts secret regardless of unicode normalization`() {
+    // Force NFC regardless of this source file's on-disk encoding so the NFD occurrence truly
+    // differs.
+    val composed = Normalizer.normalize("café-token", Normalizer.Form.NFC)
+    val values = SecretRedactor.secretValues(setOf("K"), mapOf<String, Any>("K" to composed))
+    val decomposed = Normalizer.normalize(composed, Normalizer.Form.NFD)
+    val result = SecretRedactor.redact("error: $decomposed seen", values)
+    assertTrue(result.contains(SecretRedactor.PLACEHOLDER))
+    assertFalse(result.contains('\u0301'), "the decomposed combining mark must be gone")
+  }
+
+  @Test
+  fun `resolveKeyNames resolves a parameterized key name`() {
+    val params = mapOf<String, Any>("SECRET_KEY" to "apiToken", "apiToken" to "s3cr3t")
+    val keys = SecretRedactor.resolveKeyNames(setOf("\${SECRET_KEY}"), params)
+    assertTrue(keys.contains("apiToken"))
+    val values = SecretRedactor.secretValues(keys, params)
+    assertEquals("x ${SecretRedactor.PLACEHOLDER} y", SecretRedactor.redact("x s3cr3t y", values))
+  }
+
+  @Test
+  fun `literal key resolves to itself`() {
+    assertEquals(
+      setOf("TOKEN"),
+      SecretRedactor.resolveKeyNames(setOf("TOKEN"), mapOf("TOKEN" to "v")),
+    )
+  }
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -64,9 +64,14 @@ class SecretRedactorTest {
   }
 
   @Test
-  fun `redacts longer secrets first`() {
+  fun `shorter secret substring of longer is fully redacted without residue`() {
+    // "ab" is a substring of "abcdef"; longest-first replacement masks the whole "abcdef" rather
+    // than
+    // leaving a "cdef" residue (which shortest-first would).
     val values = SecretRedactor.secretValues(listOf("ab", "abcdef"))
-    assertEquals("x ${SecretRedactor.PLACEHOLDER} y", SecretRedactor.redact("x abcdef y", values))
+    val result = SecretRedactor.redact("x abcdef y", values)
+    assertEquals("x ${SecretRedactor.PLACEHOLDER} y", result)
+    assertFalse(result.contains("cdef"), "no substring residue may remain")
   }
 
   @Test

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -7,22 +7,48 @@ import kotlin.test.assertTrue
 import org.junit.Test
 
 /**
- * Direct redaction-completeness tests for [SecretRedactor] (#6029 review): nested substitution,
- * Unicode normalization, and parameterized secret key names. Mirrors the iOS
- * `SecretRedactionCompletenessTests`.
+ * Direct tests for [SecretRedactor] — the RAW placeholder-tolerant key scanner and the Unicode-form
+ * redaction. Resolution/substitution is the executor's job (tested end-to-end in
+ * [AutoMobilePlanRedactionTest]). Mirrors iOS `PlanMetadataSecretParametersParsingTests` /
+ * `SecretRedactionTests` (#6029 convergence).
  */
 class SecretRedactorTest {
 
   @Test
-  fun `redacts fully resolved nested secret value`() {
-    // TOKEN's value embeds ${ENV}; the resolved form is what lands in the plan and must be
-    // scrubbed.
-    val params = mapOf<String, Any>("TOKEN" to "pre-\${ENV}", "ENV" to "live")
-    val values = SecretRedactor.secretValues(setOf("TOKEN"), params)
-    assertEquals(
-      "typed ${SecretRedactor.PLACEHOLDER} into field",
-      SecretRedactor.redact("typed pre-live into field", values),
-    )
+  fun `parses flush and indented and inline secret parameter lists`() {
+    val flush = "name: P\nsecretParameters:\n- TOKEN\n- PASSWORD\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(flush))
+
+    val indented = "name: P\nsecretParameters:\n  - TOKEN\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN"), SecretRedactor.parsePlanSecretKeys(indented))
+
+    val inline = "name: P\nsecretParameters: [TOKEN, \"PASSWORD\"]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(inline))
+  }
+
+  @Test
+  fun `inline list does not split on a comma inside quotes`() {
+    val yaml = "name: P\nsecretParameters: [\"API,TOKEN\", plain]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("API,TOKEN", "plain"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `tolerates placeholder key names and unrelated placeholder flow lists`() {
+    // A full YAML load would throw on `[${LABEL}, OK]`; the scanner tolerates it and ignores it.
+    val yaml =
+      """
+      name: P
+      secretParameters:
+        - ${'$'}{SECRET_KEY}
+      steps:
+        - tool: observe
+          waitFor:
+            textAny: [${'$'}{LABEL}, OK]
+        - tool: inputText
+          text: "${'$'}{SECRET_KEY}"
+      """
+        .trimIndent()
+    assertEquals(setOf("\${SECRET_KEY}"), SecretRedactor.parsePlanSecretKeys(yaml))
   }
 
   @Test
@@ -30,7 +56,7 @@ class SecretRedactorTest {
     // Force NFC regardless of this source file's on-disk encoding so the NFD occurrence truly
     // differs.
     val composed = Normalizer.normalize("café-token", Normalizer.Form.NFC)
-    val values = SecretRedactor.secretValues(setOf("K"), mapOf<String, Any>("K" to composed))
+    val values = SecretRedactor.secretValues(listOf(composed))
     val decomposed = Normalizer.normalize(composed, Normalizer.Form.NFD)
     val result = SecretRedactor.redact("error: $decomposed seen", values)
     assertTrue(result.contains(SecretRedactor.PLACEHOLDER))
@@ -38,19 +64,16 @@ class SecretRedactorTest {
   }
 
   @Test
-  fun `resolveKeyNames resolves a parameterized key name`() {
-    val params = mapOf<String, Any>("SECRET_KEY" to "apiToken", "apiToken" to "s3cr3t")
-    val keys = SecretRedactor.resolveKeyNames(setOf("\${SECRET_KEY}"), params)
-    assertTrue(keys.contains("apiToken"))
-    val values = SecretRedactor.secretValues(keys, params)
-    assertEquals("x ${SecretRedactor.PLACEHOLDER} y", SecretRedactor.redact("x s3cr3t y", values))
+  fun `redacts longer secrets first`() {
+    val values = SecretRedactor.secretValues(listOf("ab", "abcdef"))
+    assertEquals("x ${SecretRedactor.PLACEHOLDER} y", SecretRedactor.redact("x abcdef y", values))
   }
 
   @Test
-  fun `literal key resolves to itself`() {
+  fun `empty values are ignored`() {
     assertEquals(
-      setOf("TOKEN"),
-      SecretRedactor.resolveKeyNames(setOf("TOKEN"), mapOf("TOKEN" to "v")),
+      "unchanged",
+      SecretRedactor.redact("unchanged", SecretRedactor.secretValues(listOf(""))),
     )
   }
 }

--- a/android/junit-runner/src/test/resources/test-plans/redaction-parameterized-key.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-parameterized-key.yaml
@@ -1,0 +1,12 @@
+---
+name: redaction-parameterized-key
+description: Declares its secret key name via a ${...} placeholder (issue #6029 review)
+secretParameters:
+  - ${SECRET_KEY}
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "${apiToken}"
+    label: Enter the secret token

--- a/android/junit-runner/src/test/resources/test-plans/redaction-plan.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-plan.yaml
@@ -1,0 +1,15 @@
+---
+name: redaction-plan
+description: Plan carrying a sensitive parameter, used by the redaction unit tests
+secretParameters:
+  - SECRET_TOKEN
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "${SECRET_TOKEN}"
+    label: Enter the secret token
+  - tool: tapOn
+    text: "${ENVIRONMENT}"
+    label: Tap the environment control

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -65,6 +65,15 @@
       "description": "DEPRECATED: Plan parameters (legacy field)",
       "additionalProperties": true
     },
+    "secretParameters": {
+      "type": "array",
+      "description": "Names of parameter keys whose substituted values are sensitive (tokens, passwords, PII). Their values are redacted from any context sent to a third-party LLM during AI-assisted recovery (issue #6029); the values still reach the local daemon unredacted so the plan can execute.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
     "metadata": {
       "type": "object",
       "description": "Additional metadata about the plan",

--- a/docs/using/ui-tests.md
+++ b/docs/using/ui-tests.md
@@ -158,6 +158,45 @@ checkpoints so failures explain which state was missing.
 
 </details>
 
+### Redacting sensitive parameters
+
+Plans substitute `${paramName}` placeholders with values you pass from the test
+(experiment groups, environments, and occasionally a token, password, or other
+secret). When AI-assisted recovery is enabled and a step fails, the runner sends
+failure context — the substituted plan YAML, the
+error, and sampled on-screen text — to your configured LLM provider. Any secret
+substituted into the plan would be disclosed to that provider.
+
+Mark the parameter keys whose values are sensitive and the runner masks them
+(`***REDACTED***`) in everything sent to the provider — the plan YAML, the error
+string, and the on-screen samples. The values still reach the **local** daemon
+unredacted so the plan actually runs; only what leaves the process for the LLM is
+masked.
+
+Declare them in the plan (applies on both platforms):
+
+```yaml
+name: login
+secretParameters:
+  - apiToken
+  - password
+steps:
+  - tool: inputText
+    text: "${apiToken}"
+```
+
+Or pass them from the test runner. Android:
+
+```kotlin
+AutoMobilePlan("test-plans/login.yaml") { "apiToken" to token }
+    .execute(AutoMobilePlanExecutionOptions(secretParameterKeys = setOf("apiToken")))
+```
+
+iOS — set `secretParameterKeys` on `AutoMobilePlanExecutor.Configuration`. The
+plan-declared and runner-supplied sets are unioned, so either source (or both)
+protects the value. Recovery stays opt-in; this only changes what recovery may
+disclose.
+
 ## 4. Run a multi-device plan
 
 Add device labels when a flow spans two users or devices. Steps for different

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor+Configuration.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor+Configuration.swift
@@ -14,6 +14,13 @@ extension AutoMobilePlanExecutor {
         public let retryDelaySeconds: TimeInterval
         public let startStep: Int
         public let parameters: [String: String]
+        /// Parameter keys whose substituted values are sensitive (tokens, passwords, PII). Their
+        /// values are masked out of any context handed to the AI recovery handler before it reaches
+        /// the third-party LLM provider (see `AutoMobilePlanExecutor.buildFailedStepContext`), while
+        /// the base64 `executePlan` payload to the LOCAL daemon keeps the real values so the plan can
+        /// run. A plan can also declare sensitive keys via its top-level `secretParameters:` list; the
+        /// two sets are unioned. Mirrors Android's `AutoMobilePlanExecutionOptions.secretParameterKeys`.
+        public let secretParameterKeys: Set<String>
         public let cleanup: CleanupOptions?
         public let planBundle: Bundle?
         public let defaultPlatform: PlanPlatform
@@ -31,6 +38,7 @@ extension AutoMobilePlanExecutor {
             retryDelaySeconds: TimeInterval = 1,
             startStep: Int = 0,
             parameters: [String: String] = [:],
+            secretParameterKeys: Set<String> = [],
             cleanup: CleanupOptions? = nil,
             planBundle: Bundle? = nil,
             defaultPlatform: PlanPlatform = .ios,
@@ -44,6 +52,7 @@ extension AutoMobilePlanExecutor {
             self.retryDelaySeconds = retryDelaySeconds
             self.startStep = startStep
             self.parameters = parameters
+            self.secretParameterKeys = secretParameterKeys
             self.cleanup = cleanup
             self.planBundle = planBundle
             self.defaultPlatform = defaultPlatform

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
@@ -180,10 +180,15 @@ public final class AutoMobilePlanExecutor {
         }
 
         // Values to redact from any recovery context that leaves the process for the LLM provider
-        // (issue #6029). Union the plan-declared secret keys with the caller-configured ones. The
-        // `substituted` string below keeps the real values — the daemon needs them to run the plan.
+        // (issue #6029). Union the plan-declared secret keys with the caller-configured ones, resolve
+        // any parameterized key names, then collect the concrete values to scrub. The `substituted`
+        // string below keeps the real values — the daemon needs them to run the plan.
+        let secretKeys = SecretRedaction.resolveKeyNames(
+            configuration.secretParameterKeys.union(planMetadata.secretParameterKeys),
+            parameters: configuration.parameters
+        )
         let secretValues = SecretRedaction.secretValues(
-            keys: configuration.secretParameterKeys.union(planMetadata.secretParameterKeys),
+            keys: secretKeys,
             parameters: configuration.parameters
         )
         PerfTimer
@@ -339,24 +344,28 @@ public final class AutoMobilePlanExecutor {
         -> FailedStepContext
     {
         // Sequential execution stops at the first failure, so every step before failedStep.stepIndex
-        // completed. Reconstruct their tool names from the plan for the agent prompt (best effort).
-        // Tool names carry no secret values, so parsing the un-redacted plan here is safe.
+        // completed. Reconstruct their tool names from the plan for the agent prompt (best effort). A
+        // step's `tool` can itself be a substituted `${secret}` value, so scrub the reconstructed tool
+        // names too (issue #6029 review).
         let stepTools = PlanStepToolParser.toolNames(from: planContent)
         var succeeded: [SucceededStepSummary] = []
         var index = 0
         while index < failedStep.stepIndex {
             let tool = index < stepTools.count ? stepTools[index] : "step"
-            succeeded.append(SucceededStepSummary(stepIndex: index, tool: tool))
+            succeeded.append(SucceededStepSummary(
+                stepIndex: index,
+                tool: SecretRedaction.redact(tool, secretValues: secretValues)
+            ))
             index += 1
         }
 
         // Egress boundary (issue #6029): every field placed on the context is forwarded to the LLM
         // provider by the recovery handler, so mask secret values out of the plan YAML, the failure
-        // error, and the sampled on-screen text/ids here — the daemon's base64 payload above kept the
-        // real values.
+        // error, the (possibly substituted) tool name, and the sampled on-screen text/ids here — the
+        // daemon's base64 payload above kept the real values.
         return FailedStepContext(
             failedStepIndex: failedStep.stepIndex,
-            failedTool: failedStep.tool,
+            failedTool: SecretRedaction.redact(failedStep.tool, secretValues: secretValues),
             error: SecretRedaction.redact(failedStep.error, secretValues: secretValues),
             succeededSteps: succeeded,
             planContent: SecretRedaction.redact(planContent, secretValues: secretValues),

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
@@ -155,8 +155,11 @@ public final class AutoMobilePlanExecutor {
         deviceIdOverride: String?,
         sessionUuidOverride: String?,
         testMetadata: TestMetadata?
-    ) throws -> ExecutePlanResult {
-        PerfTimer.log("executeAttempt START (startStep=\(startStep), recoveryAlreadyAttempted=\(recoveryAlreadyAttempted))")
+    )
+        throws -> ExecutePlanResult
+    {
+        PerfTimer
+            .log("executeAttempt START (startStep=\(startStep), recoveryAlreadyAttempted=\(recoveryAlreadyAttempted))")
         let planContent: String
         do {
             planContent = try PerfTimer.measure("loadPlan") {
@@ -175,6 +178,14 @@ public final class AutoMobilePlanExecutor {
         let planMetadata = try PerfTimer.measure("parsePlanMetadata") {
             try PlanMetadataParser.parse(from: substituted)
         }
+
+        // Values to redact from any recovery context that leaves the process for the LLM provider
+        // (issue #6029). Union the plan-declared secret keys with the caller-configured ones. The
+        // `substituted` string below keeps the real values — the daemon needs them to run the plan.
+        let secretValues = SecretRedaction.secretValues(
+            keys: configuration.secretParameterKeys.union(planMetadata.secretParameterKeys),
+            parameters: configuration.parameters
+        )
         PerfTimer
             .log(
                 "planMetadata: platform=\(planMetadata.platform.map { String(describing: $0) } ?? "nil"), hasDevices=\(planMetadata.hasDevices), deviceLabels=\(planMetadata.deviceLabels)"
@@ -226,13 +237,16 @@ public final class AutoMobilePlanExecutor {
                 try decodeExecutePlanResult(from: response.text)
             }
             PerfTimer
-                .log("executeAttempt END - success=\(result.success), steps=\(result.executedSteps)/\(result.totalSteps)")
+                .log(
+                    "executeAttempt END - success=\(result.success), steps=\(result.executedSteps)/\(result.totalSteps)"
+                )
             if result.success {
                 return result
             }
             return try handleFailure(
                 result: result,
                 planContent: substituted,
+                secretValues: secretValues,
                 platform: platform,
                 sessionUuid: sessionUuid,
                 deviceIdOverride: deviceIdOverride,
@@ -258,12 +272,15 @@ public final class AutoMobilePlanExecutor {
     private func handleFailure(
         result: ExecutePlanResult,
         planContent: String,
+        secretValues: [String],
         platform: PlanPlatform,
         sessionUuid: String,
         deviceIdOverride: String?,
         recoveryAlreadyAttempted: Bool,
         testMetadata: TestMetadata?
-    ) throws -> ExecutePlanResult {
+    )
+        throws -> ExecutePlanResult
+    {
         let failureMessage = buildFailureMessage(from: result)
 
         // Cheap local gates first; the feature-flag read (which may hit the daemon) is last and runs
@@ -283,6 +300,7 @@ public final class AutoMobilePlanExecutor {
         let context = buildFailedStepContext(
             failedStep: failedStep,
             planContent: planContent,
+            secretValues: secretValues,
             platform: platform,
             sessionUuid: sessionUuid,
             deviceIdOverride: deviceIdOverride
@@ -313,12 +331,16 @@ public final class AutoMobilePlanExecutor {
     private func buildFailedStepContext(
         failedStep: FailedStep,
         planContent: String,
+        secretValues: [String],
         platform: PlanPlatform,
         sessionUuid: String,
         deviceIdOverride: String?
-    ) -> FailedStepContext {
+    )
+        -> FailedStepContext
+    {
         // Sequential execution stops at the first failure, so every step before failedStep.stepIndex
         // completed. Reconstruct their tool names from the plan for the agent prompt (best effort).
+        // Tool names carry no secret values, so parsing the un-redacted plan here is safe.
         let stepTools = PlanStepToolParser.toolNames(from: planContent)
         var succeeded: [SucceededStepSummary] = []
         var index = 0
@@ -328,16 +350,20 @@ public final class AutoMobilePlanExecutor {
             index += 1
         }
 
+        // Egress boundary (issue #6029): every field placed on the context is forwarded to the LLM
+        // provider by the recovery handler, so mask secret values out of the plan YAML, the failure
+        // error, and the sampled on-screen text/ids here — the daemon's base64 payload above kept the
+        // real values.
         return FailedStepContext(
             failedStepIndex: failedStep.stepIndex,
             failedTool: failedStep.tool,
-            error: failedStep.error,
+            error: SecretRedaction.redact(failedStep.error, secretValues: secretValues),
             succeededSteps: succeeded,
-            planContent: planContent,
+            planContent: SecretRedaction.redact(planContent, secretValues: secretValues),
             platform: platform.rawValue,
             sessionUuid: sessionUuid,
             deviceId: failedStep.device ?? deviceIdOverride,
-            failureObservation: failedStep.failureObservation
+            failureObservation: SecretRedaction.redact(failedStep.failureObservation, secretValues: secretValues)
         )
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
@@ -180,16 +180,14 @@ public final class AutoMobilePlanExecutor {
         }
 
         // Values to redact from any recovery context that leaves the process for the LLM provider
-        // (issue #6029). Union the plan-declared secret keys with the caller-configured ones, resolve
-        // any parameterized key names, then collect the concrete values to scrub. The `substituted`
-        // string below keeps the real values — the daemon needs them to run the plan.
-        let secretKeys = SecretRedaction.resolveKeyNames(
-            configuration.secretParameterKeys.union(planMetadata.secretParameterKeys),
-            parameters: configuration.parameters
-        )
+        // (issue #6029). Parse the declared secret keys from the RAW plan (tolerant of `${...}` and
+        // immune to substitution truncation), union the caller-configured ones, and resolve any
+        // `${...}` inside the key names. The concrete strings to scrub are derived from THIS executor's
+        // own substitution — the single source of truth for what actually landed — so the scrub target
+        // always equals the recovery context. The `substituted` string keeps the real values for the
+        // daemon.
         let secretValues = SecretRedaction.secretValues(
-            keys: secretKeys,
-            parameters: configuration.parameters
+            resolveSecretValues(rawPlan: planContent)
         )
         PerfTimer
             .log(
@@ -434,10 +432,43 @@ public final class AutoMobilePlanExecutor {
             return content
         }
         var substituted = content
-        for (key, value) in parameters {
+        // Deterministic (sorted) order so the single ordered pass produces a reproducible result — the
+        // redaction path re-runs this same function to derive exactly what landed (issue #6029), and a
+        // hash-ordered pass would make that mapping (and the daemon payload) non-reproducible. Kept in
+        // sync with Android's sorted substitution.
+        for (key, value) in parameters.sorted(by: { $0.key < $1.key }) {
             substituted = substituted.replacingOccurrences(of: "${\(key)}", with: value)
         }
         return substituted
+    }
+
+    /// The concrete secret strings to scrub, derived entirely from THIS executor's substitution so
+    /// they always equal what landed in the recovery context (issue #6029). Secret keys come from the
+    /// caller config plus the RAW plan's `secretParameters:` (parsed placeholder-tolerantly); any
+    /// `${...}` inside a key name is resolved with the same substitution; and for each key both its raw
+    /// parameter value and its actual substituted value (`substituteParameters` applied to the bare
+    /// `${key}`, matching the ordered single pass exactly) are collected.
+    private func resolveSecretValues(rawPlan: String) -> [String] {
+        let declaredKeys = configuration.secretParameterKeys
+            .union(PlanMetadataParser.parseSecretParameterKeys(from: rawPlan))
+        guard !declaredKeys.isEmpty else {
+            return []
+        }
+        let params = configuration.parameters
+        let resolvedKeys = Set(declaredKeys.map { substituteParameters(in: $0, parameters: params) })
+
+        var values: [String] = []
+        for key in resolvedKeys {
+            if let raw = params[key], !raw.isEmpty {
+                values.append(raw)
+            }
+            let placeholder = "${\(key)}"
+            let landed = substituteParameters(in: placeholder, parameters: params)
+            if landed != placeholder, !landed.isEmpty {
+                values.append(landed)
+            }
+        }
+        return values
     }
 
     private func decodeExecutePlanResult(from text: String) throws -> ExecutePlanResult {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadata.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadata.swift
@@ -5,8 +5,4 @@ struct PlanMetadata {
     let devicePlatforms: [String: AutoMobilePlanExecutor.PlanPlatform]
     let deviceLabels: [String]
     let hasDevices: Bool
-    /// Parameter keys the plan declares sensitive via its top-level `secretParameters:` list. Unioned
-    /// with `Configuration.secretParameterKeys` so their substituted values are redacted before any
-    /// recovery context reaches the LLM provider (issue #6029).
-    let secretParameterKeys: Set<String>
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadata.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadata.swift
@@ -5,4 +5,8 @@ struct PlanMetadata {
     let devicePlatforms: [String: AutoMobilePlanExecutor.PlanPlatform]
     let deviceLabels: [String]
     let hasDevices: Bool
+    /// Parameter keys the plan declares sensitive via its top-level `secretParameters:` list. Unioned
+    /// with `Configuration.secretParameterKeys` so their substituted values are redacted before any
+    /// recovery context reaches the LLM provider (issue #6029).
+    let secretParameterKeys: Set<String>
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -171,13 +171,36 @@ enum PlanMetadataParser {
     }
 
     /// Parse a YAML flow list of scalar keys, e.g. `[apiToken, "password"]`, into its trimmed,
-    /// unquoted, non-empty elements. Used for the inline form of `secretParameters:`.
+    /// unquoted, non-empty elements. Used for the inline form of `secretParameters:`. Commas inside a
+    /// quoted item are NOT separators, so `["API,TOKEN"]` yields the single key `API,TOKEN` rather
+    /// than splitting it in two (issue #6029 review).
     private static func parseInlineList(_ value: String) -> [String] {
         var inner = value
         if inner.hasPrefix("[") { inner.removeFirst() }
         if inner.hasSuffix("]") { inner.removeLast() }
-        return inner
-            .split(separator: ",")
+
+        var items: [String] = []
+        var current = ""
+        var activeQuote: Character?
+        for character in inner {
+            if let quote = activeQuote {
+                if character == quote {
+                    activeQuote = nil
+                }
+                current.append(character)
+            } else if character == "\"" || character == "'" {
+                activeQuote = character
+                current.append(character)
+            } else if character == "," {
+                items.append(current)
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+        items.append(current)
+
+        return items
             .map { unquote($0.trimmingCharacters(in: .whitespaces)) }
             .filter { !$0.isEmpty }
     }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -9,6 +9,7 @@ enum PlanMetadataParser {
         var devicePlatforms: [String: AutoMobilePlanExecutor.PlanPlatform] = [:]
         var deviceLabels: [String] = []
         var hasDevices = false
+        var secretParameterKeys: Set<String> = []
 
         var index = 0
         while index < lines.count {
@@ -20,6 +21,33 @@ enum PlanMetadataParser {
             }
 
             let indent = indentationLevel(line)
+            if indent == 0 && trimmed.hasPrefix("secretParameters:") {
+                let inline = trimmed.dropFirst("secretParameters:".count).trimmingCharacters(in: .whitespaces)
+                if !inline.isEmpty {
+                    secretParameterKeys.formUnion(parseInlineList(inline))
+                    index += 1
+                    continue
+                }
+                index += 1
+                while index < lines.count {
+                    let raw = stripComments(from: lines[index])
+                    let rawTrimmed = raw.trimmingCharacters(in: .whitespaces)
+                    if rawTrimmed.isEmpty {
+                        index += 1
+                        continue
+                    }
+                    if indentationLevel(raw) == 0 || !rawTrimmed.hasPrefix("-") {
+                        break
+                    }
+                    let item = unquote(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))
+                    if !item.isEmpty {
+                        secretParameterKeys.insert(item)
+                    }
+                    index += 1
+                }
+                continue
+            }
+
             if indent == 0 && trimmed.hasPrefix("platform:") {
                 let value = trimmed.dropFirst("platform:".count).trimmingCharacters(in: .whitespaces)
                 let normalized = unquote(value)
@@ -133,8 +161,21 @@ enum PlanMetadataParser {
             platform: platform,
             devicePlatforms: devicePlatforms,
             deviceLabels: deviceLabels,
-            hasDevices: hasDevices
+            hasDevices: hasDevices,
+            secretParameterKeys: secretParameterKeys
         )
+    }
+
+    /// Parse a YAML flow list of scalar keys, e.g. `[apiToken, "password"]`, into its trimmed,
+    /// unquoted, non-empty elements. Used for the inline form of `secretParameters:`.
+    private static func parseInlineList(_ value: String) -> [String] {
+        var inner = value
+        if inner.hasPrefix("[") { inner.removeFirst() }
+        if inner.hasSuffix("]") { inner.removeLast() }
+        return inner
+            .split(separator: ",")
+            .map { unquote($0.trimmingCharacters(in: .whitespaces)) }
+            .filter { !$0.isEmpty }
     }
 
     private static func parsePlatform(_ value: String) throws -> AutoMobilePlanExecutor.PlanPlatform {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -9,7 +9,6 @@ enum PlanMetadataParser {
         var devicePlatforms: [String: AutoMobilePlanExecutor.PlanPlatform] = [:]
         var deviceLabels: [String] = []
         var hasDevices = false
-        var secretParameterKeys: Set<String> = []
 
         var index = 0
         while index < lines.count {
@@ -21,37 +20,6 @@ enum PlanMetadataParser {
             }
 
             let indent = indentationLevel(line)
-            if indent == 0 && trimmed.hasPrefix("secretParameters:") {
-                let inline = trimmed.dropFirst("secretParameters:".count).trimmingCharacters(in: .whitespaces)
-                if !inline.isEmpty {
-                    secretParameterKeys.formUnion(parseInlineList(inline))
-                    index += 1
-                    continue
-                }
-                index += 1
-                while index < lines.count {
-                    let raw = stripComments(from: lines[index])
-                    let rawTrimmed = raw.trimmingCharacters(in: .whitespaces)
-                    if rawTrimmed.isEmpty {
-                        index += 1
-                        continue
-                    }
-                    // A block sequence's `-` items may sit at ANY indent, including flush with the
-                    // parent key (indent 0) — valid YAML that snakeyaml (Android) accepts. Only a
-                    // non-list line ends the sequence, i.e. the next top-level key. Breaking on
-                    // indent 0 dropped every key of a flush list and silently disabled redaction.
-                    if !rawTrimmed.hasPrefix("-") {
-                        break
-                    }
-                    let item = unquote(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))
-                    if !item.isEmpty {
-                        secretParameterKeys.insert(item)
-                    }
-                    index += 1
-                }
-                continue
-            }
-
             if indent == 0 && trimmed.hasPrefix("platform:") {
                 let value = trimmed.dropFirst("platform:".count).trimmingCharacters(in: .whitespaces)
                 let normalized = unquote(value)
@@ -165,9 +133,56 @@ enum PlanMetadataParser {
             platform: platform,
             devicePlatforms: devicePlatforms,
             deviceLabels: deviceLabels,
-            hasDevices: hasDevices,
-            secretParameterKeys: secretParameterKeys
+            hasDevices: hasDevices
         )
+    }
+
+    /// Scan a plan's top-level `secretParameters:` declaration for the sensitive key names, tolerating
+    /// `${...}` placeholders anywhere (they are literal text to the scanner). MUST run on the RAW,
+    /// pre-substitution plan: a substituted value can inject a newline that truncates the declaration,
+    /// and a full YAML load chokes on unquoted placeholders in flow collections (issue #6029 review).
+    /// Non-throwing — declaring secrets is best-effort metadata, never a hard execution dependency.
+    /// Only the `secretParameters:` block is scanned, so unrelated `${...}` in other lists is ignored.
+    static func parseSecretParameterKeys(from yamlContent: String) -> Set<String> {
+        let lines = yamlContent.split(whereSeparator: \.isNewline).map { String($0) }
+        var keys: Set<String> = []
+        var index = 0
+        while index < lines.count {
+            let trimmed = stripComments(from: lines[index]).trimmingCharacters(in: .whitespaces)
+            guard indentationLevel(stripComments(from: lines[index])) == 0,
+                  trimmed.hasPrefix("secretParameters:")
+            else {
+                index += 1
+                continue
+            }
+
+            let inline = trimmed.dropFirst("secretParameters:".count).trimmingCharacters(in: .whitespaces)
+            if !inline.isEmpty {
+                keys.formUnion(parseInlineList(inline))
+                index += 1
+                continue
+            }
+
+            index += 1
+            // Block sequence: `-` items at ANY indent (flush with the parent key is valid YAML) until
+            // the next non-list line, i.e. the next top-level key.
+            while index < lines.count {
+                let rawTrimmed = stripComments(from: lines[index]).trimmingCharacters(in: .whitespaces)
+                if rawTrimmed.isEmpty {
+                    index += 1
+                    continue
+                }
+                if !rawTrimmed.hasPrefix("-") {
+                    break
+                }
+                let item = unquote(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))
+                if !item.isEmpty {
+                    keys.insert(item)
+                }
+                index += 1
+            }
+        }
+        return keys
     }
 
     /// Parse a YAML flow list of scalar keys, e.g. `[apiToken, "password"]`, into its trimmed,

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -36,7 +36,11 @@ enum PlanMetadataParser {
                         index += 1
                         continue
                     }
-                    if indentationLevel(raw) == 0 || !rawTrimmed.hasPrefix("-") {
+                    // A block sequence's `-` items may sit at ANY indent, including flush with the
+                    // parent key (indent 0) — valid YAML that snakeyaml (Android) accepts. Only a
+                    // non-list line ends the sequence, i.e. the next top-level key. Breaking on
+                    // indent 0 dropped every key of a flush list and silently disabled redaction.
+                    if !rawTrimmed.hasPrefix("-") {
                         break
                     }
                     let item = unquote(rawTrimmed.dropFirst().trimmingCharacters(in: .whitespaces))

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -6,30 +6,55 @@ import Foundation
 /// values to run the plan, and it is not the egress boundary.
 ///
 /// The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
-/// substituted, a secret's value can appear in the plan YAML, in the failure error string, and in
-/// on-screen text sampled at failure. Replacing every occurrence of each value covers all of those
-/// channels uniformly. Mirrors Android's `SecretRedactor`.
+/// substituted, a secret's value can appear in the plan YAML, the failure error, a substituted tool
+/// name, and on-screen text sampled at failure. Replacing every occurrence of each value covers all of
+/// those channels uniformly. `internal` — only the executor consumes it. Mirrors Android's
+/// `SecretRedactor`.
 enum SecretRedaction {
     static let placeholder = "***REDACTED***"
 
-    /// The values to scrub: the value of every secret key that was actually supplied a non-empty
-    /// parameter. Keys with no value (declared secret but never substituted) contribute nothing.
-    static func secretValues(keys: Set<String>, parameters: [String: String]) -> [String] {
-        keys
-            .compactMap { parameters[$0] }
-            .filter { !$0.isEmpty }
+    /// Resolve `${...}` references inside declared secret key NAMES against `parameters`, so a plan may
+    /// parameterize the key it declares (`secretParameters: [${SECRET_KEY}]`). A literal key resolves
+    /// to itself. Keeps iOS and Android agreeing on the effective key set.
+    static func resolveKeyNames(_ keys: Set<String>, parameters: [String: String]) -> Set<String> {
+        Set(keys.map { resolve($0, parameters: parameters) })
     }
 
-    /// Replace every occurrence of each secret value in `text` with the redaction placeholder.
-    /// Longer values are replaced first so a secret that contains a shorter secret as a substring is
-    /// fully masked rather than partially.
+    /// The concrete strings to scrub for the given (already key-name-resolved) secret keys. For each
+    /// key we scrub BOTH its raw parameter value AND its fully-resolved value (a secret whose value
+    /// embeds another `${param}` lands in the plan as the resolved form, issue #6029 review), each in
+    /// its NFC and NFD Unicode forms so a decomposed on-screen/error occurrence still matches. Empty
+    /// values contribute nothing.
+    static func secretValues(keys: Set<String>, parameters: [String: String]) -> [String] {
+        var result: [String] = []
+        // Dedup by exact UTF-16 code units, NOT by `Set<String>`: Swift string equality is canonical,
+        // so a `Set` would collapse the NFC and NFD variants we deliberately keep distinct.
+        var seen: Set<[UInt16]> = []
+        for key in keys {
+            guard let raw = parameters[key], !raw.isEmpty else {
+                continue
+            }
+            let resolved = resolve(raw, parameters: parameters)
+            for base in [raw, resolved] where !base.isEmpty {
+                for form in normalizationForms(of: base) where seen.insert(Array(form.utf16)).inserted {
+                    result.append(form)
+                }
+            }
+        }
+        return result
+    }
+
+    /// Replace every occurrence of each secret value in `text` with the redaction placeholder. Longer
+    /// values are replaced first so a secret that contains a shorter one as a substring is fully
+    /// masked. Matching is `.literal` (exact code units) because `secretValues` already supplies the
+    /// NFC/NFD variants to match.
     static func redact(_ text: String, secretValues: [String]) -> String {
         guard !secretValues.isEmpty else {
             return text
         }
         var redacted = text
-        for value in secretValues.sorted(by: { $0.count > $1.count }) {
-            redacted = redacted.replacingOccurrences(of: value, with: placeholder)
+        for value in secretValues.sorted(by: { $0.count > $1.count }) where !value.isEmpty {
+            redacted = redacted.replacingOccurrences(of: value, with: placeholder, options: [.literal])
         }
         return redacted
     }
@@ -53,5 +78,41 @@ enum SecretRedaction {
             visibleTextsSample: observation.visibleTextsSample?.map { redact($0, secretValues: secretValues) },
             resourceIdsSample: observation.resourceIdsSample?.map { redact($0, secretValues: secretValues) }
         )
+    }
+
+    /// Fully resolve `${key}` references in `value` against `parameters`, iterating to a fixpoint so a
+    /// value that embeds another parameter (which itself embeds another) resolves completely. Bounded
+    /// by the parameter count so a reference cycle terminates instead of looping.
+    private static func resolve(_ value: String, parameters: [String: String]) -> String {
+        guard value.contains("${") else {
+            return value
+        }
+        var current = value
+        for _ in 0 ... parameters.count {
+            var next = current
+            for (key, replacement) in parameters {
+                next = next.replacingOccurrences(of: "${\(key)}", with: replacement)
+            }
+            if next == current {
+                break
+            }
+            current = next
+        }
+        return current
+    }
+
+    /// `value` plus its canonical NFC and NFD forms, so a `.literal` scrub matches the secret
+    /// regardless of the Unicode normalization it arrives in. Distinctness is compared by UTF-16 code
+    /// units because Swift string `!=` is canonical and would treat every form as equal.
+    private static func normalizationForms(of value: String) -> [String] {
+        let valueUnits = Array(value.utf16)
+        var forms = [value]
+        var seen: Set<[UInt16]> = [valueUnits]
+        for candidate in [value.precomposedStringWithCanonicalMapping, value.decomposedStringWithCanonicalMapping]
+            where seen.insert(Array(candidate.utf16)).inserted
+        {
+            forms.append(candidate)
+        }
+        return forms
     }
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Redacts sensitive parameter values from any context that will leave the process for a third-party
+/// LLM provider during AI-assisted recovery (CWE-200, issue #6029). The base64 `executePlan` payload
+/// sent to the LOCAL daemon is intentionally NOT routed through here — the daemon needs the real
+/// values to run the plan, and it is not the egress boundary.
+///
+/// The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
+/// substituted, a secret's value can appear in the plan YAML, in the failure error string, and in
+/// on-screen text sampled at failure. Replacing every occurrence of each value covers all of those
+/// channels uniformly. Mirrors Android's `SecretRedactor`.
+enum SecretRedaction {
+    static let placeholder = "***REDACTED***"
+
+    /// The values to scrub: the value of every secret key that was actually supplied a non-empty
+    /// parameter. Keys with no value (declared secret but never substituted) contribute nothing.
+    static func secretValues(keys: Set<String>, parameters: [String: String]) -> [String] {
+        keys
+            .compactMap { parameters[$0] }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Replace every occurrence of each secret value in `text` with the redaction placeholder.
+    /// Longer values are replaced first so a secret that contains a shorter secret as a substring is
+    /// fully masked rather than partially.
+    static func redact(_ text: String, secretValues: [String]) -> String {
+        guard !secretValues.isEmpty else {
+            return text
+        }
+        var redacted = text
+        for value in secretValues.sorted(by: { $0.count > $1.count }) {
+            redacted = redacted.replacingOccurrences(of: value, with: placeholder)
+        }
+        return redacted
+    }
+
+    /// Redact the sampled UI strings and observe-error that feed the recovery prompt. A secret can
+    /// surface on screen (a token echoed into a field) or in the observe error, so these channels are
+    /// scrubbed too. Returns `nil` unchanged when there is no observation.
+    static func redact(
+        _ observation: FailureObservationSummary?,
+        secretValues: [String]
+    )
+        -> FailureObservationSummary?
+    {
+        guard let observation = observation, !secretValues.isEmpty else {
+            return observation
+        }
+        return FailureObservationSummary(
+            capturedAtMs: observation.capturedAtMs,
+            observeError: observation.observeError.map { redact($0, secretValues: secretValues) },
+            awaitTimeout: observation.awaitTimeout,
+            visibleTextsSample: observation.visibleTextsSample?.map { redact($0, secretValues: secretValues) },
+            resourceIdsSample: observation.resourceIdsSample?.map { redact($0, secretValues: secretValues) }
+        )
+    }
+}

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -5,40 +5,27 @@ import Foundation
 /// sent to the LOCAL daemon is intentionally NOT routed through here — the daemon needs the real
 /// values to run the plan, and it is not the egress boundary.
 ///
-/// The redactor works on the concrete secret VALUES (not the `${key}` templates): once a plan is
-/// substituted, a secret's value can appear in the plan YAML, the failure error, a substituted tool
-/// name, and on-screen text sampled at failure. Replacing every occurrence of each value covers all of
-/// those channels uniformly. `internal` — only the executor consumes it. Mirrors Android's
-/// `SecretRedactor`.
+/// This type does NOT resolve `${...}` placeholders: substitution is owned by the executor, which is
+/// the single source of truth for what actually landed in the plan (issue #6029 review — an
+/// independent fixpoint could mismatch the executor's single ordered pass, or blow up on a
+/// self-referential value). The executor hands over the concrete substituted secret strings; this
+/// type expands each into its Unicode NFC/NFD forms and scrubs every occurrence. `internal` — its
+/// only consumer is the executor, and `SecretRedactionTests` unit-tests it directly. Mirrors
+/// Android's `SecretRedactor`.
 enum SecretRedaction {
     static let placeholder = "***REDACTED***"
 
-    /// Resolve `${...}` references inside declared secret key NAMES against `parameters`, so a plan may
-    /// parameterize the key it declares (`secretParameters: [${SECRET_KEY}]`). A literal key resolves
-    /// to itself. Keeps iOS and Android agreeing on the effective key set.
-    static func resolveKeyNames(_ keys: Set<String>, parameters: [String: String]) -> Set<String> {
-        Set(keys.map { resolve($0, parameters: parameters) })
-    }
-
-    /// The concrete strings to scrub for the given (already key-name-resolved) secret keys. For each
-    /// key we scrub BOTH its raw parameter value AND its fully-resolved value (a secret whose value
-    /// embeds another `${param}` lands in the plan as the resolved form, issue #6029 review), each in
-    /// its NFC and NFD Unicode forms so a decomposed on-screen/error occurrence still matches. Empty
-    /// values contribute nothing.
-    static func secretValues(keys: Set<String>, parameters: [String: String]) -> [String] {
+    /// Expand the executor-supplied concrete secret strings into the exact byte forms to scrub: each
+    /// value in its NFC and NFD Unicode forms, so a decomposed on-screen/error occurrence still
+    /// matches a composed value (and vice versa). Blank inputs are dropped. Dedup is by UTF-16 code
+    /// units, NOT `Set<String>`, because Swift string equality is canonical and would collapse the
+    /// distinct forms we deliberately keep.
+    static func secretValues(_ concreteValues: [String]) -> [String] {
         var result: [String] = []
-        // Dedup by exact UTF-16 code units, NOT by `Set<String>`: Swift string equality is canonical,
-        // so a `Set` would collapse the NFC and NFD variants we deliberately keep distinct.
         var seen: Set<[UInt16]> = []
-        for key in keys {
-            guard let raw = parameters[key], !raw.isEmpty else {
-                continue
-            }
-            let resolved = resolve(raw, parameters: parameters)
-            for base in [raw, resolved] where !base.isEmpty {
-                for form in normalizationForms(of: base) where seen.insert(Array(form.utf16)).inserted {
-                    result.append(form)
-                }
+        for value in concreteValues where !value.isEmpty {
+            for form in normalizationForms(of: value) where seen.insert(Array(form.utf16)).inserted {
+                result.append(form)
             }
         }
         return result
@@ -80,34 +67,11 @@ enum SecretRedaction {
         )
     }
 
-    /// Fully resolve `${key}` references in `value` against `parameters`, iterating to a fixpoint so a
-    /// value that embeds another parameter (which itself embeds another) resolves completely. Bounded
-    /// by the parameter count so a reference cycle terminates instead of looping.
-    private static func resolve(_ value: String, parameters: [String: String]) -> String {
-        guard value.contains("${") else {
-            return value
-        }
-        var current = value
-        for _ in 0 ... parameters.count {
-            var next = current
-            for (key, replacement) in parameters {
-                next = next.replacingOccurrences(of: "${\(key)}", with: replacement)
-            }
-            if next == current {
-                break
-            }
-            current = next
-        }
-        return current
-    }
-
-    /// `value` plus its canonical NFC and NFD forms, so a `.literal` scrub matches the secret
-    /// regardless of the Unicode normalization it arrives in. Distinctness is compared by UTF-16 code
-    /// units because Swift string `!=` is canonical and would treat every form as equal.
+    /// `value` plus its canonical NFC and NFD forms, distinct by UTF-16 code units (Swift string `!=`
+    /// is canonical and would treat every form as equal).
     private static func normalizationForms(of value: String) -> [String] {
-        let valueUnits = Array(value.utf16)
         var forms = [value]
-        var seen: Set<[UInt16]> = [valueUnits]
+        var seen: Set<[UInt16]> = [Array(value.utf16)]
         for candidate in [value.precomposedStringWithCanonicalMapping, value.decomposedStringWithCanonicalMapping]
             where seen.insert(Array(candidate.utf16)).inserted
         {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -31,16 +31,18 @@ enum SecretRedaction {
         return result
     }
 
-    /// Replace every occurrence of each secret value in `text` with the redaction placeholder. Longer
-    /// values are replaced first so a secret that contains a shorter one as a substring is fully
-    /// masked. Matching is `.literal` (exact code units) because `secretValues` already supplies the
-    /// NFC/NFD variants to match.
+    /// Replace every occurrence of each secret value in `text` with the redaction placeholder. Values
+    /// are replaced longest-first — by UTF-16 code-unit length, so a decomposed form (more code units
+    /// than its composed twin) and any shorter secret that is a substring of a longer one are masked
+    /// whole, with no combining-mark or substring residue. Matching is `.literal` (exact code units)
+    /// because `secretValues` already supplies the NFC/NFD variants. Matches Android's `length`-desc
+    /// ordering (Kotlin `String.length` is a UTF-16 count).
     static func redact(_ text: String, secretValues: [String]) -> String {
         guard !secretValues.isEmpty else {
             return text
         }
         var redacted = text
-        for value in secretValues.sorted(by: { $0.count > $1.count }) where !value.isEmpty {
+        for value in secretValues.sorted(by: { $0.utf16.count > $1.utf16.count }) where !value.isEmpty {
             redacted = redacted.replacingOccurrences(of: value, with: placeholder, options: [.literal])
         }
         return redacted

--- a/ios/XCTestRunner/Sources/XCTestRunner/TestCase/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TestCase/AutoMobileTestCase.swift
@@ -107,6 +107,15 @@ open class AutoMobileTestCase: XCTestCase {
         return [:]
     }
 
+    /// Parameter keys whose substituted values are sensitive (tokens, passwords, PII). Their values
+    /// are masked out of any context AI-assisted recovery sends to the LLM provider, while the local
+    /// daemon still executes with the real values (issue #6029). A plan can also declare sensitive
+    /// keys via its top-level `secretParameters:` list; the two sets are unioned. Override to protect
+    /// a `planParameters` value that carries a secret.
+    open var secretParameterKeys: Set<String> {
+        return []
+    }
+
     open var cleanupOptions: AutoMobilePlanExecutor.CleanupOptions? {
         return nil
     }
@@ -206,6 +215,7 @@ open class AutoMobileTestCase: XCTestCase {
             retryDelaySeconds: retryDelaySeconds,
             startStep: startStep,
             parameters: planParameters,
+            secretParameterKeys: secretParameterKeys,
             cleanup: cleanupOptions,
             planBundle: planBundle,
             aiAssistance: aiAssistance

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -528,7 +528,11 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         _ = try executor.execute(testMetadata: nil)
 
         let request = try XCTUnwrap(captor.captured.first)
-        XCTAssertFalse(requestText(request).contains("sec-"), "the actual substituted secret must be scrubbed")
+        let text = requestText(request)
+        XCTAssertFalse(text.contains("sec-"), "the actual substituted secret must be scrubbed")
+        // Positive assertions so the test can't pass on an empty/malformed request.
+        XCTAssertTrue(text.contains(SecretRedaction.placeholder), "the secret must be replaced by the placeholder")
+        XCTAssertTrue(text.contains("observe"), "non-secret plan structure must be preserved")
     }
 
     /// #6029 review (701): a self-referential secret must not blow up (no fixpoint expansion) and must
@@ -559,7 +563,10 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         _ = try executor.execute(testMetadata: nil)
 
         let request = try XCTUnwrap(captor.captured.first)
-        XCTAssertFalse(requestText(request).contains("marker-"), "the self-referential secret must be redacted")
+        let text = requestText(request)
+        XCTAssertFalse(text.contains("marker-"), "the self-referential secret must be redacted")
+        XCTAssertTrue(text.contains(SecretRedaction.placeholder), "the secret must be replaced by the placeholder")
+        XCTAssertTrue(text.contains("observe"), "non-secret plan structure must be preserved")
     }
 
     /// #6029 review: a plan may parameterize the declared key name (`secretParameters: [${SECRET_KEY}]`)
@@ -590,7 +597,10 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         _ = try executor.execute(testMetadata: nil)
 
         let request = try XCTUnwrap(captor.captured.first)
-        XCTAssertFalse(requestText(request).contains(secret), "a parameterized secret key name must resolve and redact")
+        let text = requestText(request)
+        XCTAssertFalse(text.contains(secret), "a parameterized secret key name must resolve and redact")
+        XCTAssertTrue(text.contains(SecretRedaction.placeholder), "the secret must be replaced by the placeholder")
+        XCTAssertTrue(text.contains("observe"), "non-secret plan structure must be preserved")
     }
 
     // MARK: - Helpers
@@ -793,9 +803,13 @@ final class SecretRedactionTests: XCTestCase {
         )
     }
 
-    func testLongerSecretsAreScrubbedFirst() {
+    func testShorterSecretSubstringOfLongerIsFullyRedactedWithoutResidue() {
+        // "ab" is a substring of "abcdef"; longest-first replacement must mask the whole "abcdef"
+        // rather than leaving a "cdef" residue (which shortest-first would).
         let values = SecretRedaction.secretValues(["ab", "abcdef"])
-        XCTAssertEqual(SecretRedaction.redact("x abcdef y", secretValues: values), "x \(SecretRedaction.placeholder) y")
+        let result = SecretRedaction.redact("x abcdef y", secretValues: values)
+        XCTAssertEqual(result, "x \(SecretRedaction.placeholder) y")
+        XCTAssertFalse(result.contains("cdef"), "no substring residue may remain")
     }
 
     func testEmptyValuesAreIgnored() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -470,6 +470,34 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
     }
 
+    func testSecretSubstitutedIntoToolNameIsRedacted() throws {
+        let client = RecoveryMCPClient()
+        // The daemon reports the failed step's tool as the substituted secret value.
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": secret, "error": "step failed"]
+        ))
+
+        let captor = CapturingModelResponder()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let executor = makeExecutor(client: client, handler: handler)
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(
+            requestText(request).contains(secret),
+            "a secret substituted into a tool name must be redacted from the recovery prompt"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeExecutor(
@@ -582,6 +610,12 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN", "PASSWORD"])
     }
 
+    func testInlineFlowListDoesNotSplitOnCommaInsideQuotes() throws {
+        // A comma inside a quoted item is part of the key, not a separator (#6029 review).
+        let yaml = "name: P\nsecretParameters: [\"API,TOKEN\", plain]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["API,TOKEN", "plain"])
+    }
+
     func testFlushBlockStopsAtNextTopLevelKeyAndDoesNotSwallowIt() throws {
         // A flush block sequence must end at the next top-level key, which must still parse.
         let yaml = """
@@ -600,6 +634,47 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
     func testNoSecretParametersYieldsEmptySet() throws {
         let yaml = "name: P\nsteps:\n  - tool: observe"
         XCTAssertTrue(try PlanMetadataParser.parse(from: yaml).secretParameterKeys.isEmpty)
+    }
+}
+
+/// Direct redaction-completeness tests for `SecretRedaction` (#6029 review): nested substitution,
+/// Unicode normalization, and parameterized secret key names.
+final class SecretRedactionCompletenessTests: XCTestCase {
+    func testRedactsFullyResolvedNestedSecretValue() {
+        // TOKEN's value embeds ${ENV}; the value that lands in the plan is the resolved form, so that
+        // is what must be scrubbed — the raw `pre-${ENV}` snapshot alone would leak `pre-live`.
+        let params = ["TOKEN": "pre-${ENV}", "ENV": "live"]
+        let values = SecretRedaction.secretValues(keys: ["TOKEN"], parameters: params)
+        XCTAssertEqual(
+            SecretRedaction.redact("typed pre-live into field", secretValues: values),
+            "typed \(SecretRedaction.placeholder) into field"
+        )
+    }
+
+    func testRedactsSecretRegardlessOfUnicodeNormalization() {
+        let composedValue = "caf\u{00E9}-token" // NFC form
+        let values = SecretRedaction.secretValues(keys: ["K"], parameters: ["K": composedValue])
+        // The same secret occurs in the target text in its decomposed (NFD) form.
+        let decomposedOccurrence = composedValue.decomposedStringWithCanonicalMapping
+        let result = SecretRedaction.redact("error: " + decomposedOccurrence + " seen", secretValues: values)
+        XCTAssertTrue(result.contains(SecretRedaction.placeholder))
+        XCTAssertFalse(
+            result.unicodeScalars.contains("\u{0301}"),
+            "the decomposed secret's combining mark must be gone"
+        )
+    }
+
+    func testResolveKeyNamesResolvesParameterizedKey() {
+        // A plan may declare `secretParameters: [${SECRET_KEY}]`; the key name resolves against params.
+        let params = ["SECRET_KEY": "apiToken", "apiToken": "s3cr3t"]
+        let keys = SecretRedaction.resolveKeyNames(["${SECRET_KEY}"], parameters: params)
+        XCTAssertTrue(keys.contains("apiToken"))
+        let values = SecretRedaction.secretValues(keys: keys, parameters: params)
+        XCTAssertEqual(SecretRedaction.redact("x s3cr3t y", secretValues: values), "x \(SecretRedaction.placeholder) y")
+    }
+
+    func testLiteralKeyResolvesToItself() {
+        XCTAssertEqual(SecretRedaction.resolveKeyNames(["TOKEN"], parameters: ["TOKEN": "v"]), ["TOKEN"])
     }
 }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -498,18 +498,130 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
     }
 
+    /// #6029 review (695): the scrubbed value must equal what the executor's single ordered pass
+    /// actually produced. With sorted-key substitution, `${TOKEN}` -> `sec-${AA}-zeta` (AA resolved
+    /// before TOKEN inserts it, ZZ after) — neither the raw value nor a fully-resolved fixpoint. Using
+    /// the executor's own substitution as the source of truth scrubs exactly that.
+    func testScrubsExactlyWhatTheExecutorSubstitutionProduced() throws {
+        let plan = """
+        name: P
+        secretParameters:
+          - TOKEN
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${TOKEN}"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["TOKEN": "sec-${AA}-${ZZ}", "AA": "alpha", "ZZ": "zeta"]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(requestText(request).contains("sec-"), "the actual substituted secret must be scrubbed")
+    }
+
+    /// #6029 review (701): a self-referential secret must not blow up (no fixpoint expansion) and must
+    /// still be redacted. The executor's single pass turns `${TOKEN}` into `marker-${TOKEN}` once.
+    func testSelfReferentialSecretTerminatesAndIsRedacted() throws {
+        let plan = """
+        name: P
+        secretParameters:
+          - TOKEN
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${TOKEN}"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["TOKEN": "marker-${TOKEN}"]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(requestText(request).contains("marker-"), "the self-referential secret must be redacted")
+    }
+
+    /// #6029 review: a plan may parameterize the declared key name (`secretParameters: [${SECRET_KEY}]`)
+    /// — parsed from the raw plan, then the key name resolved against parameters.
+    func testParameterizedSecretKeyNameIsRedacted() throws {
+        let plan = """
+        name: P
+        secretParameters:
+          - ${SECRET_KEY}
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${apiToken}"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["SECRET_KEY": "apiToken", "apiToken": secret]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(requestText(request).contains(secret), "a parameterized secret key name must resolve and redact")
+    }
+
     // MARK: - Helpers
+
+    private func makeCapturingHandler(
+        client: RecoveryMCPClient,
+        captor: CapturingModelResponder
+    )
+        -> TachikomaPlanRecoveryHandler
+    {
+        TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+    }
 
     private func makeExecutor(
         client: RecoveryMCPClient,
         handler: PlanRecoveryHandler,
         planText: String? = nil,
+        parameters: [String: String]? = nil,
         configSecretKeys: Set<String> = []
     )
         -> AutoMobilePlanExecutor
     {
         // The default plan text declares `secretParameters:` itself; configSecretKeys exercises the
-        // Configuration path, and planText lets a test swap in a different declaration form.
+        // Configuration path, and planText/parameters let a test swap in a different scenario.
         let config = AutoMobilePlanExecutor.Configuration(
             transport: .daemonUnixSocket(path: "/tmp/xctestrunner-redaction-test.sock"),
             planPath: "redaction-plan.yaml",
@@ -517,7 +629,7 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
             timeoutSeconds: 5,
             retryDelaySeconds: 0,
             startStep: 0,
-            parameters: ["TOKEN": secret, "ENVIRONMENT": visible],
+            parameters: parameters ?? ["TOKEN": secret, "ENVIRONMENT": visible],
             secretParameterKeys: configSecretKeys,
             aiAssistance: true
         )
@@ -581,8 +693,10 @@ private final class CapturingModelResponder: ModelResponding, @unchecked Sendabl
 
 /// Direct tests of `PlanMetadataParser`'s `secretParameters:` parsing (#6029). Parity note: these
 /// forms must all parse the same set of keys snakeyaml gives the Android runner.
+/// Tests of `PlanMetadataParser.parseSecretParameterKeys` — the RAW, placeholder-tolerant scanner
+/// that replaces the previous substituted-content / YAML-load parsing (#6029 convergence).
 final class PlanMetadataSecretParametersParsingTests: XCTestCase {
-    func testFlushZeroIndentBlockSequenceIsParsed() throws {
+    func testFlushZeroIndentBlockSequenceIsParsed() {
         let yaml = """
         name: P
         secretParameters:
@@ -591,10 +705,10 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         steps:
           - tool: observe
         """
-        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN", "PASSWORD"])
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD"])
     }
 
-    func testIndentedBlockSequenceIsParsed() throws {
+    func testIndentedBlockSequenceIsParsed() {
         let yaml = """
         name: P
         secretParameters:
@@ -602,22 +716,20 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         steps:
           - tool: observe
         """
-        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN"])
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN"])
     }
 
-    func testInlineFlowListIsParsed() throws {
+    func testInlineFlowListIsParsed() {
         let yaml = "name: P\nsecretParameters: [TOKEN, \"PASSWORD\"]\nsteps:\n  - tool: observe"
-        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN", "PASSWORD"])
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD"])
     }
 
-    func testInlineFlowListDoesNotSplitOnCommaInsideQuotes() throws {
-        // A comma inside a quoted item is part of the key, not a separator (#6029 review).
+    func testInlineFlowListDoesNotSplitOnCommaInsideQuotes() {
         let yaml = "name: P\nsecretParameters: [\"API,TOKEN\", plain]\nsteps:\n  - tool: observe"
-        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["API,TOKEN", "plain"])
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API,TOKEN", "plain"])
     }
 
-    func testFlushBlockStopsAtNextTopLevelKeyAndDoesNotSwallowIt() throws {
-        // A flush block sequence must end at the next top-level key, which must still parse.
+    func testFlushBlockStopsAtNextTopLevelKey() {
         let yaml = """
         name: P
         secretParameters:
@@ -626,34 +738,51 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         steps:
           - tool: observe
         """
-        let metadata = try PlanMetadataParser.parse(from: yaml)
-        XCTAssertEqual(metadata.secretParameterKeys, ["TOKEN"])
-        XCTAssertEqual(metadata.platform, .ios)
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN"])
     }
 
-    func testNoSecretParametersYieldsEmptySet() throws {
-        let yaml = "name: P\nsteps:\n  - tool: observe"
-        XCTAssertTrue(try PlanMetadataParser.parse(from: yaml).secretParameterKeys.isEmpty)
+    func testNoSecretParametersYieldsEmptySet() {
+        XCTAssertTrue(PlanMetadataParser.parseSecretParameterKeys(from: "name: P\nsteps:\n  - tool: observe").isEmpty)
+    }
+
+    func testToleratesPlaceholderKeyAndUnrelatedPlaceholderLists() {
+        // A parameterized key name is kept literal here (resolved later); an unrelated flow list with
+        // placeholders (which a full YAML load would choke on) must not affect the scan (#6029 review).
+        let yaml = """
+        name: P
+        secretParameters:
+          - ${SECRET_KEY}
+        steps:
+          - tool: observe
+            waitFor:
+              textAny: [${LABEL}, OK]
+          - tool: inputText
+            text: "${SECRET_KEY}"
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["${SECRET_KEY}"])
+    }
+
+    func testScansRawPlanSoInjectedContentInAValueCannotAddKeys() {
+        // Parsing runs on the RAW plan: a `${EVIL}` value that would expand to a fake secretParameters
+        // block cannot inject keys, because the scanner never sees substituted values (#6029 review).
+        let yaml = """
+        name: P
+        secretParameters:
+          - REAL
+        steps:
+          - tool: inputText
+            text: "${EVIL}"
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["REAL"])
     }
 }
 
-/// Direct redaction-completeness tests for `SecretRedaction` (#6029 review): nested substitution,
-/// Unicode normalization, and parameterized secret key names.
-final class SecretRedactionCompletenessTests: XCTestCase {
-    func testRedactsFullyResolvedNestedSecretValue() {
-        // TOKEN's value embeds ${ENV}; the value that lands in the plan is the resolved form, so that
-        // is what must be scrubbed — the raw `pre-${ENV}` snapshot alone would leak `pre-live`.
-        let params = ["TOKEN": "pre-${ENV}", "ENV": "live"]
-        let values = SecretRedaction.secretValues(keys: ["TOKEN"], parameters: params)
-        XCTAssertEqual(
-            SecretRedaction.redact("typed pre-live into field", secretValues: values),
-            "typed \(SecretRedaction.placeholder) into field"
-        )
-    }
-
+/// Direct redaction tests for `SecretRedaction` — the type now only expands Unicode forms and scrubs;
+/// resolution/substitution is the executor's job (tested end-to-end below). (#6029 convergence)
+final class SecretRedactionTests: XCTestCase {
     func testRedactsSecretRegardlessOfUnicodeNormalization() {
         let composedValue = "caf\u{00E9}-token" // NFC form
-        let values = SecretRedaction.secretValues(keys: ["K"], parameters: ["K": composedValue])
+        let values = SecretRedaction.secretValues([composedValue])
         // The same secret occurs in the target text in its decomposed (NFD) form.
         let decomposedOccurrence = composedValue.decomposedStringWithCanonicalMapping
         let result = SecretRedaction.redact("error: " + decomposedOccurrence + " seen", secretValues: values)
@@ -664,17 +793,16 @@ final class SecretRedactionCompletenessTests: XCTestCase {
         )
     }
 
-    func testResolveKeyNamesResolvesParameterizedKey() {
-        // A plan may declare `secretParameters: [${SECRET_KEY}]`; the key name resolves against params.
-        let params = ["SECRET_KEY": "apiToken", "apiToken": "s3cr3t"]
-        let keys = SecretRedaction.resolveKeyNames(["${SECRET_KEY}"], parameters: params)
-        XCTAssertTrue(keys.contains("apiToken"))
-        let values = SecretRedaction.secretValues(keys: keys, parameters: params)
-        XCTAssertEqual(SecretRedaction.redact("x s3cr3t y", secretValues: values), "x \(SecretRedaction.placeholder) y")
+    func testLongerSecretsAreScrubbedFirst() {
+        let values = SecretRedaction.secretValues(["ab", "abcdef"])
+        XCTAssertEqual(SecretRedaction.redact("x abcdef y", secretValues: values), "x \(SecretRedaction.placeholder) y")
     }
 
-    func testLiteralKeyResolvesToItself() {
-        XCTAssertEqual(SecretRedaction.resolveKeyNames(["TOKEN"], parameters: ["TOKEN": "v"]), ["TOKEN"])
+    func testEmptyValuesAreIgnored() {
+        XCTAssertEqual(
+            SecretRedaction.redact("unchanged", secretValues: SecretRedaction.secretValues([""])),
+            "unchanged"
+        )
     }
 }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Tachikoma
+import XCTest
 @testable import XCTestRunner
 import XCTestRunnerTestSupport
 
@@ -140,7 +140,9 @@ final class RecoveryExecutorTests: XCTestCase {
         handler: PlanRecoveryHandler,
         recoveryEnabled: Bool,
         aiAssistance: Bool = true
-    ) -> AutoMobilePlanExecutor {
+    )
+        -> AutoMobilePlanExecutor
+    {
         let config = AutoMobilePlanExecutor.Configuration(
             transport: .daemonUnixSocket(path: "/tmp/xctestrunner-recovery-test.sock"),
             planPath: "recovery-plan.yaml",
@@ -315,7 +317,9 @@ final class TachikomaPlanRecoveryHandlerTests: XCTestCase {
         client: RecoveryMCPClient,
         responder: ModelResponding,
         maxToolCalls: Int
-    ) -> TachikomaPlanRecoveryHandler {
+    )
+        -> TachikomaPlanRecoveryHandler
+    {
         TachikomaPlanRecoveryHandler(
             mcpClient: client,
             configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: maxToolCalls),
@@ -324,6 +328,175 @@ final class TachikomaPlanRecoveryHandlerTests: XCTestCase {
             logger: SilentLogger(),
             responderFactory: { _ in responder }
         )
+    }
+}
+
+/// Issue #6029 (CWE-200): a secret plan parameter must never reach the third-party LLM provider
+/// during AI-assisted recovery. These tests drive the FULL executor → recovery handler → model call
+/// path with a real `TachikomaPlanRecoveryHandler` and a capturing `ModelResponding` so the assertion
+/// is against the actual `ModelRequest` that would go over the wire, not a helper's rendering of it.
+final class PlanRecoverySecretRedactionTests: XCTestCase {
+    private let secret = "SECRET-hunter2-TOKEN"
+    private let visible = "keepme-visible-env"
+
+    private let plan = """
+    name: Redaction Plan
+    secretParameters:
+      - TOKEN
+    steps:
+      - tool: observe
+      - tool: inputText
+        text: "${TOKEN}"
+      - tool: tapOn
+        text: "${ENVIRONMENT}"
+    """
+
+    func testSecretIsRedactedFromModelRequestWhileNonSecretIsPreserved() throws {
+        let client = RecoveryMCPClient()
+        // Fail on the inputText step; the secret also surfaces in the error string and on-screen sample.
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: [
+                "stepIndex": 1,
+                "tool": "inputText",
+                "error": "timed out entering \(secret) into field",
+                "failureObservation": [
+                    "visibleTextsSample": ["Welcome \(visible)", "token: \(secret)"],
+                    "resourceIdsSample": ["field/\(secret)"],
+                ],
+            ]
+        ))
+
+        let captor = CapturingModelResponder()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let executor = makeExecutor(client: client, handler: handler)
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first, "recovery must issue a model request")
+        let text = requestText(request)
+
+        XCTAssertFalse(text.contains(secret), "secret value must not appear anywhere in the model request")
+        XCTAssertTrue(text.contains(SecretRedaction.placeholder), "the secret must be replaced by the placeholder")
+        XCTAssertTrue(text.contains(visible), "non-secret on-screen context must be preserved")
+        XCTAssertTrue(text.contains("ENVIRONMENT") || text.contains(visible), "non-secret plan context is preserved")
+
+        // The base64 executePlan payload sent to the LOCAL daemon must keep the REAL secret so the
+        // plan can actually run — the daemon is not the egress boundary.
+        let daemonPlan = try XCTUnwrap(decodedDaemonPlanContent(client.executePlanCalls.first))
+        XCTAssertTrue(daemonPlan.contains(secret), "daemon executePlan payload must stay unredacted")
+    }
+
+    func testSecretDeclaredOnlyViaConfigurationIsRedacted() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secret)"]
+        ))
+
+        let captor = CapturingModelResponder()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        // Declare the secret ONLY through Configuration.secretParameterKeys, not the plan.
+        let executor = makeExecutor(client: client, handler: handler, planSecretKeys: [], configSecretKeys: ["TOKEN"])
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(requestText(request).contains(secret), "config-declared secret must also be redacted")
+    }
+
+    // MARK: - Helpers
+
+    private func makeExecutor(
+        client: RecoveryMCPClient,
+        handler: PlanRecoveryHandler,
+        planSecretKeys _: Set<String> = ["TOKEN"],
+        configSecretKeys: Set<String> = []
+    )
+        -> AutoMobilePlanExecutor
+    {
+        // planSecretKeys unused directly — the plan text already declares `secretParameters: [TOKEN]`;
+        // the flag documents intent. configSecretKeys exercises the Configuration path.
+        let config = AutoMobilePlanExecutor.Configuration(
+            transport: .daemonUnixSocket(path: "/tmp/xctestrunner-redaction-test.sock"),
+            planPath: "redaction-plan.yaml",
+            retryCount: 0,
+            timeoutSeconds: 5,
+            retryDelaySeconds: 0,
+            startStep: 0,
+            parameters: ["TOKEN": secret, "ENVIRONMENT": visible],
+            secretParameterKeys: configSecretKeys,
+            aiAssistance: true
+        )
+        return AutoMobilePlanExecutor(
+            configuration: config,
+            planLoader: StubPlanLoader(content: plan),
+            mcpClient: client,
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            recoveryHandler: handler,
+            recoveryConfigProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5)
+        )
+    }
+
+    private func requestText(_ request: ModelRequest) -> String {
+        var parts: [String] = []
+        if let system = request.systemInstructions {
+            parts.append(system)
+        }
+        for message in request.messages {
+            switch message {
+            case let .user(_, content):
+                if case let .text(value) = content {
+                    parts.append(value)
+                }
+            case let .assistant(_, content, _):
+                for item in content {
+                    if case let .outputText(value) = item {
+                        parts.append(value)
+                    }
+                }
+            default:
+                break
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+
+    private func decodedDaemonPlanContent(_ call: RecoveryMCPClient.Call?) -> String? {
+        guard let raw = call?.arguments["planContent"] as? String else {
+            return nil
+        }
+        let base64 = raw.hasPrefix("base64:") ? String(raw.dropFirst("base64:".count)) : raw
+        guard let data = Data(base64Encoded: base64) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+/// Fake `ModelResponding` that records every `ModelRequest` it is asked to answer, then ends the
+/// recovery loop with a final (no-tool-call) response so nothing touches the device.
+private final class CapturingModelResponder: ModelResponding, @unchecked Sendable {
+    private(set) var captured: [ModelRequest] = []
+
+    func respond(_ request: ModelRequest) async throws -> ModelResponse {
+        captured.append(request)
+        return ModelResponse(id: "resp", content: [.outputText("done")])
     }
 }
 
@@ -498,12 +671,12 @@ private final class StubModelResponder: ModelResponding, @unchecked Sendable {
 
     init(_ scripted: [ModelResponse]) {
         self.scripted = scripted
-        self.repeated = nil
+        repeated = nil
     }
 
     init(alwaysReturn response: ModelResponse) {
-        self.scripted = []
-        self.repeated = response
+        scripted = []
+        repeated = response
     }
 
     func respond(_: ModelRequest) async throws -> ModelResponse {
@@ -519,7 +692,10 @@ private final class StubModelResponder: ModelResponding, @unchecked Sendable {
     static func toolCall(name: String, arguments: String = "{}") -> ModelResponse {
         ModelResponse(
             id: "resp",
-            content: [.toolCall(ToolCallItem(id: "call-\(name)", function: FunctionCall(name: name, arguments: arguments)))]
+            content: [.toolCall(ToolCallItem(
+                id: "call-\(name)",
+                function: FunctionCall(name: name, arguments: arguments)
+            ))]
         )
     }
 
@@ -551,7 +727,9 @@ private func planJSON(
     executedSteps: Int,
     totalSteps: Int,
     failedStep: [String: Any]? = nil
-) -> String {
+)
+    -> String
+{
     var payload: [String: Any] = [
         "success": success,
         "executedSteps": executedSteps,

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -410,8 +410,21 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
             logger: SilentLogger(),
             responderFactory: { _ in captor }
         )
-        // Declare the secret ONLY through Configuration.secretParameterKeys, not the plan.
-        let executor = makeExecutor(client: client, handler: handler, planSecretKeys: [], configSecretKeys: ["TOKEN"])
+        // Declare the secret ONLY through Configuration.secretParameterKeys — the plan here does NOT
+        // list `secretParameters`, isolating the Configuration path.
+        let planWithoutSecretDecl = """
+        name: Redaction Plan
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${TOKEN}"
+        """
+        let executor = makeExecutor(
+            client: client,
+            handler: handler,
+            planText: planWithoutSecretDecl,
+            configSecretKeys: ["TOKEN"]
+        )
 
         _ = try executor.execute(testMetadata: nil)
 
@@ -419,18 +432,56 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         XCTAssertFalse(requestText(request).contains(secret), "config-declared secret must also be redacted")
     }
 
+    func testSecretRedactedWhenSecretParametersIsFlushZeroIndentBlockSequence() throws {
+        // Flush (zero-indent) block sequence — valid YAML that the iOS line parser previously dropped,
+        // silently disabling redaction on iOS while Android (snakeyaml) still redacted (#6029).
+        let flushPlan = """
+        name: Redaction Plan
+        secretParameters:
+        - TOKEN
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${TOKEN}"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secret)"]
+        ))
+
+        let captor = CapturingModelResponder()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let executor = makeExecutor(client: client, handler: handler, planText: flushPlan)
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(
+            requestText(request).contains(secret),
+            "a flush-form secretParameters declaration must still redact on iOS"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeExecutor(
         client: RecoveryMCPClient,
         handler: PlanRecoveryHandler,
-        planSecretKeys _: Set<String> = ["TOKEN"],
+        planText: String? = nil,
         configSecretKeys: Set<String> = []
     )
         -> AutoMobilePlanExecutor
     {
-        // planSecretKeys unused directly — the plan text already declares `secretParameters: [TOKEN]`;
-        // the flag documents intent. configSecretKeys exercises the Configuration path.
+        // The default plan text declares `secretParameters:` itself; configSecretKeys exercises the
+        // Configuration path, and planText lets a test swap in a different declaration form.
         let config = AutoMobilePlanExecutor.Configuration(
             transport: .daemonUnixSocket(path: "/tmp/xctestrunner-redaction-test.sock"),
             planPath: "redaction-plan.yaml",
@@ -444,7 +495,7 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
         return AutoMobilePlanExecutor(
             configuration: config,
-            planLoader: StubPlanLoader(content: plan),
+            planLoader: StubPlanLoader(content: planText ?? plan),
             mcpClient: client,
             timer: FakeTimer(),
             logger: SilentLogger(),
@@ -497,6 +548,58 @@ private final class CapturingModelResponder: ModelResponding, @unchecked Sendabl
     func respond(_ request: ModelRequest) async throws -> ModelResponse {
         captured.append(request)
         return ModelResponse(id: "resp", content: [.outputText("done")])
+    }
+}
+
+/// Direct tests of `PlanMetadataParser`'s `secretParameters:` parsing (#6029). Parity note: these
+/// forms must all parse the same set of keys snakeyaml gives the Android runner.
+final class PlanMetadataSecretParametersParsingTests: XCTestCase {
+    func testFlushZeroIndentBlockSequenceIsParsed() throws {
+        let yaml = """
+        name: P
+        secretParameters:
+        - TOKEN
+        - PASSWORD
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN", "PASSWORD"])
+    }
+
+    func testIndentedBlockSequenceIsParsed() throws {
+        let yaml = """
+        name: P
+        secretParameters:
+          - TOKEN
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN"])
+    }
+
+    func testInlineFlowListIsParsed() throws {
+        let yaml = "name: P\nsecretParameters: [TOKEN, \"PASSWORD\"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(try PlanMetadataParser.parse(from: yaml).secretParameterKeys, ["TOKEN", "PASSWORD"])
+    }
+
+    func testFlushBlockStopsAtNextTopLevelKeyAndDoesNotSwallowIt() throws {
+        // A flush block sequence must end at the next top-level key, which must still parse.
+        let yaml = """
+        name: P
+        secretParameters:
+        - TOKEN
+        platform: ios
+        steps:
+          - tool: observe
+        """
+        let metadata = try PlanMetadataParser.parse(from: yaml)
+        XCTAssertEqual(metadata.secretParameterKeys, ["TOKEN"])
+        XCTAssertEqual(metadata.platform, .ios)
+    }
+
+    func testNoSecretParametersYieldsEmptySet() throws {
+        let yaml = "name: P\nsteps:\n  - tool: observe"
+        XCTAssertTrue(try PlanMetadataParser.parse(from: yaml).secretParameterKeys.isEmpty)
     }
 }
 

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -65,6 +65,15 @@
       "description": "DEPRECATED: Plan parameters (legacy field)",
       "additionalProperties": true
     },
+    "secretParameters": {
+      "type": "array",
+      "description": "Names of parameter keys whose substituted values are sensitive (tokens, passwords, PII). Their values are redacted from any context sent to a third-party LLM during AI-assisted recovery (issue #6029); the values still reach the local daemon unredacted so the plan can execute.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
     "metadata": {
       "type": "object",
       "description": "Additional metadata about the plan",


### PR DESCRIPTION
## Summary

AI-assisted plan recovery forwarded test context to a third-party LLM provider **without redaction** (CWE-200, Sensitive Data Exposure). When recovery ran, the substituted **full plan YAML** (`FailedStepContext.planContent`), the failure error string, and sampled on-screen `visibleTexts`/`resourceIds` went verbatim into the `ModelRequest` sent to the configured provider (Anthropic/OpenAI/Google). A plan parameter carrying a token, password, or PII was therefore disclosed to that provider.

This adds a way to mark plan parameters sensitive and masks their substituted **values** out of every channel that reaches the LLM, on **both** runners — the iOS `XCTestRunner` handler and the Android `junit-runner` `AutoMobileAgent` (which it mirrors).

### What changed

- **New affordance to mark parameters sensitive:**
  - iOS: `secretParameterKeys: Set<String>` on `AutoMobilePlanExecutor.Configuration`.
  - Android: `secretParameterKeys: Set<String>` on `AutoMobilePlanExecutionOptions`.
  - Shared plan schema: a top-level `secretParameters:` list (added to `schemas/test-plan.schema.json` and the Android runtime copy) so a plan can declare its own sensitive keys. Both runners parse it (iOS via `PlanMetadataParser`, Android via snakeyaml from the **raw pre-substitution** plan) and **union** it with the configured set.

- **Redaction at the egress boundary.** The substituted secret **values** are masked with `***REDACTED***` in `buildFailedStepContext` — the single point where the recovery `FailedStepContext` is assembled — via a small `SecretRedaction`/`SecretRedactor` helper. Covered channels:
  - iOS: `planContent`, the failure `error`, and the `visibleTextsSample` / `resourceIdsSample` / `observeError` in `FailureObservationSummary`.
  - Android: `planContent` and the failure `error` (the Android recovery prompt embeds only those).

- **Scope boundary — the local daemon stays unredacted.** The base64 `executePlan` payload sent to the LOCAL daemon is built from the real substituted plan and is **not** routed through the redactor — the daemon needs the real values to execute the plan, and it is not the egress boundary. Only what leaves the process for the LLM provider is masked. Recovery behavior is otherwise unchanged (still opt-in / consent-gated).

**On the shared substituted content:** the executor already reuses one substituted string for both execution and recovery. Rather than split the string, redaction is applied only inside `buildFailedStepContext` on the recovery copy, so execution/daemon keeps the real values while the recovery context is masked — no separate substitution pass needed.

Docs: `docs/using/ui-tests.md` documents `secretParameters` / `secretParameterKeys` as the opt-in affordance (a user can't protect a secret they don't know to declare).

## Linked Issue

Closes #6029

## Scope / known residual

This closes the **initial recovery-context** channel: the first `ModelRequest` built from `FailedStepContext` no longer carries secret values. It does **not** cover a second-order channel — once the recovery agent loop runs, its `observe`/tool-call results are fed back into subsequent `ModelRequest`s unredacted, so a secret still *visible on screen at recovery time* can reach the provider (masked password fields are safe). That is the same CWE-200 class but a larger change (thread the secret values into the handler/agent and scrub tool outputs; awkward on Android where Koog owns the loop) and is tracked as a follow-up: **#6094**. This PR is scoped to the initial-context leak the issue names; the residual is explicit so this does not read as "secrets can never reach the LLM during recovery."

## Bug / Regression Context

- **Observed symptom:** a secret plan parameter (token/password/PII) substituted into a plan would be sent verbatim to the configured LLM provider during AI-assisted failure recovery.
- **Repro steps / conditions:** recovery enabled (`aiAssistance` on, non-CI, `ai-recovery` flag on, provider key present) + a plan whose `${param}` value is sensitive → the value appears in the recovery `ModelRequest` (planContent / error / on-screen samples).

## Validation

Native builds/tests were validated locally:

- **iOS (`ios/XCTestRunner`):** `swift build` **and** `swift build -c release` clean; `swift test` green (new `PlanRecoverySecretRedactionTests` + `PlanMetadataSecretParametersParsingTests` + existing suite — 122/123, the one unrelated failure being the live-simulator/daemon `RemindersAddPlanTests` integration test). SwiftLint (repo `.swiftlint.yml`) and SwiftFormat clean.
  - Toolchain note: the package pins `swift-tools-version: 6.3` and only Swift 6.2.4 is installed on this machine, so build/test were run by temporarily lowering the manifest to 6.2 **with Swift 6 language mode forced** (strict concurrency preserved); the manifest change was reverted before commit and is not in this PR.
- **Android (`junit-runner`):** `:junit-runner:test` + `:test-plan-validation:test` green under JDK 21 (Robolectric) — new `AutoMobilePlanRedactionTest` included; `ktfmt --google-style` and `detektMain`/`detektTest` clean. No `apiDump` needed (BCV/`.api` tracking is scoped to `auto-mobile-sdk`, not `junit-runner`).
- **TS:** `bun run build` (copies the schema) + `bun test test/plan test/utils/plan` green — the `secretParameters` schema addition is optional and backward-compatible.

Both runners' unit suites **do** gate in PR CI (`Run JUnit Runner Unit Tests` + `test-plan-validation` in `pull_request.yml`; iOS `XCTestRunner Simulator Tests` / CircleCI `ios-swift-packages` on iOS changes). What the runner **re-cut** affects is only **on-device shipping**: `XCTestRunner` and `junit-runner` are consumed as pinned/checksummed runner artifacts, so the code+tests land now but the redaction only takes effect on real device/simulator runs after the runners are re-cut and re-pinned — flagged as the delivery follow-up.

**Red-first (security fix):** with the value-scrub disabled, the iOS and Android redaction tests fail on the "secret absent" assertions; with the fix they pass, and the non-secret context and the unredacted daemon payload are asserted preserved. The iOS flush-form parser fix was likewise verified red-first (the flush `secretParameters` block returned no keys before the fix).

- [x] Android/iOS changes: ran the matching native validation
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Kotlin Reuse Check

- [x] Reused snakeyaml (already a direct `junit-runner` dependency) to parse `secretParameters`; the stringify path is shared with parameter substitution. No new dependencies or `*Util` files.

## Follow-ups

- [ ] **Runner re-cut required** for on-device effect (code+tests land now; artifacts are pinned/checksummed).
- [ ] **#6094** — redact secret values from the recovery agent loop's tool-call results (second-order live-observe channel).
