### PR TITLE
fix(observe): recapture hierarchy after the SystemUI-overlay adb focus fallback (#6091)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1275,6 +1275,13 @@ export class RealObserveScreen implements ObserveScreen {
       return false;
     }
     this.applyRecapturedHierarchy(result, hierarchy);
+    // `deviceLock` was sampled before the original capture (collectAllData), so a
+    // keyguard that appeared during this recapture would otherwise be published
+    // as unlocked against the fresh (keyguard) tree — the #6100 seam, on the
+    // overlay recapture path. Clear first so a failed re-read yields "unknown"
+    // rather than the stale value, then re-read paired with the replacement tree.
+    delete result.deviceLock;
+    await this.deviceStateCollector.collectDeviceLock(result, signal);
     return true;
   }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1104,8 +1104,10 @@ export class RealObserveScreen implements ObserveScreen {
     // shade or keyguard that took focus mid-recapture keeps the occluded app's
     // package (so the package and back-stack checks accept it); re-run the
     // overlay reconciliation so the published window names the surface on top
-    // rather than the app beneath it (#6078, surfaced in #6088 review).
-    if (await this.applyFocusedSystemUiOverlay(result, signal)) {
+    // rather than the app beneath it (#6078, surfaced in #6088 review). The tree
+    // was just recaptured here, so the #6091 fallback recapture is redundant —
+    // skip it and confirm focus directly against this fresh tree.
+    if (await this.applyFocusedSystemUiOverlay(result, signal, true)) {
       return { sampled: false, identity: undefined, activityAttributionMismatch: false };
     }
     // Do not pair an adb activity from a later navigation with an earlier
@@ -1126,39 +1128,34 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   /**
-   * Decide whether a focused SystemUI surface currently owns input focus
-   * (issue #6078). The free primary signal is the captured accessibility
-   * `windows[]`: a window flagged `isFocused` that is a SystemUI surface
-   * confirms the overlay with no extra device round-trip. When no window on this
-   * API level carries a focus flag but the topmost window is a SystemUI surface,
-   * focus is confirmed with a single `dumpsys window` `mCurrentFocus` read (the
-   * status bar always exists but is neither focused nor topmost over an expanded
-   * shade, so an ordinary app screen never reaches the adb read).
-   */
-  private async detectFocusedSystemUiOverlay(
-    result: ObserveResult,
-    signal?: AbortSignal,
-  ): Promise<boolean> {
-    const signalKind = classifyFocusedSystemUiWindow(result.viewHierarchy);
-    if (signalKind === "focused") {
-      return true;
-    }
-    if (signalKind === "topmost-suspect") {
-      return this.deviceStateCollector.collectFocusedSystemUiSurface(signal);
-    }
-    return false;
-  }
-
-  /**
    * Mirror the SystemUI surface identity into `activeWindow` when a SystemUI
    * surface owns focus (issue #6078). Returns `true` when the overlay was
    * detected and applied — the caller then short-circuits the rest of
    * attribution. A no-op (returns `false`) when there is no `activeWindow` to
    * annotate or no focused SystemUI surface.
+   *
+   * Two detection paths (issue #6078). The free primary signal is the captured
+   * accessibility `windows[]`: a window flagged `isFocused` that is a SystemUI
+   * surface confirms the overlay with no extra device round-trip and — being
+   * sampled atomically with the hierarchy — is race-free, so it is trusted as
+   * captured. When no window on this API level carries a focus flag but the
+   * topmost window is a large SystemUI surface, focus is unconfirmed on the
+   * captured tree; that is the adb `mCurrentFocus` fallback.
+   *
+   * The fallback's focus read is not atomic with the hierarchy capture, so a
+   * shade transition in that interval can pair a stale hierarchy with the wrong
+   * attribution — e.g. a shade that closes leaves a stale shade tree stamped with
+   * the occluded app's id (issue #6091). The fallback therefore recaptures the
+   * hierarchy and re-classifies against the fresh tree so the published tree and
+   * the overlay attribution are drawn from the same post-fallback moment. When a
+   * caller already recaptured the tree (the #6088 back-stack path), it passes
+   * `skipRecapture` so the fallback confirms focus directly against that fresh
+   * tree instead of recapturing twice.
    */
   private async applyFocusedSystemUiOverlay(
     result: ObserveResult,
     signal?: AbortSignal,
+    skipRecapture: boolean = false,
   ): Promise<boolean> {
     // Android-only: `com.android.systemui`, the notification shade, and the
     // `dumpsys window` fallback are Android concepts. iOS reuses the same
@@ -1168,9 +1165,63 @@ export class RealObserveScreen implements ObserveScreen {
       return false;
     }
     const activeWindow = result.activeWindow;
-    if (activeWindow === undefined || !(await this.detectFocusedSystemUiOverlay(result, signal))) {
+    if (activeWindow === undefined) {
       return false;
     }
+    const signalKind = classifyFocusedSystemUiWindow(result.viewHierarchy);
+    if (signalKind === "none") {
+      return false;
+    }
+    if (signalKind === "focused") {
+      // Primary, race-free signal: mirror immediately, no recapture.
+      this.mirrorFocusedSystemUiOverlay(result, activeWindow);
+      return true;
+    }
+    // `topmost-suspect`: the non-atomic adb fallback path (#6091).
+    return this.applyFallbackSystemUiOverlay(result, activeWindow, skipRecapture, signal);
+  }
+
+  /**
+   * Resolve the adb `mCurrentFocus` fallback for a topmost SystemUI suspect
+   * (issue #6091). The focus read post-dates the captured tree, so — unless the
+   * caller already recaptured — recapture the hierarchy first and re-classify
+   * against the fresh tree, then confirm focus against that same tree. This keeps
+   * the published hierarchy and the overlay attribution from the same moment: a
+   * shade that closed in the interval reclassifies to `none` (fresh app tree,
+   * no overlay), and a shade genuinely up is mirrored against the fresh shade
+   * tree. When the recapture is unavailable (or skipped), fall back to the
+   * single focus read against the tree in hand — no worse than pre-#6091.
+   */
+  private async applyFallbackSystemUiOverlay(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    skipRecapture: boolean,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    if (!skipRecapture && (await this.recaptureHierarchyForSystemUiOverlay(result, signal))) {
+      const freshSignal = classifyFocusedSystemUiWindow(result.viewHierarchy);
+      if (freshSignal === "none") {
+        // The shade closed between the original capture and the recapture; the
+        // fresh tree is the underlying app and `activeWindow` already names it.
+        return false;
+      }
+      if (freshSignal === "focused") {
+        this.mirrorFocusedSystemUiOverlay(result, activeWindow);
+        return true;
+      }
+      // `topmost-suspect` on the fresh tree: confirm focus against it below.
+    }
+    if (!(await this.deviceStateCollector.collectFocusedSystemUiSurface(signal))) {
+      return false;
+    }
+    this.mirrorFocusedSystemUiOverlay(result, activeWindow);
+    return true;
+  }
+
+  private mirrorFocusedSystemUiOverlay(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+  ): void {
     const overlay = {
       ...activeWindow,
       appId: SYSTEM_UI_PACKAGE,
@@ -1181,6 +1232,49 @@ export class RealObserveScreen implements ObserveScreen {
     // describe the shade that is now on top; drop it while the overlay is up.
     delete overlay.type;
     result.activeWindow = overlay;
+  }
+
+  /**
+   * Recapture the hierarchy for the SystemUI-overlay fallback so the published
+   * tree and the overlay attribution are sampled together (issue #6091). Unlike
+   * the back-stack recapture there is no expected package to match — the goal is
+   * simply a tree newer than the one captured before the focus read. Returns
+   * `true` when a usable fresh tree replaced the original; on any failure the
+   * original hierarchy is preserved and the caller falls back to the single
+   * focus read.
+   */
+  private async recaptureHierarchyForSystemUiOverlay(
+    result: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const initialTimestamp = this.resolveObservationTimestampMs(result);
+    const minTimestamp = (initialTimestamp ?? this.timer.now()) + 1;
+    let hierarchy: ObserveResult["viewHierarchy"];
+    try {
+      // `minTimestamp` rejects the cached (initial) tree; skipping the fresh wait
+      // goes straight to the sync that produces the newer one (#6099).
+      hierarchy = await this.viewHierarchy.getViewHierarchy(
+        undefined,
+        new NoOpPerformanceTracker(),
+        true,
+        minTimestamp,
+        signal,
+      );
+    } catch (error) {
+      logger.debug(
+        `[OBSERVE] SystemUI-overlay recapture failed; preserving original hierarchy: ${error}`,
+      );
+      return false;
+    }
+    if (
+      !hierarchy ||
+      !hasUsableHierarchy(hierarchy) ||
+      hierarchy.fresh !== true ||
+      !this.platformValidator.validate(this.device.platform, hierarchy).valid
+    ) {
+      return false;
+    }
+    this.applyRecapturedHierarchy(result, hierarchy);
     return true;
   }
 

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1837,6 +1837,142 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     expect(result.activeWindow?.activityName).toBe("");
   });
 
+  // Issue #6091: the adb `mCurrentFocus` fallback read is not atomic with the
+  // hierarchy capture, so a shade transition inside that interval can pair a
+  // stale hierarchy with the wrong attribution. The fallback (topmost-suspect,
+  // no `isFocused` flag) therefore recaptures the hierarchy and re-classifies so
+  // the published tree and the overlay attribution are sampled together.
+  const appContentHierarchy = (now: number): any => ({
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    packageName: OCCLUDED_APP,
+    foregroundActivity: OCCLUDED_ACTIVITY,
+    // Topmost window is the app itself: the shade is gone, so classification is
+    // "none" (no overlay) with no further adb read.
+    windows: [
+      {
+        packageName: OCCLUDED_APP,
+        type: 1,
+        isFocused: true,
+        windowLayer: 200,
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+      },
+    ],
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [{ text: "App content", bounds: { left: 0, top: 300, right: 400, bottom: 360 } }],
+      },
+    },
+  });
+
+  test("fallback path: shade closes between capture and focus read — recapture drops the overlay and publishes the fresh app tree (#6091)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    // No isFocused flag on this API level: topmost SystemUI surface is a suspect
+    // that reaches the adb fallback. The recapture returns the app tree (the
+    // shade closed in the interval).
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+      appContentHierarchy(now + 25),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    // If the code still read mCurrentFocus against the stale shade tree, this
+    // would confirm the (already-gone) shade. It must not be trusted.
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: "  mCurrentFocus=Window{8ddaeb2 u0 NotificationShade}\n",
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    // The recapture ran (initial capture + one recapture).
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // The published tree is the fresh app tree, not the stale shade.
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("App content");
+    // Attribution agrees with the fresh tree: the app, not a SystemUI overlay.
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+  });
+
+  test("fallback path: shade genuinely up — recapture yields a fresh shade tree and the overlay is mirrored (#6091)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    // Both captures are the shade; the recapture is a fresher shade tree with a
+    // distinct marker so the test can prove the published tree is the recapture.
+    const staleShade = shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]);
+    staleShade.hierarchy.node.node = [
+      { text: "Stale shade", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+    ];
+    const freshShade = shadeHierarchy(now + 25, [unfocusedShade, occludedAppWindow(false)]);
+    freshShade.hierarchy.node.node = [
+      { text: "Fresh shade", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+    ];
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([staleShade, freshShade] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: "  mCurrentFocus=Window{8ddaeb2 u0 NotificationShade}\n",
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // The published shade tree is the recaptured one, paired with the overlay.
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Fresh shade");
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+    expect(result.activeWindow?.activityName).toBe("");
+  });
+
+  test("primary (isFocused) path never recaptures — the race-free signal is trusted as captured (#6091)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    // A different tree is queued as the (would-be) recapture; it must never be
+    // consumed, because the primary isFocused path takes no adb round-trip.
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [focusedShadeWindow(), occludedAppWindow(false)]),
+      appContentHierarchy(now + 25),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    // No recapture on the primary path.
+    expect(viewHierarchy.getCallCount()).toBe(1);
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+    // No adb dumpsys read either — the captured windows[] carried the flag.
+    expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
+  });
+
   test("adb fallback: a package/activity mCurrentFocus (shade collapsed) is NOT an overlay", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -1946,6 +1946,49 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     expect(result.activeWindow?.activityName).toBe("");
   });
 
