### PR TITLE
fix(cli): guard null/non-object payload in handleToolResult (#6086)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -571,8 +571,10 @@ function handleToolResult(result: any, toolName: string): void {
   const actualResult = cliToolResultPayload(result);
 
   if (isCliToolFailure(result)) {
-    // Write error message to STDERR
-    if (actualResult.error) {
+    // Write error message to STDERR. Guard the payload access: a failure
+    // envelope's text payload may parse to `null`/a primitive (the CLI accepts
+    // the daemon result as `any`), so only dereference `.error` on an object.
+    if (actualResult && typeof actualResult === "object" && actualResult.error) {
       console.error(actualResult.error);
     } else if (
       result?.isError === true &&
@@ -585,6 +587,8 @@ function handleToolResult(result: any, toolName: string): void {
     // Plan progress is only available in structured executePlan failures.
     if (
       toolName === "executePlan" &&
+      actualResult &&
+      typeof actualResult === "object" &&
       typeof actualResult.executedSteps === "number" &&
       typeof actualResult.totalSteps === "number"
     ) {

--- a/test/cli/toolResultFailure.test.ts
+++ b/test/cli/toolResultFailure.test.ts
@@ -85,3 +85,73 @@ describe("isCliToolFailure (issue #6017)", () => {
     expect(errorMessages).toEqual([["MCP error -32001: Request timed out"]]);
   });
 });
+
+describe("handleToolResult null/non-object payload guard (issue #6086)", () => {
+  const originalProcessExit = process.exit;
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+
+  afterEach(() => {
+    process.exit = originalProcessExit;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    resetDaemonProxyFactoryForTesting();
+  });
+
+  function runWithEnvelope(envelope: unknown): {
+    exitCodes: number[];
+    errorMessages: unknown[][];
+  } {
+    const exitCodes: number[] = [];
+    const errorMessages: unknown[][] = [];
+    process.exit = ((code?: number) => {
+      exitCodes.push(code ?? 0);
+    }) as typeof process.exit;
+    console.error = ((...args: unknown[]) => {
+      errorMessages.push(args);
+    }) as typeof console.error;
+    console.log = (() => {
+      // silence structured stdout dump
+    }) as typeof console.log;
+    setDaemonProxyFactoryForTesting((): any => ({
+      callTool: async () => envelope,
+      close: async (): Promise<void> => {
+        // no-op fake
+      },
+    }));
+    return { exitCodes, errorMessages };
+  }
+
+  test("isError envelope with JSON-null payload surfaces the payload, not a TypeError", async () => {
+    const { exitCodes, errorMessages } = runWithEnvelope({
+      content: [{ type: "text", text: "null" }],
+      isError: true,
+    });
+
+    await runCliCommand(["someTool"]);
+
+    expect(exitCodes).toEqual([1]);
+    expect(errorMessages).toEqual([["null"]]);
+  });
+
+  test("isError envelope with a JSON-primitive payload does not crash and exits non-zero", async () => {
+    const { exitCodes, errorMessages } = runWithEnvelope({
+      content: [{ type: "text", text: "42" }],
+      isError: true,
+    });
+
+    await runCliCommand(["someTool"]);
+
+    expect(exitCodes).toEqual([1]);
+    expect(errorMessages).toEqual([["42"]]);
+  });
+
+  test("isError envelope with a missing content payload exits non-zero without throwing", async () => {
+    const { exitCodes, errorMessages } = runWithEnvelope({ isError: true });
+
+    await runCliCommand(["someTool"]);
+
+    expect(exitCodes).toEqual([1]);
+    expect(errorMessages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

[PR #6047](https://github.com/kaeawc/auto-mobile/pull/6047) ("fix: return failure exit codes for MCP tool errors") rewrote the CLI failure-detection path in `src/cli/index.ts` and dropped the object/null guard that previously protected the failure branch. As a result `handleToolResult` dereferenced `actualResult.error` on a `null` payload, throwing `TypeError: null is not an object` and printing a confusing `Unexpected error: TypeError…` instead of surfacing the envelope payload.

This change restores a null/object guard so a failure envelope whose text payload parses to JSON `null` (or a primitive) falls through to the `isError` content-text branch and still exits non-zero. #6047's headline behavior (failure envelopes produce failure exit codes) is preserved; well-formed success/failure envelopes are unaffected.

## Linked Issue

Closes #6086

## Bug / Regression Context

- **Prior attempts:** #6047 rewrote the failure detection and removed the guard that made this path null-safe.
- **Observed symptom:** For a `{ content: [{ type: "text", text: "null" }], isError: true }` envelope, `cliToolResultPayload` runs `JSON.parse("null")` → `null`, then `src/cli/index.ts` line 575 `if (actualResult.error)` dereferences `null` → `TypeError: null is not an object (evaluating 'actualResult.error')`. The outer `runCliCommand` catch swallows it and prints `Unexpected error: TypeError…`. Process still exits 1, so this is a crash/wrong-diagnostic, not an exit-code inversion.
- **Repro steps / conditions:** A daemon proxy failure envelope with a `text` payload of the literal `null` (the CLI accepts the proxy result as `any` over the daemon socket). Reproduced on HEAD.

## Changes

- `src/cli/index.ts` — guard the `.error` dereference in `handleToolResult` with `actualResult && typeof actualResult === "object"` before reading `.error`; apply the same object guard to the `executePlan` diagnostics block, which dereferences the same payload.
- `test/cli/toolResultFailure.test.ts` — added a describe block for #6086: JSON-`null` payload surfaces the payload (not a TypeError) and exits non-zero; JSON-primitive payload and missing-content payload also exit non-zero without throwing. The null-payload test is red-first on current HEAD (fails with the exact `TypeError`).

## Validation

- [x] `bun run lint` — oxlint ratchet: no new violations (615 gated, unchanged)
- [x] `bun run typecheck` reports no new errors (baseline gate: 165 known)
- [x] `bun run build` succeeds
- [x] `bun test test/cli/` — 55 pass, 0 fail (<300ms)
- [x] New tests use fakes; run in <100ms
