### PR TITLE
fix(a11y): TalkBack swipe maps finger direction to the correct scroll action

### DIFF
--- a/src/features/action/swipeon/TalkBackSwipeExecutor.ts
+++ b/src/features/action/swipeon/TalkBackSwipeExecutor.ts
@@ -15,6 +15,29 @@ import { GestureExecutor, BoomerangConfig, TalkBackSwipeRunner } from "./types";
 import { Timer } from "../../../utils/interfaces/Timer";
 import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
+export type AccessibilityScrollAction = "scroll_forward" | "scroll_backward";
+
+/**
+ * Map a FINGER swipe direction to the `AccessibilityNodeInfo` scroll action that
+ * moves the content the same way the coordinate swipe would.
+ *
+ * Every caller of `executeSwipeGesture` passes the finger direction (`SwipeOn`
+ * resolves `gestureType` into a finger direction before dispatch, and the
+ * non-TalkBack path feeds the same value to `getSwipeWithinBounds`). A finger
+ * moving UP (or LEFT) reveals the content BELOW (or to the RIGHT), which is
+ * `ACTION_SCROLL_FORWARD`; a finger moving DOWN (or RIGHT) reveals content
+ * ABOVE (or to the LEFT), which is `ACTION_SCROLL_BACKWARD`. The previous
+ * mapping was inverted, so `lookFor` under TalkBack scrolled away from the
+ * target (#6116).
+ */
+export function scrollActionForFingerDirection(
+  fingerDirection: SwipeDirection,
+): AccessibilityScrollAction {
+  return fingerDirection === "up" || fingerDirection === "left"
+    ? "scroll_forward"
+    : "scroll_backward";
+}
+
 export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
   private static readonly DEFAULT_APEX_PAUSE_MS = 100;
   private static readonly DEFAULT_RETURN_SPEED = 1;
