### PR TITLE
fix(observe): let the attribution recapture skip the fresh wait and go straight to sync

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1193,10 +1193,13 @@ export class RealObserveScreen implements ObserveScreen {
     const minTimestamp = (initialTimestamp ?? this.timer.now()) + 1;
     let hierarchy: ObserveResult["viewHierarchy"];
     try {
+      // `minTimestamp` rejects the cached (initial) tree; skipping the fresh
+      // wait goes straight to the sync that produces the newer one, so a static
+      // screen (nothing pushed) does not burn the full WebSocket wait (#6099).
       hierarchy = await this.viewHierarchy.getViewHierarchy(
         undefined,
         new NoOpPerformanceTracker(),
-        false,
+        true,
         minTimestamp,
         signal,
       );

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1196,6 +1196,9 @@ export class RealObserveScreen implements ObserveScreen {
       // `minTimestamp` rejects the cached (initial) tree; skipping the fresh
       // wait goes straight to the sync that produces the newer one, so a static
       // screen (nothing pushed) does not burn the full WebSocket wait (#6099).
+      // Android-only semantics: the iOS delegate serves its stale fallback for
+      // skip + unmet minTimestamp, but this recapture is unreachable there (it
+      // requires an adb-sourced back stack).
       hierarchy = await this.viewHierarchy.getViewHierarchy(
         undefined,
         new NoOpPerformanceTracker(),

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -236,8 +236,10 @@ export class CtrlProxyHierarchy {
       }
 
       // Wait for fresh data if requested (unless skipped or recently timed out).
-      // A rejected cache (too old for `minTimestamp`) needs a newer tree, which
-      // the sync fallback below produces as well as a push does. It therefore
+      // A rejected cache (too old for `minTimestamp`) needs a newer tree. The
+      // sync fallback below re-extracts one on the runner (a fresh `updatedAt`)
+      // just as a push would; note the sync result is reported fresh without a
+      // `minTimestamp` re-check, as it always was. It therefore
       // does NOT override `skipWaitForFresh`: a caller that skips the wait with
       // a minTimestamp (the attribution recapture) goes straight to sync instead
       // of burning the full wait on a static screen that pushes nothing (#6099).

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -473,7 +473,11 @@ export class CtrlProxyHierarchy {
             androidPerfTiming = syncResult.perfTiming;
           }
           frameContext = syncResult.frameContext;
-          isFresh = true;
+          // The sync wait correlates on host receipt time, so a late push of a
+          // tree captured BEFORE `minTimestamp` can land in its window. Honor the
+          // caller's device-timestamp floor here rather than reporting such a
+          // tree fresh (#6099).
+          isFresh = this.satisfiesMinTimestamp(hierarchyData.updatedAt, minTimestamp);
           receivedAt = this.context.timer.now();
           if (hierarchyData.packageName) {
             this.lastKnownPackageName = hierarchyData.packageName;
@@ -775,6 +779,23 @@ export class CtrlProxyHierarchy {
     }
     const timeSinceTimeout = this.context.timer.now() - lastTimeout;
     return timeSinceTimeout < WEBSOCKET_TIMEOUT_COOLDOWN_MS;
+  }
+
+  /**
+   * Whether a device-stamped tree satisfies a caller's `minTimestamp` floor. A
+   * caller with no floor, or a tree with no numeric stamp, is satisfied.
+   */
+  private satisfiesMinTimestamp(updatedAt: unknown, minTimestamp: number): boolean {
+    if (minTimestamp <= 0 || typeof updatedAt !== "number" || Number.isNaN(updatedAt)) {
+      return true;
+    }
+    if (updatedAt >= minTimestamp) {
+      return true;
+    }
+    logger.warn(
+      `[CTRL_PROXY] Sync returned a tree older than minTimestamp (updatedAt=${updatedAt}, minTimestamp=${minTimestamp}); reporting it stale`,
+    );
+    return false;
   }
 
   /**

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -235,15 +235,18 @@ export class CtrlProxyHierarchy {
         }
       }
 
-      // Wait for fresh data if requested (unless skipped or recently timed out)
+      // Wait for fresh data if requested (unless skipped or recently timed out).
+      // A rejected cache (too old for `minTimestamp`) needs a newer tree, which
+      // the sync fallback below produces as well as a push does. It therefore
+      // does NOT override `skipWaitForFresh`: a caller that skips the wait with
+      // a minTimestamp (the attribution recapture) goes straight to sync instead
+      // of burning the full wait on a static screen that pushes nothing (#6099).
       const cacheRejected =
         minTimestamp > 0 &&
         cachedHierarchy &&
         !this.evaluateMinTimestamp(cachedHierarchy, minTimestamp, true).isFresh;
       const shouldWait =
-        (waitForFresh || cacheRejected) &&
-        (!skipWaitForFresh || cacheRejected) &&
-        !this.shouldSkipWebSocketWait();
+        (waitForFresh || cacheRejected) && !skipWaitForFresh && !this.shouldSkipWebSocketWait();
       if (shouldWait) {
         throwIfAborted(signal);
         const waitMinTimestamp = minTimestamp > 0 ? minTimestamp : startTime;

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -131,9 +131,13 @@ export class DeviceStateCollector {
       // has no expiry, so a `getActive()` (non-forced) read can serve a frozen
       // record — an empty activityName with a stale `layoutSeqSum` — across a
       // real navigation, which the observe layer would then publish. This path
-      // only runs during the lazy-CtrlProxy bootstrap interval (rare), so the
-      // extra dumpsys is cheap; the cache must never win over current window
-      // state (#6070).
+      // runs whenever the accessibility service supplies no usable
+      // foregroundActivity: the lazy-CtrlProxy bootstrap interval, every capture
+      // after a service start/reconnect until the app fires a window-state
+      // change, and any capture whose window root is a framework View class
+      // (#5939) — routine, not rare (#6099). The extra dumpsys is still cheap
+      // relative to a wrong window; the cache must never win over current
+      // window state (#6070).
       const activeWindow = await window.getActive(true);
       logger.debug(`Bootstrap active window retrieval took ${timer.now() - startedAt}ms`);
       if (activeWindow) {

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -855,6 +855,10 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     // Temporal confirmation ran: the initial capture plus one recapture.
     expect(viewHierarchy.getCallCount()).toBe(2);
     expect(result.freshness?.verified).toBe(true);
+    // The recapture still demands a tree newer than the initial capture (the
+    // cache is rejected) but skips the WebSocket fresh wait and goes straight
+    // to sync, so a static screen does not burn the full wait (#6099).
+    expect(viewHierarchy.getCalls()[1]).toEqual({ skipWaitForFresh: true, minTimestamp: now + 1 });
   });
 
   test("does not stamp a later same-app backStack activity onto an earlier hierarchy when a recapture cannot confirm it (#6070)", async () => {

--- a/test/features/observe/android/ctrlProxyHierarchyRecaptureSkipWait.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchyRecaptureSkipWait.test.ts
@@ -41,6 +41,8 @@ interface Harness {
   hierarchy: CtrlProxyHierarchy;
   timer: FakeTimer;
   waitCalls: number[];
+  /** Tree the (stubbed) sync returns; swap it to model a late, older push. */
+  syncTree: CachedHierarchy["hierarchy"];
   syncCalls: () => number;
   cooldownSet: () => boolean;
   restore: () => void;
@@ -89,17 +91,24 @@ function createHarness(): Harness {
     timer.advanceTime(timeoutMs);
     return null;
   }) as never);
-  // The sync produces the genuinely fresh tree.
+  // The sync produces the genuinely fresh tree by default; a test may swap it.
   let syncCalls = 0;
+  const harness = { syncTree: tree(T + 20, "synced") };
   const syncSpy = spyOn(hierarchy, "requestHierarchySync").mockImplementation(async () => {
     syncCalls += 1;
-    return { hierarchy: tree(T + 20, "synced") };
+    return { hierarchy: harness.syncTree };
   });
 
   return {
     hierarchy,
     timer,
     waitCalls,
+    get syncTree() {
+      return harness.syncTree;
+    },
+    set syncTree(value: CachedHierarchy["hierarchy"]) {
+      harness.syncTree = value;
+    },
     syncCalls: () => syncCalls,
     cooldownSet: () => cooldownSet,
     restore: () => {
@@ -138,6 +147,27 @@ describe("Android CtrlProxyHierarchy recapture skips the fresh wait (issue #6099
     // The cache was still rejected: the returned tree is the synced one, fresh.
     expect(result?.fresh).toBe(true);
     expect(result?.updatedAt).toBe(T + 20);
+  });
+
+  test("a sync that returns a tree older than minTimestamp is reported stale, not fresh", async () => {
+    h = createHarness();
+    // A late push of the pre-navigation tree lands in the sync window: its
+    // device stamp is the initial capture's, below the caller's floor.
+    h.syncTree = tree(T, "late pre-navigation push");
+
+    const result = await h.hierarchy.getAccessibilityHierarchy(
+      undefined,
+      undefined,
+      true,
+      T + 1,
+      false,
+      undefined,
+    );
+
+    expect(h.waitCalls).toEqual([]);
+    expect(h.syncCalls()).toBe(1);
+    expect(result?.fresh).toBe(false);
+    expect(result?.updatedAt).toBe(T);
   });
 
   test("a read that does not skip the wait still waits for a push before syncing", async () => {

--- a/test/features/observe/android/ctrlProxyHierarchyRecaptureSkipWait.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchyRecaptureSkipWait.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Issue #6099: the attribution recapture asks for a tree newer than the
+ * initial capture (`minTimestamp = initial + 1`). That rejects the cache, and
+ * the rejected cache used to force the WebSocket fresh-data wait even when the
+ * caller asked to skip it — so on a static screen (nothing is pushed) the
+ * recapture burned the full `DEFAULT_FRESH_WAIT_MS` before falling back to the
+ * sync that actually produces the fresh tree.
+ *
+ * `skipWaitForFresh` now means what its contract says: skip the wait and go
+ * straight to sync. The cache is still rejected (minTimestamp semantics are
+ * unchanged), and a caller that does NOT skip still waits.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/android/CtrlProxyHierarchy";
+import type {
+  CachedHierarchy,
+  HierarchyDelegateContext,
+} from "../../../../src/features/observe/android/types";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+const DEFAULT_FRESH_WAIT_MS = 1000;
+const T = 1_700_000_000_000;
+
+function tree(updatedAt: number, label: string): CachedHierarchy["hierarchy"] {
+  return {
+    packageName: "com.android.settings",
+    updatedAt,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    hierarchy: {
+      bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+      node: [{ text: label, bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+    },
+  } as never;
+}
+
+interface Harness {
+  hierarchy: CtrlProxyHierarchy;
+  timer: FakeTimer;
+  waitCalls: number[];
+  syncCalls: () => number;
+  cooldownSet: () => boolean;
+  restore: () => void;
+}
+
+function createHarness(): Harness {
+  const timer = new FakeTimer();
+  timer.setCurrentTime(T + 10);
+  let cached: CachedHierarchy | null = {
+    hierarchy: tree(T, "initial"),
+    receivedAt: T,
+    fresh: true,
+  };
+  let cooldownSet = false;
+  const waitCalls: number[] = [];
+
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => null,
+    requestManager: new RequestManager(timer),
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    device: { deviceId: "emulator-5554", platform: "android" } as never,
+    adb: {} as never,
+    getCachedHierarchy: () => cached,
+    setCachedHierarchy: (h) => {
+      cached = h;
+    },
+    getLastWebSocketTimeout: () => 0,
+    setLastWebSocketTimeout: () => {
+      cooldownSet = true;
+    },
+  };
+
+  const managerSpy = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+    isAvailable: async () => true,
+  } as never);
+
+  const hierarchy = new CtrlProxyHierarchy(context);
+  // A static screen: nothing is pushed, so a wait always runs to its timeout.
+  const waitSpy = spyOn(
+    hierarchy as never as { waitForFreshData: () => unknown },
+    "waitForFreshData",
+  ).mockImplementation((async (timeoutMs: number) => {
+    waitCalls.push(timeoutMs);
+    timer.advanceTime(timeoutMs);
+    return null;
+  }) as never);
+  // The sync produces the genuinely fresh tree.
+  let syncCalls = 0;
+  const syncSpy = spyOn(hierarchy, "requestHierarchySync").mockImplementation(async () => {
+    syncCalls += 1;
+    return { hierarchy: tree(T + 20, "synced") };
+  });
+
+  return {
+    hierarchy,
+    timer,
+    waitCalls,
+    syncCalls: () => syncCalls,
+    cooldownSet: () => cooldownSet,
+    restore: () => {
+      managerSpy.mockRestore();
+      waitSpy.mockRestore();
+      syncSpy.mockRestore();
+    },
+  };
+}
+
+describe("Android CtrlProxyHierarchy recapture skips the fresh wait (issue #6099)", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.restore();
+    h = null;
+  });
+
+  test("a skip-wait read with a rejected cache goes straight to sync without burning the fresh wait", async () => {
+    h = createHarness();
+    const started = h.timer.now();
+
+    const result = await h.hierarchy.getAccessibilityHierarchy(
+      undefined,
+      undefined,
+      true,
+      T + 1,
+      false,
+      undefined,
+    );
+
+    expect(h.waitCalls).toEqual([]);
+    expect(h.timer.now() - started).toBe(0);
+    expect(h.syncCalls()).toBe(1);
+    expect(h.cooldownSet()).toBe(false);
+    // The cache was still rejected: the returned tree is the synced one, fresh.
+    expect(result?.fresh).toBe(true);
+    expect(result?.updatedAt).toBe(T + 20);
+  });
+
+  test("a read that does not skip the wait still waits for a push before syncing", async () => {
+    h = createHarness();
+    const started = h.timer.now();
+
+    const result = await h.hierarchy.getAccessibilityHierarchy(
+      undefined,
+      undefined,
+      false,
+      T + 1,
+      false,
+      undefined,
+    );
+
+    expect(h.waitCalls).toEqual([DEFAULT_FRESH_WAIT_MS]);
+    expect(h.timer.now() - started).toBe(DEFAULT_FRESH_WAIT_MS);
+    expect(h.syncCalls()).toBe(1);
+    expect(result?.fresh).toBe(true);
+    expect(result?.updatedAt).toBe(T + 20);
+  });
+});


### PR DESCRIPTION
## Summary

The attribution recapture (`recaptureHierarchyForBackStackAttribution` in `src/features/observe/ObserveScreen.ts`) asks for a tree newer than the initial capture (`minTimestamp = initial + 1`). In `CtrlProxyHierarchy.getLatestHierarchy` that rejects the cache, and a rejected cache *overrode* `skipWaitForFresh`, forcing the WebSocket fresh-data wait. On a static screen nothing is pushed, so the recapture burned the full `DEFAULT_FRESH_WAIT_MS` (1 s) before falling back to the sync that actually produces the fresh tree. Since #6098 the recapture runs on every bootstrap-path observation with a back-stack attribution, which (#6099) is routine, not rare.

- `skipWaitForFresh` now means what its docstring says: skip the wait and go straight to sync. A rejected cache still needs a newer tree, but the sync produces one as well as a push does, so it no longer overrides the skip. The only caller that combined `skipWaitForFresh: true` with a `minTimestamp` before this change is the recapture; plain `observe` (skip by default, no `minTimestamp`) and `ObservePoll` / `waitFor` (`skipWaitForFresh: false`) are unaffected.
- The recapture passes `skipWaitForFresh: true`, keeping `minTimestamp` so the cache is still rejected.
- The `DeviceStateCollector.collectActiveWindow` comment no longer claims the bootstrap path is rare.

No timeout knob was added: `timeoutMs` is the caller's overall budget (the sync gets the remainder), so bounding the wait through it would starve the sync and turn the recapture into a retracting failure.

## Linked Issue

Closes #6099

## Bug / Regression Context

- **Prior attempts:** none; surfaced by review lenses on #6098 and #6101.
- **Observed symptom:** roughly one second of serial latency per bootstrap-path observe on a static screen (reproduced against the real `CtrlProxyHierarchy` with `FakeTimer`).
- **Repro steps / conditions:** hierarchy without a usable `foregroundActivity` (service just started/reconnected, or a framework View window root) + a back-stack attribution + no UI change during the recapture.

## Acceptance criteria → tests

- **Static-screen recapture completes without waiting out the fresh wait** (real `CtrlProxyHierarchy` + `FakeTimer`): `test/features/observe/android/ctrlProxyHierarchyRecaptureSkipWait.test.ts` — "a skip-wait read with a rejected cache goes straight to sync without burning the fresh wait": zero elapsed fake time, no wait call, one sync, `fresh: true`, no WebSocket cooldown set. Confirmed red before the change (the wait ran for 1000 ms).
- **`minTimestamp` semantics preserved:** the same file's "a read that does not skip the wait still waits for a push before syncing" pins the non-skip path; in `ObserveScreenWindowIdentity.test.ts` the #6070 backfill test now asserts the recapture call is `{ skipWaitForFresh: true, minTimestamp: initial + 1 }` (red before the change). All #5992 / #6070 / #6078 / #6088 / #6100 tests remain green.
- **Collector comment updated:** `src/features/observe/collectors/DeviceStateCollector.ts`.

## Validation

- [x] `bun run lint` + `bun test` pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` clean
- [x] New code uses interfaces + fakes + FakeTimer; new tests run in <2ms each
- [x] No new dependencies or helpers
- [x] Branched from latest `main`
