### PR TITLE
fix(plan): barrier step keeps its device label

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -383,6 +383,21 @@
         "__lockNamespace": {
           "description": "Internal plan-scoped lock namespace (injected)",
           "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
         }
       },
       "required": ["lock", "deviceCount"],

--- a/src/server/barrierTools.ts
+++ b/src/server/barrierTools.ts
@@ -5,28 +5,39 @@ import { ActionableError, BootedDevice } from "../models/index";
 import { logger } from "../utils/logger";
 import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Barrier tool schema. A barrier is a pure synchronization point: every
 // participating device arrives, and once all `deviceCount` devices have
 // arrived they all proceed concurrently. Unlike criticalSection there is no
 // serialized section and no steps — each device's own track continues in
 // parallel after the barrier lifts.
-const barrierSchema = z.object({
-  lock: z
-    .string()
-    .describe("Shared barrier name; all devices using the same name synchronize together"),
-  deviceCount: z
-    .number()
-    .int()
-    .positive()
-    .describe("Number of devices that must arrive before the barrier lifts"),
-  timeout: z.number().int().positive().optional().describe("Barrier timeout ms (default 30000)"),
-  // Internal: the plan's base session UUID, injected by PlanExecutor
-  // (buildEnhancedStepParams). Scopes the shared coordinator so two independent
-  // plans that reuse the same lock name get isolated barriers instead of
-  // colliding. Not authored by users; stripped from recordings via INTERNAL_PARAMS.
-  __lockNamespace: z.string().optional().describe("Internal plan-scoped lock namespace (injected)"),
-});
+//
+// Wrapped in addDeviceTargetingToSchema (like criticalSectionSchema) so the
+// `device` label / `sessionUuid` / `platform` PlanExecutor injects survive
+// `schema.parse`. Without them every track's barrier would route to the base
+// session's device and fail as a duplicate arrival (#6117).
+const barrierSchema = addDeviceTargetingToSchema(
+  z.object({
+    lock: z
+      .string()
+      .describe("Shared barrier name; all devices using the same name synchronize together"),
+    deviceCount: z
+      .number()
+      .int()
+      .positive()
+      .describe("Number of devices that must arrive before the barrier lifts"),
+    timeout: z.number().int().positive().optional().describe("Barrier timeout ms (default 30000)"),
+    // Internal: the plan's base session UUID, injected by PlanExecutor
+    // (buildEnhancedStepParams). Scopes the shared coordinator so two independent
+    // plans that reuse the same lock name get isolated barriers instead of
+    // colliding. Not authored by users; stripped from recordings via INTERNAL_PARAMS.
+    __lockNamespace: z
+      .string()
+      .optional()
+      .describe("Internal plan-scoped lock namespace (injected)"),
+  }),
+);
 
 type BarrierParams = z.infer<typeof barrierSchema>;
 

--- a/test/server/barrierTools.test.ts
+++ b/test/server/barrierTools.test.ts
@@ -2,6 +2,8 @@ import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { registerBarrierTools } from "../../src/server/barrierTools";
 import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import type { Plan } from "../../src/models/Plan";
 import type { BootedDevice } from "../../src/models";
 
 const makeDevice = (deviceId: string): BootedDevice => ({
@@ -119,5 +121,95 @@ describe("barrier tool", () => {
 
     expect(await aTimedOut).toBe("timed-out");
     expect(await bTimedOut).toBe("timed-out");
+  });
+
+  test("schema preserves the device label and sessionUuid (not stripped by parse)", () => {
+    // Issue #6117: PlanExecutor requires every multi-device step to carry
+    // `params.device`, then runs `tool.schema.parse` before dispatch. A schema
+    // without the device-targeting fields strips the label, so every track's
+    // barrier routes to the base session's device.
+    const tool = ToolRegistry.getToolForPlan("barrier");
+    const parsed = tool!.schema.parse({
+      device: "B",
+      lock: "sync",
+      deviceCount: 2,
+      sessionUuid: "base-uuid",
+      platform: "android",
+      __lockNamespace: "base-uuid",
+    });
+    expect(parsed).toMatchObject({
+      device: "B",
+      lock: "sync",
+      deviceCount: 2,
+      sessionUuid: "base-uuid",
+      platform: "android",
+      __lockNamespace: "base-uuid",
+    });
+  });
+
+  test("two-track plan with one barrier per track passes (each track routes to its own device)", async () => {
+    // Issue #6117 end-to-end: push the barrier through the real executeStep
+    // (buildEnhancedStepParams -> schema.parse -> callInternal -> handler
+    // routing). The fake resolver maps the surviving `device` label to a
+    // distinct device; if the label were stripped, both tracks would resolve
+    // to the base device and `awaitBarrier` would reject the duplicate arrival.
+    const devicesByLabel: Record<string, BootedDevice> = {
+      A: makeDevice("device-a"),
+      B: makeDevice("device-b"),
+    };
+    const resolvedDeviceIds: string[] = [];
+    const restore = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        resolveExecutionTarget: async (input) => {
+          const label = typeof input.args.device === "string" ? input.args.device : "A";
+          const device = devicesByLabel[label];
+          resolvedDeviceIds.push(device.deviceId);
+          return {
+            args: input.args,
+            baseSessionUuid: "base-uuid",
+            device,
+            internalCall: true,
+            sessionUuid: label === "A" ? "base-uuid" : `base-uuid:${label}`,
+            shouldResolveDevice: true,
+          };
+        },
+      },
+      auditRunner: {
+        run: async (input) => input.handler(input.device, input.args, input.progress, input.signal),
+      },
+      afterToolCall: {
+        handle: async (input) => ({ durationMs: 0, finalizedResponse: input.response }),
+      },
+      planLifecycleManager: {
+        afterExecution: async () => {},
+      },
+    });
+
+    try {
+      const plan: Plan = {
+        name: "two-track barrier",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync", deviceCount: 2, timeout: 200 } },
+          { tool: "barrier", params: { device: "B", lock: "sync", deviceCount: 2, timeout: 200 } },
+        ],
+      };
+
+      const result = await new DefaultPlanExecutor().executePlan(
+        plan,
+        0,
+        "android",
+        "device-a",
+        "base-uuid",
+      );
+
+      expect(result.failedStep?.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      expect(result.perDeviceResults?.get("A")?.success).toBe(true);
+      expect(result.perDeviceResults?.get("B")?.success).toBe(true);
+      expect(new Set(resolvedDeviceIds)).toEqual(new Set(["device-a", "device-b"]));
+    } finally {
+      restore();
+    }
   });
 });

