### PR TITLE
fix(daemon): rejoin a peer daemon that wins the socket race after our subprocess exits (#6103)

### DIFF
--- a/src/daemon/daemonSocketReachability.ts
+++ b/src/daemon/daemonSocketReachability.ts
@@ -20,6 +20,16 @@ export interface DaemonSocketReachabilityDeps {
 }
 
 /**
+ * The narrow contract the daemon manager's post-exit rejoin depends on: report
+ * whether the socket/pipe is reachable, observation-only. Injecting this (rather than
+ * subclassing the manager) lets a test drive the probe outcome under a FakeTimer
+ * without a real socket, and keeps the real probe wired to the manager's injected timer.
+ */
+export interface DaemonSocketReachabilityLike {
+  isReachable(socketPath: string, timeoutMs: number): Promise<boolean>;
+}
+
+/**
  * Observation-only reachability check for a daemon control socket/pipe (issue #6103).
  *
  * The post-exit peer rejoin needs to know "is a peer daemon accepting on the shared

--- a/src/daemon/daemonSocketReachability.ts
+++ b/src/daemon/daemonSocketReachability.ts
@@ -1,0 +1,107 @@
+import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+
+/**
+ * Attempts a bare, side-effect-free connection to a daemon socket/pipe and reports
+ * whether it is reachable. MUST NOT touch the socket file (no stat-clean, no unlink).
+ */
+export type DaemonSocketConnectAttempt = (
+  socketPath: string,
+  timeoutMs: number,
+  timer: Timer,
+) => Promise<boolean>;
+
+export interface DaemonSocketReachabilityDeps {
+  platform?: NodeJS.Platform;
+  existsSyncFn?: (path: string) => boolean;
+  connectAttempt?: DaemonSocketConnectAttempt;
+  timer?: Timer;
+}
+
+/**
+ * Observation-only reachability check for a daemon control socket/pipe (issue #6103).
+ *
+ * The post-exit peer rejoin needs to know "is a peer daemon accepting on the shared
+ * socket right now?" WITHOUT the destructive recovery behavior of
+ * {@link DaemonClient.connect}, which on a failed attempt calls
+ * `cleanupStaleSocketIfDaemonDead` and can UNLINK the socket when the PID file records
+ * a dead process. During a cross-checkout startup race the live race winner can own
+ * the shared socket without owning that PID record, so a single transient refusal
+ * there would delete the winner's live endpoint and strand every client. This probe
+ * therefore only ever attempts a connection and reports the result — it never cleans
+ * up or unlinks anything.
+ *
+ * It is also platform-aware AT THE CONNECTION LAYER: on POSIX a Unix socket has a
+ * filesystem entry, so a missing path means nothing is listening and the connect is
+ * skipped (so a missing socket isn't hammered); on Windows the socket is a named pipe
+ * with no filesystem entry, so the connect is attempted regardless (mirroring
+ * {@link DaemonClient.isAvailable}'s `platform() !== "win32"` branch). Without this a
+ * reachable Windows peer — whose pipe `existsSync` always reports absent — would never
+ * be probed or joined.
+ *
+ * All external dependencies (platform, filesystem check, the raw connect, the timer)
+ * are injected so the platform branch and the connection outcome are testable without
+ * real sockets.
+ */
+export class DaemonSocketReachability {
+  private readonly platform: NodeJS.Platform;
+  private readonly existsSyncFn: (path: string) => boolean;
+  private readonly connectAttempt: DaemonSocketConnectAttempt;
+  private readonly timer: Timer;
+
+  constructor(deps: DaemonSocketReachabilityDeps = {}) {
+    this.platform = deps.platform ?? process.platform;
+    this.existsSyncFn = deps.existsSyncFn ?? existsSync;
+    this.connectAttempt = deps.connectAttempt ?? rawObservationOnlyConnectAttempt;
+    this.timer = deps.timer ?? defaultTimer;
+  }
+
+  /**
+   * Whether the daemon socket/pipe is currently accepting connections. Returns false
+   * (rather than throwing) for every not-reachable case, and never mutates the socket
+   * file.
+   */
+  async isReachable(socketPath: string, timeoutMs: number): Promise<boolean> {
+    if (timeoutMs <= 0) {
+      return false;
+    }
+    // POSIX: a missing filesystem entry means nothing is listening yet — skip the
+    // connect so a nonexistent Unix socket isn't hammered. Windows named pipes have no
+    // filesystem entry, so the connect must be attempted regardless.
+    if (this.platform !== "win32" && !this.existsSyncFn(socketPath)) {
+      return false;
+    }
+    return this.connectAttempt(socketPath, timeoutMs, this.timer);
+  }
+}
+
+/**
+ * The default connect attempt: a raw {@link createConnection} bounded by `timeoutMs`,
+ * reporting reachable on connect and not-reachable on error or timeout. It destroys the
+ * probe socket on every exit path and — deliberately, unlike the DaemonClient recovery
+ * path — never unlinks or cleans up the socket file.
+ */
+const rawObservationOnlyConnectAttempt: DaemonSocketConnectAttempt = (
+  socketPath,
+  timeoutMs,
+  timer,
+) =>
+  new Promise<boolean>((resolve) => {
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      timer.clearTimeout(timeout);
+      socket.destroy();
+      resolve(value);
+    };
+
+    const socket = createConnection(socketPath, () => settle(true));
+    // No cleanupStaleSocketIfDaemonDead on error: this probe must never delete a live
+    // peer's endpoint (issue #6103).
+    socket.on("error", () => settle(false));
+    const timeout = timer.setTimeout(() => settle(false), timeoutMs);
+  });

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -37,7 +37,10 @@ import {
   formatSocketDiagnostics,
 } from "./debugTools";
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
-import { DaemonSocketReachability } from "./daemonSocketReachability";
+import {
+  DaemonSocketReachability,
+  type DaemonSocketReachabilityLike,
+} from "./daemonSocketReachability";
 import {
   buildIdentitiesMatch,
   buildIdentityFromStatus,
@@ -493,10 +496,11 @@ export class DaemonManager implements DaemonManagerLike {
   /**
    * Observation-only reachability probe for the post-exit peer rejoin (issue #6103):
    * it never unlinks or stale-cleans the socket, and is platform-aware at the connect
-   * layer. Kept as a field (not the recovery-capable {@link DaemonClient}) so the
-   * rejoin can never delete a live peer's endpoint. See {@link probePeerSocketReachable}.
+   * layer. Assigned in the constructor body from the injected {@link Timer} (never a
+   * field initializer, which would bind the real wall-clock even under a FakeTimer),
+   * and injectable so a test can drive the probe outcome without a real socket.
    */
-  private readonly peerSocketReachability = new DaemonSocketReachability();
+  private readonly peerSocketReachability: DaemonSocketReachabilityLike;
   private readonly launchCommandResolver: (() => DaemonLaunchCommand) | undefined;
   private heldLockLogPath: string | undefined;
   /**
@@ -525,8 +529,13 @@ export class DaemonManager implements DaemonManagerLike {
     launcher: DaemonLauncher | (() => DaemonLaunchCommand) | undefined = undefined,
     processSignaler: DaemonProcessSignaler = defaultDaemonProcessSignaler,
     idGenerator: IdGenerator = defaultIdGenerator,
+    peerSocketReachability: DaemonSocketReachabilityLike | undefined = undefined,
   ) {
     this.startupLockOwnerToken = idGenerator.next();
+    // Construct the reachability probe here (not in a field initializer) so its connect
+    // timeout is bound to the injected timer — a field initializer would capture the
+    // real wall-clock even when this manager runs under a FakeTimer (issue #6103).
+    this.peerSocketReachability = peerSocketReachability ?? new DaemonSocketReachability({ timer });
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = resolvePathFromDaemonLaunchWorkingDirectory(lockFilePath);
@@ -1800,53 +1809,65 @@ export class DaemonManager implements DaemonManagerLike {
    * becoming ready" error strands the caller even though a healthy same-namespace
    * daemon is ready ~1s later. This bounded wait joins that winner instead.
    *
-   * Prompt-failure invariant (issues #5878/#5904): the wait is GATED on a live
-   * AutoMobile daemon process being present in the table (a SINGLE up-front
-   * {@link hasComingUpPeerDaemon} scan, re-checked only at
-   * {@link PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS} — not per poll — since that scan is a
-   * synchronous `ps`/PowerShell call), so a GENUINE start failure — nothing coming up,
-   * or only an orphaned socket inode with no listener and no backing process — still
-   * fails immediately rather than burning the client's ~30s `tools/list` budget; a peer
-   * that dies mid-wait ends the loop at the next re-check. `budgetMs` is the time
-   * REMAINING under the
-   * caller's original start deadline (already capped at
-   * {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}), so when launchAndWait already
-   * consumed the client budget the caller passes a non-positive value and skips this
-   * wait entirely — the rejoin can only ever spend time the caller still has. It
-   * NEVER spawns — it only probes and joins, so it cannot double-spawn — and it joins
-   * only a daemon that answers the observation-only {@link probePeerSocketReachable}
-   * probe, which never unlinks or stale-cleans the socket (so it cannot delete a live
-   * peer's endpoint); daemon version compatibility is enforced separately by the proxy
-   * handshake.
+   * Each iteration evaluates the authoritative socket probe FIRST; only after a probe
+   * miss does it consult the process table, throttled to once up front plus once per
+   * {@link PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS} (that scan is a synchronous
+   * `ps`/PowerShell call and must never precede or preempt the socket probe).
+   *
+   * Prompt-failure invariant (issues #5878/#5904): once the socket probe misses, a
+   * GENUINE start failure — no live daemon process ({@link hasComingUpPeerDaemon}),
+   * nothing coming up, or only an orphaned socket inode with no listener and no backing
+   * process — fails immediately rather than burning the client's ~30s `tools/list`
+   * budget; a peer that dies mid-wait ends the loop at the next re-check. `budgetMs` is
+   * the time REMAINING under the caller's original start deadline, less a delivery
+   * reserve (capped at {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}), so when
+   * launchAndWait already consumed the client budget the caller passes a non-positive
+   * value and skips this wait entirely — the rejoin can only ever spend time the caller
+   * still has. It NEVER spawns — it only probes and joins, so it cannot double-spawn —
+   * and it joins only a daemon that answers the observation-only
+   * {@link peerSocketReachability} probe, which never unlinks or stale-cleans the socket
+   * (so it cannot delete a live peer's endpoint); daemon version compatibility is
+   * enforced separately by the proxy handshake.
    */
   private async tryJoinPeerDaemonAfterSpawnExit(budgetMs: number): Promise<boolean> {
     const deadline = this.timer.now() + budgetMs;
 
-    // Establish "a live peer daemon is coming up" with a SINGLE up-front process-table
-    // scan, then re-check it only at PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS — never every
-    // iteration. That scan is a synchronous `ps`/PowerShell/CIM call that blocks the
-    // event loop, so re-running it each poll would stall the loop for the whole budget
-    // (issue #6103). The per-iteration signal is the cheap socket probe below.
-    let peerProcessComingUp = this.hasComingUpPeerDaemon();
-    let nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
+    // The process-table scan is a synchronous `ps`/PowerShell/CIM call that blocks the
+    // event loop, so it must (a) never run BEFORE the authoritative socket probe, and
+    // (b) never run more than once up front plus once per
+    // PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS — otherwise a stalling scan could consume the
+    // whole deadline before an already-published peer socket is ever checked (issue
+    // #6103). It is populated lazily, only after a socket-probe miss.
+    let peerProcessComingUp: boolean | undefined;
+    let nextProcessScanAt = this.timer.now();
 
     while (this.remainingTime(deadline) > 0) {
-      // SOCKET-FIRST: a reachable socket is the AUTHORITATIVE readiness signal, so probe
-      // it before consulting the process scan and join immediately if it answers —
-      // regardless of what the (best-effort, occasionally-stale) scan reported. This is
-      // an observation-only probe: it never unlinks or stale-cleans the socket, so it
-      // cannot delete a live peer's endpoint during the race (issue #6103), and it is
+      // SOCKET-FIRST (authoritative), evaluated before any process scan: a reachable
+      // socket means join immediately, regardless of what the best-effort scan would
+      // say. This is an observation-only probe — it never unlinks or stale-cleans the
+      // socket, so it cannot delete a live peer's endpoint during the race — and it is
       // platform-aware at the connect layer so a Windows named-pipe peer (no filesystem
       // entry) is still reached.
       const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
-      if (probeBudget > 0 && (await this.probePeerSocketReachable(probeBudget))) {
+      if (
+        probeBudget > 0 &&
+        (await this.peerSocketReachability.isReachable(this.socketPath, probeBudget))
+      ) {
         stderrLog("Reusing a peer daemon that became ready after our launch exited");
         return true;
       }
-      // Socket not reachable yet. Use the process-table presence ONLY to decide whether
-      // to keep waiting: a live peer process means the socket is still coming up, so
-      // poll again; nothing coming up (genuine failure, or an orphaned socket inode with
-      // no listener and no backing process) fails promptly (#5878/#5904).
+
+      // Socket not reachable yet. NOW consult the process table — throttled — purely to
+      // decide whether to keep waiting: a live peer process means the socket is still
+      // coming up, so poll again; nothing coming up (genuine failure, or an orphaned
+      // socket inode with no listener and no backing process) fails promptly (#5878).
+      // The scan runs at most once up front (when still undefined) and once per interval
+      // thereafter, so a peer that dies mid-wait still ends the loop without a scan per
+      // poll.
+      if (peerProcessComingUp === undefined || this.timer.now() >= nextProcessScanAt) {
+        peerProcessComingUp = this.hasComingUpPeerDaemon();
+        nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
+      }
       if (!peerProcessComingUp) {
         return false;
       }
@@ -1855,30 +1876,9 @@ export class DaemonManager implements DaemonManagerLike {
         break;
       }
       await this.timer.sleep(Math.min(PEER_DAEMON_JOIN_POLL_MS, remaining));
-
-      // Coarse-cadence liveness re-check: cheap enough to run occasionally so a peer
-      // that dies mid-wait (and never publishes the socket) ends the loop before the
-      // full budget, without a synchronous scan on every poll.
-      if (this.timer.now() >= nextProcessScanAt) {
-        peerProcessComingUp = this.hasComingUpPeerDaemon();
-        nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
-      }
     }
 
     return false;
-  }
-
-  /**
-   * Observation-only, platform-aware reachability probe for the post-exit peer rejoin.
-   * Delegates to {@link DaemonSocketReachability}, which attempts a bare connection and
-   * reports reachable/not WITHOUT ever unlinking or stale-cleaning the socket — unlike
-   * {@link DaemonClient.connect}, whose `cleanupStaleSocketIfDaemonDead` path could
-   * delete a live peer's endpoint when the PID file records the just-exited child
-   * (issue #6103). Extracted as its own method so tests can inject a fake reachability
-   * outcome without a real socket.
-   */
-  protected probePeerSocketReachable(timeoutMs: number): Promise<boolean> {
-    return this.peerSocketReachability.isReachable(this.socketPath, timeoutMs);
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -376,6 +376,15 @@ const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 
 /**
+ * Poll cadence while rejoining a peer daemon that is coming up on the shared
+ * socket after our own spawned subprocess exited before becoming ready (issue
+ * #6103). Matched to the existing reachability poll interval so a peer that
+ * publishes the socket a beat after our child died is picked up within one poll,
+ * without hammering the process table between socket probes.
+ */
+const PEER_DAEMON_JOIN_POLL_MS = 100;
+
+/**
  * Cadence at which the liveness watchdog re-samples the "keep waiting" predicate
  * while a full-budget readiness probe is in flight (issue #5904). A per-poll
  * precheck only samples liveness between probes; if the holder dies *during* a
@@ -883,6 +892,20 @@ export class DaemonManager implements DaemonManagerLike {
           );
         }
       }
+    } catch (error) {
+      // Our spawned subprocess failed before becoming ready. Under a concurrent
+      // cold start, a PEER client's same-namespace daemon may still be publishing
+      // the shared socket a beat later — our child merely lost the socket-ownership
+      // race (issue #6103). Rejoin that peer within a bounded, candidate-gated wait
+      // instead of surfacing our child's exit as terminal; a genuine start failure
+      // (no peer coming up) still fails promptly (issue #5878).
+      if (await this.tryJoinPeerDaemonAfterSpawnExit()) {
+        stderrLog(
+          "A peer daemon became ready on the shared socket after our launch exited; joining it",
+        );
+        return;
+      }
+      throw error;
     } finally {
       // Close our reference to the log file (daemon process still has it open)
       closeSync(logFd);
@@ -1714,6 +1737,64 @@ export class DaemonManager implements DaemonManagerLike {
         callerSignal?.removeEventListener("abort", onCallerAbort);
       },
     };
+  }
+
+  /**
+   * Rejoin a peer daemon coming up on the shared socket after our own spawned
+   * subprocess exited before becoming ready (issue #6103).
+   *
+   * Under a concurrent cold start, multiple proxy clients each try to bring the
+   * daemon up. Only one child wins ownership of the per-user socket; a losing child
+   * exits — often with an empty launch log — a beat before the winner publishes the
+   * socket. Surfacing that lost race as a terminal "subprocess exited before
+   * becoming ready" error strands the caller even though a healthy same-namespace
+   * daemon is ready ~1s later. This bounded wait joins that winner instead.
+   *
+   * Prompt-failure invariant (issues #5878/#5904): the wait is GATED on a live
+   * candidate — a socket inode already present, or a live AutoMobile daemon process
+   * in the table — and gives up the instant no candidate remains, so a GENUINE start
+   * failure (nothing else coming up) still fails immediately rather than burning the
+   * client's ~30s `tools/list` budget. When a candidate is present the wait is
+   * capped at {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS} — the same bounded
+   * reachability budget {@link startUnlocked} already uses for an existing live
+   * daemon, deliberately held below the client deadline. It NEVER spawns — it only
+   * probes and joins, so it cannot double-spawn — and it joins only a daemon that
+   * answers the same non-destructive readiness probe every other reuse path trusts
+   * ({@link verifyDaemonConnection}, which never unlinks the socket); daemon version
+   * compatibility is enforced separately by the proxy handshake.
+   */
+  private async tryJoinPeerDaemonAfterSpawnExit(): Promise<boolean> {
+    const deadline = this.timer.now() + DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS;
+
+    while (this.remainingTime(deadline) > 0) {
+      if (!this.hasComingUpPeerDaemon()) {
+        // No socket and no live daemon process: nothing is coming up, so deliver the
+        // real subprocess-exit failure now instead of waiting out the budget (#5878).
+        return false;
+      }
+      const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
+      if (probeBudget > 0 && (await this.verifyDaemonConnection(probeBudget))) {
+        stderrLog("Reusing a peer daemon that became ready after our launch exited");
+        return true;
+      }
+      const remaining = this.remainingTime(deadline);
+      if (remaining === 0) {
+        break;
+      }
+      await this.timer.sleep(Math.min(PEER_DAEMON_JOIN_POLL_MS, remaining));
+    }
+
+    return false;
+  }
+
+  /**
+   * Whether a peer daemon might still publish this namespace's socket: either the
+   * socket inode already exists, or a live AutoMobile daemon process is present in
+   * the table. Gates {@link tryJoinPeerDaemonAfterSpawnExit} so a genuine start
+   * failure is not turned into a bounded hang.
+   */
+  private hasComingUpPeerDaemon(): boolean {
+    return existsSync(this.socketPath) || this.findLiveDaemonProcesses().length > 0;
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1751,10 +1751,11 @@ export class DaemonManager implements DaemonManagerLike {
    * daemon is ready ~1s later. This bounded wait joins that winner instead.
    *
    * Prompt-failure invariant (issues #5878/#5904): the wait is GATED on a live
-   * candidate — a socket inode already present, or a live AutoMobile daemon process
-   * in the table — and gives up the instant no candidate remains, so a GENUINE start
-   * failure (nothing else coming up) still fails immediately rather than burning the
-   * client's ~30s `tools/list` budget. When a candidate is present the wait is
+   * AutoMobile daemon process being present in the table (see
+   * {@link hasComingUpPeerDaemon}) and gives up the instant none remains, so a
+   * GENUINE start failure — nothing coming up, or only an orphaned socket inode with
+   * no listener and no backing process — still fails immediately rather than burning
+   * the client's ~30s `tools/list` budget. When a live daemon is present the wait is
    * capped at {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS} — the same bounded
    * reachability budget {@link startUnlocked} already uses for an existing live
    * daemon, deliberately held below the client deadline. It NEVER spawns — it only
@@ -1768,12 +1769,23 @@ export class DaemonManager implements DaemonManagerLike {
 
     while (this.remainingTime(deadline) > 0) {
       if (!this.hasComingUpPeerDaemon()) {
-        // No socket and no live daemon process: nothing is coming up, so deliver the
-        // real subprocess-exit failure now instead of waiting out the budget (#5878).
+        // No live daemon process is coming up: deliver the real subprocess-exit
+        // failure now instead of holding the budget on nothing — or on an orphaned
+        // socket inode with no listener and no backing process (#5878/#5904).
         return false;
       }
+      // Only probe once the socket inode exists. A live daemon that has not yet
+      // published its socket has nothing to connect to, and probing a missing path
+      // just burns the connect retry/backoff; the poll below re-checks liveness so
+      // a peer that dies mid-wait still ends the loop promptly. verifyDaemonConnection
+      // is non-destructive (never unlinks the socket), so a slow peer racing to bind
+      // is not torn down here.
       const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
-      if (probeBudget > 0 && (await this.verifyDaemonConnection(probeBudget))) {
+      if (
+        probeBudget > 0 &&
+        existsSync(this.socketPath) &&
+        (await this.verifyDaemonConnection(probeBudget))
+      ) {
         stderrLog("Reusing a peer daemon that became ready after our launch exited");
         return true;
       }
@@ -1788,13 +1800,23 @@ export class DaemonManager implements DaemonManagerLike {
   }
 
   /**
-   * Whether a peer daemon might still publish this namespace's socket: either the
-   * socket inode already exists, or a live AutoMobile daemon process is present in
-   * the table. Gates {@link tryJoinPeerDaemonAfterSpawnExit} so a genuine start
-   * failure is not turned into a bounded hang.
+   * Whether a peer daemon is genuinely coming up and worth waiting on: a live
+   * AutoMobile daemon process is present in the table.
+   *
+   * A bare socket INODE is deliberately NOT sufficient. An orphaned socket file —
+   * left in the window after {@link startUnlocked}'s stale-file cleanup by a race
+   * winner that bound the socket then died right after — has no listener and no
+   * backing process; counting it as "coming up" would make
+   * {@link tryJoinPeerDaemonAfterSpawnExit} poll out the full reachability budget
+   * before failing, a delayed failure the prompt-failure invariant (#5878/#5904)
+   * exists to prevent. The responding-listener case is handled directly by the
+   * {@link verifyDaemonConnection} join probe in that method, which returns success
+   * the instant the socket accepts — so a socket that actually has a listener is
+   * joined regardless of this gate, and a socket that does not is not waited on
+   * unless a live daemon process backs it.
    */
   private hasComingUpPeerDaemon(): boolean {
-    return existsSync(this.socketPath) || this.findLiveDaemonProcesses().length > 0;
+    return this.findLiveDaemonProcesses().length > 0;
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -748,6 +748,15 @@ export class DaemonManager implements DaemonManagerLike {
    * Internal start implementation (caller must hold lock).
    */
   private async startUnlocked(options: DaemonOptions): Promise<void> {
+    // The overall start budget, captured before any work so the post-exit peer
+    // rejoin (issue #6103) can only ever spend time the caller still has. The
+    // client times its `tools/list` out at DAEMON_STARTUP_TIMEOUT_MS; launchAndWait
+    // may consume all of it (plus the time spent stopping a timed-out child), so a
+    // rejoin bounded by a FRESH reachability budget could push the actionable
+    // diagnostic past the client deadline — the exact failure #5878/#5904 exist to
+    // prevent. Bounding the rejoin by the time REMAINING under this deadline keeps
+    // the error deliverable.
+    const startDeadline = this.timer.now() + DAEMON_STARTUP_TIMEOUT_MS;
     const status = await this.status();
     if (status.running) {
       stderrLog(`Daemon is already running (PID ${status.pid}, port ${status.port})`);
@@ -899,7 +908,17 @@ export class DaemonManager implements DaemonManagerLike {
       // race (issue #6103). Rejoin that peer within a bounded, candidate-gated wait
       // instead of surfacing our child's exit as terminal; a genuine start failure
       // (no peer coming up) still fails promptly (issue #5878).
-      if (await this.tryJoinPeerDaemonAfterSpawnExit()) {
+      //
+      // Bound the rejoin by the time REMAINING under the original start deadline, not
+      // a fresh reachability budget: if launchAndWait already consumed the client's
+      // ~30s budget (a startup timeout, plus stopping the timed-out child), skip the
+      // rejoin entirely and rethrow now, so the actionable diagnostic still beats the
+      // client deadline (issue #5878/#5904).
+      const rejoinBudget = Math.min(
+        DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
+        this.remainingTime(startDeadline),
+      );
+      if (rejoinBudget > 0 && (await this.tryJoinPeerDaemonAfterSpawnExit(rejoinBudget))) {
         stderrLog(
           "A peer daemon became ready on the shared socket after our launch exited; joining it",
         );
@@ -1755,17 +1774,19 @@ export class DaemonManager implements DaemonManagerLike {
    * {@link hasComingUpPeerDaemon}) and gives up the instant none remains, so a
    * GENUINE start failure — nothing coming up, or only an orphaned socket inode with
    * no listener and no backing process — still fails immediately rather than burning
-   * the client's ~30s `tools/list` budget. When a live daemon is present the wait is
-   * capped at {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS} — the same bounded
-   * reachability budget {@link startUnlocked} already uses for an existing live
-   * daemon, deliberately held below the client deadline. It NEVER spawns — it only
-   * probes and joins, so it cannot double-spawn — and it joins only a daemon that
-   * answers the same non-destructive readiness probe every other reuse path trusts
-   * ({@link verifyDaemonConnection}, which never unlinks the socket); daemon version
-   * compatibility is enforced separately by the proxy handshake.
+   * the client's ~30s `tools/list` budget. `budgetMs` is the time REMAINING under the
+   * caller's original start deadline (already capped at
+   * {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}), so when launchAndWait already
+   * consumed the client budget the caller passes a non-positive value and skips this
+   * wait entirely — the rejoin can only ever spend time the caller still has. It
+   * NEVER spawns — it only probes and joins, so it cannot double-spawn — and it joins
+   * only a daemon that answers the same non-destructive readiness probe every other
+   * reuse path trusts ({@link verifyDaemonConnection}, which never unlinks the
+   * socket); daemon version compatibility is enforced separately by the proxy
+   * handshake.
    */
-  private async tryJoinPeerDaemonAfterSpawnExit(): Promise<boolean> {
-    const deadline = this.timer.now() + DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS;
+  private async tryJoinPeerDaemonAfterSpawnExit(budgetMs: number): Promise<boolean> {
+    const deadline = this.timer.now() + budgetMs;
 
     while (this.remainingTime(deadline) > 0) {
       if (!this.hasComingUpPeerDaemon()) {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1795,16 +1795,18 @@ export class DaemonManager implements DaemonManagerLike {
         // socket inode with no listener and no backing process (#5878/#5904).
         return false;
       }
-      // Only probe once the socket inode exists. A live daemon that has not yet
-      // published its socket has nothing to connect to, and probing a missing path
-      // just burns the connect retry/backoff; the poll below re-checks liveness so
-      // a peer that dies mid-wait still ends the loop promptly. verifyDaemonConnection
-      // is non-destructive (never unlinks the socket), so a slow peer racing to bind
-      // is not torn down here.
+      // On POSIX, only probe once the socket inode exists: a live daemon that has not
+      // yet published its Unix socket has nothing to connect to, and probing a missing
+      // path just burns the connect retry/backoff; the poll below re-checks liveness so
+      // a peer that dies mid-wait still ends the loop promptly. On Windows the socket is
+      // a named pipe with no filesystem entry, so that gate would never open — probe
+      // directly there (see {@link socketPathWorthProbing}). verifyDaemonConnection is
+      // non-destructive (never unlinks the socket), so a slow peer racing to bind is not
+      // torn down here.
       const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
       if (
         probeBudget > 0 &&
-        existsSync(this.socketPath) &&
+        this.socketPathWorthProbing() &&
         (await this.verifyDaemonConnection(probeBudget))
       ) {
         stderrLog("Reusing a peer daemon that became ready after our launch exited");
@@ -1837,7 +1839,34 @@ export class DaemonManager implements DaemonManagerLike {
    * unless a live daemon process backs it.
    */
   private hasComingUpPeerDaemon(): boolean {
-    return this.findLiveDaemonProcesses().length > 0;
+    try {
+      return this.findLiveDaemonProcesses().length > 0;
+    } catch (error) {
+      // Best-effort recovery probe: a transient process-table inspection failure must
+      // not REPLACE the caller's original spawn/exit diagnostic (which carries the
+      // captured startup-log excerpt). Log it and treat it as "no peer coming up" so
+      // the rejoin gives up and startUnlocked rethrows the original launch error intact
+      // (issue #6103).
+      logger.warn(
+        `[DaemonManager] peer-daemon discovery failed during post-exit rejoin; treating as no peer coming up: ${errorMessage(error)}`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Whether the daemon socket path is worth a connect probe during the post-exit
+   * rejoin. On POSIX a Unix socket has a filesystem entry, so a missing path means
+   * nothing is listening yet and we skip the probe to avoid hammering a nonexistent
+   * socket with connect/backoff cycles. On Windows the socket is a NAMED PIPE with no
+   * filesystem entry — `existsSync` is always false there (mirroring
+   * {@link DaemonClient.isAvailable}'s `platform() !== "win32"` guard) — so skip the
+   * filesystem gate and let the connect attempt itself decide reachability, or a
+   * reachable Windows peer would never be probed or joined.
+   */
+  private socketPathWorthProbing(): boolean {
+    return process.platform === "win32" || existsSync(this.socketPath);
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -37,6 +37,7 @@ import {
   formatSocketDiagnostics,
 } from "./debugTools";
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
+import { DaemonSocketReachability } from "./daemonSocketReachability";
 import {
   buildIdentitiesMatch,
   buildIdentityFromStatus,
@@ -396,6 +397,18 @@ const PEER_DAEMON_JOIN_POLL_MS = 100;
 const PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS = 1000;
 
 /**
+ * Delivery headroom reserved under the client's original start deadline before the
+ * post-exit peer rejoin (issue #6103) may run. The rejoin is nested inside a
+ * `tools/list` the client times out at DAEMON_STARTUP_TIMEOUT_MS; if the rejoin were
+ * allowed to consume every last millisecond, the actionable diagnostic it rethrows on
+ * failure would land AT the deadline instead of before it (issue #5878/#5904). Skipping
+ * the rejoin once less than this remains guarantees time to format and deliver that
+ * error. A near-deadline exit therefore fails fast rather than spending its final
+ * moments on a rejoin that cannot report its own failure in time.
+ */
+const PEER_DAEMON_JOIN_DELIVERY_HEADROOM_MS = 2000;
+
+/**
  * Cadence at which the liveness watchdog re-samples the "keep waiting" predicate
  * while a full-budget readiness probe is in flight (issue #5904). A per-poll
  * precheck only samples liveness between probes; if the holder dies *during* a
@@ -477,6 +490,13 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly extractionCleaner: ExtractionCleaner;
   private readonly launcher: DaemonLauncher;
   private readonly fallbackLauncher: DaemonLauncher;
+  /**
+   * Observation-only reachability probe for the post-exit peer rejoin (issue #6103):
+   * it never unlinks or stale-cleans the socket, and is platform-aware at the connect
+   * layer. Kept as a field (not the recovery-capable {@link DaemonClient}) so the
+   * rejoin can never delete a live peer's endpoint. See {@link probePeerSocketReachable}.
+   */
+  private readonly peerSocketReachability = new DaemonSocketReachability();
   private readonly launchCommandResolver: (() => DaemonLaunchCommand) | undefined;
   private heldLockLogPath: string | undefined;
   /**
@@ -920,14 +940,14 @@ export class DaemonManager implements DaemonManagerLike {
       // instead of surfacing our child's exit as terminal; a genuine start failure
       // (no peer coming up) still fails promptly (issue #5878).
       //
-      // Bound the rejoin by the time REMAINING under the original start deadline, not
-      // a fresh reachability budget: if launchAndWait already consumed the client's
-      // ~30s budget (a startup timeout, plus stopping the timed-out child), skip the
-      // rejoin entirely and rethrow now, so the actionable diagnostic still beats the
-      // client deadline (issue #5878/#5904).
+      // Bound the rejoin by the time REMAINING under the original start deadline, LESS a
+      // delivery-headroom reserve, not a fresh reachability budget: if launchAndWait
+      // already consumed most of the client's ~30s budget (a startup timeout, plus
+      // stopping the timed-out child), skip the rejoin and rethrow now so the actionable
+      // diagnostic still beats the client deadline WITH time to spare (issue #5878/#5904).
       const rejoinBudget = Math.min(
         DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
-        this.remainingTime(startDeadline),
+        this.remainingTime(startDeadline) - PEER_DAEMON_JOIN_DELIVERY_HEADROOM_MS,
       );
       if (rejoinBudget > 0 && (await this.tryJoinPeerDaemonAfterSpawnExit(rejoinBudget))) {
         stderrLog(
@@ -1794,9 +1814,9 @@ export class DaemonManager implements DaemonManagerLike {
    * consumed the client budget the caller passes a non-positive value and skips this
    * wait entirely — the rejoin can only ever spend time the caller still has. It
    * NEVER spawns — it only probes and joins, so it cannot double-spawn — and it joins
-   * only a daemon that answers the same non-destructive readiness probe every other
-   * reuse path trusts ({@link verifyDaemonConnection}, which never unlinks the
-   * socket); daemon version compatibility is enforced separately by the proxy
+   * only a daemon that answers the observation-only {@link probePeerSocketReachable}
+   * probe, which never unlinks or stale-cleans the socket (so it cannot delete a live
+   * peer's endpoint); daemon version compatibility is enforced separately by the proxy
    * handshake.
    */
   private async tryJoinPeerDaemonAfterSpawnExit(budgetMs: number): Promise<boolean> {
@@ -1806,32 +1826,29 @@ export class DaemonManager implements DaemonManagerLike {
     // scan, then re-check it only at PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS — never every
     // iteration. That scan is a synchronous `ps`/PowerShell/CIM call that blocks the
     // event loop, so re-running it each poll would stall the loop for the whole budget
-    // (issue #6103); the cheap per-iteration signal is the socket connect probe below.
+    // (issue #6103). The per-iteration signal is the cheap socket probe below.
     let peerProcessComingUp = this.hasComingUpPeerDaemon();
     let nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
 
     while (this.remainingTime(deadline) > 0) {
-      if (!peerProcessComingUp) {
-        // No live daemon process is coming up: deliver the real subprocess-exit
-        // failure now instead of holding the budget on nothing — or on an orphaned
-        // socket inode with no listener and no backing process (#5878/#5904).
-        return false;
-      }
-      // On POSIX, only probe once the socket inode exists: a live daemon that has not
-      // yet published its Unix socket has nothing to connect to, and probing a missing
-      // path just burns the connect retry/backoff. On Windows the socket is a named
-      // pipe with no filesystem entry, so that gate would never open — probe directly
-      // there (see {@link socketPathWorthProbing}). verifyDaemonConnection is
-      // non-destructive (never unlinks the socket), so a slow peer racing to bind is not
-      // torn down here.
+      // SOCKET-FIRST: a reachable socket is the AUTHORITATIVE readiness signal, so probe
+      // it before consulting the process scan and join immediately if it answers —
+      // regardless of what the (best-effort, occasionally-stale) scan reported. This is
+      // an observation-only probe: it never unlinks or stale-cleans the socket, so it
+      // cannot delete a live peer's endpoint during the race (issue #6103), and it is
+      // platform-aware at the connect layer so a Windows named-pipe peer (no filesystem
+      // entry) is still reached.
       const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
-      if (
-        probeBudget > 0 &&
-        this.socketPathWorthProbing() &&
-        (await this.verifyDaemonConnection(probeBudget))
-      ) {
+      if (probeBudget > 0 && (await this.probePeerSocketReachable(probeBudget))) {
         stderrLog("Reusing a peer daemon that became ready after our launch exited");
         return true;
+      }
+      // Socket not reachable yet. Use the process-table presence ONLY to decide whether
+      // to keep waiting: a live peer process means the socket is still coming up, so
+      // poll again; nothing coming up (genuine failure, or an orphaned socket inode with
+      // no listener and no backing process) fails promptly (#5878/#5904).
+      if (!peerProcessComingUp) {
+        return false;
       }
       const remaining = this.remainingTime(deadline);
       if (remaining === 0) {
@@ -1852,6 +1869,19 @@ export class DaemonManager implements DaemonManagerLike {
   }
 
   /**
+   * Observation-only, platform-aware reachability probe for the post-exit peer rejoin.
+   * Delegates to {@link DaemonSocketReachability}, which attempts a bare connection and
+   * reports reachable/not WITHOUT ever unlinking or stale-cleaning the socket — unlike
+   * {@link DaemonClient.connect}, whose `cleanupStaleSocketIfDaemonDead` path could
+   * delete a live peer's endpoint when the PID file records the just-exited child
+   * (issue #6103). Extracted as its own method so tests can inject a fake reachability
+   * outcome without a real socket.
+   */
+  protected probePeerSocketReachable(timeoutMs: number): Promise<boolean> {
+    return this.peerSocketReachability.isReachable(this.socketPath, timeoutMs);
+  }
+
+  /**
    * Whether a peer daemon is genuinely coming up and worth waiting on: a live
    * AutoMobile daemon process is present in the table.
    *
@@ -1862,10 +1892,10 @@ export class DaemonManager implements DaemonManagerLike {
    * {@link tryJoinPeerDaemonAfterSpawnExit} poll out the full reachability budget
    * before failing, a delayed failure the prompt-failure invariant (#5878/#5904)
    * exists to prevent. The responding-listener case is handled directly by the
-   * {@link verifyDaemonConnection} join probe in that method, which returns success
-   * the instant the socket accepts — so a socket that actually has a listener is
-   * joined regardless of this gate, and a socket that does not is not waited on
-   * unless a live daemon process backs it.
+   * socket-first {@link probePeerSocketReachable} probe in that method, which returns
+   * success the instant the socket accepts — so a socket that actually has a listener is
+   * joined regardless of this gate, and a socket that does not is not waited on unless a
+   * live daemon process backs it.
    */
   private hasComingUpPeerDaemon(): boolean {
     try {
@@ -1882,20 +1912,6 @@ export class DaemonManager implements DaemonManagerLike {
       );
       return false;
     }
-  }
-
-  /**
-   * Whether the daemon socket path is worth a connect probe during the post-exit
-   * rejoin. On POSIX a Unix socket has a filesystem entry, so a missing path means
-   * nothing is listening yet and we skip the probe to avoid hammering a nonexistent
-   * socket with connect/backoff cycles. On Windows the socket is a NAMED PIPE with no
-   * filesystem entry — `existsSync` is always false there (mirroring
-   * {@link DaemonClient.isAvailable}'s `platform() !== "win32"` guard) — so skip the
-   * filesystem gate and let the connect attempt itself decide reachability, or a
-   * reachable Windows peer would never be probed or joined.
-   */
-  private socketPathWorthProbing(): boolean {
-    return process.platform === "win32" || existsSync(this.socketPath);
   }
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1869,6 +1869,21 @@ export class DaemonManager implements DaemonManagerLike {
         nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
       }
       if (!peerProcessComingUp) {
+        // The process scan is a best-effort snapshot that can miss (or fail to inspect)
+        // a peer that published its socket right after this iteration's probe. Do ONE
+        // final observation-only socket probe before abandoning, so a just-published
+        // winner is still joined rather than surfacing the loser's exit error (#6103).
+        const finalBudget = Math.min(
+          ABANDONED_WAIT_CONFIRM_TIMEOUT_MS,
+          this.remainingTime(deadline),
+        );
+        if (
+          finalBudget > 0 &&
+          (await this.peerSocketReachability.isReachable(this.socketPath, finalBudget))
+        ) {
+          stderrLog("Reusing a peer daemon that became ready after our launch exited");
+          return true;
+        }
         return false;
       }
       const remaining = this.remainingTime(deadline);

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -385,6 +385,17 @@ const ABANDONED_WAIT_CONFIRM_TIMEOUT_MS = 1000;
 const PEER_DAEMON_JOIN_POLL_MS = 100;
 
 /**
+ * How often the post-exit peer rejoin (issue #6103) re-runs the SYNCHRONOUS process-
+ * table scan that establishes "a live peer daemon is coming up". The scan
+ * (`ps`/PowerShell/CIM via {@link findLiveDaemonProcesses}) blocks the event loop, so
+ * running it every {@link PEER_DAEMON_JOIN_POLL_MS} poll would stall the loop for the
+ * whole budget. The per-iteration signal is the cheap socket connect probe; the
+ * process table is scanned once up front and then only at this coarser cadence, purely
+ * so a peer that DIES mid-wait still ends the loop rather than polling out the budget.
+ */
+const PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS = 1000;
+
+/**
  * Cadence at which the liveness watchdog re-samples the "keep waiting" predicate
  * while a full-budget readiness probe is in flight (issue #5904). A per-poll
  * precheck only samples liveness between probes; if the holder dies *during* a
@@ -1770,11 +1781,14 @@ export class DaemonManager implements DaemonManagerLike {
    * daemon is ready ~1s later. This bounded wait joins that winner instead.
    *
    * Prompt-failure invariant (issues #5878/#5904): the wait is GATED on a live
-   * AutoMobile daemon process being present in the table (see
-   * {@link hasComingUpPeerDaemon}) and gives up the instant none remains, so a
-   * GENUINE start failure — nothing coming up, or only an orphaned socket inode with
-   * no listener and no backing process — still fails immediately rather than burning
-   * the client's ~30s `tools/list` budget. `budgetMs` is the time REMAINING under the
+   * AutoMobile daemon process being present in the table (a SINGLE up-front
+   * {@link hasComingUpPeerDaemon} scan, re-checked only at
+   * {@link PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS} — not per poll — since that scan is a
+   * synchronous `ps`/PowerShell call), so a GENUINE start failure — nothing coming up,
+   * or only an orphaned socket inode with no listener and no backing process — still
+   * fails immediately rather than burning the client's ~30s `tools/list` budget; a peer
+   * that dies mid-wait ends the loop at the next re-check. `budgetMs` is the time
+   * REMAINING under the
    * caller's original start deadline (already capped at
    * {@link DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS}), so when launchAndWait already
    * consumed the client budget the caller passes a non-positive value and skips this
@@ -1788,8 +1802,16 @@ export class DaemonManager implements DaemonManagerLike {
   private async tryJoinPeerDaemonAfterSpawnExit(budgetMs: number): Promise<boolean> {
     const deadline = this.timer.now() + budgetMs;
 
+    // Establish "a live peer daemon is coming up" with a SINGLE up-front process-table
+    // scan, then re-check it only at PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS — never every
+    // iteration. That scan is a synchronous `ps`/PowerShell/CIM call that blocks the
+    // event loop, so re-running it each poll would stall the loop for the whole budget
+    // (issue #6103); the cheap per-iteration signal is the socket connect probe below.
+    let peerProcessComingUp = this.hasComingUpPeerDaemon();
+    let nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
+
     while (this.remainingTime(deadline) > 0) {
-      if (!this.hasComingUpPeerDaemon()) {
+      if (!peerProcessComingUp) {
         // No live daemon process is coming up: deliver the real subprocess-exit
         // failure now instead of holding the budget on nothing — or on an orphaned
         // socket inode with no listener and no backing process (#5878/#5904).
@@ -1797,10 +1819,9 @@ export class DaemonManager implements DaemonManagerLike {
       }
       // On POSIX, only probe once the socket inode exists: a live daemon that has not
       // yet published its Unix socket has nothing to connect to, and probing a missing
-      // path just burns the connect retry/backoff; the poll below re-checks liveness so
-      // a peer that dies mid-wait still ends the loop promptly. On Windows the socket is
-      // a named pipe with no filesystem entry, so that gate would never open — probe
-      // directly there (see {@link socketPathWorthProbing}). verifyDaemonConnection is
+      // path just burns the connect retry/backoff. On Windows the socket is a named
+      // pipe with no filesystem entry, so that gate would never open — probe directly
+      // there (see {@link socketPathWorthProbing}). verifyDaemonConnection is
       // non-destructive (never unlinks the socket), so a slow peer racing to bind is not
       // torn down here.
       const probeBudget = Math.min(ABANDONED_WAIT_CONFIRM_TIMEOUT_MS, this.remainingTime(deadline));
@@ -1817,6 +1838,14 @@ export class DaemonManager implements DaemonManagerLike {
         break;
       }
       await this.timer.sleep(Math.min(PEER_DAEMON_JOIN_POLL_MS, remaining));
+
+      // Coarse-cadence liveness re-check: cheap enough to run occasionally so a peer
+      // that dies mid-wait (and never publishes the socket) ends the loop before the
+      // full budget, without a synchronous scan on every poll.
+      if (this.timer.now() >= nextProcessScanAt) {
+        peerProcessComingUp = this.hasComingUpPeerDaemon();
+        nextProcessScanAt = this.timer.now() + PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS;
+      }
     }
 
     return false;

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -834,9 +834,11 @@ describe("DaemonManager readiness", () => {
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
       () => new Promise<boolean>(() => {}),
     );
-    // The peer publishes its socket shortly after our child exited.
+    // The peer publishes its socket shortly after our child exited: the inode
+    // appears and the readiness probe starts succeeding.
     fakeTimer.setTimeout(() => {
       peerSocketReady = true;
+      writeFileSync(socketPath, "peer socket placeholder");
     }, 500);
 
     try {
@@ -877,6 +879,49 @@ describe("DaemonManager readiness", () => {
         /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
       );
       // The genuine failure surfaces without arming any polling timer (no hang).
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+      expect(fakeTimer.getPendingSleepCount()).toBe(0);
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
+  test("fails promptly when only an orphaned socket inode remains after our subprocess exits (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    // A race winner bound the socket then died right after, leaving an orphaned
+    // socket inode with no listener — and our own child then exits 1.
+    spawner.onSpawn = (process) => {
+      writeFileSync(socketPath, "orphaned socket placeholder");
+      process.emit("exit", 1, null);
+    };
+
+    const manager = new DaemonManager(
+      // No listener: every readiness probe refuses to connect.
+      () => new ProbeClient(false),
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+    // No live daemon process backs the orphaned socket, so nothing is coming up.
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
+    try {
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
+      );
+      // The bare inode must NOT hold the reachability budget: no probe backoff and
+      // no poll sleep are armed, so the failure is prompt (#5878/#5904).
+      expect(existsSync(socketPath)).toBe(true);
       expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
       expect(fakeTimer.getPendingSleepCount()).toBe(0);
     } finally {

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -988,6 +988,110 @@ describe("DaemonManager readiness", () => {
     }
   });
 
+  test("probes and joins a Windows named-pipe peer that has no filesystem socket entry (#6103)", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const { lockPath, pidPath, socketPath } = createPaths();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const spawner = new FakeDaemonSpawner();
+      // Our child loses the race and exits 1; the peer is a reachable Windows named
+      // pipe with NO filesystem entry (writeFileSync is never called for socketPath).
+      spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
+
+      const clients: ProbeClient[] = [];
+      const manager = new DaemonManager(
+        () => {
+          const client = new ProbeClient(true);
+          clients.push(client);
+          return client;
+        },
+        undefined,
+        fakeTimer,
+        lockPath,
+        pidPath,
+        socketPath,
+        spawner,
+      );
+      let liveCalls = 0;
+      const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
+        liveCalls++;
+        return liveCalls <= 1 ? [] : [999999];
+      });
+      const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+        () => new Promise<boolean>(() => {}),
+      );
+
+      try {
+        // No filesystem socket entry exists, yet the reachable named-pipe peer must
+        // still be probed and joined rather than waited out (the existsSync gate would
+        // be permanently false on Windows).
+        expect(existsSync(socketPath)).toBe(false);
+        await expect(manager.start()).resolves.toBeUndefined();
+        expect(clients.some((client) => client.connectCallCount > 0)).toBe(true);
+        expect(spawner.process.signals).toEqual([]);
+      } finally {
+        readySpy.mockRestore();
+        liveSpy.mockRestore();
+      }
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
+  });
+
+  test("preserves the original spawn-exit diagnostic when peer discovery fails during recovery (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
+
+    const manager = new DaemonManager(
+      () => new ProbeClient(false),
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+    // Pre-spawn inspection succeeds (empty, so we spawn), but the recovery-path
+    // inspection throws transiently.
+    let findCalls = 0;
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockImplementation(() => {
+      findCalls++;
+      if (findCalls <= 1) {
+        return [];
+      }
+      throw new Error("Failed to inspect daemon process table: ps exploded");
+    });
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
+    try {
+      const surfaced = await manager.start().then(
+        () => {
+          throw new Error("start should have rejected");
+        },
+        (error: unknown) => (error instanceof Error ? error.message : String(error)),
+      );
+      // The original spawn-exit diagnostic (with its captured log excerpt) is surfaced,
+      // NOT the recovery-path inspection failure.
+      expect(surfaced).toMatch(/Daemon subprocess exited before becoming ready \(exit code 1\)/);
+      expect(surfaced).toContain("SQLITE_BUSY: database is locked");
+      expect(surfaced).not.toContain("Failed to inspect daemon process table");
+      // Recovery gave up immediately on the inspection failure — no poll armed.
+      expect(fakeTimer.getPendingSleepCount()).toBe(0);
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
   test("spawn failures preserve the raw spawn error", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -795,6 +795,96 @@ describe("DaemonManager readiness", () => {
     }
   });
 
+  test("joins a peer daemon that publishes the socket just after our subprocess exits (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    // Our spawned child loses the socket-ownership race and exits 1 with an empty
+    // launch log, exactly as observed in #6103.
+    spawner.onSpawn = (process) => process.emit("exit", 1, null);
+
+    // A peer client's same-version daemon is coming up: it publishes the shared
+    // socket a beat after our child died, so the readiness probe only succeeds once
+    // the peer is ready.
+    let peerSocketReady = false;
+    const clients: ProbeClient[] = [];
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(peerSocketReady);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+
+    // No live daemon before we spawn (so start() spawns our own child), but a peer
+    // daemon process is present afterwards while it finishes coming up.
+    let liveCalls = 0;
+    const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
+      liveCalls++;
+      return liveCalls <= 1 ? [] : [999999];
+    });
+    // Our own launch never reports ready — our child dies first.
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+    // The peer publishes its socket shortly after our child exited.
+    fakeTimer.setTimeout(() => {
+      peerSocketReady = true;
+    }, 500);
+
+    try {
+      await expect(manager.start()).resolves.toBeUndefined();
+      expect(clients.some((client) => client.connectCallCount > 0)).toBe(true);
+      // We must never terminate the peer daemon we joined.
+      expect(spawner.process.signals).toEqual([]);
+    } finally {
+      readySpy.mockRestore();
+      liveSpy.mockRestore();
+    }
+  });
+
+  test("still fails promptly when no peer daemon is coming up after our subprocess exits (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    spawner.onSpawn = (process) => process.emit("exit", 1, null);
+
+    const manager = new DaemonManager(
+      () => new ProbeClient(false),
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+    // No socket inode is created and no live daemon exists, so nothing is coming up.
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
+    try {
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
+      );
+      // The genuine failure surfaces without arming any polling timer (no hang).
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+      expect(fakeTimer.getPendingSleepCount()).toBe(0);
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
   test("spawn failures preserve the raw spawn error", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -6,7 +6,10 @@ import { writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manager";
-import { READINESS_PROBE_MAX_ATTEMPTS } from "../../src/daemon/constants";
+import {
+  DAEMON_STARTUP_TIMEOUT_MS,
+  READINESS_PROBE_MAX_ATTEMPTS,
+} from "../../src/daemon/constants";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import type { PidFileData } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -927,6 +930,61 @@ describe("DaemonManager readiness", () => {
     } finally {
       readySpy.mockRestore();
       findSpy.mockRestore();
+    }
+  });
+
+  test("skips the peer rejoin when the original start deadline is exhausted, so the diagnostic beats the client deadline (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    // A socket inode and a live peer process both remain after our launch, so the
+    // rejoin's own gate would let it run — a FRESH-budget rejoin would probe the
+    // socket (populating `clients`). The ONLY reason nothing gets probed must be the
+    // exhausted deadline.
+    spawner.onSpawn = () => {
+      writeFileSync(socketPath, "peer socket placeholder");
+    };
+
+    const clients: ProbeClient[] = [];
+    const manager = new DaemonManager(
+      () => {
+        // Never becomes ready, so start() still rejects; whether it is even
+        // constructed is the discriminator for "did the rejoin run".
+        const client = new ProbeClient(false);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+    // A live peer daemon process remains present after our launch.
+    let liveCalls = 0;
+    const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
+      liveCalls++;
+      return liveCalls <= 1 ? [] : [999999];
+    });
+    // Our own launch burns the entire client-facing startup budget, then times out.
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(async () => {
+      await fakeTimer.sleep(DAEMON_STARTUP_TIMEOUT_MS + 1);
+      return false;
+    });
+
+    try {
+      await expect(manager.start()).rejects.toThrow(/Daemon failed to start within \d+ms/);
+      // Rejoin skipped: no readiness probe ran, so no fresh reachability wait was
+      // armed after the budget was already spent — the diagnostic is not pushed past
+      // the client deadline (#5878/#5904).
+      expect(clients).toHaveLength(0);
+      expect(spawner.process.signals).toEqual(["SIGTERM"]);
+    } finally {
+      readySpy.mockRestore();
+      liveSpy.mockRestore();
     }
   });
 

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -94,6 +94,23 @@ class FakeDaemonSpawner implements DaemonProcessSpawner {
   }
 }
 
+/**
+ * Injects the observation-only peer-reachability outcome for the post-exit rejoin
+ * (issue #6103), so the loop logic (socket-first join, process gate, deadline headroom)
+ * can be driven deterministically without a real socket. `peerReachable` decides each
+ * probe's result; `probeCalls` records how many probes ran (0 proves the rejoin was
+ * skipped).
+ */
+class RejoinProbeDaemonManager extends DaemonManager {
+  peerReachable: () => boolean = () => false;
+  probeCalls = 0;
+
+  protected override probePeerSocketReachable(_timeoutMs: number): Promise<boolean> {
+    this.probeCalls++;
+    return Promise.resolve(this.peerReachable());
+  }
+}
+
 describe("DaemonManager readiness", () => {
   const tempDirs: string[] = [];
   const servers: Server[] = [];
@@ -798,32 +815,16 @@ describe("DaemonManager readiness", () => {
     }
   });
 
-  test("joins a peer daemon that publishes the socket just after our subprocess exits (#6103)", async () => {
+  test("joins a peer daemon that becomes reachable just after our subprocess exits (#6103)", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const spawner = new FakeDaemonSpawner();
-    // Our spawned child loses the socket-ownership race and exits 1; the race winner
-    // has bound the shared socket by then, so its inode is present.
-    spawner.onSpawn = (daemonProcess) => {
-      writeFileSync(socketPath, "peer socket placeholder");
-      daemonProcess.emit("exit", 1, null);
-    };
+    // Our spawned child loses the socket-ownership race and exits 1.
+    spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    // The peer's listener only starts accepting a beat later: the first readiness pass
-    // (up to READINESS_PROBE_MAX_ATTEMPTS clients) is refused and a later pass succeeds.
-    // Keying this off the probe count — which happens strictly during the rejoin, after
-    // the spawn is wired up — keeps ordering deterministic, rather than racing a
-    // pre-registered auto-advance timer against the spawner's own setImmediate.
-    let probeClientsCreated = 0;
-    const clients: ProbeClient[] = [];
-    const manager = new DaemonManager(
-      () => {
-        probeClientsCreated++;
-        const client = new ProbeClient(probeClientsCreated > READINESS_PROBE_MAX_ATTEMPTS);
-        clients.push(client);
-        return client;
-      },
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
       undefined,
       fakeTimer,
       lockPath,
@@ -831,6 +832,9 @@ describe("DaemonManager readiness", () => {
       socketPath,
       spawner,
     );
+    // The peer's listener only starts accepting a beat later: the observation-only
+    // socket probe is refused the first time and reachable on the second.
+    manager.peerReachable = () => manager.probeCalls >= 2;
 
     // No live daemon before we spawn (so start() spawns our own child), but a peer
     // daemon process is present afterwards while it finishes coming up.
@@ -846,13 +850,13 @@ describe("DaemonManager readiness", () => {
 
     try {
       await expect(manager.start()).resolves.toBeUndefined();
-      expect(clients.some((client) => client.connectCallCount > 0)).toBe(true);
+      expect(manager.probeCalls).toBeGreaterThanOrEqual(2);
       // We must never terminate the peer daemon we joined.
       expect(spawner.process.signals).toEqual([]);
-      // The expensive synchronous process scan runs once pre-spawn and once up front in
-      // the rejoin — NOT on every poll iteration (issue #6103). The join completes well
-      // within the coarse re-scan interval, so exactly two scans occur; a per-iteration
-      // scan would push this higher.
+      // The synchronous process scan runs once pre-spawn and once up front in the rejoin
+      // — NOT on every poll iteration (issue #6103). The join completes well within the
+      // coarse re-scan interval, so exactly two scans occur; a per-iteration scan would
+      // push this higher.
       expect(liveCalls).toBe(2);
     } finally {
       readySpy.mockRestore();
@@ -865,10 +869,10 @@ describe("DaemonManager readiness", () => {
     const fakeTimer = new FakeTimer();
     const spawner = new FakeDaemonSpawner();
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
-    spawner.onSpawn = (process) => process.emit("exit", 1, null);
+    spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new DaemonManager(
-      () => new ProbeClient(false),
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
       undefined,
       fakeTimer,
       lockPath,
@@ -876,7 +880,8 @@ describe("DaemonManager readiness", () => {
       socketPath,
       spawner,
     );
-    // No socket inode is created and no live daemon exists, so nothing is coming up.
+    manager.peerReachable = () => false; // socket never reachable
+    // No live daemon exists, so nothing is coming up.
     const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
       () => new Promise<boolean>(() => {}),
@@ -886,7 +891,8 @@ describe("DaemonManager readiness", () => {
       await expect(manager.start()).rejects.toThrow(
         /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
       );
-      // The genuine failure surfaces without arming any polling timer (no hang).
+      // Socket unreachable and no live peer process: fails without arming any polling
+      // timer (no hang).
       expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
       expect(fakeTimer.getPendingSleepCount()).toBe(0);
     } finally {
@@ -895,21 +901,15 @@ describe("DaemonManager readiness", () => {
     }
   });
 
-  test("fails promptly when only an orphaned socket inode remains after our subprocess exits (#6103)", async () => {
+  test("joins via the authoritative socket probe even when the process scan misses the peer (#6103)", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
     const spawner = new FakeDaemonSpawner();
-    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
-    // A race winner bound the socket then died right after, leaving an orphaned
-    // socket inode with no listener — and our own child then exits 1.
-    spawner.onSpawn = (process) => {
-      writeFileSync(socketPath, "orphaned socket placeholder");
-      process.emit("exit", 1, null);
-    };
+    spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new DaemonManager(
-      // No listener: every readiness probe refuses to connect.
-      () => new ProbeClient(false),
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
       undefined,
       fakeTimer,
       lockPath,
@@ -917,21 +917,20 @@ describe("DaemonManager readiness", () => {
       socketPath,
       spawner,
     );
-    // No live daemon process backs the orphaned socket, so nothing is coming up.
+    // The peer is already accepting on the socket...
+    manager.peerReachable = () => true;
+    // ...but the best-effort process scan never sees it (a transient miss). Socket
+    // reachability is authoritative, so the peer must still be joined — the scan result
+    // only governs whether to KEEP WAITING after a probe miss.
     const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
       () => new Promise<boolean>(() => {}),
     );
 
     try {
-      await expect(manager.start()).rejects.toThrow(
-        /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
-      );
-      // The bare inode must NOT hold the reachability budget: no probe backoff and
-      // no poll sleep are armed, so the failure is prompt (#5878/#5904).
-      expect(existsSync(socketPath)).toBe(true);
-      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
-      expect(fakeTimer.getPendingSleepCount()).toBe(0);
+      await expect(manager.start()).resolves.toBeUndefined();
+      expect(manager.probeCalls).toBeGreaterThanOrEqual(1);
+      expect(spawner.process.signals).toEqual([]);
     } finally {
       readySpy.mockRestore();
       findSpy.mockRestore();
@@ -944,23 +943,9 @@ describe("DaemonManager readiness", () => {
     fakeTimer.enableAutoAdvance();
     const spawner = new FakeDaemonSpawner();
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
-    // A socket inode and a live peer process both remain after our launch, so the
-    // rejoin's own gate would let it run — a FRESH-budget rejoin would probe the
-    // socket (populating `clients`). The ONLY reason nothing gets probed must be the
-    // exhausted deadline.
-    spawner.onSpawn = () => {
-      writeFileSync(socketPath, "peer socket placeholder");
-    };
 
-    const clients: ProbeClient[] = [];
-    const manager = new DaemonManager(
-      () => {
-        // Never becomes ready, so start() still rejects; whether it is even
-        // constructed is the discriminator for "did the rejoin run".
-        const client = new ProbeClient(false);
-        clients.push(client);
-        return client;
-      },
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
       undefined,
       fakeTimer,
       lockPath,
@@ -968,7 +953,9 @@ describe("DaemonManager readiness", () => {
       socketPath,
       spawner,
     );
-    // A live peer daemon process remains present after our launch.
+    // A reachable peer would be joined if probed — the ONLY reason nothing gets probed
+    // must be the exhausted deadline.
+    manager.peerReachable = () => true;
     let liveCalls = 0;
     const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
       liveCalls++;
@@ -982,10 +969,9 @@ describe("DaemonManager readiness", () => {
 
     try {
       await expect(manager.start()).rejects.toThrow(/Daemon failed to start within \d+ms/);
-      // Rejoin skipped: no readiness probe ran, so no fresh reachability wait was
-      // armed after the budget was already spent — the diagnostic is not pushed past
-      // the client deadline (#5878/#5904).
-      expect(clients).toHaveLength(0);
+      // Rejoin skipped: the socket was never probed, so no fresh reachability wait was
+      // armed after the budget was already spent (#5878/#5904).
+      expect(manager.probeCalls).toBe(0);
       expect(spawner.process.signals).toEqual(["SIGTERM"]);
     } finally {
       readySpy.mockRestore();
@@ -993,57 +979,56 @@ describe("DaemonManager readiness", () => {
     }
   });
 
-  test("probes and joins a Windows named-pipe peer that has no filesystem socket entry (#6103)", async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  test("reserves delivery headroom: skips the near-deadline rejoin so the diagnostic beats the deadline (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    // Our child exits only near the deadline: it burns all but ~1s of the ~30s start
+    // budget, then exits 1. Scheduling the exit inside onSpawn (after the spawn is wired
+    // up) keeps ordering deterministic. This leaves a SMALL positive remainder under the
+    // start deadline — less than the delivery headroom — at the point of the rejoin.
+    spawner.onSpawn = (daemonProcess) => {
+      fakeTimer.setTimeout(
+        () => daemonProcess.emit("exit", 1, null),
+        DAEMON_STARTUP_TIMEOUT_MS - 1000,
+      );
+    };
+
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+    );
+    // The socket never becomes reachable, and a live peer process is present — so a
+    // rejoin that ran would poll out its remaining budget and rethrow AT the deadline.
+    manager.peerReachable = () => false;
+    let liveCalls = 0;
+    const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
+      liveCalls++;
+      return liveCalls <= 1 ? [] : [999999];
+    });
+    // Our launch never reports ready on its own — the delayed child exit is what ends it.
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
     try {
-      const { lockPath, pidPath, socketPath } = createPaths();
-      const fakeTimer = new FakeTimer();
-      fakeTimer.enableAutoAdvance();
-      const spawner = new FakeDaemonSpawner();
-      // Our child loses the race and exits 1; the peer is a reachable Windows named
-      // pipe with NO filesystem entry (writeFileSync is never called for socketPath).
-      spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
-
-      const clients: ProbeClient[] = [];
-      const manager = new DaemonManager(
-        () => {
-          const client = new ProbeClient(true);
-          clients.push(client);
-          return client;
-        },
-        undefined,
-        fakeTimer,
-        lockPath,
-        pidPath,
-        socketPath,
-        spawner,
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess exited before becoming ready \(exit code 1\)[\s\S]*SQLITE_BUSY: database is locked/,
       );
-      let liveCalls = 0;
-      const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
-        liveCalls++;
-        return liveCalls <= 1 ? [] : [999999];
-      });
-      const readySpy = spyOn(manager, "waitForReady").mockImplementation(
-        () => new Promise<boolean>(() => {}),
-      );
-
-      try {
-        // No filesystem socket entry exists, yet the reachable named-pipe peer must
-        // still be probed and joined rather than waited out (the existsSync gate would
-        // be permanently false on Windows).
-        expect(existsSync(socketPath)).toBe(false);
-        await expect(manager.start()).resolves.toBeUndefined();
-        expect(clients.some((client) => client.connectCallCount > 0)).toBe(true);
-        expect(spawner.process.signals).toEqual([]);
-      } finally {
-        readySpy.mockRestore();
-        liveSpy.mockRestore();
-      }
+      // Skipped even though positive time remained (unlike the fully-exhausted case),
+      // because that remainder was below the delivery-headroom reserve — so the
+      // diagnostic is delivered with headroom rather than raced against the deadline.
+      expect(manager.probeCalls).toBe(0);
     } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, "platform", originalPlatform);
-      }
+      readySpy.mockRestore();
+      liveSpy.mockRestore();
     }
   });
 
@@ -1054,8 +1039,8 @@ describe("DaemonManager readiness", () => {
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
     spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new DaemonManager(
-      () => new ProbeClient(false),
+    const manager = new RejoinProbeDaemonManager(
+      undefined,
       undefined,
       fakeTimer,
       lockPath,
@@ -1063,6 +1048,7 @@ describe("DaemonManager readiness", () => {
       socketPath,
       spawner,
     );
+    manager.peerReachable = () => false; // socket not reachable
     // Pre-spawn inspection succeeds (empty, so we spawn), but the recovery-path
     // inspection throws transiently.
     let findCalls = 0;
@@ -1089,7 +1075,7 @@ describe("DaemonManager readiness", () => {
       expect(surfaced).toMatch(/Daemon subprocess exited before becoming ready \(exit code 1\)/);
       expect(surfaced).toContain("SQLITE_BUSY: database is locked");
       expect(surfaced).not.toContain("Failed to inspect daemon process table");
-      // Recovery gave up immediately on the inspection failure — no poll armed.
+      // Recovery gave up without arming a poll after the inspection failure.
       expect(fakeTimer.getPendingSleepCount()).toBe(0);
     } finally {
       readySpy.mockRestore();

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -11,6 +11,7 @@ import {
   READINESS_PROBE_MAX_ATTEMPTS,
 } from "../../src/daemon/constants";
 import type { DaemonClientLike } from "../../src/daemon/client";
+import type { DaemonSocketReachabilityLike } from "../../src/daemon/daemonSocketReachability";
 import type { PidFileData } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
@@ -95,20 +96,49 @@ class FakeDaemonSpawner implements DaemonProcessSpawner {
 }
 
 /**
- * Injects the observation-only peer-reachability outcome for the post-exit rejoin
- * (issue #6103), so the loop logic (socket-first join, process gate, deadline headroom)
- * can be driven deterministically without a real socket. `peerReachable` decides each
- * probe's result; `probeCalls` records how many probes ran (0 proves the rejoin was
- * skipped).
+ * Injected fake for the observation-only peer-reachability probe (issue #6103), so the
+ * rejoin loop (socket-first join, process gate, deadline headroom) can be driven
+ * deterministically without a real socket — and so the REAL probe path is never armed
+ * with a real 1s timer under a FakeTimer. `reachable` decides each probe's result;
+ * `calls` records how many probes ran (0 proves the rejoin was skipped).
  */
-class RejoinProbeDaemonManager extends DaemonManager {
-  peerReachable: () => boolean = () => false;
-  probeCalls = 0;
+class FakePeerSocketReachability implements DaemonSocketReachabilityLike {
+  reachable: () => boolean = () => false;
+  calls = 0;
 
-  protected override probePeerSocketReachable(_timeoutMs: number): Promise<boolean> {
-    this.probeCalls++;
-    return Promise.resolve(this.peerReachable());
+  isReachable(_socketPath: string, _timeoutMs: number): Promise<boolean> {
+    this.calls++;
+    return Promise.resolve(this.reachable());
   }
+}
+
+/**
+ * Constructs a DaemonManager with the injected peer-reachability probe at its
+ * constructor position, keeping the rejoin tests readable despite the long signature.
+ */
+function createRejoinManager(args: {
+  timer: FakeTimer;
+  lockPath: string;
+  pidPath: string;
+  socketPath: string;
+  spawner: FakeDaemonSpawner;
+  reachability: DaemonSocketReachabilityLike;
+}): DaemonManager {
+  return new DaemonManager(
+    undefined,
+    undefined,
+    args.timer,
+    args.lockPath,
+    args.pidPath,
+    args.socketPath,
+    args.spawner,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    args.reachability,
+  );
 }
 
 describe("DaemonManager readiness", () => {
@@ -823,18 +853,18 @@ describe("DaemonManager readiness", () => {
     // Our spawned child loses the socket-ownership race and exits 1.
     spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    // The peer's listener only starts accepting a beat later: the observation-only
+    // socket probe is refused the first time and reachable on the second.
+    const reachability = new FakePeerSocketReachability();
+    reachability.reachable = () => reachability.calls >= 2;
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    // The peer's listener only starts accepting a beat later: the observation-only
-    // socket probe is refused the first time and reachable on the second.
-    manager.peerReachable = () => manager.probeCalls >= 2;
+      reachability,
+    });
 
     // No live daemon before we spawn (so start() spawns our own child), but a peer
     // daemon process is present afterwards while it finishes coming up.
@@ -850,13 +880,12 @@ describe("DaemonManager readiness", () => {
 
     try {
       await expect(manager.start()).resolves.toBeUndefined();
-      expect(manager.probeCalls).toBeGreaterThanOrEqual(2);
+      expect(reachability.calls).toBeGreaterThanOrEqual(2);
       // We must never terminate the peer daemon we joined.
       expect(spawner.process.signals).toEqual([]);
-      // The synchronous process scan runs once pre-spawn and once up front in the rejoin
-      // — NOT on every poll iteration (issue #6103). The join completes well within the
-      // coarse re-scan interval, so exactly two scans occur; a per-iteration scan would
-      // push this higher.
+      // The synchronous process scan runs once pre-spawn and once in the rejoin (after
+      // the first probe miss) — NOT on every poll iteration (issue #6103). The join
+      // completes within the coarse re-scan interval, so exactly two scans occur.
       expect(liveCalls).toBe(2);
     } finally {
       readySpy.mockRestore();
@@ -871,16 +900,15 @@ describe("DaemonManager readiness", () => {
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
     spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    const reachability = new FakePeerSocketReachability(); // socket never reachable
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    manager.peerReachable = () => false; // socket never reachable
+      reachability,
+    });
     // No live daemon exists, so nothing is coming up.
     const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
@@ -901,35 +929,42 @@ describe("DaemonManager readiness", () => {
     }
   });
 
-  test("joins via the authoritative socket probe even when the process scan misses the peer (#6103)", async () => {
+  test("probes the socket BEFORE the process scan and joins without scanning when it answers (#6103)", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const spawner = new FakeDaemonSpawner();
     spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    // The peer is already accepting on the socket.
+    const reachability = new FakePeerSocketReachability();
+    reachability.reachable = () => true;
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    // The peer is already accepting on the socket...
-    manager.peerReachable = () => true;
-    // ...but the best-effort process scan never sees it (a transient miss). Socket
-    // reachability is authoritative, so the peer must still be joined — the scan result
-    // only governs whether to KEEP WAITING after a probe miss.
-    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+      reachability,
+    });
+    // The (synchronous, possibly-stalling) process scan must never run before the
+    // authoritative socket probe. Count every scan; with a reachable socket the rejoin
+    // must join on the probe and never scan, so only the single pre-spawn scan occurs.
+    let scanCalls = 0;
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockImplementation(() => {
+      scanCalls++;
+      return [];
+    });
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
       () => new Promise<boolean>(() => {}),
     );
 
     try {
       await expect(manager.start()).resolves.toBeUndefined();
-      expect(manager.probeCalls).toBeGreaterThanOrEqual(1);
+      expect(reachability.calls).toBeGreaterThanOrEqual(1);
+      // Exactly one scan (the pre-spawn reuse check); the rejoin joined via the probe
+      // without ever consulting the scan — proving socket-first ordering.
+      expect(scanCalls).toBe(1);
       expect(spawner.process.signals).toEqual([]);
     } finally {
       readySpy.mockRestore();
@@ -944,18 +979,18 @@ describe("DaemonManager readiness", () => {
     const spawner = new FakeDaemonSpawner();
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    // A reachable peer would be joined if probed — the ONLY reason nothing gets probed
+    // must be the exhausted deadline.
+    const reachability = new FakePeerSocketReachability();
+    reachability.reachable = () => true;
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    // A reachable peer would be joined if probed — the ONLY reason nothing gets probed
-    // must be the exhausted deadline.
-    manager.peerReachable = () => true;
+      reachability,
+    });
     let liveCalls = 0;
     const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
       liveCalls++;
@@ -971,7 +1006,7 @@ describe("DaemonManager readiness", () => {
       await expect(manager.start()).rejects.toThrow(/Daemon failed to start within \d+ms/);
       // Rejoin skipped: the socket was never probed, so no fresh reachability wait was
       // armed after the budget was already spent (#5878/#5904).
-      expect(manager.probeCalls).toBe(0);
+      expect(reachability.calls).toBe(0);
       expect(spawner.process.signals).toEqual(["SIGTERM"]);
     } finally {
       readySpy.mockRestore();
@@ -996,18 +1031,17 @@ describe("DaemonManager readiness", () => {
       );
     };
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    // The socket never becomes reachable, and a live peer process is present — so a
+    // rejoin that ran would poll out its remaining budget and rethrow AT the deadline.
+    const reachability = new FakePeerSocketReachability();
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    // The socket never becomes reachable, and a live peer process is present — so a
-    // rejoin that ran would poll out its remaining budget and rethrow AT the deadline.
-    manager.peerReachable = () => false;
+      reachability,
+    });
     let liveCalls = 0;
     const liveSpy = spyOn(manager, "findLiveDaemonProcesses").mockImplementation(() => {
       liveCalls++;
@@ -1025,7 +1059,7 @@ describe("DaemonManager readiness", () => {
       // Skipped even though positive time remained (unlike the fully-exhausted case),
       // because that remainder was below the delivery-headroom reserve — so the
       // diagnostic is delivered with headroom rather than raced against the deadline.
-      expect(manager.probeCalls).toBe(0);
+      expect(reachability.calls).toBe(0);
     } finally {
       readySpy.mockRestore();
       liveSpy.mockRestore();
@@ -1039,16 +1073,15 @@ describe("DaemonManager readiness", () => {
     spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
     spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
 
-    const manager = new RejoinProbeDaemonManager(
-      undefined,
-      undefined,
-      fakeTimer,
+    const reachability = new FakePeerSocketReachability(); // socket not reachable
+    const manager = createRejoinManager({
+      timer: fakeTimer,
       lockPath,
       pidPath,
       socketPath,
       spawner,
-    );
-    manager.peerReachable = () => false; // socket not reachable
+      reachability,
+    });
     // Pre-spawn inspection succeeds (empty, so we spawn), but the recovery-path
     // inspection throws transiently.
     let findCalls = 0;

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -972,6 +972,44 @@ describe("DaemonManager readiness", () => {
     }
   });
 
+  test("does one final socket probe before abandoning when the scan misses a just-published peer (#6103)", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.onSpawn = (daemonProcess) => daemonProcess.emit("exit", 1, null);
+
+    // The peer publishes its socket right after the first probe: reachable only on the
+    // SECOND probe, which is the final probe taken after the (missing) scan.
+    const reachability = new FakePeerSocketReachability();
+    reachability.reachable = () => reachability.calls >= 2;
+    const manager = createRejoinManager({
+      timer: fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner,
+      reachability,
+    });
+    // The best-effort process scan misses the peer entirely (returns empty). Without a
+    // final probe, the rejoin would abandon on this snapshot even though the winner is
+    // now accepting.
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
+    try {
+      await expect(manager.start()).resolves.toBeUndefined();
+      // Two probes: the first (miss) and the final probe after the empty scan (join).
+      expect(reachability.calls).toBe(2);
+      expect(spawner.process.signals).toEqual([]);
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
   test("skips the peer rejoin when the original start deadline is exhausted, so the diagnostic beats the client deadline (#6103)", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -803,18 +803,24 @@ describe("DaemonManager readiness", () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const spawner = new FakeDaemonSpawner();
-    // Our spawned child loses the socket-ownership race and exits 1 with an empty
-    // launch log, exactly as observed in #6103.
-    spawner.onSpawn = (process) => process.emit("exit", 1, null);
+    // Our spawned child loses the socket-ownership race and exits 1; the race winner
+    // has bound the shared socket by then, so its inode is present.
+    spawner.onSpawn = (daemonProcess) => {
+      writeFileSync(socketPath, "peer socket placeholder");
+      daemonProcess.emit("exit", 1, null);
+    };
 
-    // A peer client's same-version daemon is coming up: it publishes the shared
-    // socket a beat after our child died, so the readiness probe only succeeds once
-    // the peer is ready.
-    let peerSocketReady = false;
+    // The peer's listener only starts accepting a beat later: the first readiness pass
+    // (up to READINESS_PROBE_MAX_ATTEMPTS clients) is refused and a later pass succeeds.
+    // Keying this off the probe count — which happens strictly during the rejoin, after
+    // the spawn is wired up — keeps ordering deterministic, rather than racing a
+    // pre-registered auto-advance timer against the spawner's own setImmediate.
+    let probeClientsCreated = 0;
     const clients: ProbeClient[] = [];
     const manager = new DaemonManager(
       () => {
-        const client = new ProbeClient(peerSocketReady);
+        probeClientsCreated++;
+        const client = new ProbeClient(probeClientsCreated > READINESS_PROBE_MAX_ATTEMPTS);
         clients.push(client);
         return client;
       },
@@ -837,18 +843,17 @@ describe("DaemonManager readiness", () => {
     const readySpy = spyOn(manager, "waitForReady").mockImplementation(
       () => new Promise<boolean>(() => {}),
     );
-    // The peer publishes its socket shortly after our child exited: the inode
-    // appears and the readiness probe starts succeeding.
-    fakeTimer.setTimeout(() => {
-      peerSocketReady = true;
-      writeFileSync(socketPath, "peer socket placeholder");
-    }, 500);
 
     try {
       await expect(manager.start()).resolves.toBeUndefined();
       expect(clients.some((client) => client.connectCallCount > 0)).toBe(true);
       // We must never terminate the peer daemon we joined.
       expect(spawner.process.signals).toEqual([]);
+      // The expensive synchronous process scan runs once pre-spawn and once up front in
+      // the rejoin — NOT on every poll iteration (issue #6103). The join completes well
+      // within the coarse re-scan interval, so exactly two scans occur; a per-iteration
+      // scan would push this higher.
+      expect(liveCalls).toBe(2);
     } finally {
       readySpy.mockRestore();
       liveSpy.mockRestore();

--- a/test/daemon/daemonSocketReachability.test.ts
+++ b/test/daemon/daemonSocketReachability.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DaemonSocketReachability,
+  type DaemonSocketConnectAttempt,
+} from "../../src/daemon/daemonSocketReachability";
+import { cleanupStaleDaemonFilesForDeadPidSync } from "../../src/daemon/daemonFiles";
+import type { PidFileData } from "../../src/daemon/types";
+
+describe("DaemonSocketReachability", () => {
+  const tempDirs: string[] = [];
+  const servers: Server[] = [];
+
+  function createTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-reachability-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+    );
+    servers.length = 0;
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("attempts the connection on Windows even though the named pipe has no filesystem entry (#6103 #1)", async () => {
+    let connectCalls = 0;
+    const connectAttempt: DaemonSocketConnectAttempt = async () => {
+      connectCalls++;
+      return true;
+    };
+    const reachability = new DaemonSocketReachability({
+      platform: "win32",
+      // A named pipe never has a filesystem entry, so existsSync is always false.
+      existsSyncFn: () => false,
+      connectAttempt,
+    });
+
+    await expect(reachability.isReachable("\\\\.\\pipe\\auto-mobile", 500)).resolves.toBe(true);
+    // The FS gate must be bypassed on Windows — the connection is what decides.
+    expect(connectCalls).toBe(1);
+  });
+
+  test("skips the connect on POSIX when the socket path is missing", async () => {
+    let connectCalls = 0;
+    const connectAttempt: DaemonSocketConnectAttempt = async () => {
+      connectCalls++;
+      return true;
+    };
+    const reachability = new DaemonSocketReachability({
+      platform: "linux",
+      existsSyncFn: () => false,
+      connectAttempt,
+    });
+
+    await expect(reachability.isReachable("/tmp/missing.sock", 500)).resolves.toBe(false);
+    // A missing Unix socket must not be hammered with a connect attempt.
+    expect(connectCalls).toBe(0);
+  });
+
+  test("reports reachable on POSIX when the socket exists and the connect succeeds", async () => {
+    const reachability = new DaemonSocketReachability({
+      platform: "linux",
+      existsSyncFn: () => true,
+      connectAttempt: async () => true,
+    });
+
+    await expect(reachability.isReachable("/tmp/present.sock", 500)).resolves.toBe(true);
+  });
+
+  test("returns false without attempting a connect when the budget is non-positive", async () => {
+    let connectCalls = 0;
+    const reachability = new DaemonSocketReachability({
+      platform: "linux",
+      existsSyncFn: () => true,
+      connectAttempt: async () => {
+        connectCalls++;
+        return true;
+      },
+    });
+
+    await expect(reachability.isReachable("/tmp/present.sock", 0)).resolves.toBe(false);
+    expect(connectCalls).toBe(0);
+  });
+
+  test("never unlinks the socket file on a refused connection, unlike the cleanup-capable primitive it replaced (#6103 #2)", async () => {
+    const dir = createTempDir();
+    const socketPath = join(dir, "peer.sock");
+    const pidPath = join(dir, "daemon.pid");
+    // A stale socket inode is present but nothing is listening (a race winner that
+    // bound then died), and the PID file records a now-dead process.
+    writeFileSync(socketPath, "stale socket placeholder");
+    const pidData: PidFileData = {
+      pid: 2147483646,
+      socketPath,
+      port: 0,
+      startedAt: 0,
+      version: "test",
+    };
+    writeFileSync(pidPath, JSON.stringify(pidData), { mode: 0o600 });
+
+    // Observation-only probe: the connection is refused, but the socket file is left
+    // completely untouched. The probe has no filesystem-mutating code path at all.
+    const reachability = new DaemonSocketReachability({
+      platform: "linux",
+      existsSyncFn: () => true,
+      connectAttempt: async () => false,
+    });
+    await expect(reachability.isReachable(socketPath, 500)).resolves.toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+
+    // Contrast — the danger this replaces: the cleanup-capable recovery primitive the
+    // rejoin used to reach (via DaemonClient.connect) DELETES that same live-race
+    // endpoint on a dead-PID record. If the probe were implemented via that path, the
+    // assertion above would go red.
+    const unlinked = cleanupStaleDaemonFilesForDeadPidSync({
+      pidFilePath: pidPath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => false,
+    });
+    expect(unlinked).toBe(true);
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  // Gated off Windows: net.Server.listen(path) there is a named pipe, not a filesystem
+  // socket inode, so this real-connect happy path cannot be set up the same way.
+  test.skipIf(process.platform === "win32")(
+    "reports reachable through a real connection to a listening socket",
+    async () => {
+      const dir = createTempDir();
+      const socketPath = join(dir, "listening.sock");
+      const server = createServer();
+      servers.push(server);
+      await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+      // Default (real) connect attempt against a genuinely listening socket.
+      const reachability = new DaemonSocketReachability({ platform: process.platform });
+      await expect(reachability.isReachable(socketPath, 500)).resolves.toBe(true);
+      expect(existsSync(socketPath)).toBe(true);
+    },
+  );
+});

--- a/test/daemon/daemonSocketReachability.test.ts
+++ b/test/daemon/daemonSocketReachability.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../../src/daemon/daemonSocketReachability";
 import { cleanupStaleDaemonFilesForDeadPidSync } from "../../src/daemon/daemonFiles";
 import type { PidFileData } from "../../src/daemon/types";
+import type { Timer } from "../../src/utils/SystemTimer";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("DaemonSocketReachability", () => {
   const tempDirs: string[] = [];
@@ -74,6 +76,26 @@ describe("DaemonSocketReachability", () => {
     });
 
     await expect(reachability.isReachable("/tmp/present.sock", 500)).resolves.toBe(true);
+  });
+
+  test("threads the injected timer through to the connect attempt (#6103)", async () => {
+    // Proves the manager's `new DaemonSocketReachability({ timer })` wiring reaches the
+    // connect layer, so a slow probe under a FakeTimer advances the fake clock rather
+    // than blocking on real wall-clock.
+    const fakeTimer = new FakeTimer();
+    let receivedTimer: Timer | undefined;
+    const reachability = new DaemonSocketReachability({
+      platform: "linux",
+      existsSyncFn: () => true,
+      timer: fakeTimer,
+      connectAttempt: async (_socketPath, _timeoutMs, timer) => {
+        receivedTimer = timer;
+        return false;
+      },
+    });
+
+    await reachability.isReachable("/tmp/present.sock", 500);
+    expect(receivedTimer).toBe(fakeTimer);
   });
 
   test("returns false without attempting a connect when the budget is non-positive", async () => {


### PR DESCRIPTION
## Summary

When multiple MCP proxy clients cold-start against one AutoMobile daemon namespace, only one spawned daemon child can win ownership of the per-user Unix socket. A losing child exits (often with a zero-byte `daemon-launch-<pid>.log`) a beat before the winner publishes the socket. The manager surfaced that lost race as a terminal `Daemon subprocess exited before becoming ready (exit code 1)`, stranding the caller even though a healthy same-namespace daemon reported `Daemon started` ~1s later on the expected socket.

This makes the caller that hits "subprocess exited before ready" **re-check and rejoin** a peer daemon that is coming up on the shared socket, instead of failing terminally — while keeping a *genuine* start failure prompt.

## Linked Issue

Closes #6103

## Bug / Regression Context

- **Observed symptom:** a `listDeviceImages` request failed at `20:51:11.016Z` with `Daemon subprocess exited before becoming ready (exit code 1)` and an empty launch log, while a same-version daemon logged `Daemon started` at `20:51:12.141Z` on the same socket namespace. The caller could not distinguish a permanent failure from this transient race.
- **Repro steps / conditions:** two or more proxy clients cold-start concurrently; the lock holder's spawned child loses the in-daemon socket-ownership race and exits 1 before a peer publishes the socket.

## Reproduced mechanism

`DaemonManager.startUnlocked` spawns the daemon via `DaemonLauncher.launchAndWait`. On the child's early `exit`, `launchAndWait` rejects with the exit failure (`src/daemon/DaemonLauncher.ts:178`, `formatExitFailure` → `manager.createDaemonExitFailure`), and `startUnlocked` propagated it as terminal. The pre-spawn `findLiveDaemonProcesses` reuse check (`manager.ts:753`) runs *before* the peer exists, so it doesn't catch a peer that comes up during our own doomed launch. Unlike the follower path (`startByAwaitingLockHolder` / `waitForLockHolderReadiness`, which already re-arbitrate and confirm reachability for #5664/#5878/#5904), the lock-*holder's* own launch had no post-exit rejoin — so it lost the race and gave up.

The red-first test reproduces it deterministically with FakeTimer: our spawned child emits `exit(1)`, a peer's readiness probe only succeeds shortly after (500ms), and on current `main` `manager.start()` rejects (terminal error). See `test/daemon/daemonManagerReadiness.integration.test.ts` → *"joins a peer daemon that publishes the socket just after our subprocess exits (#6103)"*.

## Fix

A bounded rejoin (`DaemonManager.tryJoinPeerDaemonAfterSpawnExit`), invoked only when `launchAndWait` throws, that probes with a new **observation-only, socket-first, platform-aware** reachability check (`DaemonSocketReachability`):

- **Observation-only — never unlinks the socket.** The rejoin no longer probes via `DaemonClient.connect`, whose `cleanupStaleSocketIfDaemonDead` path can **delete** the shared socket on a transient refusal when the PID file records the just-exited child — which in a cross-checkout race deletes the *live winner's* endpoint and strands every client. `DaemonSocketReachability` attempts a bare connection and reports reachable/not with zero socket-file side effects. Joins, never spawns.
- **Platform-aware at the connection layer.** `DaemonClient.connectOnce` rejects on `existsSync()` before connecting, so a Windows named pipe (no filesystem entry) was never joined. The new probe skips the FS gate on `win32` and connects (mirroring `DaemonClient.isAvailable`); on POSIX a missing Unix socket still skips the connect so it isn't hammered. Platform, connect, and timer are injected seams — `DaemonManager` builds `DaemonSocketReachability` in its constructor from its **injected `Timer`** (not a field initializer), so a probe under a `FakeTimer` never arms a real wall-clock timer, and tests inject a fake probe rather than subclassing.
- **Socket-first, scan never precedes the probe.** Each iteration evaluates the authoritative socket probe **first** and joins immediately if it answers, regardless of the process scan — so neither a transient scan miss nor a *stalling* synchronous `ps`/PowerShell scan can abandon or preempt a peer that is actually accepting. The live-process scan is populated **lazily, only after a probe miss**, and governs solely whether to *keep waiting*; it runs at most once plus once per `PEER_DAEMON_PROCESS_SCAN_INTERVAL_MS` (1s), never per poll, and a transient inspection failure logs and is treated as "no peer" rather than replacing the original diagnostic.
- **Bounded by the *original* start deadline, with delivery headroom.** `startUnlocked` captures `startDeadline = now + DAEMON_STARTUP_TIMEOUT_MS` before launching; the rejoin runs for `min(DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS, remaining-until-startDeadline − PEER_DAEMON_JOIN_DELIVERY_HEADROOM_MS)`. When `launchAndWait` already consumed most of the ~30s budget, the reserve makes the rejoin **skip entirely** and rethrow *before* the client's `tools/list` deadline, not at it.

## Preserving the #5878/#5904 prompt-failure invariant

Three ways a start can fail, all kept prompt and verified by FakeTimer tests:

- **Nothing coming up** (no live daemon) → the gate returns `false` immediately, re-throwing the original diagnostic with no timer armed. Test: *"still fails promptly when no peer daemon is coming up…"* (`getPendingTimeoutCount()`/`getPendingSleepCount()` both 0).
- **Only an orphaned socket inode** (no listener, no process) → same immediate re-throw, because the gate is live-process-only. Test: *"fails promptly when only an orphaned socket inode remains…"*.
- **Our launch already spent the client budget** (timeout path) → the rejoin is skipped because no time remains under the original deadline, so the diagnostic is not pushed past the client's ~30s deadline. Test: *"skips the peer rejoin when the original start deadline is exhausted…"* (asserts the timeout diagnostic is thrown and the peer was never even probed).

Wrong-version safety is unchanged from the established follower paths (`startByAwaitingLockHolder`, `waitForExistingDaemon`): version compatibility is enforced by the proxy handshake, not this socket-reachability layer.

## Validation

- [x] `bun run lint` — no new ratchet violations (614 gated baseline), boundary-checks pass
- [x] `bun run typecheck` — no new errors (165 baseline)
- [x] `bun run format:check` / `bun run build` clean
- [x] `bun test test/daemon/` — 1834 pass, deterministic across repeated runs, new tests <100ms, FakeTimer/injected fakes only (no real DB/timer; one real listening-socket happy-path case in the reachability unit test, gated off Windows)
- [x] Red-first confirmed: **#1 Windows** — the reachability unit test returns `false` if the FS gate is applied before connecting on all platforms; **#2 no-unlink** — the observation-only probe leaves the socket present, while the same test shows the cleanup-capable primitive it replaced *does* unlink; **socket-first ordering** — the "probes before the scan" test sees 2 scans (instead of 1) if the scan runs up front; **headroom** — the near-deadline test probes 10× (instead of 0) without the reserve; **timer injection** — a unit test proves the injected timer reaches the connect attempt; plus the deadline-reuse and per-iteration-scan guards from earlier rounds
- [x] Full `bun test`: only two failures, both pre-existing/environment (worktree-without-node_modules `oxlintConfigScoping`, and the nested-`bun test` `webrtcDeviceCaptureLoad` flake) — both reproduce on the base branch with these changes stashed

## Follow-ups

- None.

