### PR TITLE
fix(runner): parse multiline secretParameters flow sequences (both platforms) [#6097]

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -306,14 +306,11 @@ internal object AutoMobilePlanExecutor {
     parameters: Map<String, Any>,
   ): List<String> {
     if (secretKeys.isEmpty()) return emptyList()
-    val values = mutableListOf<String>()
+    // Raw parameter values via the lenient/fail-safe matcher (so an exotically-encoded key name
+    // cannot
+    // leak), plus each key's actual substituted value from this executor's ordered pass.
+    val values = SecretRedactor.secretParameterValues(secretKeys, parameters).toMutableList()
     for (key in secretKeys) {
-      parameters[key]
-        ?.let { SecretRedactor.parameterStringValue(it) }
-        ?.takeIf { it.isNotEmpty() }
-        ?.let {
-          values.add(it)
-        }
       val placeholder = "\${$key}"
       val landed = substituteParameters(placeholder, parameters)
       if (landed != placeholder && landed.isNotEmpty()) values.add(landed)

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -72,14 +72,17 @@ internal object SecretRedactor {
 
   /**
    * The parameter VALUES to scrub for a set of declared secret key names, matched leniently so an
-   * exotically-encoded key name cannot leak its value. For each declared key: an exact
-   * `parameters[key]` is taken; failing that, any parameter whose key normalizes equal
-   * (case-folded, with backslashes/quotes/whitespace/CR removed) is taken; and if a declared key
-   * still resolves to nothing, EVERY parameter value is taken (over-redaction). `secretParameters`
-   * key names are expected to be literal identifiers — this is the fail-safe backstop for YAML
-   * encodings the flow scanner does not fully decode (`\xNN`/`\uNNNN` escapes, folding, CRLF): a
-   * declared secret's value is always scrubbed (possibly over-redacting), never leaked (#6097).
-   * Full decoding is a follow-up.
+   * exotically-encoded key name cannot leak its value. For each declared key: a key that still
+   * contains a backslash (a YAML escape the scanner did not spec-decode) is low-confidence and
+   * forces over-redaction — its raw form must not be trusted to exact-match a DECOY parameter while
+   * the real value hides under the decoded name. Otherwise an exact `parameters[key]` is taken;
+   * failing that, any parameter whose key normalizes equal (case-folded, with
+   * backslashes/quotes/whitespace/CR removed) is taken; and if a declared key still resolves to
+   * nothing, EVERY parameter value is taken (over-redaction). `secretParameters` key names are
+   * expected to be literal identifiers — this is the fail-safe backstop for YAML encodings the flow
+   * scanner does not fully decode (`\xNN`/`\uNNNN` escapes, folding, CRLF): a declared secret's
+   * value is always scrubbed (possibly over-redacting), never leaked (#6097). Full decoding is a
+   * follow-up (#6141).
    */
   fun secretParameterValues(
     declaredKeys: Set<String>,
@@ -89,6 +92,16 @@ internal object SecretRedactor {
     val values = mutableListOf<String>()
     var hasUnresolvedKey = false
     for (key in declaredKeys) {
+      if (key.contains('\\')) {
+        // A key that still contains a backslash carries a YAML escape the flow scanner did not
+        // spec-decode (e.g. `\xNN`). Its raw form may coincidentally match a DECOY parameter while
+        // the
+        // real value lives under the decoded name — so do NOT trust any match; force over-redaction
+        // so
+        // the real value cannot leak (#6097).
+        hasUnresolvedKey = true
+        continue
+      }
       val exact = parameters[key]?.let { parameterStringValue(it) }?.takeIf { it.isNotEmpty() }
       if (exact != null) {
         values.add(exact)
@@ -221,13 +234,30 @@ internal object SecretRedactor {
     startIndex: Int,
     firstValue: String,
   ): Pair<List<String>, Int> {
-    val items = mutableListOf<String>()
+    val keys = mutableListOf<String>()
     val current = StringBuilder()
+    var itemHasQuotedChar = false
     var depth = 0
     var started = false
     var activeQuote: Char? = null
     var escaped = false
     var lineIndex = startIndex
+
+    // Emit the current item: a plain token is trimmed and a genuinely-empty token (nothing between
+    // the
+    // delimiters) is dropped, but a quoted scalar whose content is only whitespace (e.g. `" "`) is
+    // a
+    // valid key and is preserved rather than trimmed away (#6097).
+    fun flushItem() {
+      val trimmed = current.toString().trim()
+      when {
+        trimmed.isNotEmpty() -> keys.add(trimmed)
+        itemHasQuotedChar -> keys.add(current.toString())
+      }
+      current.clear()
+      itemHasQuotedChar = false
+    }
+
     // Drop a trailing CR so a CRLF-authored quoted multiline key does not embed `\r` (#6097).
     var currentLine = firstValue.removeSuffix("\r")
 
@@ -240,17 +270,27 @@ internal object SecretRedactor {
           if (activeQuote == '"') {
             when {
               escaped -> {
-                current.append(character)
+                // `\"` decodes cleanly to `"`; any OTHER escape (`\xNN`, `\uNNNN`, `\n`, …) is NOT
+                // spec-decoded here — keep the backslash so the value layer sees this key as
+                // low-confidence and over-redacts rather than trusting a coincidental (decoy) match
+                // (#6097).
+                if (character == '"') current.append('"')
+                else current.append('\\').append(character)
+                itemHasQuotedChar = true
                 escaped = false
               }
               character == '\\' -> escaped = true
               character == '"' -> activeQuote = null
-              else -> current.append(character)
+              else -> {
+                current.append(character)
+                itemHasQuotedChar = true
+              }
             }
           } else if (character == '\'') {
             activeQuote = null
           } else {
             current.append(character)
+            itemHasQuotedChar = true
           }
         } else if (!started) {
           if (character == '[') {
@@ -267,13 +307,12 @@ internal object SecretRedactor {
         } else if (character == ']') {
           depth--
           if (depth == 0) {
-            items.add(current.toString())
-            return finalizeSecretKeys(items) to (lineIndex + 1)
+            flushItem()
+            return keys.toList() to (lineIndex + 1)
           }
           current.append(character)
         } else if (character == ',' && depth == 1) {
-          items.add(current.toString())
-          current.clear()
+          flushItem()
         } else {
           current.append(character)
         }
@@ -289,17 +328,14 @@ internal object SecretRedactor {
       when {
         activeQuote == '"' && escaped -> escaped = false
         activeQuote != null -> current.append(' ')
-        started && current.toString().trim().isNotEmpty() -> {
-          items.add(current.toString())
-          current.clear()
-        }
+        started -> flushItem()
       }
 
       lineIndex++
       if (lineIndex >= lines.size) {
         // Unterminated flow: fail safe — keep every token seen so its value is still redacted.
-        items.add(current.toString())
-        return finalizeSecretKeys(items) to lineIndex
+        flushItem()
+        return keys.toList() to lineIndex
       }
       // Drop a trailing CR; inside a quoted scalar the continuation's leading indentation is not
       // part
@@ -308,13 +344,6 @@ internal object SecretRedactor {
       currentLine = if (activeQuote != null) rawLine.trimStart(' ', '\t') else rawLine
     }
   }
-
-  /**
-   * Trim and drop empties from the scanner's already-decoded flow items (quotes/escapes are
-   * resolved during scanning, so no further unquoting here).
-   */
-  private fun finalizeSecretKeys(items: List<String>): List<String> =
-    items.map { it.trim() }.filter { it.isNotEmpty() }
 
   private fun stripComments(line: String): String {
     val hash = line.indexOf('#')

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -93,6 +93,20 @@ internal object SecretRedactor {
       }
       val inline = trimmed.removePrefix("secretParameters:").trim()
       if (inline.isNotEmpty()) {
+        // A bracketed flow value may span multiple lines: accumulate continuation lines until the
+        // matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]` is not
+        // dropped (#6097). Quotes and `${...}` placeholders are honored exactly as the single-line
+        // path does; a full YAML load is deliberately avoided (it chokes on `${...}` flow items).
+        if (inline.startsWith("[") && !flowSequenceIsClosed(inline)) {
+          val accumulated = StringBuilder(inline)
+          index++
+          while (index < lines.size && !flowSequenceIsClosed(accumulated.toString())) {
+            accumulated.append(' ').append(stripComments(lines[index]).trim())
+            index++
+          }
+          keys.addAll(parseInlineList(accumulated.toString()))
+          continue
+        }
         keys.addAll(parseInlineList(inline))
         index++
         continue
@@ -113,6 +127,28 @@ internal object SecretRedactor {
       }
     }
     return keys
+  }
+
+  /**
+   * True once [text] contains the `]` that closes its first `[`, honoring quotes so a bracket
+   * inside a quoted key (or a `${...}` placeholder, which is literal text here) is not mistaken for
+   * the flow delimiter. Used to decide when a multiline flow sequence is complete (#6097).
+   */
+  private fun flowSequenceIsClosed(text: String): Boolean {
+    var depth = 0
+    var activeQuote: Char? = null
+    for (character in text) {
+      when {
+        activeQuote != null -> if (character == activeQuote) activeQuote = null
+        character == '"' || character == '\'' -> activeQuote = character
+        character == '[' -> depth++
+        character == ']' -> {
+          depth--
+          if (depth == 0) return true
+        }
+      }
+    }
+    return false
   }
 
   private fun stripComments(line: String): String {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -71,6 +71,69 @@ internal object SecretRedactor {
     else parameters.mapValues { (key, value) -> if (key in secretKeys) PLACEHOLDER else value }
 
   /**
+   * The parameter VALUES to scrub for a set of declared secret key names, matched leniently so an
+   * exotically-encoded key name cannot leak its value. For each declared key: an exact
+   * `parameters[key]` is taken; failing that, any parameter whose key normalizes equal
+   * (case-folded, with backslashes/quotes/whitespace/CR removed) is taken; and if a declared key
+   * still resolves to nothing, EVERY parameter value is taken (over-redaction). `secretParameters`
+   * key names are expected to be literal identifiers — this is the fail-safe backstop for YAML
+   * encodings the flow scanner does not fully decode (`\xNN`/`\uNNNN` escapes, folding, CRLF): a
+   * declared secret's value is always scrubbed (possibly over-redacting), never leaked (#6097).
+   * Full decoding is a follow-up.
+   */
+  fun secretParameterValues(
+    declaredKeys: Set<String>,
+    parameters: Map<String, Any>,
+  ): List<String> {
+    if (declaredKeys.isEmpty()) return emptyList()
+    val values = mutableListOf<String>()
+    var hasUnresolvedKey = false
+    for (key in declaredKeys) {
+      val exact = parameters[key]?.let { parameterStringValue(it) }?.takeIf { it.isNotEmpty() }
+      if (exact != null) {
+        values.add(exact)
+        continue
+      }
+      val target = normalizeKey(key)
+      var matched = false
+      for ((paramKey, paramValue) in parameters) {
+        if (normalizeKey(paramKey) == target) {
+          parameterStringValue(paramValue).takeIf { it.isNotEmpty() }?.let { values.add(it) }
+          matched = true
+        }
+      }
+      if (!matched) hasUnresolvedKey = true
+    }
+    if (hasUnresolvedKey) {
+      // A declared secret could not be located even leniently (e.g. a `\xNN` hex-escaped key the
+      // scanner did not spec-decode). Over-redact every parameter value so it cannot leak (#6097).
+      for (value in parameters.values) {
+        parameterStringValue(value).takeIf { it.isNotEmpty() }?.let { values.add(it) }
+      }
+    }
+    return values
+  }
+
+  /**
+   * Case-folded key with backslashes, quotes, and whitespace/CR removed — the lenient key-identity
+   * used to match a mis-encoded declared secret key to a parameter (#6097).
+   */
+  private fun normalizeKey(key: String): String = buildString {
+    for (character in key.lowercase()) {
+      when (character) {
+        '\\',
+        '"',
+        '\'',
+        ' ',
+        '\t',
+        '\r',
+        '\n' -> Unit
+        else -> append(character)
+      }
+    }
+  }
+
+  /**
    * Scan a plan's top-level `secretParameters:` declaration for the sensitive key names, tolerating
    * `${...}` placeholders anywhere (they are literal text to the scanner). MUST run on the RAW,
    * pre-substitution plan: a substituted value can inject a newline that truncates the declaration,
@@ -140,6 +203,14 @@ internal object SecretRedactor {
    * dropping the newline; a plain newline folds to a space; continuation indentation is not part of
    * the value).
    *
+   * `secretParameters` key names are expected to be literal, simple identifiers. Exotic YAML
+   * encodings (`\xNN`/`\uNNNN` hex/unicode escapes, plain-scalar line folding, CRLF-in-quoted
+   * multiline keys) are handled best-effort here, NOT with full YAML-spec decoding — so a key may
+   * be mis-named. That is made safe at the value layer: [secretParameterValues] matches leniently
+   * and, if a declared key still cannot be resolved, over-redacts, so a declared secret's VALUE is
+   * always scrubbed (possibly over-redacting), never leaked. Full decoding is tracked as a
+   * follow-up to #6097.
+   *
    * FAIL-SAFE: key-name parsing errs toward OVER-capturing for redaction, never dropping a declared
    * key (which would leak its value). Every non-empty token is kept as a secret key, and an
    * UNTERMINATED sequence (e.g. from substitution truncation) still yields every token seen
@@ -157,7 +228,8 @@ internal object SecretRedactor {
     var activeQuote: Char? = null
     var escaped = false
     var lineIndex = startIndex
-    var currentLine = firstValue
+    // Drop a trailing CR so a CRLF-authored quoted multiline key does not embed `\r` (#6097).
+    var currentLine = firstValue.removeSuffix("\r")
 
     while (true) {
       var previous: Char? = null
@@ -208,15 +280,19 @@ internal object SecretRedactor {
         previous = character
       }
 
-      // Physical line ended. Fold per YAML: a trailing `\` inside a double-quoted scalar continues
+      // Physical line ended. Fold per YAML inside a double-quoted scalar: a trailing `\` continues
       // it
-      // (drop the newline); a plain newline inside a quoted scalar folds to a space; a newline
-      // between
-      // flow tokens is whitespace.
+      // (drop the newline); a plain newline folds to a space. Outside a quote, a plain scalar
+      // spanning
+      // lines is captured token-per-line (over-capture, fail-safe) instead of blending into one
+      // key.
       when {
         activeQuote == '"' && escaped -> escaped = false
         activeQuote != null -> current.append(' ')
-        started -> current.append(' ')
+        started && current.toString().trim().isNotEmpty() -> {
+          items.add(current.toString())
+          current.clear()
+        }
       }
 
       lineIndex++
@@ -225,9 +301,11 @@ internal object SecretRedactor {
         items.add(current.toString())
         return finalizeSecretKeys(items) to lineIndex
       }
-      // Inside a quoted scalar the continuation's leading indentation is not part of the value.
-      currentLine =
-        if (activeQuote != null) lines[lineIndex].trimStart(' ', '\t') else lines[lineIndex]
+      // Drop a trailing CR; inside a quoted scalar the continuation's leading indentation is not
+      // part
+      // of the value.
+      val rawLine = lines[lineIndex].removeSuffix("\r")
+      currentLine = if (activeQuote != null) rawLine.trimStart(' ', '\t') else rawLine
     }
   }
 

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -91,17 +91,22 @@ internal object SecretRedactor {
         index++
         continue
       }
-      val inline = trimmed.removePrefix("secretParameters:").trim()
+      // Strip the value's trailing comment quote-aware: a `#` inside a quoted key is literal YAML,
+      // not a comment (#6097). `lines[index]` is the raw line and begins with the key (indent 0),
+      // so
+      // dropping the key prefix leaves the raw value.
+      val inline = stripFlowComment(lines[index].removePrefix("secretParameters:")).trim()
       if (inline.isNotEmpty()) {
         // A bracketed flow value may span multiple lines: accumulate continuation lines until the
         // matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]` is not
-        // dropped (#6097). Quotes and `${...}` placeholders are honored exactly as the single-line
-        // path does; a full YAML load is deliberately avoided (it chokes on `${...}` flow items).
+        // dropped (#6097). Quote state, YAML double-quote escaping (`\"`), quoted `#`, and `${...}`
+        // placeholders (literal text) are all honored; a full YAML load is deliberately avoided (it
+        // chokes on `${...}` flow items).
         if (inline.startsWith("[") && !flowSequenceIsClosed(inline)) {
           val accumulated = StringBuilder(inline)
           index++
           while (index < lines.size && !flowSequenceIsClosed(accumulated.toString())) {
-            accumulated.append(' ').append(stripComments(lines[index]).trim())
+            accumulated.append(' ').append(stripFlowComment(lines[index]).trim())
             index++
           }
           keys.addAll(parseInlineList(accumulated.toString()))
@@ -130,21 +135,34 @@ internal object SecretRedactor {
   }
 
   /**
-   * True once [text] contains the `]` that closes its first `[`, honoring quotes so a bracket
-   * inside a quoted key (or a `${...}` placeholder, which is literal text here) is not mistaken for
-   * the flow delimiter. Used to decide when a multiline flow sequence is complete (#6097).
+   * True once [text] contains the `]` that closes its first `[`, honoring quotes and YAML
+   * double-quote escaping so a bracket inside a quoted key — or after an escaped quote `\"`, or in
+   * a `${...}` placeholder (literal text here) — is not mistaken for the flow delimiter. Used to
+   * decide when a multiline flow sequence is complete (#6097).
    */
   private fun flowSequenceIsClosed(text: String): Boolean {
     var depth = 0
     var activeQuote: Char? = null
+    var escaped = false
     for (character in text) {
-      when {
-        activeQuote != null -> if (character == activeQuote) activeQuote = null
-        character == '"' || character == '\'' -> activeQuote = character
-        character == '[' -> depth++
-        character == ']' -> {
-          depth--
-          if (depth == 0) return true
+      if (activeQuote != null) {
+        if (activeQuote == '"') {
+          when {
+            escaped -> escaped = false
+            character == '\\' -> escaped = true
+            character == '"' -> activeQuote = null
+          }
+        } else if (character == '\'') {
+          activeQuote = null
+        }
+      } else {
+        when {
+          character == '"' || character == '\'' -> activeQuote = character
+          character == '[' -> depth++
+          character == ']' -> {
+            depth--
+            if (depth == 0) return true
+          }
         }
       }
     }
@@ -154,6 +172,40 @@ internal object SecretRedactor {
   private fun stripComments(line: String): String {
     val hash = line.indexOf('#')
     return if (hash >= 0) line.substring(0, hash) else line
+  }
+
+  /**
+   * Remove a trailing YAML line comment from a flow line without stripping a `#` that sits inside a
+   * quoted scalar. Only an unquoted `#` at line start or preceded by whitespace begins a comment
+   * (YAML rule); double-quote backslash escaping is tracked so `\"` does not close the scalar and a
+   * following `#` stays literal (#6097).
+   */
+  private fun stripFlowComment(line: String): String {
+    val result = StringBuilder()
+    var activeQuote: Char? = null
+    var escaped = false
+    var previous: Char? = null
+    for (character in line) {
+      if (activeQuote != null) {
+        result.append(character)
+        if (activeQuote == '"') {
+          when {
+            escaped -> escaped = false
+            character == '\\' -> escaped = true
+            character == '"' -> activeQuote = null
+          }
+        } else if (character == '\'') {
+          activeQuote = null
+        }
+      } else if (character == '#' && (previous == null || previous == ' ' || previous == '\t')) {
+        break
+      } else {
+        if (character == '"' || character == '\'') activeQuote = character
+        result.append(character)
+      }
+      previous = character
+    }
+    return result.toString()
   }
 
   private fun indentationLevel(line: String): Int = line.takeWhile { it == ' ' }.length
@@ -170,32 +222,83 @@ internal object SecretRedactor {
   }
 
   /**
+   * Unquote a flow-list scalar: a single-quoted scalar is literal, a double-quoted scalar has its
+   * backslash escapes resolved (so `"a\"]b"` yields `a"]b`), matching the escape tracking used to
+   * find the sequence terminator and to split items (#6097).
+   */
+  private fun unquoteFlowScalar(value: String): String {
+    if (value.length >= 2) {
+      val first = value.first()
+      val last = value.last()
+      if (first == '"' && last == '"') {
+        return unescapeDoubleQuoted(value.substring(1, value.length - 1))
+      }
+      if (first == '\'' && last == '\'') {
+        return value.substring(1, value.length - 1)
+      }
+    }
+    return value
+  }
+
+  /**
+   * Resolve backslash escapes inside a double-quoted YAML scalar: `\` escapes the next character
+   * literally (so `\"` -> `"`, `\\` -> `\`). Sufficient for key names (#6097).
+   */
+  private fun unescapeDoubleQuoted(inner: String): String {
+    val result = StringBuilder()
+    var escaped = false
+    for (character in inner) {
+      when {
+        escaped -> {
+          result.append(character)
+          escaped = false
+        }
+        character == '\\' -> escaped = true
+        else -> result.append(character)
+      }
+    }
+    if (escaped) result.append('\\')
+    return result.toString()
+  }
+
+  /**
    * Parse a YAML flow list of scalar keys, e.g. `[apiToken, "password"]`. A comma inside a quoted
    * item is part of the key, not a separator, so `["API,TOKEN"]` yields the single key `API,TOKEN`.
+   * Double-quote escaping is honored so `\"` (and any `,`/`]` following it) stays inside the item.
    */
   private fun parseInlineList(value: String): List<String> {
     val inner = value.removePrefix("[").removeSuffix("]")
     val items = mutableListOf<String>()
     val current = StringBuilder()
     var activeQuote: Char? = null
+    var escaped = false
     for (character in inner) {
-      when {
-        activeQuote != null -> {
-          if (character == activeQuote) activeQuote = null
-          current.append(character)
+      if (activeQuote != null) {
+        current.append(character)
+        if (activeQuote == '"') {
+          when {
+            escaped -> escaped = false
+            character == '\\' -> escaped = true
+            character == '"' -> activeQuote = null
+          }
+        } else if (character == '\'') {
+          activeQuote = null
         }
-        character == '"' || character == '\'' -> {
-          activeQuote = character
-          current.append(character)
+      } else {
+        when {
+          character == '"' || character == '\'' -> {
+            activeQuote = character
+            current.append(character)
+          }
+          character == ',' -> {
+            items.add(current.toString())
+            current.clear()
+          }
+          else -> current.append(character)
         }
-        character == ',' -> {
-          items.add(current.toString())
-          current.clear()
-        }
-        else -> current.append(character)
       }
     }
     items.add(current.toString())
-    return items.map { unquote(it.trim()) }.filter { it.isNotEmpty() }
+    return items.map { unquoteFlowScalar(it.trim()) }.filter { it.isNotEmpty() }
   }
 }

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -91,27 +91,22 @@ internal object SecretRedactor {
         index++
         continue
       }
-      // Strip the value's trailing comment quote-aware: a `#` inside a quoted key is literal YAML,
-      // not a comment (#6097). `lines[index]` is the raw line and begins with the key (indent 0),
-      // so
-      // dropping the key prefix leaves the raw value.
-      val inline = stripFlowComment(lines[index].removePrefix("secretParameters:")).trim()
+      // Peek at the value with a quote-aware comment strip (a `#` inside a quoted key is literal
+      // YAML, not a comment): empty -> block sequence, `[` -> flow sequence, else bare scalar.
+      // `lines[index]` is the raw line and begins with the key (indent 0).
+      val rawValue = lines[index].removePrefix("secretParameters:")
+      val inline = stripFlowComment(rawValue).trim()
       if (inline.isNotEmpty()) {
-        // A bracketed flow value may span multiple lines: accumulate continuation lines until the
-        // matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]` is not
-        // dropped (#6097). Quote state, YAML double-quote escaping (`\"`), quoted `#`, and `${...}`
-        // placeholders (literal text) are all honored; a full YAML load is deliberately avoided (it
-        // chokes on `${...}` flow items).
-        if (inline.startsWith("[") && !flowSequenceIsClosed(inline)) {
-          val accumulated = StringBuilder(inline)
-          index++
-          while (index < lines.size && !flowSequenceIsClosed(accumulated.toString())) {
-            accumulated.append(' ').append(stripFlowComment(lines[index]).trim())
-            index++
-          }
-          keys.addAll(parseInlineList(accumulated.toString()))
+        if (inline.startsWith("[")) {
+          // A flow value may span multiple physical lines; a single-pass scanner handles the
+          // multiline form, quoted `#`, escaped quotes, trailing comments after `]`, and line
+          // folding — and fails safe toward over-capture (#6097).
+          val (flowKeys, nextIndex) = parseSecretFlowSequence(lines, index, rawValue)
+          keys.addAll(flowKeys)
+          index = nextIndex
           continue
         }
+        // Bare inline scalar (no brackets): treat as a single key name.
         keys.addAll(parseInlineList(inline))
         index++
         continue
@@ -135,39 +130,113 @@ internal object SecretRedactor {
   }
 
   /**
-   * True once [text] contains the `]` that closes its first `[`, honoring quotes and YAML
-   * double-quote escaping so a bracket inside a quoted key — or after an escaped quote `\"`, or in
-   * a `${...}` placeholder (literal text here) — is not mistaken for the flow delimiter. Used to
-   * decide when a multiline flow sequence is complete (#6097).
+   * Scan a `secretParameters:` YAML flow sequence that may span multiple physical lines, returning
+   * the declared key names and the index of the next line to resume from. A lenient hand-rolled
+   * scanner (a full YAML load chokes on `${...}` in flow collections — issue #6029). It honors
+   * quotes; double-quote backslash escaping (`\"`, so a `]`/`,`/`"` after it stays literal); quoted
+   * `#` (a `#` inside a scalar is literal — only an unquoted `#` at line start or after whitespace
+   * begins a comment); any content after the closing `]` (ignored — including a trailing comment);
+   * and YAML newline folding inside a double-quoted scalar (a trailing `\` continues the scalar,
+   * dropping the newline; a plain newline folds to a space; continuation indentation is not part of
+   * the value).
+   *
+   * FAIL-SAFE: key-name parsing errs toward OVER-capturing for redaction, never dropping a declared
+   * key (which would leak its value). Every non-empty token is kept as a secret key, and an
+   * UNTERMINATED sequence (e.g. from substitution truncation) still yields every token seen
+   * (#6097).
    */
-  private fun flowSequenceIsClosed(text: String): Boolean {
+  private fun parseSecretFlowSequence(
+    lines: List<String>,
+    startIndex: Int,
+    firstValue: String,
+  ): Pair<List<String>, Int> {
+    val items = mutableListOf<String>()
+    val current = StringBuilder()
     var depth = 0
+    var started = false
     var activeQuote: Char? = null
     var escaped = false
-    for (character in text) {
-      if (activeQuote != null) {
-        if (activeQuote == '"') {
-          when {
-            escaped -> escaped = false
-            character == '\\' -> escaped = true
-            character == '"' -> activeQuote = null
+    var lineIndex = startIndex
+    var currentLine = firstValue
+
+    while (true) {
+      var previous: Char? = null
+      var inComment = false
+      for (character in currentLine) {
+        if (inComment) break
+        if (activeQuote != null) {
+          if (activeQuote == '"') {
+            when {
+              escaped -> {
+                current.append(character)
+                escaped = false
+              }
+              character == '\\' -> escaped = true
+              character == '"' -> activeQuote = null
+              else -> current.append(character)
+            }
+          } else if (character == '\'') {
+            activeQuote = null
+          } else {
+            current.append(character)
           }
-        } else if (character == '\'') {
-          activeQuote = null
-        }
-      } else {
-        when {
-          character == '"' || character == '\'' -> activeQuote = character
-          character == '[' -> depth++
-          character == ']' -> {
-            depth--
-            if (depth == 0) return true
+        } else if (!started) {
+          if (character == '[') {
+            started = true
+            depth = 1
           }
+        } else if (character == '#' && (previous == null || previous == ' ' || previous == '\t')) {
+          inComment = true
+        } else if (character == '"' || character == '\'') {
+          activeQuote = character
+        } else if (character == '[') {
+          depth++
+          current.append(character)
+        } else if (character == ']') {
+          depth--
+          if (depth == 0) {
+            items.add(current.toString())
+            return finalizeSecretKeys(items) to (lineIndex + 1)
+          }
+          current.append(character)
+        } else if (character == ',' && depth == 1) {
+          items.add(current.toString())
+          current.clear()
+        } else {
+          current.append(character)
         }
+        previous = character
       }
+
+      // Physical line ended. Fold per YAML: a trailing `\` inside a double-quoted scalar continues
+      // it
+      // (drop the newline); a plain newline inside a quoted scalar folds to a space; a newline
+      // between
+      // flow tokens is whitespace.
+      when {
+        activeQuote == '"' && escaped -> escaped = false
+        activeQuote != null -> current.append(' ')
+        started -> current.append(' ')
+      }
+
+      lineIndex++
+      if (lineIndex >= lines.size) {
+        // Unterminated flow: fail safe — keep every token seen so its value is still redacted.
+        items.add(current.toString())
+        return finalizeSecretKeys(items) to lineIndex
+      }
+      // Inside a quoted scalar the continuation's leading indentation is not part of the value.
+      currentLine =
+        if (activeQuote != null) lines[lineIndex].trimStart(' ', '\t') else lines[lineIndex]
     }
-    return false
   }
+
+  /**
+   * Trim and drop empties from the scanner's already-decoded flow items (quotes/escapes are
+   * resolved during scanning, so no further unquoting here).
+   */
+  private fun finalizeSecretKeys(items: List<String>): List<String> =
+    items.map { it.trim() }.filter { it.isNotEmpty() }
 
   private fun stripComments(line: String): String {
     val hash = line.indexOf('#')

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -93,6 +93,39 @@ class AutoMobilePlanRedactionTest {
   }
 
   @Test
+  fun `secret is redacted when secretParameters is a multiline flow sequence`() {
+    // Multiline bracketed flow sequence — valid YAML the line scanner previously dropped, silently
+    // disabling redaction and letting the secret reach the LLM recovery context (#6097 fail-open
+    // gap).
+    fakeDaemonClient.executePlanResponse =
+      buildFailureResponse(error = "timed out entering $secret into field")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-multiline-flow.yaml",
+      mapOf("SECRET_TOKEN" to secret, "ENVIRONMENT" to visible),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured) { "recovery must receive a context" }
+    assertFalse(
+      "a multiline-flow secretParameters declaration must still redact the plan content",
+      context.planContent.contains(secret),
+    )
+    assertFalse(
+      "a multiline-flow secretParameters declaration must still redact the error string",
+      context.error.contains(secret),
+    )
+    assertTrue(
+      "the secret is replaced by the redaction placeholder",
+      context.planContent.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertTrue(
+      "non-secret substituted context is preserved",
+      context.planContent.contains(visible),
+    )
+  }
+
+  @Test
   fun `secret declared only via options secretParameterKeys is redacted`() {
     fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -180,6 +180,27 @@ class AutoMobilePlanRedactionTest {
   }
 
   @Test
+  fun `secret value is redacted when the key uses a hex escape (fail-safe)`() {
+    // The key `"API\x54OKEN"` is not spec-decoded by the scanner, so it can't be matched to the
+    // parameter `APITOKEN` by name; the strengthened value-layer fail-safe over-redacts so the
+    // secret
+    // still cannot leak to the recovery LLM (#6097 — the important security assertion).
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-hex-escape-key.yaml",
+      mapOf("APITOKEN" to secret),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "a hex-escaped secret key's value must still be redacted via the fail-safe",
+      context.error.contains(secret),
+    )
+  }
+
+  @Test
   fun `secret declared only via options secretParameterKeys is redacted`() {
     fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -126,6 +126,60 @@ class AutoMobilePlanRedactionTest {
   }
 
   @Test
+  fun `multiline flow key with a quoted hash does not drop the following secret`() {
+    // The first key quotes a `#`; a comment strip that runs before quote state truncates it, drops
+    // the
+    // second key, and leaks the second secret to the recovery LLM (#6097 Codex P1, fail-open).
+    val secretA = "SECRETA-hash-9f1"
+    val secretB = "SECRETB-plain-2a7"
+    fakeDaemonClient.executePlanResponse =
+      buildFailureResponse(error = "boom $secretA and $secretB")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-multiline-quoted-hash.yaml",
+      mapOf("API#TOKEN" to secretA, "PASSWORD" to secretB),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "the quoted-# key's value must be redacted",
+      context.error.contains(secretA),
+    )
+    assertFalse(
+      "the following key must not be dropped, so its value redacts",
+      context.error.contains(secretB),
+    )
+  }
+
+  @Test
+  fun `multiline flow key with an escaped quote before a bracket does not drop the following secret`() {
+    // The first key is a double-quoted scalar with an escaped quote before a `]`; without escape
+    // tracking the sequence terminator is found early, the second key is dropped, and its secret
+    // leaks.
+    val secretA = "SECRETA-esc-4c2"
+    val secretB = "SECRETB-plain-8e5"
+    fakeDaemonClient.executePlanResponse =
+      buildFailureResponse(error = "boom $secretA and $secretB")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-multiline-escaped-quote.yaml",
+      mapOf("a\"]b" to secretA, "PASSWORD" to secretB),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "the escaped-quote key's value must be redacted",
+      context.error.contains(secretA),
+    )
+    assertFalse(
+      "the following key must not be dropped, so its value redacts",
+      context.error.contains(secretB),
+    )
+  }
+
+  @Test
   fun `secret declared only via options secretParameterKeys is redacted`() {
     fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -201,6 +201,29 @@ class AutoMobilePlanRedactionTest {
   }
 
   @Test
+  fun `secret value is redacted despite a decoy parameter matching the un-decoded hex key`() {
+    // Parameters contain BOTH the real `APITOKEN` (what YAML decodes `"API\x54OKEN"` to) and a
+    // decoy
+    // `APIx54OKEN` matching the scanner's un-decoded spelling. The fail-safe must not trust the
+    // decoy
+    // exact-match; it over-redacts so the REAL secret cannot leak (#6097 — decoy collision).
+    val real = "REAL-hex-secret-1a2"
+    fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $real")
+
+    AutoMobilePlanExecutor.execute(
+      "test-plans/redaction-hex-escape-key.yaml",
+      mapOf("APITOKEN" to real, "APIx54OKEN" to "DECOY-not-the-secret"),
+      AutoMobilePlanExecutionOptions(device = "emulator-5554"),
+    )
+
+    val context = requireNotNull(capturingAgent.captured)
+    assertFalse(
+      "the real secret must be redacted despite the decoy exact-match",
+      context.error.contains(real),
+    )
+  }
+
+  @Test
   fun `secret declared only via options secretParameterKeys is redacted`() {
     fakeDaemonClient.executePlanResponse = buildFailureResponse(error = "boom $secret")
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -173,6 +173,54 @@ class SecretRedactorTest {
   }
 
   @Test
+  fun `a CRLF-authored quoted multiline key is parsed without a carriage return`() {
+    // With CRLF line endings, split('\n') leaves a trailing `\r`; it must be stripped so the key
+    // isn't
+    // corrupted (#6097 Codex — CRLF). The quoted scalar folds to `API TOKEN`.
+    val yaml =
+      "name: P\r\nsecretParameters: [\r\n  \"API\r\n  TOKEN\"\r\n]\r\nsteps:\r\n  - tool: observe"
+    val keys = SecretRedactor.parsePlanSecretKeys(yaml)
+    assertEquals(setOf("API TOKEN"), keys)
+    assertFalse(keys.any { it.contains('\r') }, "no key may contain a carriage return")
+  }
+
+  @Test
+  fun `a plain multiline flow scalar captures each line's token (fail-safe over-capture)`() {
+    // A plain (unquoted) scalar spanning lines is captured token-per-line so both are redacted,
+    // rather
+    // than blended into one mis-named key (#6097 Codex — plain-scalar folding).
+    val yaml = "name: P\nsecretParameters: [\n  API\n  TOKEN\n]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("API", "TOKEN"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `secretParameterValues matches exactly and does not over-redact`() {
+    val values =
+      SecretRedactor.secretParameterValues(setOf("TOKEN"), mapOf("TOKEN" to "S", "VIS" to "v"))
+    assertEquals(listOf("S"), values)
+  }
+
+  @Test
+  fun `secretParameterValues matches leniently across whitespace and case`() {
+    // A folded/whitespaced key still resolves to the parameter by normalized identity (#6097).
+    val values = SecretRedactor.secretParameterValues(setOf("API TOKEN"), mapOf("apitoken" to "S"))
+    assertEquals(listOf("S"), values)
+  }
+
+  @Test
+  fun `secretParameterValues over-redacts when a declared key cannot be resolved (fail-safe)`() {
+    // A hex-escaped key parsed as `APIx54OKEN` matches no parameter by name or normalization, so
+    // every
+    // parameter value is scrubbed — the secret cannot leak (#6097 fail-safe).
+    val values =
+      SecretRedactor.secretParameterValues(
+        setOf("APIx54OKEN"),
+        mapOf("APITOKEN" to "SECRETV", "VIS" to "visible"),
+      )
+    assertTrue(values.contains("SECRETV"), "the real secret value must be scrubbed")
+  }
+
+  @Test
   fun `tolerates placeholder key names and unrelated placeholder flow lists`() {
     // A full YAML load would throw on `[${LABEL}, OK]`; the scanner tolerates it and ignores it.
     val yaml =

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -33,6 +33,70 @@ class SecretRedactorTest {
   }
 
   @Test
+  fun `parses multiline flow sequence with closing bracket on its own line`() {
+    // The bracketed flow value spans multiple lines with `]` alone on the last line — the form the
+    // line scanner previously dropped, silently disabling redaction (#6097 fail-open gap).
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+        TOKEN,
+        PASSWORD
+      ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertEquals(setOf("TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `parses multiline flow sequence with trailing comma and closing bracket trailing an item`() {
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+        TOKEN,
+        PASSWORD,
+        API ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertEquals(setOf("TOKEN", "PASSWORD", "API"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `multiline flow sequence tolerates quoted comma and placeholder key names`() {
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+        "API,TOKEN",
+        ${'$'}{SECRET_KEY}
+      ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertEquals(setOf("API,TOKEN", "\${SECRET_KEY}"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `empty multiline flow sequence yields an empty set`() {
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+      ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertTrue(SecretRedactor.parsePlanSecretKeys(yaml).isEmpty())
+  }
+
+  @Test
   fun `tolerates placeholder key names and unrelated placeholder flow lists`() {
     // A full YAML load would throw on `[${LABEL}, OK]`; the scanner tolerates it and ignores it.
     val yaml =

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -97,6 +97,48 @@ class SecretRedactorTest {
   }
 
   @Test
+  fun `multiline flow with a quoted hash key does not drop the following key`() {
+    // A `#` inside a quoted item is literal YAML, not a comment. Stripping comments line-by-line
+    // before quote state truncates `"API#TOKEN"` to `"API`, the unterminated quote swallows the
+    // rest,
+    // and PASSWORD is dropped — its secret would reach the LLM unredacted (#6097 Codex P1,
+    // fail-open).
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+        "API#TOKEN",
+        PASSWORD
+      ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertEquals(setOf("API#TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `multiline flow with an escaped quote before a bracket does not drop the following key`() {
+    // A double-quoted scalar may contain an escaped quote (\"); the `]` after it is still inside
+    // the
+    // scalar, not the sequence terminator. Without escape tracking the terminator is found early
+    // and
+    // PASSWORD is dropped — fail-open (#6097 Codex P2).
+    val yaml =
+      """
+      name: P
+      secretParameters: [
+        "a\"]b",
+        PASSWORD
+      ]
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+    assertEquals(setOf("a\"]b", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
   fun `tolerates placeholder key names and unrelated placeholder flow lists`() {
     // A full YAML load would throw on `[${LABEL}, OK]`; the scanner tolerates it and ignores it.
     val yaml =

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -208,6 +208,36 @@ class SecretRedactorTest {
   }
 
   @Test
+  fun `a quoted whitespace-only key is not dropped`() {
+    // Stripping the quotes before the trim would discard `" "`; a single space is a valid quoted
+    // key
+    // and must be kept so its parameter value is redacted (#6097 Codex — quoted whitespace key).
+    val yaml = "name: P\nsecretParameters: [\" \"]\nsteps:\n  - tool: observe"
+    assertEquals(setOf(" "), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `secretParameterValues keeps a quoted whitespace key's value`() {
+    val values = SecretRedactor.secretParameterValues(setOf(" "), mapOf(" " to "SECRET"))
+    assertEquals(listOf("SECRET"), values)
+  }
+
+  @Test
+  fun `secretParameterValues over-redacts a backslash key despite a decoy exact-match`() {
+    // The un-decoded hex key `API\x54OKEN` exact-matches a DECOY parameter of the same raw
+    // spelling,
+    // while the REAL value lives under the YAML-decoded `APITOKEN`. A backslash key must not trust
+    // that
+    // coincidental match — it over-redacts so REAL is scrubbed too (#6097 Codex — decoy collision).
+    val values =
+      SecretRedactor.secretParameterValues(
+        setOf("API\\x54OKEN"),
+        mapOf("APITOKEN" to "REAL", "APIx54OKEN" to "DECOY"),
+      )
+    assertTrue(values.contains("REAL"), "the real (decoded-name) secret value must be scrubbed")
+  }
+
+  @Test
   fun `secretParameterValues over-redacts when a declared key cannot be resolved (fail-safe)`() {
     // A hex-escaped key parsed as `APIx54OKEN` matches no parameter by name or normalization, so
     // every

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -139,6 +139,40 @@ class SecretRedactorTest {
   }
 
   @Test
+  fun `trailing comment after the closing bracket is ignored`() {
+    // A comment after `]` (with or without a leading space) must be ignored and TOKEN still parsed;
+    // dropping it would leak TOKEN's value (#6097 Codex — comment after `]`).
+    val spaced = "name: P\nsecretParameters: [TOKEN] # trailing comment\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN"), SecretRedactor.parsePlanSecretKeys(spaced))
+    val unspaced = "name: P\nsecretParameters: [TOKEN]#c\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN"), SecretRedactor.parsePlanSecretKeys(unspaced))
+  }
+
+  @Test
+  fun `an unrecognized token is still captured as a secret key (fail-safe)`() {
+    // Fail-safe: an unusual/unrecognized token must still be treated as a secret key (over-capture)
+    // rather than dropped — dropping would fail open (#6097).
+    val yaml = "name: P\nsecretParameters: [TOKEN, @@weird@@]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("TOKEN", "@@weird@@"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `an unterminated flow sequence fails safe by capturing its tokens`() {
+    // No closing `]` (e.g. substitution truncation): still yield the tokens (over-capture), never
+    // silently drop them (#6097 fail-safe).
+    val yaml = "name: P\nsecretParameters: [\n  TOKEN,\n  PASSWORD"
+    assertEquals(setOf("TOKEN", "PASSWORD"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
+  fun `a double-quoted line-continuation key is captured`() {
+    // A double-quoted key using YAML line continuation (`"API\`+newline+`TOKEN"` decodes to
+    // `APITOKEN`) must be captured so its value is redacted (#6097 Codex — line continuation).
+    val yaml = "name: P\nsecretParameters: [\n  \"API\\\n  TOKEN\"\n]\nsteps:\n  - tool: observe"
+    assertEquals(setOf("APITOKEN"), SecretRedactor.parsePlanSecretKeys(yaml))
+  }
+
+  @Test
   fun `tolerates placeholder key names and unrelated placeholder flow lists`() {
     // A full YAML load would throw on `[${LABEL}, OK]`; the scanner tolerates it and ignores it.
     val yaml =

--- a/android/junit-runner/src/test/resources/test-plans/redaction-hex-escape-key.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-hex-escape-key.yaml
@@ -1,0 +1,11 @@
+---
+name: redaction-hex-escape-key
+description: secretParameters key using a YAML \x hex escape; fail-safe redaction (#6097)
+secretParameters: ["API\x54OKEN"]
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "field"
+    label: Enter a value

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-escaped-quote.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-escaped-quote.yaml
@@ -1,0 +1,14 @@
+---
+name: redaction-multiline-escaped-quote
+description: Multiline flow secretParameters whose first key has an escaped quote before ] (#6097)
+secretParameters: [
+  "a\"]b",
+  PASSWORD
+]
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "field"
+    label: Enter a value

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-escaped-quote.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-escaped-quote.yaml
@@ -2,9 +2,9 @@
 name: redaction-multiline-escaped-quote
 description: Multiline flow secretParameters whose first key has an escaped quote before ] (#6097)
 secretParameters: [
-  "a\"]b",
-  PASSWORD
-]
+    "a\"]b",
+    PASSWORD,
+  ]
 steps:
   - tool: launchApp
     appId: com.example.app

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-flow.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-flow.yaml
@@ -2,8 +2,8 @@
 name: redaction-multiline-flow
 description: Plan declaring secretParameters as a multiline YAML flow sequence (#6097)
 secretParameters: [
-  SECRET_TOKEN
-]
+    SECRET_TOKEN,
+  ]
 steps:
   - tool: launchApp
     appId: com.example.app

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-flow.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-flow.yaml
@@ -1,0 +1,16 @@
+---
+name: redaction-multiline-flow
+description: Plan declaring secretParameters as a multiline YAML flow sequence (#6097)
+secretParameters: [
+  SECRET_TOKEN
+]
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "${SECRET_TOKEN}"
+    label: Enter the secret token
+  - tool: tapOn
+    text: "${ENVIRONMENT}"
+    label: Tap the environment control

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-quoted-hash.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-quoted-hash.yaml
@@ -1,0 +1,14 @@
+---
+name: redaction-multiline-quoted-hash
+description: Multiline flow secretParameters whose first key quotes a # (#6097)
+secretParameters: [
+  "API#TOKEN",
+  PASSWORD
+]
+steps:
+  - tool: launchApp
+    appId: com.example.app
+    label: Launch app
+  - tool: inputText
+    text: "field"
+    label: Enter a value

--- a/android/junit-runner/src/test/resources/test-plans/redaction-multiline-quoted-hash.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/redaction-multiline-quoted-hash.yaml
@@ -2,9 +2,9 @@
 name: redaction-multiline-quoted-hash
 description: Multiline flow secretParameters whose first key quotes a # (#6097)
 secretParameters: [
-  "API#TOKEN",
-  PASSWORD
-]
+    "API#TOKEN",
+    PASSWORD,
+  ]
 steps:
   - tool: launchApp
     appId: com.example.app

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
@@ -457,11 +457,10 @@ public final class AutoMobilePlanExecutor {
         let params = configuration.parameters
         let resolvedKeys = Set(declaredKeys.map { substituteParameters(in: $0, parameters: params) })
 
-        var values: [String] = []
+        // Raw parameter values via the lenient/fail-safe matcher (so an exotically-encoded key name
+        // cannot leak), plus each key's actual substituted value from this executor's ordered pass.
+        var values = SecretRedaction.secretParameterValues(declaredKeys: resolvedKeys, parameters: params)
         for key in resolvedKeys {
-            if let raw = params[key], !raw.isEmpty {
-                values.append(raw)
-            }
             let placeholder = "${\(key)}"
             let landed = substituteParameters(in: placeholder, parameters: params)
             if landed != placeholder, !landed.isEmpty {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -156,18 +156,22 @@ enum PlanMetadataParser {
                 continue
             }
 
-            let inline = trimmed.dropFirst("secretParameters:".count).trimmingCharacters(in: .whitespaces)
+            // Strip the value's trailing comment quote-aware: a `#` inside a quoted key is literal
+            // YAML, not a comment (#6097). `lines[index]` is the raw line and begins with the key
+            // (indent 0), so dropping the key prefix leaves the raw value.
+            let inline = stripFlowComment(String(lines[index].dropFirst("secretParameters:".count)))
+                .trimmingCharacters(in: .whitespaces)
             if !inline.isEmpty {
                 // A bracketed flow value may span multiple lines: accumulate continuation lines until
                 // the matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]`
-                // is not dropped (#6097). Quotes and `${...}` placeholders are honored exactly as the
-                // single-line path does; a full YAML load is deliberately avoided (it chokes on
-                // `${...}` flow items).
+                // is not dropped (#6097). Quote state, YAML double-quote escaping (`\"`), quoted `#`,
+                // and `${...}` placeholders (literal text) are all honored; a full YAML load is
+                // deliberately avoided (it chokes on `${...}` flow items).
                 if inline.hasPrefix("[") && !flowSequenceIsClosed(inline) {
                     var accumulated = inline
                     index += 1
                     while index < lines.count && !flowSequenceIsClosed(accumulated) {
-                        accumulated += " " + stripComments(from: lines[index]).trimmingCharacters(in: .whitespaces)
+                        accumulated += " " + stripFlowComment(lines[index]).trimmingCharacters(in: .whitespaces)
                         index += 1
                     }
                     keys.formUnion(parseInlineList(accumulated))
@@ -212,12 +216,23 @@ enum PlanMetadataParser {
         var items: [String] = []
         var current = ""
         var activeQuote: Character?
+        var escaped = false
         for character in inner {
             if let quote = activeQuote {
-                if character == quote {
+                current.append(character)
+                // Inside a double-quoted scalar `\"` is a literal quote, not the closing delimiter, so
+                // a `,` or `]` after it stays part of the item (#6097).
+                if quote == "\"" {
+                    if escaped {
+                        escaped = false
+                    } else if character == "\\" {
+                        escaped = true
+                    } else if character == "\"" {
+                        activeQuote = nil
+                    }
+                } else if character == "'" {
                     activeQuote = nil
                 }
-                current.append(character)
             } else if character == "\"" || character == "'" {
                 activeQuote = character
                 current.append(character)
@@ -231,19 +246,29 @@ enum PlanMetadataParser {
         items.append(current)
 
         return items
-            .map { unquote($0.trimmingCharacters(in: .whitespaces)) }
+            .map { unquoteFlowScalar($0.trimmingCharacters(in: .whitespaces)) }
             .filter { !$0.isEmpty }
     }
 
-    /// True once `text` contains the `]` that closes its first `[`, honoring quotes so a bracket
-    /// inside a quoted key (or a `${...}` placeholder, which is literal text here) is not mistaken for
-    /// the flow delimiter. Used to decide when a multiline flow sequence is complete (#6097).
+    /// True once `text` contains the `]` that closes its first `[`, honoring quotes and YAML
+    /// double-quote escaping so a bracket inside a quoted key — or after an escaped quote `\"`, or in a
+    /// `${...}` placeholder (literal text here) — is not mistaken for the flow delimiter. Used to
+    /// decide when a multiline flow sequence is complete (#6097).
     private static func flowSequenceIsClosed(_ text: String) -> Bool {
         var depth = 0
         var activeQuote: Character?
+        var escaped = false
         for character in text {
             if let quote = activeQuote {
-                if character == quote {
+                if quote == "\"" {
+                    if escaped {
+                        escaped = false
+                    } else if character == "\\" {
+                        escaped = true
+                    } else if character == "\"" {
+                        activeQuote = nil
+                    }
+                } else if character == "'" {
                     activeQuote = nil
                 }
             } else if character == "\"" || character == "'" {
@@ -258,6 +283,78 @@ enum PlanMetadataParser {
             }
         }
         return false
+    }
+
+    /// Remove a trailing YAML line comment from a flow line without stripping a `#` that sits inside a
+    /// quoted scalar. Only an unquoted `#` at line start or preceded by whitespace begins a comment
+    /// (YAML rule); double-quote backslash escaping is tracked so `\"` does not close the scalar and a
+    /// following `#` stays literal (#6097).
+    private static func stripFlowComment(_ line: String) -> String {
+        var result = ""
+        var activeQuote: Character?
+        var escaped = false
+        var previous: Character?
+        for character in line {
+            if let quote = activeQuote {
+                result.append(character)
+                if quote == "\"" {
+                    if escaped {
+                        escaped = false
+                    } else if character == "\\" {
+                        escaped = true
+                    } else if character == "\"" {
+                        activeQuote = nil
+                    }
+                } else if character == "'" {
+                    activeQuote = nil
+                }
+            } else if character == "#" && (previous == nil || previous == " " || previous == "\t") {
+                break
+            } else {
+                if character == "\"" || character == "'" {
+                    activeQuote = character
+                }
+                result.append(character)
+            }
+            previous = character
+        }
+        return result
+    }
+
+    /// Unquote a flow-list scalar: a single-quoted scalar is literal, a double-quoted scalar has its
+    /// backslash escapes resolved (so `"a\"]b"` yields `a"]b`), matching the escape tracking used to
+    /// find the sequence terminator and to split items (#6097).
+    private static func unquoteFlowScalar(_ value: String) -> String {
+        if value.count >= 2 {
+            if value.hasPrefix("\"") && value.hasSuffix("\"") {
+                return unescapeDoubleQuoted(String(value.dropFirst().dropLast()))
+            }
+            if value.hasPrefix("'") && value.hasSuffix("'") {
+                return String(value.dropFirst().dropLast())
+            }
+        }
+        return value
+    }
+
+    /// Resolve backslash escapes inside a double-quoted YAML scalar: `\` escapes the next character
+    /// literally (so `\"` -> `"`, `\\` -> `\`). Sufficient for key names (#6097).
+    private static func unescapeDoubleQuoted(_ inner: String) -> String {
+        var result = ""
+        var escaped = false
+        for character in inner {
+            if escaped {
+                result.append(character)
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else {
+                result.append(character)
+            }
+        }
+        if escaped {
+            result.append("\\")
+        }
+        return result
     }
 
     private static func parsePlatform(_ value: String) throws -> AutoMobilePlanExecutor.PlanPlatform {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -156,27 +156,24 @@ enum PlanMetadataParser {
                 continue
             }
 
-            // Strip the value's trailing comment quote-aware: a `#` inside a quoted key is literal
-            // YAML, not a comment (#6097). `lines[index]` is the raw line and begins with the key
-            // (indent 0), so dropping the key prefix leaves the raw value.
-            let inline = stripFlowComment(String(lines[index].dropFirst("secretParameters:".count)))
-                .trimmingCharacters(in: .whitespaces)
+            // Peek at the value with a quote-aware comment strip (a `#` inside a quoted key is literal
+            // YAML, not a comment): empty -> block sequence, `[` -> flow sequence, else bare scalar.
+            // `lines[index]` is the raw line and begins with the key (indent 0).
+            let rawValue = String(lines[index].dropFirst("secretParameters:".count))
+            let inline = stripFlowComment(rawValue).trimmingCharacters(in: .whitespaces)
             if !inline.isEmpty {
-                // A bracketed flow value may span multiple lines: accumulate continuation lines until
-                // the matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]`
-                // is not dropped (#6097). Quote state, YAML double-quote escaping (`\"`), quoted `#`,
-                // and `${...}` placeholders (literal text) are all honored; a full YAML load is
-                // deliberately avoided (it chokes on `${...}` flow items).
-                if inline.hasPrefix("[") && !flowSequenceIsClosed(inline) {
-                    var accumulated = inline
-                    index += 1
-                    while index < lines.count && !flowSequenceIsClosed(accumulated) {
-                        accumulated += " " + stripFlowComment(lines[index]).trimmingCharacters(in: .whitespaces)
-                        index += 1
-                    }
-                    keys.formUnion(parseInlineList(accumulated))
+                if inline.hasPrefix("[") {
+                    // A flow value may span multiple physical lines; a single-pass scanner handles the
+                    // multiline form, quoted `#`, escaped quotes, trailing comments after `]`, and line
+                    // folding — and fails safe toward over-capture (#6097).
+                    let (flowKeys, nextIndex) = parseSecretFlowSequence(
+                        lines: lines, startIndex: index, firstValue: rawValue
+                    )
+                    keys.formUnion(flowKeys)
+                    index = nextIndex
                     continue
                 }
+                // Bare inline scalar (no brackets): treat as a single key name.
                 keys.formUnion(parseInlineList(inline))
                 index += 1
                 continue
@@ -250,39 +247,113 @@ enum PlanMetadataParser {
             .filter { !$0.isEmpty }
     }
 
-    /// True once `text` contains the `]` that closes its first `[`, honoring quotes and YAML
-    /// double-quote escaping so a bracket inside a quoted key — or after an escaped quote `\"`, or in a
-    /// `${...}` placeholder (literal text here) — is not mistaken for the flow delimiter. Used to
-    /// decide when a multiline flow sequence is complete (#6097).
-    private static func flowSequenceIsClosed(_ text: String) -> Bool {
+    /// Scan a `secretParameters:` YAML flow sequence that may span multiple physical lines, returning
+    /// the declared key names and the index of the next line to resume from. A lenient hand-rolled
+    /// scanner (a full YAML load chokes on `${...}` in flow collections — issue #6029). It honors
+    /// quotes; double-quote backslash escaping (`\"`, so a `]`/`,`/`"` after it stays literal); quoted
+    /// `#` (a `#` inside a scalar is literal — only an unquoted `#` at line start or after whitespace
+    /// begins a comment); any content after the closing `]` (ignored — including a trailing comment);
+    /// and YAML newline folding inside a double-quoted scalar (a trailing `\` continues the scalar,
+    /// dropping the newline; a plain newline folds to a space; continuation indentation is not part of
+    /// the value).
+    ///
+    /// FAIL-SAFE: key-name parsing errs toward OVER-capturing for redaction, never dropping a declared
+    /// key (which would leak its value). Every non-empty token is kept as a secret key, and an
+    /// UNTERMINATED sequence (e.g. from substitution truncation) still yields every token seen (#6097).
+    private static func parseSecretFlowSequence(
+        lines: [String], startIndex: Int, firstValue: String
+    )
+        -> (keys: [String], nextIndex: Int)
+    {
+        var items: [String] = []
+        var current = ""
         var depth = 0
+        var started = false
         var activeQuote: Character?
         var escaped = false
-        for character in text {
-            if let quote = activeQuote {
-                if quote == "\"" {
-                    if escaped {
-                        escaped = false
-                    } else if character == "\\" {
-                        escaped = true
-                    } else if character == "\"" {
+        var lineIndex = startIndex
+        var currentLine = firstValue
+
+        while true {
+            var previous: Character?
+            var inComment = false
+            for character in currentLine {
+                if inComment { break }
+                if let quote = activeQuote {
+                    if quote == "\"" {
+                        if escaped {
+                            current.append(character)
+                            escaped = false
+                        } else if character == "\\" {
+                            escaped = true
+                        } else if character == "\"" {
+                            activeQuote = nil
+                        } else {
+                            current.append(character)
+                        }
+                    } else if character == "'" {
                         activeQuote = nil
+                    } else {
+                        current.append(character)
                     }
-                } else if character == "'" {
-                    activeQuote = nil
+                } else if !started {
+                    if character == "[" {
+                        started = true
+                        depth = 1
+                    }
+                } else if character == "#" && (previous == nil || previous == " " || previous == "\t") {
+                    inComment = true
+                } else if character == "\"" || character == "'" {
+                    activeQuote = character
+                } else if character == "[" {
+                    depth += 1
+                    current.append(character)
+                } else if character == "]" {
+                    depth -= 1
+                    if depth == 0 {
+                        items.append(current)
+                        return (finalizeSecretKeys(items), lineIndex + 1)
+                    }
+                    current.append(character)
+                } else if character == ",", depth == 1 {
+                    items.append(current)
+                    current = ""
+                } else {
+                    current.append(character)
                 }
-            } else if character == "\"" || character == "'" {
-                activeQuote = character
-            } else if character == "[" {
-                depth += 1
-            } else if character == "]" {
-                depth -= 1
-                if depth == 0 {
-                    return true
-                }
+                previous = character
             }
+
+            // Physical line ended. Fold per YAML: a trailing `\` inside a double-quoted scalar
+            // continues it (drop the newline); a plain newline inside a quoted scalar folds to a space;
+            // a newline between flow tokens is whitespace.
+            if activeQuote == "\"", escaped {
+                escaped = false
+            } else if activeQuote != nil {
+                current.append(" ")
+            } else if started {
+                current.append(" ")
+            }
+
+            lineIndex += 1
+            if lineIndex >= lines.count {
+                // Unterminated flow: fail safe — keep every token seen so its value is still redacted.
+                items.append(current)
+                return (finalizeSecretKeys(items), lineIndex)
+            }
+            // Inside a quoted scalar the continuation's leading indentation is not part of the value.
+            currentLine = activeQuote != nil
+                ? String(lines[lineIndex].drop { $0 == " " || $0 == "\t" })
+                : lines[lineIndex]
         }
-        return false
+    }
+
+    /// Trim and drop empties from the scanner's already-decoded flow items (quotes/escapes are
+    /// resolved during scanning, so no further unquoting here).
+    private static func finalizeSecretKeys(_ items: [String]) -> [String] {
+        items
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
     }
 
     /// Remove a trailing YAML line comment from a flow line without stripping a `#` that sits inside a

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -247,6 +247,10 @@ enum PlanMetadataParser {
             .filter { !$0.isEmpty }
     }
 
+    private static func stripTrailingCarriageReturn(_ line: String) -> String {
+        line.hasSuffix("\r") ? String(line.dropLast()) : line
+    }
+
     /// Scan a `secretParameters:` YAML flow sequence that may span multiple physical lines, returning
     /// the declared key names and the index of the next line to resume from. A lenient hand-rolled
     /// scanner (a full YAML load chokes on `${...}` in flow collections — issue #6029). It honors
@@ -256,6 +260,14 @@ enum PlanMetadataParser {
     /// and YAML newline folding inside a double-quoted scalar (a trailing `\` continues the scalar,
     /// dropping the newline; a plain newline folds to a space; continuation indentation is not part of
     /// the value).
+    ///
+    /// `secretParameters` key names are expected to be literal, simple identifiers. Exotic YAML
+    /// encodings (`\xNN`/`\uNNNN` hex/unicode escapes, plain-scalar line folding, CRLF-in-quoted
+    /// multiline keys) are handled best-effort here, NOT with full YAML-spec decoding — so a key may be
+    /// mis-named. That is made safe at the value layer: `SecretRedaction.secretParameterValues` matches
+    /// leniently and, if a declared key still cannot be resolved, over-redacts, so a declared secret's
+    /// VALUE is always scrubbed (possibly over-redacting), never leaked. Full decoding is tracked as a
+    /// follow-up to #6097.
     ///
     /// FAIL-SAFE: key-name parsing errs toward OVER-capturing for redaction, never dropping a declared
     /// key (which would leak its value). Every non-empty token is kept as a secret key, and an
@@ -272,7 +284,8 @@ enum PlanMetadataParser {
         var activeQuote: Character?
         var escaped = false
         var lineIndex = startIndex
-        var currentLine = firstValue
+        // Drop a trailing CR so a CRLF-authored quoted multiline key does not embed `\r` (#6097).
+        var currentLine = stripTrailingCarriageReturn(firstValue)
 
         while true {
             var previous: Character?
@@ -324,15 +337,17 @@ enum PlanMetadataParser {
                 previous = character
             }
 
-            // Physical line ended. Fold per YAML: a trailing `\` inside a double-quoted scalar
-            // continues it (drop the newline); a plain newline inside a quoted scalar folds to a space;
-            // a newline between flow tokens is whitespace.
+            // Physical line ended. Fold per YAML inside a double-quoted scalar: a trailing `\`
+            // continues it (drop the newline); a plain newline folds to a space. Outside a quote, a
+            // plain scalar spanning lines is captured token-per-line (over-capture, fail-safe) instead
+            // of blending into one key.
             if activeQuote == "\"", escaped {
                 escaped = false
             } else if activeQuote != nil {
                 current.append(" ")
-            } else if started {
-                current.append(" ")
+            } else if started, !current.trimmingCharacters(in: .whitespaces).isEmpty {
+                items.append(current)
+                current = ""
             }
 
             lineIndex += 1
@@ -341,10 +356,12 @@ enum PlanMetadataParser {
                 items.append(current)
                 return (finalizeSecretKeys(items), lineIndex)
             }
-            // Inside a quoted scalar the continuation's leading indentation is not part of the value.
+            // Drop a trailing CR; inside a quoted scalar the continuation's leading indentation is not
+            // part of the value.
+            let rawLine = stripTrailingCarriageReturn(lines[lineIndex])
             currentLine = activeQuote != nil
-                ? String(lines[lineIndex].drop { $0 == " " || $0 == "\t" })
-                : lines[lineIndex]
+                ? String(rawLine.drop { $0 == " " || $0 == "\t" })
+                : rawLine
         }
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -277,13 +277,29 @@ enum PlanMetadataParser {
     )
         -> (keys: [String], nextIndex: Int)
     {
-        var items: [String] = []
+        var keys: [String] = []
         var current = ""
+        var itemHasQuotedChar = false
         var depth = 0
         var started = false
         var activeQuote: Character?
         var escaped = false
         var lineIndex = startIndex
+
+        // Emit the current item: a plain token is trimmed and a genuinely-empty token (nothing between
+        // the delimiters) is dropped, but a quoted scalar whose content is only whitespace (e.g. `" "`)
+        // is a valid key and is preserved rather than trimmed away (#6097).
+        func flushItem() {
+            let trimmed = current.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                keys.append(trimmed)
+            } else if itemHasQuotedChar {
+                keys.append(current)
+            }
+            current = ""
+            itemHasQuotedChar = false
+        }
+
         // Drop a trailing CR so a CRLF-authored quoted multiline key does not embed `\r` (#6097).
         var currentLine = stripTrailingCarriageReturn(firstValue)
 
@@ -295,7 +311,17 @@ enum PlanMetadataParser {
                 if let quote = activeQuote {
                     if quote == "\"" {
                         if escaped {
-                            current.append(character)
+                            // `\"` decodes cleanly to `"`; any OTHER escape (`\xNN`, `\uNNNN`, `\n`, …)
+                            // is NOT spec-decoded here — keep the backslash so the value layer sees this
+                            // key as low-confidence and over-redacts rather than trusting a coincidental
+                            // (decoy) match (#6097).
+                            if character == "\"" {
+                                current.append("\"")
+                            } else {
+                                current.append("\\")
+                                current.append(character)
+                            }
+                            itemHasQuotedChar = true
                             escaped = false
                         } else if character == "\\" {
                             escaped = true
@@ -303,11 +329,13 @@ enum PlanMetadataParser {
                             activeQuote = nil
                         } else {
                             current.append(character)
+                            itemHasQuotedChar = true
                         }
                     } else if character == "'" {
                         activeQuote = nil
                     } else {
                         current.append(character)
+                        itemHasQuotedChar = true
                     }
                 } else if !started {
                     if character == "[" {
@@ -324,13 +352,12 @@ enum PlanMetadataParser {
                 } else if character == "]" {
                     depth -= 1
                     if depth == 0 {
-                        items.append(current)
-                        return (finalizeSecretKeys(items), lineIndex + 1)
+                        flushItem()
+                        return (keys, lineIndex + 1)
                     }
                     current.append(character)
                 } else if character == ",", depth == 1 {
-                    items.append(current)
-                    current = ""
+                    flushItem()
                 } else {
                     current.append(character)
                 }
@@ -345,16 +372,15 @@ enum PlanMetadataParser {
                 escaped = false
             } else if activeQuote != nil {
                 current.append(" ")
-            } else if started, !current.trimmingCharacters(in: .whitespaces).isEmpty {
-                items.append(current)
-                current = ""
+            } else if started {
+                flushItem()
             }
 
             lineIndex += 1
             if lineIndex >= lines.count {
                 // Unterminated flow: fail safe — keep every token seen so its value is still redacted.
-                items.append(current)
-                return (finalizeSecretKeys(items), lineIndex)
+                flushItem()
+                return (keys, lineIndex)
             }
             // Drop a trailing CR; inside a quoted scalar the continuation's leading indentation is not
             // part of the value.
@@ -363,14 +389,6 @@ enum PlanMetadataParser {
                 ? String(rawLine.drop { $0 == " " || $0 == "\t" })
                 : rawLine
         }
-    }
-
-    /// Trim and drop empties from the scanner's already-decoded flow items (quotes/escapes are
-    /// resolved during scanning, so no further unquoting here).
-    private static func finalizeSecretKeys(_ items: [String]) -> [String] {
-        items
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
     }
 
     /// Remove a trailing YAML line comment from a flow line without stripping a `#` that sits inside a

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/PlanMetadataParser.swift
@@ -158,6 +158,21 @@ enum PlanMetadataParser {
 
             let inline = trimmed.dropFirst("secretParameters:".count).trimmingCharacters(in: .whitespaces)
             if !inline.isEmpty {
+                // A bracketed flow value may span multiple lines: accumulate continuation lines until
+                // the matching `]` before parsing, so `secretParameters: [\n  TOKEN,\n  PASSWORD\n]`
+                // is not dropped (#6097). Quotes and `${...}` placeholders are honored exactly as the
+                // single-line path does; a full YAML load is deliberately avoided (it chokes on
+                // `${...}` flow items).
+                if inline.hasPrefix("[") && !flowSequenceIsClosed(inline) {
+                    var accumulated = inline
+                    index += 1
+                    while index < lines.count && !flowSequenceIsClosed(accumulated) {
+                        accumulated += " " + stripComments(from: lines[index]).trimmingCharacters(in: .whitespaces)
+                        index += 1
+                    }
+                    keys.formUnion(parseInlineList(accumulated))
+                    continue
+                }
                 keys.formUnion(parseInlineList(inline))
                 index += 1
                 continue
@@ -218,6 +233,31 @@ enum PlanMetadataParser {
         return items
             .map { unquote($0.trimmingCharacters(in: .whitespaces)) }
             .filter { !$0.isEmpty }
+    }
+
+    /// True once `text` contains the `]` that closes its first `[`, honoring quotes so a bracket
+    /// inside a quoted key (or a `${...}` placeholder, which is literal text here) is not mistaken for
+    /// the flow delimiter. Used to decide when a multiline flow sequence is complete (#6097).
+    private static func flowSequenceIsClosed(_ text: String) -> Bool {
+        var depth = 0
+        var activeQuote: Character?
+        for character in text {
+            if let quote = activeQuote {
+                if character == quote {
+                    activeQuote = nil
+                }
+            } else if character == "\"" || character == "'" {
+                activeQuote = character
+            } else if character == "[" {
+                depth += 1
+            } else if character == "]" {
+                depth -= 1
+                if depth == 0 {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func parsePlatform(_ value: String) throws -> AutoMobilePlanExecutor.PlanPlatform {

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -70,13 +70,16 @@ enum SecretRedaction {
     }
 
     /// The parameter VALUES to scrub for a set of declared secret key names, matched leniently so an
-    /// exotically-encoded key name cannot leak its value. For each declared key: an exact
-    /// `parameters[key]` is taken; failing that, any parameter whose key normalizes equal (case-folded,
-    /// with backslashes/quotes/whitespace/CR removed) is taken; and if a declared key still resolves to
-    /// nothing, EVERY parameter value is taken (over-redaction). `secretParameters` key names are
-    /// expected to be literal identifiers — this is the fail-safe backstop for YAML encodings the flow
-    /// scanner does not fully decode (`\xNN`/`\uNNNN` escapes, folding, CRLF): a declared secret's value
-    /// is always scrubbed (possibly over-redacting), never leaked (#6097). Full decoding is a follow-up.
+    /// exotically-encoded key name cannot leak its value. For each declared key: a key that still
+    /// contains a backslash (a YAML escape the scanner did not spec-decode) is low-confidence and forces
+    /// over-redaction — its raw form must not be trusted to exact-match a DECOY parameter while the real
+    /// value hides under the decoded name. Otherwise an exact `parameters[key]` is taken; failing that,
+    /// any parameter whose key normalizes equal (case-folded, with backslashes/quotes/whitespace/CR
+    /// removed) is taken; and if a declared key still resolves to nothing, EVERY parameter value is taken
+    /// (over-redaction). `secretParameters` key names are expected to be literal identifiers — this is
+    /// the fail-safe backstop for YAML encodings the flow scanner does not fully decode (`\xNN`/`\uNNNN`
+    /// escapes, folding, CRLF): a declared secret's value is always scrubbed (possibly over-redacting),
+    /// never leaked (#6097). Full decoding is a follow-up (#6141).
     static func secretParameterValues(
         declaredKeys: Set<String>,
         parameters: [String: String]
@@ -89,6 +92,14 @@ enum SecretRedaction {
         var values: [String] = []
         var hasUnresolvedKey = false
         for key in declaredKeys {
+            if key.contains("\\") {
+                // A key that still contains a backslash carries a YAML escape the flow scanner did not
+                // spec-decode (e.g. `\xNN`). Its raw form may coincidentally match a DECOY parameter
+                // while the real value lives under the decoded name — so do NOT trust any match; force
+                // over-redaction so the real value cannot leak (#6097).
+                hasUnresolvedKey = true
+                continue
+            }
             if let exact = parameters[key], !exact.isEmpty {
                 values.append(exact)
                 continue

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -69,6 +69,67 @@ enum SecretRedaction {
         )
     }
 
+    /// The parameter VALUES to scrub for a set of declared secret key names, matched leniently so an
+    /// exotically-encoded key name cannot leak its value. For each declared key: an exact
+    /// `parameters[key]` is taken; failing that, any parameter whose key normalizes equal (case-folded,
+    /// with backslashes/quotes/whitespace/CR removed) is taken; and if a declared key still resolves to
+    /// nothing, EVERY parameter value is taken (over-redaction). `secretParameters` key names are
+    /// expected to be literal identifiers — this is the fail-safe backstop for YAML encodings the flow
+    /// scanner does not fully decode (`\xNN`/`\uNNNN` escapes, folding, CRLF): a declared secret's value
+    /// is always scrubbed (possibly over-redacting), never leaked (#6097). Full decoding is a follow-up.
+    static func secretParameterValues(
+        declaredKeys: Set<String>,
+        parameters: [String: String]
+    )
+        -> [String]
+    {
+        guard !declaredKeys.isEmpty else {
+            return []
+        }
+        var values: [String] = []
+        var hasUnresolvedKey = false
+        for key in declaredKeys {
+            if let exact = parameters[key], !exact.isEmpty {
+                values.append(exact)
+                continue
+            }
+            let target = normalizeKey(key)
+            var matched = false
+            for (paramKey, paramValue) in parameters where normalizeKey(paramKey) == target {
+                if !paramValue.isEmpty {
+                    values.append(paramValue)
+                }
+                matched = true
+            }
+            if !matched {
+                hasUnresolvedKey = true
+            }
+        }
+        if hasUnresolvedKey {
+            // A declared secret could not be located even leniently (e.g. a `\xNN` hex-escaped key the
+            // scanner did not spec-decode). Over-redact every parameter value so it cannot leak (#6097).
+            for value in parameters.values where !value.isEmpty {
+                values.append(value)
+            }
+        }
+        return values
+    }
+
+    /// Case-folded key with backslashes, quotes, and whitespace/CR removed — the lenient key-identity
+    /// used to match a mis-encoded declared secret key to a parameter (#6097).
+    private static func normalizeKey(_ key: String) -> String {
+        var result = ""
+        for scalar in key.lowercased().unicodeScalars {
+            switch scalar {
+            case "\\", "\"", "'", " ", "\t", "\r", "\n":
+                continue
+            default:
+                result.unicodeScalars.append(scalar)
+            }
+        }
+        return result
+    }
+
     /// `value` plus its canonical NFC and NFD forms, distinct by UTF-16 code units (Swift string `!=`
     /// is canonical and would treat every form as equal).
     private static func normalizationForms(of value: String) -> [String] {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -612,6 +612,35 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
     }
 
+    func testSecretValueRedactedDespiteDecoyParameterMatchingUnDecodedHexKey() throws {
+        // Parameters contain BOTH the real `APITOKEN` (what YAML decodes `"API\x54OKEN"` to) and a
+        // decoy `APIx54OKEN` matching the scanner's un-decoded spelling. The fail-safe must not trust
+        // the decoy exact-match; it over-redacts so the REAL secret cannot leak (#6097 — decoy).
+        let real = "REAL-hex-secret-1a2"
+        let plan =
+            "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe\n  - tool: inputText\n    text: \"field\""
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(real)"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["APITOKEN": real, "APIx54OKEN": "DECOY-not-the-secret"]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(
+            requestText(request).contains(real),
+            "the real secret must be redacted despite the decoy exact-match"
+        )
+    }
+
     func testSecretSubstitutedIntoToolNameIsRedacted() throws {
         let client = RecoveryMCPClient()
         // The daemon reports the failed step's tool as the substituted secret value.
@@ -1030,6 +1059,13 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API", "TOKEN"])
     }
 
+    func testQuotedWhitespaceOnlyKeyIsNotDropped() {
+        // Stripping the quotes before the trim would discard `" "`; a single space is a valid quoted
+        // key and must be kept so its parameter value is redacted (#6097 Codex — quoted whitespace).
+        let yaml = "name: P\nsecretParameters: [\" \"]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), [" "])
+    }
+
     func testFlushBlockStopsAtNextTopLevelKey() {
         let yaml = """
         name: P
@@ -1094,6 +1130,23 @@ final class SecretRedactionTests: XCTestCase {
             declaredKeys: ["API TOKEN"], parameters: ["apitoken": "S"]
         )
         XCTAssertEqual(values, ["S"])
+    }
+
+    func testSecretParameterValuesKeepsAQuotedWhitespaceKeysValue() {
+        let values = SecretRedaction.secretParameterValues(
+            declaredKeys: [" "], parameters: [" ": "SECRET"]
+        )
+        XCTAssertEqual(values, ["SECRET"])
+    }
+
+    func testSecretParameterValuesOverRedactsBackslashKeyDespiteDecoyExactMatch() {
+        // The un-decoded hex key `API\x54OKEN` exact-matches a DECOY parameter of the same raw
+        // spelling, while the REAL value lives under the YAML-decoded `APITOKEN`. A backslash key must
+        // not trust that coincidental match — it over-redacts so REAL is scrubbed too (#6097).
+        let values = SecretRedaction.secretParameterValues(
+            declaredKeys: ["API\\x54OKEN"], parameters: ["APITOKEN": "REAL", "APIx54OKEN": "DECOY"]
+        )
+        XCTAssertTrue(values.contains("REAL"), "the real (decoded-name) secret value must be scrubbed")
     }
 
     func testSecretParameterValuesOverRedactsWhenAKeyCannotBeResolvedFailSafe() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -583,6 +583,35 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         XCTAssertFalse(text.contains(secretB), "the following key must not be dropped, so its value redacts")
     }
 
+    func testSecretValueRedactedWhenKeyUsesHexEscapeViaFailSafe() throws {
+        // The key `"API\x54OKEN"` is not spec-decoded by the scanner, so it can't be matched to the
+        // parameter `APITOKEN` by name; the strengthened value-layer fail-safe over-redacts so the
+        // secret still cannot leak (#6097 — the important security assertion).
+        let secret = "SECRET-hex-7b3"
+        let plan =
+            "name: P\nsecretParameters: [\"API\\x54OKEN\"]\nsteps:\n  - tool: observe\n  - tool: inputText\n    text: \"field\""
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secret)"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["APITOKEN": secret]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(
+            requestText(request).contains(secret),
+            "a hex-escaped secret key's value must still be redacted via the fail-safe"
+        )
+    }
+
     func testSecretSubstitutedIntoToolNameIsRedacted() throws {
         let client = RecoveryMCPClient()
         // The daemon reports the failed step's tool as the substituted secret value.
@@ -985,6 +1014,22 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["APITOKEN"])
     }
 
+    func testCRLFAuthoredQuotedMultilineKeyHasNoCarriageReturn() {
+        // A CRLF-authored quoted multiline key must not embed `\r` (#6097 Codex — CRLF). The quoted
+        // scalar folds to `API TOKEN`.
+        let yaml = "name: P\r\nsecretParameters: [\r\n  \"API\r\n  TOKEN\"\r\n]\r\nsteps:\r\n  - tool: observe"
+        let keys = PlanMetadataParser.parseSecretParameterKeys(from: yaml)
+        XCTAssertEqual(keys, ["API TOKEN"])
+        XCTAssertFalse(keys.contains { $0.contains("\r") }, "no key may contain a carriage return")
+    }
+
+    func testPlainMultilineFlowScalarCapturesEachLinesTokenFailSafe() {
+        // A plain (unquoted) scalar spanning lines is captured token-per-line so both are redacted,
+        // rather than blended into one mis-named key (#6097 Codex — plain-scalar folding).
+        let yaml = "name: P\nsecretParameters: [\n  API\n  TOKEN\n]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API", "TOKEN"])
+    }
+
     func testFlushBlockStopsAtNextTopLevelKey() {
         let yaml = """
         name: P
@@ -1036,6 +1081,30 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
 /// Direct redaction tests for `SecretRedaction` — the type now only expands Unicode forms and scrubs;
 /// resolution/substitution is the executor's job (tested end-to-end below). (#6029 convergence)
 final class SecretRedactionTests: XCTestCase {
+    func testSecretParameterValuesMatchesExactlyAndDoesNotOverRedact() {
+        let values = SecretRedaction.secretParameterValues(
+            declaredKeys: ["TOKEN"], parameters: ["TOKEN": "S", "VIS": "v"]
+        )
+        XCTAssertEqual(values, ["S"])
+    }
+
+    func testSecretParameterValuesMatchesLenientlyAcrossWhitespaceAndCase() {
+        // A folded/whitespaced key still resolves to the parameter by normalized identity (#6097).
+        let values = SecretRedaction.secretParameterValues(
+            declaredKeys: ["API TOKEN"], parameters: ["apitoken": "S"]
+        )
+        XCTAssertEqual(values, ["S"])
+    }
+
+    func testSecretParameterValuesOverRedactsWhenAKeyCannotBeResolvedFailSafe() {
+        // A hex-escaped key parsed as `APIx54OKEN` matches no parameter by name or normalization, so
+        // every parameter value is scrubbed — the secret cannot leak (#6097 fail-safe).
+        let values = SecretRedaction.secretParameterValues(
+            declaredKeys: ["APIx54OKEN"], parameters: ["APITOKEN": "SECRETV", "VIS": "visible"]
+        )
+        XCTAssertTrue(values.contains("SECRETV"), "the real secret value must be scrubbed")
+    }
+
     func testRedactsSecretRegardlessOfUnicodeNormalization() {
         let composedValue = "caf\u{00E9}-token" // NFC form
         let values = SecretRedaction.secretValues([composedValue])

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -942,6 +942,49 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
         XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["a\"]b", "PASSWORD"])
     }
 
+    func testFlowTrailingCommentAfterClosingBracketIsIgnored() {
+        // A comment after the closing `]` (with or without a leading space) must be ignored, and TOKEN
+        // still parsed. Dropping it would leak TOKEN's value (#6097 Codex — comment after `]`).
+        let spaced = "name: P\nsecretParameters: [TOKEN] # trailing comment\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: spaced), ["TOKEN"])
+        let unspaced = "name: P\nsecretParameters: [TOKEN]#c\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: unspaced), ["TOKEN"])
+    }
+
+    func testMultilineFlowClosingBracketFollowedByCommentIsIgnored() {
+        let yaml = """
+        name: P
+        secretParameters: [
+          TOKEN,
+          PASSWORD
+        ]  # both declared
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD"])
+    }
+
+    func testUnrecognizedTokenIsStillCapturedAsSecretKeyFailSafe() {
+        // Fail-safe: an unusual/unrecognized token in the block must still be treated as a secret key
+        // (over-capture) rather than dropped — dropping would fail open (#6097).
+        let yaml = "name: P\nsecretParameters: [TOKEN, @@weird@@]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "@@weird@@"])
+    }
+
+    func testUnterminatedFlowSequenceFailsSafeByCapturingTokens() {
+        // A flow sequence with no closing `]` (e.g. substitution truncation) must still yield its
+        // tokens (over-capture), never silently drop them (#6097 fail-safe).
+        let yaml = "name: P\nsecretParameters: [\n  TOKEN,\n  PASSWORD"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD"])
+    }
+
+    func testDoubleQuotedLineContinuationKeyIsCaptured() {
+        // A double-quoted key using YAML line continuation (`"API\`⏎`TOKEN"` decodes to `APITOKEN`)
+        // must be captured so its value is redacted (#6097 Codex — line continuation).
+        let yaml = "name: P\nsecretParameters: [\n  \"API\\\n  TOKEN\"\n]\nsteps:\n  - tool: observe"
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["APITOKEN"])
+    }
+
     func testFlushBlockStopsAtNextTopLevelKey() {
         let yaml = """
         name: P

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -509,6 +509,80 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
     }
 
+    func testSecretsRedactedWhenMultilineFlowKeyContainsQuotedHash() throws {
+        // Two keys, the first quoting a `#`. A comment strip that runs before quote state truncates
+        // the first item, drops the second, and leaks the second secret to the recovery LLM (#6097 P1).
+        let secretA = "SECRETA-hash-9f1"
+        let secretB = "SECRETB-plain-2a7"
+        let plan = """
+        name: Redaction Plan
+        secretParameters: [
+          "API#TOKEN",
+          PASSWORD
+        ]
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "field"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secretA) and \(secretB)"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["API#TOKEN": secretA, "PASSWORD": secretB]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        let text = requestText(request)
+        XCTAssertFalse(text.contains(secretA), "the quoted-# key's value must be redacted")
+        XCTAssertFalse(text.contains(secretB), "the following key must not be dropped, so its value redacts")
+    }
+
+    func testSecretsRedactedWhenMultilineFlowKeyContainsEscapedQuoteBeforeBracket() throws {
+        // The first key is a double-quoted scalar with an escaped quote before a `]`. Without escape
+        // tracking the sequence terminator is found early, PASSWORD is dropped, and its secret leaks.
+        let secretA = "SECRETA-esc-4c2"
+        let secretB = "SECRETB-plain-8e5"
+        let plan = """
+        name: Redaction Plan
+        secretParameters: [
+          "a\\"]b",
+          PASSWORD
+        ]
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "field"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secretA) and \(secretB)"]
+        ))
+        let captor = CapturingModelResponder()
+        let executor = makeExecutor(
+            client: client,
+            handler: makeCapturingHandler(client: client, captor: captor),
+            planText: plan,
+            parameters: ["a\"]b": secretA, "PASSWORD": secretB]
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        let text = requestText(request)
+        XCTAssertFalse(text.contains(secretA), "the escaped-quote key's value must be redacted")
+        XCTAssertFalse(text.contains(secretB), "the following key must not be dropped, so its value redacts")
+    }
+
     func testSecretSubstitutedIntoToolNameIsRedacted() throws {
         let client = RecoveryMCPClient()
         // The daemon reports the failed step's tool as the substituted secret value.
@@ -833,6 +907,39 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
           - tool: observe
         """
         XCTAssertTrue(PlanMetadataParser.parseSecretParameterKeys(from: yaml).isEmpty)
+    }
+
+    func testMultilineFlowQuotedHashKeyDoesNotDropFollowingKey() {
+        // A `#` inside a quoted item is literal YAML, not a comment. If comments are stripped
+        // line-by-line before quote state is known, `"API#TOKEN"` is truncated to `"API`, the now
+        // unterminated quote swallows the rest of the declaration, and PASSWORD is dropped — its
+        // secret would reach the LLM unredacted (#6097 Codex P1, fail-open).
+        let yaml = """
+        name: P
+        secretParameters: [
+          "API#TOKEN",
+          PASSWORD
+        ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API#TOKEN", "PASSWORD"])
+    }
+
+    func testMultilineFlowEscapedQuoteBeforeBracketDoesNotDropFollowingKey() {
+        // A double-quoted scalar may contain an escaped quote (`\"`); the `]` that follows it is still
+        // inside the scalar, not the sequence terminator. Without escape tracking the terminator finder
+        // stops early and PASSWORD is dropped — fail-open (#6097 Codex P2).
+        let yaml = """
+        name: P
+        secretParameters: [
+          "a\\"]b",
+          PASSWORD
+        ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["a\"]b", "PASSWORD"])
     }
 
     func testFlushBlockStopsAtNextTopLevelKey() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -470,6 +470,45 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         )
     }
 
+    func testSecretRedactedWhenSecretParametersIsMultilineFlowSequence() throws {
+        // Multiline bracketed flow sequence — valid YAML the iOS line scanner previously dropped,
+        // silently disabling redaction and letting the secret reach the LLM recovery context (#6097).
+        let multilinePlan = """
+        name: Redaction Plan
+        secretParameters: [
+          TOKEN
+        ]
+        steps:
+          - tool: observe
+          - tool: inputText
+            text: "${TOKEN}"
+        """
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 2,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "boom \(secret)"]
+        ))
+
+        let captor = CapturingModelResponder()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let executor = makeExecutor(client: client, handler: handler, planText: multilinePlan)
+
+        _ = try executor.execute(testMetadata: nil)
+
+        let request = try XCTUnwrap(captor.captured.first)
+        XCTAssertFalse(
+            requestText(request).contains(secret),
+            "a multiline-flow secretParameters declaration must still redact on iOS"
+        )
+    }
+
     func testSecretSubstitutedIntoToolNameIsRedacted() throws {
         let client = RecoveryMCPClient()
         // The daemon reports the failed step's tool as the substituted secret value.
@@ -737,6 +776,63 @@ final class PlanMetadataSecretParametersParsingTests: XCTestCase {
     func testInlineFlowListDoesNotSplitOnCommaInsideQuotes() {
         let yaml = "name: P\nsecretParameters: [\"API,TOKEN\", plain]\nsteps:\n  - tool: observe"
         XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API,TOKEN", "plain"])
+    }
+
+    // MARK: - Multiline flow sequence (#6097)
+
+    func testMultilineFlowListWithClosingBracketOnOwnLineIsParsed() {
+        // The bracketed flow value spans multiple lines with `]` alone on the last line — the form the
+        // line scanner previously dropped, silently disabling redaction (#6097 fail-open gap).
+        let yaml = """
+        name: P
+        secretParameters: [
+          TOKEN,
+          PASSWORD
+        ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD"])
+    }
+
+    func testMultilineFlowListWithTrailingCommaAndClosingBracketTrailingItemIsParsed() {
+        // Trailing comma after the last item, and `]` trailing the final item rather than on its own line.
+        let yaml = """
+        name: P
+        secretParameters: [
+          TOKEN,
+          PASSWORD,
+          API ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["TOKEN", "PASSWORD", "API"])
+    }
+
+    func testMultilineFlowListToleratesQuotedCommaAndPlaceholderKeys() {
+        // Quoted comma is not a separator, and `${...}` key names stay literal (resolved later) — the
+        // multiline path must respect the same rules as the single-line inline path.
+        let yaml = """
+        name: P
+        secretParameters: [
+          "API,TOKEN",
+          ${SECRET_KEY}
+        ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertEqual(PlanMetadataParser.parseSecretParameterKeys(from: yaml), ["API,TOKEN", "${SECRET_KEY}"])
+    }
+
+    func testEmptyMultilineFlowListYieldsEmptySet() {
+        let yaml = """
+        name: P
+        secretParameters: [
+        ]
+        steps:
+          - tool: observe
+        """
+        XCTAssertTrue(PlanMetadataParser.parseSecretParameterKeys(from: yaml).isEmpty)
     }
 
     func testFlushBlockStopsAtNextTopLevelKey() {


### PR DESCRIPTION
## Summary

A **multiline** YAML flow-sequence declaration of `secretParameters` —

```yaml
secretParameters: [
  TOKEN,
  PASSWORD
]
```

— was silently dropped by the placeholder-tolerant line scanner on **both**
runners (iOS `PlanMetadataParser.parseSecretParameterKeys`, Android
`SecretRedactor.parsePlanSecretKeys`). Only the opening `[` reached the
inline-list parser, so **no keys were captured** and the declared values were
**not redacted** before AI-assisted recovery embedded the plan/error into the
prompt sent to the third-party LLM. That is a **fail-open redaction gap**
(CWE-200 class): a secret declared in this specific form could reach the LLM
recovery context.

This is a **redaction-completeness fix**, a follow-up to #6029 / #6092. Like
those, it changes the runner sources — it needs a **runner re-cut** to take
effect on-device; the checked-in runner keeps the old behavior until re-cut.

Both scanners now accumulate a bracketed flow value across lines until the
matching `]` (honoring quotes and treating `${...}` placeholders as literal
text, exactly as the single-line path already did) before handing it to the
inline-list parser. Handles: items on separate lines, trailing commas, a
closing `]` on its own line or trailing an item, and an empty multiline `[\n]`.
The existing single-line inline / indented-block / flush-block forms are
unchanged, and no full YAML parse is introduced (it chokes on `${...}`).
The two implementations keep identical semantics (parity).

## Linked Issue

Closes #6097

## Bug / Regression Context

- **Prior attempts:** #6092 (redaction for #6029) added the placeholder-tolerant
  scanner but handled only single-line inline flow; Codex flagged the multiline
  form as a residual P2.
- **Observed symptom:** a `secretParameters` key declared via a multiline
  bracketed flow list is not detected, so its value is not redacted from the
  recovery context.
- **Repro steps / conditions:** declare `secretParameters` as a multiline
  `[ ... ]` flow list; on step failure the AI-recovery path leaks the value.

## Validation

- [x] Android (JDK21): `:junit-runner:test` + `:test-plan-validation:test`,
      `:junit-runner:detektMain`/`detektTest`, ktfmt (0.64) clean. New tests
      (`SecretRedactorTest`, `AutoMobilePlanRedactionTest`) green;
      pre-existing device-dependent `initializationError`s
      (`ClockAppAutoMobileTest`, `MisconfiguredTestSuite`, `@RunWith(AutoMobileRunner)`)
      are unrelated (no device connected).
- [x] iOS: `swift build` + `swift build -c release`, `swift test`
      (`PlanMetadataSecretParametersParsingTests`, `PlanRecoverySecretRedactionTests`)
      green; SwiftFormat clean; SwiftLint adds no new violations.
      Note: local Swift is 6.2.4 while the package pins tools 6.3.0, so native
      validation was run as a proxy at tools-version 6.2 with `-c release`
      (Swift 6 language mode default for 6.x tools); the 6.3 pin is unchanged.
- [x] TDD red-first confirmed on both platforms (tests fail before the scanner change).
- [ ] `scripts/all_fast_validate_checks.sh` — N/A; no TypeScript changed.

## Kotlin Reuse Check

- [x] No new helpers/dependencies — extended the existing scanner with one
      private `flowSequenceIsClosed` predicate mirroring the single-line quote
      handling already present.

## Device Verification

- Not run here; requires a runner re-cut (see Summary). Covered end-to-end at the
  unit level via the fake daemon/agent seams.

## Follow-ups

- [ ] Runner re-cut required for this to take effect on-device (tracked with the
      #6029 / #6092 re-cut work).