--- a/test/server/barrierTools.test.ts
+++ b/test/server/barrierTools.test.ts
@@ -158,6 +158,13 @@ describe("barrier tool", () => {
       B: makeDevice("device-b"),
     };
     const resolvedDeviceIds: string[] = [];
+    // The device-aware wrapper's `finally` records every call through
+    // ToolCallRepository, which would resolve the real file-backed DB (#3067).
+    // Swap in a no-op repository for the duration of this test, as
+    // toolRegistry.pipeline.test.ts does.
+    const registryInternals = ToolRegistry as unknown as { toolCallRepository: unknown };
+    const originalToolCallRepository = registryInternals.toolCallRepository;
+    registryInternals.toolCallRepository = { recordToolCall: async () => {} };
     const restore = ToolRegistry.setPipelineOverridesForTesting({
       executionTargetResolver: {
         resolveExecutionTarget: async (input) => {
@@ -210,6 +217,7 @@ describe("barrier tool", () => {
       expect(new Set(resolvedDeviceIds)).toEqual(new Set(["device-a", "device-b"]));
     } finally {
       restore();
+      registryInternals.toolCallRepository = originalToolCallRepository;
     }
   });
 });


### PR DESCRIPTION
## Summary

`barrier` plan steps dropped their `device` label at `schema.parse`, so every device track's barrier routed to the base session's device and the second arrival was rejected as a duplicate — every multi-device plan using `barrier` failed. `barrierSchema` is now wrapped in `addDeviceTargetingToSchema(...)`, exactly as `criticalSectionSchema` already is, so the injected `device` / `sessionUuid` / `platform` survive parsing and each track routes to its own device. `schemas/tool-definitions.json` is regenerated via `scripts/update-tool-definitions.sh`.

## Linked Issue

Closes #6117

## Bug / Regression Context

- **Prior attempts:** none. Regression introduced in [PR #3670](https://github.com/kaeawc/auto-mobile/pull/3670), which added the `barrier` tool with a plain `z.object` schema while `criticalSection` used the device-targeting wrapper.
- **Observed symptom:** `Barrier "sync" failed for device X: Device X already arrived at barrier for lock "sync". Nested critical sections with the same lock are not supported.` on any two-track plan with a barrier per track.
- **Repro steps / conditions:** daemon mode, `executePlan` with `devices: [A, B]` and one `barrier` step per label. `PlanExecutor.executeStep` runs `tool.schema.parse(enhancedParams)` (strips unknown keys) before `callInternal`; `executeDeviceTrack` passes the same base `sessionUuid`/`deviceId` to every track, so the `device` label was the only thing routing a track to its own device.

## Changes

- `src/server/barrierTools.ts` — wrap `barrierSchema` in `addDeviceTargetingToSchema(...)`.
- `schemas/tool-definitions.json` — regenerated (`barrier` gains `platform`, `sessionUuid`, `keepScreenAwake`, `device`, matching `criticalSection`).
- `test/server/barrierTools.test.ts` — two new tests:
  - schema parse retains `device`, `sessionUuid`, `platform`, `__lockNamespace`;
  - PlanExecutor-level two-track plan (`devices: [A, B]`, one barrier per track) pushed through the real `executeStep` → `schema.parse` → `callInternal` path with a fake `executionTargetResolver` (via `ToolRegistry.setPipelineOverridesForTesting`) that maps the surviving label to a distinct `BootedDevice`. Both tracks pass and the fake sees two distinct device ids.

## Acceptance criteria

- [x] `barrierSchema.parse({device: "B", lock, deviceCount, sessionUuid})` retains `device` and `sessionUuid` — schema test.
- [x] A two-track plan with one barrier per track passes the barrier; the fake sees two distinct device ids — PlanExecutor test.
- [x] Red before / green after — both new tests failed on `origin/main` with the exact issue symptom (`device-a already arrived at barrier`) and pass with the fix.

## Validation

- [x] `turbo run lint build test` passes (all 14 test shards, 0 failures; oxlint ratchet: no new violations)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` passes
- [x] New code uses interfaces + fakes; new unit tests run in <100ms apart from the plan-level test, which is bounded by its 200 ms barrier timeout only on failure (passes immediately on success)
- [x] No new dependencies or helpers; reuses `addDeviceTargetingToSchema` and the existing `setPipelineOverridesForTesting` seam
- [x] Based on latest `main`
