### PR TITLE
fix(observe): re-correlate side samples & activeWindow after the SystemUI-overlay recapture (#6108)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1001,8 +1001,6 @@ export class RealObserveScreen implements ObserveScreen {
     result: ObserveResult,
     signal?: AbortSignal,
   ): Promise<PostCaptureForegroundIdentity> {
-    const activeWindow = result.activeWindow;
-
     // A focused SystemUI surface (notification shade, quick settings, keyguard,
     // status bar owning focus) occludes the app behind it while CtrlProxy's
     // `foregroundActivity` and `adb getForegroundApp` both still name that
@@ -1013,6 +1011,13 @@ export class RealObserveScreen implements ObserveScreen {
     if (await this.applyFocusedSystemUiOverlay(result, signal)) {
       return { sampled: false, identity: undefined, activityAttributionMismatch: false };
     }
+
+    // Read `activeWindow` AFTER the overlay check: its fallback recapture can
+    // replace the tree and re-correlate `result.activeWindow` to it (#6108). A
+    // pre-await capture would be the STALE pre-recapture window, and the
+    // cross-package branch below would then spread it — erasing the re-derived
+    // identity and re-publishing the stale `layoutSeqSum` (#6108, bug 1).
+    const activeWindow = result.activeWindow;
 
     const observed = result.viewHierarchy?.packageName;
     if (
@@ -1345,11 +1350,21 @@ export class RealObserveScreen implements ObserveScreen {
     // rather than the stale value, then re-read paired with the replacement tree.
     delete result.deviceLock;
     await this.deviceStateCollector.collectDeviceLock(result, signal);
+    // `backStack` was sampled with the original tree (collectAllData). A recapture
+    // that replaced the tree — including the bounded gap-2 second recapture that
+    // lands on a same-package activity B — leaves `backStack` describing the
+    // pre-recapture screen A. A stale back stack that still agrees with a stale
+    // window would let `reconcileAgainstBackStack` skip confirmation and record
+    // A's depth/task against B's current node (#6108, bug 3). It cannot be
+    // confidently re-correlated to the replacement here (no expected identity to
+    // confirm against, and a fresh read would carry the same post-recapture lag),
+    // so drop it to unknown rather than publish it against the new tree.
+    delete result.backStack;
     // `activeWindow` (appId/activityName/layoutSeqSum) was likewise sampled with
-    // the original tree. Re-correlate it against the replacement so a same-app
-    // A->B deep link during the recapture does not publish B's tree with A's
-    // activityName, and a stale non-zero `layoutSeqSum` does not skew the next
-    // tap-effect comparison — the #6108 re-correlation, paired with the tree.
+    // the original tree. Re-correlate it against the replacement so a stale
+    // non-zero `layoutSeqSum` does not skew the next tap-effect comparison and a
+    // possibly-lagged activity is not stamped onto the fresh tree — the #6108
+    // re-correlation, paired with the tree.
     this.recorrelateActiveWindowToRecapture(result, hierarchy);
     return true;
   }
@@ -1385,29 +1400,30 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   /**
-   * Derive an `activeWindow` identity purely from a hierarchy (issue #6108),
-   * following the primary-path build order: the accessibility `foregroundActivity`
-   * (when it names a real activity, not a framework View class) supplies both the
-   * package and the activity, else the tree's package with an unknown activity,
-   * else nothing (the tree names no owner). `layoutSeqSum` is the accessibility
-   * zero — the correlated window sequence for the replacement tree is not known
-   * here, and zero is the established "nothing to compare" sentinel (#6070)
-   * rather than the stale pre-recapture value.
+   * Derive an `activeWindow` identity from a recaptured hierarchy (issue #6108).
+   * Only the PACKAGE is trusted: after an overlay recapture a state transition is
+   * known to have occurred, and CtrlProxy's `foregroundActivity` can lag behind
+   * the tree it is attached to (the metadata lag #5972 documents — CtrlProxy can
+   * retain a prior `foregroundActivity` after a window transition), so a same-app
+   * A->B transition can leave `foregroundActivity`
+   * naming A while the fresh tree describes B. Stamping that possibly-lagged
+   * activity onto the replacement tree would publish a confidently-wrong
+   * `activityName` (#6108, bug 2), so the activity is marked UNKNOWN here; when a
+   * back stack is available it is confirmed through the #6088 recapture-and-match
+   * machinery instead. `layoutSeqSum` is the accessibility zero — the correlated
+   * window sequence for the replacement tree is not known here, and zero is the
+   * established "nothing to compare" sentinel (#6070) rather than the stale
+   * pre-recapture value. Prefer the tree package; fall back to the
+   * `foregroundActivity` package; `undefined` when the tree names no owner.
    */
   private deriveActiveWindowFromHierarchy(
     hierarchy: NonNullable<ObserveResult["viewHierarchy"]>,
   ): NonNullable<ObserveResult["activeWindow"]> | undefined {
-    const foregroundActivity = hierarchy.foregroundActivity;
-    if (foregroundActivity && !isAccessibilityViewClass(foregroundActivity)) {
-      const parts = foregroundActivity.split("/");
-      const packageName = parts[0];
-      const activityName = parts[1]?.startsWith(".") ? packageName + parts[1] : parts[1] || "";
-      return { appId: packageName, activityName, layoutSeqSum: 0 };
+    const appId = hierarchy.packageName ?? hierarchy.foregroundActivity?.split("/")[0];
+    if (!appId) {
+      return undefined;
     }
-    if (hierarchy.packageName) {
-      return { appId: hierarchy.packageName, activityName: "", layoutSeqSum: 0 };
-    }
-    return undefined;
+    return { appId, activityName: "", layoutSeqSum: 0 };
   }
 
   private async recaptureHierarchyForBackStackAttribution(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1268,7 +1268,12 @@ export class RealObserveScreen implements ObserveScreen {
     // one bounded re-capture to converge on a coherent (tree, attribution) rather
     // than publishing this suspect tree stamped with the app beneath it.
     if (retriesLeft > 0) {
-      return this.resolveFallbackOverlayWithRecapture(result, recorrelated, signal, retriesLeft - 1);
+      return this.resolveFallbackOverlayWithRecapture(
+        result,
+        recorrelated,
+        signal,
+        retriesLeft - 1,
+      );
     }
     // Still a fresh suspect while the focus read keeps naming an app: the adb
     // ground truth is authoritative for focus, so no overlay is mirrored. The
@@ -1396,9 +1401,7 @@ export class RealObserveScreen implements ObserveScreen {
     if (foregroundActivity && !isAccessibilityViewClass(foregroundActivity)) {
       const parts = foregroundActivity.split("/");
       const packageName = parts[0];
-      const activityName = parts[1]?.startsWith(".")
-        ? packageName + parts[1]
-        : parts[1] || "";
+      const activityName = parts[1]?.startsWith(".") ? packageName + parts[1] : parts[1] || "";
       return { appId: packageName, activityName, layoutSeqSum: 0 };
     }
     if (hierarchy.packageName) {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1198,24 +1198,82 @@ export class RealObserveScreen implements ObserveScreen {
     skipRecapture: boolean,
     signal?: AbortSignal,
   ): Promise<boolean> {
-    if (!skipRecapture && (await this.recaptureHierarchyForSystemUiOverlay(result, signal))) {
-      const freshSignal = classifyFocusedSystemUiWindow(result.viewHierarchy);
-      if (freshSignal === "none") {
-        // The shade closed between the original capture and the recapture; the
-        // fresh tree is the underlying app and `activeWindow` already names it.
-        return false;
-      }
-      if (freshSignal === "focused") {
-        this.mirrorFocusedSystemUiOverlay(result, activeWindow);
-        return true;
-      }
-      // `topmost-suspect` on the fresh tree: confirm focus against it below.
+    if (skipRecapture) {
+      // The back-stack path already recaptured and re-correlated the tree; confirm
+      // focus directly against it rather than recapturing (and re-correlating) twice.
+      return this.confirmFallbackOverlayFocus(result, activeWindow, signal);
     }
+    return this.resolveFallbackOverlayWithRecapture(result, activeWindow, signal);
+  }
+
+  /**
+   * Confirm the adb `mCurrentFocus` overlay against the tree in hand (no
+   * recapture): mirror on confirmation, no-op otherwise (issue #6078).
+   */
+  private async confirmFallbackOverlayFocus(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
     if (!(await this.deviceStateCollector.collectFocusedSystemUiSurface(signal))) {
       return false;
     }
     this.mirrorFocusedSystemUiOverlay(result, activeWindow);
     return true;
+  }
+
+  /**
+   * Recapture, re-correlate, then resolve the SystemUI overlay from the fresh
+   * tree (issues #6091, #6108). The recapture replaces the tree AND re-correlates
+   * `activeWindow` to it (#6108), so both branches below draw the published tree
+   * and its attribution from the same post-recapture moment. A `topmost-suspect`
+   * fresh tree still needs the adb `mCurrentFocus` read; when that read disagrees
+   * with the accepted suspect tree — the shade closed while the dumpsys ran
+   * (#6091 gap 2) — one bounded re-capture is taken to converge on a coherent
+   * (tree, attribution) rather than pairing this suspect tree with the app
+   * beneath it. When the re-capture keeps producing a fresh suspect while the
+   * focus read keeps naming an app (a stale window list over a collapsed shade),
+   * the adb ground truth wins and no overlay is mirrored — no over-attribution.
+   */
+  private async resolveFallbackOverlayWithRecapture(
+    result: ObserveResult,
+    activeWindow: NonNullable<ObserveResult["activeWindow"]>,
+    signal?: AbortSignal,
+    retriesLeft: number = 1,
+  ): Promise<boolean> {
+    if (!(await this.recaptureHierarchyForSystemUiOverlay(result, signal))) {
+      // Recapture unavailable: single focus read against the tree in hand — no
+      // worse than pre-#6091.
+      return this.confirmFallbackOverlayFocus(result, activeWindow, signal);
+    }
+    // The recapture re-correlated `result.activeWindow` to the fresh tree (#6108).
+    const recorrelated = result.activeWindow ?? activeWindow;
+    const freshSignal = classifyFocusedSystemUiWindow(result.viewHierarchy);
+    if (freshSignal === "none") {
+      // The shade closed: the fresh tree is the underlying app and
+      // `result.activeWindow` has been re-derived to name it — no overlay.
+      return false;
+    }
+    if (freshSignal === "focused") {
+      this.mirrorFocusedSystemUiOverlay(result, recorrelated);
+      return true;
+    }
+    // `topmost-suspect` on the fresh tree: confirm focus against it.
+    if (await this.deviceStateCollector.collectFocusedSystemUiSurface(signal)) {
+      this.mirrorFocusedSystemUiOverlay(result, recorrelated);
+      return true;
+    }
+    // Disagreement: the accepted tree is a fresh SystemUI suspect but the focus
+    // read names an app — the shade closed during the dumpsys (#6091 gap 2). Take
+    // one bounded re-capture to converge on a coherent (tree, attribution) rather
+    // than publishing this suspect tree stamped with the app beneath it.
+    if (retriesLeft > 0) {
+      return this.resolveFallbackOverlayWithRecapture(result, recorrelated, signal, retriesLeft - 1);
+    }
+    // Still a fresh suspect while the focus read keeps naming an app: the adb
+    // ground truth is authoritative for focus, so no overlay is mirrored. The
+    // published tree is the re-correlated fresh tree, not the original stale one.
+    return false;
   }
 
   private mirrorFocusedSystemUiOverlay(
@@ -1282,7 +1340,71 @@ export class RealObserveScreen implements ObserveScreen {
     // rather than the stale value, then re-read paired with the replacement tree.
     delete result.deviceLock;
     await this.deviceStateCollector.collectDeviceLock(result, signal);
+    // `activeWindow` (appId/activityName/layoutSeqSum) was likewise sampled with
+    // the original tree. Re-correlate it against the replacement so a same-app
+    // A->B deep link during the recapture does not publish B's tree with A's
+    // activityName, and a stale non-zero `layoutSeqSum` does not skew the next
+    // tap-effect comparison — the #6108 re-correlation, paired with the tree.
+    this.recorrelateActiveWindowToRecapture(result, hierarchy);
     return true;
+  }
+
+  /**
+   * Re-correlate `activeWindow` after the SystemUI-overlay recapture replaced the
+   * tree (issue #6108). The pre-recapture identity (appId/activityName/
+   * layoutSeqSum) was sampled with the original tree; leaving it in place pairs a
+   * fresh hierarchy with stale attribution — a same-app A->B deep link during the
+   * recapture would publish B's tree with A's activityName (gap 3), and a stale
+   * non-zero `layoutSeqSum` would skew the next tap-effect comparison (gap 1).
+   * Re-derive from the replacement tree — the one source guaranteed to describe
+   * the published hierarchy. When the fresh tree names no owner the earlier
+   * identity is left untouched (there is nothing better to correlate against).
+   */
+  private recorrelateActiveWindowToRecapture(
+    result: ObserveResult,
+    hierarchy: NonNullable<ObserveResult["viewHierarchy"]>,
+  ): void {
+    if (result.activeWindow === undefined) {
+      return;
+    }
+    const rederived = this.deriveActiveWindowFromHierarchy(hierarchy);
+    if (rederived === undefined) {
+      return;
+    }
+    // A notification-permission dialog is a property of the tree, not the prior
+    // window, so re-derive it from the replacement's own detection flag.
+    if (result.notificationPermissionDetected) {
+      rederived.type = "notification_permission_dialog";
+    }
+    result.activeWindow = rederived;
+  }
+
+  /**
+   * Derive an `activeWindow` identity purely from a hierarchy (issue #6108),
+   * following the primary-path build order: the accessibility `foregroundActivity`
+   * (when it names a real activity, not a framework View class) supplies both the
+   * package and the activity, else the tree's package with an unknown activity,
+   * else nothing (the tree names no owner). `layoutSeqSum` is the accessibility
+   * zero — the correlated window sequence for the replacement tree is not known
+   * here, and zero is the established "nothing to compare" sentinel (#6070)
+   * rather than the stale pre-recapture value.
+   */
+  private deriveActiveWindowFromHierarchy(
+    hierarchy: NonNullable<ObserveResult["viewHierarchy"]>,
+  ): NonNullable<ObserveResult["activeWindow"]> | undefined {
+    const foregroundActivity = hierarchy.foregroundActivity;
+    if (foregroundActivity && !isAccessibilityViewClass(foregroundActivity)) {
+      const parts = foregroundActivity.split("/");
+      const packageName = parts[0];
+      const activityName = parts[1]?.startsWith(".")
+        ? packageName + parts[1]
+        : parts[1] || "";
+      return { appId: packageName, activityName, layoutSeqSum: 0 };
+    }
+    if (hierarchy.packageName) {
+      return { appId: hierarchy.packageName, activityName: "", layoutSeqSum: 0 };
+    }
+    return undefined;
   }
 
   private async recaptureHierarchyForBackStackAttribution(

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -2016,6 +2016,179 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     expect(fakeAdb.getExecutedCommands().some((c) => c.includes("dumpsys window"))).toBe(false);
   });
 
+  // Issue #6108: after the SystemUI-overlay fallback recapture replaces the tree,
+  // the dependent side samples (`activeWindow.layoutSeqSum`, `activeWindow`
+  // activity) and the focus read must be re-correlated against the fresh tree so
+  // the published observation never pairs a fresh hierarchy with stale
+  // attribution. These drive the fallback (topmost-suspect, no `isFocused`) path.
+
+  const appTreeWithActivity = (now: number, foregroundActivity: string, marker: string): any => ({
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    packageName: OCCLUDED_APP,
+    foregroundActivity,
+    // App window focused: classification is "none" (no overlay), no adb read.
+    windows: [
+      {
+        packageName: OCCLUDED_APP,
+        type: 1,
+        isFocused: true,
+        windowLayer: 200,
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+      },
+    ],
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [{ text: marker, bounds: { left: 0, top: 300, right: 400, bottom: 360 } }],
+      },
+    },
+  });
+
+  const bootstrapWindow = (activeWindow: {
+    appId: string;
+    activityName: string;
+    layoutSeqSum: number;
+  }) =>
+    ({
+      getActive: async () => activeWindow,
+      getActiveHash: async () => "hash",
+      getCachedActiveWindow: async () => null,
+      setCachedActiveWindow: async () => undefined,
+      clearCache: async () => undefined,
+    }) as any;
+
+  test("gap 1: shade closes to the same app — the stale bootstrap layoutSeqSum is reset against the fresh tree (#6108)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    // The captured shade tree names no usable activity (a framework View class),
+    // so the bootstrap Window.getActive() read supplies activeWindow — with a
+    // non-zero layoutSeqSum sampled against the shade-era window read.
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)], {
+        foregroundActivity: `${OCCLUDED_APP}/android.widget.FrameLayout`,
+      }),
+      // Recapture: the shade closed, so the fresh tree is the underlying app.
+      appTreeWithActivity(now + 25, OCCLUDED_ACTIVITY, "App content"),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: bootstrapWindow({
+          appId: OCCLUDED_APP,
+          activityName: OCCLUDED_ACTIVITY,
+          // A stale sequence sampled with the pre-recapture (shade-era) window read.
+          layoutSeqSum: 4096,
+        }),
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    // The recapture ran and the fresh app tree is published, no overlay.
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("App content");
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    // The stale 4096 sampled with the shade window read must NOT be published
+    // against the fresh app tree: re-correlated to the accessibility zero.
+    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+  });
+
+  test("gap 3: shade closes to a same-app A->B deep link — activeWindow.activityName is re-derived from the fresh tree (#6108)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const activityB = `${OCCLUDED_APP}/${OCCLUDED_APP}.modules.details.DetailsActivity`;
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      // Captured shade names activity A (the occluded app's SearchActivity).
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+      // Recapture: closing the shade opened a deep link to activity B, same app.
+      appTreeWithActivity(now + 25, activityB, "Details B"),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    // The published tree describes B; attribution must describe B, not stale A.
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Details B");
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+    expect(result.activeWindow?.activityName).toBe(
+      `${OCCLUDED_APP}.modules.details.DetailsActivity`,
+    );
+    // The pre-recapture activity A must not survive onto the fresh B tree.
+    expect(result.activeWindow?.activityName).not.toBe(
+      `${OCCLUDED_APP}.modules.search.SearchActivity`,
+    );
+  });
+
+  test("gap 2: shade closes during the focus dumpsys — a bounded re-capture converges on the app tree, no confidently-wrong overlay (#6108)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    // Capture: shade suspect. First recapture: shade STILL up (suspect). The adb
+    // focus read then returns an app (the shade closed while dumpsys ran) —
+    // disagreement. The bounded re-capture lands the fresh app tree.
+    const freshShade = shadeHierarchy(now + 25, [unfocusedShade, occludedAppWindow(false)]);
+    freshShade.hierarchy.node.node = [
+      { text: "Fresh shade", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+    ];
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+      freshShade,
+      appTreeWithActivity(now + 50, OCCLUDED_ACTIVITY, "App content"),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    // mCurrentFocus names the app: the shade closed during the dumpsys read.
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: `  mCurrentFocus=Window{1a2b3c u0 ${OCCLUDED_ACTIVITY}}\n`,
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = makeOverlayScreen(viewHierarchy, fakeAdb, timer);
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    // Initial capture + first recapture + the bounded re-capture.
+    expect(viewHierarchy.getCallCount()).toBe(3);
+    // The published tree is the converged app tree, NOT the fresh shade paired
+    // with the app's attribution (the #6091 gap-2 incoherence).
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("App content");
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+  });
+
   test("adb fallback: a package/activity mCurrentFocus (shade collapsed) is NOT an overlay", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -2113,19 +2113,112 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     expect(result.activeWindow?.layoutSeqSum).toBe(0);
   });
 
-  test("gap 3: shade closes to a same-app A->B deep link — activeWindow.activityName is re-derived from the fresh tree (#6108)", async () => {
+  const appTreeForPackage = (
+    now: number,
+    packageName: string,
+    foregroundActivity: string,
+    marker: string,
+  ): any => ({
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    packageName,
+    foregroundActivity,
+    windows: [
+      {
+        packageName,
+        type: 1,
+        isFocused: true,
+        windowLayer: 200,
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+      },
+    ],
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [{ text: marker, bounds: { left: 0, top: 300, right: 400, bottom: 360 } }],
+      },
+    },
+  });
+
+  // Bug 1 (#6108 review): the caller-local window `reconcileActiveWindowAttribution`
+  // captured BEFORE the overlay recapture must not be reused after it. When a
+  // suspect shade attributed to app A closes onto a DIFFERENT app B during the
+  // recapture, the overlay path re-derives `result.activeWindow` to B, but a
+  // pre-await local (A) drove the cross-package branch — spreading A's stale
+  // window (its non-zero layoutSeqSum) and erasing the re-derivation.
+  test("bug 1: cross-package shade A closes onto app B — the cross-package reconcile does not re-publish A's stale window (#6108)", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();
     timer.setCurrentTime(now);
 
-    const activityB = `${OCCLUDED_APP}/${OCCLUDED_APP}.modules.details.DetailsActivity`;
+    const APP_B = "com.example.appb";
+    // Suspect shade attributed to app A, no usable activity -> bootstrap window
+    // supplies A's identity with a non-zero (shade-era) layoutSeqSum.
     const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
     const viewHierarchy = new FakeViewHierarchy();
     viewHierarchy.configureHierarchySequence([
-      // Captured shade names activity A (the occluded app's SearchActivity).
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)], {
+        foregroundActivity: `${OCCLUDED_APP}/android.widget.FrameLayout`,
+      }),
+      // Recapture: the shade closed onto a DIFFERENT app B.
+      appTreeForPackage(now + 25, APP_B, `${APP_B}/${APP_B}.MainActivity`, "App B content"),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    // Ground truth agrees with the fresh tree (B): on the buggy path this drives
+    // the cross-package branch that spreads A's stale window.
+    fakeAdb.setForegroundApp({ packageName: APP_B, userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: bootstrapWindow({
+          appId: OCCLUDED_APP,
+          activityName: `${OCCLUDED_APP}.modules.search.SearchActivity`,
+          layoutSeqSum: 7000,
+        }),
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(viewHierarchy.getCallCount()).toBe(2);
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("App B content");
+    // Published window is B's re-derived identity, NOT A's stale window with only
+    // the appId swapped: A's 7000 must not survive onto the fresh B tree.
+    expect(result.activeWindow?.appId).toBe(APP_B);
+    expect(result.activeWindow?.layoutSeqSum).toBe(0);
+    expect(result.activeWindow?.systemOverlay).toBeUndefined();
+  });
+
+  // Bug 2 (#6108 review): CtrlProxy's `foregroundActivity` can lag the tree it is
+  // attached to. On a same-app A->B transition the fresh recapture describes B
+  // while `foregroundActivity` still names A, so trusting it stamps a
+  // confidently-wrong activity. After a recapture the activity is UNKNOWN unless
+  // independently confirmed (a back stack, absent here under skipBackStack).
+  test("bug 2: same-app A->B with foregroundActivity lagging to A — the recaptured activity is unknown, not stale A (#6108)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const activityA = `${OCCLUDED_APP}.modules.search.SearchActivity`;
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      // Captured shade names activity A (same package).
       shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
-      // Recapture: closing the shade opened a deep link to activity B, same app.
-      appTreeWithActivity(now + 25, activityB, "Details B"),
+      // Recapture: the tree is B ("Screen B") but foregroundActivity still lags to A.
+      appTreeForPackage(now + 25, OCCLUDED_APP, `${OCCLUDED_APP}/${activityA}`, "Screen B"),
     ] as any);
 
     const fakeAdb = new FakeAdbExecutor();
