### PR TITLE
fix(desktop): restart a wedged daemon on recovery (protocol-health-aware)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -493,6 +493,10 @@ fun AutoMobileDesktopApp(
               // Only offer Close when there is an observed workspace to return to.
               canClose = workspaceState is WorkspaceUiState.Content,
               bootstrapState = bootstrapState,
+              // Retry shares the workspace status-dot's coalescing recovery (#6082 / #6080), so a
+              // wedged daemon is restarted rather than short-circuited past; a no-op on an inactive
+              // (non-daemon) transport.
+              onRecoverDaemon = { recoveryLauncher.launch() },
             )
           else ->
             Box(Modifier.fillMaxSize()) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrap.kt
@@ -63,15 +63,28 @@ internal constructor(lifecycleFactory: ((DaemonLifecyclePhase) -> Unit) -> Daemo
   }
 
   /**
-   * Runs one lifecycle pass — detect the current daemon, or install Bun and start the pinned
-   * package when none is reachable. Blocking (up to the daemon-startup budget); call on an IO
+   * Runs one recovery lifecycle pass — detect the current daemon, install Bun and start the pinned
+   * package when none is reachable, OR restart a socket-open-but-wedged daemon whose `ide/status`
+   * probe fails (#6082). This is the shared recovery primitive behind BOTH the workspace status-dot
+   * "Start daemon" button and the device-picker Retry, so both un-stick a wedged daemon rather than
+   * short-circuiting on the open socket. Blocking (up to the daemon-startup budget); call on an IO
    * dispatcher. Progress and the terminal outcome land in [state] via the phase listener. Safe to
    * call again to retry a failure. A no-op for an [markInactive]-marked bootstrap (non-daemon
    * transport) — the app must never install/start a local daemon it is not connected to.
    */
   fun ensureReady() {
     if (inactive) return
-    lifecycle.ensureVersionMatchedDaemon()
+    lifecycle.ensureHealthyDaemon()
+  }
+
+  /**
+   * Installs the protocol-health probe that [ensureReady] uses to tell a wedged daemon from a
+   * reachable one. Wired once the daemon client exists (the client supplies the `ide/status` call
+   * the probe issues), so it cannot be a constructor dependency of the lifecycle the client is
+   * built around.
+   */
+  internal fun attachHealthProbe(probe: DaemonHealthProbe) {
+    lifecycle.attachHealthProbe(probe)
   }
 
   /** Marks bootstrap as not applicable for this run (non-daemon transport). */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -31,6 +31,50 @@ internal class FileDaemonSocketChecker(
   }
 }
 
+/**
+ * Protocol-level liveness of a socket-reachable daemon. A [DaemonSocketChecker] only proves the
+ * Unix socket accepts a connection; a WEDGED daemon accepts the socket and keeps a matching PID
+ * file yet never answers a request — so the workspace status dot goes Red while
+ * [FileDaemonSocketChecker] still reports Ready. This is the protocol-health signal that tells the
+ * two apart (#6082).
+ */
+internal enum class DaemonHealth {
+  /** `ide/status` answered within its hang ceiling — the daemon is serving requests. */
+  HEALTHY,
+
+  /** `ide/status` failed/timed out against an open socket — the daemon is wedged. */
+  UNHEALTHY,
+
+  /** No probe is available (not wired, or a non-daemon transport) — health is indeterminate. */
+  UNKNOWN,
+}
+
+/**
+ * Probes protocol-level daemon health. The real implementation ([healthProbeFor]) reuses the same
+ * bounded `ide/status` call that drives the Red status dot, so a momentarily-slow-but-healthy
+ * daemon that still answers within the ceiling reads [DaemonHealth.HEALTHY] and is never restarted;
+ * only a daemon that exceeds the same ceiling that turns the dot Red reads
+ * [DaemonHealth.UNHEALTHY].
+ */
+internal fun interface DaemonHealthProbe {
+  fun check(): DaemonHealth
+}
+
+/**
+ * The production [DaemonHealthProbe]: a successful `ide/status` round trip is
+ * [DaemonHealth.HEALTHY]; a thrown error (the client's status hang ceiling closed the wedged
+ * socket) is [DaemonHealth.UNHEALTHY]. This is exactly the signal the connectivity monitor uses to
+ * drive Red, so recovery restarts a daemon precisely when — and only when — the dot would be Red.
+ */
+internal fun healthProbeFor(client: AutoMobileClient): DaemonHealthProbe = DaemonHealthProbe {
+  try {
+    client.getDaemonStatus()
+    DaemonHealth.HEALTHY
+  } catch (_: Exception) {
+    DaemonHealth.UNHEALTHY
+  }
+}
+
 internal interface DaemonPidFileReader {
   fun read(): DaemonPidReadResult
 }
