### PR TITLE
fix(mcp): tapOn returns isError on selector miss

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -138,8 +138,6 @@ src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be
 src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
 src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
 src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
-src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.
-src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.
 src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
 src/server/navigationTools.ts: error TS2339: Property 'coverage' does not exist on type 'ExploreExecutionResult'.
 src/server/navigationTools.ts: error TS2339: Property 'interactionsPerformed' does not exist on type 'ExploreExecutionResult'.
@@ -206,10 +204,10 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 3 :: src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
 # swap-fp: 30 :: src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, null | number | string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 30 :: src/features/observe/DeviceServiceUtils.ts: error TS2694: Namespace '"src/features/observe/DeviceService"' has no exported member 'ImeActionResult'.
+# swap-fp: 30 :: src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
 # swap-fp: 30 :: src/server/observeTools.ts: error TS2322: Type 'TimingData' is not assignable to type 'TimingEntry'.
 # swap-fp: 32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'class' does not exist on type 'ViewHierarchyNode'.
 # swap-fp: 32 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2459: Module '"./types"' declares 'GestureTimingResult' locally, but it is not exported.
-# swap-fp: 32 :: src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
 # swap-fp: 32,40 :: src/db/performanceAuditRepository.ts: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "performance_audit_results", "timestamp">'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableElementsInContainer' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableParentsContainingText' does not exist on type 'ElementFinder'.
@@ -250,10 +248,10 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 57 :: src/utils/filesystem/DefaultFileSystem.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 # swap-fp: 58,58 :: src/db/migrator.ts: error TS2339: Property 'execute' does not exist on type 'never'.
 # swap-fp: 59 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2345: Argument of type '{ idPrefix: string; responseType: string; messageType: string; params: { x1: number; y1: number; x2: number; y2: number; fingerCount: number; duration: number; offset: number | undefined; }; timeoutMs: number; perf: PerformanceTracker | undefined; notConnectedMessage: string; errorLabel: string; }' is not assignable to parameter of type 'SendCommandOptions<GestureTimingResult>'.
+# swap-fp: 59 :: src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
 # swap-fp: 6 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
 # swap-fp: 6 :: src/doctor/index.ts: error TS2367: This comparison appears to be unintentional because the types 'false | undefined' and 'true' have no overlap.
 # swap-fp: 6,6,6,6 :: src/db/migrator.ts: error TS2339: Property 'select' does not exist on type 'never'.
-# swap-fp: 61 :: src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
 # swap-fp: 63 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
 # swap-fp: 64,64 :: src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 # swap-fp: 67,73 :: src/features/utility/ElementFinder.ts: error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
@@ -270,7 +268,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7,7,11,13,13 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
-# swap-fp: 8,9 :: src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
 # swap-fp: 9 :: src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -1031,10 +1031,11 @@ export async function tapOnHandler(
   // A selector miss must not read as a completed tap: gate the message on the
   // outcome and mark the MCP envelope `isError`, exactly as inputText does since
   // #5902 (#6152). `||` not `??`: an empty-string error must still yield the
-  // non-empty fallback (#4183 P4).
+  // non-empty fallback (#4183 P4). The failure keeps the search summary so the
+  // user still sees how long the selector was looked for before it missed.
   const message = result.success
     ? buildTapOnResultMessage(result.selectedElement, searchSummary, result.activatedSubtext)
-    : `Failed to tap: ${result.error || "unknown error"}`;
+    : `Failed to tap: ${result.error || "unknown error"}${searchSummary ? ` (${searchSummary})` : ""}`;
   const payload = { message, observation: result.observation, ...result };
   const response: StructuredToolResponse<typeof payload> & { isError?: true } =
     createStructuredToolResponse(payload);

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -28,6 +28,7 @@ import {
   PinchOnResult,
   SendTextResult,
   SwipeOnToolPayload,
+  type TapOnElementResult,
   type TapOnSelectedElement,
 } from "../models";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
@@ -952,68 +953,101 @@ export function buildTapOnResultMessage(
   return details.length > 0 ? `Tapped on element (${details.join("; ")})` : "Tapped on element";
 }
 