+  test("fallback path: re-reads device lock when the recapture accepts a keyguard tree (#6091, #6100 seam)", async () => {
+    // A keyguard that appears during the fallback recapture must not be published
+    // with the pre-capture "unlocked" sample: the overlay recapture replaces the
+    // tree, so the lock sample is re-read paired with the replacement tree.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const keyguardTree = shadeHierarchy(now + 25, [unfocusedShade, occludedAppWindow(false)]);
+    keyguardTree.hierarchy.node.node = [
+      { text: "Swipe up to unlock", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+    ];
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+      keyguardTree,
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    // Unlocked at the original capture; locked by the time the recapture lands.
+    fakeAdb.setDeviceLockSequence([
+      { locked: false, keyguardShowing: false, secure: false },
+      { locked: true, keyguardShowing: true, secure: true },
+    ]);
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: "  mCurrentFocus=Window{8ddaeb2 u0 Keyguard}\n",
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.activeWindow?.appId).toBe("com.android.systemui");
+    expect(result.activeWindow?.systemOverlay).toBe(true);
+    // The lock state published is the post-recapture read, not the stale sample.
+    expect(result.deviceLock?.locked).toBe(true);
+    expect(result.deviceLock?.keyguardShowing).toBe(true);
+  });
+
   test("primary (isFocused) path never recaptures — the race-free signal is trusted as captured (#6091)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();


### PR DESCRIPTION
## Summary

Follow-up to #6078 / #6089. The focused-SystemUI overlay detection (`activeWindow.systemOverlay`, mirroring `com.android.systemui` when a focused SystemUI surface owns focus) has two paths:

1. **Primary (race-free):** the captured accessibility `windows[]` carries an `isFocused` SystemUI window, sampled atomically with the hierarchy.
2. **Fallback:** on API levels that populate no `isFocused` flag, when the topmost window is a large SystemUI surface, a `dumpsys window` `mCurrentFocus` read confirms focus **after** the hierarchy was captured.

The fallback's focus read is not atomic with hierarchy capture, so a shade transition in that interval can pair a stale hierarchy with the wrong attribution — most notably when the shade **closes** mid-interval, leaving a stale shade hierarchy stamped with the occluded app's `appId`.

This PR makes the `topmost-suspect` fallback path **recapture the hierarchy and re-classify against the fresh tree** before confirming focus, so the published tree and the overlay attribution are drawn from the same post-fallback moment:

- Shade closed in the interval -> the fresh tree reclassifies to `none` (the app screen); no overlay, and the published tree is the fresh app tree instead of the stale shade.
- Shade genuinely up -> the fresh tree still classifies as a SystemUI surface and the overlay is mirrored against the fresh shade tree.
- Recapture unavailable/skipped -> fall back to the single focus read against the tree in hand (no worse than pre-#6091).

The **primary race-free path is unchanged and never recaptures**. The #6088 back-stack path already recaptures, so it passes `skipRecapture` and the fallback confirms focus directly against that fresh tree rather than recapturing twice. Recapture fires **only** on the fallback path, so no legitimate observation is falsely retracted.

## Linked Issue

Closes #6091

## Bug / Regression Context

- **Prior attempts:** #6078 / #6089 added the two-path detection but left the fallback focus read non-atomic with the capture.
- **Observed symptom:** on the adb-fallback path only, a shade that closes between hierarchy capture and the `mCurrentFocus` read publishes a stale shade hierarchy carrying the occluded app's `appId` (the original #6078 incoherence, for that stale instant).
- **Repro steps / conditions:** API level that populates no `windows[].isFocused` flag; observe while the notification shade is closing.

## Validation

- [x] `bun run lint` passes (oxlint ratchet: no new violations)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] `bun test test/features/observe` (2293 pass) + `test/features/observe/output` + `test/daemon/hierarchyStreamDiff.test.ts` (428 pass) + `Window.test.ts` (46 pass) — no golden churn (only two source files changed)
- [x] New tests use fakes + FakeTimer; each runs in <5ms

### Tests (fixture-driven, TDD, red-first)

Added to `test/features/observe/ObserveScreenWindowIdentity.test.ts`:

- **shade closes mid-interval** — fallback path, hierarchy captured as shade, recapture returns the app tree; asserts the published tree is the fresh app tree and `systemOverlay` is undefined. Red on `main` (no recapture: `getCallCount()` was 1, stale shade tree published).
- **shade genuinely up** — fallback path recaptures a fresher shade tree; asserts the published tree is the recapture and `systemOverlay: true`. Red on `main` (`getCallCount()` was 1).
- **primary (`isFocused`) path** — asserts no recapture and no adb read (race-free signal trusted as captured).

## Kotlin Reuse Check

Not applicable — TypeScript-only change under `src/features/observe/`.
