### PR TITLE
fix(observe): always recapture on the bootstrap active-window path when backStack is present

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1205,6 +1205,12 @@ export class RealObserveScreen implements ObserveScreen {
     );
     const confirmed = resolveBackStackActivityAttribution(recapturedState);
     if (!this.matchesExpectedBackStackAttribution(confirmed, expected)) {
+      // A failed confirming back-stack read retracts freshness; surface its
+      // cause on the published result so the retraction is diagnosable rather
+      // than an unexplained "could not reconcile" (#6088).
+      for (const error of recapturedState.errors ?? []) {
+        appendObserveError(result, error);
+      }
       return false;
     }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -226,6 +226,18 @@ function isAccessibilityViewClass(foregroundActivity: string): boolean {
   );
 }
 
+/**
+ * Whether the captured hierarchy itself names the foreground activity (the
+ * accessibility-service path). When it does not — the lazy-CtrlProxy bootstrap
+ * interval, where `activeWindow` comes from the legacy `Window.getActive()`
+ * read — the tree carries no activity signal that could be correlated with the
+ * adb reads that follow it (#6088).
+ */
+function hierarchyCarriesActivitySignal(hierarchy: ObserveResult["viewHierarchy"]): boolean {
+  const foregroundActivity = hierarchy?.foregroundActivity;
+  return typeof foregroundActivity === "string" && !isAccessibilityViewClass(foregroundActivity);
+}
+
 function isActivityInPackage(activityName: string, packageName: string): boolean {
   return activityName === packageName || activityName.startsWith(`${packageName}.`);
 }
@@ -1012,39 +1024,16 @@ export class RealObserveScreen implements ObserveScreen {
     }
 
     const backStackAttribution = resolveBackStackActivityAttribution(result);