@@ -482,7 +526,29 @@ sealed interface DaemonLifecyclePhase {
 }
 
 internal interface DaemonLifecycleEnsurer {
+  /**
+   * The cheap per-request preflight: detect the daemon, or install/start one when none is
+   * reachable. A socket-open, version-matched daemon short-circuits to Ready WITHOUT a protocol
+   * health probe, so ordinary requests never pay an extra `ide/status` round trip and a wedged
+   * daemon is never restarted from under an in-flight request.
+   */
   fun ensureVersionMatchedDaemon(): DaemonLifecycleResult
+
+  /**
+   * The explicit recovery entry point (status-dot "Start daemon" and the device-picker Retry). Like
+   * [ensureVersionMatchedDaemon], but when the daemon is socket-open and version-matched it also
+   * probes protocol health and FORCES a restart if the daemon is wedged (`ide/status` times out),
+   * instead of reporting Ready (#6082). The default delegates to the plain preflight so fakes and
+   * non-daemon transports keep their existing behavior.
+   */
+  fun ensureHealthyDaemon(): DaemonLifecycleResult = ensureVersionMatchedDaemon()
+
+  /**
+   * Installs the protocol-health probe used by [ensureHealthyDaemon]. Wired after the daemon client
+   * exists (the client supplies the `ide/status` call), so it cannot be a constructor dependency of
+   * the lifecycle the client itself is built around. A no-op by default.
+   */
+  fun attachHealthProbe(probe: DaemonHealthProbe) {}
 }
 
 /**
@@ -505,11 +571,25 @@ internal class DesktopDaemonLifecycle(
    * implementations must be non-blocking (e.g. a `StateFlow.value` write).
    */
   private val phaseListener: (DaemonLifecyclePhase) -> Unit = {},