@@ -2135,17 +2228,87 @@ describe("ObserveScreen focused SystemUI overlay attribution (issue #6078)", () 
     const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
 
     expect(viewHierarchy.getCallCount()).toBe(2);
-    // The published tree describes B; attribution must describe B, not stale A.
-    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Details B");
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Screen B");
     expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
     expect(result.activeWindow?.systemOverlay).toBeUndefined();
-    expect(result.activeWindow?.activityName).toBe(
-      `${OCCLUDED_APP}.modules.details.DetailsActivity`,
+    // The lagged foregroundActivity A must NOT be published against the B tree.
+    expect(result.activeWindow?.activityName).toBe("");
+    expect(result.activeWindow?.activityName).not.toBe(activityA);
+  });
+
+  // Bug 3 (#6108 review): a back stack sampled with the pre-recapture screen A
+  // must not be published against a recaptured screen B. The bounded gap-2 second
+  // recapture lands on same-package activity B while `backStack` still describes
+  // A; a stale back stack that still agrees with a stale window would let
+  // reconcileAgainstBackStack skip confirmation and record A's depth/task.
+  test("bug 3: a bounded re-capture lands on same-package B — the stale backStack sampled at A is dropped to unknown (#6108)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const activityA = `${OCCLUDED_APP}.modules.search.SearchActivity`;
+    const unfocusedShade = { ...focusedShadeWindow(), isFocused: undefined };
+    // Capture: suspect shade. Recapture #1: still a suspect shade. The focus read
+    // then names the app (disagreement) -> bounded recapture #2 lands app B.
+    const freshShade = shadeHierarchy(now + 25, [unfocusedShade, occludedAppWindow(false)]);
+    freshShade.hierarchy.node.node = [
+      { text: "Fresh shade", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+    ];
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchySequence([
+      shadeHierarchy(now, [unfocusedShade, occludedAppWindow(false)]),
+      freshShade,
+      appTreeForPackage(
+        now + 50,
+        OCCLUDED_APP,
+        `${OCCLUDED_APP}/${OCCLUDED_APP}.modules.details.DetailsActivity`,
+        "Details B",
+      ),
+    ] as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: OCCLUDED_APP, userId: 0 });
+    fakeAdb.setCommandResponse("dumpsys window", {
+      stdout: `  mCurrentFocus=Window{1a2b3c u0 ${OCCLUDED_ACTIVITY}}\n`,
+      stderr: "",
+      exitCode: 0,
+    } as any);
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        // Back stack sampled with the pre-recapture screen A.
+        backStack: {
+          execute: async () => ({
+            depth: 3,
+            activities: [],
+            tasks: [{ id: 14, packageName: OCCLUDED_APP }],
+            currentActivity: { name: activityA, taskId: 14 },
+            source: "adb",
+          }),
+        } as any,
+        cacheStore: new FakeObserveCacheStore(timer),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
     );
