### PR TITLE
fix(redaction): guard reverse marker collision on both runners

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -86,23 +86,42 @@ internal object SecretRedactor {
     }
 
   /**
-   * Replace every occurrence of each secret value in [text] with [PLACEHOLDER]. Longer values are
-   * replaced first so a secret that contains a shorter secret as a substring is fully masked.
-   * [String.replace] matches literal code units; [secretValues] already supplies the NFC/NFD
-   * variants.
+   * Replace every occurrence of each secret value in [text] with [PLACEHOLDER], guaranteeing that
+   * NO declared value survives in the result. Longer values are replaced first so a secret that
+   * contains a shorter secret as a substring is fully masked. [String.replace] matches literal code
+   * units; [secretValues] already supplies the NFC/NFD variants.
+   *
+   * A single pass is not enough: substituting the marker can SYNTHESIZE another declared value out
+   * of the marker plus its surrounding context (declared `abc` and `X***REDACTED***Y`, text `XabcY`
+   * — #6146), or reintroduce a declared value that is a substring of the marker (declared
+   * `REDACTED` and `abc`). So the pass repeats until one finds nothing (the proof that no declared
+   * value is present), bounded by the number of values plus one. If the bound is exhausted without
+   * converging, the whole text is over-redacted to the marker alone — or to the empty string when
+   * the marker itself contains a declared value. Over-redact, never leak.
    */
   fun redact(text: String, secretValues: List<String>): String {
-    if (secretValues.isEmpty()) return text
+    val ordered = secretValues.filter { it.isNotEmpty() }.sortedByDescending { it.length }
+    if (ordered.isEmpty()) return text
     var redacted = text
-    for (value in secretValues.sortedByDescending { it.length }) {
-      if (value.isEmpty()) continue
-      // If the secret is itself a substring of the placeholder (e.g. a secret value of "REDACTED"
-      // or "***REDACTED***"), substituting the placeholder would reintroduce the secret — so remove
-      // it instead, guaranteeing it cannot survive in the result (#6094).
-      val replacement = if (PLACEHOLDER.contains(value)) "" else PLACEHOLDER
-      redacted = redacted.replace(value, replacement)
+    repeat(ordered.size + 1) { redacted = replaceEach(redacted, ordered) ?: return redacted }
+    return if (ordered.any { PLACEHOLDER.contains(it) }) "" else PLACEHOLDER
+  }
+
+  /**
+   * One longest-first replacement pass over [text], or `null` when no value of [ordered] occurs in
+   * it (the fixpoint). A value that is itself a substring of the placeholder (e.g. `REDACTED` or
+   * `***REDACTED***`) is removed rather than substituted, since substituting the placeholder would
+   * reintroduce it (#6094).
+   */
+  private fun replaceEach(text: String, ordered: List<String>): String? {
+    var result = text
+    var changed = false
+    for (value in ordered) {
+      if (!result.contains(value)) continue
+      result = result.replace(value, if (PLACEHOLDER.contains(value)) "" else PLACEHOLDER)
+      changed = true
     }
-    return redacted
+    return if (changed) result else null
   }
 
   /**

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/SecretRedactor.kt
@@ -95,15 +95,19 @@ internal object SecretRedactor {
    * of the marker plus its surrounding context (declared `abc` and `X***REDACTED***Y`, text `XabcY`
    * — #6146), or reintroduce a declared value that is a substring of the marker (declared
    * `REDACTED` and `abc`). So the pass repeats until one finds nothing (the proof that no declared
-   * value is present), bounded by the number of values plus one. If the bound is exhausted without
-   * converging, the whole text is over-redacted to the marker alone — or to the empty string when
-   * the marker itself contains a declared value. Over-redact, never leak.
+   * value is present), bounded by the number of values plus one. If the bound is exhausted and the
+   * last pass's output still contains a declared value, the whole text is over-redacted to the
+   * marker alone — or to the empty string when the marker itself contains a declared value.
+   * Over-redact, never leak.
    */
   fun redact(text: String, secretValues: List<String>): String {
     val ordered = secretValues.filter { it.isNotEmpty() }.sortedByDescending { it.length }
     if (ordered.isEmpty()) return text
     var redacted = text
     repeat(ordered.size + 1) { redacted = replaceEach(redacted, ordered) ?: return redacted }
+    // The final permitted pass may itself have produced a secret-free result; keep that rather
+    // than discarding the whole context.
+    if (ordered.none { redacted.contains(it) }) return redacted
     return if (ordered.any { PLACEHOLDER.contains(it) }) "" else PLACEHOLDER
   }
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -377,4 +377,87 @@ class SecretRedactorTest {
       assertTrue(result.contains("token "), "non-secret context is preserved")
     }
   }
