### PR TITLE
fix(ci): acquire emulator session in Android nav-graph integration script

### DIFF
--- a/scripts/android/navigation-graph-sdk-event-integration.sh
+++ b/scripts/android/navigation-graph-sdk-event-integration.sh
@@ -13,7 +13,7 @@ bun_bin_dir="${HOME}/.bun/bin"
 device_id="${1:-}"
 package_id="dev.jasonpearson.automobile.playground"
 emit_action="dev.jasonpearson.automobile.playground.action.TEST_EMIT_SDK_NAVIGATION"
-session_uuid="52150000-0000-4000-8000-000000000000"
+session_uuid=""
 timestamp_ms="$(($(date +%s) * 1000))"
 destination="Issue5215SdkNavigation-${timestamp_ms}"
 graph=""
@@ -59,6 +59,30 @@ fi
 # the selected emulator's adbd as root before launching the session it serves.
 "$adb_bin" -s "$device_id" root >/dev/null
 "$adb_bin" -s "$device_id" wait-for-device
+
+# Acquire the booted emulator before issuing session-scoped calls. A caller must
+# not fabricate a UUID to access a device it has not acquired; the daemon now
+# rejects never-issued session UUIDs (#6045, #6079).
+session_result="$(auto-mobile --debug --embedded-sdk --cli getAndroid --deviceId "${device_id}")"
+if ! session_uuid="$(
+  jq -er '
+    (
+      if .sessionUuid? then .sessionUuid
+      elif .content? then
+        .content[]
+        | select(.type == "text")
+        | .text
+        | fromjson
+        | .sessionUuid
+      else empty
+      end
+    )
+    | select(type == "string" and length > 0)
+  ' <<<"${session_result}"
+)"; then
+  echo "error: could not acquire navigation graph session for emulator ${device_id}" >&2
+  exit 1
+fi
 
 # Bind CtrlProxy's SDK-event client and the graph query to the same daemon
 # session before emitting the event. The debug-only Playground receiver invokes

--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -6,6 +6,7 @@ setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIGINAL_PATH="$PATH"
   ORIGINAL_HOME="$HOME"
+  export REAL_JQ="$(command -v jq)"
   export HOME="${MOCK_BIN}/home"
   export ADB_LOG="${MOCK_BIN}/adb.log"
   export AUTO_MOBILE_LOG="${MOCK_BIN}/auto-mobile.log"
@@ -76,6 +77,9 @@ fi
 '
   make_mock sleep 'exit 0'
   make_mock jq '
+if [ "$1" = "-er" ] && [[ "$2" == *"sessionUuid"* ]]; then
+  exec "$REAL_JQ" "$@"
+fi
 if [ "$1" = "-e" ] && [ "$2" = "--arg" ] && [ "$3" = "destination" ] &&
   grep -Fq -- "$4"; then
   exit 0
@@ -84,6 +88,18 @@ exit 1
 '
   make_mock auto-mobile '
 printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "getAndroid" ]; then
+  [ -f "$DEVICE_READY_FILE" ] || {
+    echo "session acquired before rooted device was ready" >&2
+    exit 1
+  }
+  [ "$5" = "--deviceId" ] && [ "$6" = "emulator-5554" ] || {
+    echo "getAndroid acquired without target deviceId" >&2
+    exit 1
+  }
+  printf "{\"sessionUuid\":\"52150000-0000-4000-8000-000000000000\"}\n"
+  exit 0
+fi
 if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ]; then
   case "$6" in
     launchApp)
@@ -163,6 +179,9 @@ fi
 '
   make_mock sleep 'exit 0'
   make_mock jq '
+if [ "$1" = "-er" ] && [[ "$2" == *"sessionUuid"* ]]; then
+  exec "$REAL_JQ" "$@"
+fi
 if [ "$1" = "-e" ] && [ "$2" = "--arg" ] && [ "$3" = "destination" ] &&
   grep -Fq -- "$4"; then
   exit 0
@@ -174,6 +193,10 @@ exit 1
   ln -s "${HOME}/.bun/bin/missing-auto-mobile" "${HOME}/.bun/bin/auto-mobile"
   make_executable "${GITHUB_WORKSPACE}/dist/src/index.js" '
 printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
+if [ "$4" = "getAndroid" ]; then
+  printf "{\"sessionUuid\":\"52150000-0000-4000-8000-000000000000\"}\n"
+  exit 0
+fi
 case "$6" in
   launchApp)
     exit 0
