### PR TITLE
fix(deviceState): align networkCondition JSON/plan schemas with the runtime classifier

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -1116,18 +1116,47 @@
           "properties": { "reset": { "const": true } }
         },
         {
-          "required": ["delayMs"]
+          "required": ["delayMs"],
+          "properties": { "delayMs": { "not": { "const": 0 } } }
         },
         {
-          "required": ["downloadKbps"]
+          "required": ["downloadKbps"],
+          "properties": { "downloadKbps": { "not": { "const": 0 } } }
         },
         {
-          "required": ["uploadKbps"]
+          "required": ["uploadKbps"],
+          "properties": { "uploadKbps": { "not": { "const": 0 } } }
         },
         {
-          "required": ["packetLossPercent"]
+          "required": ["packetLossPercent"],
+          "properties": { "packetLossPercent": { "not": { "const": 0 } } }
         }
       ],
+      "if": {
+        "required": ["profile"],
+        "properties": { "profile": { "const": "offline" } },
+        "not": {
+          "anyOf": [
+            {
+              "required": ["cancel"],
+              "properties": { "cancel": { "const": true } }
+            },
+            {
+              "required": ["reset"],
+              "properties": { "reset": { "const": true } }
+            }
+          ]
+        }
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["delayMs"] },
+            { "required": ["downloadKbps"] },
+            { "required": ["uploadKbps"] }
+          ]
+        }
+      },
       "description": "Device-wide network condition input (Android emulator)"
     },
     "getNotificationPolicyParams": {

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -689,9 +689,6 @@
               },
               "biometrics": {
                 "$ref": "#/$defs/biometricStateInput"
-              },
-              "networkCondition": {
-                "$ref": "#/$defs/networkConditionStateInput"
               }
             },
             "anyOf": [
@@ -706,6 +703,27 @@
               },
               {
                 "required": ["params"]
+              }
+            ],
+            "allOf": [
+              {
+                "$comment": "params.networkCondition (when present) fully overrides an inline networkCondition at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict networkConditionStateInput rules to the inline form ONLY when params.networkCondition is absent, otherwise a valid params reset would false-reject the discarded inline value (#6090 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["networkCondition"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "networkCondition": {
+                      "$ref": "#/$defs/networkConditionStateInput"
+                    }
+                  }
+                }
               }
             ]
           }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -1116,18 +1116,47 @@
           "properties": { "reset": { "const": true } }
         },
         {
-          "required": ["delayMs"]
+          "required": ["delayMs"],
+          "properties": { "delayMs": { "not": { "const": 0 } } }
         },
         {
-          "required": ["downloadKbps"]
+          "required": ["downloadKbps"],
+          "properties": { "downloadKbps": { "not": { "const": 0 } } }
         },
         {
-          "required": ["uploadKbps"]
+          "required": ["uploadKbps"],
+          "properties": { "uploadKbps": { "not": { "const": 0 } } }
         },
         {
-          "required": ["packetLossPercent"]
+          "required": ["packetLossPercent"],
+          "properties": { "packetLossPercent": { "not": { "const": 0 } } }
         }
       ],