@@ -218,9 +241,8 @@ export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
   ): Promise<SwipeResult> {
     // Try accessibility scroll actions if container is known and has resource-id
     if (containerElement && containerElement["resource-id"]) {
-      // Map swipe direction to ACTION_SCROLL semantics (forward = down/right, backward = up/left).
-      const scrollAction =
-        direction === "down" || direction === "right" ? "scroll_forward" : "scroll_backward";
+      // `direction` is the FINGER direction; see scrollActionForFingerDirection.
+      const scrollAction = scrollActionForFingerDirection(direction);
 
       logger.info(
         `[SwipeOn] Attempting ACTION_SCROLL (${scrollAction}) on container: ${containerElement["resource-id"]}`,

--- a/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
@@ -11,9 +11,14 @@ import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
 import type {
   SwipeOnResolvedOptions,
+  TalkBackSwipeRunner,
   VoiceOverSwipeRunner,
 } from "../../../../src/features/action/swipeon/types";
 import type { FeatureFlagService } from "../../../../src/features/featureFlags/FeatureFlagService";
+import { TalkBackSwipeExecutor } from "../../../../src/features/action/swipeon/TalkBackSwipeExecutor";
+import { FakeCtrlProxy } from "../../../fakes/FakeCtrlProxy";
+import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
+import type { ViewHierarchyResult } from "../../../../src/models";
 
 const DEVICE: BootedDevice = {
   name: "test-device",
@@ -51,6 +56,7 @@ function makeScrollUntilVisible({
   timer,
   accessibilityService,
   observeResults,
+  resolveObservation,
   talkBackExecutor,
   featureFlags,
   device = DEVICE,
@@ -61,17 +67,26 @@ function makeScrollUntilVisible({
   timer: FakeTimer;
   accessibilityService: FakeScrollAccessibilityService;
   observeResults: ObserveResult[];
-  talkBackExecutor: FakeTalkBackSwipeExecutor;
+  /**
+   * Optional override for what the device "shows" at a given interaction index
+   * (0 = before any swipe). Lets a test derive the observation from side effects
+   * (e.g. which ACTION_SCROLL the fake service received) instead of a fixed list.
+   */
+  resolveObservation?: (callIdx: number) => ObserveResult;
+  talkBackExecutor: TalkBackSwipeRunner;
   featureFlags?: FeatureFlagService;
   device?: BootedDevice;
   voiceOverExecutor?: VoiceOverSwipeRunner;
 }): ScrollUntilVisible {
   let callIdx = 0;
+  const observationAt = (idx: number): ObserveResult =>
+    resolveObservation
+      ? resolveObservation(idx)
+      : observeResults[Math.min(idx, observeResults.length - 1)];
 
   const fakeObserveScreen = {
-    execute: async () => observeResults[Math.min(callIdx, observeResults.length - 1)],
-    getMostRecentCachedObserveResult: async () =>
-      observeResults[Math.min(callIdx, observeResults.length - 1)],
+    execute: async () => observationAt(callIdx),
+    getMostRecentCachedObserveResult: async () => observationAt(callIdx),
   };
 
   const fakeGeometry = new FakeElementGeometry();
@@ -80,10 +95,10 @@ function makeScrollUntilVisible({
 
   // Each observedInteraction call advances to the next observation
   const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, _opts: any) => {
-    const obs = observeResults[Math.min(callIdx, observeResults.length - 1)];
+    const obs = observationAt(callIdx);
     const result = await action(obs);
     callIdx++;
-    const nextObs = observeResults[Math.min(callIdx, observeResults.length - 1)];
+    const nextObs = observationAt(callIdx);
     return { ...result, observation: nextObs };
   };
 
@@ -398,6 +413,77 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
     });
+  });
+});
+
+describe("ScrollUntilVisible TalkBack ACTION_SCROLL direction (#6116)", () => {
+  // Marker the fake device puts on the hierarchy once the list has actually
+  // scrolled forward (finger up) far enough to bring the target on screen.
+  const TARGET_REVEALED = "target-revealed";
+
+  const hierarchyShowsTarget = (hierarchy: ViewHierarchyResult): boolean =>
+    (hierarchy.hierarchy as { node?: { $?: { _id?: string } } })?.node?.$?._id === TARGET_REVEALED;
+
+  const makeRevealedObserveResult = (): ObserveResult => ({
+    ...makeObserveResult(0),
+    viewHierarchy: { hierarchy: { node: { $: { _id: TARGET_REVEALED } } } },
+  });
+
+  test("lookFor below the viewport (finger up) issues scroll_forward and finds the target on the first scroll", async () => {
+    const detector = new FakeAccessibilityDetector();
+    detector.setTalkBackEnabled(true);
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fakeCtrlProxy = new FakeCtrlProxy();
+    const finder = new FakeElementFinder();
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+    // The target is only in the hierarchy once the device has scrolled forward.
+    finder.findElementByText = (hierarchy: ViewHierarchyResult, _text: string) =>
+      hierarchyShowsTarget(hierarchy) ? TARGET_ELEMENT : null;
+
+    // Real executor + fake accessibility service: the fake "device" reveals the
+    // target only after it receives scroll_forward. Anything else (the inverted
+    // scroll_backward) leaves the list where it was.
+    const talkBackExecutor = new TalkBackSwipeExecutor(
+      DEVICE,
+      new FakeGestureExecutor(),
+      fakeCtrlProxy as any,
+      detector,
+      new FakeAdbClient() as any,
+      timer,
+    );
+    const scrolledForward = () =>
+      fakeCtrlProxy.getActionHistory().some((call) => call.action === "scroll_forward");
+    const resolveObservation = (callIdx: number): ObserveResult =>
+      callIdx > 0 && scrolledForward() ? makeRevealedObserveResult() : makeObserveResult(0);
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService: new FakeScrollAccessibilityService(),
+      observeResults: [],
+      resolveObservation,
+      talkBackExecutor,
+    });
+
+    // direction is the FINGER direction: swiping up reveals the content below.
+    const result = await suv.execute({
+      direction: "up",
+      lookFor: { text: "Target Item", maxTime: 3000 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.found).toBe(true);
+    // Toward the target on the very first scroll — no scroll_backward, and no
+    // overshoot-recovery reversal needed to stumble onto it.
+    expect(result.scrollIterations).toBe(1);
+    expect(fakeCtrlProxy.getActionHistory().map((call) => call.action)).toEqual(["scroll_forward"]);
+    expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+      resourceId: "test:id/list",
+      timeoutMs: 5000,
+    });
+    expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
   });
 });
 

--- a/test/features/action/swipeon/SwipeOn.test.ts
+++ b/test/features/action/swipeon/SwipeOn.test.ts
@@ -8,6 +8,138 @@ import { FakeObserveScreen } from "../../../fakes/FakeObserveScreen";
 import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
 import { FakeWindow } from "../../../fakes/FakeWindow";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeCtrlProxy } from "../../../fakes/FakeCtrlProxy";