+
+  @Test
+  fun `a shorter secret's replacement cannot synthesize a longer secret containing the marker`() {
+    // Reverse marker collision (#6146): declared `abc` and `X***REDACTED***Y`, text `XabcY`.
+    // Longest-first finds the longer secret nowhere, replaces `abc` with the marker, and the result
+    // IS the longer secret — fully present after its only removal opportunity passed.
+    val longer = "X${SecretRedactor.PLACEHOLDER}Y"
+    val values = SecretRedactor.secretValues(listOf("abc", longer))
+    val result = SecretRedactor.redact("XabcY", values)
+    assertFalse(result.contains(longer), "the marker-containing secret must not be synthesized")
+    assertFalse(result.contains("abc"), "the shorter secret must be redacted")
+    assertEquals(SecretRedactor.PLACEHOLDER, result)
+  }
+
+  @Test
+  fun `a marker-substring secret is not reintroduced by another secret's replacement`() {
+    // `REDACTED` is itself a declared secret, so substituting `***REDACTED***` for `abc` would put
+    // that declared value in the output verbatim (#6146).
+    val values = SecretRedactor.secretValues(listOf("REDACTED", "abc"))
+    val result = SecretRedactor.redact("token abc here", values)
+    assertFalse(result.contains("REDACTED"), "the marker-substring secret must not survive")
+    assertFalse(result.contains("abc"), "the ordinary secret must be redacted")
+    assertTrue(result.startsWith("token ") && result.endsWith(" here"), "context is preserved")
+  }
+
+  @Test
+  fun `a secret equal to the marker is not reintroduced by another secret's replacement`() {
+    val values = SecretRedactor.secretValues(listOf(SecretRedactor.PLACEHOLDER, "abc"))
+    val result = SecretRedactor.redact("token abc here", values)
+    assertFalse(result.contains(SecretRedactor.PLACEHOLDER), "the marker secret must not survive")
+    assertFalse(result.contains("abc"), "the ordinary secret must be redacted")
+  }
+
+  @Test
+  fun `ordinary text is unchanged and an ordinary secret keeps its context`() {
+    val values = SecretRedactor.secretValues(listOf("s3cr3t"))
+    assertEquals("nothing to see", SecretRedactor.redact("nothing to see", values))
+    assertEquals(
+      "token ${SecretRedactor.PLACEHOLDER} here",
+      SecretRedactor.redact("token s3cr3t here", values),
+    )
+  }
+
+  @Test
+  fun `a replacement chain that does not converge over-redacts the whole text`() {
+    // Each pass of `X***REDACTED***` -> marker consumes one leading `X`, so a run of `X`s longer
+    // than the pass budget cannot converge in time. The fail-safe is the marker alone —
+    // over-redact,
+    // never leak (#6146).
+    val chained = "X${SecretRedactor.PLACEHOLDER}"
+    val values = SecretRedactor.secretValues(listOf("abc", chained))
+    val result = SecretRedactor.redact("XXXXXXXXabc", values)
+    assertEquals(SecretRedactor.PLACEHOLDER, result)
+  }
+
+  @Test
+  fun `no declared value survives redaction for a table of adversarial inputs`() {
+    val marker = SecretRedactor.PLACEHOLDER
+    val cases =
+      listOf(
+        listOf("abc", "X${marker}Y") to "XabcY",
+        listOf("REDACTED", "abc") to "abc",
+        listOf(marker, "abc") to "token abc",
+        listOf("ab", "abcdef") to "x abcdef y",
+        listOf("***", "a") to "a*a*a",
+        listOf("X$marker", "abc") to "XXXabc XabcX",
+        listOf("$marker$marker", "q") to "qq q",
+        listOf("*", "R") to "R*R",
+        listOf("é", "café") to "café café",
+        listOf("pa\"ss", "\\\"") to "{\"v\":\"pa\\\"ss\"}",
+        listOf("s3cr3t") to "nothing to see",
+      )
+    for ((secrets, text) in cases) {
+      val values = SecretRedactor.secretValues(secrets)
+      val result = SecretRedactor.redact(text, values)
+      for (value in values) {
+        assertFalse(
+          result.contains(value),
+          "declared value \"$value\" survived as \"$result\" for input \"$text\"",
+        )
+      }
+    }
+  }
 }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SecretRedactorTest.kt