+      "if": {
+        "required": ["profile"],
+        "properties": { "profile": { "const": "offline" } },
+        "not": {
+          "anyOf": [
+            {
+              "required": ["cancel"],
+              "properties": { "cancel": { "const": true } }
+            },
+            {
+              "required": ["reset"],
+              "properties": { "reset": { "const": true } }
+            }
+          ]
+        }
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["delayMs"] },
+            { "required": ["downloadKbps"] },
+            { "required": ["uploadKbps"] }
+          ]
+        }
+      },
       "description": "Device-wide network condition input (Android emulator)"
     },
     "getNotificationPolicyParams": {

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -689,9 +689,6 @@
               },
               "biometrics": {
                 "$ref": "#/$defs/biometricStateInput"
-              },
-              "networkCondition": {
-                "$ref": "#/$defs/networkConditionStateInput"
               }
             },
             "anyOf": [
@@ -706,6 +703,27 @@
               },
               {
                 "required": ["params"]
+              }
+            ],
+            "allOf": [
+              {
+                "$comment": "params.networkCondition (when present) fully overrides an inline networkCondition at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict networkConditionStateInput rules to the inline form ONLY when params.networkCondition is absent, otherwise a valid params reset would false-reject the discarded inline value (#6090 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["networkCondition"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "networkCondition": {
+                      "$ref": "#/$defs/networkConditionStateInput"
+                    }
+                  }
+                }
               }
             ]
           }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8144,25 +8144,73 @@
               }
             },
             {
-              "required": ["delayMs"]
+              "required": ["delayMs"],
+              "properties": {
+                "delayMs": {
+                  "not": {
+                    "const": 0
+                  }
+                }
+              }
             },
             {
-              "required": ["downloadKbps"]
+              "required": ["downloadKbps"],
+              "properties": {
+                "downloadKbps": {
+                  "not": {
+                    "const": 0
+                  }
+                }
+              }
             },
             {
-              "required": ["uploadKbps"]
+              "required": ["uploadKbps"],
+              "properties": {
+                "uploadKbps": {
+                  "not": {
+                    "const": 0
+                  }
+                }
+              }
             },
             {
-              "required": ["packetLossPercent"]
+              "required": ["packetLossPercent"],
+              "properties": {
+                "packetLossPercent": {
+                  "not": {
+                    "const": 0
+                  }
+                }
+              }
             }
           ],
           "if": {
+            "required": ["profile"],
             "properties": {
               "profile": {
                 "const": "offline"
               }
             },
-            "required": ["profile"]
+            "not": {
+              "anyOf": [
+                {
+                  "required": ["cancel"],
+                  "properties": {
+                    "cancel": {
+                      "const": true
+                    }
+                  }
+                },
+                {
+                  "required": ["reset"],
+                  "properties": {
+                    "reset": {
+                      "const": true
+                    }
+                  }
+                }
+              ]
+            }
           },
           "then": {
             "not": {

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -390,10 +390,12 @@ function resolveNetworkValues(
  *                with a `delayMs`/`downloadKbps`/`uploadKbps` shaping override
  *                that cannot apply. Rejected (issue #6012 review P2).
  * - `reset`:     `cancel===true`, `reset===true`, or an explicit `profile:"none"`
- *                with no shaping override. Restores normal connectivity.
- * - `degrade`:   a real profile, or a bandwidth/latency override over `none`.
- * - `loss-only`: ONLY `packetLossPercent` (which the emulator console cannot
- *                enforce) — an unsupported no-op, never reported verified.
+ *                with no EFFECTIVE (non-neutral) shaping override — `none` plus
+ *                only zero/no-op overrides is a clean reset (issue #6090).
+ * - `degrade`:   a real profile, or a NON-NEUTRAL bandwidth/latency override over
+ *                `none` (a zero override is a documented no-op, not shaping).
+ * - `loss-only`: ONLY a non-zero `packetLossPercent` (which the emulator console
+ *                cannot enforce) — an unsupported no-op, never reported verified.
  */
 export type NetworkConditionRequestKind = "empty" | "invalid" | "reset" | "degrade" | "loss-only";
 
@@ -416,10 +418,14 @@ export function classifyNetworkConditionRequest(
   if (input.profile !== undefined && input.profile !== "none") {
     return "degrade";
   }
-  if (hasShapingOverride(input)) {
+  // Only a NON-NEUTRAL override degrades: a zero (documented no-op) delay/speed is
+  // not shaping, so `none` + all-neutral overrides falls through to `reset` rather
+  // than needlessly disabling Wi-Fi (issue #6090). The offline-invalid check above
+  // stays presence-based, matching the advertised schema's presence-based rule.
+  if (hasEffectiveShapingOverride(input)) {
     return "degrade";
   }
-  if (input.packetLossPercent !== undefined) {
+  if (isEffectivePacketLoss(input.packetLossPercent)) {
     return "loss-only";
   }
   if (input.profile === "none") {
@@ -472,6 +478,35 @@ function hasShapingOverride(input: SetNetworkConditionInput): boolean {
     input.downloadKbps !== undefined ||
     input.uploadKbps !== undefined
   );
+}
+
+/**
+ * A neutral override value is the documented no-op: `0` (no added latency, and
+ * `0` kbps means "unlimited" for the emulator `network speed` cap). `undefined`
+ * is likewise neutral. Only a non-neutral value shapes traffic, so a request
+ * carrying only neutral overrides is not a degrade (issue #6090).
+ */
+function isNeutralOverrideValue(value: number | undefined): boolean {
+  return value === undefined || value === 0;
+}
+
+/**
+ * True when the request carries a bandwidth/latency override that actually shapes
+ * traffic (a non-neutral value). Unlike `hasShapingOverride` (which is
+ * presence-based, used for the offline contradiction), this ignores neutral
+ * (zero) values so `none` + all-neutral overrides classifies as a `reset`.
+ */
+function hasEffectiveShapingOverride(input: SetNetworkConditionInput): boolean {
+  return (
+    !isNeutralOverrideValue(input.delayMs) ||
+    !isNeutralOverrideValue(input.downloadKbps) ||
+    !isNeutralOverrideValue(input.uploadKbps)
+  );
+}
+
+/** True only when a packet-loss request carries a non-neutral (non-zero) target. */
+function isEffectivePacketLoss(packetLossPercent: number | undefined): boolean {
+  return !isNeutralOverrideValue(packetLossPercent);
 }
 
 /**

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -191,21 +191,38 @@ export const getDeviceStateSchema = addDeviceTargetingToSchema(
 // setting a top-level `anyOf` collapses the object under `flattenTopLevelUnion`.)
 // cancel/reset count only when `true` (a falsy value is not a request), so their
 // branches pin `const: true` to match the runtime classifier (issue #6012 audit).
+// A bare zero override is the documented no-op, not a request, so its anyOf
+// branch requires a NON-NEUTRAL value — mirroring the runtime classifier, which
+// treats `{delayMs:0}` as `empty` (issue #6090). `{profile:"none", delayMs:0}`
+// still satisfies the `profile` branch and classifies as a reset.
 const NETWORK_CONDITION_REQUIRED_ANY_OF = [
   { required: ["profile"] },
   { required: ["cancel"], properties: { cancel: { const: true } } },
   { required: ["reset"], properties: { reset: { const: true } } },
-  { required: ["delayMs"] },
-  { required: ["downloadKbps"] },
-  { required: ["uploadKbps"] },
-  { required: ["packetLossPercent"] },
+  { required: ["delayMs"], properties: { delayMs: { not: { const: 0 } } } },
+  { required: ["downloadKbps"], properties: { downloadKbps: { not: { const: 0 } } } },
+  { required: ["uploadKbps"], properties: { uploadKbps: { not: { const: 0 } } } },
+  { required: ["packetLossPercent"], properties: { packetLossPercent: { not: { const: 0 } } } },
 ];
 
 // `offline` cuts the link, so a shaping override cannot apply — mirror the
 // runtime `invalid` rejection in JSON schema so tools/list matches invocation
 // (issue #6012 review): if profile is offline, forbid delayMs/downloadKbps/uploadKbps.
+// The rejection is cancel/reset-aware (issue #6090): `cancel`/`reset` win at the
+// runtime classifier ("make it clean"), so an offline+override request that also
+// carries a true cancel/reset is a valid reset and must NOT be false-rejected —
+// the `if` therefore only fires when NO true cancel/reset is present.
 const NETWORK_CONDITION_OFFLINE_NO_OVERRIDE = {
-  if: { properties: { profile: { const: "offline" } }, required: ["profile"] },
+  if: {
+    required: ["profile"],
+    properties: { profile: { const: "offline" } },
+    not: {
+      anyOf: [
+        { required: ["cancel"], properties: { cancel: { const: true } } },
+        { required: ["reset"], properties: { reset: { const: true } } },
+      ],
+    },
+  },
   then: {
     not: {
       anyOf: [

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -469,6 +469,28 @@ describe("DeviceState", () => {
     ]);
   });
 
+  test("#6090: `none` + neutral (zero) overrides is a clean reset that re-enables Wi-Fi", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+
+    const deviceState = new DeviceState(androidDevice, { adbFactory });
+    const result = await deviceState.setState({
+      networkCondition: { profile: "none", delayMs: 0, downloadKbps: 0, uploadKbps: 0 },
+    });
+
+    // Neutral overrides carry no shaping, so this is a reset, not a degrade: it
+    // must re-enable Wi-Fi (`svc wifi enable`), never disable it.
+    expect(result.success).toBe(true);
+    expect(result.networkCondition).toMatchObject({
+      capability: "full",
+      appliedProfile: "none",
+      verified: true,
+    });
+    const commands = client.getAllCommands();
+    expect(commands).toContain("shell svc wifi enable");
+    expect(commands).not.toContain("shell svc wifi disable");
+  });
+
   test("honors explicit numeric overrides over the profile's named specs", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
@@ -604,6 +626,26 @@ describe("DeviceState", () => {
       [{ profile: "offline", packetLossPercent: 50 }, "degrade"],
       // cancel:true wins even over an offline+override combo.
       [{ profile: "offline", delayMs: 500, cancel: true }, "reset"],
+      // #6090: neutral (zero / documented no-op) overrides do NOT degrade. `none`
+      // plus all-neutral overrides is a clean reset, not a Wi-Fi-disabling degrade.
+      [{ profile: "none", delayMs: 0 }, "reset"],
+      [{ profile: "none", downloadKbps: 0 }, "reset"],
+      [{ profile: "none", uploadKbps: 0 }, "reset"],
+      [{ profile: "none", packetLossPercent: 0 }, "reset"],
+      [
+        { profile: "none", delayMs: 0, downloadKbps: 0, uploadKbps: 0, packetLossPercent: 0 },
+        "reset",
+      ],
+      // A bare neutral override with no profile is a no-op, not a request.
+      [{ delayMs: 0 }, "empty"],
+      [{ downloadKbps: 0 }, "empty"],
+      [{ uploadKbps: 0 }, "empty"],
+      [{ packetLossPercent: 0 }, "empty"],
+      // A non-neutral override over `none` still degrades.
+      [{ profile: "none", delayMs: 500 }, "degrade"],
+      [{ profile: "none", downloadKbps: 100 }, "degrade"],
+      // A neutral delay alongside a real non-neutral override still degrades.
+      [{ delayMs: 0, downloadKbps: 100 }, "degrade"],
     ];
     for (const [input, expected] of cases) {
       expect(classifyNetworkConditionRequest(input)).toBe(expected as never);

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -79,6 +79,56 @@ steps:
       expect(result.valid).toBe(true);
     });
 
+    // #6090: the plan schema must encode the same offline+override rule as the
+    // live Zod refinement, so a plan that PlanSchemaValidator accepts also passes
+    // at execution — and never false-rejects a valid cancel-reset.
+    it("should accept a valid setDeviceState networkCondition (offline)", () => {
+      const yaml = `
+name: net-offline
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: offline
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(true);
+    });
+
+    it("should accept an offline networkCondition override when cancel/reset is set", () => {
+      const cancel = `
+name: net-offline-cancel
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: offline
+      delayMs: 500
+      cancel: true
+`;
+      expect(validator.validateYaml(cancel).valid).toBe(true);
+      const reset = `
+name: net-offline-reset
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: offline
+      delayMs: 500
+      reset: true
+`;
+      expect(validator.validateYaml(reset).valid).toBe(true);
+    });
+
+    it("should accept `none` with neutral (zero) overrides as a reset", () => {
+      const yaml = `
+name: net-none-neutral
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: none
+      delayMs: 0
+      downloadKbps: 0
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(true);
+    });
+
     it("should validate cross-platform permission / appop steps in sequence", () => {
       const yaml = `
 name: grant-explicit
@@ -221,6 +271,19 @@ steps:
   - tool: setDeviceState
     networkCondition:
       cancel: false
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject offline + a shaping override with no cancel/reset (#6090)", () => {
+      const yaml = `
+name: network-condition-offline-override
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: offline
+      delayMs: 500
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(false);

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -129,6 +129,36 @@ steps:
       expect(validator.validateYaml(yaml).valid).toBe(true);
     });
 
+    it("should accept an inline networkCondition that params.networkCondition overrides (#6090 review)", () => {
+      // PlanNormalizer gives params precedence, so at execution this step receives
+      // ONLY the valid params reset — the inline `{delayMs:0}` is discarded. Schema
+      // validation must not false-reject the discarded inline form.
+      const neutral = `
+name: net-inline-overridden-neutral
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      delayMs: 0
+    params:
+      networkCondition:
+        profile: none
+`;
+      expect(validator.validateYaml(neutral).valid).toBe(true);
+      // Same for an inline offline+override overridden by a valid params reset.
+      const offline = `
+name: net-inline-overridden-offline
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: offline
+      delayMs: 500
+    params:
+      networkCondition:
+        cancel: true
+`;
+      expect(validator.validateYaml(offline).valid).toBe(true);
+    });
+
     it("should validate cross-platform permission / appop steps in sequence", () => {
       const yaml = `
 name: grant-explicit
@@ -287,6 +317,20 @@ steps:
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(false);
+    });
+
+    it("should still reject a standalone inline neutral-only networkCondition (no params override) (#6090)", () => {
+      // Guards against weakening the standalone-inline validation: with no
+      // overriding params.networkCondition, a bare zero override is a no-op the
+      // schema must still reject (matching the runtime `empty`).
+      const yaml = `
+name: network-condition-inline-neutral
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      delayMs: 0
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(false);
     });
 
     it("should validate iOS simulator permissions through cross-platform permission tools", () => {

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import Ajv from "ajv";
+import fs from "node:fs";
+import path from "node:path";
 import { registerUtilityTools } from "../../src/server/utilityTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { DaemonState } from "../../src/daemon/daemonState";
@@ -89,6 +92,47 @@ describe("device state tools", () => {
     ).not.toThrow();
     // 5g was dropped (identical to none) → no longer a valid enum value.
     expect(() => setTool!.schema.parse({ networkCondition: { profile: "5g" } })).toThrow();
+  });
+
+  // #6090: the ADVERTISED JSON schema (tool-definitions.json) must encode the same
+  // networkCondition edges as the runtime classifier, so a client that validates
+  // against tools/list agrees with invocation. Validate the generated sub-schema
+  // directly with the same Ajv the plan validator uses.
+  test("advertised networkCondition JSON schema matches the runtime classifier on edge inputs", () => {
+    const toolDefsPath = path.join(process.cwd(), "schemas/tool-definitions.json");
+    const toolDefs = JSON.parse(fs.readFileSync(toolDefsPath, "utf8")) as Array<{
+      name: string;
+      inputSchema: { properties?: Record<string, unknown> };
+    }>;
+    const setDeviceState = toolDefs.find((t) => t.name === "setDeviceState");
+    expect(setDeviceState).toBeDefined();
+    const ncSchema = setDeviceState!.inputSchema.properties?.networkCondition;
+    expect(ncSchema).toBeDefined();
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(ncSchema as object);
+
+    // offline + a shaping override with NO cancel/reset is invalid (matches runtime).
+    expect(validate({ profile: "offline", delayMs: 500 })).toBe(false);
+    // offline + override + cancel:true is a valid cancel-reset — must NOT be
+    // false-rejected (the #6090 issue-3 fix; runtime classifies it `reset`).
+    expect(validate({ profile: "offline", delayMs: 500, cancel: true })).toBe(true);
+    expect(validate({ profile: "offline", delayMs: 500, reset: true })).toBe(true);
+    // offline alone stays valid; offline + packetLossPercent is redundant, not
+    // contradictory (packet loss is not a shaping override).
+    expect(validate({ profile: "offline" })).toBe(true);
+    expect(validate({ profile: "offline", packetLossPercent: 50 })).toBe(true);
+
+    // #6090 issue-1 mirror: `none` + neutral (zero) overrides is a reset, so the
+    // advertised anyOf must accept it, while a bare zero override is a no-op the
+    // schema rejects (matching the runtime `empty`).
+    expect(validate({ profile: "none", delayMs: 0 })).toBe(true);
+    expect(validate({ profile: "none", downloadKbps: 0, uploadKbps: 0 })).toBe(true);
+    expect(validate({ delayMs: 0 })).toBe(false);
+    expect(validate({ downloadKbps: 0 })).toBe(false);
+    expect(validate({ packetLossPercent: 0 })).toBe(false);
+    // A real (non-zero) override remains a valid request.
+    expect(validate({ delayMs: 500 })).toBe(true);
   });
 
   test("threads networkCondition through the setDeviceState handler", async () => {

--- a/test/utils/plan/PlanNormalizer.test.ts
+++ b/test/utils/plan/PlanNormalizer.test.ts
@@ -27,6 +27,21 @@ describe("PlanNormalizer", () => {
     expect(normalized.label).toBe("Tap button");
   });
 
+  test("params.networkCondition wins over an inline networkCondition (#6090 review)", () => {
+    const normalized = PlanNormalizer.normalizeStep(
+      {
+        tool: "setDeviceState",
+        networkCondition: { profile: "offline", delayMs: 500 },
+        params: { networkCondition: { profile: "none" } },
+      },
+      0,
+    );
+
+    // The inline value is fully discarded — the step executes as the valid reset,
+    // which is why the schema must not false-reject the overridden inline form.
+    expect(normalized.params).toEqual({ networkCondition: { profile: "none" } });
+  });
+
   test("promotes optional flag to the step, not into tool params", () => {
     const normalized = PlanNormalizer.normalizeStep(
       { tool: "tapOn", text: "Not Now", optional: true },


### PR DESCRIPTION
## Summary

The runtime `classifyNetworkConditionRequest` in `src/features/utility/DeviceState.ts` is the single source of truth for `networkCondition`, and it is correct. But the advertised JSON schema (`schemas/tool-definitions.json`) and both `test-plan.schema.json` copies disagreed with it on three rare combined inputs, so a client relying on schema validation saw a mismatch versus runtime validation. This PR aligns the schemas to the classifier (never the reverse) and fixes the one genuine runtime edge (neutral overrides).

Follow-up to #6012 / PR #6084; tracks the three deferred review findings.

## Linked Issue

Closes #6090

## Changes

1. **Neutral overrides no longer degrade (runtime fix).** `{ profile:"none", delayMs:0 }` / `downloadKbps:0` / `uploadKbps:0` / `packetLossPercent:0` were presence-classified as a degrade, so the setter needlessly disabled Wi-Fi. The classifier now normalizes neutral (zero / documented no-op) override values: `none` + all-neutral overrides classifies as a `reset` (clean re-enable), and a bare zero override with no profile is `empty`. The offline-contradiction check stays presence-based (unchanged), matching the schema's presence-based rule.
2. **Plan schema now enforces the offline-override rule.** A plan `networkCondition:{ profile:"offline", delayMs:500 }` previously passed `PlanSchemaValidator` but failed the live Zod refinement at execution. Both plan-schema copies now carry the same `if/then` rejection.
3. **Offline-override rejection is cancel/reset-aware.** `cancel`/`reset` win at the classifier ("make it clean"), so `{ profile:"offline", delayMs:500, cancel:true }` is a valid `reset`. The tool JSON `if/then` (and both plan copies) previously false-rejected it by checking only `profile:"offline"`; the `if` now fires only when no true `cancel`/`reset` is present. The plan schema's inverse false-accept is fixed by the same rule.

The advertised `anyOf` override branches now require a non-neutral value (`not: { const: 0 }`), mirroring the classifier's neutral normalization so a bare zero override is rejected identically by schema and runtime.

`schemas/tool-definitions.json` was regenerated via `scripts/update-tool-definitions.sh` (not hand-edited). Both `test-plan.schema.json` copies are kept drift-identical (`check-schema-copy-drift` gate passes). `ios/control-proxy/` untouched.

## Validation

- [x] Targeted unit tests green: `test/features/utility/DeviceState.test.ts`, `test/server/utilityTools.deviceState.test.ts`, `test/plan/PlanSchemaValidator.test.ts` (98 pass)
- [x] `bun run lint` — oxlint ratchet: no new violations; boundary-checks pass
- [x] `bun run typecheck` — no new type errors (baseline gate)
- [x] `bun run format:check` — clean
- [x] `bun scripts/check-schema-copy-drift.ts` — copies structurally identical
- [x] `bunx turbo run build` — success
- [x] New tests are red-first (classifier + both schema layers), then green
- [x] Full `bun test` suite: the only 2 failures are pre-existing environment artifacts in the `.claude/worktrees` checkout (`oxlintConfigScoping` ENOENT on the missing `node_modules/.bin/oxlint`, and a WebRTC device-capture hardware integration test) — neither touches `networkCondition`

## Testing

- `classifyNetworkConditionRequest` pins the new neutral cases (`none`+zero → `reset`; bare zero → `empty`; non-zero → `degrade`).
- A behavioral setter test asserts `{ profile:"none", delayMs:0, downloadKbps:0, uploadKbps:0 }` re-enables Wi-Fi (`svc wifi enable`) and never disables it.
- The advertised JSON schema (`tool-definitions.json`) is validated with Ajv for the offline+override+cancel edge and the neutral-override anyOf.
- Both plan schemas accept a valid cancel/reset-with-override and reject a bare offline+override.