+  healthProbe: DaemonHealthProbe = DaemonHealthProbe { DaemonHealth.UNKNOWN },
 ) : DaemonLifecycleEnsurer {
+  // Wired after the daemon client exists (see [attachHealthProbe]); until then it reads UNKNOWN, so
+  // the recovery pass preserves the legacy socket-open+version-match short-circuit.
+  @Volatile private var healthProbe: DaemonHealthProbe = healthProbe
+
+  override fun attachHealthProbe(probe: DaemonHealthProbe) {
+    healthProbe = probe
+  }
+
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
+    runPass(forceRestartUnhealthy = false)
+
+  override fun ensureHealthyDaemon(): DaemonLifecycleResult = runPass(forceRestartUnhealthy = true)
+
+  private fun runPass(forceRestartUnhealthy: Boolean): DaemonLifecycleResult =
     synchronized(lifecycleLock) {
       phaseListener(DaemonLifecyclePhase.Probing)
-      val result = ensureLocked()
+      val result = ensureLocked(forceRestartUnhealthy)
       phaseListener(
         when (result) {
           is DaemonLifecycleResult.Ready -> DaemonLifecyclePhase.Completed(result.restarted)
@@ -519,7 +599,7 @@ internal class DesktopDaemonLifecycle(
       result
     }
 
-  private fun ensureLocked(): DaemonLifecycleResult {
+  private fun ensureLocked(forceRestartUnhealthy: Boolean): DaemonLifecycleResult {
     val expectedVersion =
       expectedVersionProvider()
         ?: return DaemonLifecycleResult.Failure(
@@ -538,7 +618,15 @@ internal class DesktopDaemonLifecycle(
     val currentVersion = currentDaemon?.version
     val daemonAvailable = socketIsReady(currentVersion, expectedVersion)
     if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
-      return DaemonLifecycleResult.Ready(restarted = false)
+      // Socket-open and version-matched. On the ordinary preflight this is Ready. On an explicit
+      // recovery pass, first probe protocol health: a wedged daemon (open socket, but `ide/status`
+      // times out — the same signal that drives Red) must be RESTARTED rather than reported Ready,
+      // so the status-dot recovery and the picker Retry actually un-stick it (#6082). Only an
+      // explicit UNHEALTHY forces the restart; HEALTHY or UNKNOWN preserves the short-circuit, so a
+      // momentarily-slow-but-healthy daemon is never spuriously restarted.
+      if (!(forceRestartUnhealthy && healthProbe.check() == DaemonHealth.UNHEALTHY)) {
+        return DaemonLifecycleResult.Ready(restarted = false)
+      }
     }
 
     if (declaresFullVersion(expectedVersion)) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.di
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonBootstrap
 import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
+import dev.jasonpearson.automobile.desktop.core.daemon.healthProbeFor
 import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
 import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
@@ -33,7 +34,13 @@ interface ApplicationModule {
     fun provideAutoMobileClient(daemonBootstrap: DaemonBootstrap): AutoMobileClient {
       // Shares the bootstrap's lifecycle with the daemon client so install/start progress from any
       // trigger (startup bootstrap or a request preflight) reaches the launch surfaces.
-      return McpClientFactory.createPreferred(daemonBootstrap)
+      val client = McpClientFactory.createPreferred(daemonBootstrap)
+      // Teach recovery to tell a wedged daemon from a reachable one, using the client's own
+      // `ide/status` call — the same bounded probe that drives the Red status dot (#6082). Wired
+      // here (not in the lifecycle constructor) because the probe needs the very client that is
+      // built around the bootstrap's lifecycle. A no-op on an inactive (non-daemon) bootstrap.
+      daemonBootstrap.attachHealthProbe(healthProbeFor(client))
+      return client
     }
 
     @Provides

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -75,6 +75,9 @@ class FakeAutoMobileClient : AutoMobileClient {
   var observeResult: ObserveResult = ObserveResult()
   var killDeviceResult: KillDeviceResult = KillDeviceResult(success = true)
   var getDaemonStatusResult: DaemonStatusResponse = DaemonStatusResponse()
+  // When set, getDaemonStatus throws it instead of returning — models a wedged daemon whose
+  // ide/status hang ceiling closed the socket, so the health probe reads UNHEALTHY (#6082).
+  var getDaemonStatusError: Throwable? = null
   var updateServiceResult: UpdateServiceResult = UpdateServiceResult(success = true)
   var inputTapResult: InputActionResult = InputActionResult(action = "input/tap", success = true)
   var inputSwipeResult: InputActionResult =
@@ -356,6 +359,7 @@ class FakeAutoMobileClient : AutoMobileClient {
 
   override fun getDaemonStatus(): DaemonStatusResponse {
     calls.add("getDaemonStatus")
+    getDaemonStatusError?.let { throw it }
     return getDaemonStatusResult
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -65,6 +65,11 @@ fun DevicePicker(
   // work instead of sitting on "Loading devices…", and the Error state surfaces the bootstrap
   // failure with its actionable message.
   bootstrapState: DaemonBootstrapState = DaemonBootstrapState.Inactive,
+  // Protocol-health-aware daemon recovery, shared with the workspace status-dot "Start daemon"
+  // button. The Error state's Retry runs this so a WEDGED daemon (socket open, but ide/status times
+  // out) is actually restarted — a plain reload would short-circuit on the still-open socket and
+  // re-fail (#6082). Defaults to a no-op so the reload alone still covers a plain down daemon.
+  onRecoverDaemon: () -> Unit = {},
   // The per-card device thumbnail. Hoisted (default = the screenshot [DeviceThumbnail]) so a test
   // can stub it and never open an observation socket while composing the grid. Thumbnails are
   // stills by design — a per-card live-video subscription would put a standing capture/decode cost
@@ -91,9 +96,18 @@ fun DevicePicker(
             else "Couldn't load devices",
           detail = bootstrapFailure ?: state.message,
         ) {
-          // Retry re-runs the whole chain: the load's preflight re-detects the daemon and, when
-          // none is reachable, re-attempts the install/start pipeline before reading devices.
-          Button(onClick = { onAction(DevicePickerAction.Refresh) }) { Text("Retry") }
+          // Retry runs the shared health-aware recovery first — restarting a wedged daemon (socket
+          // open, ide/status times out) that a plain reload's preflight would short-circuit past
+          // (#6082) — then reloads. The reload's preflight still covers a plain down daemon
+          // (install/start), and the daemon-up transition auto-refreshes once recovery restarts it.
+          Button(
+            onClick = {
+              onRecoverDaemon()
+              onAction(DevicePickerAction.Refresh)
+            }
+          ) {
+            Text("Retry")
+          }
         }
       }
       is DevicePickerUiState.Content -> Content(state, onAction, onClose, canClose, thumbnail)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonBootstrapTest.kt
@@ -12,11 +12,17 @@ class DaemonBootstrapTest {
   ) : DaemonLifecycleEnsurer {
     lateinit var listener: (DaemonLifecyclePhase) -> Unit
     var passes = 0
+    var healthyPasses = 0
 
     override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult {
       passes++
       phases.forEach(listener)
       return result
+    }
+
+    override fun ensureHealthyDaemon(): DaemonLifecycleResult {
+      healthyPasses++
+      return ensureVersionMatchedDaemon()
     }
   }
 
@@ -46,6 +52,24 @@ class DaemonBootstrapTest {
     bootstrap.ensureReady()
 
     assertEquals(1, lifecycle.passes)
+    assertEquals(DaemonBootstrapState.Ready(restarted = true), bootstrap.state.value)
+  }
+
+  @Test
+  fun `ensureReady drives the health-aware recovery entry point`() {
+    // The recovery affordance and the picker Retry both share this seam, so ensureReady must route
+    // through the protocol-health-aware pass that can restart a wedged (socket-open) daemon
+    // (#6082),
+    // not the plain preflight that short-circuits to Ready.
+    val lifecycle =
+      ScriptedLifecycle(
+        listOf(DaemonLifecyclePhase.Probing, DaemonLifecyclePhase.Completed(restarted = true))
+      )
+    val bootstrap = bootstrapOf(lifecycle)
+
+    bootstrap.ensureReady()
+
+    assertEquals(1, lifecycle.healthyPasses)
     assertEquals(DaemonBootstrapState.Ready(restarted = true), bootstrap.state.value)
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -699,6 +699,166 @@ class DesktopDaemonLifecycleTest {
     assertEquals(DaemonLifecyclePhase.Failed(result.message), phases.last())
   }
 
+  @Test
+  fun `restarts a wedged socket-open daemon when recovery finds it unhealthy`() {
+    // Socket reachable, version matched, but the ide/status health probe reports the daemon is
+    // wedged. A protocol-health-aware recovery pass must restart it instead of short-circuiting to
+    // Ready (#6082).
+    val commands = FakeDaemonCommandExecutor()
+    val healthProbe = FakeDaemonHealthProbe(DaemonHealth.UNHEALTHY)
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40", "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        healthProbe = healthProbe,
+      )
+
+    val result = lifecycle.ensureHealthyDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      commands.commands,
+    )
+    assertEquals(1, healthProbe.checks)
+  }
+
+  @Test
+  fun `does not restart a healthy socket-open daemon on recovery`() {
+    // A momentarily-slow-but-healthy daemon still answers ide/status within the probe's ceiling, so
+    // recovery must NOT spuriously restart it (#6082).
+    val commands = FakeDaemonCommandExecutor()
+    val healthProbe = FakeDaemonHealthProbe(DaemonHealth.HEALTHY)
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        healthProbe = healthProbe,
+      )
+
+    val result = lifecycle.ensureHealthyDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+    assertEquals(1, healthProbe.checks)
+  }
+
+  @Test
+  fun `does not restart when the health probe is indeterminate on recovery`() {
+    // No probe wired (UNKNOWN) preserves the legacy socket-open+version-match short-circuit: an
+    // indeterminate signal must never force a restart.
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        healthProbe = FakeDaemonHealthProbe(DaemonHealth.UNKNOWN),
+      )
+
+    val result = lifecycle.ensureHealthyDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+  }
+
+  @Test
+  fun `the ordinary preflight never probes health or restarts a wedged daemon`() {
+    // Per-request preflight (ensureVersionMatchedDaemon) must stay cheap: no ide/status round trip
+    // per request, and no restart of a socket-open+version-matched daemon even if it is wedged.
+    // Only
+    // the explicit recovery entry point (ensureHealthyDaemon) forces a restart (#6082).
+    val commands = FakeDaemonCommandExecutor()
+    val healthProbe = FakeDaemonHealthProbe(DaemonHealth.UNHEALTHY)
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        healthProbe = healthProbe,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+    assertEquals(0, healthProbe.checks)
+  }
+
+  @Test
+  fun `recovery still starts a fully down daemon without probing health`() {
+    // A daemon-down recovery is unchanged: the socket is unreachable, so the health probe is never
+    // consulted and the normal start pipeline runs.
+    val commands = FakeDaemonCommandExecutor()
+    val healthProbe = FakeDaemonHealthProbe(DaemonHealth.UNHEALTHY)
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false, false, false, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        healthProbe = healthProbe,
+      )
+
+    val result = lifecycle.ensureHealthyDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      commands.commands,
+    )
+    assertEquals(0, healthProbe.checks)
+  }
+
+  @Test
+  fun `health probe maps a successful ide status to healthy`() {
+    val client = dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient()
+
+    assertEquals(DaemonHealth.HEALTHY, healthProbeFor(client).check())
+  }
+
+  @Test
+  fun `health probe maps an ide status failure to unhealthy`() {
+    // getDaemonStatus is the same bounded ide/status call that drives the Red status dot: when it
+    // throws (its hang ceiling closed the wedged socket) the daemon is unhealthy.
+    val client =
+      dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient().apply {
+        getDaemonStatusError = java.io.IOException("status timed out")
+      }
+
+    assertEquals(DaemonHealth.UNHEALTHY, healthProbeFor(client).check())
+  }
+
+  private class FakeDaemonHealthProbe(private val health: DaemonHealth) : DaemonHealthProbe {
+    var checks = 0
+
+    override fun check(): DaemonHealth {
+      checks++
+      return health
+    }
+  }
+
   private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {
     private var reads = 0
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
@@ -129,4 +129,29 @@ class DevicePickerUiTest {
     picker(canClose = false)
     onNodeWithContentDescription("Close picker").assertDoesNotExist()
   }
+
+  @Test
+  fun `retry triggers protocol-health-aware recovery and reloads`() = runComposeUiTest {
+    // A wedged daemon (socket open, but ide/status times out) makes the load fail with the grid in
+    // Error. The Retry must run the shared health-aware recovery so a wedged daemon is restarted —
+    // not only reload, which would short-circuit on the still-open socket and re-fail (#6082).
+    var recovered = false
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme {
+        DevicePicker(
+          DevicePickerUiState.Error("Couldn't load devices"),
+          onAction = { action = it },
+          onClose = {},
+          onRecoverDaemon = { recovered = true },
+          thumbnail = { _, _ -> },
+        )
+      }
+    }
+
+    onNodeWithText("Retry").performClick()
+
+    assertTrue(recovered)
+    assertEquals(DevicePickerAction.Refresh, action)
+  }
 }


### PR DESCRIPTION
## Summary

The desktop recovery/retry affordances were no-ops on a **wedged** daemon — one whose Unix socket is open and whose PID/version match, but whose protocol-level `ide/status` probe times out (so the workspace status dot goes Red). Both recovery surfaces funnel through the shared `DesktopDaemonLifecycle`, whose socket-open + version-match check short-circuited straight to `Ready`, so clicking "Start daemon" (or the picker's Retry) did nothing and the daemon stayed wedged.

This makes recovery **protocol-health-aware**: a new explicit recovery entry point probes daemon health and *forces a restart* when the daemon is wedged, while the ordinary per-request preflight stays cheap and a healthy (or merely slow) daemon is never restarted.

## Linked Issue

Closes #6082

## Bug / Regression Context

- **Prior attempts:** #6035 / PR #6080 added the workspace status-dot recovery button with parity to the device-picker Retry; this deeper fix was intentionally deferred there because it changes behavior for both surfaces at once.
- **Observed symptom:** Red status dot from a wedged daemon; "Start daemon" and the picker Retry both report Ready without restarting anything, leaving the daemon and the Red status unchanged.
- **Repro conditions:** daemon process alive with its socket bound and a matching PID/version, but not answering requests (`ide/status` exceeds its hang ceiling).

## Changes

- **New protocol-health seam** (`DesktopDaemonLifecycle.kt`): `DaemonHealth { HEALTHY, UNHEALTHY, UNKNOWN }` + `DaemonHealthProbe`, and `healthProbeFor(client)` which maps a successful `ide/status` round trip to `HEALTHY` and a thrown one (the client's status hang ceiling closed the wedged socket) to `UNHEALTHY`. This reuses the **same bounded `getDaemonStatus()` call that drives the Red status dot**, so a daemon is restarted precisely when — and only when — the dot would be Red.
- **New recovery entry point**: `DaemonLifecycleEnsurer.ensureHealthyDaemon()`. When the daemon is socket-open + version-matched it now probes health and, only on an explicit `UNHEALTHY`, falls through to the existing `restart` pipeline instead of returning `Ready`. `ensureVersionMatchedDaemon()` (the per-request preflight) is unchanged — no extra `ide/status` round trip per request, and no restart of a wedged daemon from under an in-flight request. `UNKNOWN`/`HEALTHY` preserves the legacy short-circuit.
- **Shared primitive routing**: `DaemonBootstrap.ensureReady()` now calls `ensureHealthyDaemon()`, so the status-dot recovery becomes health-aware automatically. The probe is wired in DI (`ApplicationModule`) via `attachHealthProbe(healthProbeFor(client))` after the client exists (it supplies the `ide/status` call) — a no-op on an inactive/non-daemon transport.
- **Device-picker Retry** now also runs the shared recovery (`onRecoverDaemon`, wired to the existing `CoalescingRecoveryLauncher`) before reloading, so a wedged daemon is restarted rather than short-circuited past. The reload still covers a plain down daemon, and the daemon-up transition auto-refreshes once recovery restarts it.

## How a healthy / slow daemon is protected

The probe is the app's own `ide/status` call bounded by `STATUS_REQUEST_TIMEOUT_MS` — the identical signal the connectivity monitor uses for the Red dot. A momentarily-slow-but-healthy daemon answers within that ceiling → `HEALTHY` → no restart. Only a daemon exceeding the same ceiling (i.e. one the dot already shows Red) reads `UNHEALTHY`. The forced restart is gated behind the explicit recovery entry point, so ordinary requests never trigger it.

## Validation

- [x] `:desktop-core:test` green (full suite, `--rerun-tasks`), including the new tests
- [x] `:desktop-app:compileKotlin` / `compileTestKotlin` green
- [x] ktfmt (google-style, 0.64) clean on all touched files
- [x] detekt clean (`detekt`, `detektMain`, `detektTest` for desktop-core + desktop-app)
- [x] New code uses interfaces + fakes; unit tests are sub-100ms JVM/Compose tests
- [ ] `scripts/all_fast_validate_checks.sh` (TS/lint) — N/A, Kotlin-only change

### Red-first proof

Reverting the three behavior changes (the `ensureLocked` health branch, `ensureReady → ensureHealthyDaemon`, and the picker Retry recovery call) turns exactly the four new behavioral tests red for the right reasons:

- `DesktopDaemonLifecycleTest > restarts a wedged socket-open daemon when recovery finds it unhealthy` FAILED (no restart)
- `DesktopDaemonLifecycleTest > does not restart a healthy socket-open daemon on recovery` FAILED (probe never consulted)
- `DaemonBootstrapTest > ensureReady drives the health-aware recovery entry point` FAILED
- `DevicePickerUiTest > retry triggers protocol-health-aware recovery and reloads` FAILED

Restoring the implementation makes all green.

## Kotlin Reuse Check

- [x] Reused the existing `AutoMobileClient.getDaemonStatus()` (`ide/status`) and the existing `DesktopDaemonLifecycle` restart pipeline / `CoalescingRecoveryLauncher`; no new helpers, wrappers, or dependencies.
- [x] The one new abstraction (`DaemonHealthProbe` seam) exists to break the client↔lifecycle construction cycle and to keep the probe injectable for fast tests.

## Follow-ups

- [ ] None required. Ordinary per-request preflight is deliberately left non-health-probing to avoid per-request latency and mid-operation restarts; if fully-automatic wedged recovery (without a user gesture) is later wanted, that would be a separate, scoped change.