@@ -424,12 +424,23 @@ class SecretRedactorTest {
   fun `a replacement chain that does not converge over-redacts the whole text`() {
     // Each pass of `X***REDACTED***` -> marker consumes one leading `X`, so a run of `X`s longer
     // than the pass budget cannot converge in time. The fail-safe is the marker alone —
-    // over-redact,
-    // never leak (#6146).
+    // over-redact, never leak (#6146). The surrounding `pre`/`post` context distinguishes the
+    // fail-safe (whole text -> marker) from a converged result (`pre ***REDACTED*** post`).
     val chained = "X${SecretRedactor.PLACEHOLDER}"
     val values = SecretRedactor.secretValues(listOf("abc", chained))
-    val result = SecretRedactor.redact("XXXXXXXXabc", values)
+    val result = SecretRedactor.redact("pre XXXXXXXXabc post", values)
     assertEquals(SecretRedactor.PLACEHOLDER, result)
+  }
+
+  @Test
+  fun `a chain that converges on the final permitted pass keeps its context`() {
+    // Secret `*X` alone allows two passes: `prefix *XX suffix` -> `prefix ***REDACTED***X suffix`
+    // (still contains `*X`) -> `prefix ***REDACTED*****REDACTED*** suffix`, which is clean. That
+    // final result must be kept, not discarded for the whole-text fallback (#6146 Codex review).
+    val values = SecretRedactor.secretValues(listOf("*X"))
+    val result = SecretRedactor.redact("prefix *XX suffix", values)
+    assertFalse(result.contains("*X"), "the secret must not survive")
+    assertTrue(result.startsWith("prefix ") && result.endsWith(" suffix"), "context is preserved")
   }
 
   @Test

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -84,9 +84,10 @@ enum SecretRedaction {
     /// out of the marker plus its surrounding context (declared `abc` and `X***REDACTED***Y`, text
     /// `XabcY` — #6146), or reintroduce a declared value that is a substring of the marker (declared
     /// `REDACTED` and `abc`). So the pass repeats until one finds nothing (the proof that no declared
-    /// value is present), bounded by the number of values plus one. If the bound is exhausted without
-    /// converging, the whole text is over-redacted to the marker alone — or to the empty string when
-    /// the marker itself contains a declared value. Over-redact, never leak.
+    /// value is present), bounded by the number of values plus one. If the bound is exhausted and the
+    /// last pass's output still contains a declared value, the whole text is over-redacted to the
+    /// marker alone — or to the empty string when the marker itself contains a declared value.
+    /// Over-redact, never leak.
     static func redact(_ text: String, secretValues: [String]) -> String {
         let ordered = secretValues.filter { !$0.isEmpty }.sorted(by: { $0.utf16.count > $1.utf16.count })
         guard !ordered.isEmpty else {
@@ -98,6 +99,11 @@ enum SecretRedaction {
                 return redacted
             }
             redacted = next
+        }
+        // The final permitted pass may itself have produced a secret-free result; keep that rather
+        // than discarding the whole context.
+        if !ordered.contains(where: { redacted.range(of: $0, options: [.literal]) != nil }) {
+            return redacted
         }
         return ordered.contains(where: { placeholder.contains($0) }) ? "" : placeholder
     }

--- a/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/Recovery/SecretRedaction.swift
@@ -72,25 +72,49 @@ enum SecretRedaction {
         return result
     }
 
-    /// Replace every occurrence of each secret value in `text` with the redaction placeholder. Values
-    /// are replaced longest-first — by UTF-16 code-unit length, so a decomposed form (more code units
-    /// than its composed twin) and any shorter secret that is a substring of a longer one are masked
-    /// whole, with no combining-mark or substring residue. Matching is `.literal` (exact code units)
-    /// because `secretValues` already supplies the NFC/NFD variants. Matches Android's `length`-desc
-    /// ordering (Kotlin `String.length` is a UTF-16 count).
+    /// Replace every occurrence of each secret value in `text` with the redaction placeholder,
+    /// guaranteeing that NO declared value survives in the result. Values are replaced longest-first
+    /// — by UTF-16 code-unit length, so a decomposed form (more code units than its composed twin)
+    /// and any shorter secret that is a substring of a longer one are masked whole, with no
+    /// combining-mark or substring residue. Matching is `.literal` (exact code units) because
+    /// `secretValues` already supplies the NFC/NFD variants. Matches Android's `length`-desc ordering
+    /// (Kotlin `String.length` is a UTF-16 count).
+    ///
+    /// A single pass is not enough: substituting the marker can SYNTHESIZE another declared value
+    /// out of the marker plus its surrounding context (declared `abc` and `X***REDACTED***Y`, text
+    /// `XabcY` — #6146), or reintroduce a declared value that is a substring of the marker (declared
+    /// `REDACTED` and `abc`). So the pass repeats until one finds nothing (the proof that no declared
+    /// value is present), bounded by the number of values plus one. If the bound is exhausted without
+    /// converging, the whole text is over-redacted to the marker alone — or to the empty string when
+    /// the marker itself contains a declared value. Over-redact, never leak.
     static func redact(_ text: String, secretValues: [String]) -> String {
-        guard !secretValues.isEmpty else {
+        let ordered = secretValues.filter { !$0.isEmpty }.sorted(by: { $0.utf16.count > $1.utf16.count })
+        guard !ordered.isEmpty else {
             return text
         }
         var redacted = text
-        for value in secretValues.sorted(by: { $0.utf16.count > $1.utf16.count }) where !value.isEmpty {
-            // If the secret is itself a substring of the placeholder (e.g. a secret value of
-            // "REDACTED" or "***REDACTED***"), substituting the placeholder would reintroduce the
-            // secret — so remove it instead, guaranteeing it cannot survive in the result (#6094).
-            let replacement = placeholder.contains(value) ? "" : placeholder
-            redacted = redacted.replacingOccurrences(of: value, with: replacement, options: [.literal])
+        for _ in 0 ... ordered.count {
+            guard let next = replaceEach(redacted, ordered: ordered) else {
+                return redacted
+            }
+            redacted = next
         }
-        return redacted
+        return ordered.contains(where: { placeholder.contains($0) }) ? "" : placeholder
+    }
+
+    /// One longest-first replacement pass over `text`, or `nil` when no value of `ordered` occurs in
+    /// it (the fixpoint). A value that is itself a substring of the placeholder (e.g. `REDACTED` or
+    /// `***REDACTED***`) is removed rather than substituted, since substituting the placeholder would
+    /// reintroduce it (#6094).
+    private static func replaceEach(_ text: String, ordered: [String]) -> String? {
+        var result = text
+        var changed = false
+        for value in ordered where result.range(of: value, options: [.literal]) != nil {
+            let replacement = placeholder.contains(value) ? "" : placeholder
+            result = result.replacingOccurrences(of: value, with: replacement, options: [.literal])
+            changed = true
+        }
+        return changed ? result : nil
     }
 
     /// Redact the sampled UI strings and observe-error that feed the recovery prompt. A secret can

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -1352,6 +1352,81 @@ final class SecretRedactionTests: XCTestCase {
             XCTAssertTrue(result.contains("token "), "non-secret context is preserved")
         }
     }
+
+    func testShorterSecretReplacementCannotSynthesizeLongerSecretContainingTheMarker() {
+        // Reverse marker collision (#6146): declared `abc` and `X***REDACTED***Y`, text `XabcY`.
+        // Longest-first finds the longer secret nowhere, replaces `abc` with the marker, and the
+        // result IS the longer secret — fully present after its only removal opportunity passed.
+        let longer = "X" + SecretRedaction.placeholder + "Y"
+        let values = SecretRedaction.secretValues(["abc", longer])
+        let result = SecretRedaction.redact("XabcY", secretValues: values)
+        XCTAssertFalse(result.contains(longer), "the marker-containing secret must not be synthesized")
+        XCTAssertFalse(result.contains("abc"), "the shorter secret must be redacted")
+        XCTAssertEqual(result, SecretRedaction.placeholder)
+    }
+
+    func testMarkerSubstringSecretIsNotReintroducedByAnotherSecretsReplacement() {
+        // `REDACTED` is itself a declared secret, so substituting `***REDACTED***` for `abc` would
+        // put that declared value in the output verbatim (#6146).
+        let values = SecretRedaction.secretValues(["REDACTED", "abc"])
+        let result = SecretRedaction.redact("token abc here", secretValues: values)
+        XCTAssertFalse(result.contains("REDACTED"), "the marker-substring secret must not survive")
+        XCTAssertFalse(result.contains("abc"), "the ordinary secret must be redacted")
+        XCTAssertTrue(result.hasPrefix("token ") && result.hasSuffix(" here"), "context is preserved")
+    }
+
+    func testSecretEqualToTheMarkerIsNotReintroducedByAnotherSecretsReplacement() {
+        let values = SecretRedaction.secretValues([SecretRedaction.placeholder, "abc"])
+        let result = SecretRedaction.redact("token abc here", secretValues: values)
+        XCTAssertFalse(result.contains(SecretRedaction.placeholder), "the marker secret must not survive")
+        XCTAssertFalse(result.contains("abc"), "the ordinary secret must be redacted")
+    }
+
+    func testOrdinaryTextIsUnchangedAndAnOrdinarySecretKeepsItsContext() {
+        let values = SecretRedaction.secretValues(["s3cr3t"])
+        XCTAssertEqual(SecretRedaction.redact("nothing to see", secretValues: values), "nothing to see")
+        XCTAssertEqual(
+            SecretRedaction.redact("token s3cr3t here", secretValues: values),
+            "token " + SecretRedaction.placeholder + " here"
+        )
+    }
+
+    func testReplacementChainThatDoesNotConvergeOverRedactsTheWholeText() {
+        // Each pass of `X***REDACTED***` -> marker consumes one leading `X`, so a run of `X`s longer
+        // than the pass budget cannot converge in time. The fail-safe is the marker alone —
+        // over-redact, never leak (#6146).
+        let chained = "X" + SecretRedaction.placeholder
+        let values = SecretRedaction.secretValues(["abc", chained])
+        let result = SecretRedaction.redact("XXXXXXXXabc", secretValues: values)
+        XCTAssertEqual(result, SecretRedaction.placeholder)
+    }
+
+    func testNoDeclaredValueSurvivesRedactionForATableOfAdversarialInputs() {
+        let marker = SecretRedaction.placeholder
+        let cases: [(secrets: [String], text: String)] = [
+            (["abc", "X" + marker + "Y"], "XabcY"),
+            (["REDACTED", "abc"], "abc"),
+            ([marker, "abc"], "token abc"),
+            (["ab", "abcdef"], "x abcdef y"),
+            (["***", "a"], "a*a*a"),
+            (["X" + marker, "abc"], "XXXabc XabcX"),
+            ([marker + marker, "q"], "qq q"),
+            (["*", "R"], "R*R"),
+            (["\u{00E9}", "cafe\u{0301}"], "caf\u{00E9} cafe\u{0301}"),
+            (["pa\"ss", "\\\""], "{\"v\":\"pa\\\"ss\"}"),
+            (["s3cr3t"], "nothing to see"),
+        ]
+        for testCase in cases {
+            let values = SecretRedaction.secretValues(testCase.secrets)
+            let result = SecretRedaction.redact(testCase.text, secretValues: values)
+            for value in values {
+                XCTAssertNil(
+                    result.range(of: value, options: [.literal]),
+                    "declared value \"\(value)\" survived as \"\(result)\" for input \"\(testCase.text)\""
+                )
+            }
+        }
+    }
 }
 
 final class RunBlockingBoundTests: XCTestCase {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -1394,11 +1394,22 @@ final class SecretRedactionTests: XCTestCase {
     func testReplacementChainThatDoesNotConvergeOverRedactsTheWholeText() {
         // Each pass of `X***REDACTED***` -> marker consumes one leading `X`, so a run of `X`s longer
         // than the pass budget cannot converge in time. The fail-safe is the marker alone —
-        // over-redact, never leak (#6146).
+        // over-redact, never leak (#6146). The surrounding `pre`/`post` context distinguishes the
+        // fail-safe (whole text -> marker) from a converged result (`pre ***REDACTED*** post`).
         let chained = "X" + SecretRedaction.placeholder
         let values = SecretRedaction.secretValues(["abc", chained])
-        let result = SecretRedaction.redact("XXXXXXXXabc", secretValues: values)
+        let result = SecretRedaction.redact("pre XXXXXXXXabc post", secretValues: values)
         XCTAssertEqual(result, SecretRedaction.placeholder)
+    }
+
+    func testChainThatConvergesOnTheFinalPermittedPassKeepsItsContext() {
+        // Secret `*X` alone allows two passes: `prefix *XX suffix` -> `prefix ***REDACTED***X suffix`
+        // (still contains `*X`) -> `prefix ***REDACTED*****REDACTED*** suffix`, which is clean. That
+        // final result must be kept, not discarded for the whole-text fallback (#6146 Codex review).
+        let values = SecretRedaction.secretValues(["*X"])
+        let result = SecretRedaction.redact("prefix *XX suffix", secretValues: values)
+        XCTAssertNil(result.range(of: "*X", options: [.literal]), "the secret must not survive")
+        XCTAssertTrue(result.hasPrefix("prefix ") && result.hasSuffix(" suffix"), "context is preserved")
     }
 
     func testNoDeclaredValueSurvivesRedactionForATableOfAdversarialInputs() {


### PR DESCRIPTION
## Summary

`SecretRedactor.redact` (Android junit-runner) and `SecretRedaction.redact` (iOS XCTestRunner) now guarantee that **no declared secret value survives** in the redacted output, instead of relying on a single longest-first replacement pass plus a one-directional marker guard.

The pass is unchanged (longest-first, marker-substring secrets removed rather than substituted — #6094), but it now repeats until a pass finds no declared value (the proof of the post-condition), bounded by `values.size + 1`. If the bound is exhausted without converging, the whole text is over-redacted to the marker alone (or to `""` when the marker itself contains a declared value). Over-redact, never leak — the same value-layer fail-safe principle as #6097.

Both runners get the identical helper shape: `redact` (bounded fixpoint) + private `replaceEach` (one pass, `null`/`nil` at the fixpoint).

## Linked Issue

Closes [#6146](https://github.com/kaeawc/auto-mobile/issues/6146)

## Bug / Regression Context

- **Prior attempts:** [#6143](https://github.com/kaeawc/auto-mobile/pull/6143) (for [#6094](https://github.com/kaeawc/auto-mobile/issues/6094)) guarded only the *forward* collision — a secret that is a substring of `***REDACTED***` is removed instead of substituted. The reverse direction was deliberately deferred to this issue.
- **Observed symptom:** with declared secrets `abc` and `X***REDACTED***Y` and text `XabcY`, the single pass finds the longer secret nowhere, replaces `abc` with the marker, and the result *is* the longer secret — fully present after its only removal opportunity has passed. A second, previously untested variant: declared `REDACTED` and `abc`, text `abc` — substituting the marker for `abc` reintroduces the declared value `REDACTED` verbatim.
- **Root cause:** replacement output was never re-checked against the declared values, so the marker plus surrounding context could synthesize (or reintroduce) a declared value that the ordered pass could no longer see.
- **Repro:** the new `a shorter secret's replacement cannot synthesize a longer secret containing the marker` / `testShorterSecretReplacementCannotSynthesizeLongerSecretContainingTheMarker` tests fail on `main` for exactly this reason (verified red before the change).

## Tests

Mirrored on both platforms (`SecretRedactorTest.kt`, `SecretRedactionTests` in `RecoveryTests.swift`):

- secret containing the marker, synthesized by a shorter secret's replacement (the issue example)
- marker-substring secret (`REDACTED`) alongside an ordinary secret — not reintroduced
- secret equal to the marker alongside an ordinary secret — not reintroduced
- ordinary text unchanged; ordinary secret keeps its surrounding context
- a replacement chain that cannot converge within the pass budget over-redacts to the marker alone
- a property-style table of adversarial inputs asserting the post-condition: no declared value (including NFC/NFD and JSON-escaped variants from `secretValues`) survives

All pre-existing redaction tests (substring-of-longer, Unicode normalization, JSON single/double escaping, marker collision) remain green.

## Validation

- [x] `bun run lint` / `bun run build` / `bun test` (turbo) — TS untouched, run as the whole-suite regression gate
- [x] `bun run format:check` and `bun run typecheck` report no changes / no new errors
- [x] Android: `./gradlew :junit-runner:test --tests '*SecretRedactorTest*' :junit-runner:detekt` green; ktfmt (pinned 0.64) validated
- [x] iOS: `swiftformat --lint` and `swiftlint --strict` clean on the touched files. The full `swift test` needs the Swift 6.3 toolchain (Xcode 26.5) which is not installed locally, so the new `redact` was additionally compiled and exercised standalone under `swiftc -swift-version 6` with every new case; the required **Swift Code Coverage** lane is the authoritative run
- [x] No new dependency or helper beyond a private one-pass function in each existing type

## Kotlin Reuse Check

- [x] Uses only `String.replace` / `contains` / `sortedByDescending` / `repeat` from the stdlib; no new helper types or dependencies

## On-device effect

This change is **inert on-device until the runners are re-cut** — the junit-runner AAR and XCTestRunner package consumed by the fleet are the last published cut, and the re-cut ([#6150](https://github.com/kaeawc/auto-mobile/issues/6150)) is deliberately not part of this round.

## Follow-ups

- None filed. The bound (`values.size + 1` passes) trades a little extra over-redaction on long synthesized chains for guaranteed termination; if a real plan ever trips it, the fix is a larger budget, not a different algorithm.
