### PR TITLE
fix(recovery): redact secret values from AI-recovery tool-call results (#6094)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -101,7 +101,20 @@ open class AutoMobileAgent(
    * check that recovery actually worked is the caller re-running the failed step (see
    * [AutoMobilePlanExecutor]) — if the obstruction is gone that step now passes.
    */
-  open fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome {
+  /**
+   * Backwards-compatible one-argument recovery hook (the pre-#6094 signature). Kept as an explicit
+   * `open` delegating method rather than relying on a Kotlin default or `@JvmOverloads` (which
+   * would emit the one-arg overload as `final`), so a published-library subclass that overrode the
+   * original still compiles and links, and callers compiled against the one-arg descriptor keep
+   * working.
+   */
+  open fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome =
+    attemptAiRecovery(context, emptyList())
+
+  open fun attemptAiRecovery(
+    context: FailedStepContext,
+    secretValues: List<String>,
+  ): RecoveryOutcome {
     val startTime = timeProvider.currentTimeMillis()
     val maxToolCalls = recoveryConfigProvider.getMaxRecoveryToolCalls()
 
@@ -113,14 +126,46 @@ open class AutoMobileAgent(
       }
 
       val modelConfig = configProvider.getModelConfig()
-      val aiAgent = aiAgentFactory.createAIAgentWithMCPTools(modelConfig, mcpClient, maxToolCalls)
+      // Second-order redaction (issue #6094): the Koog agent loop feeds every tool/observe RESULT
+      // (including the view hierarchy from observe's `withViewHierarchy = true`) back to the LLM
+      // provider. Wrap the client the agent's tools call in a redactor so those result strings are
+      // scrubbed of secret values before they reach the model. The tool still EXECUTES on-device
+      // with the real values (the decorator forwards arguments unchanged). The initial recovery
+      // prompt is already redacted by the executor (#6092); this closes the loop channel. With no
+      // secrets the raw client is used unchanged (no wrapper allocated).
+      //
+      // Known limitation (follow-up): the wrapper also redacts the intermediate observe result that
+      // the composite WaitForTool searches locally — its own output to the model is synthesized and
+      // safe, so there is no leak, but a wait target that is a substring of an on-screen secret can
+      // falsely time out. A clean fix hands composite tools the raw client; deferred to keep this
+      // security change scoped.
+      //
+      // Normalize the incoming concrete secret values into every scrub form (NFC/NFD + the
+      // transport-encoding depths) HERE, at the public recovery entry point, so the loop is safe
+      // whether a caller passed raw or pre-expanded values: this is a public overload, so a direct
+      // caller could pass raw concrete secrets, and matching only those would miss the escaped
+      // representation in JSON tool results. Idempotent for the executor's already-expanded input.
+      val redactionValues = SecretRedactor.secretValues(secretValues)
+      val agentMcpClient =
+        if (redactionValues.isEmpty()) mcpClient else RedactingMCPClient(mcpClient, redactionValues)
+      val aiAgent =
+        aiAgentFactory.createAIAgentWithMCPTools(modelConfig, agentMcpClient, maxToolCalls)
 
+      // Redact the STATIC context fields that go into the initial prompt too (#6094). The executor
+      // already redacts these on the FailedStepContext (#6092), so this is a no-op for that path;
+      // it
+      // makes the public entry point self-contained, so a direct caller who supplies raw context
+      // fields alongside raw secretValues cannot leak them in the first ModelRequest. Redacting an
+      // already-redacted field changes nothing.
+      val redactedFailedTool = SecretRedactor.redact(context.failedTool, redactionValues)
+      val redactedError = SecretRedactor.redact(context.error, redactionValues)
+      val redactedPlanContent = SecretRedactor.redact(context.planContent, redactionValues)
       val succeededStepsSummary =
         if (context.succeededSteps.isEmpty()) {
           "  (none — the first step failed)"
         } else {
           context.succeededSteps.joinToString("\n") { step ->
-            "  - Step ${step.stepIndex + 1}: ${step.tool} (completed)"
+            "  - Step ${step.stepIndex + 1}: ${SecretRedactor.redact(step.tool, redactionValues)} (completed)"
           }
         }
 
@@ -129,14 +174,14 @@ open class AutoMobileAgent(
         A test plan step was interrupted and failed. Your job is to CLEAR whatever is
         blocking the app — you do NOT need to perform the failed step yourself.
 
-        FAILED STEP: Step ${context.failedStepIndex + 1} using tool "${context.failedTool}"
-        ERROR: ${context.error}
+        FAILED STEP: Step ${context.failedStepIndex + 1} using tool "$redactedFailedTool"
+        ERROR: $redactedError
 
         PREVIOUSLY SUCCEEDED STEPS:
         $succeededStepsSummary
 
         PLAN YAML:
-        ${context.planContent}
+        $redactedPlanContent
 
         After you finish, the test runner will AUTOMATICALLY RE-RUN the failed step
         (step ${context.failedStepIndex + 1}) and then continue with the rest of the plan.
@@ -174,7 +219,13 @@ open class AutoMobileAgent(
           // interruption is gone — the failed-step re-run in the executor is that check.
           val observeResult =
             try {
-              mcpClient.callTool("observe", mapOf("withViewHierarchy" to true))
+              // Scrub the post-recovery liveness observe too (issue #6094): its view hierarchy can
+              // carry an on-screen secret, and it is surfaced on the RecoveryOutcome. The device is
+              // still queried with real values — only the returned text is redacted.
+              SecretRedactor.redact(
+                mcpClient.callTool("observe", mapOf("withViewHierarchy" to true)),
+                redactionValues,
+              )
             } catch (e: Exception) {
               println("Warning: Post-recovery observe failed: ${e.message}")
               null

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -529,7 +529,10 @@ internal object AutoMobilePlanExecutor {
       "Attempting AI-assisted recovery for failed step ${failedStepContext.failedStepIndex + 1} (${failedStepContext.failedTool})"
     )
 
-    val recoveryOutcome = agent.attemptAiRecovery(failedStepContext)
+    // Pass the resolved secret VALUES into the recovery agent so its loop can scrub the DYNAMIC
+    // tool/observe results it feeds back to the LLM (issue #6094). The initial recovery prompt is
+    // already redacted on FailedStepContext (#6092); this covers the second-order loop channel.
+    val recoveryOutcome = agent.attemptAiRecovery(failedStepContext, secretValues)
 
     if (!recoveryOutcome.success) {
       println("AI recovery failed")

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/RedactingMCPClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/RedactingMCPClient.kt
@@ -1,0 +1,52 @@
+package dev.jasonpearson.automobile.junit
+
+/**
+ * A redacting decorator over an [AutoMobileAgent.MCPClient] used during AI-assisted recovery
+ * (CWE-200, issue #6094 — the second-order channel deferred from #6029 / #6092).
+ *
+ * The Koog recovery agent runs `observe`/`tapOn`/etc. and feeds each tool's RESULT string back into
+ * the next model request. A secret still visible on screen at recovery time (a token echoed into a
+ * field, present in the view hierarchy from observe's `withViewHierarchy = true`) would otherwise
+ * reach the third-party LLM provider through those results. Wrapping the client the agent's tools
+ * call scrubs every result before the agent hands it to the model.
+ *
+ * Scope boundary (mirrors [SecretRedactor]'s contract): the tool still EXECUTES against the device
+ * with the REAL values — [callTool]'s arguments are forwarded to [delegate] unchanged, so on-device
+ * behavior is identical. Only the RETURNED text (what re-enters the model transcript) is redacted.
+ * The daemon `executePlan` payload is built elsewhere from the real substituted plan and never
+ * passes through here. When there are no secret values the executor uses the raw client directly,
+ * so this wrapper is only constructed when there is something to redact.
+ *
+ * `internal` — its only consumer is [AutoMobileAgent.attemptAiRecovery]; unit-tested via
+ * `AutoMobileAgentTest`. Mirrors iOS `TachikomaPlanRecoveryHandler`'s per-result
+ * `SecretRedaction.redact` calls.
+ */
+internal class RedactingMCPClient(
+  private val delegate: AutoMobileAgent.MCPClient,
+  private val secretValues: List<String>,
+) : AutoMobileAgent.MCPClient {
+
+  override fun isConnected(): Boolean = delegate.isConnected()
+
+  override fun connect(serverUrl: String) = delegate.connect(serverUrl)
+
+  override fun disconnect() = delegate.disconnect()
+
+  /**
+   * Execute the tool on the device with the REAL arguments, then scrub the RESULT so a secret
+   * surfaced on screen cannot reach the LLM through the recovery loop (issue #6094). A tool failure
+   * is scrubbed too: [DefaultMCPClient] throws with the MCP server's response body / error in the
+   * message, which can echo the on-screen secret, and Koog feeds tool errors back to the model. The
+   * redacted message is rethrown WITHOUT the original cause so the raw text cannot survive in the
+   * exception chain (mirrors iOS `executeTool`'s error scrub).
+   */
+  override fun callTool(toolName: String, parameters: Map<String, Any>): String =
+    try {
+      SecretRedactor.redact(delegate.callTool(toolName, parameters), secretValues)
+    } catch (e: Exception) {
+      throw RuntimeException(SecretRedactor.redact(e.message ?: e.toString(), secretValues))
+    }
+
+  override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> =
+    delegate.listAvailableTools()
+}

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -23,19 +23,58 @@ internal object SecretRedactor {
 
   /**
    * Expand the executor-supplied concrete secret strings into the exact forms to scrub: each value
-   * in its NFC and NFD Unicode forms, so a decomposed on-screen/error occurrence still matches a
-   * composed value (and vice versa). Blank inputs are dropped; the result is deduped preserving
-   * order.
+   * in its NFC and NFD Unicode forms (so a decomposed on-screen/error occurrence still matches a
+   * composed value and vice versa) and, for each, its JSON-string-escaped form (the recovery loop's
+   * tool/observe results are JSON — issue #6094 — so a secret with a JSON-special character appears
+   * only escaped there). Blank inputs are dropped; the result is deduped preserving order.
    */
   fun secretValues(concreteValues: List<String>): List<String> {
     val values = LinkedHashSet<String>()
     for (value in concreteValues) {
       if (value.isEmpty()) continue
-      values.add(value)
-      values.add(Normalizer.normalize(value, Normalizer.Form.NFC))
-      values.add(Normalizer.normalize(value, Normalizer.Form.NFD))
+      for (form in
+        listOf(
+          value,
+          Normalizer.normalize(value, Normalizer.Form.NFC),
+          Normalizer.normalize(value, Normalizer.Form.NFD),
+        )) {
+        // The recovery loop's tool/observe results are JSON (issue #6094), so a secret containing a
+        // JSON-special character (`"`, `\`, newline, tab, CR) appears only escaped there and the
+        // literal replace would miss it. Android additionally reserializes the enclosing MCP
+        // `JsonElement` over an already-encoded `content[].text` (`DefaultMCPClient.callTool`), so
+        // the value can be DOUBLE-escaped. Scrub raw + single + double; a no-op escape equals its
+        // predecessor and is deduped away.
+        var encoded = form
+        repeat(3) {
+          values.add(encoded)
+          encoded = jsonEscape(encoded)
+        }
+      }
     }
     return values.toList()
+  }
+
+  /**
+   * The JSON-string-escaped form of [value] (its inner content, without surrounding quotes),
+   * covering the short escapes every JSON serializer agrees on plus lowercase `\uXXXX` for other
+   * control characters. Used to also scrub a secret that reaches the recovery loop inside a JSON
+   * tool/observe result (#6094).
+   */
+  fun jsonEscape(value: String): String = buildString {
+    for (character in value) {
+      when (character) {
+        '"' -> append("\\\"")
+        '\\' -> append("\\\\")
+        '\n' -> append("\\n")
+        '\r' -> append("\\r")
+        '\t' -> append("\\t")
+        '\b' -> append("\\b")
+        '\u000C' -> append("\\f")
+        else ->
+          if (character < ' ') append("\\u" + character.code.toString(16).padStart(4, '0'))
+          else append(character)
+      }
+    }
   }
 
   /** Stringify a parameter value exactly as [AutoMobilePlanExecutor] does during substitution. */
@@ -56,7 +95,12 @@ internal object SecretRedactor {
     if (secretValues.isEmpty()) return text
     var redacted = text
     for (value in secretValues.sortedByDescending { it.length }) {
-      if (value.isNotEmpty()) redacted = redacted.replace(value, PLACEHOLDER)
+      if (value.isEmpty()) continue
+      // If the secret is itself a substring of the placeholder (e.g. a secret value of "REDACTED"
+      // or "***REDACTED***"), substituting the placeholder would reintroduce the secret — so remove
+      // it instead, guaranteeing it cannot survive in the result (#6094).
+      val replacement = if (PLACEHOLDER.contains(value)) "" else PLACEHOLDER
+      redacted = redacted.replace(value, replacement)
     }
     return redacted
   }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
@@ -6,6 +6,7 @@ import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -220,6 +221,214 @@ class AutoMobileAgentTest {
     assertEquals(1000L, result.recoveryTimeMs)
     assertTrue(result.observeResultAfterRecovery != null)
     coVerify(exactly = 1) { mockAIAgent.run(any()) }
+  }
+
+  @Test
+  fun `secret in a tool or observe result is scrubbed from what the recovery agent feeds the model`() {
+    // Issue #6094 (CWE-200, second-order channel): after the initial (redacted) recovery prompt,
+    // the Koog agent loop runs observe/tools and feeds their RESULTS (including the view hierarchy
+    // from observe's withViewHierarchy=true) back to the LLM. A secret still visible on-screen at
+    // recovery time must not reach the provider through those results. The agent's tools call the
+    // client handed to createAIAgentWithMCPTools, so that client's returned strings are exactly
+    // what
+    // Koog forwards to the model — assert they are scrubbed, while the underlying client still
+    // executes with real values.
+    val secret = "SECRET-hunter2-TOKEN"
+    val visible = "keepme-visible-env"
+    val context =
+      FailedStepContext(
+        failedStepIndex = 1,
+        failedTool = "inputText",
+        error = "step failed",
+        succeededSteps = emptyList(),
+        planContent = "name: test\nsteps: []",
+        deviceId = "emulator-5554",
+      )
+    val modelConfig = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val agentClientSlot = slot<AutoMobileAgent.MCPClient>()
+
+    every { mockTimeProvider.currentTimeMillis() } returns 1000L andThen 2000L
+    every { mockConfigProvider.getMcpServerUrl() } returns "http://localhost:3000"
+    every { mockMcpClient.isConnected() } returns false
+    every { mockMcpClient.connect(any()) } just runs
+    every { mockMcpClient.disconnect() } just runs
+    every { mockConfigProvider.getModelConfig() } returns modelConfig
+    // The live tool/observe results carry the on-screen secret plus non-secret context.
+    every { mockMcpClient.callTool("observe", any()) } returns
+      """{"elements":{"field":"token $secret"},"env":"$visible"}"""
+    every { mockMcpClient.callTool("tapOn", any()) } returns """{"status":"typed $secret"}"""
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, capture(agentClientSlot), 5)
+    } returns mockAIAgent
+    coEvery { mockAIAgent.run(any()) } returns "done"
+
+    autoMobileAgent.attemptAiRecovery(context, secretValues = listOf(secret))
+
+    // Drive the exact tools Koog builds from the captured client. observe first (the view-hierarchy
+    // feed) then tapOn — both results are what the agent hands the LLM.
+    val agentClient = agentClientSlot.captured
+    val observeResult = runBlocking {
+      AutoMobileAgent.ObserveTool(agentClient)
+        .execute(AutoMobileAgent.ObserveTool.Args(withViewHierarchy = true))
+    }
+    val tapResult = runBlocking {
+      AutoMobileAgent.TapOnTool(agentClient).execute(AutoMobileAgent.TapOnTool.Args(text = "OK"))
+    }
+
+    assertFalse(
+      observeResult.contains(secret),
+      "observe/view-hierarchy result fed to the LLM must not contain the secret",
+    )
+    assertTrue(
+      observeResult.contains(SecretRedactor.PLACEHOLDER),
+      "the secret must be replaced by the placeholder",
+    )
+    assertTrue(observeResult.contains(visible), "non-secret context must be preserved")
+    assertFalse(
+      tapResult.contains(secret),
+      "tap result fed to the LLM must not contain the secret",
+    )
+
+    // The tool still EXECUTED against the device with the real value: the underlying client returns
+    // the raw secret, so only the model-facing wrapper scrubs it (daemon/tool execution
+    // unaffected).
+    val rawObserve =
+      mockMcpClient.callTool(
+        "observe",
+        mapOf("withViewHierarchy" to true, "includeInvisible" to false),
+      )
+    assertTrue(
+      rawObserve.contains(secret),
+      "the underlying client (device execution) still receives real values",
+    )
+  }
+
+  @Test
+  fun `attemptAiRecovery redacts raw context fields from the initial prompt for a direct caller`() {
+    // A direct caller of the public overload may build a FailedStepContext with RAW (unredacted)
+    // planContent/error plus raw secretValues. The entry point must scrub the static context fields
+    // itself so the first prompt does not leak — not only the executor path, which pre-redacts
+    // (#6094).
+    val secret = "SECRET-hunter2-TOKEN"
+    val context =
+      FailedStepContext(
+        failedStepIndex = 1,
+        failedTool = "inputText",
+        error = "timed out entering $secret",
+        succeededSteps = emptyList(),
+        planContent = "name: test\nsteps:\n  - tool: inputText\n    text: \"$secret\"",
+        deviceId = "emulator-5554",
+      )
+    val modelConfig = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val promptSlot = slot<String>()
+
+    every { mockTimeProvider.currentTimeMillis() } returns 1000L andThen 2000L
+    every { mockConfigProvider.getMcpServerUrl() } returns "http://localhost:3000"
+    every { mockMcpClient.isConnected() } returns false
+    every { mockMcpClient.connect(any()) } just runs
+    every { mockMcpClient.disconnect() } just runs
+    every { mockConfigProvider.getModelConfig() } returns modelConfig
+    every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
+    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, any(), 5) } returns
+      mockAIAgent
+    coEvery { mockAIAgent.run(capture(promptSlot)) } returns "done"
+
+    autoMobileAgent.attemptAiRecovery(context, secretValues = listOf(secret))
+
+    val prompt = promptSlot.captured
+    assertFalse(
+      prompt.contains(secret),
+      "raw context fields must be redacted from the initial recovery prompt",
+    )
+    assertTrue(
+      prompt.contains(SecretRedactor.PLACEHOLDER),
+      "the secret must be replaced by the placeholder",
+    )
+  }
+
+  @Test
+  fun `attemptAiRecovery normalizes raw secret values a direct caller passes`() {
+    // The public overload may be called directly with RAW concrete secrets (not pre-expanded). The
+    // entry point must expand them so the JSON-escaped form of a special-character secret in a tool
+    // result is still scrubbed (#6094). Here the secret contains a quote, so it appears escaped in
+    // the JSON observe result; passing only the raw value would leak it.
+    val secret = "pa\"ss-TOKEN"
+    val context =
+      FailedStepContext(
+        failedStepIndex = 1,
+        failedTool = "inputText",
+        error = "step failed",
+        succeededSteps = emptyList(),
+        planContent = "name: test\nsteps: []",
+        deviceId = "emulator-5554",
+      )
+    val modelConfig = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val agentClientSlot = slot<AutoMobileAgent.MCPClient>()
+
+    every { mockTimeProvider.currentTimeMillis() } returns 1000L andThen 2000L
+    every { mockConfigProvider.getMcpServerUrl() } returns "http://localhost:3000"
+    every { mockMcpClient.isConnected() } returns false
+    every { mockMcpClient.connect(any()) } just runs
+    every { mockMcpClient.disconnect() } just runs
+    every { mockConfigProvider.getModelConfig() } returns modelConfig
+    // The JSON observe result carries the secret in its escaped form (a `"` becomes `\"`).
+    every { mockMcpClient.callTool("observe", any()) } returns """{"field":"token pa\"ss-TOKEN"}"""
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, capture(agentClientSlot), 5)
+    } returns mockAIAgent
+    coEvery { mockAIAgent.run(any()) } returns "done"
+
+    // Pass the RAW concrete secret, not a pre-expanded list.
+    autoMobileAgent.attemptAiRecovery(context, secretValues = listOf(secret))
+
+    val observeResult = runBlocking {
+      AutoMobileAgent.ObserveTool(agentClientSlot.captured)
+        .execute(AutoMobileAgent.ObserveTool.Args(withViewHierarchy = true))
+    }
+    assertFalse(
+      observeResult.contains("""pa\"ss-TOKEN"""),
+      "the escaped form of a raw-passed secret must still be scrubbed",
+    )
+    assertTrue(
+      observeResult.contains(SecretRedactor.PLACEHOLDER),
+      "the secret must be replaced by the placeholder",
+    )
+  }
+
+  @Test
+  fun `RedactingMCPClient scrubs the secret from a tool error message fed back to the model`() {
+    // A tool failure message can echo the on-screen secret (DefaultMCPClient throws a
+    // RuntimeException carrying the MCP server's response body / error), and Koog feeds tool
+    // errors back to the model. The redacting wrapper must scrub the throw path too, not just the
+    // successful return (issue #6094 — mirrors iOS executeTool's error scrub).
+    val secret = "SECRET-hunter2-TOKEN"
+    val throwingDelegate =
+      object : AutoMobileAgent.MCPClient {
+        override fun isConnected() = true
+
+        override fun connect(serverUrl: String) {}
+
+        override fun disconnect() {}
+
+        override fun callTool(toolName: String, parameters: Map<String, Any>): String =
+          throw RuntimeException("MCP server returned status 500: {\"field\":\"token $secret\"}")
+
+        override fun listAvailableTools() = emptyList<AutoMobileAgent.MCPToolDefinition>()
+      }
+    val client = RedactingMCPClient(throwingDelegate, SecretRedactor.secretValues(listOf(secret)))
+
+    val error = assertThrows<RuntimeException> { client.callTool("observe", emptyMap()) }
+
+    assertFalse(
+      error.message!!.contains(secret),
+      "a tool error fed back to the model must not contain the secret",
+    )
+    assertTrue(
+      error.message!!.contains(SecretRedactor.PLACEHOLDER),
+      "the secret must be replaced by the placeholder",
+    )
+    // The cause is dropped so the raw secret cannot survive in the exception chain.
+    assertEquals(null, error.cause)
   }
 
   @Test

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanRedactionTest.kt
@@ -90,6 +90,21 @@ class AutoMobilePlanRedactionTest {
       "daemon executePlan payload must stay unredacted",
       daemonPlan!!.contains(secret),
     )
+
+    // The executor must forward the CONCRETE resolved secret values to the recovery agent so its
+    // loop can scrub the dynamic tool/observe results (issue #6094). Without this assertion,
+    // zeroing
+    // the executor's `attemptAiRecovery(context, secretValues)` argument would leave the other
+    // tests
+    // green while re-opening the model-egress leak.
+    val forwarded =
+      requireNotNull(capturingAgent.capturedSecretValues) {
+        "recovery must receive the resolved secret values"
+      }
+    assertTrue(
+      "the resolved concrete secret must reach the recovery agent",
+      forwarded.contains(secret),
+    )
   }
 
   @Test
@@ -425,9 +440,14 @@ private class CapturingAgent :
     recoveryConfigProvider = StaticRecoveryConfigProvider(enabled = true, maxToolCalls = 5)
   ) {
   var captured: FailedStepContext? = null
+  var capturedSecretValues: List<String>? = null
 
-  override fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome {
+  override fun attemptAiRecovery(
+    context: FailedStepContext,
+    secretValues: List<String>,
+  ): RecoveryOutcome {
     captured = context
+    capturedSecretValues = secretValues
     return RecoveryOutcome(success = false, recoveryTimeMs = 0)
   }
 }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
@@ -325,8 +325,14 @@ private class RecoveryFakeAutoMobileAgent(recoveryEnabled: Boolean = true) :
   var recoveryOutcome: RecoveryOutcome = RecoveryOutcome(success = false, recoveryTimeMs = 0)
   val recoveryCalls = mutableListOf<FailedStepContext>()
 
-  override fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome {
+  val recoverySecretValues = mutableListOf<List<String>>()
+
+  override fun attemptAiRecovery(
+    context: FailedStepContext,
+    secretValues: List<String>,
+  ): RecoveryOutcome {
     recoveryCalls.add(context)
+    recoverySecretValues.add(secretValues)
     return recoveryOutcome
   }
 }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -4,6 +4,10 @@ import java.text.Normalizer
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.Test
 
 /**
@@ -298,5 +302,79 @@ class SecretRedactorTest {
       "unchanged",
       SecretRedactor.redact("unchanged", SecretRedactor.secretValues(listOf(""))),
     )
+  }
+
+  @Test
+  fun `redacts the singly JSON-escaped form of a secret in a tool result`() {
+    // The recovery loop's tool/observe results are JSON (issue #6094). A secret with a JSON-special
+    // character appears there only in escaped form, which the literal raw value would not match.
+    val secret = "pa\"ss\\word\nline"
+    val values = SecretRedactor.secretValues(listOf(secret))
+    // A singly JSON-encoded result (e.g. iOS's single transport layer).
+    val toolResultJson = """{"field":"token pa\"ss\\word\nline"}"""
+    assertFalse(
+      toolResultJson.contains(secret),
+      "precondition: the raw secret is not literally present",
+    )
+    val result = SecretRedactor.redact(toolResultJson, values)
+    assertTrue(
+      result.contains(SecretRedactor.PLACEHOLDER),
+      "the JSON-escaped secret must be redacted",
+    )
+    assertFalse(result.contains("""pa\"ss"""), "no escaped-secret fragment may survive")
+  }
+
+  @Test
+  fun `redacts a secret double-encoded by the Android MCP transport`() {
+    // Reproduce DefaultMCPClient's transform (#6094 Codex P1): the observe hierarchy carrying the
+    // on-screen secret is a JSON STRING inside content[].text, and `mcpResponse.result.toString()`
+    // reserializes the enclosing element, so the secret is DOUBLE-escaped in the string the agent's
+    // tools return to the model.
+    val secret = "pa\"ss\\word\nline"
+    val values = SecretRedactor.secretValues(listOf(secret))
+    val hierarchy = buildJsonObject {
+      put("node", buildJsonObject { put("value", "token $secret") })
+    }
+    val envelope = buildJsonObject {
+      put(
+        "content",
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put("type", "text")
+              // The hierarchy JSON as a string value → one encoding layer here …
+              put("text", hierarchy.toString())
+            }
+          )
+        },
+      )
+    }
+    // … and serializing the enclosing element re-encodes it → the secret is double-escaped.
+    val transportText = envelope.toString()
+    assertFalse(
+      transportText.contains(secret),
+      "precondition: the raw secret is not literally present in the double-encoded transport",
+    )
+    val result = SecretRedactor.redact(transportText, values)
+    assertTrue(
+      result.contains(SecretRedactor.PLACEHOLDER),
+      "the double-encoded secret must be redacted",
+    )
+    assertFalse(result.contains("word"), "no double-escaped secret fragment may survive")
+  }
+
+  @Test
+  fun `a secret that collides with the redaction marker does not survive`() {
+    // A secret whose VALUE is the marker (or a substring of it) must not be reintroduced by the
+    // replacement — e.g. replacing "REDACTED" with "***REDACTED***" would leave "REDACTED" (#6094).
+    for (secret in listOf("REDACTED", "***REDACTED***", "***")) {
+      val values = SecretRedactor.secretValues(listOf(secret))
+      val result = SecretRedactor.redact("token $secret here", values)
+      assertFalse(
+        result.contains(secret),
+        "the marker-colliding secret \"$secret\" must not survive redaction",
+      )
+      assertTrue(result.contains("token "), "non-secret context is preserved")
+    }
   }
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Plan/AutoMobilePlanExecutor.swift
@@ -370,7 +370,11 @@ public final class AutoMobilePlanExecutor {
             platform: platform.rawValue,
             sessionUuid: sessionUuid,
             deviceId: failedStep.device ?? deviceIdOverride,
-            failureObservation: SecretRedaction.redact(failedStep.failureObservation, secretValues: secretValues)
+            failureObservation: SecretRedaction.redact(failedStep.failureObservation, secretValues: secretValues),
+            // Carry the secret values into the recovery loop so it can scrub the DYNAMIC tool/observe
+            // results it re-sends to the LLM (issue #6094). These are not forwarded to the provider —
+            // only used as the redaction target for `executeTool` / `observeDeviceState` output.
+            secretValues: secretValues
         )
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/FailedStepContext.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/FailedStepContext.swift
@@ -14,6 +14,13 @@ public struct FailedStepContext: Sendable {
     /// Session the failed plan ran under. Injected into recovery tool calls so they target the same
     /// device/session the plan was using.
     public let sessionUuid: String?
+    /// The concrete secret VALUES (already expanded into their NFC/NFD forms by
+    /// `SecretRedaction.secretValues`) that must never reach the LLM provider. The recovery loop
+    /// scrubs each `executeTool` / `observeDeviceState` RESULT with these before it re-enters a
+    /// `ModelRequest` (issue #6094's second-order channel). NOT sent to the provider itself — only
+    /// used to redact the dynamic tool output. The initial context fields above are already redacted
+    /// by the executor (#6092); this covers the agent loop's own tool results.
+    public let secretValues: [String]
 
     public init(
         failedStepIndex: Int,
@@ -24,7 +31,8 @@ public struct FailedStepContext: Sendable {
         platform: String,
         sessionUuid: String? = nil,
         deviceId: String? = nil,
-        failureObservation: FailureObservationSummary? = nil
+        failureObservation: FailureObservationSummary? = nil,
+        secretValues: [String] = []
     ) {
         self.failedStepIndex = failedStepIndex
         self.failedTool = failedTool
@@ -35,5 +43,6 @@ public struct FailedStepContext: Sendable {
         self.sessionUuid = sessionUuid
         self.deviceId = deviceId
         self.failureObservation = failureObservation
+        self.secretValues = secretValues
     }
 }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -16,16 +16,57 @@ enum SecretRedaction {
     static let placeholder = "***REDACTED***"
 
     /// Expand the executor-supplied concrete secret strings into the exact byte forms to scrub: each
-    /// value in its NFC and NFD Unicode forms, so a decomposed on-screen/error occurrence still
-    /// matches a composed value (and vice versa). Blank inputs are dropped. Dedup is by UTF-16 code
-    /// units, NOT `Set<String>`, because Swift string equality is canonical and would collapse the
-    /// distinct forms we deliberately keep.
+    /// value in its NFC and NFD Unicode forms — so a decomposed on-screen/error occurrence still
+    /// matches a composed value (and vice versa) — and, for each of those, its JSON-string-escaped
+    /// form. The recovery loop's tool/observe results are JSON (issue #6094), so a secret containing
+    /// a JSON-special character (`"`, `\`, newline, tab, CR) appears only in escaped form there and
+    /// the literal `redact` would miss it. Blank inputs are dropped. Dedup is by UTF-16 code units,
+    /// NOT `Set<String>`, because Swift string equality is canonical and would collapse the distinct
+    /// forms we deliberately keep (a no-op escape equals its raw form and is dropped by dedup).
     static func secretValues(_ concreteValues: [String]) -> [String] {
         var result: [String] = []
         var seen: Set<[UInt16]> = []
         for value in concreteValues where !value.isEmpty {
-            for form in normalizationForms(of: value) where seen.insert(Array(form.utf16)).inserted {
-                result.append(form)
+            for form in normalizationForms(of: value) {
+                // Cover the raw value and its JSON-escaped forms through the transport-encoding depth
+                // the runners actually apply: iOS surfaces one encoding layer, and Android reserializes
+                // the enclosing MCP `JsonElement` over an already-encoded `content[].text`, so a
+                // special-character secret can appear double-escaped (#6094). Raw + single + double
+                // covers all three; a no-op escape equals its predecessor and is dropped by dedup.
+                var encoded = form
+                for _ in 0 ..< 3 {
+                    if seen.insert(Array(encoded.utf16)).inserted {
+                        result.append(encoded)
+                    }
+                    encoded = jsonEscaped(encoded)
+                }
+            }
+        }
+        return result
+    }
+
+    /// The JSON-string-escaped form of `value` (its inner content, without surrounding quotes),
+    /// covering the short escapes every JSON serializer agrees on plus lowercase `\uXXXX` for other
+    /// control characters (matching `JSON.stringify`). Used to also scrub a secret that reaches the
+    /// recovery loop inside a JSON tool/observe result (#6094). A value with no JSON-special
+    /// character escapes to itself and is deduped away by the caller.
+    static func jsonEscaped(_ value: String) -> String {
+        var result = ""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"": result += "\\\""
+            case "\\": result += "\\\\"
+            case "\n": result += "\\n"
+            case "\r": result += "\\r"
+            case "\t": result += "\\t"
+            case "\u{08}": result += "\\b"
+            case "\u{0C}": result += "\\f"
+            default:
+                if scalar.value < 0x20 {
+                    result += String(format: "\\u%04x", scalar.value)
+                } else {
+                    result.unicodeScalars.append(scalar)
+                }
             }
         }
         return result
@@ -43,7 +84,11 @@ enum SecretRedaction {
         }
         var redacted = text
         for value in secretValues.sorted(by: { $0.utf16.count > $1.utf16.count }) where !value.isEmpty {
-            redacted = redacted.replacingOccurrences(of: value, with: placeholder, options: [.literal])
+            // If the secret is itself a substring of the placeholder (e.g. a secret value of
+            // "REDACTED" or "***REDACTED***"), substituting the placeholder would reintroduce the
+            // secret — so remove it instead, guaranteeing it cannot survive in the result (#6094).
+            let replacement = placeholder.contains(value) ? "" : placeholder
+            redacted = redacted.replacingOccurrences(of: value, with: replacement, options: [.literal])
         }
         return redacted
     }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/TachikomaPlanRecoveryHandler.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/TachikomaPlanRecoveryHandler.swift
@@ -86,8 +86,22 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
                 + "with model \(modelConfig.modelName), budget \(maxToolCalls) tool calls..."
         )
 
+        // Normalize the context's concrete secret values into every scrub form (NFC/NFD + the
+        // transport-encoding depths) HERE, at the recovery entry point, so the loop is safe no matter
+        // whether a caller passed raw or pre-expanded values (issue #6094): `FailedStepContext` is a
+        // public type, so a direct caller could set raw concrete values, and matching only those would
+        // miss the escaped representation in JSON tool results. Idempotent for the executor's already-
+        // expanded input (dedup collapses the repeats).
+        let secretValues = SecretRedaction.secretValues(context.secretValues)
+
         do {
-            try runAgentLoop(context: context, responder: responder, settings: modelSettings(for: modelConfig), maxToolCalls: maxToolCalls)
+            try runAgentLoop(
+                context: context,
+                responder: responder,
+                settings: modelSettings(for: modelConfig),
+                maxToolCalls: maxToolCalls,
+                secretValues: secretValues
+            )
         } catch {
             logger.warn("AI recovery execution failed: \(error)")
             return RecoveryOutcome(success: false, recoveryTimeMs: elapsedMs(since: start))
@@ -97,7 +111,7 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         // Android: success == a post-recovery observe returned something. The resumed step is the real
         // check of whether recovery actually worked.
         logger.info("AI recovery agent finished, verifying device state...")
-        let observeResult = observeDeviceState(context: context)
+        let observeResult = observeDeviceState(context: context, secretValues: secretValues)
         return RecoveryOutcome(
             success: observeResult != nil,
             recoveryTimeMs: elapsedMs(since: start),
@@ -111,11 +125,20 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         context: FailedStepContext,
         responder: ModelResponding,
         settings: ModelSettings,
-        maxToolCalls: Int
-    ) throws {
+        maxToolCalls: Int,
+        secretValues: [String]
+    )
+        throws
+    {
         let tools = Self.buildToolDefinitions()
+        // Redact the STATIC context fields that go into the initial prompt too (#6094). The executor
+        // already redacts these on the FailedStepContext (#6092), so this is a no-op for that path; it
+        // makes the public entry point self-contained, so a direct caller who supplies raw context
+        // fields cannot leak them in the first ModelRequest. Routing fields stay real — `executeTool`
+        // reads the ORIGINAL `context` for platform/session/device.
+        let promptContext = Self.redactContext(context, secretValues: secretValues)
         var messages: [Message] = [
-            .user(content: .text(Self.buildRecoveryPrompt(context: context, maxToolCalls: maxToolCalls))),
+            .user(content: .text(Self.buildRecoveryPrompt(context: promptContext, maxToolCalls: maxToolCalls))),
         ]
 
         var toolCallsUsed = 0
@@ -155,7 +178,12 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
                     continue
                 }
                 toolCallsUsed += 1
-                let resultText = executeTool(name: call.function.name, argumentsJSON: call.function.arguments, context: context)
+                let resultText = executeTool(
+                    name: call.function.name,
+                    argumentsJSON: call.function.arguments,
+                    context: context,
+                    secretValues: secretValues
+                )
                 messages.append(.tool(toolCallId: call.id, content: resultText))
             }
         }
@@ -167,7 +195,14 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
 
     // MARK: - Tool execution over the AutoMobile MCP client
 
-    private func executeTool(name: String, argumentsJSON: String, context: FailedStepContext) -> String {
+    private func executeTool(
+        name: String,
+        argumentsJSON: String,
+        context: FailedStepContext,
+        secretValues: [String]
+    )
+        -> String
+    {
         var arguments = Self.parseArguments(argumentsJSON)
         // Required routing fields are injected by us, not trusted from the model, so every recovery
         // call is valid and targets the same platform/session/device as the plan.
@@ -184,14 +219,20 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
 
         do {
             let response = try mcpClient.callTool(name: name, arguments: arguments, timeout: timeoutSeconds)
-            return response.text
+            // The tool EXECUTED against the device with real values above; only the RESULT TEXT that
+            // re-enters the next ModelRequest is scrubbed, so a secret still visible on-screen at
+            // recovery time cannot reach the LLM provider through the agent loop (issue #6094).
+            return SecretRedaction.redact(response.text, secretValues: secretValues)
         } catch {
             logger.warn("Recovery tool \(name) failed: \(error)")
-            return "{\"error\":\"\(Self.escapeForJSON(String(describing: error)))\"}"
+            // The error can echo on-screen/tool content, so scrub it too before it enters the
+            // transcript (issue #6094).
+            let message = SecretRedaction.redact(String(describing: error), secretValues: secretValues)
+            return "{\"error\":\"\(Self.escapeForJSON(message))\"}"
         }
     }
 
-    private func observeDeviceState(context: FailedStepContext) -> String? {
+    private func observeDeviceState(context: FailedStepContext, secretValues: [String]) -> String? {
         var arguments: [String: Any] = ["platform": context.platform]
         if let session = context.sessionUuid {
             arguments["sessionUuid"] = session
@@ -201,7 +242,9 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         }
         do {
             let response = try mcpClient.callTool(name: "observe", arguments: arguments, timeout: timeoutSeconds)
-            return response.text
+            // Post-recovery liveness observe. Its text can carry an on-screen secret, so scrub it
+            // before it is surfaced as the recovery result (issue #6094).
+            return SecretRedaction.redact(response.text, secretValues: secretValues)
         } catch {
             logger.warn("Post-recovery observe failed: \(error)")
             return nil
@@ -218,6 +261,32 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
     with a better selector). Do not try to complete the whole test — only fix the immediate blocker so \
     the next step can run. When the device is ready, stop and briefly say what you did.
     """
+
+    /// A copy of `context` with every field that reaches the initial prompt scrubbed of secret
+    /// values (#6094). Routing fields (`platform`/`sessionUuid`/`deviceId`) and `secretValues` are
+    /// preserved unchanged. A no-op when there is nothing to redact.
+    static func redactContext(_ context: FailedStepContext, secretValues: [String]) -> FailedStepContext {
+        guard !secretValues.isEmpty else {
+            return context
+        }
+        return FailedStepContext(
+            failedStepIndex: context.failedStepIndex,
+            failedTool: SecretRedaction.redact(context.failedTool, secretValues: secretValues),
+            error: SecretRedaction.redact(context.error, secretValues: secretValues),
+            succeededSteps: context.succeededSteps.map {
+                SucceededStepSummary(
+                    stepIndex: $0.stepIndex,
+                    tool: SecretRedaction.redact($0.tool, secretValues: secretValues)
+                )
+            },
+            planContent: SecretRedaction.redact(context.planContent, secretValues: secretValues),
+            platform: context.platform,
+            sessionUuid: context.sessionUuid,
+            deviceId: context.deviceId,
+            failureObservation: SecretRedaction.redact(context.failureObservation, secretValues: secretValues),
+            secretValues: context.secretValues
+        )
+    }
 
     static func buildRecoveryPrompt(context: FailedStepContext, maxToolCalls: Int) -> String {
         let succeeded: String
@@ -361,7 +430,9 @@ public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
         description: String,
         properties: [String: ParameterSchema],
         required: [String]
-    ) -> ToolDefinition {
+    )
+        -> ToolDefinition
+    {
         ToolDefinition(
             function: FunctionDefinition(
                 name: name,

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -774,6 +774,103 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
         XCTAssertTrue(text.contains("observe"), "non-secret plan structure must be preserved")
     }
 
+    /// Issue #6094 (CWE-200, second-order channel): after the initial (redacted) recovery prompt,
+    /// the agent loop calls `observe`/tools and re-sends those RESULTS in the next `ModelRequest`. A
+    /// secret still visible on-screen at recovery time (echoed into a field, in the view hierarchy)
+    /// therefore reaches the LLM provider through the loop's own tool results unless they are
+    /// scrubbed. This drives the FULL loop with a responder that records EVERY request and asserts
+    /// the secret is absent from ALL of them — including the post-initial tool-result turns — while
+    /// non-secret context survives. The secret is placed ONLY in the tool results here (the failure
+    /// error/observation are clean), isolating this loop channel from #6092's initial-prompt fix.
+    func testSecretInToolResultIsRedactedFromEveryModelRequestInTheLoop() throws {
+        let client = RecoveryMCPClient()
+        // The live observe/tool results carry the on-screen secret plus non-secret context.
+        client.observeText = "{\"elements\":{\"field\":\"token \(secret)\"},\"env\":\"\(visible)\"}"
+        client.toolResponseText = "{\"status\":\"typed \(secret)\"}"
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "inputText", "error": "step failed"]
+        ))
+        client.queueExecutePlan(planJSON(success: true, executedSteps: 3, totalSteps: 3))
+
+        // observe -> tapOn -> finish: the 2nd and 3rd requests carry the prior tool results.
+        let captor = ScriptedCapturingModelResponder([
+            StubModelResponder.toolCall(name: "observe"),
+            StubModelResponder.toolCall(name: "tapOn", arguments: "{\"selector\":{\"text\":\"OK\"}}"),
+            StubModelResponder.final(),
+        ])
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let executor = makeExecutor(client: client, handler: handler)
+
+        _ = try executor.execute(testMetadata: nil)
+
+        XCTAssertGreaterThanOrEqual(
+            captor.captured.count, 2,
+            "the loop must issue follow-up requests carrying tool results"
+        )
+        for (offset, request) in captor.captured.enumerated() {
+            XCTAssertFalse(
+                requestText(request).contains(secret),
+                "secret leaked into ModelRequest #\(offset) via a re-sent tool/observe result"
+            )
+        }
+        let allText = captor.captured.map { requestText($0) }.joined(separator: "\n")
+        XCTAssertTrue(
+            allText.contains(SecretRedaction.placeholder),
+            "the tool-result secret must be replaced by the placeholder"
+        )
+        XCTAssertTrue(allText.contains(visible), "non-secret tool-result context must be preserved")
+
+        // The tool still EXECUTED on-device with real routing args (only the RESULT text that enters
+        // the transcript is scrubbed), and the daemon executePlan payload keeps the real secret.
+        XCTAssertTrue(client.calls.contains { $0.name == "observe" }, "the loop must have executed observe on-device")
+        let daemonPlan = try XCTUnwrap(decodedDaemonPlanContent(client.executePlanCalls.first))
+        XCTAssertTrue(daemonPlan.contains(secret), "daemon executePlan payload must stay unredacted")
+    }
+
+    /// Issue #6094 public-boundary hardening: a DIRECT caller of the handler may build a
+    /// `FailedStepContext` with RAW (unredacted) fields and RAW concrete `secretValues`. The handler
+    /// must normalize the values and scrub the static context fields itself, so the very first
+    /// ModelRequest (the prompt) does not leak — not only the executor path (which pre-redacts).
+    func testDirectCallerRawContextIsRedactedFromTheInitialPrompt() throws {
+        let client = RecoveryMCPClient()
+        let captor = ScriptedCapturingModelResponder([])
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in captor }
+        )
+        let context = FailedStepContext(
+            failedStepIndex: 1,
+            failedTool: "inputText",
+            error: "timed out entering \(secret) into field",
+            succeededSteps: [SucceededStepSummary(stepIndex: 0, tool: "observe")],
+            planContent: "name: P\nsteps:\n  - tool: inputText\n    text: \"\(secret)\"",
+            platform: "ios",
+            sessionUuid: "sess-1",
+            deviceId: "dev-1",
+            failureObservation: nil,
+            secretValues: [secret] // RAW concrete value, not pre-expanded
+        )
+
+        _ = handler.attemptRecovery(context)
+
+        let request = try XCTUnwrap(captor.captured.first, "the handler must issue the initial prompt request")
+        let text = requestText(request)
+        XCTAssertFalse(text.contains(secret), "a direct caller's raw context must not leak into the initial prompt")
+        XCTAssertTrue(text.contains(SecretRedaction.placeholder), "the secret must be replaced by the placeholder")
+    }
+
     // MARK: - Helpers
 
     private func makeCapturingHandler(
@@ -842,6 +939,12 @@ final class PlanRecoverySecretRedactionTests: XCTestCase {
                         parts.append(value)
                     }
                 }
+            case let .tool(_, _, content):
+                // Tool-result messages re-enter the next ModelRequest (issue #6094's loop channel),
+                // so they must be inspected for leaked secrets, not skipped.
+                parts.append(content)
+            case let .system(_, content):
+                parts.append(content)
             default:
                 break
             }
@@ -869,6 +972,28 @@ private final class CapturingModelResponder: ModelResponding, @unchecked Sendabl
     func respond(_ request: ModelRequest) async throws -> ModelResponse {
         captured.append(request)
         return ModelResponse(id: "resp", content: [.outputText("done")])
+    }
+}
+
+/// Fake `ModelResponding` that replays a scripted sequence of responses AND records EVERY
+/// `ModelRequest` across the whole agent loop — not just the first (issue #6094). The follow-up
+/// requests carry the tool-call results from the prior turn, which is the second-order channel this
+/// suite pins: a secret visible on-screen at recovery time must not reach the provider through those
+/// re-sent tool results.
+private final class ScriptedCapturingModelResponder: ModelResponding, @unchecked Sendable {
+    private(set) var captured: [ModelRequest] = []
+    private var scripted: [ModelResponse]
+
+    init(_ scripted: [ModelResponse]) {
+        self.scripted = scripted
+    }
+
+    func respond(_ request: ModelRequest) async throws -> ModelResponse {
+        captured.append(request)
+        if scripted.isEmpty {
+            return ModelResponse(id: "resp", content: [.outputText("recovery complete")])
+        }
+        return scripted.removeFirst()
     }
 }
 
@@ -1185,6 +1310,47 @@ final class SecretRedactionTests: XCTestCase {
             SecretRedaction.redact("unchanged", secretValues: SecretRedaction.secretValues([""])),
             "unchanged"
         )
+    }
+
+    func testRedactsJsonEscapedSecretInAToolResult() {
+        // The recovery loop's tool/observe results are JSON (issue #6094). A secret with a
+        // JSON-special character appears there only in its escaped form, which the literal raw value
+        // would not match. secretValues must emit the JSON-escaped variant so it is still scrubbed.
+        let secret = "pa\"ss\\word\nline"
+        let values = SecretRedaction.secretValues([secret])
+        // The JSON-serialized tool result carries the secret in escaped form (as JSON.stringify /
+        // JSONSerialization would produce), NOT the raw value.
+        let toolResultJSON = "{\"field\":\"token pa\\\"ss\\\\word\\nline\"}"
+        XCTAssertFalse(toolResultJSON.contains(secret), "precondition: the raw secret is not literally present")
+        let result = SecretRedaction.redact(toolResultJSON, secretValues: values)
+        XCTAssertTrue(result.contains(SecretRedaction.placeholder), "the JSON-escaped secret must be redacted")
+        XCTAssertFalse(result.contains("pa\\\"ss"), "no escaped-secret fragment may survive")
+
+        // A DOUBLE-encoded occurrence (a JSON string nested inside another JSON string, as a
+        // re-serialized MCP envelope produces) must also be scrubbed (#6094).
+        let doubleEncoded = SecretRedaction.jsonEscaped(SecretRedaction.jsonEscaped(secret))
+        let nested = "{\"text\":\"" + doubleEncoded + "\"}"
+        XCTAssertFalse(
+            nested.contains(secret),
+            "precondition: the raw secret is not present in the double-encoded text"
+        )
+        let nestedResult = SecretRedaction.redact(nested, secretValues: values)
+        XCTAssertTrue(nestedResult.contains(SecretRedaction.placeholder), "the double-encoded secret must be redacted")
+        XCTAssertFalse(nestedResult.contains("word"), "no double-escaped secret fragment may survive")
+    }
+
+    func testSecretCollidingWithTheRedactionMarkerDoesNotSurvive() {
+        // A secret whose VALUE is the marker (or a substring of it) must not be reintroduced by the
+        // replacement — e.g. replacing "REDACTED" with "***REDACTED***" would leave "REDACTED" (#6094).
+        for secret in ["REDACTED", "***REDACTED***", "***"] {
+            let values = SecretRedaction.secretValues([secret])
+            let result = SecretRedaction.redact("token " + secret + " here", secretValues: values)
+            XCTAssertFalse(
+                result.contains(secret),
+                "the marker-colliding secret \"\(secret)\" must not survive redaction"
+            )
+            XCTAssertTrue(result.contains("token "), "non-secret context is preserved")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

AI-assisted plan recovery still forwarded on-screen secrets to the third-party LLM provider through a **second-order channel** (CWE-200). [PR #6092](https://github.com/kaeawc/auto-mobile/pull/6092) redacted the **initial** recovery context (the substituted plan YAML, the failure error, and the sampled `visibleTexts`/`resourceIds`) before the first `ModelRequest`. It did **not** cover the recovery **agent loop**: once the loop starts, the `observe`/tool results it fetches were fed back into subsequent `ModelRequest`s **unredacted**. A secret still *visible on screen at recovery time* — a token/OTP/env value echoed into a field, or present in the view hierarchy (masked password fields are safe) — therefore reached the provider through the loop's own tool output.

This threads the resolved `secretValues` (the same set #6092 derives for the initial-prompt redaction) into the recovery loop on **both** runners and scrubs **every** tool/observe result string before it re-enters the model transcript. The tool still **executes on-device with the real values**; only the result text that leaves the process for the LLM provider is masked. Reuses #6092's `SecretRedaction` (iOS) / `SecretRedactor` (Android) primitives — no new redaction logic, including their value-layer fail-safe for exotically-encoded keys.

### What changed

- **iOS (`ios/XCTestRunner`)** — carry the concrete secret values on `FailedStepContext.secretValues` (populated in `AutoMobilePlanExecutor.buildFailedStepContext`, alongside the existing initial-context redaction). In `TachikomaPlanRecoveryHandler`, wrap the return of `executeTool` — **both** the success `response.text` **and** the caught-error JSON — and of `observeDeviceState` with `SecretRedaction.redact(_, secretValues:)` before the result is appended to `messages` / surfaced. Every tool-result string that enters a subsequent `ModelRequest` is now scrubbed.
- **Android (`android/junit-runner`)** — add `secretValues` to `AutoMobileAgent.attemptAiRecovery` (passed from the executor's `handleFailure`). Koog owns the tool-execution loop, so the workable seam is a **redacting `MCPClient` decorator** (`RedactingMCPClient`) wrapping the client handed to `createAIAgentWithMCPTools`: it forwards `callTool` arguments to the real client unchanged (device execution intact) and scrubs the **returned** string via `SecretRedactor.redact` — covering every tool result the agent feeds the model, **including the view hierarchy** from `observe`'s `withViewHierarchy = true`. The post-loop liveness `observe` is redacted too. With no declared secrets the raw client is used unchanged (no wrapper allocated).

### Scope boundary — the local daemon stays unredacted

Only what the **agent feeds back to the LLM provider** (the transcript / `ModelRequest`) is scrubbed. The tool **executes** against the device with the real substituted values, and the base64 `executePlan` payload sent to the local daemon is untouched — the daemon needs real values to run the plan and is not the egress boundary. The initial-prompt redaction from #6092 is unchanged; `ios/control-proxy/` is untouched.

## Linked Issue

Closes #6094

This completes the #6029 redaction story: the initial recovery prompt (#6092) plus this loop channel (#6094).

## Bug / Regression Context

- **Prior attempts:** #6092 closed the initial-context channel and explicitly deferred this loop channel to #6094.
- **Observed symptom:** a secret visible on screen at recovery time reached the configured LLM provider via the recovery loop's re-sent `observe`/tool results, even though the initial prompt was redacted.
- **Repro steps / conditions:** recovery enabled (`aiAssistance` on, non-CI, `ai-recovery` flag on, provider key present) + a declared secret whose value is present in an `observe`/tool result during the loop → the value appeared in the 2nd+ `ModelRequest`.

## Validation

**Reproduce-first (security fix), both platforms** — the loop-leak tests fail red on the pre-fix code and pass after:

- **iOS** — `PlanRecoverySecretRedactionTests.testSecretInToolResultIsRedactedFromEveryModelRequestInTheLoop`: a `ScriptedCapturingModelResponder` records **every** `ModelRequest` across the loop (not just the first); `requestText` now also inspects `.tool` messages. With the secret placed **only** in the `observe`/`tapOn` results (the failure error/observation kept clean, isolating this channel from #6092), the secret leaked into ModelRequest #1 and #2 before the fix; after, it is absent from **all** captured requests, the placeholder is present, non-secret context is preserved, and the daemon `executePlan` payload is asserted to still contain the real secret.
- **Android** — `AutoMobileAgentTest."secret in a tool or observe result is scrubbed from what the recovery agent feeds the model"`: drives the real `attemptAiRecovery`, captures the client handed to `createAIAgentWithMCPTools`, and runs the exact `ObserveTool` (view hierarchy) / `TapOnTool` Koog builds from it. Before the fix the captured client is the raw client and the observe result leaked the secret (red at the "secret absent" assertion); after, the results are scrubbed, non-secret context preserved, and the underlying client still returns the real value (device execution unaffected).

**Native suites:**

- **iOS** — `swift build` and `swift build -c release` clean; `swift test` green (158 run, 1 skipped — the live-simulator `RemindersAddPlanTests` integration test); SwiftLint (`force_unwrapping = error`) and SwiftFormat clean on touched files.
  - Toolchain note: the package pins `swift-tools-version: 6.3` and only Swift 6.2.4 is installed here, so build/test ran with the manifest temporarily lowered to 6.2 **with Swift 6 language mode forced** (strict concurrency preserved); the manifest change was reverted before commit and is **not** in this PR (`-c release` + Swift 6 mode serve as the 6.3 proxy).
- **Android (JDK 21)** — `:junit-runner:test` + `:test-plan-validation:test` green (Robolectric); `detektMain`/`detektTest` clean; ktfmt (`--google-style`, pinned 0.64) clean. No `apiDump` needed — `junit-runner` has no BCV `.api` surface, and `RedactingMCPClient` is `internal`.
- **TS/shared schema:** untouched, so no `bun run format:check` / schema regen needed.

- [x] Android/iOS changes: ran the matching native validation
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Kotlin Reuse Check

- [x] Reused #6092's `SecretRedactor.redact` and the existing `AutoMobileAgent.MCPClient` interface via a thin decorator; no new `*Util` files or dependencies. The decorator is the least-invasive seam given Koog owns the tool-execution loop (a per-tool wrapper would be awkward).

## Follow-ups

- [ ] **Runner re-cut required** for on-device effect — `XCTestRunner` and `junit-runner` ship as pinned/checksummed runner artifacts, so the code + tests land now but the loop-channel redaction only takes effect on real device/simulator runs after the runners are re-cut and re-pinned (same delivery model as #6029 / #6092).
