### PR TITLE
fix(observe): retract freshness for app-labelled status-bar-only captures (#5981)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1662,15 +1662,40 @@ export class RealObserveScreen implements ObserveScreen {
   ): Promise<{ foreground: string } | undefined> {
     const foreground = await foregroundIdentity;
     const hierarchy = result.viewHierarchy;
-    if (!isStatusBarOnlyCandidate(hierarchy, foreground)) {
+
+    // Two independent entry conditions, both cheap (no device round-trip):
+    //  - package identity: a system-UI or incomplete tree is being served while a
+    //    real app is foregrounded (isStatusBarOnlyCandidate); or
+    //  - geometry: every extracted node lies within the status-bar strip. This is
+    //    the reliable signal after #5976 corrected the reported package to the
+    //    focused application — the label then matches the foreground app while the
+    //    selected window stays status-bar-only (#5981), silencing the identity
+    //    check and leaving the geometry as the only evidence.
+    const geometryStatusBarOnly = isStatusBarOnlyHierarchy(result);
+    if (!isStatusBarOnlyCandidate(hierarchy, foreground) && !geometryStatusBarOnly) {
       return undefined;
     }
-    const confirmed = await this.resolvePostCaptureForegroundIdentity(
-      foreground,
-      hierarchy?.packageName ?? "",
-      postCaptureForeground,
-      signal,
-    );
+    // A real (non-system) app must be the resumed foreground for this to be a
+    // wrong-window capture rather than a legitimate system surface (e.g. an open
+    // notification shade owned by com.android.systemui).
+    if (foreground === undefined || SYSTEM_UI_WINDOW_PACKAGES.has(foreground)) {
+      return undefined;
+    }
+    // When the tree is geometrically status-bar-only it carries no application
+    // content regardless of the package it is labelled with, so the observed/foreground
+    // equality that short-circuits resolvePostCaptureForegroundIdentity is exactly the
+    // #5981 shape (label corrected to the foreground app) and must not block the gate.
+    // Still take the confirming foreground read so a genuine A→B transition reports the
+    // settled app. Otherwise (identity-only candidate) confirm the foreground is stably
+    // a real app before retracting.
+    const confirmed = geometryStatusBarOnly
+      ? await this.confirmForegroundIdentity(postCaptureForeground, signal)
+      : await this.resolvePostCaptureForegroundIdentity(
+          foreground,
+          hierarchy?.packageName ?? "",
+          postCaptureForeground,
+          signal,
+        );
     if (
       !confirmed ||
       SYSTEM_UI_WINDOW_PACKAGES.has(confirmed) ||
@@ -1679,6 +1704,23 @@ export class RealObserveScreen implements ObserveScreen {
       return undefined;
     }
     return { foreground: confirmed };
+  }
+
+  /**
+   * The confirming (post-capture) foreground read, without the observed/foreground
+   * equality short-circuit that {@link resolvePostCaptureForegroundIdentity} applies
+   * for the window-identity path. The status-bar geometry gate must fire even when the
+   * capture is labelled with the foreground app itself (#5981), so equality cannot be a
+   * reason to skip confirmation. Reuses an already-sampled read when one exists.
+   */
+  private async confirmForegroundIdentity(
+    postCaptureForeground: PostCaptureForegroundIdentity,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    if (postCaptureForeground.sampled) {
+      return postCaptureForeground.identity;
+    }
+    return this.deviceStateCollector.collectForegroundIdentity(signal);
   }
 
   private async resolvePostCaptureForegroundIdentity(

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -548,6 +548,62 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     );
   });
 
