### PR TITLE
feat(deviceState): active networkCondition TTL + structured status readback (#6085)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8117,9 +8117,10 @@
               "maximum": 100
             },
             "expiresInSeconds": {
-              "description": "TTL in seconds. When set on a degrading request, a timer resets the device to normal connectivity after it elapses, independent of session lifetime; session release/expiry also restores connectivity, whichever comes first.",
+              "description": "TTL in seconds. When set on a degrading request, a timer resets the device to normal connectivity after it elapses, independent of session lifetime; session release/expiry also restores connectivity, whichever comes first. Capped at 2147483s (~24.8 days) to fit the timer's 32-bit limit.",
               "type": "number",
-              "minimum": 0
+              "minimum": 0,
+              "maximum": 2147483
             }
           },
           "additionalProperties": false,

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8117,7 +8117,7 @@
               "maximum": 100
             },
             "expiresInSeconds": {
-              "description": "Advisory TTL; session release/expiry restores normal connectivity.",
+              "description": "TTL in seconds. When set on a degrading request, a timer resets the device to normal connectivity after it elapses, independent of session lifetime; session release/expiry also restores connectivity, whichever comes first.",
               "type": "number",
               "minimum": 0
             }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -332,6 +332,15 @@ export class SessionManager {
    * late setup or keep-awake restore.
    */
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
+  /**
+   * Active per-condition network TTLs (issue #6085 item 2), keyed by session id.
+   * When a session degrades the network with an `expiresInSeconds`, a timer resets
+   * the profile to `none` when it elapses — independent of session lifetime. The
+   * timer is cancelled on release/rebind (whichever restore runs first wins) and
+   * clears the restore slot when it fires, so it can never fire against a freed
+   * device or double-restore.
+   */
+  private readonly networkConditionExpiryTimers: Map<string, NodeJS.Timeout> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
   /** Automatic device assignments that have not yet started their creation write. */
@@ -965,6 +974,10 @@ export class SessionManager {
     // against that device below, so DevicePool.releaseDevice defers idling it.
     const pendingBiometricRestoration = (await this.restoreBiometricEnrollmentBestEffort(existing))
       .pending;
+    // Rebind restores the old device to `none` here, so cancel any standalone TTL
+    // for this session — it must not later fire against the now-released old
+    // device (issue #6085 item 2).
+    this.cancelNetworkConditionExpiry(existing.sessionId);
     const pendingNetworkRestoration = existing.cacheData.networkCondition
       ? (await this.restoreNetworkConditionBestEffort(existing)).pending
       : null;
@@ -1376,6 +1389,11 @@ export class SessionManager {
     reason: ReleaseReasonState,
   ): Promise<string | null> {
     try {
+      // Release restores the device to `none` itself, so a standalone TTL is now
+      // redundant — cancel it first so the two restore paths cannot both fire
+      // (issue #6085 item 2). Whichever runs first (this release, or the TTL that
+      // already cleared the slot) wins.
+      this.cancelNetworkConditionExpiry(sessionId);
       const setups = Array.from(this.sessionSetupPromises, (setup) =>
         setup.session === session ? setup.promise : null,
       ).filter((setup): setup is Promise<void> => setup !== null);
@@ -2027,6 +2045,85 @@ export class SessionManager {
     );
   }
 
+  /**
+   * Arm a standalone per-condition network TTL (issue #6085 item 2): when it
+   * elapses, the device is reset to `none` independent of session lifetime.
+   * Re-scheduling (a re-applied condition) cancels the prior timer first, so only
+   * the latest TTL is armed. A non-positive TTL arms nothing (and still clears any
+   * prior timer), matching the "TTL-only / neutral request applies nothing" rule.
+   */
+  scheduleNetworkConditionExpiry(sessionId: string, expiresInSeconds: number): void {
+    this.cancelNetworkConditionExpiry(sessionId);
+    if (!(expiresInSeconds > 0)) {
+      return;
+    }
+    const handle = this.timer.setTimeout(() => {
+      this.handleNetworkConditionExpiry(sessionId);
+    }, expiresInSeconds * 1000);
+    this.networkConditionExpiryTimers.set(sessionId, handle);
+  }
+
+  /**
+   * Cancel a pending network TTL. Called on release, rebind, and any subsequent
+   * non-degrading network mutation (a manual reset) so the release-restore and the
+   * TTL can never both fire. A no-op when no timer is armed.
+   */
+  cancelNetworkConditionExpiry(sessionId: string): void {
+    const handle = this.networkConditionExpiryTimers.get(sessionId);
+    if (handle !== undefined) {
+      this.timer.clearTimeout(handle);
+      this.networkConditionExpiryTimers.delete(sessionId);
+    }
+  }
+
+  /**
+   * TTL elapsed: reset the device to `none` via the shared restore path, then clear
+   * the restore slot so a later release cannot double-restore. Handles a session
+   * that was already released/rebound (its slot is gone → nothing to do), so the
+   * timer never acts on a freed device. The reset is tracked as pending device
+   * cleanup — the same channel release uses — so the pool keeps the device
+   * quarantined until it settles.
+   */
+  private handleNetworkConditionExpiry(sessionId: string): void {
+    this.networkConditionExpiryTimers.delete(sessionId);
+    // Read the raw session map rather than getSession(), so a timer fire cannot
+    // trigger a lazy-expiry release as a side effect. An absent session was
+    // already released — its release-restore handled connectivity.
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    const target = this.networkConditionRestoreTarget(session);
+    if (!target) {
+      // Slot already cleared by a prior restore: nothing to do, no double-restore.
+      return;
+    }
+    // Clear the slot BEFORE restoring, so a release racing this fire observes no
+    // slot and does not schedule a second restore of the same device.
+    this.clearNetworkCondition(sessionId);
+    logger.info(
+      `Network condition TTL elapsed for session ${sessionId}; resetting device ${target.deviceId} to none`,
+    );
+    const restore = this.restoreNetworkCondition(target).then(
+      () => undefined,
+      (error) => {
+        logger.warn(
+          `Failed to reset network condition on TTL expiry for session ${sessionId}; device ` +
+            `${target.deviceId} may hold session-modified shaping: ${error}`,
+        );
+      },
+    );
+    this.trackPendingDeviceCleanup(target.deviceId, [restore]);
+  }
+
+  /** Drop the network restore slot once a TTL reset has satisfied it (issue #6085). */
+  private clearNetworkCondition(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session?.cacheData.networkCondition) {
+      delete session.cacheData.networkCondition;
+    }
+  }
+
   private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {
     const previous = this.pendingDeviceCleanups.get(deviceId);
     const cleanup = Promise.allSettled(previous ? [previous, ...cleanups] : cleanups).then(
@@ -2448,6 +2545,12 @@ export class SessionManager {
       this.timer.clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+    // Cancel any armed per-condition network TTLs so a stopped manager leaves no
+    // dangling timer (issue #6085 item 2).
+    for (const handle of this.networkConditionExpiryTimers.values()) {
+      this.timer.clearTimeout(handle);
+    }
+    this.networkConditionExpiryTimers.clear();
   }
 
   // Intentionally NOT barrier-tracked: this write is `await`ed by its caller

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -13,6 +13,7 @@ import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
 import {
   DeviceState,
+  MAX_NETWORK_CONDITION_TTL_SECONDS,
   type BiometricEnrollment,
   type NetworkConditionProfile,
 } from "../features/utility/DeviceState";
@@ -340,7 +341,10 @@ export class SessionManager {
    * clears the restore slot when it fires, so it can never fire against a freed
    * device or double-restore.
    */
-  private readonly networkConditionExpiryTimers: Map<string, NodeJS.Timeout> = new Map();
+  private readonly networkConditionExpiryTimers: Map<
+    string,
+    { handle: NodeJS.Timeout; session: Session }
+  > = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
   /** Automatic device assignments that have not yet started their creation write. */
@@ -2021,6 +2025,19 @@ export class SessionManager {
     target: NetworkConditionRestoreTarget,
     initialError: unknown,
   ): Promise<void> {
+    await this.retryNetworkConditionRestoreUntilSuccess(target, initialError);
+  }
+
+  /**
+   * Bounded restore retries after an initial failure. Returns `true` if any retry
+   * succeeded, `false` once the attempts are exhausted. The boolean lets the TTL
+   * path decide whether it may release restoration ownership (clear the slot),
+   * while the release path (which discards the session anyway) ignores it.
+   */
+  private async retryNetworkConditionRestoreUntilSuccess(
+    target: NetworkConditionRestoreTarget,
+    initialError: unknown,
+  ): Promise<boolean> {
     let lastError = initialError;
     for (let attempt = 1; attempt <= NETWORK_CONDITION_RESTORE_RETRY_ATTEMPTS; attempt++) {
       await this.timer.sleep(NETWORK_CONDITION_RESTORE_RETRY_DELAY_MS);
@@ -2029,7 +2046,7 @@ export class SessionManager {
         logger.info(
           `Restored network condition for session ${target.sessionId} on retry ${attempt}`,
         );
-        return;
+        return true;
       } catch (error) {
         // Teardown is best-effort: keep retrying, then report the last failure.
         lastError = error;
@@ -2043,6 +2060,7 @@ export class SessionManager {
         `${NETWORK_CONDITION_RESTORE_RETRY_ATTEMPTS} retries; device ${target.deviceId} ` +
         `may hold session-modified shaping: ${lastError}`,
     );
+    return false;
   }
 
   /**
@@ -2051,46 +2069,76 @@ export class SessionManager {
    * Re-scheduling (a re-applied condition) cancels the prior timer first, so only
    * the latest TTL is armed. A non-positive TTL arms nothing (and still clears any
    * prior timer), matching the "TTL-only / neutral request applies nothing" rule.
+   *
+   * Keyed by session id but IDENTITY-GUARDED by the captured `Session` instance
+   * (issue #6085 review): the caller passes the exact session it just mutated, and
+   * the timer fires against that instance only — so a stale schedule from a
+   * timed-out setup cannot arm or fire a TTL against a same-UUID REPLACEMENT
+   * session. The TTL is clamped to `MAX_NETWORK_CONDITION_TTL_SECONDS` so the
+   * millisecond product cannot overflow `setTimeout`'s signed 32-bit delay (item 4).
    */
-  scheduleNetworkConditionExpiry(sessionId: string, expiresInSeconds: number): void {
+  scheduleNetworkConditionExpiry(session: Session, expiresInSeconds: number): void {
+    const sessionId = session.sessionId;
     this.cancelNetworkConditionExpiry(sessionId);
     if (!(expiresInSeconds > 0)) {
       return;
     }
+    // A stale schedule (e.g. a setup that finished after this session was released
+    // and replaced) must not arm a timer against the replacement — bail unless the
+    // captured instance is still the live session.
+    if (this.sessions.get(sessionId) !== session) {
+      return;
+    }
+    const effectiveSeconds = Math.min(expiresInSeconds, MAX_NETWORK_CONDITION_TTL_SECONDS);
+    if (effectiveSeconds < expiresInSeconds) {
+      logger.warn(
+        `networkCondition TTL of ${expiresInSeconds}s exceeds the ${MAX_NETWORK_CONDITION_TTL_SECONDS}s ` +
+          `setTimeout limit for session ${sessionId}; clamping to ${effectiveSeconds}s`,
+      );
+    }
     const handle = this.timer.setTimeout(() => {
-      this.handleNetworkConditionExpiry(sessionId);
-    }, expiresInSeconds * 1000);
-    this.networkConditionExpiryTimers.set(sessionId, handle);
+      this.handleNetworkConditionExpiry(session);
+    }, effectiveSeconds * 1000);
+    this.networkConditionExpiryTimers.set(sessionId, { handle, session });
   }
 
   /**
    * Cancel a pending network TTL. Called on release, rebind, and any subsequent
-   * non-degrading network mutation (a manual reset) so the release-restore and the
-   * TTL can never both fire. A no-op when no timer is armed.
+   * network mutation (a manual reset, or a re-apply BEFORE it re-arms) so the
+   * release-restore and the TTL can never both fire. A no-op when no timer is armed.
    */
   cancelNetworkConditionExpiry(sessionId: string): void {
-    const handle = this.networkConditionExpiryTimers.get(sessionId);
-    if (handle !== undefined) {
-      this.timer.clearTimeout(handle);
+    const entry = this.networkConditionExpiryTimers.get(sessionId);
+    if (entry !== undefined) {
+      this.timer.clearTimeout(entry.handle);
       this.networkConditionExpiryTimers.delete(sessionId);
     }
   }
 
   /**
-   * TTL elapsed: reset the device to `none` via the shared restore path, then clear
-   * the restore slot so a later release cannot double-restore. Handles a session
-   * that was already released/rebound (its slot is gone → nothing to do), so the
-   * timer never acts on a freed device. The reset is tracked as pending device
-   * cleanup — the same channel release uses — so the pool keeps the device
-   * quarantined until it settles.
+   * TTL elapsed: reset the device to `none` via the SAME bounded restore/retry the
+   * session-release path uses, and RETAIN restoration ownership — keep the restore
+   * slot and the device quarantined — until the reset actually SUCCEEDS (issue
+   * #6085 review). A transient emulator-console rejection therefore does not end
+   * quarantine and hand a still-shaped device back to the pool: it retries, and if
+   * every attempt is exhausted the slot is left in place so a later release still
+   * retries. Only on success is the slot cleared, so a subsequent release cannot
+   * double-restore.
+   *
+   * Identity-guarded on the captured `Session`: a fire against a same-UUID
+   * REPLACEMENT session (or an already-released one) is a no-op, so it never acts
+   * on a freed or replaced device.
    */
-  private handleNetworkConditionExpiry(sessionId: string): void {
-    this.networkConditionExpiryTimers.delete(sessionId);
+  private handleNetworkConditionExpiry(session: Session): void {
+    const sessionId = session.sessionId;
+    const entry = this.networkConditionExpiryTimers.get(sessionId);
+    if (entry && entry.session === session) {
+      this.networkConditionExpiryTimers.delete(sessionId);
+    }
     // Read the raw session map rather than getSession(), so a timer fire cannot
-    // trigger a lazy-expiry release as a side effect. An absent session was
-    // already released — its release-restore handled connectivity.
-    const session = this.sessions.get(sessionId);
-    if (!session) {
+    // trigger a lazy-expiry release as a side effect. A missing or replaced
+    // session was already released — its release-restore handled connectivity.
+    if (this.sessions.get(sessionId) !== session) {
       return;
     }
     const target = this.networkConditionRestoreTarget(session);
@@ -2098,28 +2146,51 @@ export class SessionManager {
       // Slot already cleared by a prior restore: nothing to do, no double-restore.
       return;
     }
-    // Clear the slot BEFORE restoring, so a release racing this fire observes no
-    // slot and does not schedule a second restore of the same device.
-    this.clearNetworkCondition(sessionId);
     logger.info(
       `Network condition TTL elapsed for session ${sessionId}; resetting device ${target.deviceId} to none`,
     );
-    const restore = this.restoreNetworkCondition(target).then(
-      () => undefined,
-      (error) => {
-        logger.warn(
-          `Failed to reset network condition on TTL expiry for session ${sessionId}; device ` +
-            `${target.deviceId} may hold session-modified shaping: ${error}`,
-        );
-      },
-    );
-    this.trackPendingDeviceCleanup(target.deviceId, [restore]);
+    this.trackPendingDeviceCleanup(target.deviceId, [
+      this.restoreNetworkConditionOnExpiry(session, target),
+    ]);
   }
 
-  /** Drop the network restore slot once a TTL reset has satisfied it (issue #6085). */
-  private clearNetworkCondition(sessionId: string): void {
-    const session = this.sessions.get(sessionId);
-    if (session?.cacheData.networkCondition) {
+  /**
+   * Reset the device on TTL expiry, then bounded-retry on failure — the same
+   * machinery `restoreNetworkConditionBestEffort` uses on release. The restore slot
+   * is cleared only after a definitive success, so ownership (and quarantine) is
+   * retained until the device is actually clean.
+   */
+  private async restoreNetworkConditionOnExpiry(
+    session: Session,
+    target: NetworkConditionRestoreTarget,
+  ): Promise<void> {
+    try {
+      await this.restoreNetworkCondition(target);
+      this.clearNetworkConditionIfOwned(session);
+      return;
+    } catch (error) {
+      logger.warn(
+        `Failed to reset network condition on TTL expiry for session ${session.sessionId}; ` +
+          `device ${target.deviceId} may hold session-modified shaping, retrying: ${error}`,
+      );
+      const succeeded = await this.retryNetworkConditionRestoreUntilSuccess(target, error);
+      if (succeeded) {
+        this.clearNetworkConditionIfOwned(session);
+      }
+      // On exhaustion the slot is intentionally retained so a later release retries.
+    }
+  }
+
+  /**
+   * Drop the network restore slot once a reset has satisfied it (issue #6085),
+   * but ONLY while the captured session is still the live one — a same-UUID
+   * replacement must keep its own freshly-published slot.
+   */
+  private clearNetworkConditionIfOwned(session: Session): void {
+    if (this.sessions.get(session.sessionId) !== session) {
+      return;
+    }
+    if (session.cacheData.networkCondition) {
       delete session.cacheData.networkCondition;
     }
   }
@@ -2547,8 +2618,8 @@ export class SessionManager {
     }
     // Cancel any armed per-condition network TTLs so a stopped manager leaves no
     // dangling timer (issue #6085 item 2).
-    for (const handle of this.networkConditionExpiryTimers.values()) {
-      this.timer.clearTimeout(handle);
+    for (const entry of this.networkConditionExpiryTimers.values()) {
+      this.timer.clearTimeout(entry.handle);
     }
     this.networkConditionExpiryTimers.clear();
   }

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -202,10 +202,23 @@ export interface NetworkConditionState {
   /** Explicit documented values applied (may reflect caller overrides). */
   values?: NetworkConditionValues;
   verified?: boolean;
-  /** Advisory TTL echoed back; enforced by the session layer on release/expiry. */
+  /**
+   * TTL echoed back. Enforced by the session layer: a per-condition timer resets
+   * the device to `none` when it elapses (issue #6085 item 2), and session
+   * release/expiry also restores connectivity — whichever comes first.
+   */
   expiresInSeconds?: number;
   /** Best-effort emulator `network status` readback (reads only). */
   rawStatus?: string;
+  /**
+   * Best-effort structured parse of the emulator `network status` readback (reads
+   * only, issue #6085 item 3). Only the fields the free-text output could be
+   * parsed into are present; an unparseable or absent field is omitted, and the
+   * verbatim `rawStatus` is always kept alongside. It is deliberately NOT used to
+   * claim `verified` at the read layer — the read carries no requested profile to
+   * compare against — so it is a diagnostic signal, not a verification verdict.
+   */
+  observedValues?: Partial<NetworkConditionValues>;
   warning?: string;
   error?: string;
 }
@@ -229,7 +242,11 @@ export interface SetNetworkConditionInput {
   downloadKbps?: number;
   uploadKbps?: number;
   packetLossPercent?: number;
-  /** Advisory TTL; session release/expiry restores normal connectivity. */
+  /**
+   * TTL in seconds. When set on a degrade, the session layer schedules a timer
+   * that resets the device to `none` when it elapses (issue #6085 item 2);
+   * session release/expiry also restores connectivity, whichever comes first.
+   */
   expiresInSeconds?: number;
 }
 
@@ -350,6 +367,62 @@ function emulatorConsoleReportsFailure(stdout: string, stderr: string): boolean 
     return true;
   }
   return outputLooksLikeShellFailure(stdout, stderr);
+}
+
+/**
+ * Best-effort parse of the emulator console `network status` free text into the
+ * structured applied values (issue #6085 item 3). The output — per the Android
+ * emulator console — is roughly:
+ *
+ *   Current network status:
+ *     download speed:   236800 bits/s (231.2 KB/s)
+ *     upload speed:     118400 bits/s (115.6 KB/s)
+ *     minimum latency:  80 ms
+ *     maximum latency:  400 ms
+ *
+ * The exact shape varies by emulator version, so this is DELIBERATELY DEFENSIVE:
+ * every field is optional, an absent or unparseable field is simply omitted, and
+ * it never throws. It returns only the subset it could extract, or `null` when
+ * nothing parsed — callers then fall back to surfacing `rawStatus` verbatim
+ * without claiming any structured value they could not actually read.
+ *
+ * `download/uploadKbps` are converted from the reported bits/s to kbps (the
+ * vocabulary the `network speed` setter uses); `delayMs` reflects the MAXIMUM
+ * latency (a profile's documented delay is its max), falling back to the minimum
+ * latency when only that is present. `packetLossPercent` is never derived — the
+ * console has no loss verb, so the status output carries none.
+ */
+export function parseEmulatorNetworkStatus(raw: string): Partial<NetworkConditionValues> | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed: Partial<NetworkConditionValues> = {};
+  const bitsPerSecToKbps = (match: RegExpMatchArray | null): number | undefined => {
+    if (!match) {
+      return undefined;
+    }
+    const bits = Number.parseInt(match[1].replace(/,/g, ""), 10);
+    return Number.isFinite(bits) ? Math.round(bits / 1000) : undefined;
+  };
+  const download = bitsPerSecToKbps(raw.match(/download speed:\s*([\d,]+)\s*bits\/s/i));
+  if (download !== undefined) {
+    parsed.downloadKbps = download;
+  }
+  const upload = bitsPerSecToKbps(raw.match(/upload speed:\s*([\d,]+)\s*bits\/s/i));
+  if (upload !== undefined) {
+    parsed.uploadKbps = upload;
+  }
+  // Prefer the max latency (matches a profile's documented delay); fall back to
+  // the min when only that is reported.
+  const latencyMatch =
+    raw.match(/maximum latency:\s*(\d+)\s*ms/i) ?? raw.match(/minimum latency:\s*(\d+)\s*ms/i);
+  if (latencyMatch) {
+    const ms = Number.parseInt(latencyMatch[1], 10);
+    if (Number.isFinite(ms)) {
+      parsed.delayMs = ms;
+    }
+  }
+  return Object.keys(parsed).length > 0 ? parsed : null;
 }
 
 /**
@@ -1036,11 +1109,18 @@ export class DeviceState {
           error: `${stdout}\n${stderr}`.trim() || "emu network status reported an error",
         };
       }
+      // Best-effort structured readback (issue #6085 item 3): parse the free-text
+      // status into applied delay/speed when the format allows, keeping rawStatus
+      // verbatim as the fallback. A parse failure is silent — no structured field
+      // is claimed and rawStatus still carries the raw signal.
+      const trimmed = stdout.trim();
+      const observedValues = trimmed ? parseEmulatorNetworkStatus(trimmed) : null;
       return {
         supported: true,
         capability: "full",
         method: "android_emulator_console",
-        ...(stdout.trim() ? { rawStatus: stdout.trim() } : {}),
+        ...(trimmed ? { rawStatus: trimmed } : {}),
+        ...(observedValues ? { observedValues } : {}),
       };
     } catch (error) {
       return {

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -191,6 +191,15 @@ export const NETWORK_CONDITION_PROFILES: Record<NetworkConditionProfile, Network
     ),
   ) as Record<NetworkConditionProfile, NetworkConditionValues>;
 
+/**
+ * Upper bound for `expiresInSeconds` (issue #6085 item 4). A single
+ * `setTimeout(ms)` in Node/Bun truncates its delay to a signed 32-bit int, so any
+ * value above `2_147_483_647` ms (~24.85 days) wraps to a tiny delay and would
+ * reset the network almost immediately. Cap the accepted TTL at
+ * `floor(2_147_483_647 / 1000)` seconds so the millisecond product always fits.
+ */
+export const MAX_NETWORK_CONDITION_TTL_SECONDS = Math.floor(2_147_483_647 / 1000);
+
 export interface NetworkConditionState {
   supported: boolean;
   capability?: NetworkConditionCapability;

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -20,6 +20,7 @@ export async function runSessionNetworkMutation<T>(
   deviceId: string,
   registerRestore: boolean,
   mutation: () => Promise<T>,
+  expiresInSeconds?: number,
 ): Promise<T> {
   if (!sessionManager || !sessionUuid) {
     return await mutation();
@@ -60,6 +61,17 @@ export async function runSessionNetworkMutation<T>(
     throw new Error(
       `Cannot mutate network condition: session ${sessionUuid} began releasing before the mutation started.`,
     );
+  }
+  // Arm / cancel the standalone per-condition TTL (issue #6085 item 2). A degrade
+  // that registered a restore slot AND carries a positive TTL schedules a timer
+  // that resets the device to `none` when it elapses, independent of session
+  // lifetime; any other network mutation (a reset, or a degrade with no TTL)
+  // cancels a previously-armed timer instead, so a manual reset supersedes a
+  // pending TTL rather than racing it.
+  if (registerRestore && expiresInSeconds !== undefined && expiresInSeconds > 0) {
+    sessionManager.scheduleNetworkConditionExpiry(sessionUuid, expiresInSeconds);
+  } else {
+    sessionManager.cancelNetworkConditionExpiry(sessionUuid);
   }
   return result;
 }

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -51,6 +51,13 @@ export async function runSessionNetworkMutation<T>(
     sessionManager.setNetworkCondition(sessionUuid, { initialProfile: "none" });
   }
 
+  // Cancel any prior TTL BEFORE the mutation, not after (issue #6085 review): a
+  // slow re-apply would otherwise leave the OLD timer armed, and it could fire
+  // mid-mutation, reset the just-shaped device, and clear the freshly-published
+  // restore slot. Cancelling up front closes that overlap window; the new TTL (if
+  // any) is armed only after the mutation settles, below.
+  sessionManager.cancelNetworkConditionExpiry(sessionUuid);
+
   let completed = false;
   let result!: T;
   await sessionManager.trackSessionSetup(session, async () => {
@@ -62,16 +69,15 @@ export async function runSessionNetworkMutation<T>(
       `Cannot mutate network condition: session ${sessionUuid} began releasing before the mutation started.`,
     );
   }
-  // Arm / cancel the standalone per-condition TTL (issue #6085 item 2). A degrade
-  // that registered a restore slot AND carries a positive TTL schedules a timer
-  // that resets the device to `none` when it elapses, independent of session
-  // lifetime; any other network mutation (a reset, or a degrade with no TTL)
-  // cancels a previously-armed timer instead, so a manual reset supersedes a
-  // pending TTL rather than racing it.
+  // Arm the standalone per-condition TTL (issue #6085 item 2) for a degrade that
+  // registered a restore slot AND carries a positive TTL. Pass the CAPTURED
+  // `session` instance so a stale re-apply — one whose tracked setup finished only
+  // after this session was released and replaced under the same UUID — cannot arm
+  // a TTL against the replacement (scheduleNetworkConditionExpiry identity-guards
+  // on it). A reset, or a degrade with no TTL, arms nothing; the pre-mutation
+  // cancel above already cleared any prior timer.
   if (registerRestore && expiresInSeconds !== undefined && expiresInSeconds > 0) {
-    sessionManager.scheduleNetworkConditionExpiry(sessionUuid, expiresInSeconds);
-  } else {
-    sessionManager.cancelNetworkConditionExpiry(sessionUuid);
+    sessionManager.scheduleNetworkConditionExpiry(session, expiresInSeconds);
   }
   return result;
 }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -156,7 +156,11 @@ const networkConditionInputSchema = z
       .number()
       .min(0)
       .optional()
-      .describe("Advisory TTL; session release/expiry restores normal connectivity."),
+      .describe(
+        "TTL in seconds. When set on a degrading request, a timer resets the device to normal " +
+          "connectivity after it elapses, independent of session lifetime; session release/expiry " +
+          "also restores connectivity, whichever comes first.",
+      ),
   })
   // Reject non-actionable / contradictory requests using the SAME classifier the
   // setter uses, so schema acceptance and runtime behavior cannot disagree
@@ -541,6 +545,7 @@ export function registerUtilityTools() {
             device.deviceId,
             registerNetworkRestore,
             () => deviceState.setState(input),
+            input.networkCondition.expiresInSeconds,
           )
         : deviceState.setState(input);
 
@@ -580,6 +585,7 @@ export function registerUtilityTools() {
         device.deviceId,
         registerNetworkRestore,
         mutation,
+        args.networkCondition.expiresInSeconds,
       );
     } else {
       result = await runSessionBiometricMutation(

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -4,6 +4,7 @@ import { ActionableError } from "../models/ActionableError";
 import { SystemConfigurationManager } from "../features/utility/SystemConfigurationManager";
 import {
   DeviceState,
+  MAX_NETWORK_CONDITION_TTL_SECONDS,
   networkConditionInputDegrades,
   networkConditionInputError,
   type BiometricEnrollment,
@@ -126,6 +127,47 @@ const biometricStateInputSchema = z.object({
     .describe("Set iOS Simulator biometric enrollment state."),
 });
 
+// In direct/sessionless mode there is no session lifecycle owner to enforce a
+// networkCondition TTL, so accepting `expiresInSeconds` there would echo a TTL we
+// will never honor and leave the emulator shaped indefinitely (issue #6085 review
+// item 3). Reject it up front rather than make a false promise.
+const NETWORK_CONDITION_TTL_UNENFORCEABLE_ERROR =
+  "networkCondition.expiresInSeconds cannot be honored in direct/sessionless mode: there is no " +
+  "session lifecycle owner to enforce the TTL, so the device would stay shaped indefinitely. " +
+  "Omit expiresInSeconds (and reset the condition yourself when done), or run within a session.";
+
+/**
+ * A networkCondition mutation needs a session restore slot only when it degrades
+ * the link on an Android emulator (issue #6012) — the single decision shared by
+ * the restore-slot registration and the TTL-enforceability check.
+ */
+function shouldRegisterNetworkRestore(device: BootedDevice, args: SetDeviceStateArgs): boolean {
+  return (
+    args.networkCondition !== undefined &&
+    networkConditionInputDegrades(args.networkCondition) &&
+    device.platform === "android" &&
+    device.deviceId.startsWith("emulator-")
+  );
+}
+
+/**
+ * True when a request carries a networkCondition TTL that WOULD shape an emulator
+ * (`registerNetworkRestore`) but has no session lifecycle owner to enforce it —
+ * the case that must be rejected rather than shaped indefinitely (issue #6085).
+ */
+function networkConditionTtlIsUnenforceable(
+  expiresInSeconds: number | undefined,
+  registerNetworkRestore: boolean,
+  hasLifecycleOwner: boolean,
+): boolean {
+  return (
+    registerNetworkRestore &&
+    expiresInSeconds !== undefined &&
+    expiresInSeconds > 0 &&
+    !hasLifecycleOwner
+  );
+}
+
 const networkConditionInputSchema = z
   .object({
     profile: z
@@ -155,11 +197,13 @@ const networkConditionInputSchema = z
     expiresInSeconds: z
       .number()
       .min(0)
+      .max(MAX_NETWORK_CONDITION_TTL_SECONDS)
       .optional()
       .describe(
         "TTL in seconds. When set on a degrading request, a timer resets the device to normal " +
           "connectivity after it elapses, independent of session lifetime; session release/expiry " +
-          "also restores connectivity, whichever comes first.",
+          "also restores connectivity, whichever comes first. Capped at " +
+          `${MAX_NETWORK_CONDITION_TTL_SECONDS}s (~24.8 days) to fit the timer's 32-bit limit.`,
       ),
   })
   // Reject non-actionable / contradictory requests using the SAME classifier the
@@ -526,11 +570,28 @@ export function registerUtilityTools() {
         : undefined;
     // Single decision for whether an applied networkCondition needs a session
     // restore slot: a degrading request on an Android emulator (issue #6012).
-    const registerNetworkRestore =
-      args.networkCondition !== undefined &&
-      networkConditionInputDegrades(args.networkCondition) &&
-      device.platform === "android" &&
-      device.deviceId.startsWith("emulator-");
+    const registerNetworkRestore = shouldRegisterNetworkRestore(device, args);
+
+    // A degrade that WOULD shape an emulator but carries a TTL with no lifecycle
+    // owner to enforce it must be rejected, not applied — otherwise the device is
+    // shaped indefinitely while the result falsely echoes a TTL (issue #6085
+    // review item 3).
+    const hasLifecycleOwner = Boolean(sessionManager && args.sessionUuid);
+    if (
+      networkConditionTtlIsUnenforceable(
+        args.networkCondition?.expiresInSeconds,
+        registerNetworkRestore,
+        hasLifecycleOwner,
+      )
+    ) {
+      return createJSONToolResponse({
+        message: NETWORK_CONDITION_TTL_UNENFORCEABLE_ERROR,
+        success: false,
+        deviceId: device.deviceId,
+        platform: device.platform,
+        error: NETWORK_CONDITION_TTL_UNENFORCEABLE_ERROR,
+      });
+    }
 
     // A setter that routes ANY networkCondition-bearing mutation through
     // runSessionNetworkMutation, so the restore slot is registered before the

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2034,6 +2034,142 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("network condition TTL scheduling (#6085 item 2)", () => {
+    const noopBiometric = () => ({ restore: async () => {} });
+    const makeManagerWithNetworkRestorer = (
+      timer: FakeTimer,
+      restored: Array<{ deviceId: string; profile: string }>,
+    ): SessionManager =>
+      new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        noopBiometric,
+        (device): NetworkConditionRestorer => ({
+          restore: async (profile) => {
+            restored.push({ deviceId: device.deviceId, profile });
+          },
+        }),
+      );
+
+    test("resets the device to none when the per-condition TTL elapses", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        await manager.createSession("net-ttl", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry("net-ttl", 60);
+
+        // Not yet elapsed: no restore, slot still armed.
+        timer.advanceTime(59_000);
+        expect(restored).toEqual([]);
+
+        // Elapsed: the TTL resets the device to `none`, independent of release.
+        timer.advanceTime(1_000);
+        const cleanup = manager.getPendingDeviceCleanup("emulator-5554");
+        expect(cleanup).not.toBeNull();
+        await cleanup;
+
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+        // The restore slot is cleared so a later release cannot double-restore.
+        expect(manager.getNetworkCondition("net-ttl")).toBeUndefined();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("cancels the pending TTL when the session releases before it elapses", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        await manager.createSession("net-ttl-release", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-release", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry("net-ttl-release", 60);
+
+        // Release before the TTL: the release-restore runs exactly once.
+        await manager.releaseSession("net-ttl-release");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+
+        // Advancing past the TTL must NOT fire a second restore (timer cancelled).
+        timer.advanceTime(120_000);
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not double-restore when the TTL fires and then the session releases", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        await manager.createSession("net-ttl-first", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-first", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry("net-ttl-first", 60);
+
+        // TTL fires first and restores once.
+        timer.advanceTime(60_000);
+        await manager.getPendingDeviceCleanup("emulator-5554");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+
+        // Release afterwards sees the cleared slot, so it does not restore again.
+        await manager.releaseSession("net-ttl-first");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("cancels the pending TTL when the session rebinds before it elapses", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        await manager.createSession("net-ttl-rebind", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-rebind", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry("net-ttl-rebind", 60);
+
+        // Rebind restores the old device once and discards its cache.
+        await manager.rebindSession("net-ttl-rebind", "emulator-5556", "android");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+
+        // The TTL for the old device must not fire after the rebind cancelled it.
+        timer.advanceTime(120_000);
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("re-scheduling a TTL cancels the prior timer so only the latest fires", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        await manager.createSession("net-ttl-reapply", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-reapply", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry("net-ttl-reapply", 60);
+        // Re-apply with a longer TTL: the first (60s) timer must be cancelled.
+        manager.scheduleNetworkConditionExpiry("net-ttl-reapply", 120);
+
+        timer.advanceTime(60_000);
+        expect(restored).toEqual([]);
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+
+        timer.advanceTime(60_000);
+        await manager.getPendingDeviceCleanup("emulator-5554");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+  });
+
   describe("statistics", () => {
     test("should return correct session statistics", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2058,9 +2058,9 @@ describe("SessionManager", () => {
       const restored: Array<{ deviceId: string; profile: string }> = [];
       const manager = makeManagerWithNetworkRestorer(timer, restored);
       try {
-        await manager.createSession("net-ttl", "emulator-5554", "android");
+        const session = await manager.createSession("net-ttl", "emulator-5554", "android");
         manager.setNetworkCondition("net-ttl", { initialProfile: "none" });
-        manager.scheduleNetworkConditionExpiry("net-ttl", 60);
+        manager.scheduleNetworkConditionExpiry(session, 60);
 
         // Not yet elapsed: no restore, slot still armed.
         timer.advanceTime(59_000);
@@ -2085,9 +2085,9 @@ describe("SessionManager", () => {
       const restored: Array<{ deviceId: string; profile: string }> = [];
       const manager = makeManagerWithNetworkRestorer(timer, restored);
       try {
-        await manager.createSession("net-ttl-release", "emulator-5554", "android");
+        const session = await manager.createSession("net-ttl-release", "emulator-5554", "android");
         manager.setNetworkCondition("net-ttl-release", { initialProfile: "none" });
-        manager.scheduleNetworkConditionExpiry("net-ttl-release", 60);
+        manager.scheduleNetworkConditionExpiry(session, 60);
 
         // Release before the TTL: the release-restore runs exactly once.
         await manager.releaseSession("net-ttl-release");
@@ -2107,9 +2107,9 @@ describe("SessionManager", () => {
       const restored: Array<{ deviceId: string; profile: string }> = [];
       const manager = makeManagerWithNetworkRestorer(timer, restored);
       try {
-        await manager.createSession("net-ttl-first", "emulator-5554", "android");
+        const session = await manager.createSession("net-ttl-first", "emulator-5554", "android");
         manager.setNetworkCondition("net-ttl-first", { initialProfile: "none" });
-        manager.scheduleNetworkConditionExpiry("net-ttl-first", 60);
+        manager.scheduleNetworkConditionExpiry(session, 60);
 
         // TTL fires first and restores once.
         timer.advanceTime(60_000);
@@ -2129,9 +2129,9 @@ describe("SessionManager", () => {
       const restored: Array<{ deviceId: string; profile: string }> = [];
       const manager = makeManagerWithNetworkRestorer(timer, restored);
       try {
-        await manager.createSession("net-ttl-rebind", "emulator-5554", "android");
+        const session = await manager.createSession("net-ttl-rebind", "emulator-5554", "android");
         manager.setNetworkCondition("net-ttl-rebind", { initialProfile: "none" });
-        manager.scheduleNetworkConditionExpiry("net-ttl-rebind", 60);
+        manager.scheduleNetworkConditionExpiry(session, 60);
 
         // Rebind restores the old device once and discards its cache.
         await manager.rebindSession("net-ttl-rebind", "emulator-5556", "android");
@@ -2151,11 +2151,11 @@ describe("SessionManager", () => {
       const restored: Array<{ deviceId: string; profile: string }> = [];
       const manager = makeManagerWithNetworkRestorer(timer, restored);
       try {
-        await manager.createSession("net-ttl-reapply", "emulator-5554", "android");
+        const session = await manager.createSession("net-ttl-reapply", "emulator-5554", "android");
         manager.setNetworkCondition("net-ttl-reapply", { initialProfile: "none" });
-        manager.scheduleNetworkConditionExpiry("net-ttl-reapply", 60);
+        manager.scheduleNetworkConditionExpiry(session, 60);
         // Re-apply with a longer TTL: the first (60s) timer must be cancelled.
-        manager.scheduleNetworkConditionExpiry("net-ttl-reapply", 120);
+        manager.scheduleNetworkConditionExpiry(session, 120);
 
         timer.advanceTime(60_000);
         expect(restored).toEqual([]);
@@ -2163,6 +2163,133 @@ describe("SessionManager", () => {
 
         timer.advanceTime(60_000);
         await manager.getPendingDeviceCleanup("emulator-5554");
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("clamps an overlong TTL so it does not overflow setTimeout and fire near-immediately (#6085 item 4)", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        const session = await manager.createSession("net-ttl-overflow", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-overflow", { initialProfile: "none" });
+        // 30 days in seconds: 30*24*3600*1000 ms overflows setTimeout's signed
+        // 32-bit delay and, unclamped, would wrap to ~1ms and reset immediately.
+        manager.scheduleNetworkConditionExpiry(session, 30 * 24 * 3600);
+
+        // The armed delay is the clamped ceiling, not a wrapped tiny value.
+        expect(timer.getPendingTimeouts()).toContain(2_147_483 * 1000);
+        // Advancing well past the wrapped-delay window fires nothing.
+        timer.advanceTime(5_000);
+        expect(restored).toEqual([]);
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("routes TTL expiry through the bounded retry, keeping the device quarantined on a transient failure (#6085 review)", async () => {
+      const timer = new FakeTimer();
+      let attempts = 0;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        noopBiometric,
+        (): NetworkConditionRestorer => ({
+          restore: async () => {
+            attempts += 1;
+            if (attempts === 1) {
+              throw new Error("emulator console transiently rejected the reset");
+            }
+          },
+        }),
+      );
+      try {
+        const session = await manager.createSession("net-ttl-retry", "emulator-5554", "android");
+        manager.setNetworkCondition("net-ttl-retry", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry(session, 60);
+
+        await timer.advanceTimeAsync(60_000);
+        const cleanup = manager.getPendingDeviceCleanup("emulator-5554");
+        // First attempt failed: the device stays quarantined and the slot is
+        // RETAINED (not released shaped, unlike the pre-fix fire-and-forget path).
+        expect(cleanup).not.toBeNull();
+        expect(attempts).toBe(1);
+        expect(manager.getNetworkCondition("net-ttl-retry")).toEqual({ initialProfile: "none" });
+
+        await timer.advanceTimeAsync(250);
+        await cleanup;
+        // The retry succeeds; only on success is the slot cleared.
+        expect(attempts).toBe(2);
+        expect(manager.getNetworkCondition("net-ttl-retry")).toBeUndefined();
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("retains the restore slot when TTL retries are exhausted so a later release still restores (#6085 review)", async () => {
+      const timer = new FakeTimer();
+      let attempts = 0;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        noopBiometric,
+        (): NetworkConditionRestorer => ({
+          restore: async () => {
+            attempts += 1;
+            throw new Error("emulator console rejected the reset");
+          },
+        }),
+      );
+      try {
+        const session = await manager.createSession("net-ttl-exhaust", "emulator-5556", "android");
+        manager.setNetworkCondition("net-ttl-exhaust", { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry(session, 60);
+
+        await timer.advanceTimeAsync(60_000);
+        const cleanup = manager.getPendingDeviceCleanup("emulator-5556");
+        await timer.advanceTimeAsync(250);
+        await timer.advanceTimeAsync(250);
+        await cleanup;
+
+        // One initial attempt plus two bounded retries, all rejected.
+        expect(attempts).toBe(3);
+        // The slot is RETAINED (not cleared) so a subsequent release retries the
+        // restore rather than handing back a still-shaped emulator.
+        expect(manager.getNetworkCondition("net-ttl-exhaust")).toEqual({ initialProfile: "none" });
+        expect(manager.getPendingDeviceCleanup("emulator-5556")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not arm a stale TTL against a released same-UUID session (#6085 review)", async () => {
+      const timer = new FakeTimer();
+      const restored: Array<{ deviceId: string; profile: string }> = [];
+      const manager = makeManagerWithNetworkRestorer(timer, restored);
+      try {
+        const original = await manager.createSession("net-uuid", "emulator-5554", "android");
+        manager.setNetworkCondition("net-uuid", { initialProfile: "none" });
+        await manager.releaseSession("net-uuid");
+        // The release-restore ran once.
+        expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
+
+        // A late/stale setup tries to arm a TTL against the now-released instance:
+        // the identity guard must refuse to arm it (a same-UUID replacement must
+        // never inherit this stale timer).
+        manager.scheduleNetworkConditionExpiry(original, 60);
+        expect(timer.getPendingTimeoutCount()).toBe(0);
+
+        timer.advanceTime(120_000);
+        expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
         expect(restored).toEqual([{ deviceId: "emulator-5554", profile: "none" }]);
       } finally {
         manager.stopCleanupTimer();

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -8,6 +8,7 @@ import {
   networkConditionInputDegrades,
   networkConditionInputError,
   networkConditionInputIsRequest,
+  parseEmulatorNetworkStatus,
   type SetNetworkConditionInput,
 } from "../../../src/features/utility/DeviceState";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
@@ -551,6 +552,61 @@ describe("DeviceState", () => {
     expect(result.networkCondition?.verified).toBeUndefined();
     expect(result.networkCondition?.rawStatus).toContain("network status");
     expect(client.getAllCommands()).toEqual(["emu network status"]);
+  });
+
+  test("parses a full emulator network status into structured observed values (#6085)", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    client.setCommandResult(
+      "emu network status",
+      [
+        "Current network status:",
+        "  download speed:   236800 bits/s (231.2 KB/s)",
+        "  upload speed:     118400 bits/s (115.6 KB/s)",
+        "  minimum latency:  80 ms",
+        "  maximum latency:  400 ms",
+      ].join("\n"),
+    );
+
+    const deviceState = new DeviceState(androidDevice, { adbFactory });
+    const result = await deviceState.getState(["networkCondition"]);
+
+    // bits/s -> kbps, delay reflects the MAX latency.
+    expect(result.networkCondition?.observedValues).toEqual({
+      downloadKbps: 237,
+      uploadKbps: 118,
+      delayMs: 400,
+    });
+    // rawStatus is still surfaced verbatim, and the read never claims verified.
+    expect(result.networkCondition?.rawStatus).toContain("download speed");
+    expect(result.networkCondition?.verified).toBeUndefined();
+  });
+
+  test("keeps rawStatus and omits observed values when the status is unparseable (#6085)", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    client.setCommandResult("emu network status", "network shaping: unknown legacy format\n");
+
+    const deviceState = new DeviceState(androidDevice, { adbFactory });
+    const result = await deviceState.getState(["networkCondition"]);
+
+    expect(result.success).toBe(true);
+    expect(result.networkCondition?.rawStatus).toContain("unknown legacy format");
+    // No field could be parsed, so no structured values are claimed.
+    expect(result.networkCondition?.observedValues).toBeUndefined();
+  });
+
+  test("parseEmulatorNetworkStatus extracts partial fields defensively without throwing (#6085)", () => {
+    // Only latency present (min, no max): fall back to the minimum latency.
+    expect(parseEmulatorNetworkStatus("  minimum latency:  35 ms\n")).toEqual({ delayMs: 35 });
+    // Only download speed present, comma-grouped digits tolerated.
+    expect(parseEmulatorNetworkStatus("download speed: 1,920,000 bits/s (1875 KB/s)")).toEqual({
+      downloadKbps: 1920,
+    });
+    // Empty / whitespace / non-matching all fall back to null, never throw.
+    expect(parseEmulatorNetworkStatus("")).toBeNull();
+    expect(parseEmulatorNetworkStatus("   ")).toBeNull();
+    expect(parseEmulatorNetworkStatus("OK")).toBeNull();
   });
 
   test("reports network conditioning unsupported on a physical Android device", async () => {

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -161,6 +161,63 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
+  test("schedules a per-condition TTL for a degrade carrying expiresInSeconds (#6085)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-ttl-wire", "emulator-5554", "android");
+      await runSessionNetworkMutation(
+        manager,
+        "net-ttl-wire",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      // The TTL fires after 30s and resets the device to `none`.
+      timer.advanceTime(30_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+      expect(manager.getNetworkCondition("net-ttl-wire")).toBeUndefined();
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("a later reset cancels a pending TTL rather than racing it (#6085)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-ttl-cancel", "emulator-5554", "android");
+      // Degrade with a TTL, then a manual reset (registerRestore=false) before it fires.
+      await runSessionNetworkMutation(
+        manager,
+        "net-ttl-cancel",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+      await runSessionNetworkMutation(
+        manager,
+        "net-ttl-cancel",
+        "emulator-5554",
+        false,
+        async () => {},
+      );
+
+      // The reset cancelled the timer, so advancing past the TTL fires no restore.
+      timer.advanceTime(60_000);
+      expect(manager.getPendingDeviceCleanup("emulator-5554")).toBeNull();
+      expect(restored).toEqual([]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("runs the mutation untracked when there is no session", async () => {
     let ran = false;
     const result = await runSessionNetworkMutation(

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -218,6 +218,57 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
+  test("cancels the prior TTL before a slow re-apply so it cannot clear the freshly-shaped slot (#6085 review)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    const started = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+    try {
+      await manager.createSession("net-reapply", "emulator-5554", "android");
+      // First apply arms a 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-reapply",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      // A slow re-apply begins; its tracked mutation blocks partway through.
+      const reapply = runSessionNetworkMutation(
+        manager,
+        "net-reapply",
+        "emulator-5554",
+        true,
+        async () => {
+          started.resolve();
+          await finished.promise;
+        },
+        30,
+      );
+      await started.promise;
+
+      // The prior TTL was cancelled BEFORE the mutation ran, so advancing past its
+      // original deadline while the re-apply is still in flight fires NO restore —
+      // the freshly-published slot is not cleared out from under the re-apply.
+      timer.advanceTime(60_000);
+      expect(restored).toEqual([]);
+      expect(manager.getNetworkCondition("net-reapply")).toEqual({ initialProfile: "none" });
+
+      finished.resolve();
+      await reapply;
+
+      // The new TTL is armed only after the mutation settled, and fires on its own clock.
+      timer.advanceTime(30_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("runs the mutation untracked when there is no session", async () => {
     let ran = false;
     const result = await runSessionNetworkMutation(

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -82,7 +82,11 @@ describe("device state tools", () => {
     expect(() =>
       setTool!.schema.parse({ networkCondition: { delayMs: 400, expiresInSeconds: 5 } }),
     ).not.toThrow();
-    // #6012 final: offline + a shaping override is contradictory → rejected.
+    // #6085 item 4: an expiresInSeconds above the 32-bit setTimeout ceiling is
+    // rejected by the schema so the ms product cannot overflow.
+    expect(() =>
+      setTool!.schema.parse({ networkCondition: { profile: "3g", expiresInSeconds: 2_147_484 } }),
+    ).toThrow();
     expect(() =>
       setTool!.schema.parse({ networkCondition: { profile: "offline", delayMs: 500 } }),
     ).toThrow();
@@ -153,6 +157,24 @@ describe("device state tools", () => {
       capability: "unsupported",
       requestedProfile: "3g",
     });
+  });
+
+  test("rejects networkCondition.expiresInSeconds in sessionless mode where no lifecycle owner can enforce it (#6085)", async () => {
+    // Direct/sessionless mode: DaemonState is uninitialized, so the handler has no
+    // SessionManager to schedule a TTL. A degrade that WOULD shape an emulator with
+    // a TTL must be rejected rather than shape the device indefinitely while falsely
+    // echoing the TTL.
+    DaemonState.getInstance().reset();
+    const setTool = ToolRegistry.getTool("setDeviceState");
+    const emulator = createBootedDevice("emulator-5554", "android", "Pixel");
+
+    const response = await setTool!.deviceAwareHandler!(emulator, {
+      networkCondition: { profile: "3g", expiresInSeconds: 30 },
+    });
+
+    const payload = JSON.parse((response as { content: Array<{ text: string }> }).content[0].text);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain("cannot be honored in direct/sessionless mode");
   });
 
   test("does not register a network restore slot for an unsupported (iOS) platform", async () => {


### PR DESCRIPTION
## Summary

Follow-ups to [#6012](https://github.com/kaeawc/auto-mobile/issues/6012) / PR [#6084](https://github.com/kaeawc/auto-mobile/pull/6084), tracked in [#6085](https://github.com/kaeawc/auto-mobile/issues/6085). All concern the device-wide `networkCondition` concern (Android emulator only) in `src/features/utility/DeviceState.ts` + `src/daemon/sessionManager.ts`.

**Item 1 (retry the session-release network restore on fast failure) already shipped in [#6084](https://github.com/kaeawc/auto-mobile/pull/6084)** (`retryNetworkConditionRestore`); this PR builds items **2** and **3**.

## Changes

### Item 2 — Active per-condition TTL for `expiresInSeconds`
`expiresInSeconds` was accepted and echoed as advisory metadata only; cleanup was enforced solely by session release/expiry. This adds a genuine standalone timer:

- `SessionManager.scheduleNetworkConditionExpiry` / `cancelNetworkConditionExpiry` / `handleNetworkConditionExpiry` schedule a per-condition timer on the injected `Timer` seam (never real `setTimeout`). Wired through `runSessionNetworkMutation`: any degrade carrying a positive `expiresInSeconds` arms a timer; any other network mutation (a reset, or a degrade with no TTL) cancels a previously-armed one.
- On expiry the device is reset to `none` via the same `restoreNetworkCondition` path, the restore slot is cleared (so a later release can't double-restore), and the reset is tracked as pending device cleanup (keeping the device quarantined until it settles). A session already released/rebound before the TTL fires is a no-op — the timer never acts on a freed device.
- Release (`releaseSessionInternal`) and rebind (`persistAndPublishRebind`) cancel a pending TTL. Whichever restore runs first wins, so the TTL and the release-restore never double-fire or conflict. `stopCleanupTimer` clears any armed timers so a stopped manager leaves nothing dangling.

### Item 3 — Structured `network status` readback
`getAndroidNetworkCondition` surfaced the emulator console `network status` output verbatim as `rawStatus` only. New `parseEmulatorNetworkStatus()` best-effort parses it into structured applied values (bits/s → kbps for up/down speed, max latency → `delayMs`), surfaced as a new `observedValues?: Partial<NetworkConditionValues>` field alongside the verbatim `rawStatus`.

- Deliberately defensive: every field is optional, an absent/unparseable field is omitted, and it never throws. When nothing parses it returns `null` and the read falls back to `rawStatus` only.
- Honest about verification: the read still does **not** set `verified` — it carries no requested profile to compare against, so `observedValues` is a diagnostic signal, not a verification verdict. (The emulator `network status` format varies by version, hence best-effort per-field parsing rather than an over-claimed full reconstruction.)

## Testing

- `test/daemon/sessionManager.test.ts` (new `network condition TTL scheduling (#6085 item 2)` block): TTL elapses → device reset to `none` + slot cleared; release before TTL cancels the timer (no post-release restore); TTL-then-release does not double-restore; rebind cancels the timer; re-scheduling cancels the prior timer.
- `test/server/sessionNetworkCondition.test.ts`: `runSessionNetworkMutation` with `expiresInSeconds` schedules the TTL; a later reset cancels it rather than racing it.
- `test/features/utility/DeviceState.test.ts`: full status string → structured `observedValues`; unparseable/absent → `rawStatus` kept, `observedValues` undefined, no throw; direct `parseEmulatorNetworkStatus` partial-field cases.
- All new tests are FakeTimer-driven, inject fakes (no real device/DB), and run well under 100ms. Red-first confirmed for item 2 (methods missing).
- Full local gate green: `bun run format:check`, `bun run typecheck` (no new baseline errors), `bun run lint` (no new ratchet violations), `bun run build`, `bun test` (2 pre-existing failures unrelated to this change: the `.claude`-worktree missing-`oxlint`-binary lint test and an unrelated WebRTC capture-load test — both fail identically on the clean base).
- `schemas/tool-definitions.json` regenerated for the updated `expiresInSeconds` description.

Closes #6085
