### PR TITLE
fix(observe): select the focused dialog/app window over the systemui status bar

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -724,6 +724,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           layer = it.layer,
           hasRoot = it.root != null,
           isFocused = it.isFocused,
+          isActive = it.isActive,
         )
       }
     )
@@ -738,6 +739,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val layer: Int,
     val hasRoot: Boolean,
     val isFocused: Boolean = false,
+    val isActive: Boolean = false,
   )
 
   /** Single-pass variant used by tests and by the production overload. */
@@ -746,6 +748,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var anyWindowFocused = false
     var focusedAppId: Int? = null
     var focusedAppLayer = Int.MIN_VALUE
+    var activeAppId: Int? = null
     var topAppId: Int? = null
     var topAppLayer = Int.MIN_VALUE
     for (w in windows) {
@@ -753,6 +756,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       when (w.type) {
         AccessibilityWindowInfo.TYPE_INPUT_METHOD -> if (w.hasRoot) hasIme = true
         AccessibilityWindowInfo.TYPE_APPLICATION -> {
+          if (w.hasRoot && w.isActive) {
+            activeAppId = w.id
+          }
           if (w.hasRoot && w.layer > topAppLayer) {
             topAppLayer = w.layer
             topAppId = w.id
@@ -767,10 +773,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     if (focusedAppId != null) {
       return focusedAppId
     }
-    // The IME owns focus, or the focus flag is populated nowhere: the topmost application window
-    // with readable content is the user-facing window. A focused non-app window (shade, quick
-    // settings, keyguard) keeps the active-window fallback.
-    return if (hasIme || !anyWindowFocused) topAppId else null
+    // The IME owns focus, or the focus flag is populated nowhere: the application window with
+    // readable content is the user-facing window — the active one when several coexist
+    // (split-screen, picture-in-picture), else the topmost. A focused non-app window (shade,
+    // quick settings, keyguard) keeps the active-window fallback.
+    return if (hasIme || !anyWindowFocused) activeAppId ?: topAppId else null
   }
 
   /**

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -305,10 +305,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         if (isPrimaryWindow) {
           mainHierarchy = processedElement
           mainPackageName = packageName
-          if (notificationPermissionDetected == null && processedElement != null) {
-            notificationPermissionDetected =
-              detectNotificationPermissionDialog(processedElement, packageName)
-          }
+        }
+        // A runtime permission dialog is its own permissioncontroller window. Detect it in
+        // whichever window carries it, not only the primary one, so the flag cannot read false
+        // while the dialog is on screen because selection landed on another window (#6151).
+        if (notificationPermissionDetected != true && processedElement != null) {
+          notificationPermissionDetected =
+            detectNotificationPermissionDialog(processedElement, packageName)
         }
 
         if (processedElement != null) {
@@ -362,7 +365,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       if (!intentChooserDetected && mainHierarchy != null) {
         intentChooserDetected = detectIntentChooserIndicators(mainHierarchy!!)
       }
-      if (notificationPermissionDetected == null && mainHierarchy != null) {
+      if (notificationPermissionDetected != true && mainHierarchy != null) {
         notificationPermissionDetected =
           detectNotificationPermissionDialog(mainHierarchy!!, mainPackageName)
       }
@@ -696,13 +699,21 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   /**
    * Selects the window id hierarchy extraction should treat as the "primary" user-facing window.
    * Prefers a focused application window even when its root is temporarily unavailable. When the
-   * IME owns focus, falls back to the topmost application window with a root. Returns null when
-   * neither condition applies so callers can retain the active-window fallback for genuine system
-   * UI.
+   * IME owns focus, or when no window reports focus at all, falls back to the topmost application
+   * window with a root. Returns null when neither condition applies so callers can retain the
+   * active-window fallback for genuine system UI (a focused shade, quick settings, or keyguard).
    *
    * Android can mark a system window active while the foreground application is focused, and marks
    * the IME active/focused while the keyboard is showing. In either case, relying on
-   * [AccessibilityWindowInfo.isActive] alone can select non-app content.
+   * [AccessibilityWindowInfo.isActive] alone can select non-app content. The
+   * [AccessibilityWindowInfo.isFocused] flag is not populated on every API level either; when it is
+   * absent everywhere, an application window that has readable content still outranks a status bar
+   * that merely happens to be marked active (#6151).
+   *
+   * Note that a focused application window whose root is null is a different failure: on Android
+   * 14+ the framework hides accessibility-data-sensitive surfaces (runtime permission dialogs, the
+   * Settings Wi-Fi picker) from services that do not declare `isAccessibilityTool`, which is why
+   * the service config declares it. No ranking rule can recover content the framework withholds.
    */
   private fun pickPrimaryAppWindowId(windows: List<AccessibilityWindowInfo>): Int? =
     pickPrimaryAppWindowId(
@@ -732,11 +743,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   /** Single-pass variant used by tests and by the production overload. */
   internal fun pickPrimaryAppWindowId(windows: List<WindowMeta>): Int? {
     var hasIme = false
+    var anyWindowFocused = false
     var focusedAppId: Int? = null
     var focusedAppLayer = Int.MIN_VALUE
     var topAppId: Int? = null
     var topAppLayer = Int.MIN_VALUE
     for (w in windows) {
+      if (w.isFocused) anyWindowFocused = true
       when (w.type) {
         AccessibilityWindowInfo.TYPE_INPUT_METHOD -> if (w.hasRoot) hasIme = true
         AccessibilityWindowInfo.TYPE_APPLICATION -> {
@@ -751,7 +764,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         }
       }
     }
-    return focusedAppId ?: if (hasIme) topAppId else null
+    if (focusedAppId != null) {
+      return focusedAppId
+    }
+    // The IME owns focus, or the focus flag is populated nowhere: the topmost application window
+    // with readable content is the user-facing window. A focused non-app window (shade, quick
+    // settings, keyguard) keeps the active-window fallback.
+    return if (hasIme || !anyWindowFocused) topAppId else null
   }
 
   /**

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -306,10 +306,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           mainHierarchy = processedElement
           mainPackageName = packageName
         }
-        // A runtime permission dialog is its own permissioncontroller window. Detect it in
-        // whichever window carries it, not only the primary one, so the flag cannot read false
-        // while the dialog is on screen because selection landed on another window (#6151).
-        if (notificationPermissionDetected != true && processedElement != null) {
+        // A runtime permission dialog is its own permissioncontroller window. Detect it in the
+        // primary window or in a focused/active one (a dialog owns focus while it is on screen,
+        // even mid-transition when selection still lands on the app beneath it), so the flag
+        // cannot read false while the dialog is up (#6151). Windows that are neither — e.g.
+        // another app's dialog in split-screen — do not flag the primary app's observation.
+        val canCarryDialog = isPrimaryWindow || window.isFocused || window.isActive
+        if (notificationPermissionDetected != true && processedElement != null && canCarryDialog) {
           notificationPermissionDetected =
             detectNotificationPermissionDialog(processedElement, packageName)
         }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -211,6 +211,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     // fall back to the topmost application window with a root.
     val primaryAppWindowId: Int? = pickPrimaryAppWindowId(windows)
 
+    // The primary app window's own bounds, used below to correlate a permission-controller
+    // dialog window with the app it belongs to (issue #6151 follow-up). `null` when no distinct
+    // primary window was picked, in which case `isPrimaryWindow` already covers the active
+    // window directly and correlation is moot.
+    val primaryAppWindowBounds: Rect? = primaryAppWindowId?.let { id ->
+      windows.firstOrNull { it.id == id }?.let { w -> Rect().also(w::getBoundsInScreen) }
+    }
+
     // Extract from each window
     for (window in windows) {
       try {
@@ -307,11 +315,17 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           mainPackageName = packageName
         }
         // A runtime permission dialog is its own permissioncontroller window. Detect it in the
-        // primary window or in a focused/active one (a dialog owns focus while it is on screen,
-        // even mid-transition when selection still lands on the app beneath it), so the flag
-        // cannot read false while the dialog is up (#6151). Windows that are neither — e.g.
-        // another app's dialog in split-screen — do not flag the primary app's observation.
-        val canCarryDialog = isPrimaryWindow || window.isFocused || window.isActive
+        // primary window or in a focused/active one that also overlaps the primary app window's
+        // bounds (a dialog owns focus while it is on screen, even mid-transition when selection
+        // still lands on the app beneath it), so the flag cannot read false while the dialog is
+        // up (#6151). A focused/active window that does NOT overlap the primary app — e.g.
+        // another app's own dialog in an unrelated split-screen pane — does not flag the primary
+        // app's observation (#6151 follow-up: cross-app false-positive correlation).
+        val canCarryDialog =
+          isPrimaryWindow ||
+            ((window.isFocused || window.isActive) &&
+              (primaryAppWindowBounds == null ||
+                Rect.intersects(primaryAppWindowBounds, windowBounds)))
         if (notificationPermissionDetected != true && processedElement != null && canCarryDialog) {
           notificationPermissionDetected =
             detectNotificationPermissionDialog(processedElement, packageName)

--- a/android/control-proxy/src/main/res/xml/accessibility_service_config.xml
+++ b/android/control-proxy/src/main/res/xml/accessibility_service_config.xml
@@ -7,4 +7,5 @@
     android:notificationTimeout="100"
     android:canRetrieveWindowContent="true"
     android:canPerformGestures="true"
-    android:canTakeScreenshot="true" />
+    android:canTakeScreenshot="true"
+    android:isAccessibilityTool="true" />

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1025,6 +1025,36 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `pickPrimaryAppWindowId prefers the active app over a higher-layer app when no window reports focus`() {
+    // Split-screen / picture-in-picture with the focus flag populated nowhere: the resumed
+    // (active) application must win over a merely topmost one, so mainPackageName agrees with
+    // adb's resumed package and freshness is not retracted against the wrong app.
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 10,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 1,
+          hasRoot = true,
+          isActive = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 12,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 3,
+          hasRoot = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 11,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 6,
+          hasRoot = true,
+        ),
+      )
+    assertEquals(10, extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
   fun `pickPrimaryAppWindowId selects a focused permission dialog over the app beneath it`() {
     // API 34 shape with a runtime permission dialog in front: the permissioncontroller dialog
     // is its own focused TYPE_APPLICATION window layered above the (unfocused) app window.

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -8,6 +8,7 @@ import android.view.accessibility.AccessibilityWindowInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.SemanticLink
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -978,7 +979,33 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
-  fun `pickPrimaryAppWindowId leaves active-window fallback when no app is focused or IME is present`() {
+  fun `pickPrimaryAppWindowId leaves active-window fallback when a system window owns focus`() {
+    // Genuine system UI: an expanded shade / quick settings / keyguard reports isFocused, and
+    // the app beneath it must not be promoted over it (the systemTray workflow observes the
+    // shade).
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 10,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 5,
+          hasRoot = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 11,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 6,
+          hasRoot = true,
+          isFocused = true,
+        ),
+      )
+    assertNull(extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId prefers an app window with content when no window reports focus`() {
+    // Regression for #6151: when the isFocused flag is populated nowhere, the topmost application
+    // window with a root outranks a status bar that merely happens to be marked active.
     val windows =
       listOf(
         ViewHierarchyExtractor.WindowMeta(
@@ -994,7 +1021,214 @@ class ViewHierarchyExtractorTest {
           hasRoot = true,
         ),
       )
+    assertEquals(10, extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId selects a focused permission dialog over the app beneath it`() {
+    // API 34 shape with a runtime permission dialog in front: the permissioncontroller dialog
+    // is its own focused TYPE_APPLICATION window layered above the (unfocused) app window.
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 219,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 2,
+          hasRoot = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 318,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 0,
+          hasRoot = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 322,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 1,
+          hasRoot = true,
+          isFocused = true,
+        ),
+      )
+    assertEquals(322, extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId selects a focused Settings sub-panel over the status bar`() {
+    // API 34 shape with the Settings Wi-Fi picker in front (dumpsys accessibility ground truth
+    // from #6151): status bar TYPE_SYSTEM layer 1, Settings window focused+active layer 0.
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 219,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 1,
+          hasRoot = true,
+        ),
+        ViewHierarchyExtractor.WindowMeta(
+          id = 256,
+          type = AccessibilityWindowInfo.TYPE_APPLICATION,
+          layer = 0,
+          hasRoot = true,
+          isFocused = true,
+        ),
+      )
+    assertEquals(256, extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId keeps the active-window fallback for a status bar alone`() {
+    val windows =
+      listOf(
+        ViewHierarchyExtractor.WindowMeta(
+          id = 219,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+          layer = 1,
+          hasRoot = true,
+        )
+      )
     assertNull(extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `extractFromAllWindows detects a notification permission dialog in a non-primary window`() {
+    // #6151: the flag exists to catch this dialog, so it must be computed from whichever window
+    // carries it. Here the app window (still focused, as observed mid-transition) is primary and
+    // the permissioncontroller dialog is a second, unfocused application window.
+    val appRoot =
+      fakeNode(
+        packageName = "com.google.android.contacts",
+        bounds = Rect(0, 0, 1080, 2400),
+        children = listOf(fakeNode(packageName = "com.google.android.contacts", text = "Contacts")),
+      )
+    val dialogRoot =
+      fakeNode(
+        packageName = "com.google.android.permissioncontroller",
+        bounds = Rect(28, 682, 1052, 1654),
+        children =
+          listOf(
+            fakeNode(
+              packageName = "com.google.android.permissioncontroller",
+              text = "Allow Contacts to send you notifications?",
+              bounds = Rect(100, 700, 1000, 800),
+            ),
+            fakeNode(
+              packageName = "com.google.android.permissioncontroller",
+              text = "Allow",
+              resourceId = "com.android.permissioncontroller:id/permission_allow_button",
+              bounds = Rect(100, 1500, 500, 1600),
+            ),
+            fakeNode(
+              packageName = "com.google.android.permissioncontroller",
+              text = "Don't allow",
+              resourceId = "com.android.permissioncontroller:id/permission_deny_button",
+              bounds = Rect(600, 1500, 1000, 1600),
+            ),
+          ),
+      )
+    val windows =
+      listOf(
+        fakeWindow(id = 318, layer = 0, root = appRoot, focused = true, active = true),
+        fakeWindow(id = 322, layer = 1, root = dialogRoot),
+      )
+
+    val result = extractor.extractFromAllWindows(windows, appRoot, occlusionEnabled = false)
+
+    assertEquals(true, result.notificationPermissionDetected)
+    assertEquals("com.google.android.contacts", result.packageName)
+    assertNull(result.ctrlProxyIncomplete)
+    val serialized = json.encodeToString(ViewHierarchy.serializer(), result)
+    assertTrue(serialized.contains("permission_allow_button"))
+    assertTrue(serialized.contains("Allow Contacts to send you notifications?"))
+  }
+
+  @Test
+  fun `extractFromAllWindows reports an incomplete capture when the focused app root is withheld`() {
+    // The #6151 device shape before the isAccessibilityTool declaration: the status bar has a
+    // root, the focused Settings window does not, and rootInActiveWindow is null too. The
+    // capture must be flagged incomplete with no package rather than labelled as app content.
+    val statusBarRoot =
+      fakeNode(
+        packageName = "com.android.systemui",
+        bounds = Rect(0, 0, 1080, 63),
+        children =
+          listOf(
+            fakeNode(
+              packageName = "com.android.systemui",
+              text = "8:33",
+              resourceId = "com.android.systemui:id/clock",
+              bounds = Rect(21, 0, 107, 63),
+            )
+          ),
+      )
+    val windows =
+      listOf(
+        fakeWindow(
+          id = 219,
+          layer = 1,
+          root = statusBarRoot,
+          type = AccessibilityWindowInfo.TYPE_SYSTEM,
+        ),
+        fakeWindow(id = 256, layer = 0, root = null, focused = true, active = true),
+      )
+
+    val result = extractor.extractFromAllWindows(windows, null, occlusionEnabled = false)
+
+    assertEquals(true, result.ctrlProxyIncomplete)
+    assertNull(result.packageName)
+    assertNotNull(result.hierarchy)
+    val serialized = json.encodeToString(ViewHierarchy.serializer(), result)
+    assertTrue(serialized.contains("com.android.systemui:id/clock"))
+  }
+
+  private fun fakeNode(
+    packageName: String,
+    text: String? = null,
+    resourceId: String? = null,
+    bounds: Rect = Rect(0, 100, 1080, 200),
+    children: List<android.view.accessibility.AccessibilityNodeInfo> = emptyList(),
+  ): android.view.accessibility.AccessibilityNodeInfo {
+    val node = android.view.accessibility.AccessibilityNodeInfo.obtain()
+    node.packageName = packageName
+    node.className = "android.widget.TextView"
+    node.text = text
+    node.viewIdResourceName = resourceId
+    node.setBoundsInScreen(bounds)
+    node.isVisibleToUser = true
+    val shadow = org.robolectric.Shadows.shadowOf(node)
+    for (child in children) {
+      shadow.addChild(child)
+    }
+    // The extractor calls findFocus on each window root, which the framework only allows on a
+    // sealed (service-delivered) node. setSealed is a hidden API, so seal via reflection after
+    // the setters above (which in turn require an unsealed node).
+    android.view.accessibility.AccessibilityNodeInfo::class
+      .java
+      .getMethod("setSealed", Boolean::class.javaPrimitiveType)
+      .invoke(node, true)
+    return node
+  }
+
+  private fun fakeWindow(
+    id: Int,
+    layer: Int,
+    root: android.view.accessibility.AccessibilityNodeInfo?,
+    type: Int = AccessibilityWindowInfo.TYPE_APPLICATION,
+    focused: Boolean = false,
+    active: Boolean = false,
+  ): AccessibilityWindowInfo {
+    val window = AccessibilityWindowInfo.obtain()
+    val shadow = org.robolectric.Shadows.shadowOf(window)
+    shadow.setId(id)
+    shadow.setLayer(layer)
+    shadow.setType(type)
+    shadow.setRoot(root)
+    shadow.setFocused(focused)
+    shadow.setActive(active)
+    shadow.setBoundsInScreen(
+      Rect(0, 0, 1080, if (type == AccessibilityWindowInfo.TYPE_SYSTEM) 63 else 2400)
+    )
+    return window
   }
 
   @Test
@@ -1029,7 +1263,8 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `pickPrimaryAppWindowId ignores IME with null root`() {
     // An IME window present in the windows list but without a root cannot contribute
-    // occlusion and should not trigger the primary-window remap.
+    // occlusion and should not trigger the IME primary-window remap. The IME owns focus here
+    // (the keyboard-showing shape), so the no-focus-anywhere rule (#6151) does not apply either.
     val windows =
       listOf(
         ViewHierarchyExtractor.WindowMeta(
@@ -1043,6 +1278,7 @@ class ViewHierarchyExtractorTest {
           type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
           layer = 10,
           hasRoot = false,
+          isFocused = true,
         ),
       )
     assertNull(extractor.pickPrimaryAppWindowId(windows))

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1158,8 +1158,8 @@ class ViewHierarchyExtractorTest {
       )
     val windows =
       listOf(
-        fakeWindow(id = 318, layer = 0, root = appRoot, focused = true, active = true),
-        fakeWindow(id = 322, layer = 1, root = dialogRoot),
+        fakeWindow(id = 318, layer = 0, root = appRoot, focused = true),
+        fakeWindow(id = 322, layer = 1, root = dialogRoot, active = true),
       )
 
     val result = extractor.extractFromAllWindows(windows, appRoot, occlusionEnabled = false)
@@ -1170,6 +1170,17 @@ class ViewHierarchyExtractorTest {
     val serialized = json.encodeToString(ViewHierarchy.serializer(), result)
     assertTrue(serialized.contains("permission_allow_button"))
     assertTrue(serialized.contains("Allow Contacts to send you notifications?"))
+
+    // An unfocused, inactive permissioncontroller window beside the app (another app's dialog
+    // in split-screen) must not flag this app's observation as a permission dialog.
+    val bystander =
+      listOf(
+        fakeWindow(id = 318, layer = 0, root = appRoot, focused = true, active = true),
+        fakeWindow(id = 322, layer = 1, root = dialogRoot),
+      )
+    val bystanderResult =
+      extractor.extractFromAllWindows(bystander, appRoot, occlusionEnabled = false)
+    assertEquals(false, bystanderResult.notificationPermissionDetected)
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1184,6 +1184,62 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `extractFromAllWindows does not flag an unrelated app's active dialog in a split-screen pane`() {
+    // #6151 follow-up: `canCarryDialog` used to accept ANY focused-or-active permissioncontroller
+    // window, so a foreign app's own active dialog in the other split-screen pane could still set
+    // the primary app's `notificationPermissionDetected`. Here App A (primary, focused) occupies
+    // the top half of the screen; App B's own active permission dialog occupies the bottom half —
+    // a disjoint region, so it does not overlap App A's window and must not be correlated with it.
+    val appARoot =
+      fakeNode(
+        packageName = "com.google.android.contacts",
+        bounds = Rect(0, 0, 1080, 1200),
+        children = listOf(fakeNode(packageName = "com.google.android.contacts", text = "Contacts")),
+      )
+    val foreignDialogRoot =
+      fakeNode(
+        packageName = "com.google.android.permissioncontroller",
+        bounds = Rect(28, 1300, 1052, 2300),
+        children =
+          listOf(
+            fakeNode(
+              packageName = "com.google.android.permissioncontroller",
+              text = "Allow Maps to send you notifications?",
+              bounds = Rect(100, 1350, 1000, 1450),
+            ),
+            fakeNode(
+              packageName = "com.google.android.permissioncontroller",
+              text = "Allow",
+              resourceId = "com.android.permissioncontroller:id/permission_allow_button",
+              bounds = Rect(100, 2100, 500, 2200),
+            ),
+          ),
+      )
+    val windows =
+      listOf(
+        fakeWindow(
+          id = 318,
+          layer = 0,
+          root = appARoot,
+          focused = true,
+          bounds = Rect(0, 0, 1080, 1200),
+        ),
+        fakeWindow(
+          id = 322,
+          layer = 0,
+          root = foreignDialogRoot,
+          active = true,
+          bounds = Rect(0, 1200, 1080, 2400),
+        ),
+      )
+
+    val result = extractor.extractFromAllWindows(windows, appARoot, occlusionEnabled = false)
+
+    assertEquals(false, result.notificationPermissionDetected)
+    assertEquals("com.google.android.contacts", result.packageName)
+  }
+
+  @Test
   fun `extractFromAllWindows reports an incomplete capture when the focused app root is withheld`() {
     // The #6151 device shape before the isAccessibilityTool declaration: the status bar has a
     // root, the focused Settings window does not, and rootInActiveWindow is null too. The
@@ -1257,6 +1313,7 @@ class ViewHierarchyExtractorTest {
     type: Int = AccessibilityWindowInfo.TYPE_APPLICATION,
     focused: Boolean = false,
     active: Boolean = false,
+    bounds: Rect? = null,
   ): AccessibilityWindowInfo {
     val window = AccessibilityWindowInfo.obtain()
     val shadow = org.robolectric.Shadows.shadowOf(window)
@@ -1267,7 +1324,7 @@ class ViewHierarchyExtractorTest {
     shadow.setFocused(focused)
     shadow.setActive(active)
     shadow.setBoundsInScreen(
-      Rect(0, 0, 1080, if (type == AccessibilityWindowInfo.TYPE_SYSTEM) 63 else 2400)
+      bounds ?: Rect(0, 0, 1080, if (type == AccessibilityWindowInfo.TYPE_SYSTEM) 63 else 2400)
     )
     return window
   }

--- a/docs/design-docs/plat/android/accessibility-data-sensitive-windows.md
+++ b/docs/design-docs/plat/android/accessibility-data-sensitive-windows.md
@@ -1,0 +1,72 @@
+# Accessibility-data-sensitive windows (Android 14+)
+
+Issue #6151: `observe` returned only the `com.android.systemui` status bar — and
+`tapOn` had nothing to hit — whenever a runtime permission dialog or the Settings
+Wi-Fi picker was in front, while `uiautomator dump` at the same moment saw the
+full window.
+
+## Root cause
+
+Android 14 added `View#setAccessibilityDataSensitive` /
+`android:accessibilityDataSensitive`. Views marked sensitive (and the windows
+built from them) are delivered only to accessibility services whose service
+config declares `android:isAccessibilityTool="true"`. Every other service gets a
+`null` root for that window: `AccessibilityWindowInfo.getRoot()` and
+`rootInActiveWindow` both return `null`, even though the window is listed with
+the correct `focused=true` / `active=true` flags. `uiautomator` is exempt because
+`UiAutomation` is registered as an accessibility tool.
+
+The permission controller's `GrantPermissionsActivity` and the Settings
+`Settings$WifiSettingsActivity` panel are such surfaces on the API 34 GA image.
+Ground truth captured on `am-api34-ga-arm64`:
+
+```
+$ adb shell dumpsys accessibility | grep A11yWindow
+... id=219, type=TYPE_SYSTEM,      layer=1, bounds=Rect(0, 0 - 1080, 63),   focused=false, active=false ...
+... id=256, type=TYPE_APPLICATION, layer=0, bounds=Rect(0, 0 - 1080, 2400), focused=true,  active=true ...
+
+$ adb logcat -s ViewHierarchyExtractor
+[HIERARCHY-DEBUG] Active window 256 has null root node - accessibility service incomplete
+Occlusion filtering active: false (... windowCount=1)
+```
+
+The window flags were right and `pickPrimaryAppWindowId` selected window 256;
+there was simply no content to extract. The same capture with the tool-declared
+CtrlProxy build returns the Settings panel (14 text nodes) and, for a permission
+dialog, the dialog buttons.
+
+## Fix
+
+- `android/control-proxy/src/main/res/xml/accessibility_service_config.xml`
+  declares `android:isAccessibilityTool="true"`. The attribute is ignored on
+  API < 33. This is the only change that recovers the content; no window-ranking
+  rule can produce nodes the framework withholds.
+- `ViewHierarchyExtractor` detects the notification-permission dialog in
+  whichever window carries it (not only the primary window), and when no window
+  reports focus at all, prefers the topmost application window with a root over
+  a status bar that happens to be marked active.
+- The host freshness verdict distinguishes an incomplete capture
+  (`ctrlProxyIncomplete: true` — the service could not read the focused window)
+  from a stale one, so the client is told to update CtrlProxy instead of pressing
+  home / relaunching, which does not recover this shape.
+
+## Play policy note
+
+Declaring `isAccessibilityTool` is a framework capability, not a Play Store
+entitlement. CtrlProxy is side-loaded onto test devices by AutoMobile and is not
+distributed through Play, so the Play "accessibility tool" declaration review
+does not apply.
+
+## Verifying on a device
+
+```
+adb shell pm revoke com.android.camera2 android.permission.CAMERA
+adb shell am start -n com.android.camera2/com.android.camera.CameraLauncher
+# GrantPermissionsActivity is now in front
+adb shell dumpsys accessibility | grep A11yWindow
+```
+
+Then `observe` must list the dialog's buttons ("While using the app", "Only
+this time", "Don't allow") and `tapOn { selector: { text: "Don't allow" } }`
+must succeed. Note the native fix is inert until the CtrlProxy APK the daemon
+installs is re-cut with the new service config.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - "Screen control mapping": design-docs/mcp/daemon/screen-control-mapping.md
       - "Android JUnit runner": design-docs/plat/android/junit-runner/index.md
       - "Android system tray": design-docs/plat/android/system-tray-lookfor.md
+      - "Android accessibility-data-sensitive windows": design-docs/plat/android/accessibility-data-sensitive-windows.md
       - "Desktop App": design-docs/plat/android/desktop-app.md
       - "iOS Simulator continuity": release/ios-simulator-continuity.md
       - "XCTestRunner CI integration": design-docs/plat/ios/xctestrunner/ci-integration.md

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -233,6 +233,17 @@ function describeStatusBarOnlyCapture(
   };
 }
 
+/**
+ * The service's own incomplete-capture signal (issue #6151), for the freshness
+ * `unavailable` path: a rootless payload never reaches the status-bar geometry
+ * gate, so this is what lets the verdict still name the unreadable focused window.
+ */
+function describeIncompleteCapture(
+  hierarchy: ObserveResult["viewHierarchy"],
+): { sdkInt: number | undefined } | undefined {
+  return hierarchy?.ctrlProxyIncomplete === true ? { sdkInt: hierarchy.sdkInt } : undefined;
+}
+
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
   const activityName = foregroundActivity.split("/")[1] ?? "";
   return (
@@ -643,6 +654,7 @@ export class RealObserveScreen implements ObserveScreen {
           signal,
         ),
         activityAttributionMismatch: postCaptureForeground.activityAttributionMismatch,
+        incompleteCapture: describeIncompleteCapture(result.viewHierarchy),
       });
 
       // Cache the result for future use

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -234,14 +234,38 @@ function describeStatusBarOnlyCapture(
 }
 
 /**
- * The service's own incomplete-capture signal (issue #6151), for the freshness
- * `unavailable` path: a rootless payload never reaches the status-bar geometry
- * gate, so this is what lets the verdict still name the unreadable focused window.
+ * The service's own incomplete-capture signal (issue #6151), scoped to whether it
+ * actually pertains to the SELECTED/focused window.
+ *
+ * `ctrlProxyIncomplete` on the wire is a single, generic flag: CtrlProxy sets it
+ * whenever ANY active window was rootless, including an unrelated active
+ * SystemUI/overlay window that has nothing to do with the focused application
+ * (#6151 follow-up). Converting that flag unconditionally into a retracted
+ * verdict over-corrects: a perfectly good, verified focused-app hierarchy would
+ * be reported `verified: false` / `isFresh: false` on every observe that happens
+ * to catch a transient rootless overlay elsewhere on screen.
+ *
+ * Correlate it the same way `resolveStatusBarOnlyHierarchy` correlates a
+ * wrong-window capture: the observed package is the selected window's own
+ * identity, so when it matches the device's current foreground app, that
+ * window's content is trustworthy and the flag does not describe it — do not
+ * retract. It only describes the selected window when the observed package is
+ * absent or does not match the foreground app (a substituted window from the
+ * incomplete-capture fallback, or no content at all) — the genuine #6151 case,
+ * where the focused app's OWN root was null.
  */
 function describeIncompleteCapture(
   hierarchy: ObserveResult["viewHierarchy"],
+  foreground: string | undefined,
 ): { sdkInt: number | undefined } | undefined {
-  return hierarchy?.ctrlProxyIncomplete === true ? { sdkInt: hierarchy.sdkInt } : undefined;
+  if (hierarchy?.ctrlProxyIncomplete !== true) {
+    return undefined;
+  }
+  const observed = hierarchy.packageName;
+  if (foreground !== undefined && observed !== undefined && observed === foreground) {
+    return undefined;
+  }
+  return { sdkInt: hierarchy.sdkInt };
 }
 
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
@@ -654,7 +678,10 @@ export class RealObserveScreen implements ObserveScreen {
           signal,
         ),
         activityAttributionMismatch: postCaptureForeground.activityAttributionMismatch,
-        incompleteCapture: describeIncompleteCapture(result.viewHierarchy),
+        incompleteCapture: describeIncompleteCapture(
+          result.viewHierarchy,
+          await foregroundIdentity,
+        ),
       });
 
       // Cache the result for future use

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -253,6 +253,16 @@ function describeStatusBarOnlyCapture(
  * absent or does not match the foreground app (a substituted window from the
  * incomplete-capture fallback, or no content at all) — the genuine #6151 case,
  * where the focused app's OWN root was null.
+ *
+ * `foreground` MUST be the SETTLED/confirmed identity (the same post-capture
+ * sample `resolveWindowIdentityMismatch` and `resolveStatusBarOnlyHierarchy`
+ * trust), never the initial parallel sample taken before capture. During an
+ * A→B app transition the initial sample can still read A while the hierarchy
+ * (and the confirming read) are already on B; comparing against the stale
+ * initial sample would see `observed (B) !== initial foreground (A)` and
+ * retract freshness even though B was just confirmed as the settled foreground
+ * — discarding the very confirmation the rest of this freshness logic relies on
+ * (#6151 follow-up).
  */
 function describeIncompleteCapture(
   hierarchy: ObserveResult["viewHierarchy"],
@@ -678,9 +688,16 @@ export class RealObserveScreen implements ObserveScreen {
           signal,
         ),
         activityAttributionMismatch: postCaptureForeground.activityAttributionMismatch,
+        // The SETTLED/confirmed foreground, not the initial parallel sample: during an
+        // A→B transition the initial sample can still read A while the hierarchy and the
+        // confirming read are already on B, and comparing against stale A would retract a
+        // capture that was just confirmed as B (#6151 follow-up). Only sampled when the
+        // flag is actually set — the common case never pays the extra device read.
         incompleteCapture: describeIncompleteCapture(
           result.viewHierarchy,
-          await foregroundIdentity,
+          result.viewHierarchy?.ctrlProxyIncomplete === true
+            ? await this.confirmForegroundIdentity(postCaptureForeground, signal)
+            : undefined,
         ),
       });
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1654,12 +1654,22 @@ export class RealObserveScreen implements ObserveScreen {
     return { observed, foreground };
   }
 
+  /**
+   * Status-bar-only capture gate. The returned `ctrlProxyIncomplete` distinguishes
+   * the two device-side causes so the verdict can name the right recovery:
+   * a stale window the runner keeps serving (home/relaunch recovers it) versus a
+   * focused application window the accessibility service could not read at all
+   * (issue #6151 — an accessibility-data-sensitive surface such as a runtime
+   * permission dialog or the Settings Wi-Fi picker, which Android 14+ withholds
+   * from a service that does not declare `isAccessibilityTool`; only a CtrlProxy
+   * update recovers it, and home/relaunch does not).
+   */
   private async resolveStatusBarOnlyHierarchy(
     result: ObserveResult,
     foregroundIdentity: Promise<string | undefined>,
     postCaptureForeground: PostCaptureForegroundIdentity,
     signal?: AbortSignal,
-  ): Promise<{ foreground: string } | undefined> {
+  ): Promise<{ foreground: string; ctrlProxyIncomplete: boolean } | undefined> {
     const foreground = await foregroundIdentity;
     const hierarchy = result.viewHierarchy;
 
@@ -1703,7 +1713,7 @@ export class RealObserveScreen implements ObserveScreen {
     ) {
       return undefined;
     }
-    return { foreground: confirmed };
+    return { foreground: confirmed, ctrlProxyIncomplete: hierarchy?.ctrlProxyIncomplete === true };
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -217,6 +217,22 @@ function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
   return hasBounds;
 }
 
+/**
+ * The status-bar-only verdict inputs (issue #6151): whether the service itself
+ * reported the focused window as unreadable, and the device API level that
+ * decides whether that can be Android 14+ data-sensitive withholding.
+ */
+function describeStatusBarOnlyCapture(
+  hierarchy: ObserveResult["viewHierarchy"],
+  foreground: string,
+): { foreground: string; ctrlProxyIncomplete: boolean; sdkInt: number | undefined } {
+  return {
+    foreground,
+    ctrlProxyIncomplete: hierarchy?.ctrlProxyIncomplete === true,
+    sdkInt: hierarchy?.sdkInt,
+  };
+}
+
 function isAccessibilityViewClass(foregroundActivity: string): boolean {
   const activityName = foregroundActivity.split("/")[1] ?? "";
   return (
@@ -1669,7 +1685,9 @@ export class RealObserveScreen implements ObserveScreen {
     foregroundIdentity: Promise<string | undefined>,
     postCaptureForeground: PostCaptureForegroundIdentity,
     signal?: AbortSignal,
-  ): Promise<{ foreground: string; ctrlProxyIncomplete: boolean } | undefined> {
+  ): Promise<
+    { foreground: string; ctrlProxyIncomplete: boolean; sdkInt: number | undefined } | undefined
+  > {
     const foreground = await foregroundIdentity;
     const hierarchy = result.viewHierarchy;
 
@@ -1713,7 +1731,7 @@ export class RealObserveScreen implements ObserveScreen {
     ) {
       return undefined;
     }
-    return { foreground: confirmed, ctrlProxyIncomplete: hierarchy?.ctrlProxyIncomplete === true };
+    return describeStatusBarOnlyCapture(hierarchy, confirmed);
   }
 
   /**

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -670,6 +670,9 @@ export class CtrlProxyHierarchy {
           rotation: accessibilityHierarchy.rotation,
           systemInsets: accessibilityHierarchy.systemInsets,
           insets: accessibilityHierarchy.insets,
+          // The API level decides whether a rootless incomplete capture can be Android 14+
+          // data-sensitive withholding (issue #6151), so keep it on this branch too.
+          sdkInt: accessibilityHierarchy.sdkInt,
           // Carry the #4548 scale metadata through the rootless / UIAutomator-fallback branch too,
           // so #4549 can consume it regardless of which route produced the hierarchy. Same
           // all-or-nothing validator as the main return and client retention.

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -89,6 +89,13 @@ export interface FreshnessInputs {
    */
   statusBarOnlyHierarchy?: { foreground: string; ctrlProxyIncomplete?: boolean; sdkInt?: number };
   /**
+   * The accessibility service reported the capture as incomplete (`ctrlProxyIncomplete`): it
+   * could not read the focused application window. Consulted on the `unavailable` path, where a
+   * rootless payload (no hierarchy node at all) never reaches the status-bar geometry gate but
+   * still deserves the same recovery guidance (issue #6151).
+   */
+  incompleteCapture?: { sdkInt?: number };
+  /**
    * ADB and CtrlProxy disagree about the current activity within the same
    * application, and a forced recapture could not safely reconcile them.
    */
@@ -184,7 +191,17 @@ const ACCESSIBILITY_DATA_SENSITIVE_MIN_SDK = 34;
  * which a CtrlProxy update (not home/relaunch) recovers.
  */
 function unreadableFocusedWindowWarning(foreground: string, sdkInt: number | undefined): string {
-  const generic = `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}, and the accessibility service reported the focused application window as unreadable (no root node). This capture is incomplete rather than a stale window: the foreground window's content did not reach the service. Observe again; if it stays unreadable after relaunching the app, the window's content is being withheld from the service.`;
+  return `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}, and the accessibility service reported the focused application window as unreadable (no root node). This capture is incomplete rather than a stale window: the foreground window's content did not reach the service. ${incompleteCaptureGuidance(sdkInt)}`;
+}
+
+/**
+ * Recovery guidance shared by every incomplete-capture verdict: retry first
+ * (the null root can be transient), and on Android 14+ name the data-sensitive
+ * withholding that only a CtrlProxy update recovers.
+ */
+function incompleteCaptureGuidance(sdkInt: number | undefined): string {
+  const generic =
+    "Observe again; if it stays unreadable after relaunching the app, the window's content is being withheld from the service.";
   if (sdkInt === undefined || sdkInt < ACCESSIBILITY_DATA_SENSITIVE_MIN_SDK) {
     return generic;
   }
@@ -235,6 +252,18 @@ function resolveIdentityMismatch(
 }
 
 /**
+ * The `unavailable` warning. A rootless payload that carries the service's own
+ * incomplete flag (issue #6151) names the unreadable focused window and its
+ * recovery instead of a bare "could not be retrieved".
+ */
+function unavailableWarning(incompleteCapture: FreshnessInputs["incompleteCapture"]): string {
+  if (!incompleteCapture) {
+    return "View hierarchy could not be retrieved, so its freshness cannot be established.";
+  }
+  return `View hierarchy could not be retrieved: the accessibility service reported the capture as incomplete because it could not read the focused application window (no root node). ${incompleteCaptureGuidance(incompleteCapture.sdkInt)}`;
+}
+
+/**
  * Compute the freshness verdict.
  *
  * The `requestedAfter` branch is unchanged from the original implementation, so
@@ -254,7 +283,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       ageMs,
       verified,
       isFresh: false,
-      warning: "View hierarchy could not be retrieved, so its freshness cannot be established.",
+      warning: unavailableWarning(inputs.incompleteCapture),
     };
   }
 

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -92,7 +92,10 @@ export interface FreshnessInputs {
    * The accessibility service reported the capture as incomplete (`ctrlProxyIncomplete`): it
    * could not read the focused application window. Consulted on the `unavailable` path, where a
    * rootless payload (no hierarchy node at all) never reaches the status-bar geometry gate but
-   * still deserves the same recovery guidance (issue #6151).
+   * still deserves the same recovery guidance, AND on the otherwise-readable path: split-screen
+   * or a dialog transition can leave a non-error hierarchy for another window while the focused
+   * application's root was still null, which trips neither `unavailable` nor
+   * `statusBarOnlyHierarchy`. Either way freshness is retracted (issue #6151).
    */
   incompleteCapture?: { sdkInt?: number };
   /**
@@ -246,6 +249,23 @@ function resolveIdentityMismatch(
       isFresh: false,
       warning:
         "CtrlProxy and adb disagree about the current activity, and a fresh hierarchy could not reconcile them. The observation was not verified against the current activity; call observe again.",
+    };
+  }
+  // The service reported the focused application's root as unreadable even
+  // though the capture is otherwise readable (a status bar or an unrelated
+  // window's content came through) — a split-screen pane or a dialog
+  // transition can leave a non-null, non-error hierarchy that never trips the
+  // `unavailable` or status-bar-only gates above. Retract freshness anyway:
+  // the tree is honest about SOME window, but not about the focused
+  // application (issue #6151).
+  if (inputs.incompleteCapture) {
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning: `The accessibility service reported the capture as incomplete: it could not read the focused application's root window, even though another window's content was readable. ${incompleteCaptureGuidance(inputs.incompleteCapture.sdkInt)}`,
     };
   }
   return undefined;

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -80,9 +80,11 @@ export interface FreshnessInputs {
   /**
    * The hierarchy contains only status-bar content while a non-system app is resumed. This is a
    * device-side wrong-window capture even when System UI would normally be a legitimate
-   * accessibility window.
+   * accessibility window. `ctrlProxyIncomplete` is set when the accessibility service itself
+   * reported that it could not read the focused application window (a null root), which is an
+   * incomplete capture rather than a stale one and needs a different recovery (issue #6151).
    */
-  statusBarOnlyHierarchy?: { foreground: string };
+  statusBarOnlyHierarchy?: { foreground: string; ctrlProxyIncomplete?: boolean };
   /**
    * ADB and CtrlProxy disagree about the current activity within the same
    * application, and a forced recapture could not safely reconcile them.
@@ -181,13 +183,18 @@ function resolveIdentityMismatch(
     };
   }
   if (inputs.statusBarOnlyHierarchy) {
+    const { foreground, ctrlProxyIncomplete } = inputs.statusBarOnlyHierarchy;
     return {
       requestedAfter,
       actualTimestamp,
       ageMs,
       verified: false,
       isFresh: false,
-      warning: `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${inputs.statusBarOnlyHierarchy.foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+      warning: ctrlProxyIncomplete
+        ? // The service could not read the focused window at all: home/relaunch does not
+          // recover it (issue #6151), so do not send the client down that path.
+          `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}, and the accessibility service reported the focused application window as unreadable (no root node). This capture is incomplete, not stale: the foreground window's content was withheld from the service. On Android 14+ this is the shape of an accessibility-data-sensitive surface (a runtime permission dialog, the Settings Wi-Fi picker) read by a CtrlProxy build that does not declare isAccessibilityTool; pressing home or relaunching the app will not recover it. Update CtrlProxy to a build that declares isAccessibilityTool (fix for #6151) and observe again.`
+        : `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
     };
   }
   if (inputs.activityAttributionMismatch) {

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -83,8 +83,11 @@ export interface FreshnessInputs {
    * accessibility window. `ctrlProxyIncomplete` is set when the accessibility service itself
    * reported that it could not read the focused application window (a null root), which is an
    * incomplete capture rather than a stale one and needs a different recovery (issue #6151).
+   * `sdkInt` is the device API level when the capture reported one: the null root is a generic
+   * signal (transient, app-restricted, or withheld), and only on Android 14+ can it be the
+   * accessibility-data-sensitive withholding that a CtrlProxy update fixes.
    */
-  statusBarOnlyHierarchy?: { foreground: string; ctrlProxyIncomplete?: boolean };
+  statusBarOnlyHierarchy?: { foreground: string; ctrlProxyIncomplete?: boolean; sdkInt?: number };
   /**
    * ADB and CtrlProxy disagree about the current activity within the same
    * application, and a forced recapture could not safely reconcile them.
@@ -166,6 +169,28 @@ function resolveAgeMs(
   return ageBasis !== undefined ? Math.max(0, now - ageBasis) : undefined;
 }
 
+/**
+ * First API level on which the framework withholds accessibility-data-sensitive
+ * views (and so whole windows such as runtime permission dialogs) from an
+ * accessibility service that does not declare `isAccessibilityTool`.
+ */
+const ACCESSIBILITY_DATA_SENSITIVE_MIN_SDK = 34;
+
+/**
+ * The service could not read the focused application window (issue #6151). The
+ * null root is a generic signal — it also covers a transient root and an app
+ * that restricts accessibility — so the advice is to retry first; only on
+ * Android 14+ is the persistent case attributable to data-sensitive withholding,
+ * which a CtrlProxy update (not home/relaunch) recovers.
+ */
+function unreadableFocusedWindowWarning(foreground: string, sdkInt: number | undefined): string {
+  const generic = `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}, and the accessibility service reported the focused application window as unreadable (no root node). This capture is incomplete rather than a stale window: the foreground window's content did not reach the service. Observe again; if it stays unreadable after relaunching the app, the window's content is being withheld from the service.`;
+  if (sdkInt === undefined || sdkInt < ACCESSIBILITY_DATA_SENSITIVE_MIN_SDK) {
+    return generic;
+  }
+  return `${generic} On Android 14+ a persistently unreadable focused window is the shape of an accessibility-data-sensitive surface (a runtime permission dialog, the Settings Wi-Fi picker) read by a CtrlProxy build that does not declare isAccessibilityTool; pressing home or relaunching does not recover that case. Update CtrlProxy to a build that declares isAccessibilityTool (fix for #6151) and observe again.`;
+}
+
 function resolveIdentityMismatch(
   inputs: FreshnessInputs,
   ageMs: number | undefined,
@@ -183,7 +208,7 @@ function resolveIdentityMismatch(
     };
   }
   if (inputs.statusBarOnlyHierarchy) {
-    const { foreground, ctrlProxyIncomplete } = inputs.statusBarOnlyHierarchy;
+    const { foreground, ctrlProxyIncomplete, sdkInt } = inputs.statusBarOnlyHierarchy;
     return {
       requestedAfter,
       actualTimestamp,
@@ -191,9 +216,7 @@ function resolveIdentityMismatch(
       verified: false,
       isFresh: false,
       warning: ctrlProxyIncomplete
-        ? // The service could not read the focused window at all: home/relaunch does not
-          // recover it (issue #6151), so do not send the client down that path.
-          `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}, and the accessibility service reported the focused application window as unreadable (no root node). This capture is incomplete, not stale: the foreground window's content was withheld from the service. On Android 14+ this is the shape of an accessibility-data-sensitive surface (a runtime permission dialog, the Settings Wi-Fi picker) read by a CtrlProxy build that does not declare isAccessibilityTool; pressing home or relaunching the app will not recover it. Update CtrlProxy to a build that declares isAccessibilityTool (fix for #6151) and observe again.`
+        ? unreadableFocusedWindowWarning(foreground, sdkInt)
         : `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
     };
   }

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -737,6 +737,52 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).not.toContain("stale wrong-window");
   });
 
+  test("names the incomplete capture on a rootless payload that never reaches the geometry gate (#6151)", async () => {
+    // The shape the pinned CtrlProxy emits for a runtime permission dialog on API 34: no
+    // window could be extracted at all, so there is no hierarchy node and the status-bar
+    // geometry gate cannot fire. The service's own incomplete flag must still drive the
+    // verdict, and the rootless conversion must keep the API level for the diagnosis.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      ctrlProxyIncomplete: true,
+      sdkInt: 34,
+      hierarchy: { error: "No visible windows available" },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.permissioncontroller", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("incomplete");
+    expect(result.freshness?.warning).toContain("no root node");
+    expect(result.freshness?.warning).toContain("isAccessibilityTool");
+  });
+
   test("keeps the incomplete-capture verdict generic below Android 14 (#6151)", async () => {
     // `ctrlProxyIncomplete` is a generic null-root signal (transient root, an app that
     // restricts accessibility). Only Android 14+ can withhold a data-sensitive window, so on

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -934,6 +934,50 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.verified).toBe(true);
   });
 
+  test("REGRESSION: an incomplete-capture flag from an unrelated overlay is not retracted against a stale initial sample during an A→B transition (#6151 follow-up)", async () => {
+    // Same A→B transition shape as the test above (initial sample lags on A =
+    // settings, the hierarchy and confirming read are already on B = calendar),
+    // but this time the hierarchy ALSO carries `ctrlProxyIncomplete: true` (an
+    // unrelated overlay was transiently rootless). Correlating that flag
+    // against the STALE INITIAL sample (A) would see observed(B) != initial(A)
+    // and wrongly retract freshness even though B was just confirmed as the
+    // settled foreground — discarding the very confirmation
+    // `resolveWindowIdentityMismatch` already trusts.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(now),
+      // CtrlProxy has not yet updated the active window from Settings.
+      foregroundActivity: "com.android.settings/.Settings",
+      ctrlProxyIncomplete: true,
+      sdkInt: 34,
+    }); // observed = calendar (B), fully readable
+
+    // First getForegroundApp read lags (still reports settings = A); the
+    // confirming read reports calendar (B), matching the observed hierarchy.
+    const sequence = [
+      { packageName: "com.android.settings", userId: 0 },
+      { packageName: "com.google.android.calendar", userId: 0 },
+    ];
+    class SequencedForegroundAdb extends FakeAdbExecutor {
+      async getForegroundApp(): Promise<{ packageName: string; userId: number } | null> {
+        return sequence.shift() ?? { packageName: "com.google.android.calendar", userId: 0 };
+      }
+    }
+    const fakeAdb = new SequencedForegroundAdb();
+
+    const screen = makeScreen(viewHierarchy, fakeAdb);
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.google.android.calendar");
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("does not overwrite a newer active window with a stale hierarchy", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -656,6 +656,121 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toContain("com.android.settings");
   });
 
+  // Issue #6151: the exact shape captured on an API 34 emulator with the Settings
+  // Wi-Fi picker (or a runtime permission dialog) in front. The focused
+  // application window exists but the accessibility service cannot read its root
+  // (Android 14+ withholds accessibility-data-sensitive surfaces from a service
+  // that does not declare `isAccessibilityTool`), so CtrlProxy emits only the
+  // status-bar window, no package, `ctrlProxyIncomplete: true`, and no activity.
+  // The verdict must retract freshness AND name the actual cause: pressing home
+  // or relaunching (the stale-window advice) does not recover this capture.
+  const unreadableFocusedWindowHierarchy = (now: number) => ({
+    updatedAt: now,
+    receivedAt: now,
+    fresh: true,
+    screenWidth: 1080,
+    screenHeight: 2400,
+    systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+    ctrlProxyIncomplete: true,
+    windows: [
+      {
+        id: 219,
+        type: 3,
+        isActive: false,
+        isFocused: false,
+        bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+      },
+    ],
+    hierarchy: {
+      node: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+        node: [
+          {
+            "resource-id": "com.android.systemui:id/clock",
+            text: "8:33",
+            bounds: { left: 21, top: 0, right: 107, bottom: 63 },
+          },
+          {
+            "resource-id": "com.android.systemui:id/wifi_signal",
+            "content-desc": "Wifi signal full.",
+            bounds: { left: 892, top: 11, right: 931, bottom: 50 },
+          },
+        ],
+      },
+    },
+  });
+
+  test("names the unreadable focused window as the cause when the service reports an incomplete capture (#6151)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy(unreadableFocusedWindowHierarchy(now) as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("com.android.settings");
+    expect(result.freshness?.warning).toContain("unreadable");
+    expect(result.freshness?.warning).toContain("isAccessibilityTool");
+    // The stale-window recovery advice is wrong for this cause and must not be given.
+    expect(result.freshness?.warning).not.toContain("pressButton");
+    expect(result.freshness?.warning).not.toContain("stale wrong-window");
+  });
+
+  test("keeps the stale-window advice for a status-bar-only capture the service did not report as incomplete (#6151)", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      ...unreadableFocusedWindowHierarchy(now),
+      ctrlProxyIncomplete: undefined,
+      packageName: "com.android.systemui",
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("stale wrong-window");
+    expect(result.freshness?.warning).not.toContain("isAccessibilityTool");
+  });
+
   test("a transient app transition is not flagged: the confirming read settles onto the observed app", async () => {
     // The parallel foreground sample lags the newer captured hierarchy during an
     // A→B transition: sample1 = the old app, observed hierarchy = the new app.

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -857,6 +857,34 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).not.toContain("isAccessibilityTool");
   });
 
+  test("REGRESSION: does not retract freshness when an unrelated overlay is rootless but the focused app is fully readable (#6151 follow-up)", async () => {
+    // `ctrlProxyIncomplete` is a generic wire flag: CtrlProxy sets it whenever ANY active
+    // window was rootless, including a transient SystemUI/overlay window that has nothing to
+    // do with the focused application. Here the captured hierarchy IS the focused app's own,
+    // full content (package matches the foreground app), so the flag must not retract
+    // freshness — that would be an over-correction of the real #6151 fix.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      ...calendarHierarchy(now),
+      ctrlProxyIncomplete: true,
+      sdkInt: 34,
+    });
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.calendar", userId: 0 });
+
+    const screen = makeScreen(viewHierarchy, fakeAdb);
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.verified).toBe(true);
+  });
+
   test("a transient app transition is not flagged: the confirming read settles onto the observed app", async () => {
     // The parallel foreground sample lags the newer captured hierarchy during an
     // A→B transition: sample1 = the old app, observed hierarchy = the new app.

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -672,6 +672,7 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     screenHeight: 2400,
     systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
     ctrlProxyIncomplete: true,
+    sdkInt: 34,
     windows: [
       {
         id: 219,
@@ -733,6 +734,45 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     expect(result.freshness?.warning).toContain("isAccessibilityTool");
     // The stale-window recovery advice is wrong for this cause and must not be given.
     expect(result.freshness?.warning).not.toContain("pressButton");
+    expect(result.freshness?.warning).not.toContain("stale wrong-window");
+  });
+
+  test("keeps the incomplete-capture verdict generic below Android 14 (#6151)", async () => {
+    // `ctrlProxyIncomplete` is a generic null-root signal (transient root, an app that
+    // restricts accessibility). Only Android 14+ can withhold a data-sensitive window, so on
+    // an older API the verdict must not attribute the cause to isAccessibilityTool.
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      ...unreadableFocusedWindowHierarchy(now),
+      sdkInt: 31,
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.warning).toContain("unreadable");
+    expect(result.freshness?.warning).toContain("Observe again");
+    expect(result.freshness?.warning).not.toContain("isAccessibilityTool");
     expect(result.freshness?.warning).not.toContain("stale wrong-window");
   });
 

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -249,6 +249,37 @@ describe("computeFreshness", () => {
     });
   });
 
+  describe("incomplete-but-readable capture (issue #6151 follow-up)", () => {
+    test("REGRESSION: a readable capture with a null focused-app root is NOT verified or fresh", () => {
+      // The focused application's root was null (split-screen or a dialog
+      // transition), but CtrlProxy still emitted a non-error, non-status-bar
+      // hierarchy for another window. `unavailable` is false and the
+      // status-bar gate does not match, so without this branch the verdict
+      // fell through to the device-verified/recent case and read fresh.
+      const v = computeFreshness({
+        actualTimestamp: NOW - 50,
+        now: NOW,
+        verified: true,
+        unavailable: false,
+        incompleteCapture: { sdkInt: 34 },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("could not read the focused application's root window");
+    });
+
+    test("the unavailable path still wins when the capture has no readable content at all", () => {
+      const v = computeFreshness({
+        actualTimestamp: NOW,
+        now: NOW,
+        unavailable: true,
+        incompleteCapture: { sdkInt: 34 },
+      });
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("could not be retrieved");
+    });
+  });
+
   test("every `isFresh: false` names its cause", () => {
     const falseCases = [
       computeFreshness({ actualTimestamp: NOW - 999_999, now: NOW }),


### PR DESCRIPTION
Closes #6151

## Summary

`observe` returned only the `com.android.systemui` status bar — and `tapOn` had nothing to hit — whenever a runtime permission dialog or the Settings Wi-Fi picker was in front, while `uiautomator dump` saw the full window at the same moment.

## Root cause (verified on `am-api34-ga-arm64`, `emulator-5554`)

This is **not** a window-ranking bug. `dumpsys accessibility` at the failing moment shows the focused window with the right flags, and `pickPrimaryAppWindowId` selects it:

```
A11yWindow[... id=219, type=TYPE_SYSTEM,      layer=1, bounds=Rect(0, 0 - 1080, 63),   focused=false, active=false ...]
A11yWindow[... id=256, type=TYPE_APPLICATION, layer=0, bounds=Rect(0, 0 - 1080, 2400), focused=true,  active=true  ...]   <- Settings$WifiSettingsActivity
```

but CtrlProxy cannot read it:

```
W ViewHierarchyExtractor: [HIERARCHY-DEBUG] Active window 256 has null root node - accessibility service incomplete
D ViewHierarchyExtractor: Occlusion filtering active: false (... windowCount=1)
```

`AccessibilityWindowInfo.getRoot()` **and** `rootInActiveWindow` are both `null` for that window. Android 14 added `accessibilityDataSensitive`: views/windows marked sensitive are delivered only to accessibility services whose config declares `android:isAccessibilityTool="true"`. The permission controller's `GrantPermissionsActivity` and the Settings Wi-Fi panel are such surfaces; `uiautomator` sees them because `UiAutomation` is registered as an accessibility tool. CtrlProxy's `accessibility_service_config.xml` never declared it, so the framework withheld the whole window — there was no content for any selection rule to pick.

Control experiment against the same permission dialog (`GrantPermissionsActivity`, camera permission), driving the on-device CtrlProxy directly over its WebSocket so the daemon's APK re-pin could not interfere:

| CtrlProxy build | Wi-Fi picker | Permission dialog |
|---|---|---|
| pinned (no `isAccessibilityTool`) | `packageName: null, ctrlProxyIncomplete: true`, 1 status-bar window, 1 text | 1.6 KB frame, no hierarchy |
| this branch (`isAccessibilityTool="true"`) | `packageName: com.android.settings`, windows 219+302, 14 texts (`Wi-Fi`, `AndroidWifi`, `Add network`, ...) | `packageName: ...permissioncontroller`, 4 texts (`Allow Camera to take pictures and record video?`, `While using the app`, `Only this time`, `Don't allow`) |

Why the reporter also saw `freshness.verified: true`: the published `0.0.67` npm daemon predates the host status-bar-only gate (#6048 / #6142 landed after the publish). Current `main` already retracts freshness for this shape, but tells the client to press home / relaunch, which does not recover it.

## Changes

**Native (`android/control-proxy`)** — inert for users until the CtrlProxy APK is re-cut/re-pinned (the nightly re-cut only updates the NIGHTLY registry entry):
- `accessibility_service_config.xml`: declare `android:isAccessibilityTool="true"` (ignored on API < 33). This is the change that recovers the content.
- `ViewHierarchyExtractor`: detect the notification-permission dialog in the primary window or any focused/active window (a dialog owns focus while it is up, even mid-transition), never in a bystander window such as another app's dialog in split-screen; when no window reports focus at all (the flag is not populated on every API level), prefer the active application window with a root, then the topmost one, over a status bar that happens to be marked active. A focused non-app window (shade / quick settings / keyguard) keeps the active-window fallback so `systemTray` is unaffected.

**Host (`src/features/observe`)**:
- `resolveStatusBarOnlyHierarchy` carries `ctrlProxyIncomplete` and the device `sdkInt`; the freshness verdict now distinguishes an *incomplete* capture (the service reported the focused window as unreadable) from a *stale* one. The null root is a generic signal, so the verdict keeps retry/relaunch guidance and only on Android 14+ adds the data-sensitive diagnosis and the "update CtrlProxy" recovery (home/relaunch does not apply to that case). The same guidance is given on the `unavailable` path for a rootless payload (no hierarchy node at all — the shape the pinned CtrlProxy emits for a permission dialog), which never reaches the status-bar geometry gate; the rootless conversion in `CtrlProxyHierarchy.ts` now keeps `sdkInt` for that.

Follow-up: #6172 tracks re-cutting and re-pinning the CtrlProxy Android APK so the `isAccessibilityTool` declaration reaches plain daemon installs.

**Docs**: `docs/design-docs/plat/android/accessibility-data-sensitive-windows.md` (+ mkdocs nav) records the mechanism, the ground-truth captures, and the device verification recipe.

## Tests

- Kotlin (`ViewHierarchyExtractorTest`, 85 pass): new `pickPrimaryAppWindowId` shapes — app + permission dialog, app + Settings sub-panel, plain app with no focus flags, status bar only, focused system window; two `extractFromAllWindows` tests on Robolectric `AccessibilityWindowInfo`/`AccessibilityNodeInfo` fakes: notification dialog detected in a non-primary window, and the withheld-root shape reported as `ctrlProxyIncomplete` with no package label.
- Host (`ObserveScreenWindowIdentity.test.ts`, red-first): the exact device shape (`packageName` absent, `ctrlProxyIncomplete: true`, `sdkInt: 34`, status-bar-only geometry) retracts freshness and names the unreadable window / `isAccessibilityTool`, never the stale-window advice; the same shape on API 31 stays generic (no `isAccessibilityTool` attribution); the plain status-bar-only shape keeps the stale-window advice.

## Validation

- `bun run lint`, `bun run build`, `bun test` (15380 pass; the one failure, `test/integration/webrtcDeviceCaptureLoad.integration.test.ts`, is a pre-existing local bun-output-format assertion unrelated to this change), `bun run format:check`, `bun run typecheck` (no new errors), `scripts/all_fast_validate_checks.sh`.
- `./gradlew :control-proxy:testDebugUnitTest --tests '*ViewHierarchyExtractorTest*'`, `:control-proxy:detekt`, ktfmt 0.64 (`scripts/ktfmt/validate_ktfmt.sh`).
- Device: CtrlProxy debug APK built from this branch, installed on the API 34 emulator, both repro scenarios probed directly at the CtrlProxy WebSocket (table above). Not verified end-to-end through the daemon's `tapOn`: the shared resident daemon on this machine is another session's published `0.0.67` and re-pins its own APK on SHA mismatch, so the daemon path could only ever exercise the old build.
