### PR TITLE
fix(explore): tap with a single selector and gate periodic home reset

### DIFF
--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -15,6 +15,7 @@ import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
 import { SwipeOnElement } from "../action/SwipeOnElement";
 import { PressButton } from "../action/PressButton";
+import { LaunchApp } from "../action/LaunchApp";
 import { DefaultElementParser } from "../utility/ElementParser";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { throwIfAborted } from "../../utils/toolUtils";
@@ -44,6 +45,7 @@ import {
   extractAllElements,
   getElementKey,
   filterUnexhaustedElements,
+  tapSelectorFor,
 } from "./ExploreElementExtraction";
 
 // Import element scoring functions
@@ -83,6 +85,7 @@ export class Explore extends BaseVisualChange {
   private navigationManager: NavigationGraphService;
   private exploredElements: Map<string, TrackedElement>;
   private interactionCount: number = 0;
+  private lastResetAt: number = 0;
   private explorationPath: string[] = [];
   private elementSelections: ElementSelectionStats[] = [];
   private consecutiveBackCount: number = 0;
@@ -151,6 +154,7 @@ export class Explore extends BaseVisualChange {
       this.elementSelections = [];
       this.explorationPath = [];
       this.interactionCount = 0;
+      this.lastResetAt = 0;
       this.consecutiveBackCount = 0;
       this.consecutiveNoChangeCount = 0;
       this.stopReason = "";
@@ -345,7 +349,8 @@ export class Explore extends BaseVisualChange {
         }
 
         // Periodic reset if configured
-        if (options.resetToHome && this.interactionCount % resetInterval === 0) {
+        if (options.resetToHome && this.isResetDue(resetInterval)) {
+          this.lastResetAt = this.interactionCount;
           await this.resetToHome(progress);
         }
       }
@@ -744,17 +749,14 @@ export class Explore extends BaseVisualChange {
         return swipeResult.success;
       } else {
         // Perform tap interaction
+        const selector = tapSelectorFor(element);
+        if (!selector) {
+          logger.warn(`[Explore] Element has no tap selector: ${elementKey}`);
+          return false;
+        }
         const tapOn = new TapOnElement(this.device, this.adb);
 
-        const tapResult = await tapOn.execute(
-          {
-            text: element.text,
-            elementId: element["resource-id"],
-            action: "tap",
-          },
-          progress,
-          signal,
-        );
+        const tapResult = await tapOn.execute({ ...selector, action: "tap" }, progress, signal);
 
         // Reset consecutive back count since we did a tap
         this.consecutiveBackCount = 0;
@@ -842,11 +844,57 @@ export class Explore extends BaseVisualChange {
       // Wait for home screen
       await this.timer.sleep(2000);
 
+      // Home alone leaves the launcher in the foreground, which the next
+      // observation would treat as having left the target app (issue #6126).
+      if (this.targetPackageName) {
+        await this.relaunchTargetApp(this.targetPackageName);
+      }
+
       // Reset consecutive back count
       this.consecutiveBackCount = 0;
     } catch (error) {
       logger.warn(`[Explore] Failed to reset to home: ${error}`);
       this.stopReason = `Home-screen recovery failed: ${errorMessage(error)}`;
+    }
+  }
+
+  /**
+   * A periodic reset is due once per resetInterval successful interactions.
+   * interactionCount only advances on success, so the modulo check alone would
+   * re-fire on every iteration the count sits on a multiple, including 0
+   * before anything was explored (issue #6126).
+   */
+  private isResetDue(resetInterval: number): boolean {
+    return (
+      this.interactionCount > 0 &&
+      this.interactionCount !== this.lastResetAt &&
+      this.interactionCount % resetInterval === 0
+    );
+  }
+
+  /**
+   * Bring the target app back to the foreground after a home reset.
+   */
+  private async relaunchTargetApp(packageName: string): Promise<void> {
+    if (this.device.platform === "android") {
+      // Same injected transport and timer as the home press above.
+      const result = await new LaunchApp(this.device, this.adb, null, this.timer).execute(
+        packageName,
+        false,
+        false,
+      );
+      if (!result.success) {
+        throw new Error(result.error ?? `Android relaunch of ${packageName} failed`);
+      }
+    } else {
+      // Keep iOS recovery session/device-aware without nested progress.
+      const response = await ToolRegistry.callInternal("launchApp", {
+        appId: packageName,
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {}),
+      });
+      throwIfInternalToolFailed(response, "launchApp", this.device.platform);
     }
   }
 

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -877,9 +877,11 @@ export class Explore extends BaseVisualChange {
   /**
    * Bring the target app back to the foreground after a home reset.
    *
-   * This is a warm launch on purpose: it recovers the foreground (issue #6126)
-   * and resumes the app's existing task rather than clearing state or cold
-   * booting, so the reset never destroys what exploration has reached.
+   * This is a plain warm launchApp on purpose (no clearAppData, no coldBoot):
+   * it recovers the foreground (issue #6126) with the platform's cheapest
+   * launch. What "warm" means is launchApp's contract per platform — Android
+   * and the iOS simulator foreground the existing process, while a physical
+   * iOS device relaunches it because devicectl has no foreground verb.
    */
   private async relaunchTargetApp(packageName: string, signal?: AbortSignal): Promise<void> {
     if (this.device.platform === "android") {

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -196,7 +196,7 @@ export class Explore extends BaseVisualChange {
           const elements = extractAllElements(viewHierarchy, this.elementParser);
           if (isPermissionDialog(elements)) {
             logger.info("[Explore] Detected permission dialog, attempting to dismiss");
-            await handlePermissionDialog(elements, this.device, this.adb, progress);
+            await handlePermissionDialog(elements, viewHierarchy, this.device, this.adb, progress);
             continue;
           }
         }
@@ -749,10 +749,9 @@ export class Explore extends BaseVisualChange {
         return swipeResult.success;
       } else {
         // Perform tap interaction
-        const onScreen = observation.viewHierarchy
-          ? extractAllElements(observation.viewHierarchy, this.elementParser)
-          : [];
-        const selector = tapSelectorFor(element, onScreen);
+        const selector = observation.viewHierarchy
+          ? tapSelectorFor(element, observation.viewHierarchy)
+          : null;
         if (!selector) {
           logger.warn(`[Explore] Element has no tap selector: ${elementKey}`);
           return false;

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -351,7 +351,7 @@ export class Explore extends BaseVisualChange {
         // Periodic reset if configured
         if (options.resetToHome && this.isResetDue(resetInterval)) {
           this.lastResetAt = this.interactionCount;
-          await this.resetToHome(progress);
+          await this.resetToHome(progress, signal);
         }
       }
 
@@ -749,7 +749,10 @@ export class Explore extends BaseVisualChange {
         return swipeResult.success;
       } else {
         // Perform tap interaction
-        const selector = tapSelectorFor(element);
+        const onScreen = observation.viewHierarchy
+          ? extractAllElements(observation.viewHierarchy, this.elementParser)
+          : [];
+        const selector = tapSelectorFor(element, onScreen);
         if (!selector) {
           logger.warn(`[Explore] Element has no tap selector: ${elementKey}`);
           return false;
@@ -814,7 +817,7 @@ export class Explore extends BaseVisualChange {
   /**
    * Reset to home screen
    */
-  private async resetToHome(progress?: ProgressCallback): Promise<void> {
+  private async resetToHome(progress?: ProgressCallback, signal?: AbortSignal): Promise<void> {
     try {
       if (progress) {
         await progress(
@@ -847,7 +850,7 @@ export class Explore extends BaseVisualChange {
       // Home alone leaves the launcher in the foreground, which the next
       // observation would treat as having left the target app (issue #6126).
       if (this.targetPackageName) {
-        await this.relaunchTargetApp(this.targetPackageName);
+        await this.relaunchTargetApp(this.targetPackageName, signal);
       }
 
       // Reset consecutive back count
@@ -874,26 +877,39 @@ export class Explore extends BaseVisualChange {
 
   /**
    * Bring the target app back to the foreground after a home reset.
+   *
+   * This is a warm launch on purpose: it recovers the foreground (issue #6126)
+   * and resumes the app's existing task rather than clearing state or cold
+   * booting, so the reset never destroys what exploration has reached.
    */
-  private async relaunchTargetApp(packageName: string): Promise<void> {
+  private async relaunchTargetApp(packageName: string, signal?: AbortSignal): Promise<void> {
     if (this.device.platform === "android") {
       // Same injected transport and timer as the home press above.
       const result = await new LaunchApp(this.device, this.adb, null, this.timer).execute(
         packageName,
         false,
         false,
+        undefined,
+        undefined,
+        undefined,
+        signal,
       );
       if (!result.success) {
         throw new Error(result.error ?? `Android relaunch of ${packageName} failed`);
       }
     } else {
       // Keep iOS recovery session/device-aware without nested progress.
-      const response = await ToolRegistry.callInternal("launchApp", {
-        appId: packageName,
-        platform: this.device.platform,
-        deviceId: this.device.deviceId,
-        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {}),
-      });
+      const response = await ToolRegistry.callInternal(
+        "launchApp",
+        {
+          appId: packageName,
+          platform: this.device.platform,
+          deviceId: this.device.deviceId,
+          ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {}),
+        },
+        undefined,
+        signal,
+      );
       throwIfInternalToolFailed(response, "launchApp", this.device.platform);
     }
   }

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -109,7 +109,7 @@ export async function handlePermissionDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (allowKeywords.some((keyword) => text.includes(keyword))) {
-      const selector = tapSelectorFor(element);
+      const selector = tapSelectorFor(element, elements);
       if (!selector) {
         continue;
       }
@@ -147,7 +147,7 @@ async function dismissDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (dismissKeywords.some((keyword) => text.includes(keyword))) {
-      const selector = tapSelectorFor(element);
+      const selector = tapSelectorFor(element, elements);
       if (!selector) {
         continue;
       }

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -1,4 +1,4 @@
-import type { BootedDevice, Element, ObserveResult } from "../../models";
+import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../models";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { ProgressCallback } from "../action/BaseVisualChange";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
@@ -93,6 +93,7 @@ export function isRatingDialog(elements: Element[]): boolean {
  */
 export async function handlePermissionDialog(
   elements: Element[],
+  viewHierarchy: ViewHierarchyResult,
   device: BootedDevice,
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
@@ -109,7 +110,7 @@ export async function handlePermissionDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (allowKeywords.some((keyword) => text.includes(keyword))) {
-      const selector = tapSelectorFor(element, elements);
+      const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;
       }
@@ -132,6 +133,7 @@ export async function handlePermissionDialog(
  */
 async function dismissDialog(
   elements: Element[],
+  viewHierarchy: ViewHierarchyResult,
   device: BootedDevice,
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
@@ -147,7 +149,7 @@ async function dismissDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (dismissKeywords.some((keyword) => text.includes(keyword))) {
-      const selector = tapSelectorFor(element, elements);
+      const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;
       }
@@ -192,7 +194,7 @@ export async function detectAndHandleBlockers(
   // Check for permission dialogs
   if (isPermissionDialog(elements)) {
     logger.info("[Explore] Detected permission dialog, attempting to dismiss");
-    return await handlePermissionDialog(elements, device, adb, progress);
+    return await handlePermissionDialog(elements, viewHierarchy, device, adb, progress);
   }
 
   // Check for login/signup screens
@@ -205,7 +207,7 @@ export async function detectAndHandleBlockers(
   // Check for app rating/review dialogs
   if (isRatingDialog(elements)) {
     logger.info("[Explore] Detected rating dialog, attempting to dismiss");
-    return await dismissDialog(elements, device, adb, progress);
+    return await dismissDialog(elements, viewHierarchy, device, adb, progress);
   }
 
   return false;

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -4,7 +4,7 @@ import type { ProgressCallback } from "../action/BaseVisualChange";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { TapOnElement } from "../action/TapOnElement";
 import { logger } from "../../utils/logger";
-import { extractAllElements } from "./ExploreElementExtraction";
+import { extractAllElements, tapSelectorFor } from "./ExploreElementExtraction";
 import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
@@ -109,16 +109,13 @@ export async function handlePermissionDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (allowKeywords.some((keyword) => text.includes(keyword))) {
+      const selector = tapSelectorFor(element);
+      if (!selector) {
+        continue;
+      }
       try {
         const tapOn = new TapOnElement(device, adb);
-        await tapOn.execute(
-          {
-            text: element.text,
-            elementId: element["resource-id"],
-            action: "tap",
-          },
-          progress,
-        );
+        await tapOn.execute({ ...selector, action: "tap" }, progress);
         await defaultTimer.sleep(1000);
         return true;
       } catch (error) {
@@ -150,16 +147,13 @@ async function dismissDialog(
       (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
 
     if (dismissKeywords.some((keyword) => text.includes(keyword))) {
+      const selector = tapSelectorFor(element);
+      if (!selector) {
+        continue;
+      }
       try {
         const tapOn = new TapOnElement(device, adb);
-        await tapOn.execute(
-          {
-            text: element.text,
-            elementId: element["resource-id"],
-            action: "tap",
-          },
-          progress,
-        );
+        await tapOn.execute({ ...selector, action: "tap" }, progress);
         await defaultTimer.sleep(1000);
         return true;
       } catch (error) {

--- a/src/features/navigation/ExploreElementExtraction.ts
+++ b/src/features/navigation/ExploreElementExtraction.ts
@@ -2,6 +2,7 @@ import type { Element, ViewHierarchyResult } from "../../models";
 import { isTruthy, isFalsy } from "../../models";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { TrackedElement } from "./ExploreTypes";
+import { boundsEqual } from "../../utils/bounds";
 
 /**
  * Extract elements likely to be navigation controls
@@ -157,6 +158,54 @@ export function extractAllElements(
   return flatElements.map(({ element }) => element);
 }
 
+/** A single tapOn selector; `index` pins one occurrence when the selector is not unique. */
+export type TapSelector = { elementId: string; index?: number } | { text: string; index?: number };
+
+/**
+ * Single tapOn selector for an element among the elements currently on screen.
+ *
+ * tapOn rejects any call carrying more than one selector (issue #6121), and its
+ * first-match default would collapse repeated controls that share a resource-id
+ * (list rows) onto the first row. So prefer a resource-id that is unique on
+ * screen, then unique text or content-desc (the text selector matches both),
+ * and otherwise pin the occurrence with tapOn's hierarchy-order `index`.
+ * Returns null when the element has no selector at all.
+ */
+export function tapSelectorFor(element: Element, onScreen: Element[]): TapSelector | null {
+  const id = element["resource-id"];
+  const text = textSelectorValue(element);
+  const sharingId = id ? onScreen.filter((other) => other["resource-id"] === id) : [];
+  if (id && sharingId.length <= 1) {
+    return { elementId: id };
+  }
+  const sharingText = text
+    ? onScreen.filter(
+        (other) =>
+          other.text === text ||
+          other["content-desc"] === text ||
+          other["ios-accessibility-label"] === text,
+      )
+    : [];
+  if (text && sharingText.length <= 1) {
+    return { text };
+  }
+  if (id) {
+    return { elementId: id, ...occurrenceIndex(sharingId, element) };
+  }
+  return text ? { text, ...occurrenceIndex(sharingText, element) } : null;
+}
+
+/** The value tapOn's text selector would match for this element, if any. */
+function textSelectorValue(element: Element): string | undefined {
+  return element.text || element["content-desc"] || element["ios-accessibility-label"];
+}
+
+/** Position of `element` among `matches` in hierarchy order, located by bounds. */
+function occurrenceIndex(matches: Element[], element: Element): { index?: number } {
+  const index = matches.findIndex((match) => boundsEqual(match.bounds, element.bounds));
+  return index >= 0 ? { index } : {};
+}
+
 /**
  * Generate unique key for element tracking
  */
@@ -182,21 +231,6 @@ export function getElementKey(element: Element): string {
 /**
  * Filter out elements that have been exhausted
  */
-/**
- * Single tapOn selector for an element.
- *
- * tapOn rejects any call carrying more than one selector (issue #6121), so
- * prefer the stable resource-id, then text, then content-desc (which the text
- * selector also matches). Returns null when the element has none of them.
- */
-export function tapSelectorFor(element: Element): { elementId: string } | { text: string } | null {
-  if (element["resource-id"]) {
-    return { elementId: element["resource-id"] };
-  }
-  const text = element.text || element["content-desc"];
-  return text ? { text } : null;
-}
-
 export function filterUnexhaustedElements(
   elements: Element[],
   exploredElements: Map<string, TrackedElement>,

--- a/src/features/navigation/ExploreElementExtraction.ts
+++ b/src/features/navigation/ExploreElementExtraction.ts
@@ -182,6 +182,21 @@ export function getElementKey(element: Element): string {
 /**
  * Filter out elements that have been exhausted
  */
+/**
+ * Single tapOn selector for an element.
+ *
+ * tapOn rejects any call carrying more than one selector (issue #6121), so
+ * prefer the stable resource-id, then text, then content-desc (which the text
+ * selector also matches). Returns null when the element has none of them.
+ */
+export function tapSelectorFor(element: Element): { elementId: string } | { text: string } | null {
+  if (element["resource-id"]) {
+    return { elementId: element["resource-id"] };
+  }
+  const text = element.text || element["content-desc"];
+  return text ? { text } : null;
+}
+
 export function filterUnexhaustedElements(
   elements: Element[],
   exploredElements: Map<string, TrackedElement>,

--- a/src/features/navigation/ExploreElementExtraction.ts
+++ b/src/features/navigation/ExploreElementExtraction.ts
@@ -2,6 +2,9 @@ import type { Element, ViewHierarchyResult } from "../../models";
 import { isTruthy, isFalsy } from "../../models";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { TrackedElement } from "./ExploreTypes";
+import type { ElementSelectionResult } from "../../models/ElementSelectionResult";
+import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
+import { DefaultElementSelector } from "../utility/DefaultElementSelector";
 import { boundsEqual } from "../../utils/bounds";
 
 /**
@@ -161,49 +164,70 @@ export function extractAllElements(
 /** A single tapOn selector; `index` pins one occurrence when the selector is not unique. */
 export type TapSelector = { elementId: string; index?: number } | { text: string; index?: number };
 
+type SelectOccurrence = (index?: number) => ElementSelectionResult;
+
 /**
- * Single tapOn selector for an element among the elements currently on screen.
+ * Single tapOn selector for an element on the given screen.
  *
  * tapOn rejects any call carrying more than one selector (issue #6121), and its
  * first-match default would collapse repeated controls that share a resource-id
- * (list rows) onto the first row. So prefer a resource-id that is unique on
- * screen, then unique text or content-desc (the text selector matches both),
- * and otherwise pin the occurrence with tapOn's hierarchy-order `index`.
+ * (list rows) onto the first row. Uniqueness and occurrence are measured through
+ * the same {@link ElementSelector} tapOn uses, with tapOn's own options, so they
+ * see exactly its matches: a bare Compose id matching a qualified one, and
+ * off-screen matches dropped before `index` applies. Prefer a unique resource-id,
+ * then unique text / content-desc / iOS label (all matched by the text selector),
+ * and otherwise pin the occurrence with tapOn's on-screen `index`.
  * Returns null when the element has no selector at all.
  */
-export function tapSelectorFor(element: Element, onScreen: Element[]): TapSelector | null {
+export function tapSelectorFor(
+  element: Element,
+  viewHierarchy: ViewHierarchyResult,
+  selector: ElementSelector = new DefaultElementSelector(),
+): TapSelector | null {
   const id = element["resource-id"];
-  const text = textSelectorValue(element);
-  const sharingId = id ? onScreen.filter((other) => other["resource-id"] === id) : [];
-  if (id && sharingId.length <= 1) {
-    return { elementId: id };
-  }
-  const sharingText = text
-    ? onScreen.filter(
-        (other) =>
-          other.text === text ||
-          other["content-desc"] === text ||
-          other["ios-accessibility-label"] === text,
-      )
-    : [];
-  if (text && sharingText.length <= 1) {
-    return { text };
-  }
+  const text = element.text || element["content-desc"] || element["ios-accessibility-label"];
+  const candidates: Array<{ selector: TapSelector; select: SelectOccurrence }> = [];
   if (id) {
-    return { elementId: id, ...occurrenceIndex(sharingId, element) };
+    candidates.push({
+      selector: { elementId: id },
+      select: (index) =>
+        selector.selectByResourceId(viewHierarchy, id, { partialMatch: false, index }),
+    });
   }
-  return text ? { text, ...occurrenceIndex(sharingText, element) } : null;
+  if (text) {
+    candidates.push({
+      selector: { text },
+      select: (index) =>
+        selector.selectByText(viewHierarchy, text, {
+          partialMatch: true,
+          caseSensitive: false,
+          index,
+        }),
+    });
+  }
+  const unique = candidates.find((candidate) => candidate.select().totalMatches <= 1);
+  if (unique) {
+    return unique.selector;
+  }
+  const [preferred] = candidates;
+  return preferred
+    ? { ...preferred.selector, ...occurrenceIndex(preferred.select, element) }
+    : null;
 }
 
-/** The value tapOn's text selector would match for this element, if any. */
-function textSelectorValue(element: Element): string | undefined {
-  return element.text || element["content-desc"] || element["ios-accessibility-label"];
-}
-
-/** Position of `element` among `matches` in hierarchy order, located by bounds. */
-function occurrenceIndex(matches: Element[], element: Element): { index?: number } {
-  const index = matches.findIndex((match) => boundsEqual(match.bounds, element.bounds));
-  return index >= 0 ? { index } : {};
+/** Position of `element` among the selector's on-screen matches, located by bounds. */
+function occurrenceIndex(select: SelectOccurrence, element: Element): { index?: number } {
+  const total = select().totalMatches;
+  for (let index = 0; index < total; index++) {
+    const match = select(index).element;
+    if (!match) {
+      break;
+    }
+    if (boundsEqual(match.bounds, element.bounds)) {
+      return { index };
+    }
+  }
+  return {};
 }
 
 /**

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -454,6 +454,67 @@ describe("Explore", () => {
         { elementId: rowId, index: 2, action: "tap" },
       ]);
     });
+
+    test("counts the occurrence index over tapOn's on-screen matches, skipping off-screen rows", async () => {
+      // tapOn drops matches whose center is off screen before applying `index`,
+      // so a scrolled-away duplicate row above the target must not shift it.
+      const rowId = "com.test:id/row_title";
+      const row = (text: string, top: number) => ({
+        $: { class: "android.widget.TextView", text, "resource-id": rowId, clickable: "true" },
+        bounds: { left: 0, top, right: 100, bottom: top + 50 },
+      });
+      const observation = {
+        viewHierarchy: {
+          hierarchy: {
+            node: [row("Beta", -100), row("Alpha", 0), row("Beta", 50), row("Beta", 100)],
+          },
+          packageName: "com.test.app",
+          screenWidth: 100,
+          screenHeight: 200,
+        },
+      } as unknown as ObserveResult;
+      const { calls, restore } = captureTapOptions();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+
+      try {
+        await (explore as any).performInteraction(
+          createMockElement({
+            text: "Beta",
+            "resource-id": rowId,
+            bounds: { left: 0, top: 100, right: 100, bottom: 150 },
+          }),
+          observation,
+        );
+      } finally {
+        restore();
+      }
+
+      // Visible matches in hierarchy order: Alpha, Beta@50, Beta@100 -> index 2
+      // (a raw count over the hierarchy would say 3 and miss the row).
+      expect(calls).toEqual([{ elementId: rowId, index: 2, action: "tap" }]);
+    });
+
+    test("treats a qualified id as shared with a bare Compose id, as tapOn's finder does", async () => {
+      // The finder matches "pkg:id/row" against a bare "row" node, so the
+      // qualified id is not unique on this screen and unique text must win.
+      const observation = createMockObservation([
+        createMockViewHierarchyNode({ text: "Alpha", "resource-id": "com.test:id/row" }),
+        createMockViewHierarchyNode({ text: "Beta", "resource-id": "row" }),
+      ]);
+      const { calls, restore } = captureTapOptions();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+
+      try {
+        await (explore as any).performInteraction(
+          createMockElement({ text: "Alpha", "resource-id": "com.test:id/row" }),
+          observation,
+        );
+      } finally {
+        restore();
+      }
+
+      expect(calls).toEqual([{ text: "Alpha", action: "tap" }]);
+    });
   });
 
   describe("periodic reset to home", () => {

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -404,6 +404,56 @@ describe("Explore", () => {
         { text: "Open settings", action: "tap" },
       ]);
     });
+
+    test("disambiguates a resource-id shared by list rows by unique text, else by hierarchy index", async () => {
+      // tapOn's default picks the first on-screen match, so a shared row id
+      // must not be used alone: unique text wins, and identical rows pin their
+      // 0-based occurrence with `index`.
+      const rowId = "com.test:id/row_title";
+      const row = (text: string, top: number) => ({
+        $: {
+          class: "android.widget.TextView",
+          text,
+          "resource-id": rowId,
+          clickable: "true",
+          enabled: "true",
+        },
+        bounds: { left: 0, top, right: 100, bottom: top + 50 },
+      });
+      const observation = createMockObservation([
+        row("Alpha", 0),
+        row("Beta", 50),
+        row("Beta", 100),
+      ]);
+      const { calls, restore } = captureTapOptions();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+
+      try {
+        await (explore as any).performInteraction(
+          createMockElement({
+            text: "Alpha",
+            "resource-id": rowId,
+            bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          }),
+          observation,
+        );
+        await (explore as any).performInteraction(
+          createMockElement({
+            text: "Beta",
+            "resource-id": rowId,
+            bounds: { left: 0, top: 100, right: 100, bottom: 150 },
+          }),
+          observation,
+        );
+      } finally {
+        restore();
+      }
+
+      expect(calls).toEqual([
+        { text: "Alpha", action: "tap" },
+        { elementId: rowId, index: 2, action: "tap" },
+      ]);
+    });
   });
 
   describe("periodic reset to home", () => {
@@ -456,12 +506,42 @@ describe("Explore", () => {
       const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
         requestGlobalAction: async () => ({ success: false, error: "unavailable" }),
       } as never);
+      const signal = new AbortController().signal;
+      // Capture the launch flags too: clearAppData/coldBoot must stay off, and
+      // the exploration signal must reach the launch so cancellation is honored.
       const launchSpy = spyOn(LaunchApp.prototype, "execute").mockImplementation(
-        async (packageName: string) => {
-          commands.push(`launch ${packageName}`);
-          return { success: true, packageName } as never;
+        async (...args: unknown[]) => {
+          commands.push(`launch ${JSON.stringify(args.slice(0, 3))} signal=${args[6] === signal}`);
+          return { success: true, packageName: args[0] } as never;
         },
       );
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
+      (explore as any).targetPackageName = "com.test.app";
+
+      try {
+        await (explore as any).resetToHome(undefined, signal);
+      } finally {
+        launchSpy.mockRestore();
+        ctrlProxySpy.mockRestore();
+      }
+
+      expect(commands).toEqual([
+        "shell input keyevent 3",
+        'launch ["com.test.app",false,false] signal=true',
+      ]);
+      expect((explore as any).stopReason).toBe("");
+    });
+
+    test("records a failed relaunch as a terminal partial-report reason", async () => {
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" }),
+      } as never);
+      const launchSpy = spyOn(LaunchApp.prototype, "execute").mockResolvedValue({
+        success: false,
+        packageName: "com.test.app",
+        error: "App is not installed",
+      } as never);
+      const adb = { execute: async () => "" } as AdbClient;
       explore = new Explore(device, adb, fakeTimer, fakeGraph);
       (explore as any).targetPackageName = "com.test.app";
 
@@ -472,8 +552,7 @@ describe("Explore", () => {
         ctrlProxySpy.mockRestore();
       }
 
-      expect(commands).toEqual(["shell input keyevent 3", "launch com.test.app"]);
-      expect((explore as any).stopReason).toBe("");
+      expect((explore as any).stopReason).toBe("Home-screen recovery failed: App is not installed");
     });
 
     test("relaunches the target app through the internal launchApp tool on iOS", async () => {
@@ -482,19 +561,21 @@ describe("Explore", () => {
         platform: "ios",
         source: "local",
       } as BootedDevice;
-      const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+      const calls: Array<{ name: string; args: Record<string, unknown>; signal?: AbortSignal }> =
+        [];
       ToolRegistry.register("homeScreen", "homeScreen", {}, async (args) => {
         calls.push({ name: "homeScreen", args });
         return { success: true };
       });
-      ToolRegistry.register("launchApp", "launchApp", {}, async (args) => {
-        calls.push({ name: "launchApp", args });
+      ToolRegistry.register("launchApp", "launchApp", {}, async (args, _progress, signal) => {
+        calls.push({ name: "launchApp", args, signal });
         return { success: true };
       });
+      const signal = new AbortController().signal;
       explore = new Explore(iOSDevice, null, fakeTimer, fakeGraph, "session-1");
       (explore as any).targetPackageName = "com.test.app";
 
-      await (explore as any).resetToHome();
+      await (explore as any).resetToHome(undefined, signal);
 
       expect(calls.map((call) => call.name)).toEqual(["homeScreen", "launchApp"]);
       expect(calls[1].args).toEqual({
@@ -504,6 +585,7 @@ describe("Explore", () => {
         sessionUuid: "session-1",
         [INTERNAL_NO_DIFF_PARAM]: true,
       });
+      expect(calls[1].signal).toBe(signal);
     });
   });
 

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -29,6 +29,8 @@ import {
 import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
 import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { LaunchApp } from "../../../src/features/action/LaunchApp";
 
 describe("Explore", () => {
   let explore: Explore;
@@ -344,6 +346,167 @@ describe("Explore", () => {
     });
   });
 
+  describe("performInteraction tap selector", () => {
+    // TapOnElement.validateOptions rejects any call carrying more than one
+    // selector, so an element with both text and resource-id must reach tapOn
+    // with exactly one of them (issue #6121).
+    function captureTapOptions(): { calls: unknown[]; restore: () => void } {
+      const calls: unknown[] = [];
+      const spy = spyOn(TapOnElement.prototype, "execute").mockImplementation(
+        async (options: unknown) => {
+          calls.push(options);
+          return { success: true, action: "tap" } as never;
+        },
+      );
+      return { calls, restore: () => spy.mockRestore() };
+    }
+
+    test("taps an element with both text and resource-id once, by id only", async () => {
+      const { calls, restore } = captureTapOptions();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+
+      try {
+        const success = await (explore as any).performInteraction(
+          createMockElement({ text: "Settings", "resource-id": "com.test:id/settings_btn" }),
+          createMockObservation(),
+        );
+        expect(success).toBe(true);
+      } finally {
+        restore();
+      }
+
+      expect(calls).toEqual([{ elementId: "com.test:id/settings_btn", action: "tap" }]);
+    });
+
+    test("falls back to text, then content-desc, when no resource-id is present", async () => {
+      const { calls, restore } = captureTapOptions();
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+
+      try {
+        await (explore as any).performInteraction(
+          createMockElement({ text: "Settings", "resource-id": undefined }),
+          createMockObservation(),
+        );
+        await (explore as any).performInteraction(
+          createMockElement({
+            text: undefined,
+            "resource-id": undefined,
+            "content-desc": "Open settings",
+          }),
+          createMockObservation(),
+        );
+      } finally {
+        restore();
+      }
+
+      expect(calls).toEqual([
+        { text: "Settings", action: "tap" },
+        { text: "Open settings", action: "tap" },
+      ]);
+    });
+  });
+
+  describe("periodic reset to home", () => {
+    // resetToHome is gated on interactionCount, which only advances on a
+    // successful interaction, so the gate must not re-fire while the count sits
+    // on a multiple of resetInterval — including 0 (issue #6126).
+    test("resets once per resetInterval successful interactions and never at count 0", async () => {
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+      (explore as any).observeScreen = {
+        execute: async () => createMockObservation(),
+      };
+      const outcomes = [false, true, true, false, true];
+      const log: string[] = [];
+      (explore as any).performInteraction = async () => {
+        const success = outcomes.shift() ?? true;
+        log.push(success ? "interaction:ok" : "interaction:fail");
+        return success;
+      };
+      (explore as any).resetToHome = async () => {
+        log.push("reset");
+      };
+
+      const result = await explore.execute({
+        maxInteractions: 3,
+        timeoutMs: 5000,
+        packageName: "com.test.app",
+        resetToHome: true,
+        resetInterval: 2,
+      });
+
+      expect(result.interactionsPerformed).toBe(3);
+      expect(log).toEqual([
+        "interaction:fail",
+        "interaction:ok",
+        "interaction:ok",
+        "reset",
+        "interaction:fail",
+        "interaction:ok",
+      ]);
+    });
+
+    test("relaunches the target app after pressing home on Android", async () => {
+      const commands: string[] = [];
+      const adb = {
+        execute: async (args: string[]) => {
+          commands.push(args.join(" "));
+          return "";
+        },
+      } as AdbClient;
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" }),
+      } as never);
+      const launchSpy = spyOn(LaunchApp.prototype, "execute").mockImplementation(
+        async (packageName: string) => {
+          commands.push(`launch ${packageName}`);
+          return { success: true, packageName } as never;
+        },
+      );
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
+      (explore as any).targetPackageName = "com.test.app";
+
+      try {
+        await (explore as any).resetToHome();
+      } finally {
+        launchSpy.mockRestore();
+        ctrlProxySpy.mockRestore();
+      }
+
+      expect(commands).toEqual(["shell input keyevent 3", "launch com.test.app"]);
+      expect((explore as any).stopReason).toBe("");
+    });
+
+    test("relaunches the target app through the internal launchApp tool on iOS", async () => {
+      const iOSDevice = {
+        deviceId: "ios-simulator-123",
+        platform: "ios",
+        source: "local",
+      } as BootedDevice;
+      const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+      ToolRegistry.register("homeScreen", "homeScreen", {}, async (args) => {
+        calls.push({ name: "homeScreen", args });
+        return { success: true };
+      });
+      ToolRegistry.register("launchApp", "launchApp", {}, async (args) => {
+        calls.push({ name: "launchApp", args });
+        return { success: true };
+      });
+      explore = new Explore(iOSDevice, null, fakeTimer, fakeGraph, "session-1");
+      (explore as any).targetPackageName = "com.test.app";
+
+      await (explore as any).resetToHome();
+
+      expect(calls.map((call) => call.name)).toEqual(["homeScreen", "launchApp"]);
+      expect(calls[1].args).toEqual({
+        appId: "com.test.app",
+        platform: "ios",
+        deviceId: "ios-simulator-123",
+        sessionUuid: "session-1",
+        [INTERNAL_NO_DIFF_PARAM]: true,
+      });
+    });
+  });
+
   // Exploration strategies and modes are tested through unit tests
   // Full device integration tests are in JUnitRunner and XCTestRunner
 
@@ -367,6 +530,9 @@ describe("Explore", () => {
       (explore as any).handleDeadEnd = async () => {
         backPresses.push("back");
       };
+      // The first observation is in-app, so the loop reaches performInteraction;
+      // stub it so the test stays on the enforcement path and off the tap pipeline.
+      (explore as any).performInteraction = async () => true;
 
       let observeCount = 0;
       (explore as any).observeScreen = {

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test } from "bun:test";
+import { expect, describe, test, spyOn } from "bun:test";
 import { Element } from "../../../src/models";
 import type { BootedDevice, ObserveResult } from "../../../src/models";
 import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
@@ -7,7 +7,10 @@ import {
   isLoginScreen,
   isRatingDialog,
   detectAndHandleBlockers,
+  handlePermissionDialog,
 } from "../../../src/features/navigation/ExploreBlockerDetection";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { defaultTimer } from "../../../src/utils/SystemTimer";
 
 describe("ExploreBlockerDetection", () => {
   function createMockElement(overrides: Partial<Element> = {}): Element {
@@ -275,6 +278,86 @@ describe("ExploreBlockerDetection", () => {
       expect(isPermissionDialog(elements)).toBe(false);
       expect(isLoginScreen(elements)).toBe(false);
       expect(isRatingDialog(elements)).toBe(false);
+    });
+  });
+
+  describe("dialog tap selector", () => {
+    // TapOnElement.validateOptions rejects a call carrying both text and
+    // elementId, so an Allow / dismiss button that has both must be tapped
+    // with exactly one selector (issue #6121). The handlers hard-sleep 1s
+    // after a tap via defaultTimer, so that is stubbed to keep the test fast.
+    function captureTapOptions(): { calls: unknown[]; restore: () => void } {
+      const calls: unknown[] = [];
+      const tapSpy = spyOn(TapOnElement.prototype, "execute").mockImplementation(
+        async (options: unknown) => {
+          calls.push(options);
+          return { success: true, action: "tap" } as never;
+        },
+      );
+      const sleepSpy = spyOn(defaultTimer, "sleep").mockResolvedValue(undefined);
+      return {
+        calls,
+        restore: () => {
+          tapSpy.mockRestore();
+          sleepSpy.mockRestore();
+        },
+      };
+    }
+
+    const androidDevice = { deviceId: "emulator-5554", platform: "android" } as BootedDevice;
+
+    test("handlePermissionDialog taps an Allow button with text and resource-id by id only", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Allow camera access?", clickable: false }),
+        createMockElement({
+          text: "Allow",
+          "resource-id": "com.android.permissioncontroller:id/permission_allow_button",
+        }),
+      ];
+
+      let handled: boolean;
+      try {
+        handled = await handlePermissionDialog(elements, androidDevice, null);
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(true);
+      expect(calls).toEqual([
+        {
+          elementId: "com.android.permissioncontroller:id/permission_allow_button",
+          action: "tap",
+        },
+      ]);
+    });
+
+    test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+        createMockElement({ text: "Not now", "resource-id": "com.test:id/dismiss_button" }),
+      ];
+      const parser = {
+        flattenViewHierarchy: () =>
+          elements.map((element, index) => ({ element, index, depth: 0 })),
+      } as unknown as ElementParser;
+
+      let handled: boolean;
+      try {
+        handled = await detectAndHandleBlockers(
+          { viewHierarchy: { hierarchy: {}, packageName: "com.test" } } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          parser,
+          async () => {},
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(true);
+      expect(calls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
     });
   });
 

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, spyOn } from "bun:test";
 import { Element } from "../../../src/models";
-import type { BootedDevice, ObserveResult } from "../../../src/models";
+import type { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
 import {
   isPermissionDialog,
@@ -306,6 +306,27 @@ describe("ExploreBlockerDetection", () => {
 
     const androidDevice = { deviceId: "emulator-5554", platform: "android" } as BootedDevice;
 
+    // The selector is chosen against the real hierarchy (tapOn's own finder
+    // decides uniqueness), so give the handlers one built from the elements.
+    function hierarchyOf(elements: Element[]): ViewHierarchyResult {
+      return {
+        hierarchy: {
+          node: elements.map((element) => ({
+            $: {
+              class: element.class,
+              text: element.text,
+              "resource-id": element["resource-id"],
+              "content-desc": element["content-desc"],
+              clickable: String(element.clickable ?? false),
+              enabled: "true",
+            },
+            bounds: element.bounds,
+          })),
+        },
+        packageName: "com.test",
+      } as unknown as ViewHierarchyResult;
+    }
+
     test("handlePermissionDialog taps an Allow button with text and resource-id by id only", async () => {
       const { calls, restore } = captureTapOptions();
       const elements = [
@@ -318,7 +339,12 @@ describe("ExploreBlockerDetection", () => {
 
       let handled: boolean;
       try {
-        handled = await handlePermissionDialog(elements, androidDevice, null);
+        handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+        );
       } finally {
         restore();
       }
@@ -346,7 +372,7 @@ describe("ExploreBlockerDetection", () => {
       let handled: boolean;
       try {
         handled = await detectAndHandleBlockers(
-          { viewHierarchy: { hierarchy: {}, packageName: "com.test" } } as unknown as ObserveResult,
+          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
           androidDevice,
           null,
           parser,


### PR DESCRIPTION
## Summary

Two causally-linked `explore` defects, fixed together because the first keeps `interactionCount` at 0 and thereby triggers the second on every loop iteration:

- **Single tap selector (#6121).** `Explore.performInteraction`, `handlePermissionDialog`, and `dismissDialog` all passed both `text` and `elementId` to `tapOn`. `TapOnElement.validateOptions` rejects any call with more than one selector, so every element carrying both text and a resource-id (buttons, list rows, permission "Allow") failed before any device IO and was marked tried. A new `tapSelectorFor(element, onScreen)` helper in `ExploreElementExtraction.ts` picks exactly one selector and all three call sites use it. Because tapOn resolves an `elementId` to the *first* on-screen match, a resource-id shared by repeated list rows would otherwise collapse every row onto the first one (review finding), so the helper prefers whichever of resource-id or text/content-desc is unique on the current screen and pins the occurrence with tapOn's on-screen `index` when neither is. Uniqueness and occurrence are measured through the same `ElementSelector` (with tapOn's own options) that `TapOnElement` uses, so they see exactly its matches — a bare Compose id counts as sharing a qualified one, and off-screen matches are dropped before `index` applies (second review round).
- **Periodic reset gating + relaunch (#6126).** The `resetToHome` check was `interactionCount % resetInterval === 0`, evaluated every iteration while the count only advances on success, so it fired at count 0 and re-fired on every failed iteration at a boundary. It now requires `interactionCount > 0`, tracks `lastResetAt`, and fires exactly once per interval. `resetToHome` also relaunches the target package after going home (Android via `LaunchApp` with the injected adb/timer, iOS via the internal `launchApp` tool — mirroring the existing `PressButton` / `homeScreen` split), so the next observation is the app rather than the launcher tripping `enforceTargetApp`. The relaunch is a plain warm `launchApp` (no `clearAppData`/`coldBoot`) whose meaning is the platform's: Android and the iOS simulator foreground the existing process, while a physical iOS device relaunches it because devicectl has no foreground verb (pre-existing `launchApp` behavior, tracked in #2881). The exploration `AbortSignal` is threaded through it so cancellation is honored mid-reset.

## Linked Issue

Closes #6121
Closes #6126

## Bug / Regression Context

- **Prior attempts:** none.
- **Observed symptom:** `explore` never taps elements that have both text and an id; with `resetToHome: true` the run goes home before any exploration and terminates almost immediately with "Left target app".
- **Repro steps / conditions:** `explore` (discover/hybrid) on any screen whose best candidate has text + resource-id; `explore { resetToHome: true }` with any failed interaction at an interval boundary.

## Testing

Regression tests in `test/features/navigation/Explore.test.ts` and `ExploreBlockerDetection.test.ts` (fake tool layer, no device; each red before / green after):

- `performInteraction` with text + resource-id issues exactly one `tapOn` call carrying only `elementId`; text-only and content-desc-only elements fall back to the `text` selector.
- Three rows sharing one resource-id: the row with unique text is tapped by `text`; a row whose text is also duplicated is tapped by `elementId` + `index: 2`.
- A scrolled-off duplicate row above the target does not shift the index (on-screen matches only: `index: 2`, where a raw hierarchy count would say 3).
- A qualified id sharing a screen with a bare Compose id is not unique, so unique text is used instead.
- `handlePermissionDialog` / `dismissDialog` now take the view hierarchy so the same selector logic applies to dialog buttons.
- `handlePermissionDialog` / `dismissDialog` tap an Allow / Not-now button that has both fields by id only.
- Loop-level: with outcomes `[fail, ok, ok, fail, ok]`, `resetInterval: 2`, `maxInteractions: 3`, the reset fires exactly once — after the second success, not at count 0, and not again while the count sits on 2.
- `resetToHome` relaunches the target app after home on Android (`LaunchApp.execute` with `clearAppData`/`coldBoot` off and the signal forwarded) and on iOS (internal `launchApp` with `appId`, device, session, signal); a failed relaunch records `Home-screen recovery failed: …` as the stop reason.

One pre-existing test (`should default to initial foreground package…`) was silently relying on the double-selector rejection to short-circuit the tap; it now stubs `performInteraction` like its siblings.

## Validation

- [x] `turbo run lint build test` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run format:check` passes
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses existing project helpers; no new dependencies
- [x] Based on latest `main`
