### PR TITLE
fix(logger): survive WriteStream construction throw instead of crashing the process

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -166,7 +166,24 @@ const logsDir = logSink === "stderr" ? undefined : ensureSecureLogsDirSync();
 // parallel on the same host.
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = logsDir ? path.join(logsDir, `${ownLogPrefix}.log`) : undefined;
-let logStream = logFilePath ? fs.createWriteStream(logFilePath, { flags: "a" }) : undefined;
+
+// Constructing an appending WriteStream can throw synchronously — e.g. bun's
+// internal fast path occasionally races its epoll registration and throws
+// `EEXIST: ... epoll_ctl` (issue #5930 family). At module load this crashes the
+// importing process ("Unhandled error between tests" in the host-integration
+// lane). File logging is best-effort, so swallow the construction failure and
+// fall back to console-only logging rather than taking the process down.
+const openLogStream = (target: string): fs.WriteStream | undefined => {
+  try {
+    return fs.createWriteStream(target, { flags: "a" });
+  } catch (error) {
+    // Logger init is the thing failing, so it cannot log itself — warn to stderr.
+    process.stderr.write(`Failed to open log stream ${target}: ${String(error)}\n`);
+    return undefined;
+  }
+};
+
+let logStream = logFilePath ? openLogStream(logFilePath) : undefined;
 
 function fileLogPaths(): { dir: string; path: string } | undefined {
   if (!logsDir || !logFilePath) {
@@ -258,7 +275,7 @@ const checkAndRotateLog = async (): Promise<void> => {
         }
 
         // Always create a new log stream after rotation attempt
-        logStream = fs.createWriteStream(paths.path, { flags: "a" });
+        logStream = openLogStream(paths.path);
 
         // Prune old log files to stay within the cap
         await pruneOldLogFiles();
@@ -267,7 +284,7 @@ const checkAndRotateLog = async (): Promise<void> => {
   } catch (err) {
     // If rotation fails, ensure we have a valid log stream
     if (logStream?.destroyed || !logStream?.writable) {
-      logStream = fs.createWriteStream(paths.path, { flags: "a" });
+      logStream = openLogStream(paths.path);
     }
     await reportLogFailure("Log rotation failed", err);
   }


### PR DESCRIPTION
## Problem — the recurring host-integration flake

The **Node Host Integration Tests (ubuntu-latest)** lane intermittently reddens with an unhandled error thrown from bun's internal WriteStream fast path:

```
error: EEXIST: file already exists, epoll_ctl
      at new WriteStream (internal:fs/streams:244:58)
# Unhandled error between tests
error: Cannot call describe() after the test run has completed
      at test/server/deviceLabelSessionReleaseOrdering.integration.test.ts:14:1
 1 fail   2 errors
```

The `describe()` error is a **cascade** — the unhandled WriteStream throw aborts the bun test process mid-run, so the next test file to load reports a phantom failure. macOS and windows run the identical suite green; it is ubuntu-only and non-deterministic. It surfaced on #6104 (whose diff is shell-only and cannot touch Node tests) and is already in our flake catalog with "rerun the failed job" as the only remedy.

## Root cause

The throwing `new WriteStream` has **no application frame** in its stack, meaning it is constructed at module load. [`src/utils/logger.ts`](src/utils/logger.ts) creates a module-level appending stream — `fs.createWriteStream(logFilePath, { flags: "a" })` — that runs on **every import**, i.e. "between tests." Under bun (1.3.14 here) the stream's internal epoll registration occasionally races to `EEXIST` (the same fd-registration family as #5930). Because the construction throws synchronously at import, it becomes an unhandled crash rather than a catchable stream `error` event.

## Fix

File logging is best-effort — a failure to open the log sink must never take the process down. Wrap all three `createWriteStream` sites in an `openLogStream` helper that catches the throw, warns to stderr (the logger itself is what failed, so it cannot log through itself), and returns `undefined` to fall back to console-only logging. The existing sinks already tolerate an undefined `logStream`.

This removes the crash at the source, so the flake can no longer redden CI — no more "rerun and hope."

## Validation

- Logger unit suites: 58 pass / 0 fail
- `deviceLabelSessionReleaseOrdering.integration.test.ts` (the cascade victim): pass
- `bun run build`, `bun run typecheck` gate, `bun run lint` ratchet: all green

Follow-up to #6104; addresses the last remaining CI flake seen on that PR.