### PR TITLE
fix(daemon): value-taking flags do not swallow the next flag

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -2163,8 +2163,8 @@ export function parseDaemonArgs(
       const host = args[i + 1];
       if (host && !host.startsWith("--")) {
         options.host = host;
+        i++;
       }
-      i++;
     } else if (args[i] === "--debug") {
       options.debug = true;
     } else if (args[i] === "--debug-perf" || args[i] === "--ui-perf-debug") {
@@ -2173,8 +2173,8 @@ export function parseDaemonArgs(
       const scope = args[i + 1];
       if (scope === "global" || scope === "session") {
         options.planExecutionLockScope = scope;
+        i++;
       }
-      i++;
     } else if (args[i] === RUNNER_READINESS_TIMEOUT_FLAG) {
       const timeoutMs = parseRunnerReadinessTimeout(args[i + 1]);
       if (timeoutMs !== undefined) {
@@ -2203,8 +2203,8 @@ export function parseDaemonArgs(
       const toolOutputsDir = args[i + 1];
       if (toolOutputsDir && !toolOutputsDir.startsWith("--")) {
         options.toolOutputsDir = toolOutputsDir;
+        i++;
       }
-      i++;
     } else if (args[i] === "--network-mockable") {
       options.networkMockable = true;
     } else if (args[i] === "--embedded-sdk") {

--- a/test/daemon/daemonOptionsPropagation.test.ts
+++ b/test/daemon/daemonOptionsPropagation.test.ts
@@ -146,6 +146,40 @@ describe("daemon startup-option propagation", () => {
     expect(parsed.runnerReadinessTimeoutMs).toBeUndefined();
   });
 
+  // Issue #6136: value-taking options used to advance past the next token even
+  // when the value was rejected as `--`-prefixed, so `--host --debug` silently
+  // started a non-debug daemon. The missing value must be ignored, not the flag
+  // that follows it.
+  test.each<{ flag: string; field: keyof DaemonOptions }>([
+    { flag: "--host", field: "host" },
+    { flag: "--plan-execution-lock-scope", field: "planExecutionLockScope" },
+    { flag: "--tool-outputs-dir", field: "toolOutputsDir" },
+    { flag: "--tool-output-dir", field: "toolOutputsDir" },
+    { flag: "--enable-tool", field: "enabledTools" },
+  ])("a missing $flag value does not consume the following flag", ({ flag, field }) => {
+    const parsed = parseDaemonArgs([flag, "--debug"]);
+    expect(parsed.debug).toBe(true);
+    expect(parsed[field]).toBeUndefined();
+  });
+
+  test.each<{ args: string[]; expected: Partial<DaemonOptions> }>([
+    { args: ["--host", "0.0.0.0"], expected: { host: "0.0.0.0" } },
+    {
+      args: ["--plan-execution-lock-scope", "session"],
+      expected: { planExecutionLockScope: "session" },
+    },
+    {
+      args: ["--tool-outputs-dir", "/tmp/artifacts"],
+      expected: { toolOutputsDir: "/tmp/artifacts" },
+    },
+  ])(
+    "a present value for $args is consumed and the next flag still parses",
+    ({ args, expected }) => {
+      const parsed = parseDaemonArgs([...args, "--debug"]);
+      expect(parsed).toMatchObject({ ...expected, debug: true });
+    },
+  );
+
   test("exact tool defaults round-trip through daemon startup arguments", () => {
     const options: DaemonOptions = {
       enabledTools: ["clipboard", "sqlQuery"],

--- a/test/daemon/daemonOptionsPropagation.test.ts
+++ b/test/daemon/daemonOptionsPropagation.test.ts
@@ -157,7 +157,10 @@ describe("daemon startup-option propagation", () => {
     { flag: "--tool-output-dir", field: "toolOutputsDir" },
     { flag: "--enable-tool", field: "enabledTools" },
   ])("a missing $flag value does not consume the following flag", ({ flag, field }) => {
-    const parsed = parseDaemonArgs([flag, "--debug"]);
+    // Isolated env: parseDaemonArgs seeds toolOutputsDir from
+    // AUTOMOBILE_TOOL_OUTPUTS_DIR, which would make the tool-output rows
+    // environment-dependent under process.env.
+    const parsed = parseDaemonArgs([flag, "--debug"], {});
     expect(parsed.debug).toBe(true);
     expect(parsed[field]).toBeUndefined();
   });
@@ -175,7 +178,7 @@ describe("daemon startup-option propagation", () => {
   ])(
     "a present value for $args is consumed and the next flag still parses",
     ({ args, expected }) => {
-      const parsed = parseDaemonArgs([...args, "--debug"]);
+      const parsed = parseDaemonArgs([...args, "--debug"], {});
       expect(parsed).toMatchObject({ ...expected, debug: true });
     },
   );


### PR DESCRIPTION
## Summary

`parseDaemonArgs` advanced `i` past the token following `--host`, `--plan-execution-lock-scope`, and `--tool-outputs-dir` / `--tool-output-dir` unconditionally — even when that token had just been rejected as a `--`-prefixed flag. The rejected value was correctly ignored, but the flag after it was consumed and silently dropped, so `auto-mobile --daemon start --host --debug` started a non-debug daemon with no warning.

The fix moves `i++` inside the accepted-value branch for those three options, matching the shape `--enable-tool`, `--disable-tool`, and `--runner-readiness-timeout-ms` already use in the same function. Nothing else in `manager.ts` is touched (in particular not `waitForReady` or the connect/rejoin paths owned by [#6140](https://github.com/kaeawc/auto-mobile/issues/6140)).

## Linked Issue

Closes #6136

## Bug / Regression Context

- **Prior attempts:** none for this mechanism; [#3846](https://github.com/kaeawc/auto-mobile/issues/3846) and [#2065](https://github.com/kaeawc/auto-mobile/issues/2065) were earlier daemon flag-loss bugs with a different cause.
- **Observed symptom:** `parseDaemonArgs(["--host", "--debug"])` → `{}`; same for `--plan-execution-lock-scope` and `--tool-outputs-dir`. The `--enable-tool` control already returned `{ debug: true }`.
- **Repro steps / conditions:** any daemon `start`/`restart` invocation where one of the three value-taking options is given no value and is immediately followed by another flag.

## Root cause

Three branches guarded the assignment on `value && !value.startsWith("--")` but kept `i++` outside the guard, so a missing value still cost the parser one token.

## Tests

`test/daemon/daemonOptionsPropagation.test.ts` gains two `test.each` tables next to the existing runner-readiness case:

- missing value: `--host`, `--plan-execution-lock-scope`, `--tool-outputs-dir`, `--tool-output-dir`, plus the `--enable-tool` control, each followed by `--debug` → `debug: true` and the option field left undefined. The first four failed before the fix (`debug` was `undefined`); the control passed throughout.
- present value: `--host 0.0.0.0`, `--plan-execution-lock-scope session`, `--tool-outputs-dir /tmp/artifacts`, each followed by `--debug` → both the value and `debug: true` parse.

## Validation

- [x] `turbo run lint build test` — lint and build green; all unit shards green except one 20 s timeout in `DetectIntentChooser … should detect intent chooser when provided with view hierarchy`, which is unrelated to this change (a known macOS shard-contention timeout) and passes in 1.3 s when the file is run in isolation
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` passes
- [x] New tests run in well under 100 ms; no DB, no timers, no fakes needed (pure parser); both tables pass an isolated `{}` env so `AUTOMOBILE_TOOL_OUTPUTS_DIR` in the host environment cannot skew them
- [x] Rebased onto latest `main`

## Follow-ups

- Refs #6168 — `src/cli/parseArgs.ts` has the same unconditional `i++` after `--port` / `--host` / `--initial-session-uuid` (proxy-mode sibling; kept out of this PR to stay scoped to `parseDaemonArgs`).