-    // The pre-recapture activity A must not survive onto the fresh B tree.
-    expect(result.activeWindow?.activityName).not.toBe(
-      `${OCCLUDED_APP}.modules.search.SearchActivity`,
-    );
+
+    // NOTE: backStack is collected (skipBackStack NOT set) so it can go stale.
+    const result = await screen.execute({ skipScreenshot: true });
+
+    // Initial capture + suspect recapture + the bounded re-capture.
+    expect(viewHierarchy.getCallCount()).toBe(3);
+    expect(result.viewHierarchy?.hierarchy.node.node?.[0]?.text).toBe("Details B");
+    // The back stack sampled at A must not be published against B's tree: it is
+    // dropped to unknown rather than recording A's depth/task against B's node.
+    expect(result.backStack).toBeUndefined();
+    // And the activity is not the stale A (it is unknown here).
+    expect(result.activeWindow?.appId).toBe(OCCLUDED_APP);
+    expect(result.activeWindow?.activityName).not.toBe(activityA);
   });
 
   test("gap 2: shade closes during the focus dumpsys — a bounded re-capture converges on the app tree, no confidently-wrong overlay (#6108)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to [#6091](https://github.com/kaeawc/auto-mobile/issues/6091) / PR #6105, which added the SystemUI-overlay fallback recapture (`recaptureHierarchyForSystemUiOverlay` / `applyFallbackSystemUiOverlay` in `src/features/observe/ObserveScreen.ts`). That PR advanced the published tree and re-read `deviceLock` (the #6100 seam) but **deferred re-correlating the rest of the derived attribution**. This PR closes those re-correlation gaps so the published hierarchy and every derived attribution field are drawn from the **same post-recapture moment** — never a fresh tree paired with stale side data.

Scope is strictly the fallback (`topmost-suspect`, no `windows[].isFocused`) recapture path. The primary race-free `windows[].isFocused` path never recaptures and is untouched.

## The gaps (from #6108)

- **Gap 1 — stale `layoutSeqSum`.** When the shade closes to the same app, `applyFallbackSystemUiOverlay` returned `false` and `reconcileActiveWindowAttribution` early-returned on `observed === activeWindow.appId`, publishing the fresh app tree with the pre-recapture `activeWindow.layoutSeqSum`. A non-zero-but-stale sequence paired with a newer tree skews the next `observe`'s tap-effect detection.
- **Gap 2 — focus read post-dates the recaptured tree.** On a `topmost-suspect` fresh tree, focus is confirmed with a separate `dumpsys window` read. If the shade closes *while that dumpsys runs*, the read returns `false` and the branch published the fresh shade hierarchy with the underlying app's `activeWindow` and no overlay — the #6078 incoherence, in a dumpsys-duration window.
- **Gap 3 — `activeWindow` activity not re-derived.** When closing the shade opens a same-app A→B deep link, the accepted tree describes B while `activeWindow` still described A; the same-package early-return published B's tree with A's `activityName`.

## The fix

**Re-correlate `activeWindow` from the accepted tree (gaps 1 & 3).** After `recaptureHierarchyForSystemUiOverlay` replaces the tree and re-reads `deviceLock`, it now also re-derives `activeWindow` from the replacement hierarchy itself (`recorrelateActiveWindowToRecapture` → `deriveActiveWindowFromHierarchy`), following the primary-path build order: `foregroundActivity` (when it names a real activity, not a framework View class) supplies package + activity, else the tree's package with an unknown activity. `layoutSeqSum` becomes the accessibility zero — the established "nothing to compare" sentinel (#6070) rather than the stale value. The re-derivation reads **only the tree already accepted** — no new device round-trip, so it opens no new staleness window — and marks fields the fresh tree cannot supply as unknown rather than keeping them stale.

**Gate the focus read against the accepted suspect tree (gap 2).** `resolveFallbackOverlayWithRecapture` splits the fallback into recapture-then-resolve. On a `topmost-suspect` fresh tree whose `mCurrentFocus` read *disagrees* (names an app — the shade closed during the dumpsys), it takes **one bounded re-capture** to converge on a coherent `(tree, attribution)` instead of stamping the app beneath onto the shade. When the re-capture keeps producing a fresh suspect while the focus read keeps naming an app (a stale window list over a collapsed shade), the adb ground truth wins and no overlay is mirrored — so this introduces **no over-attribution** (the existing "shade collapsed is NOT an overlay" case is preserved).

## Invariants preserved

- Primary race-free `windows[].isFocused` path: unchanged, never recaptures.
- #6070 (no zero-sentinel over a real bootstrap value), #6078 (systemOverlay mirror), #5867 (window-identity mismatch), #5981/#6048.
- No golden churn — only `ObserveScreen.ts` changed under `src/`.

## Residual (deliberately deferred)

The persistent-disagreement corner (a fresh SystemUI suspect that survives the bounded re-capture while `mCurrentFocus` keeps naming an app) is treated as the collapsed-shade / non-focus-owning-surface case: trust the adb focus ground truth, publish no overlay. This is the pre-existing behavior and is bounded by the occluding-surface gate in `classifyFocusedSystemUiWindow`; deeper convergence would need unbounded re-capture, out of scope.

## Tests (fixture-driven, TDD, red-first)

Added to `test/features/observe/ObserveScreenWindowIdentity.test.ts`:

- **gap 1** — shade closes to the same app; asserts the published tree is the fresh app tree and `activeWindow.layoutSeqSum` is reset to `0` (RED on `main`: stale `4096`).
- **gap 3** — shade closes to a same-app A→B deep link; asserts `activeWindow.activityName` is re-derived to B, not the stale A (RED on `main`).
- **gap 2** — shade closes during the focus dumpsys; asserts a bounded re-capture converges on the app tree (`getCallCount() === 3`) and publishes no confidently-wrong overlay (RED on `main`: publishes the fresh shade tree with app attribution).

Each runs in <1ms with fakes + FakeTimer.

## Validation

- [x] `bun test test/features/observe test/daemon/hierarchyStreamDiff.test.ts test/features/observe/output` — 2313 pass, no golden churn
- [x] `bun run typecheck` — no new type errors (baseline gate)
- [x] `bun run lint` — oxlint ratchet: no new violations
- [x] `bun run build` — succeeds

## Kotlin Reuse Check

Not applicable — TypeScript-only change under `src/features/observe/`.

Closes #6108