+// Injection seam for the tapOn handler (mirrors the pinchOn factory seam above).
+// Lets a unit test exercise the registered handler wiring with a fake
+// TapOnElement whose execute() returns a selector miss, so a revert of the
+// failure gating below is caught by a test — not just the formatter (#6152).
+export type TapOnElementLike = Pick<TapOnElement, "execute">;
+
+let tapOnElementFactory: (device: BootedDevice) => TapOnElementLike = (device) =>
+  new TapOnElement(device);
+
+export function setTapOnElementFactory(factory: (device: BootedDevice) => TapOnElementLike): void {
+  tapOnElementFactory = factory;
+}
+
+export function resetTapOnElementFactory(): void {
+  tapOnElementFactory = (device) => new TapOnElement(device);
+}
+
+/**
+ * The hierarchy-changed search summary appended to the tapOn message. Emitted
+ * when the search polled or observed changes, or when `searchUntil` was
+ * requested and the observation is confirmed fresh.
+ */
+function buildTapOnSearchSummary(
+  result: Pick<TapOnElementResult, "searchUntil" | "observation">,
+  searchUntilRequested: boolean,
+): string | undefined {
+  const searchStats = result.searchUntil;
+  if (!searchStats) {
+    return undefined;
+  }
+  const freshness = result.observation?.freshness;
+  const hasFreshnessTimestamp =
+    typeof freshness?.requestedAfter === "number" && typeof freshness?.actualTimestamp === "number";
+  const hasConfirmedFreshObservation =
+    hasFreshnessTimestamp && freshness.actualTimestamp >= freshness.requestedAfter;
+  const shouldIncludeSearchSummary =
+    searchStats.requestCount > 0 ||
+    searchStats.changeCount > 0 ||
+    (searchUntilRequested && hasConfirmedFreshObservation);
+  return shouldIncludeSearchSummary
+    ? `${searchStats.changeCount} view hierarchy changes over ${searchStats.requestCount} requests within ${searchStats.durationMs}ms`
+    : undefined;
+}
+
+export async function tapOnHandler(
+  device: BootedDevice,
+  args: TapOnArgs,
+  progress?: ProgressCallback,
+) {
+  RecompositionTracker.getInstance().recordInteraction();
+  const tapOnTextCommand = tapOnElementFactory(device);
+  const result = await tapOnTextCommand.execute(
+    {
+      container: args.container,
+      text: args.selector.text,
+      textAny: args.selector.textAny,
+      elementId: args.selector.elementId,
+      testTag: args.selector.testTag,
+      accessibilityLink: args.selector.accessibilityLink,
+      sibling: args.sibling,
+      selectionStrategy: args.selectionStrategy,
+      index: args.index,
+      action: args.action,
+      duration: args.duration,
+      searchUntil: args.searchUntil,
+      preTapStability: args.preTapStability,
+      retryIfNoChange: args.retryIfNoChange,
+      ensureTap: args.ensureTap,
+      subtext: args.subtext,
+    },
+    progress,
+  );
+
+  const searchSummary = buildTapOnSearchSummary(result, Boolean(args.searchUntil));
+
+  // A selector miss must not read as a completed tap: gate the message on the
+  // outcome and mark the MCP envelope `isError`, exactly as inputText does since
+  // #5902 (#6152). `||` not `??`: an empty-string error must still yield the
+  // non-empty fallback (#4183 P4).
+  const message = result.success
+    ? buildTapOnResultMessage(result.selectedElement, searchSummary, result.activatedSubtext)
+    : `Failed to tap: ${result.error || "unknown error"}`;
+  const payload = { message, observation: result.observation, ...result };
+  const response: StructuredToolResponse<typeof payload> & { isError?: true } =
+    createStructuredToolResponse(payload);
+  return result.success ? response : { ...response, isError: true as const };
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
 
 export function registerInteractionTools() {
-  // Tap on handler
-  const tapOnHandler = async (
-    device: BootedDevice,
-    args: TapOnArgs,
-    progress?: ProgressCallback,
-  ) => {
-    RecompositionTracker.getInstance().recordInteraction();
-    const tapOnTextCommand = new TapOnElement(device);
-    const result = await tapOnTextCommand.execute(
-      {
-        container: args.container,
-        text: args.selector.text,
-        textAny: args.selector.textAny,
-        elementId: args.selector.elementId,
-        testTag: args.selector.testTag,
-        accessibilityLink: args.selector.accessibilityLink,
-        sibling: args.sibling,
-        selectionStrategy: args.selectionStrategy,
-        index: args.index,
-        action: args.action,
-        duration: args.duration,
-        searchUntil: args.searchUntil,
-        preTapStability: args.preTapStability,
-        retryIfNoChange: args.retryIfNoChange,
-        ensureTap: args.ensureTap,
-        subtext: args.subtext,
-      },
-      progress,
-    );
-
-    const searchStats = result.searchUntil;
-    const freshness = result.observation?.freshness;
-    const hasFreshnessTimestamp =
-      typeof freshness?.requestedAfter === "number" &&
-      typeof freshness?.actualTimestamp === "number";
-    const hasConfirmedFreshObservation =
-      hasFreshnessTimestamp && freshness.actualTimestamp >= freshness.requestedAfter;
-    const shouldIncludeSearchSummary =
-      Boolean(searchStats) &&
-      (searchStats.requestCount > 0 ||
-        searchStats.changeCount > 0 ||
-        (Boolean(args.searchUntil) && hasConfirmedFreshObservation));
-    const searchSummary =
-      shouldIncludeSearchSummary && searchStats
-        ? `${searchStats.changeCount} view hierarchy changes over ${searchStats.requestCount} requests within ${searchStats.durationMs}ms`
-        : undefined;
-
-    return createStructuredToolResponse({
-      message: buildTapOnResultMessage(
-        result.selectedElement,
-        searchSummary,
-        result.activatedSubtext,
-      ),
-      observation: result.observation,
-      ...result,
-    });
-  };
+  // tapOn handler is defined at module scope (with an injectable TapOnElement
+  // factory) so a unit test can exercise the registered handler wiring (#6152).
 
   // TapAny handler
   const tapAnyHandler = async (

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildInputTextResultMessage,
   buildTapOnResultMessage,
+  registerInteractionTools,
   resetTapOnElementFactory,
   setTapOnElementFactory,
   tapOnHandler,
 } from "../../src/server/interactionTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
 import type { TapOnArgs } from "../../src/server/interactionToolTypes";
 import { getStructuredField } from "../../src/utils/toolUtils";
 import type { BootedDevice, TapOnElementResult, TapOnSelectedElement } from "../../src/models";
@@ -176,6 +178,15 @@ describe("tapOnHandler (registered handler wiring)", () => {
 
   afterEach(() => {
     resetTapOnElementFactory();
+    ToolRegistry.clearTools();
+  });
+
+  // The direct-call tests below only pin the wiring if the handler they call is
+  // the one registered for "tapOn" — pin that identity so the two cannot drift.
+  test("the module-scope handler is the one registered for tapOn", () => {
+    ToolRegistry.clearTools();
+    registerInteractionTools();
+    expect(ToolRegistry.getTool("tapOn")?.deviceAwareHandler).toBe(tapOnHandler);
   });
 
   const fakeResult = (overrides: Partial<TapOnElementResult>): TapOnElementResult =>
@@ -202,13 +213,27 @@ describe("tapOnHandler (registered handler wiring)", () => {
     const response = await tapOnHandler(fakeDevice, args);
     expect(response.isError).toBe(true);
     const message = parseMessage(response);
+    // The failure keeps the search summary: the user sees both that nothing
+    // matched and how long the selector was looked for.
     expect(message).toBe(
-      "Failed to tap: Failed to perform tap on element: Element not found with provided text 'ZZZ_NO_SUCH_TEXT_ZZZ'",
+      "Failed to tap: Failed to perform tap on element: Element not found with provided text 'ZZZ_NO_SUCH_TEXT_ZZZ' (0 view hierarchy changes over 29 requests within 1521ms)",
     );
     expect(message).not.toContain("Tapped on element");
     // The failure message must also be the one on the wire (structuredContent).
     expect(getStructuredField(response, "message")).toBe(message);
     expect(getStructuredField(response, "success")).toBe(false);
+  });
+
+  test("a failure without search stats carries no empty summary parenthetical", async () => {
+    setTapOnElementFactory(() => ({
+      execute: async () => fakeResult({ error: "Element not found with provided text 'Missing'" }),
+    }));
+
+    const response = await tapOnHandler(fakeDevice, args);
+    expect(response.isError).toBe(true);
+    expect(parseMessage(response)).toBe(
+      "Failed to tap: Element not found with provided text 'Missing'",
+    );
   });
 
   // `||` not `??`: an empty-string error must still yield a non-empty failure

--- a/test/server/interactionTools.tapOnMessage.test.ts
+++ b/test/server/interactionTools.tapOnMessage.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildInputTextResultMessage,
   buildTapOnResultMessage,
+  resetTapOnElementFactory,
+  setTapOnElementFactory,
+  tapOnHandler,
 } from "../../src/server/interactionTools";
-import type { TapOnSelectedElement } from "../../src/models";
+import type { TapOnArgs } from "../../src/server/interactionToolTypes";
+import { getStructuredField } from "../../src/utils/toolUtils";
+import type { BootedDevice, TapOnElementResult, TapOnSelectedElement } from "../../src/models";
 
 const selected = (overrides: Partial<TapOnSelectedElement>): TapOnSelectedElement => ({
   text: "",
@@ -158,6 +163,83 @@ describe("buildTapOnResultMessage", () => {
   test("uses only the search summary when there is no selected element", () => {
     const summary = "2 view hierarchy changes over 5 requests within 300ms";
     expect(buildTapOnResultMessage(undefined, summary)).toBe(`Tapped on element (${summary})`);
+  });
+});
+
+// Handler-level coverage: exercise the REGISTERED tapOn handler path with an
+// injected fake TapOnElement and assert the serialized envelope. Before #6152 a
+// selector that matched nothing still produced "Tapped on element (...)" and no
+// `isError` on the envelope — the exact shape #5902 fixed for inputText only.
+describe("tapOnHandler (registered handler wiring)", () => {
+  const fakeDevice = { deviceId: "fake", platform: "android" } as unknown as BootedDevice;
+  const args: TapOnArgs = { selector: { text: "ZZZ_NO_SUCH_TEXT_ZZZ" }, platform: "android" };
+
+  afterEach(() => {
+    resetTapOnElementFactory();
+  });
+
+  const fakeResult = (overrides: Partial<TapOnElementResult>): TapOnElementResult =>
+    ({
+      success: false,
+      action: "tap",
+      element: { bounds: { left: 0, top: 0, right: 0, bottom: 0 } },
+      ...overrides,
+    }) as TapOnElementResult;
+
+  const parseMessage = (response: { content: Array<{ type: string; text: string }> }): string =>
+    (JSON.parse(response.content[0].text) as { message: string }).message;
+
+  test("a selector miss sets isError and reports the failure, not a tap", async () => {
+    setTapOnElementFactory(() => ({
+      execute: async () =>
+        fakeResult({
+          error:
+            "Failed to perform tap on element: Element not found with provided text 'ZZZ_NO_SUCH_TEXT_ZZZ'",
+          searchUntil: { durationMs: 1521, requestCount: 29, changeCount: 0 },
+        }),
+    }));
+
+    const response = await tapOnHandler(fakeDevice, args);
+    expect(response.isError).toBe(true);
+    const message = parseMessage(response);
+    expect(message).toBe(
+      "Failed to tap: Failed to perform tap on element: Element not found with provided text 'ZZZ_NO_SUCH_TEXT_ZZZ'",
+    );
+    expect(message).not.toContain("Tapped on element");
+    // The failure message must also be the one on the wire (structuredContent).
+    expect(getStructuredField(response, "message")).toBe(message);
+    expect(getStructuredField(response, "success")).toBe(false);
+  });
+
+  // `||` not `??`: an empty-string error must still yield a non-empty failure
+  // message (#4183 P4), never a blank or success-shaped one.
+  test.each([
+    [undefined, "Failed to tap: unknown error"],
+    ["", "Failed to tap: unknown error"],
+  ])("a failure with error %p yields %p", async (error, expected) => {
+    setTapOnElementFactory(() => ({ execute: async () => fakeResult({ error }) }));
+
+    const response = await tapOnHandler(fakeDevice, args);
+    expect(response.isError).toBe(true);
+    expect(parseMessage(response)).toBe(expected);
+  });
+
+  test("a successful tap keeps the success message and no isError", async () => {
+    setTapOnElementFactory(() => ({
+      execute: async () =>
+        fakeResult({
+          success: true,
+          selectedElement: selected({ text: "Internet" }),
+          searchUntil: { durationMs: 300, requestCount: 5, changeCount: 2 },
+        }),
+    }));
+
+    const response = await tapOnHandler(fakeDevice, args);
+    expect(response.isError).toBeUndefined();
+    expect(parseMessage(response)).toBe(
+      'Tapped on element (matched text="Internet"; 1 match; 2 view hierarchy changes over 5 requests within 300ms)',
+    );
+    expect(getStructuredField(response, "success")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`tapOn` with a selector that matches nothing still returned a success-shaped result: the `message` read `"Tapped on element (0 view hierarchy changes over 29 requests within 1521ms)"` and the MCP envelope carried no `isError`, so a conforming client saw an ordinary successful tool result and moved on. [#5902](https://github.com/kaeawc/auto-mobile/issues/5902) fixed this exact shape for `inputText` (commit `6b4b96637`) but left `tapOn` untouched.

This mirrors that fix for `tapOn`: the message is gated on `result.success` (`"Failed to tap: <error>"`, where `<error>` already names the selector that matched nothing, followed by the existing search summary when the tap polled — e.g. `"Failed to tap: … Element not found with provided text 'ZZZ' (0 view hierarchy changes over 29 requests within 1521ms)"`) and the envelope gets `isError: true` on failure. Successful taps are byte-for-byte unchanged.

## Linked Issue

Closes #6152

## Bug / Regression Context

- **Prior attempts:** [#5941](https://github.com/kaeawc/auto-mobile/pull/5941) fixed the same failure shape for `inputText` only.
- **Observed symptom:** selector miss → `message: "Tapped on element (…)"`, `success: false`, `error: "… Element not found …"`, and no `isError` on the envelope.
- **Repro steps / conditions:** any `tapOn` whose selector resolves nothing (e.g. `selector: { text: "ZZZ_NO_SUCH_TEXT_ZZZ" }` or a nonexistent resource id).

## Root cause

`tapOnHandler` in `src/server/interactionTools.ts` called `buildTapOnResultMessage(...)` unconditionally (that helper only knows how to describe a match, so it always emits "Tapped on element") and returned `createStructuredToolResponse(...)` as-is, never setting `isError`. The non-standard top-level `success`/`error` keys that `createStructuredToolResponse` hoists are not part of the MCP contract, so a generic client never saw the failure.

## Changes

- `src/server/interactionTools.ts`
  - `tapOnHandler`: message is `result.success ? buildTapOnResultMessage(...) : "Failed to tap: <error>"` (`||` not `??` so an empty-string error still yields `"unknown error"`, per the #4183 P4 precedent), and the response is `result.success ? response : { ...response, isError: true }` — the same one-liner `inputTextHandler` uses.
  - Hoisted `tapOnHandler` to module scope with an injectable `TapOnElement` factory (`setTapOnElementFactory` / `resetTapOnElementFactory`), the same seam `pinchOnHandler` gained in #6056, so the registered handler wiring — not just a formatter — is pinned by a unit test.
  - Extracted the search-summary computation into `buildTapOnSearchSummary` (pure move; keeps the handler under the `complexity` 12 threshold). Its early `return` narrows `searchStats`, retiring two baselined `TS18048` errors.
- `scripts/typecheck-baseline.txt`: ratcheted down 165 → 163 (`bun run typecheck:update`).
- `test/server/interactionTools.tapOnMessage.test.ts`: new `tapOnHandler (registered handler wiring)` suite.

No tool schema or description text changed; `schemas/tool-definitions.json` is unchanged (pre-commit regen confirmed).

## Tests

- registration pin: `ToolRegistry.getTool("tapOn")?.deviceAwareHandler` is the module-scope `tapOnHandler` the direct-call tests exercise, so the two cannot drift.
- selector miss with search stats → `isError: true`, message `"Failed to tap: Failed to perform tap on element: Element not found with provided text 'ZZZ_NO_SUCH_TEXT_ZZZ' (0 view hierarchy changes over 29 requests within 1521ms)"`, message does not contain "Tapped on element", and `structuredContent.message`/`success` agree with the wire text.
- selector miss without search stats → `"Failed to tap: Element not found with provided text 'Missing'"` (no empty parenthetical).
- `error: undefined` and `error: ""` → `isError: true` with `"Failed to tap: unknown error"` (never blank).
- successful tap → no `isError`, message unchanged (`Tapped on element (matched text="Internet"; 1 match; 2 view hierarchy changes over 5 requests within 300ms)`).

All of these failed before the change (the seam did not exist; with the old wiring the miss case produced "Tapped on element (…)" and no `isError`).

## Review notes

Reviewed with the repo's three-lens code review (runtime behavior, delivery/enforcement, and a generated lens over downstream consumers of the `isError` bit — `src/server/index.ts` session binding, `daemonMcpProxy` replay lease, plan executor, CLI). No blocking findings; every downstream consumer already treats an `inputText` miss the same way. One adjacent gap the downstream lens surfaced — `DefaultUIStateSetup.tapCloseButton` returning `true` after the first candidate regardless of outcome — is already tracked as [#6123](https://github.com/kaeawc/auto-mobile/issues/6123) and is deliberately not touched here.

## Audit of the other action handlers (not changed here)

The issue asks for an audit of the rest of the family. None of the others is the identical one-line pattern, so they are deliberately left out of this PR to keep it minimal:

- `swipeOn`, `pinchOn`: message is already outcome-gated, but the envelope never sets `isError` on `success: false`.
- `tapAny`, `dragAndDrop`, `clearText`, `selectAllText`, `pressButton`, `imeAction`: hard-coded success message **and** no `isError` — the same two-part gap `tapOn` had.

Tracked as a follow-up (linked in the comments below).

## Validation

- [x] `turbo run lint build test` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` reports no new errors (baseline ratcheted down to 163)
- [x] New code uses interfaces + fakes; the new suite runs in well under 100ms with no device or DB
- [x] No new dependencies or helpers beyond the two module-scope functions above
- [x] Based on latest `main` (`fb68db14f`)
