### PR TITLE
fix(observe): refresh deviceLock and bootstrap layoutSeqSum after an accepted attribution recapture

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1092,6 +1092,12 @@ export class RealObserveScreen implements ObserveScreen {
       }
       return { sampled: false, identity: undefined, activityAttributionMismatch: true };
     }
+    // Pair the accepted tree with a layout sequence read after it (bootstrap
+    // path only: elsewhere `layoutSeqSum` is the accessibility-path zero).
+    const confirmedWindow = bootstrapAttribution
+      ? await this.refreshBootstrapLayoutSeqSum(result, activeWindow)
+      : activeWindow;
+    result.activeWindow = confirmedWindow;
     // The recapture replaced the tree AFTER the focused-SystemUI check ran. A
     // shade or keyguard that took focus mid-recapture keeps the occluded app's
     // package (so the package and back-stack checks accept it); re-run the
@@ -1104,7 +1110,7 @@ export class RealObserveScreen implements ObserveScreen {
     // hierarchy. The forced recapture and repeated back-stack read establish
     // that both sources still describe the same destination (#5992).
     const reconciled = {
-      ...activeWindow,
+      ...confirmedWindow,
       appId: backStackAttribution.packageName,
       activityName: backStackAttribution.activityName,
     };
@@ -1224,7 +1230,29 @@ export class RealObserveScreen implements ObserveScreen {
 
     this.applyRecapturedHierarchy(result, hierarchy);
     result.backStack = recapturedState.backStack;
+    // The lock state was sampled before the original capture. A keyguard that
+    // appeared during the recapture is in the accepted tree, so publish the
+    // lock state that goes with that tree, not the earlier sample (#6100).
+    await this.deviceStateCollector.collectDeviceLock(result, signal);
     return true;
+  }
+
+  /**
+   * On the bootstrap path `activeWindow.layoutSeqSum` came from a window read
+   * taken before the recapture. A same-activity layout pass that completed
+   * during the recapture would leave that value older than the accepted tree
+   * and make the next tap-effect comparison misreport a change, so pair the
+   * tree with a sequence read after it (#6100). A failed re-read keeps the
+   * earlier correlated value rather than a zero sentinel (#6070).
+   */
+  private async refreshBootstrapLayoutSeqSum(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+  ): Promise<NonNullable<ObserveResult["activeWindow"]>> {
+    const refreshed: ObserveResult = { ...result, activeWindow: undefined, errors: undefined };
+    await this.deviceStateCollector.collectActiveWindow(refreshed);
+    const layoutSeqSum = refreshed.activeWindow?.layoutSeqSum ?? activeWindow.layoutSeqSum;
+    return { ...activeWindow, layoutSeqSum };
   }
 
   private isUsableAttributionRecapture(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1285,11 +1285,18 @@ export class RealObserveScreen implements ObserveScreen {
       appendObserveError(result, error);
     }
     const reread = refreshed.activeWindow;
+    if (!reread?.layoutSeqSum) {
+      return activeWindow;
+    }
+    // `dumpsys window` reports an in-package activity in shorthand (`pkg/.Foo`),
+    // which the Window parser keeps, while the back stack expands it to
+    // `pkg.Foo`; compare the expanded form.
+    const rereadActivity = reread.activityName.startsWith(".")
+      ? reread.appId + reread.activityName
+      : reread.activityName;
     const sameIdentity =
-      reread?.appId === expected.packageName && reread.activityName === expected.activityName;
-    return sameIdentity && reread.layoutSeqSum
-      ? { ...activeWindow, layoutSeqSum: reread.layoutSeqSum }
-      : activeWindow;
+      reread.appId === expected.packageName && rereadActivity === expected.activityName;
+    return sameIdentity ? { ...activeWindow, layoutSeqSum: reread.layoutSeqSum } : activeWindow;
   }
 
   private isUsableAttributionRecapture(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1095,6 +1095,7 @@ export class RealObserveScreen implements ObserveScreen {
     const confirmedWindow = await this.refreshRecaptureSideSamples(
       result,
       activeWindow,
+      backStackAttribution,
       bootstrapAttribution,
       signal,
     );
@@ -1248,6 +1249,7 @@ export class RealObserveScreen implements ObserveScreen {
   private async refreshRecaptureSideSamples(
     result: ObserveResult,
     activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    expected: { packageName: string; activityName: string },
     bootstrapAttribution: boolean,
     signal?: AbortSignal,
   ): Promise<NonNullable<ObserveResult["activeWindow"]>> {
@@ -1255,7 +1257,7 @@ export class RealObserveScreen implements ObserveScreen {
     const [confirmedWindow] = await Promise.all([
       // Elsewhere `layoutSeqSum` is the accessibility-path zero: nothing to refresh.
       bootstrapAttribution
-        ? this.refreshBootstrapLayoutSeqSum(result, activeWindow)
+        ? this.refreshBootstrapLayoutSeqSum(result, activeWindow, expected)
         : Promise.resolve(activeWindow),
       this.deviceStateCollector.collectDeviceLock(result, signal),
     ]);
@@ -1268,18 +1270,26 @@ export class RealObserveScreen implements ObserveScreen {
    * on failure; it returns a zero-sentinel record, so a missing OR zero sequence
    * keeps the earlier correlated value rather than the sentinel (#6070), and the
    * re-read's error is surfaced on the result so the kept value is diagnosable.
+   * A sequence is adopted only when the re-read names the confirmed identity: a
+   * navigation landing between the confirmation and this read would otherwise
+   * graft the next screen's sequence onto the confirmed tree.
    */
   private async refreshBootstrapLayoutSeqSum(
     result: ObserveResult,
     activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    expected: { packageName: string; activityName: string },
   ): Promise<NonNullable<ObserveResult["activeWindow"]>> {
     const refreshed: ObserveResult = { ...result, activeWindow: undefined, errors: undefined };
     await this.deviceStateCollector.collectActiveWindow(refreshed);
     for (const error of refreshed.errors ?? []) {
       appendObserveError(result, error);
     }
-    const layoutSeqSum = refreshed.activeWindow?.layoutSeqSum;
-    return layoutSeqSum ? { ...activeWindow, layoutSeqSum } : activeWindow;
+    const reread = refreshed.activeWindow;
+    const sameIdentity =
+      reread?.appId === expected.packageName && reread.activityName === expected.activityName;
+    return sameIdentity && reread.layoutSeqSum
+      ? { ...activeWindow, layoutSeqSum: reread.layoutSeqSum }
+      : activeWindow;
   }
 
   private isUsableAttributionRecapture(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1075,9 +1075,9 @@ export class RealObserveScreen implements ObserveScreen {
     // re-reads the hierarchy so the adb activity is paired with a *fresh* tree.
     // A same-app mid-flight navigation between capture and back-stack read is
     // therefore surfaced as a mismatch/unknown rather than a confidently-wrong
-    // name, and the confirmed window keeps its correlated `layoutSeqSum` (the
-    // freshness of which is guaranteed by the `getActive(true)` bootstrap read)
-    // so tap-effect detection is not blinded by a zero sentinel (#6070).
+    // name, and the confirmed window keeps a correlated `layoutSeqSum` (re-read
+    // after the accepted recapture, #6100) so tap-effect detection is not
+    // blinded by a zero sentinel (#6070).
     const recaptured = await this.recaptureHierarchyForBackStackAttribution(
       result,
       backStackAttribution,
@@ -1092,11 +1092,12 @@ export class RealObserveScreen implements ObserveScreen {
       }
       return { sampled: false, identity: undefined, activityAttributionMismatch: true };
     }
-    // Pair the accepted tree with a layout sequence read after it (bootstrap
-    // path only: elsewhere `layoutSeqSum` is the accessibility-path zero).
-    const confirmedWindow = bootstrapAttribution
-      ? await this.refreshBootstrapLayoutSeqSum(result, activeWindow)
-      : activeWindow;
+    const confirmedWindow = await this.refreshRecaptureSideSamples(
+      result,
+      activeWindow,
+      bootstrapAttribution,
+      signal,
+    );
     result.activeWindow = confirmedWindow;
     // The recapture replaced the tree AFTER the focused-SystemUI check ran. A
     // shade or keyguard that took focus mid-recapture keeps the occluded app's
@@ -1230,20 +1231,43 @@ export class RealObserveScreen implements ObserveScreen {
 
     this.applyRecapturedHierarchy(result, hierarchy);
     result.backStack = recapturedState.backStack;
-    // The lock state was sampled before the original capture. A keyguard that
-    // appeared during the recapture is in the accepted tree, so publish the
-    // lock state that goes with that tree, not the earlier sample (#6100).
-    await this.deviceStateCollector.collectDeviceLock(result, signal);
     return true;
   }
 
   /**
-   * On the bootstrap path `activeWindow.layoutSeqSum` came from a window read
-   * taken before the recapture. A same-activity layout pass that completed
-   * during the recapture would leave that value older than the accepted tree
-   * and make the next tap-effect comparison misreport a change, so pair the
-   * tree with a sequence read after it (#6100). A failed re-read keeps the
-   * earlier correlated value rather than a zero sentinel (#6070).
+   * Side samples taken before an accepted recapture must not be published
+   * against the replacement tree (#6100). The lock state was collected before
+   * the original capture, so a keyguard that appeared mid-recapture would be
+   * published as unlocked; it is re-read, and cleared first so a failed re-read
+   * yields "unknown" rather than the earlier wrong value. On the bootstrap path
+   * `layoutSeqSum` came from a window read taken before the recapture, so a
+   * same-activity layout pass that completed during it would make the next
+   * tap-effect comparison misreport a change; it is re-read too. The two reads
+   * are independent adb calls and run together.
+   */
+  private async refreshRecaptureSideSamples(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    bootstrapAttribution: boolean,
+    signal?: AbortSignal,
+  ): Promise<NonNullable<ObserveResult["activeWindow"]>> {
+    delete result.deviceLock;
+    const [confirmedWindow] = await Promise.all([
+      // Elsewhere `layoutSeqSum` is the accessibility-path zero: nothing to refresh.
+      bootstrapAttribution
+        ? this.refreshBootstrapLayoutSeqSum(result, activeWindow)
+        : Promise.resolve(activeWindow),
+      this.deviceStateCollector.collectDeviceLock(result, signal),
+    ]);
+    return confirmedWindow;
+  }
+
+  /**
+   * Re-read the bootstrap window after an accepted recapture and pair the tree
+   * with its layout sequence. The production `Window.getActive` does not throw
+   * on failure; it returns a zero-sentinel record, so a missing OR zero sequence
+   * keeps the earlier correlated value rather than the sentinel (#6070), and the
+   * re-read's error is surfaced on the result so the kept value is diagnosable.
    */
   private async refreshBootstrapLayoutSeqSum(
     result: ObserveResult,
@@ -1251,8 +1275,11 @@ export class RealObserveScreen implements ObserveScreen {
   ): Promise<NonNullable<ObserveResult["activeWindow"]>> {
     const refreshed: ObserveResult = { ...result, activeWindow: undefined, errors: undefined };
     await this.deviceStateCollector.collectActiveWindow(refreshed);
-    const layoutSeqSum = refreshed.activeWindow?.layoutSeqSum ?? activeWindow.layoutSeqSum;
-    return { ...activeWindow, layoutSeqSum };
+    for (const error of refreshed.errors ?? []) {
+      appendObserveError(result, error);
+    }
+    const layoutSeqSum = refreshed.activeWindow?.layoutSeqSum;
+    return layoutSeqSum ? { ...activeWindow, layoutSeqSum } : activeWindow;
   }
 
   private isUsableAttributionRecapture(

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1191,12 +1191,20 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     ],
   });
 
-  const countingBootstrapWindow = (sequence: number[]) => {
+  // Each window read records the number of hierarchy reads that preceded it,
+  // so a test can prove the re-read happened AFTER the recapture.
+  const countingBootstrapWindow = (sequence: number[], viewHierarchy?: FakeViewHierarchy) => {
     const reads: number[] = [];
+    const hierarchyReadsBefore: number[] = [];
     const window = {
       getActive: async () => {
         const layoutSeqSum = sequence[Math.min(reads.length, sequence.length - 1)] ?? 0;
         reads.push(layoutSeqSum);
+        hierarchyReadsBefore.push(viewHierarchy?.getCallCount() ?? 0);
+        if (layoutSeqSum === 0) {
+          // The production Window.getActive failure shape: a sentinel, not a throw.
+          return { appId: "", activityName: "", layoutSeqSum: 0 };
+        }
         return {
           appId: "com.android.settings",
           activityName: "com.android.settings.SubSettings",
@@ -1208,7 +1216,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
       setCachedActiveWindow: async () => undefined,
       clearCache: async () => undefined,
     } as any;
-    return { window, reads };
+    return { window, reads, hierarchyReadsBefore };
   };
 
   test("re-collects device lock state when the recapture accepts a keyguard tree (#6100)", async () => {
@@ -1272,7 +1280,10 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     // A same-activity layout pass completes during the recapture: the window
     // read before it reports 5120, the one after it 5121.
-    const { window, reads } = countingBootstrapWindow([5120, 5121]);
+    const { window, reads, hierarchyReadsBefore } = countingBootstrapWindow(
+      [5120, 5121],
+      viewHierarchy,
+    );
     const screen = new RealObserveScreen(
       androidDevice,
       new FakeAdbClientFactory(fakeAdb),
@@ -1292,9 +1303,135 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
 
     expect(viewHierarchy.getCallCount()).toBe(2);
     expect(reads).toEqual([5120, 5121]);
+    // The first window read precedes the recapture (one hierarchy read so far);
+    // the second follows it (two hierarchy reads), so the published sequence is
+    // the one correlated with the accepted tree.
+    expect(hierarchyReadsBefore).toEqual([1, 2]);
     expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
     expect(result.activeWindow?.layoutSeqSum).toBe(5121);
     expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("keeps the earlier correlated layoutSeqSum when the post-recapture window read fails (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+
+    // The re-read returns the production failure shape (zero sentinel).
+    const { window, reads } = countingBootstrapWindow([5120, 0], viewHierarchy);
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(reads).toEqual([5120, 0]);
+    // Never the zero sentinel: it would blind tap-effect detection (#6070).
+    expect(result.activeWindow?.layoutSeqSum).toBe(5120);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("does not re-read the window on a non-bootstrap recapture (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // The accessibility service names a stale activity that disagrees with the
+    // back stack, so the #5992 recapture runs — but the window's layoutSeqSum
+    // is the accessibility-path zero, and there is nothing to refresh.
+    viewHierarchy.configureHierarchy({
+      ...settingsHierarchy(now, "Sub settings"),
+      foregroundActivity: "com.android.settings/.Settings",
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+
+    const { window, reads } = countingBootstrapWindow([9000], viewHierarchy);
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(reads).toEqual([]);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+  });
+
+  test("reports device lock as unknown when the post-recapture lock read fails (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      settingsHierarchy(now, "Sub settings"),
+      keyguardOverSettings(now),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    // Unlocked at the original capture; the confirming re-read yields nothing.
+    fakeAdb.setDeviceLockSequence([{ locked: false, keyguardShowing: false, secure: false }, null]);
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 5120,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    // The stale pre-recapture "unlocked" sample is not published as fact.
+    expect(result.deviceLock).toBeUndefined();
   });
 
   test("adds no device reads on the non-recapture path (#6100)", async () => {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1350,6 +1350,64 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("keeps the earlier correlated layoutSeqSum when the post-recapture window names a different activity (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+
+    // A navigation lands between the back-stack confirmation and the window
+    // re-read: the second read names the NEXT activity with a newer sequence.
+    let windowReads = 0;
+    const window = {
+      getActive: async () => {
+        windowReads += 1;
+        return windowReads === 1
+          ? {
+              appId: "com.android.settings",
+              activityName: "com.android.settings.SubSettings",
+              layoutSeqSum: 5120,
+            }
+          : {
+              appId: "com.android.settings",
+              activityName: "com.android.settings.DeviceInfoSettings",
+              layoutSeqSum: 5400,
+            };
+      },
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    } as any;
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(windowReads).toBe(2);
+    // The next screen's sequence is not grafted onto the confirmed tree.
+    expect(result.activeWindow?.layoutSeqSum).toBe(5120);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+  });
+
   test("does not re-read the window on a non-bootstrap recapture (#6100)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1350,6 +1350,57 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("adopts the post-recapture layoutSeqSum when the window reports the activity in dumpsys shorthand (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+
+    // `dumpsys window` names an in-package activity as `pkg/.Activity`; the
+    // Window parser keeps the shorthand while the back stack expands it.
+    let windowReads = 0;
+    const window = {
+      getActive: async () => {
+        windowReads += 1;
+        return {
+          appId: "com.android.settings",
+          activityName: ".SubSettings",
+          layoutSeqSum: windowReads === 1 ? 5120 : 5121,
+        };
+      },
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    } as any;
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(windowReads).toBe(2);
+    expect(result.activeWindow?.layoutSeqSum).toBe(5121);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+  });
+
   test("keeps the earlier correlated layoutSeqSum when the post-recapture window names a different activity (#6100)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1174,6 +1174,173 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.activeWindow?.systemOverlay).toBe(true);
   });
 
+  // Issue #6100: side samples taken BEFORE the recapture (device lock, the
+  // bootstrap window's layoutSeqSum) must not be published against the
+  // replacement tree. An accepted recapture re-reads both; the non-recapture
+  // path pays no extra device reads.
+  const keyguardOverSettings = (now: number) => ({
+    ...settingsHierarchy(now + 50, "Swipe up to unlock"),
+    windows: [
+      {
+        packageName: "com.android.systemui",
+        type: 3,
+        isFocused: true,
+        windowLayer: 200,
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+      },
+    ],
+  });
+
+  const countingBootstrapWindow = (sequence: number[]) => {
+    const reads: number[] = [];
+    const window = {
+      getActive: async () => {
+        const layoutSeqSum = sequence[Math.min(reads.length, sequence.length - 1)] ?? 0;
+        reads.push(layoutSeqSum);
+        return {
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum,
+        };
+      },
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    } as any;
+    return { window, reads };
+  };
+
+  test("re-collects device lock state when the recapture accepts a keyguard tree (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      settingsHierarchy(now, "Sub settings"),
+      keyguardOverSettings(now),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    // Unlocked at the original capture; locked by the time the recapture lands.
+    fakeAdb.setDeviceLockSequence([
+      { locked: false, keyguardShowing: false, secure: false },
+      { locked: true, keyguardShowing: true, secure: true },
+    ]);
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: emptyBootstrapWindow({
+          appId: "com.android.settings",
+          activityName: "com.android.settings.SubSettings",
+          layoutSeqSum: 5120,
+        }),
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Swipe up to unlock");
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.deviceLock?.locked).toBe(true);
+    expect(result.deviceLock?.keyguardShowing).toBe(true);
+  });
+
+  test("pairs an accepted bootstrap recapture with a post-recapture layoutSeqSum (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(settingsHierarchy(now, "Sub settings") as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+
+    // A same-activity layout pass completes during the recapture: the window
+    // read before it reports 5120, the one after it 5121.
+    const { window, reads } = countingBootstrapWindow([5120, 5121]);
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(reads).toEqual([5120, 5121]);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+    expect(result.activeWindow?.layoutSeqSum).toBe(5121);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
+  test("adds no device reads on the non-recapture path (#6100)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // The accessibility service names the activity, and it agrees with the
+    // back stack: no recapture, so no second lock read and no window read.
+    viewHierarchy.configureHierarchy({
+      ...settingsHierarchy(now, "Sub settings"),
+      foregroundActivity: "com.android.settings/.SubSettings",
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+    fakeAdb.setDeviceLockSequence([
+      { locked: false, keyguardShowing: false, secure: false },
+      { locked: true, keyguardShowing: true, secure: true },
+    ]);
+
+    const { window, reads } = countingBootstrapWindow([9000]);
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window,
+        backStack: subSettingsBackStack,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(1);
+    expect(reads).toEqual([]);
+    expect(result.deviceLock?.locked).toBe(false);
+    expect(result.activeWindow?.activityName).toBe("com.android.settings.SubSettings");
+  });
+
   test("surfaces a failed confirming back-stack read on the retracted result (#6088)", async () => {
     // The bootstrap recapture now runs on every agreeing observation, so an adb
     // hiccup on the confirming back-stack read retracts a stable observation.


### PR DESCRIPTION
## Summary

The attribution recapture (`recaptureHierarchyForBackStackAttribution` / `reconcileAgainstBackStack` in `src/features/observe/ObserveScreen.ts`) replaces the hierarchy but published two side samples taken *before* it against the replacement tree: the device lock state collected before the original capture, and (on the bootstrap path) the window `layoutSeqSum` read before the recapture. Since #6098 the recapture runs on every bootstrap-path observation with a back-stack attribution, so both were reachable more often.

- An accepted recapture now re-collects `deviceLock`, so a keyguard that appeared mid-recapture is published with `locked: true` and `BaseVisualChange.annotateDeviceLock` keeps its unlock warning.
- On the bootstrap path an accepted recapture re-reads the window and pairs the tree with the post-recapture `layoutSeqSum` (a failed re-read keeps the earlier correlated value, never the zero sentinel from #6070), so a same-activity layout pass that completes during the recapture is not misreported as a change by the next `TapOnElement.compareActiveWindow`.
- The non-recapture path pays no extra device reads.

## Linked Issue

Closes #6100

## Bug / Regression Context

- **Prior attempts:** none; surfaced by Codex review on #6098 and deferred there.
- **Observed symptom:** keyguard elements and a SystemUI `activeWindow` with `deviceLock.locked: false`; a no-op tap after a bootstrap observe reported `screenChanged: true`.
- **Repro steps / conditions:** device locks (or a same-activity layout pass lands) during the forced bootstrap recapture.

## Acceptance criteria → tests (`test/features/observe/ObserveScreenWindowIdentity.test.ts`)

- **Keyguard recapture → `deviceLock` reflects post-recapture state:** "re-collects device lock state when the recapture accepts a keyguard tree (#6100)".
- **Recaptured tree paired with a post-recapture `layoutSeqSum`, #6070 non-zero preservation still pinned:** "pairs an accepted bootstrap recapture with a post-recapture layoutSeqSum (#6100)"; the existing #6070 backfill test (fixed window, 5120 preserved) is unchanged.
- **No extra device reads on the non-recapture path:** "adds no device reads on the non-recapture path (#6100)" asserts one lock read and zero window reads when the accessibility-supplied activity agrees with the back stack.

Both behavioral tests were confirmed red before the change.

## Validation

- [x] `bun run lint` + `bun test` pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` clean
- [x] New code uses interfaces + fakes + FakeTimer; new tests run in <1ms each
- [x] No new dependencies; reuses `DeviceStateCollector.collectDeviceLock` / `collectActiveWindow`
- [x] Branched from latest `main`

## Follow-ups

- #6099 (recapture fresh-wait latency on the same path) is unchanged by this PR.