+import { FakeElementFinder } from "../../../fakes/FakeElementFinder";
+import type { Element, ViewHierarchyResult } from "../../../../src/models";
+
+describe("SwipeOn TalkBack ACTION_SCROLL direction (#6116)", () => {
+  const device = { name: "test-device", platform: "android", deviceId: "device-1" } as const;
+  const LIST_ID = "test:id/list";
+  const TARGET_REVEALED = "target-revealed";
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeGesture: FakeGestureExecutor;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeWindow: FakeWindow;
+  let fakeTimer: FakeTimer;
+  let fakeAccessibilityDetector: FakeAccessibilityDetector;
+  let fakeCtrlProxy: FakeCtrlProxy;
+  let finder: FakeElementFinder;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  const container: Element = {
+    bounds: { left: 0, top: 0, right: 1000, bottom: 2000 },
+    "resource-id": LIST_ID,
+    scrollable: true,
+  } as unknown as Element;
+
+  const target: Element = {
+    bounds: { left: 10, top: 500, right: 990, bottom: 600 },
+    "resource-id": "test:id/target",
+    text: "Target Item",
+  } as unknown as Element;
+
+  const createObserveResult = (hierarchyId: string): ObserveResult => ({
+    timestamp: 0,
+    screenSize: { width: 1000, height: 2000 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: { hierarchy: { node: { $: { _id: hierarchyId } } } },
+  });
+
+  const hierarchyShowsTarget = (hierarchy: ViewHierarchyResult): boolean =>
+    (hierarchy.hierarchy as { node?: { $?: { _id?: string } } })?.node?.$?._id === TARGET_REVEALED;
+
+  const scrolledForward = () =>
+    fakeCtrlProxy.getActionHistory().some((call) => call.action === "scroll_forward");
+
+  const createSwipeOn = () => {
+    const swipeOn = new SwipeOn(device, {} as any, {
+      executeGesture: fakeGesture,
+      observeScreen: fakeObserveScreen,
+      accessibilityDetector: fakeAccessibilityDetector,
+      finder,
+    });
+    (swipeOn as any).awaitIdle = fakeAwaitIdle;
+    (swipeOn as any).window = fakeWindow;
+    (swipeOn as any).timer = fakeTimer;
+    (swipeOn as any).scrollUntilVisible.deps.timer = fakeTimer;
+    return swipeOn;
+  };
+
+  beforeEach(() => {
+    fakeAccessibilityDetector = new FakeAccessibilityDetector();
+    fakeAccessibilityDetector.setTalkBackEnabled(true);
+    fakeCtrlProxy = new FakeCtrlProxy();
+    // The real TalkBackSwipeExecutor inside SwipeOn talks to this fake service.
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeCtrlProxy as unknown as AndroidCtrlProxyClient,
+    );
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeGesture = new FakeGestureExecutor();
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeWindow = new FakeWindow();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    fakeWindow.configureCachedActiveWindow(null);
+    finder = new FakeElementFinder();
+    finder.nextScrollableContainer = container;
+    finder.nextElementByResourceId = container;
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+  });
+
+  test("lookFor target below the viewport with finger-up issues scroll_forward and reaches it in one scroll", async () => {
+    // The fake device reveals the target only after the list has scrolled
+    // forward; the inverted scroll_backward would leave it off screen.
+    fakeObserveScreen.setObserveResult(() =>
+      scrolledForward() ? createObserveResult(TARGET_REVEALED) : createObserveResult("top"),
+    );
+    finder.findElementByText = (hierarchy: ViewHierarchyResult, _text: string) =>
+      hierarchyShowsTarget(hierarchy) ? target : null;
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "up",
+      lookFor: { text: "Target Item", maxTime: 3000 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.found).toBe(true);
+    expect(result.scrollIterations).toBe(1);
+    expect(fakeCtrlProxy.getActionHistory().map((call) => call.action)).toEqual(["scroll_forward"]);
+    expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({ resourceId: LIST_ID });
+    expect(fakeGesture.getSwipeCalls()).toHaveLength(0);
+  });
+
+  test("scrollTowardsDirection down resolves to finger-up and issues the same content motion as the coordinate path", async () => {
+    fakeObserveScreen.setObserveResult(createObserveResult("top"));
+    const options = {
+      direction: "down",
+      gestureType: "scrollTowardsDirection",
+      container: { elementId: LIST_ID },
+    } as const;
+
+    // Reference: with TalkBack off the same request moves the finger UP
+    // (startY > endY), which reveals the content below.
+    fakeAccessibilityDetector.setTalkBackEnabled(false);
+    const coordinateResult = await createSwipeOn().execute(options);
+    expect(coordinateResult.success).toBe(true);
+    const fingerSwipe = fakeGesture.getSwipeCalls();
+    expect(fingerSwipe).toHaveLength(1);
+    expect(fingerSwipe[0].y1).toBeGreaterThan(fingerSwipe[0].y2);
+
+    // Under TalkBack the same request must scroll the content the same way:
+    // finger up == ACTION_SCROLL_FORWARD.
+    fakeAccessibilityDetector.setTalkBackEnabled(true);
+    fakeAccessibilityDetector.invalidateCache(device.deviceId);
+    const talkBackResult = await createSwipeOn().execute(options);
+    expect(talkBackResult.success).toBe(true);
+    expect(fakeCtrlProxy.getActionHistory().map((call) => call.action)).toEqual(["scroll_forward"]);
+    expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({ resourceId: LIST_ID });
+    expect(fakeGesture.getSwipeCalls()).toHaveLength(1);
+  });
+});
 
 describe("SwipeOn boomerang", () => {
   const device = { name: "test-device", platform: "android", deviceId: "device-1" } as const;

--- a/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { TalkBackSwipeExecutor } from "../../../../src/features/action/swipeon/TalkBackSwipeExecutor";
+import {
+  TalkBackSwipeExecutor,
+  scrollActionForFingerDirection,
+} from "../../../../src/features/action/swipeon/TalkBackSwipeExecutor";
 import { FakeAccessibilityDetector } from "../../../fakes/FakeAccessibilityDetector";
 import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
 import { FakeTimer } from "../../../fakes/FakeTimer";
@@ -419,7 +422,10 @@ describe("TalkBackSwipeExecutor", () => {
       fakeAccessibilityDetector.setTalkBackEnabled(true);
     });
 
-    test("tries ACTION_SCROLL (scroll_forward) when container has resource-id and direction is down", async () => {
+    // `direction` is the FINGER direction (what the coordinate path feeds to
+    // getSwipeWithinBounds). Finger UP reveals the content BELOW, which is
+    // ACTION_SCROLL_FORWARD — the mapping used to be inverted (#6116).
+    test("tries ACTION_SCROLL (scroll_forward) when container has resource-id and finger swipes up", async () => {
       const containerElement = {
         bounds: { left: 0, top: 100, right: 400, bottom: 800 },
         "resource-id": "test:id/scrollView",
@@ -431,7 +437,7 @@ describe("TalkBackSwipeExecutor", () => {
         500,
         100,
         200,
-        "down" as SwipeDirection,
+        "up" as SwipeDirection,
         containerElement,
         { duration: 300 },
         perf,
@@ -446,17 +452,17 @@ describe("TalkBackSwipeExecutor", () => {
       expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
 
-    test("maps up direction to scroll_backward", async () => {
+    test("maps finger-down direction to scroll_backward (reveals content above)", async () => {
       const containerElement = {
         "resource-id": "test:id/scrollView",
       } as any;
 
       await executor.executeAndroidSwipeWithAccessibility(
         100,
-        500,
+        200,
         100,
         700,
-        "up" as SwipeDirection,
+        "down" as SwipeDirection,
         containerElement,
         { duration: 300 },
         perf,
@@ -469,28 +475,7 @@ describe("TalkBackSwipeExecutor", () => {
       });
     });
 
-    test("maps right direction to scroll_forward", async () => {
-      const containerElement = {
-        "resource-id": "test:id/scrollView",
-      } as any;
-
-      await executor.executeAndroidSwipeWithAccessibility(
-        100,
-        200,
-        300,
-        200,
-        "right" as SwipeDirection,
-        containerElement,
-        { duration: 300 },
-        perf,
-      );
-
-      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
-        action: "scroll_forward",
-      });
-    });
-
-    test("maps left direction to scroll_backward", async () => {
+    test("maps finger-left direction to scroll_forward (reveals content to the right)", async () => {
       const containerElement = {
         "resource-id": "test:id/scrollView",
       } as any;
@@ -507,14 +492,49 @@ describe("TalkBackSwipeExecutor", () => {
       );
 
       expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "scroll_forward",
+      });
+    });
+
+    test("maps finger-right direction to scroll_backward (reveals content to the left)", async () => {
+      const containerElement = {
+        "resource-id": "test:id/scrollView",
+      } as any;
+
+      await executor.executeAndroidSwipeWithAccessibility(
+        100,
+        200,
+        300,
+        200,
+        "right" as SwipeDirection,
+        containerElement,
+        { duration: 300 },
+        perf,
+      );
+
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
         action: "scroll_backward",
       });
     });
 
+    test.each([
+      ["up", "scroll_forward"],
+      ["down", "scroll_backward"],
+      ["left", "scroll_forward"],
+      ["right", "scroll_backward"],
+    ] as Array<[SwipeDirection, string]>)(
+      "scrollActionForFingerDirection(%s) is %s, matching the coordinate-swipe content motion (#6116)",
+      (fingerDirection, expectedAction) => {
+        // The non-TalkBack path moves the finger in `fingerDirection`; the
+        // TalkBack ACTION_SCROLL must move the content the same way.
+        expect(scrollActionForFingerDirection(fingerDirection)).toBe(expectedAction);
+      },
+    );
+
     test("falls back to two-finger swipe when ACTION_SCROLL fails", async () => {
       fakeCtrlProxy.setActionResult({
         success: false,
-        action: "scroll_backward",
+        action: "scroll_forward",
         totalTimeMs: 100,
         error: "Scroll not supported",
       });


### PR DESCRIPTION
## Summary

Under TalkBack, `swipeOn` mapped the **finger** direction it receives to the inverted `AccessibilityNodeInfo` scroll action (finger `up` → `scroll_backward`), so the TalkBack path scrolled the content the opposite way from the coordinate path and `lookFor` scrolled away from its target. This PR extracts the mapping into a named, documented helper `scrollActionForFingerDirection(fingerDirection)` in `src/features/action/swipeon/TalkBackSwipeExecutor.ts` (`up`/`left` → `scroll_forward`, `down`/`right` → `scroll_backward`) and uses it in the ACTION_SCROLL path, so the finger-direction semantic is explicit and cannot regress silently. The Kotlin side (`CtrlProxy.kt`) is a pure passthrough (`scroll_forward` → `ACTION_SCROLL_FORWARD`) and is unchanged; the fix is TypeScript-only.

## Linked Issue

Closes #6116

Related: #3915, #3917, #3937.

## Bug / Regression Context

- **Prior attempts:** none for this mapping; #3915 / #3917 fixed adjacent TalkBack detection and degradation bugs in the same executor, and this inversion survived them because the existing tests only pinned what the code did.
- **Observed symptom:** with TalkBack enabled, `swipeOn { direction: "up" }` (default `swipeFingerTowardsDirection`), `swipeOn { direction: "down", gestureType: "scrollTowardsDirection", container }`, and `swipeOn { lookFor }` all issued `scroll_backward` — scrolling to the top of the list — while the non-TalkBack path scrolled forward. `lookFor` therefore scrolled away from the target and reported it not found.
- **Repro steps / conditions:** every caller of `executeSwipeGesture` passes the finger direction (`SwipeOn.execute` resolves `gestureType` via `resolveSwipeDirection` first; the coordinate path feeds the same value to `getSwipeWithinBounds`, where finger `up` reveals the content **below** = `ACTION_SCROLL_FORWARD`). `executeAndroidSwipeWithAccessibility` treated that value as a content-scroll direction (`down`/`right` → `scroll_forward`).

## Tests

All new/updated tests are red on `main` and green with the fix (verified by temporarily re-inverting the helper: 11 fail → 0 fail).

- `test/features/action/swipeon/TalkBackSwipeExecutor.test.ts`: the four tests that pinned the inverted mapping now assert the finger-direction semantic, plus a `test.each` table over `scrollActionForFingerDirection` for all four directions.
- `test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts`: `lookFor` under TalkBack with the **real** `TalkBackSwipeExecutor` and a `FakeCtrlProxy` whose "device" reveals the target only after receiving `scroll_forward`; asserts the target is reached in one iteration with exactly `["scroll_forward"]` issued (no overshoot-recovery reversal stumbling onto it). The harness gained an optional `resolveObservation` hook so an observation can be derived from the fake service's side effects.
- `test/features/action/swipeon/SwipeOn.test.ts`: two end-to-end `SwipeOn.execute` tests under TalkBack — (1) `lookFor` a target below the viewport with finger `up` issues `scroll_forward` and finds it in one scroll; (2) `gestureType: "scrollTowardsDirection", direction: "down"` produces a finger-up coordinate swipe with TalkBack off (`y1 > y2`) and `scroll_forward` with TalkBack on, i.e. the same content motion on both paths.

Acceptance criteria from the issue:

- [x] Finger `up` / content-scroll `down` under TalkBack issues `scroll_forward`.
- [x] `swipeOn lookFor` under TalkBack scrolls toward the target (fake service reveals the target only after `scroll_forward`).
- [x] Existing TalkBack executor tests updated, red before / green after.

## Validation

- [x] `turbo run lint build test` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] No new helpers beyond the one-line mapping function; no new dependencies
- [x] Based on latest `main`