+  test("retracts freshness when the app-labelled hierarchy is confined to the status bar", async () => {
+    // Regression for #5981 after #5976: the label half is now correct — the capture
+    // reports the focused application package (com.android.settings) — but the selected
+    // window is still the status bar, so every extracted node lies within the status-bar
+    // strip. The package-identity candidate check no longer fires (observed === foreground),
+    // so the geometric signal must carry the honesty gate on its own.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      // #5976 corrected the label: the observed package is the foreground app itself.
+      packageName: "com.android.settings",
+      foregroundActivity: "com.android.settings/.SubSettings",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          node: [
+            { text: "12:34", bounds: { left: 21, top: 0, right: 107, bottom: 63 } },
+            { text: "Wifi signal full.", bounds: { left: 892, top: 11, right: 931, bottom: 50 } },
+          ],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("status-bar");
+    expect(result.freshness?.warning).toContain("com.android.settings");
+  });
+
   test("uses the confirmed foreground for a status-bar-only hierarchy after transition", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();


### PR DESCRIPTION
## Summary

On Android, `observe` could report `freshness.verified: true` with no warning
over a capture that contained **only status-bar content** and no application
nodes — leaving `tapOn`/`swipeOn` unable to find any on-screen element and the
device effectively unusable for automation.

The honesty gate for this (`resolveStatusBarOnlyHierarchy` →
`statusBarOnlyHierarchy` freshness input) already existed, but its entry check
`isStatusBarOnlyCandidate` only treated a capture as suspect when the reported
package was a SystemUI package **or** the tree was `ctrlProxyIncomplete`. After
#5976 corrected the reported package to the *focused application* (e.g.
`com.android.settings`), the label matched the foreground app while the selected
window stayed status-bar-only, so the candidate check silently stopped firing —
the exact regression #5981 reports.

**Layer fixed: TS observe pipeline** (`src/features/observe/ObserveScreen.ts`),
not native CtrlProxy. The native `pickPrimaryAppWindowId` already prefers the
`isFocused` `TYPE_APPLICATION` window over a higher-layer `TYPE_SYSTEM` status-bar
window (covered by existing `ViewHierarchyExtractorTest` regressions for #5971 and
#5981), so **no CtrlProxy re-cut is required** for this change.

### The selection/gate change

- Make the **geometric** signal (`isStatusBarOnlyHierarchy` — every extracted
  node bounded within `systemInsets.top`) an *independent* entry condition
  alongside the package-identity check. This is the issue author's own stated
  reliable detector (`maxY <= 63`), and it fires regardless of what package label
  the capture claims.
- For the geometry path, resolve the confirming foreground via a dedicated
  `confirmForegroundIdentity` that omits the `observed === foreground`
  short-circuit — that short-circuit is correct for the window-identity path but
  is precisely the #5981 shape (label corrected to the foreground app) and must
  not block the gate. A genuine A→B transition still reports the settled app.
- A legitimate system surface (undefined foreground, or a SystemUI foreground
  such as an open notification shade) still passes unflagged, so the #6078
  `systemOverlay` shade workflows are unaffected.

When the gate fires, freshness is now `verified: false, isFresh: false` with the
actionable warning (relaunch / `pressButton home`) — restoring the self-flagging
behavior #5971 had and #5976 regressed away.

## Linked Issue

Closes #5981

## Bug / Regression Context

- **Prior attempts:** #5976 (closing #5971) fixed the *label* (reported appId) but
  not the honesty gate for the *selection*; #6048 added the verified-rejection
  plumbing.
- **Observed symptom:** `observe` returns a 7-row status-bar-only hierarchy
  (`maxY=63`) with `verified: true` and no warning; every subsequent tap fails
  "element not found".
- **Repro conditions:** transient, entered via in-app navigation into Settings
  sub-screens (reproduces on API 31 and API 34 per the issue's own correction),
  cleared by `homeScreen`.

## Validation

- [x] `bun run lint` (oxlint ratchet: no new violations) + `bun test`
- [x] `bun run typecheck` — no new errors (baseline gate, 165 known)
- [x] `bun run build` succeeds
- [x] New tests use interfaces + fakes + FakeTimer; run in <100ms
- Full suite: 15401 pass, 2 fail — both failures pre-exist on clean
  `origin/main` (unrelated flaky device-suite-loading tests), zero new failures.

### Red-first test

`test/features/observe/ObserveScreenWindowIdentity.test.ts` →
"retracts freshness when the app-labelled hierarchy is confined to the status bar":
a capture labelled `com.android.settings` (the corrected label) whose every node
lies within the 63px status-bar strip, with Settings foregrounded. Fails on the
pre-fix code (`verified: true`), passes after.

## Device Verification

- [ ] Not run here (unit-tested with fixtures). A manual-test API-31/API-34 pass
      is recommended to confirm the on-device repro is silenced, but the change is
      host-side TS only — no re-cut needed.

## Follow-ups

- None. The native window-selection path is already handled; this PR closes the
  remaining honesty-gate gap.