@@ -198,4 +221,39 @@ exit 1
   [ "$(readlink "${HOME}/.bun/bin/auto-mobile")" = "${GITHUB_WORKSPACE}/dist/src/index.js" ]
   [[ "$output" == *"linking ${HOME}/.bun/bin/auto-mobile -> ${GITHUB_WORKSPACE}/dist/src/index.js"* ]]
   grep -q -- 'getNavigationGraph --platform android --deviceId emulator-5554' "$AUTO_MOBILE_LOG"
+}
+
+# The daemon rejects never-issued session UUIDs (#6045, #6079). The script must
+# acquire the emulator via getAndroid rather than fabricate a session UUID, so an
+# empty acquisition result must abort before any session-scoped call.
+@test "aborts when getAndroid does not return a session UUID" {
+  make_mock adb '
+if [ "$1" = "devices" ]; then
+  printf "List of devices attached\nemulator-5554\tdevice\n"
+  exit 0
+fi
+exit 0
+'
+  make_mock sleep 'exit 0'
+  make_mock jq '
+if [ "$1" = "-er" ] && [[ "$2" == *"sessionUuid"* ]]; then
+  exec "$REAL_JQ" "$@"
+fi
+exit 1
+'
+  make_mock auto-mobile '
+printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
+if [ "$4" = "getAndroid" ]; then
+  printf "{\"sessionUuid\":\"\"}\n"
+  exit 0
+fi
+echo "unexpected session-scoped call before acquisition: $*" >&2
+exit 1
+'
+
+  run env PATH="${MOCK_BIN}:${PATH}" bash "$SCRIPT" "emulator-5554"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not acquire navigation graph session"* ]]
+  ! grep -q -- "--session-uuid" "$AUTO_MOBILE_LOG"
 }


### PR DESCRIPTION
## Problem

The **Run Playground Automobile Emulator Tests** lane (Pull Request workflow) has failed on *every* PR since ~2026-09-04, regardless of content — confirmed on trivial dep-bump [#6081](https://github.com/kaeawc/auto-mobile/pull/6081) and desktop-only [#6080](https://github.com/kaeawc/auto-mobile/pull/6080). The failure surfaces only as `✗ Emulator tests failed after retry`; the real error is buried by the `reactivecircus/android-emulator-runner` wrapper.

This is a **real regression on main, not a flake / AVD-boot issue** — the sibling `Run JUnit Runner Emulator Tests` lane (same emulator, same action) stays green.

## Root cause

Digging past the wrapper into the gradle/script output, the permission-contract step passes and `:playground:app:test` is *never reached*. The failing step is `scripts/android/navigation-graph-sdk-event-integration.sh`, which aborts at its first `launchApp`:

```
Error: MCP error -32603: Session 52150000-0000-4000-8000-000000000000 is not an
active daemon session (not found). Acquire a device with getAndroid or getApple
before using its sessionUuid.
error: could not launch Android graph target app
```

The script injects a **hardcoded** `--session-uuid` (`52150000-…`). [#6079](https://github.com/kaeawc/auto-mobile/pull/6079) ("hardening: reject never-issued session UUIDs at the pooled-mint primitive", merged 2026-09-04 08:35Z), following [#6045](https://github.com/kaeawc/auto-mobile/pull/6045), tightened daemon session admission to reject any UUID the daemon never issued. [#6045](https://github.com/kaeawc/auto-mobile/pull/6045) already migrated the **iOS** sibling script to acquire via `getApple --deviceId`, but left the **Android** one on the fabricated UUID — so the Android lane broke at #6079.

Timeline confirms it: [#6053](https://github.com/kaeawc/auto-mobile/pull/6053)'s Playground lane passed at 2026-09-03 16:43Z (after #6045, before #6079); all failing runs are after #6079.

## Fix

Apply the same acquire-first pattern the iOS script already uses: resolve the session from `getAndroid --deviceId "$device_id"` and drop the fabricated UUID.

- `scripts/android/navigation-graph-sdk-event-integration.sh` — acquire session via `getAndroid`, `session_uuid=""` default.
- `test/bats/android-navigation-graph-sdk-event-integration.bats` — mock the acquisition (delegating the `sessionUuid` parse to real `jq`); add a regression test that the script aborts before any session-scoped call when `getAndroid` returns no session UUID.

## Validation

- `bats test/bats/android-navigation-graph-sdk-event-integration.bats` → 3/3 pass
- `shellcheck scripts/android/navigation-graph-sdk-event-integration.sh` → clean