-    if (backStackAttribution && activeWindow.activityName !== backStackAttribution.activityName) {
-      // An empty `activityName` (the bootstrap `Window.getActive()` / last-resort
-      // package path) is reconciled through the SAME temporal confirmation as a
-      // stale non-empty name (#5992), never a blind backfill: the recapture
-      // re-reads the hierarchy so the adb activity is paired with a *fresh* tree.
-      // A same-app mid-flight navigation between capture and back-stack read is
-      // therefore surfaced as a mismatch/unknown rather than a confidently-wrong
-      // name, and the confirmed window keeps its correlated `layoutSeqSum` (the
-      // freshness of which is guaranteed by the `getActive(true)` bootstrap read)
-      // so tap-effect detection is not blinded by a zero sentinel (#6070).
-      const recaptured = await this.recaptureHierarchyForBackStackAttribution(
+    if (backStackAttribution) {
+      const reconciled = await this.reconcileAgainstBackStack(
         result,
+        activeWindow,
         backStackAttribution,
         signal,
       );
-      if (!recaptured) {
-        return { sampled: false, identity: undefined, activityAttributionMismatch: true };
+      if (reconciled) {
+        return reconciled;
       }
-      // Do not pair an adb activity from a later navigation with an earlier
-      // hierarchy. The forced recapture and repeated back-stack read establish
-      // that both sources still describe the same destination (#5992).
-      const reconciled = {
-        ...activeWindow,
-        appId: backStackAttribution.packageName,
-        activityName: backStackAttribution.activityName,
-      };
-      if (result.notificationPermissionDetected) {
-        reconciled.type = "notification_permission_dialog";
-      } else {
-        delete reconciled.type;
-      }
-      result.activeWindow = reconciled;
-      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
     }
 
     if (activeWindow.appId === observed) {
@@ -1056,6 +1045,68 @@ export class RealObserveScreen implements ObserveScreen {
       result.activeWindow = { ...activeWindow, appId: observed, activityName: "" };
     }
     return { sampled: true, identity: confirmed, activityAttributionMismatch: false };
+  }
+
+  /**
+   * Temporal confirmation of the adb back-stack activity against a fresh
+   * hierarchy (#5992, #6070, #6088). Returns the reconciled outcome, or
+   * `undefined` when the back-stack read needs no reconciliation (the hierarchy
+   * itself named the activity and it already agrees with `activeWindow`).
+   */
+  private async reconcileAgainstBackStack(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    backStackAttribution: { packageName: string; activityName: string },
+    signal?: AbortSignal,
+  ): Promise<PostCaptureForegroundIdentity | undefined> {
+    // On the bootstrap path the hierarchy names no activity, so `activeWindow`
+    // and `backStack` are two adb reads taken AFTER the capture. Their agreeing
+    // is not evidence the tree is aligned with either: a same-app A->B
+    // navigation between the capture and those reads makes both report B while
+    // the tree still describes A, and the package-level guard (#5867) cannot
+    // tell A from B. Always confirm through the recapture there (#6088).
+    const bootstrapAttribution = !hierarchyCarriesActivitySignal(result.viewHierarchy);
+    if (!bootstrapAttribution && activeWindow.activityName === backStackAttribution.activityName) {
+      return undefined;
+    }
+    // An empty `activityName` (the bootstrap `Window.getActive()` / last-resort
+    // package path) is reconciled through the SAME temporal confirmation as a
+    // stale non-empty name (#5992), never a blind backfill: the recapture
+    // re-reads the hierarchy so the adb activity is paired with a *fresh* tree.
+    // A same-app mid-flight navigation between capture and back-stack read is
+    // therefore surfaced as a mismatch/unknown rather than a confidently-wrong
+    // name, and the confirmed window keeps its correlated `layoutSeqSum` (the
+    // freshness of which is guaranteed by the `getActive(true)` bootstrap read)
+    // so tap-effect detection is not blinded by a zero sentinel (#6070).
+    const recaptured = await this.recaptureHierarchyForBackStackAttribution(
+      result,
+      backStackAttribution,
+      signal,
+    );
+    if (!recaptured) {
+      // Unconfirmed: the bootstrap window name is a post-capture adb read that
+      // may post-date the tree, so it resolves to unknown rather than staying
+      // published against a hierarchy it was never correlated with (#6088).
+      if (bootstrapAttribution && activeWindow.activityName !== "") {
+        result.activeWindow = { ...activeWindow, activityName: "" };
+      }
+      return { sampled: false, identity: undefined, activityAttributionMismatch: true };
+    }
+    // Do not pair an adb activity from a later navigation with an earlier
+    // hierarchy. The forced recapture and repeated back-stack read establish
+    // that both sources still describe the same destination (#5992).
+    const reconciled = {
+      ...activeWindow,
+      appId: backStackAttribution.packageName,
+      activityName: backStackAttribution.activityName,
+    };
+    if (result.notificationPermissionDetected) {
+      reconciled.type = "notification_permission_dialog";
+    } else {
+      delete reconciled.type;
+    }
+    result.activeWindow = reconciled;
+    return { sampled: false, identity: undefined, activityAttributionMismatch: false };
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1092,6 +1092,14 @@ export class RealObserveScreen implements ObserveScreen {
       }
       return { sampled: false, identity: undefined, activityAttributionMismatch: true };
     }
+    // The recapture replaced the tree AFTER the focused-SystemUI check ran. A
+    // shade or keyguard that took focus mid-recapture keeps the occluded app's
+    // package (so the package and back-stack checks accept it); re-run the
+    // overlay reconciliation so the published window names the surface on top
+    // rather than the app beneath it (#6078, surfaced in #6088 review).
+    if (await this.applyFocusedSystemUiOverlay(result, signal)) {
+      return { sampled: false, identity: undefined, activityAttributionMismatch: false };
+    }
     // Do not pair an adb activity from a later navigation with an earlier
     // hierarchy. The forced recapture and repeated back-stack read establish
     // that both sources still describe the same destination (#5992).

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -934,6 +934,174 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     // Temporal confirmation was attempted: initial capture plus the recapture read.
     expect(viewHierarchy.getCallCount()).toBe(2);
   });
+
+  // Issue #6088: on the bootstrap path the hierarchy carries no activity signal,
+  // so a window read that AGREES with the back-stack read is not proof the
+  // hierarchy is aligned with either: both adb reads can post-date a same-app
+  // A->B navigation that the hierarchy pre-dates. The recapture must therefore
+  // run whenever a back-stack attribution exists on the bootstrap path, not only
+  // when the two adb reads disagree.
+  const settingsHierarchy = (now: number, label: string) => ({
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    packageName: "com.android.settings",
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [{ text: label, bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+      },
+    },
+  });
+
+  const subSettingsBackStack = {
+    execute: async () => ({
+      depth: 1,
+      activities: [],
+      tasks: [],
+      currentActivity: { name: "com.android.settings.SubSettings", taskId: 14 },
+      source: "adb",
+    }),
+  } as any;
+
+  test("does not publish an agreeing later same-app window/backStack activity onto an earlier hierarchy when the recapture cannot confirm it (#6088)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // Hierarchy captured for activity A; the navigation A->B lands before the
+    // back-stack and window reads, which therefore both report B and agree.
+    viewHierarchy.configureHierarchySequence([
+      settingsHierarchy(now, "Settings home"),
+      { hierarchy: { error: "CtrlProxy timed out" }, fresh: false },
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 3478,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    // Agreement between the two adb reads must not short-circuit the recapture.
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // B is not paired with A's tree: the name resolves to unknown and the
+    // observation is retracted rather than confidently mis-attributed.
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.activeWindow?.appId).toBe("com.android.settings");
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("disagree about the current activity");
+    // The original A hierarchy is preserved (not replaced by an unusable recapture).
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Settings home");
+  });
+
+  test("resolves a genuine bootstrap A->B skew to B's fresh hierarchy when the recapture confirms it (#6088)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      settingsHierarchy(now, "Settings home"),
+      settingsHierarchy(now + 50, "Sub settings"),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 3478,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // The published tree is the recaptured B tree, paired with B's name.
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Sub settings");
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.activeWindow?.layoutSeqSum).toBe(3478);
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+  });
+
+  test("does not over-retract a stable bootstrap observation whose window and backStack agree (#6088)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // Stable device: every read returns the same fresh B hierarchy.
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 5120,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    // The recapture ran (bootstrap path + back-stack present) and confirmed.
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.activeWindow?.appId).toBe("com.android.settings");
+    expect(result.activeWindow?.layoutSeqSum).toBe(5120);
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.warning).toBeUndefined();
+  });
 });
 
 /**

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1107,6 +1107,73 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toBeUndefined();
   });
 
+  test("mirrors a SystemUI surface that takes focus during the bootstrap recapture instead of the app beneath it (#6088)", async () => {
+    // The focused-SystemUI check (#6078) runs before the recapture. When the
+    // shade takes focus mid-recapture, the replacement tree still carries the
+    // occluded app's package, so the package and back-stack checks accept it;
+    // the overlay reconciliation must run again on the installed tree.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    const shadeOverSettings = {
+      ...settingsHierarchy(now + 50, "Notifications"),
+      windows: [
+        {
+          packageName: "com.android.systemui",
+          type: 3,
+          isFocused: true,
+          windowLayer: 200,
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        },
+        {
+          packageName: "com.android.settings",
+          type: 1,
+          isFocused: false,
+          windowLayer: 10,
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        },
+      ],
+    };
+    viewHierarchy.configureHierarchySequence([
+      settingsHierarchy(now, "Sub settings"),
+      shadeOverSettings,
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 5120,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // The published tree is the recaptured shade tree...
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Notifications");
+    // ...and the window names the surface on top, never the occluded app's activity.
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+  });
+
   test("surfaces a failed confirming back-stack read on the retracted result (#6088)", async () => {
     // The bootstrap recapture now runs on every agreeing observation, so an adb
     // hiccup on the confirming back-stack read retracts a stable observation.

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -974,6 +974,10 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     const viewHierarchy = new FakeViewHierarchy();
     // Hierarchy captured for activity A; the navigation A->B lands before the
     // back-stack and window reads, which therefore both report B and agree.
+    // Note this fixture is indistinguishable from a STABLE screen whose
+    // recapture fails: the code cannot tell the two apart, and tolerating a
+    // failed recapture on agreement would reinstate the #6088 skew, so the
+    // honest verdict for both is unknown + retracted.
     viewHierarchy.configureHierarchySequence([
       settingsHierarchy(now, "Settings home"),
       { hierarchy: { error: "CtrlProxy timed out" }, fresh: false },
@@ -1060,7 +1064,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.isFresh).toBe(true);
   });
 
-  test("does not over-retract a stable bootstrap observation whose window and backStack agree (#6088)", async () => {
+  test("confirms a stable bootstrap observation through the recapture without retracting freshness (#6088)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();
     timer.setCurrentTime(now);
@@ -1101,6 +1105,64 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
     expect(result.freshness?.isFresh).toBe(true);
     expect(result.freshness?.warning).toBeUndefined();
+  });
+
+  test("surfaces a failed confirming back-stack read on the retracted result (#6088)", async () => {
+    // The bootstrap recapture now runs on every agreeing observation, so an adb
+    // hiccup on the confirming back-stack read retracts a stable observation.
+    // The cause must reach `result.errors` so the retraction is diagnosable.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    let backStackReads = 0;
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 5120,
+        }),
+        backStack: {
+          execute: async () => {
+            backStackReads += 1;
+            if (backStackReads > 1) {
+              throw new Error("adb: device offline");
+            }
+            return {
+              depth: 1,
+              activities: [],
+              tasks: [],
+              currentActivity: { name: "com.android.settings.SubSettings", taskId: 14 },
+              source: "adb",
+            };
+          },
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(backStackReads).toBe(2);
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.freshness?.verified).toBe(false);
+    const backStackErrors = (result.errors ?? []).filter((e) => e.phase === "backStack");
+    expect(backStackErrors.length).toBeGreaterThan(0);
+    expect(backStackErrors[0]?.cause).toContain("device offline");
   });
 });
 


### PR DESCRIPTION
## Summary

On `observe`'s bootstrap active-window path (lazy CtrlProxy install interval, no usable `foregroundActivity` from the accessibility service), `reconcileActiveWindowAttribution` only ran its recapture/temporal confirmation when `activeWindow.activityName` disagreed with `backStack.currentActivity.name`. But on that path both values are post-capture adb reads, so a same-app A→B navigation between the hierarchy capture and those reads made both report B — the "agrees" path then published B's activity name onto A's hierarchy with `freshness.verified: true`. The package-level guard from #5867 cannot distinguish A from B.

The fix follows the issue's second suggested direction: **always recapture on the bootstrap path when a back-stack attribution is present**. The back-stack branch of `reconcileActiveWindowAttribution` is extracted into `reconcileAgainstBackStack` (also keeps the method under the complexity ratchet), with a `hierarchyCarriesActivitySignal` helper identifying the bootstrap case. When the recapture cannot confirm, the bootstrap window's activity name resolves to `""` (unknown) instead of staying published against an uncorrelated tree, and freshness is retracted through the existing `activityAttributionMismatch` path.

## Linked Issue

Closes #6088

## Bug / Regression Context

- **Prior attempts:** #6087 fixed the deterministic frozen-cache half of #6070 via `Window.getActive(true)`; that force-refresh widened the frequency of this pre-existing skew, tracked as #6088.
- **Observed symptom:** `waitFor(activeWindow.activityName == B)` could succeed while `elements` still described screen A, with `freshness.verified: true`.
- **Repro steps / conditions:** bootstrap interval; hierarchy captured for A; same-app navigation A→B; `backStack` and `Window.getActive` both read B.

## Acceptance criteria → tests (all in `test/features/observe/ObserveScreenWindowIdentity.test.ts`)

- **Genuine A→B skew, recapture unusable → must resolve to unknown / retract:** "does not publish an agreeing later same-app window/backStack activity onto an earlier hierarchy when the recapture cannot confirm it (#6088)" — recapture runs (2 hierarchy reads), `activityName` is `""`, `verified: false`, A's tree preserved.
- **Stable bootstrap observation → must NOT over-retract:** "does not over-retract a stable bootstrap observation whose window and backStack agree (#6088)" — recapture confirms, name backfilled, `layoutSeqSum` kept, `verified: true`, no warning.
- **Skew where the recapture does confirm B (inferred):** "resolves a genuine bootstrap A->B skew to B's fresh hierarchy when the recapture confirms it (#6088)" — B's fresh tree is published with B's name, `verified: true`.

Existing #5992 / #6070 / #6078 tests are unchanged and green.

## Validation

- [x] `bun run lint` + `bun test` pass (two pre-existing worktree-only failures: `oxlintConfigScoping.integration` needs `node_modules/.bin/oxlint` absent in a `.claude` worktree; `webrtcDeviceCaptureLoad.integration` asserts on bun skip-line output — both unrelated to this diff)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` clean
- [x] New code uses interfaces + fakes + FakeTimer; new tests run in <1ms each
- [x] No new dependencies or helpers beyond a one-line private predicate
- [x] Branched from latest `main`

## Trade-off noted in the issue

A recapture that fails during the bootstrap interval now retracts freshness on the agreeing path too (previously it was skipped). This is deliberate: on that path the window name cannot be correlated with the tree without the recapture, so "unknown + retracted" is the honest verdict, and the caller re-observes. The stable-observation test pins that a successful recapture never over-retracts.
