### PR TITLE
fix(swipeon): stop counting the container's own ancestors as overlays

### DIFF
--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -55,12 +55,22 @@ export class OverlayDetector implements OverlayAnalyzer {
     // exact "No unobstructed swipe area" fallback this file exists to avoid.
     // Resolving strictly against containerElement's own bounds (requiring a
     // unique match) anchors identity to the node actually being swiped.
-    const containerNode = this.resolveSelectedContainerNode(
+    //
+    // resolveSelectedContainerNode also hands back the exact root-node list
+    // the identified node came from (main hierarchy, or one specific
+    // window). The ancestor walk MUST run over that same source tree, not
+    // `rootGroups`: `rootGroups` holds only the per-window trees once any
+    // window exists, so a node the finder resolved from the main hierarchy
+    // would never be found there by identity, always yielding an empty
+    // (safe-fallback) ancestor set — silently reintroducing the full-cover
+    // overlay / blocked-swipe bug for every main-hierarchy selection.
+    const selectedContainer = this.resolveSelectedContainerNode(
       viewHierarchy,
       parser,
       containerElement,
       containerBounds,
     );
+    const containerNode = selectedContainer?.node ?? null;
 
     // The container's own ancestors are visited before the container in the
     // pre-order walk below and always geometrically contain it, so a
@@ -68,7 +78,11 @@ export class OverlayDetector implements OverlayAnalyzer {
     // overlay covering the whole container, which left no safe swipe area and
     // forced the "No unobstructed swipe area" fallback (#6128). Ancestors are
     // never overlays — only siblings and other windows are.
-    const containerAncestors = this.collectContainerAncestors(rootGroups, parser, containerNode);
+    const containerAncestors = this.collectContainerAncestors(
+      selectedContainer?.roots ?? null,
+      parser,
+      containerNode,
+    );
 
     rootGroups.forEach((rootNodes, windowIndex) => {
       const windowRank = totalWindows - windowIndex;
@@ -343,8 +357,10 @@ export class OverlayDetector implements OverlayAnalyzer {
   }
 
   /**
-   * Pre-order walk of the same root groups that records the ancestor chain of
-   * the *specific* hierarchy node the finder resolved for the selected
+   * Pre-order walk of the SAME source tree `resolveSelectedContainerNode`
+   * identified the container node from (the main hierarchy's root list, or
+   * the specific window's root list) that records the ancestor chain of the
+   * *specific* hierarchy node the finder resolved for the selected
    * container. Only strict object identity (`===`) anchors the walk: a
    * look-alike node elsewhere in the tree — same resource-id, text, or even
    * identical bounds — is still a distinct parsed object and can never match
@@ -352,19 +368,25 @@ export class OverlayDetector implements OverlayAnalyzer {
    * the skip set (the earlier resource-id/text/bounds heuristic could still
    * be fooled by such a look-alike sharing the real container's bounds).
    *
-   * When the finder did not resolve a container node at all, there is no
-   * identity to anchor the walk to, so this returns an empty skip set rather
-   * than falling back to a selector guess. Missing a real ancestor here is
-   * safe (worst case: a slightly smaller safe-swipe area); suppressing a
-   * genuine overlay is not.
+   * Walking any OTHER source tree than the one the node actually came from
+   * — e.g. `rootGroups`, which holds only the per-window trees once any
+   * window exists — can never find the node by identity even though it was
+   * correctly resolved, silently reintroducing the full-cover-overlay /
+   * blocked-swipe bug for containers selected from the main hierarchy.
+   *
+   * When the finder did not resolve a container node at all (no roots, or
+   * no `containerNode`), there is no identity to anchor the walk to, so this
+   * returns an empty skip set rather than falling back to a selector guess.
+   * Missing a real ancestor here is safe (worst case: a slightly smaller
+   * safe-swipe area); suppressing a genuine overlay is not.
    */
   private collectContainerAncestors(
-    rootGroups: ViewHierarchyNode[][],
+    containerRoots: ViewHierarchyNode[] | null,
     parser: ElementParser,
     containerNode: ViewHierarchyNode | null,
   ): Set<ViewHierarchyNode> {
     const ancestors = new Set<ViewHierarchyNode>();
-    if (!containerNode) {
+    if (!containerNode || !containerRoots) {
       return ancestors;
     }
 
@@ -372,25 +394,23 @@ export class OverlayDetector implements OverlayAnalyzer {
     const path: ViewHierarchyNode[] = [];
     let found = false;
 
-    for (const rootNodes of rootGroups) {
-      for (const rootNode of rootNodes) {
-        parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
-          if (found) {
-            return;
-          }
-          path.length = depth;
-          path[depth] = node;
-
-          if (node === containerNode) {
-            for (const ancestor of path.slice(0, depth)) {
-              ancestors.add(ancestor);
-            }
-            found = true;
-          }
-        });
+    for (const rootNode of containerRoots) {
+      parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
         if (found) {
-          return ancestors;
+          return;
         }
+        path.length = depth;
+        path[depth] = node;
+
+        if (node === containerNode) {
+          for (const ancestor of path.slice(0, depth)) {
+            ancestors.add(ancestor);
+          }
+          found = true;
+        }
+      });
+      if (found) {
+        return ancestors;
       }
     }
 
@@ -407,6 +427,10 @@ export class OverlayDetector implements OverlayAnalyzer {
    * carries none of those) and the exact bounds of the already-selected
    * `containerElement` — i.e. the specific node findTargetElement's
    * area-sorted resolution picked, not merely "a" node sharing its selector.
+   * Returns that node together with the root-node list it was found in, so
+   * callers (see collectContainerAncestors) can walk the SAME source tree
+   * the node actually lives in rather than a different one that would never
+   * contain it.
    *
    * Searches the SAME source set in the SAME order ElementFinder itself
    * uses to resolve an element: the main hierarchy first, then the
@@ -419,16 +443,16 @@ export class OverlayDetector implements OverlayAnalyzer {
    *
    * When more than one node satisfies both the selector and those exact
    * bounds within the chosen source, or none does anywhere, identity is
-   * ambiguous: callers (see collectContainerAncestors) must treat that the
-   * same as "not found" rather than guess, since guessing wrong donates a
-   * stranger's ancestors to the skip set instead of the real target's.
+   * ambiguous: callers must treat that the same as "not found" rather than
+   * guess, since guessing wrong donates a stranger's ancestors to the skip
+   * set instead of the real target's.
    */
   private resolveSelectedContainerNode(
     viewHierarchy: ViewHierarchyResult,
     parser: ElementParser,
     containerElement: Element,
     containerBounds: Element["bounds"],
-  ): ViewHierarchyNode | null {
+  ): { node: ViewHierarchyNode; roots: ViewHierarchyNode[] } | null {
     const mainRootNodes = parser.extractRootNodes(viewHierarchy);
     const mainResult = this.findSelectorBoundsMatch(
       mainRootNodes,
@@ -437,7 +461,9 @@ export class OverlayDetector implements OverlayAnalyzer {
       containerBounds,
     );
     if (mainResult.matchCount > 0) {
-      return mainResult.matchCount === 1 ? mainResult.match : null;
+      return mainResult.matchCount === 1 && mainResult.match
+        ? { node: mainResult.match, roots: mainRootNodes }
+        : null;
     }
 
     const windowRootGroups = parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
@@ -449,7 +475,9 @@ export class OverlayDetector implements OverlayAnalyzer {
         containerBounds,
       );
       if (windowResult.matchCount > 0) {
-        return windowResult.matchCount === 1 ? windowResult.match : null;
+        return windowResult.matchCount === 1 && windowResult.match
+          ? { node: windowResult.match, roots: windowRoots }
+          : null;
       }
     }
 
@@ -501,38 +529,44 @@ export class OverlayDetector implements OverlayAnalyzer {
     return this.matchesContainerSelector(node, nodeProperties, containerElement, containerBounds);
   }
 
+  /**
+   * A node matches the selected `containerElement` only when EVERY one of
+   * its populated identifying fields (resource-id, text, content-desc)
+   * agrees — AND, not OR. OR-matching on any single populated field meant a
+   * sibling sharing only one of several identifying fields (e.g. the same
+   * resource-id but different text) counted as a match too. During identity
+   * resolution that turns a genuinely unique node into a false second match
+   * (ambiguous → the safe empty-ancestor fallback → the full-cover-overlay
+   * bug resurfaces for a case that was never actually ambiguous).
+   *
+   * Bounds-only fallback matching applies only when containerElement carries
+   * none of resource-id/text/content-desc at all — an anonymous element
+   * identified purely by position.
+   */
   private matchesContainerSelector(
     node: ViewHierarchyNode,
     nodeProperties: Record<string, unknown>,
     containerElement: Element,
     containerBounds: Element["bounds"],
   ): boolean {
-    const resourceId = nodeProperties["resource-id"];
-    if (containerElement["resource-id"] && resourceId === containerElement["resource-id"]) {
-      return true;
-    }
+    const hasResourceId = Boolean(containerElement["resource-id"]);
+    const hasText = Boolean(containerElement.text);
+    const hasContentDesc = Boolean(containerElement["content-desc"]);
 
-    const nodeText = nodeProperties.text;
-    if (containerElement.text && nodeText === containerElement.text) {
-      return true;
-    }
-
-    const nodeContentDesc = nodeProperties["content-desc"];
-    if (containerElement["content-desc"] && nodeContentDesc === containerElement["content-desc"]) {
-      return true;
-    }
-
-    if (
-      !containerElement["resource-id"] &&
-      !containerElement.text &&
-      !containerElement["content-desc"]
-    ) {
-      const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
-      if (parsedBounds && boundsEqual(parsedBounds, containerBounds)) {
-        return true;
+    if (hasResourceId || hasText || hasContentDesc) {
+      if (hasResourceId && nodeProperties["resource-id"] !== containerElement["resource-id"]) {
+        return false;
       }
+      if (hasText && nodeProperties.text !== containerElement.text) {
+        return false;
+      }
+      if (hasContentDesc && nodeProperties["content-desc"] !== containerElement["content-desc"]) {
+        return false;
+      }
+      return true;
     }
 
-    return false;
+    const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
+    return parsedBounds !== null && boundsEqual(parsedBounds, containerBounds);
   }
 }

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -336,6 +336,12 @@ export class OverlayDetector implements OverlayAnalyzer {
    * the first node matching the container (same matching as the main walk, so
    * the resource-id / text / content-desc / bounds fallbacks all apply).
    * Returns an empty set when the container is not found in the hierarchy.
+   *
+   * The chain must belong to the *selected* element: windows are walked
+   * topmost-first, and a popup may carry a node sharing the container's id or
+   * text. Such a look-alike would donate its clickable ancestors — genuine
+   * overlays — to the skip set, so a candidate whose bounds are parseable must
+   * also match the selected element's bounds.
    */
   private collectContainerAncestors(
     rootGroups: ViewHierarchyNode[][],
@@ -359,6 +365,10 @@ export class OverlayDetector implements OverlayAnalyzer {
           path[depth] = node;
 
           const nodeProperties = parser.extractNodeProperties(node);
+          const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
+          if (parsedBounds && !boundsEqual(parsedBounds, containerBounds)) {
+            return;
+          }
           if (
             this.isContainerNode(
               node,

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -33,7 +33,6 @@ export class OverlayDetector implements OverlayAnalyzer {
       return [];
     }
 
-    const containerNode = this.finder.findContainerNode(viewHierarchy, containerSelector);
     const parser = new DefaultElementParser();
 
     const windowRootGroups = parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
@@ -44,6 +43,25 @@ export class OverlayDetector implements OverlayAnalyzer {
     const overlays: OverlayCandidate[] = [];
     const seenNodes = new Set<ViewHierarchyNode>();
     const containerBounds = containerElement.bounds;
+
+    // `containerElement` is whatever findTargetElement's own resolution
+    // (ElementFinder.findElementByResourceId/findElementByText) already
+    // selected for the swipe — an area-sorted pick among possibly several
+    // same-selector matches. finder.findContainerNode() answers a different
+    // question (the first traversal match, used elsewhere to scope nested
+    // searches) and can name a different node than the one actually being
+    // swiped when the selector is ambiguous. Anchoring ancestor-exemption to
+    // that other node exempted the wrong element's ancestors while treating
+    // the real target's ancestor as a full-cover overlay — reproducing the
+    // exact "No unobstructed swipe area" fallback this file exists to avoid.
+    // Resolving strictly against containerElement's own bounds (requiring a
+    // unique match) anchors identity to the node actually being swiped.
+    const containerNode = this.resolveSelectedContainerNode(
+      rootGroups,
+      parser,
+      containerElement,
+      containerBounds,
+    );
 
     // The container's own ancestors are visited before the container in the
     // pre-order walk below and always geometrically contain it, so a
@@ -384,6 +402,52 @@ export class OverlayDetector implements OverlayAnalyzer {
     return isTruthyFlag(nodeProperties.clickable) || isTruthyFlag(nodeProperties.focusable);
   }
 
+  /**
+   * Finds the single hierarchy node matching both the container selector
+   * (resource-id / text / content-desc, or bounds alone when the selector
+   * carries none of those) and the exact bounds of the already-selected
+   * `containerElement` — i.e. the specific node findTargetElement's
+   * area-sorted resolution picked, not merely "a" node sharing its selector.
+   *
+   * When more than one node satisfies both the selector and those exact
+   * bounds, or none does, identity is ambiguous: callers (see
+   * collectContainerAncestors) must treat that the same as "not found"
+   * rather than guess, since guessing wrong donates a stranger's ancestors
+   * to the skip set instead of the real target's.
+   */
+  private resolveSelectedContainerNode(
+    rootGroups: ViewHierarchyNode[][],
+    parser: DefaultElementParser,
+    containerElement: Element,
+    containerBounds: Element["bounds"],
+  ): ViewHierarchyNode | null {
+    let match: ViewHierarchyNode | null = null;
+    let matchCount = 0;
+
+    for (const rootNodes of rootGroups) {
+      for (const rootNode of rootNodes) {
+        parser.traverseNode(rootNode, (node: ViewHierarchyNode) => {
+          const nodeProperties = parser.extractNodeProperties(node);
+          if (
+            !this.matchesContainerSelector(node, nodeProperties, containerElement, containerBounds)
+          ) {
+            return;
+          }
+
+          const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
+          if (parsedBounds === null || !boundsEqual(parsedBounds, containerBounds)) {
+            return;
+          }
+
+          matchCount++;
+          match = node;
+        });
+      }
+    }
+
+    return matchCount === 1 ? match : null;
+  }
+
   private isContainerNode(
     node: ViewHierarchyNode,
     nodeProperties: Record<string, unknown>,
@@ -395,6 +459,15 @@ export class OverlayDetector implements OverlayAnalyzer {
       return true;
     }
 
+    return this.matchesContainerSelector(node, nodeProperties, containerElement, containerBounds);
+  }
+
+  private matchesContainerSelector(
+    node: ViewHierarchyNode,
+    nodeProperties: Record<string, unknown>,
+    containerElement: Element,
+    containerBounds: Element["bounds"],
+  ): boolean {
     const resourceId = nodeProperties["resource-id"];
     if (containerElement["resource-id"] && resourceId === containerElement["resource-id"]) {
       return true;

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -45,6 +45,20 @@ export class OverlayDetector implements OverlayAnalyzer {
     const seenNodes = new Set<ViewHierarchyNode>();
     const containerBounds = containerElement.bounds;
 
+    // The container's own ancestors are visited before the container in the
+    // pre-order walk below and always geometrically contain it, so a
+    // clickable/focusable parent (card, Compose root) used to be recorded as an
+    // overlay covering the whole container, which left no safe swipe area and
+    // forced the "No unobstructed swipe area" fallback (#6128). Ancestors are
+    // never overlays — only siblings and other windows are.
+    const containerAncestors = this.collectContainerAncestors(
+      rootGroups,
+      parser,
+      containerNode,
+      containerElement,
+      containerBounds,
+    );
+
     rootGroups.forEach((rootNodes, windowIndex) => {
       const windowRank = totalWindows - windowIndex;
       let nodeOrder = 0;
@@ -82,7 +96,7 @@ export class OverlayDetector implements OverlayAnalyzer {
             containerDepth = -1;
           }
 
-          if (insideContainer) {
+          if (insideContainer || containerAncestors.has(node)) {
             return;
           }
 
@@ -315,6 +329,58 @@ export class OverlayDetector implements OverlayAnalyzer {
     }
 
     return { left, top, right, bottom };
+  }
+
+  /**
+   * Pre-order walk of the same root groups that records the ancestor chain of
+   * the first node matching the container (same matching as the main walk, so
+   * the resource-id / text / content-desc / bounds fallbacks all apply).
+   * Returns an empty set when the container is not found in the hierarchy.
+   */
+  private collectContainerAncestors(
+    rootGroups: ViewHierarchyNode[][],
+    parser: DefaultElementParser,
+    containerNode: ViewHierarchyNode | null,
+    containerElement: Element,
+    containerBounds: Element["bounds"],
+  ): Set<ViewHierarchyNode> {
+    const ancestors = new Set<ViewHierarchyNode>();
+    // path[depth] is the node currently open at that depth of the pre-order walk.
+    const path: ViewHierarchyNode[] = [];
+    let found = false;
+
+    for (const rootNodes of rootGroups) {
+      for (const rootNode of rootNodes) {
+        parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
+          if (found) {
+            return;
+          }
+          path.length = depth;
+          path[depth] = node;
+
+          const nodeProperties = parser.extractNodeProperties(node);
+          if (
+            this.isContainerNode(
+              node,
+              nodeProperties,
+              containerNode,
+              containerElement,
+              containerBounds,
+            )
+          ) {
+            for (const ancestor of path.slice(0, depth)) {
+              ancestors.add(ancestor);
+            }
+            found = true;
+          }
+        });
+        if (found) {
+          return ancestors;
+        }
+      }
+    }
+
+    return ancestors;
   }
 
   private isClickableNode(nodeProperties: Record<string, unknown>): boolean {

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -51,13 +51,7 @@ export class OverlayDetector implements OverlayAnalyzer {
     // overlay covering the whole container, which left no safe swipe area and
     // forced the "No unobstructed swipe area" fallback (#6128). Ancestors are
     // never overlays — only siblings and other windows are.
-    const containerAncestors = this.collectContainerAncestors(
-      rootGroups,
-      parser,
-      containerNode,
-      containerElement,
-      containerBounds,
-    );
+    const containerAncestors = this.collectContainerAncestors(rootGroups, parser, containerNode);
 
     rootGroups.forEach((rootNodes, windowIndex) => {
       const windowRank = totalWindows - windowIndex;
@@ -333,24 +327,30 @@ export class OverlayDetector implements OverlayAnalyzer {
 
   /**
    * Pre-order walk of the same root groups that records the ancestor chain of
-   * the first node matching the container (same matching as the main walk, so
-   * the resource-id / text / content-desc / bounds fallbacks all apply).
-   * Returns an empty set when the container is not found in the hierarchy.
+   * the *specific* hierarchy node the finder resolved for the selected
+   * container. Only strict object identity (`===`) anchors the walk: a
+   * look-alike node elsewhere in the tree — same resource-id, text, or even
+   * identical bounds — is still a distinct parsed object and can never match
+   * by reference, so it can no longer donate its own clickable ancestors to
+   * the skip set (the earlier resource-id/text/bounds heuristic could still
+   * be fooled by such a look-alike sharing the real container's bounds).
    *
-   * The chain must belong to the *selected* element: windows are walked
-   * topmost-first, and a popup may carry a node sharing the container's id or
-   * text. Such a look-alike would donate its clickable ancestors — genuine
-   * overlays — to the skip set, so a candidate whose bounds are parseable must
-   * also match the selected element's bounds.
+   * When the finder did not resolve a container node at all, there is no
+   * identity to anchor the walk to, so this returns an empty skip set rather
+   * than falling back to a selector guess. Missing a real ancestor here is
+   * safe (worst case: a slightly smaller safe-swipe area); suppressing a
+   * genuine overlay is not.
    */
   private collectContainerAncestors(
     rootGroups: ViewHierarchyNode[][],
     parser: DefaultElementParser,
     containerNode: ViewHierarchyNode | null,
-    containerElement: Element,
-    containerBounds: Element["bounds"],
   ): Set<ViewHierarchyNode> {
     const ancestors = new Set<ViewHierarchyNode>();
+    if (!containerNode) {
+      return ancestors;
+    }
+
     // path[depth] is the node currently open at that depth of the pre-order walk.
     const path: ViewHierarchyNode[] = [];
     let found = false;
@@ -364,25 +364,7 @@ export class OverlayDetector implements OverlayAnalyzer {
           path.length = depth;
           path[depth] = node;
 
-          const nodeProperties = parser.extractNodeProperties(node);
-          // Accept only a node whose bounds equal the selected element's. A
-          // look-alike with unequal, missing, or malformed bounds must not be
-          // taken as the container — and the finder's own `containerNode` is not
-          // a substitute, since it too is resolved topmost-first and can be the
-          // look-alike.
-          const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
-          if (parsedBounds === null || !boundsEqual(parsedBounds, containerBounds)) {
-            return;
-          }
-          if (
-            this.isContainerNode(
-              node,
-              nodeProperties,
-              containerNode,
-              containerElement,
-              containerBounds,
-            )
-          ) {
+          if (node === containerNode) {
             for (const ancestor of path.slice(0, depth)) {
               ancestors.add(ancestor);
             }

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -8,7 +8,6 @@ import {
 import type { ElementFinder } from "../../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry";
 import type { ElementParser } from "../../../utils/interfaces/ElementParser";
-import { DefaultElementParser } from "../../utility/ElementParser";
 import { SwipeInterval, OverlayCandidate, OverlayAnalyzer } from "./types";
 import { boundsArea, boundsEqual, clamp } from "../../../utils/bounds";
 import { isTruthyFlag, buildContainerFromElement } from "../../../utils/elementProperties";
@@ -33,7 +32,7 @@ export class OverlayDetector implements OverlayAnalyzer {
       return [];
     }
 
-    const parser = new DefaultElementParser();
+    const parser = this.elementParser;
 
     const windowRootGroups = parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
     const rootGroups =
@@ -57,7 +56,7 @@ export class OverlayDetector implements OverlayAnalyzer {
     // Resolving strictly against containerElement's own bounds (requiring a
     // unique match) anchors identity to the node actually being swiped.
     const containerNode = this.resolveSelectedContainerNode(
-      rootGroups,
+      viewHierarchy,
       parser,
       containerElement,
       containerBounds,
@@ -361,7 +360,7 @@ export class OverlayDetector implements OverlayAnalyzer {
    */
   private collectContainerAncestors(
     rootGroups: ViewHierarchyNode[][],
-    parser: DefaultElementParser,
+    parser: ElementParser,
     containerNode: ViewHierarchyNode | null,
   ): Set<ViewHierarchyNode> {
     const ancestors = new Set<ViewHierarchyNode>();
@@ -409,43 +408,83 @@ export class OverlayDetector implements OverlayAnalyzer {
    * `containerElement` — i.e. the specific node findTargetElement's
    * area-sorted resolution picked, not merely "a" node sharing its selector.
    *
+   * Searches the SAME source set in the SAME order ElementFinder itself
+   * uses to resolve an element: the main hierarchy first, then the
+   * per-window hierarchies (topmost-first), stopping at the first source
+   * that has any match at all. Scanning only the per-window hierarchies —
+   * which is all `rootGroups` holds once any window exists — would miss a
+   * container that the finder actually resolved from the main hierarchy,
+   * and a same-id/same-bounds look-alike sitting in a popup window could
+   * then be mistaken for the (never-checked) real match.
+   *
    * When more than one node satisfies both the selector and those exact
-   * bounds, or none does, identity is ambiguous: callers (see
-   * collectContainerAncestors) must treat that the same as "not found"
-   * rather than guess, since guessing wrong donates a stranger's ancestors
-   * to the skip set instead of the real target's.
+   * bounds within the chosen source, or none does anywhere, identity is
+   * ambiguous: callers (see collectContainerAncestors) must treat that the
+   * same as "not found" rather than guess, since guessing wrong donates a
+   * stranger's ancestors to the skip set instead of the real target's.
    */
   private resolveSelectedContainerNode(
-    rootGroups: ViewHierarchyNode[][],
-    parser: DefaultElementParser,
+    viewHierarchy: ViewHierarchyResult,
+    parser: ElementParser,
     containerElement: Element,
     containerBounds: Element["bounds"],
   ): ViewHierarchyNode | null {
-    let match: ViewHierarchyNode | null = null;
-    let matchCount = 0;
+    const mainRootNodes = parser.extractRootNodes(viewHierarchy);
+    const mainResult = this.findSelectorBoundsMatch(
+      mainRootNodes,
+      parser,
+      containerElement,
+      containerBounds,
+    );
+    if (mainResult.matchCount > 0) {
+      return mainResult.matchCount === 1 ? mainResult.match : null;
+    }
 
-    for (const rootNodes of rootGroups) {
-      for (const rootNode of rootNodes) {
-        parser.traverseNode(rootNode, (node: ViewHierarchyNode) => {
-          const nodeProperties = parser.extractNodeProperties(node);
-          if (
-            !this.matchesContainerSelector(node, nodeProperties, containerElement, containerBounds)
-          ) {
-            return;
-          }
-
-          const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
-          if (parsedBounds === null || !boundsEqual(parsedBounds, containerBounds)) {
-            return;
-          }
-
-          matchCount++;
-          match = node;
-        });
+    const windowRootGroups = parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowResult = this.findSelectorBoundsMatch(
+        windowRoots,
+        parser,
+        containerElement,
+        containerBounds,
+      );
+      if (windowResult.matchCount > 0) {
+        return windowResult.matchCount === 1 ? windowResult.match : null;
       }
     }
 
-    return matchCount === 1 ? match : null;
+    return null;
+  }
+
+  private findSelectorBoundsMatch(
+    rootNodes: ViewHierarchyNode[],
+    parser: ElementParser,
+    containerElement: Element,
+    containerBounds: Element["bounds"],
+  ): { match: ViewHierarchyNode | null; matchCount: number } {
+    let match: ViewHierarchyNode | null = null;
+    let matchCount = 0;
+
+    for (const rootNode of rootNodes) {
+      parser.traverseNode(rootNode, (node: ViewHierarchyNode) => {
+        const nodeProperties = parser.extractNodeProperties(node);
+        if (
+          !this.matchesContainerSelector(node, nodeProperties, containerElement, containerBounds)
+        ) {
+          return;
+        }
+
+        const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
+        if (parsedBounds === null || !boundsEqual(parsedBounds, containerBounds)) {
+          return;
+        }
+
+        matchCount++;
+        match = node;
+      });
+    }
+
+    return { match, matchCount };
   }
 
   private isContainerNode(

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -365,8 +365,13 @@ export class OverlayDetector implements OverlayAnalyzer {
           path[depth] = node;
 
           const nodeProperties = parser.extractNodeProperties(node);
+          // Accept only a node whose bounds equal the selected element's. A
+          // look-alike with unequal, missing, or malformed bounds must not be
+          // taken as the container — and the finder's own `containerNode` is not
+          // a substitute, since it too is resolved topmost-first and can be the
+          // look-alike.
           const parsedBounds = this.elementParser.parseBounds(node.bounds ?? nodeProperties.bounds);
-          if (parsedBounds && !boundsEqual(parsedBounds, containerBounds)) {
+          if (parsedBounds === null || !boundsEqual(parsedBounds, containerBounds)) {
             return;
           }
           if (

--- a/test/fakes/FakeElementParser.ts
+++ b/test/fakes/FakeElementParser.ts
@@ -2,24 +2,33 @@ import type { Element } from "../../src/models/Element";
 import type { ElementBounds, ViewHierarchyNode, ViewHierarchyResult } from "../../src/models";
 import type { ElementParser } from "../../src/utils/interfaces/ElementParser";
 import { parseBounds as parseBoundsValue } from "../../src/utils/bounds";
+import { DefaultElementParser } from "../../src/features/utility/ElementParser";
 
+// undefined (the default) on any `next*` field below means "delegate to a
+// real DefaultElementParser" rather than return a canned value. Hierarchy
+// parsing (bounds, node properties, tree walking) is a pure, deterministic
+// utility with no I/O or timing dependency, so a caller exercising real
+// tree-walking logic (e.g. OverlayDetector's container-identity resolution)
+// gets correct behavior without every test having to hand-roll a full
+// parser. Set a field explicitly (including to an empty array or null) to
+// force a specific result for a test that wants that instead.
 export class FakeElementParser implements ElementParser {
-  nextNodeProperties: any = {};
-  // undefined (the default) means "parse for real" — bounds parsing is a
-  // pure, deterministic utility (src/utils/bounds.ts), not an I/O or timing
-  // dependency, so callers exercising real bounds equality (e.g.
-  // OverlayDetector's container-identity resolution) get correct behavior
-  // without every test having to stub bounds per node. Set this explicitly
-  // to force a specific parseBounds result (including null) for a test.
-  nextParsedBounds: ElementBounds | null | undefined = undefined;
-  nextParsedNode: Element | null = null;
-  nextRootNodes: ViewHierarchyNode[] = [];
-  nextWindowRootGroups: ViewHierarchyNode[][] = [];
-  nextFlattenedElements: Array<{ element: Element; index: number; depth: number; text?: string }> =
-    [];
+  private readonly real = new DefaultElementParser();
 
-  extractNodeProperties(_node: ViewHierarchyNode): any {
-    return this.nextNodeProperties;
+  nextNodeProperties: any = undefined;
+  nextParsedBounds: ElementBounds | null | undefined = undefined;
+  nextParsedNode: Element | null | undefined = undefined;
+  nextRootNodes: ViewHierarchyNode[] | undefined = undefined;
+  nextWindowRootGroups: ViewHierarchyNode[][] | undefined = undefined;
+  nextFlattenedElements:
+    | Array<{ element: Element; index: number; depth: number; text?: string }>
+    | undefined = undefined;
+
+  extractNodeProperties(node: ViewHierarchyNode): any {
+    if (this.nextNodeProperties !== undefined) {
+      return this.nextNodeProperties;
+    }
+    return this.real.extractNodeProperties(node);
   }
 
   parseBounds(bounds: unknown): ElementBounds | null {
@@ -29,26 +38,35 @@ export class FakeElementParser implements ElementParser {
     return parseBoundsValue(bounds);
   }
 
-  parseNodeBounds(_node: ViewHierarchyNode): Element | null {
-    return this.nextParsedNode;
+  parseNodeBounds(node: ViewHierarchyNode): Element | null {
+    if (this.nextParsedNode !== undefined) {
+      return this.nextParsedNode;
+    }
+    return this.real.parseNodeBounds(node);
   }
 
-  extractRootNodes(_viewHierarchy: ViewHierarchyResult): ViewHierarchyNode[] {
-    return this.nextRootNodes;
+  extractRootNodes(viewHierarchy: ViewHierarchyResult): ViewHierarchyNode[] {
+    if (this.nextRootNodes !== undefined) {
+      return this.nextRootNodes;
+    }
+    return this.real.extractRootNodes(viewHierarchy);
   }
 
   extractWindowRootGroups(
-    _viewHierarchy: ViewHierarchyResult,
-    _order?: "topmost-first" | "bottommost-first",
+    viewHierarchy: ViewHierarchyResult,
+    order?: "topmost-first" | "bottommost-first",
   ): ViewHierarchyNode[][] {
-    return this.nextWindowRootGroups;
+    if (this.nextWindowRootGroups !== undefined) {
+      return this.nextWindowRootGroups;
+    }
+    return this.real.extractWindowRootGroups(viewHierarchy, order);
   }
 
   extractWindowRootNodes(
-    _viewHierarchy: ViewHierarchyResult,
-    _order?: "topmost-first" | "bottommost-first",
+    viewHierarchy: ViewHierarchyResult,
+    order?: "topmost-first" | "bottommost-first",
   ): ViewHierarchyNode[] {
-    return this.nextWindowRootGroups.flat();
+    return this.extractWindowRootGroups(viewHierarchy, order).flat();
   }
 
   traverseNode(node: any, callback: (node: any, depth: number) => void, depth: number = 0): void {
@@ -66,9 +84,12 @@ export class FakeElementParser implements ElementParser {
   }
 
   flattenViewHierarchy(
-    _viewHierarchy: ViewHierarchyResult,
-    _options?: { includeWindows?: boolean; windowOrder?: "topmost-first" | "bottommost-first" },
+    viewHierarchy: ViewHierarchyResult,
+    options?: { includeWindows?: boolean; windowOrder?: "topmost-first" | "bottommost-first" },
   ): Array<{ element: Element; index: number; depth: number; text?: string }> {
-    return this.nextFlattenedElements;
+    if (this.nextFlattenedElements !== undefined) {
+      return this.nextFlattenedElements;
+    }
+    return this.real.flattenViewHierarchy(viewHierarchy, options);
   }
 }

--- a/test/fakes/FakeElementParser.ts
+++ b/test/fakes/FakeElementParser.ts
@@ -1,10 +1,17 @@
 import type { Element } from "../../src/models/Element";
 import type { ElementBounds, ViewHierarchyNode, ViewHierarchyResult } from "../../src/models";
 import type { ElementParser } from "../../src/utils/interfaces/ElementParser";
+import { parseBounds as parseBoundsValue } from "../../src/utils/bounds";
 
 export class FakeElementParser implements ElementParser {
   nextNodeProperties: any = {};
-  nextParsedBounds: ElementBounds | null = null;
+  // undefined (the default) means "parse for real" — bounds parsing is a
+  // pure, deterministic utility (src/utils/bounds.ts), not an I/O or timing
+  // dependency, so callers exercising real bounds equality (e.g.
+  // OverlayDetector's container-identity resolution) get correct behavior
+  // without every test having to stub bounds per node. Set this explicitly
+  // to force a specific parseBounds result (including null) for a test.
+  nextParsedBounds: ElementBounds | null | undefined = undefined;
   nextParsedNode: Element | null = null;
   nextRootNodes: ViewHierarchyNode[] = [];
   nextWindowRootGroups: ViewHierarchyNode[][] = [];
@@ -15,8 +22,11 @@ export class FakeElementParser implements ElementParser {
     return this.nextNodeProperties;
   }
 
-  parseBounds(_bounds: unknown): ElementBounds | null {
-    return this.nextParsedBounds;
+  parseBounds(bounds: unknown): ElementBounds | null {
+    if (this.nextParsedBounds !== undefined) {
+      return this.nextParsedBounds;
+    }
+    return parseBoundsValue(bounds);
   }
 
   parseNodeBounds(_node: ViewHierarchyNode): Element | null {

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -128,6 +128,48 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     expect(overlays[0].bounds).toEqual(popupBounds);
     expect(overlays[0].overlapBounds).toEqual(popupBounds);
   });
+
+  test("a same-id look-alike with missing or malformed bounds is not taken as the container either", () => {
+    // Unparseable bounds must not fall through to the id/text match: the
+    // popup's clickable root is still the one overlay in both variants.
+    const popupBounds = b(100, 600, 900, 1400);
+    const makeHierarchy = (lookAlikeAttrs: Record<string, string>) => ({
+      hierarchy: { node: [] },
+      windows: [
+        {
+          windowLayer: 0,
+          hierarchy: {
+            node: [
+              node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [
+                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+              ]),
+            ],
+          },
+        },
+        {
+          windowLayer: 5,
+          hierarchy: {
+            node: [
+              node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
+                { $: { "resource-id": "list", scrollable: "true", ...lookAlikeAttrs }, node: [] },
+              ]),
+            ],
+          },
+        },
+      ],
+    });
+
+    for (const lookAlike of [{}, { bounds: "not-a-rect" }]) {
+      const overlays = detector().collectOverlayCandidates(
+        makeHierarchy(lookAlike) as any,
+        { elementId: "list" },
+        listElement,
+      );
+
+      expect(overlays).toHaveLength(1);
+      expect(overlays[0].bounds).toEqual(popupBounds);
+    }
+  });
 });
 
 describe("SwipeOn container overlays", () => {

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -8,7 +8,84 @@ import { FakeObserveScreen } from "../../../fakes/FakeObserveScreen";
 import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
 import { FakeWindow } from "../../../fakes/FakeWindow";
 import { FakeTimer } from "../../../fakes/FakeTimer";
-import type { ElementBounds } from "../../../../src/models";
+import type { Element, ElementBounds } from "../../../../src/models";
+import { OverlayDetector } from "../../../../src/features/action/swipeon/OverlayDetector";
+import { DefaultElementFinder } from "../../../../src/features/utility/ElementFinder";
+import { DefaultElementGeometry } from "../../../../src/features/utility/ElementGeometry";
+import { DefaultElementParser } from "../../../../src/features/utility/ElementParser";
+
+describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)", () => {
+  const b = (left: number, top: number, right: number, bottom: number): ElementBounds => ({
+    left,
+    top,
+    right,
+    bottom,
+  });
+  const node = (bounds: ElementBounds, attrs: Record<string, string>, children: any[] = []) => ({
+    $: { bounds, ...attrs },
+    node: children,
+  });
+  const LIST_BOUNDS = b(0, 0, 1000, 2000);
+  const listElement: Element = {
+    bounds: LIST_BOUNDS,
+    "resource-id": "list",
+    scrollable: true,
+  } as unknown as Element;
+  const detector = () =>
+    new OverlayDetector(
+      new DefaultElementFinder(),
+      new DefaultElementGeometry(),
+      new DefaultElementParser(),
+    );
+
+  test("a clickable ancestor of the container is not an overlay (issue repro: root(clickable) > list > row(clickable))", () => {
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
+            node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }, [
+              node(b(0, 0, 1000, 100), { "resource-id": "row", clickable: "true" }),
+            ]),
+          ]),
+        ],
+      },
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toEqual([]);
+  });
+
+  test("a genuine clickable sibling under a clickable root is still an overlay, and only it", () => {
+    const fabBounds = b(800, 1700, 1000, 1900);
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "root", focusable: "true" }, [
+            node(b(0, 0, 1000, 2000), { "resource-id": "card", clickable: "true" }, [
+              node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+            ]),
+            node(fabBounds, { "resource-id": "fab", clickable: "true" }),
+          ]),
+        ],
+      },
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(fabBounds);
+    expect(overlays[0].overlapBounds).toEqual(fabBounds);
+  });
+});
 
 describe("SwipeOn container overlays", () => {
   const device = { name: "test-device", platform: "android", deviceId: "device-1" } as const;
@@ -143,6 +220,91 @@ describe("SwipeOn container overlays", () => {
     expect(call).toBeDefined();
     expect(call.x1).toBe(500);
     expect(call.y1).toBe(200);
+  });
+
+  test("does not treat the container's clickable ancestor as an overlay (#6128)", async () => {
+    // root(clickable) > list(scrollable) > row(clickable): the root is visited
+    // before the container and fully covers it, so it used to be recorded as
+    // an overlay and force the "No unobstructed swipe area" fallback.
+    const row = createNode(b(0, 0, 1000, 100), { "resource-id": "row", clickable: "true" });
+    const containerNode = createContainerNode(b(0, 0, 1000, 2000), "list-container", [row]);
+    const clickableRoot = {
+      $: { bounds: b(0, 0, 1000, 2000), "resource-id": "root", clickable: "true" },
+      node: [containerNode],
+    };
+
+    fakeObserveScreen.setObserveResult(createObserveResult(createHierarchy([clickableRoot])));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "list-container" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Same coordinates as an unobstructed container: center x, default start y.
+    expect(call.x1).toBe(500);
+    expect(call.y1).toBe(200);
+  });
+
+  test("still avoids a genuine sibling overlay under a clickable root (#6128)", async () => {
+    const containerNode = createContainerNode(b(0, 0, 1000, 2000), "list-container");
+    const bottomBar = createNode(b(0, 1700, 1000, 2000), {
+      "resource-id": "bottom-bar",
+      clickable: "true",
+    });
+    const clickableRoot = {
+      $: { bounds: b(0, 0, 1000, 2000), "resource-id": "root", clickable: "true" },
+      node: [containerNode, bottomBar],
+    };
+
+    fakeObserveScreen.setObserveResult(createObserveResult(createHierarchy([clickableRoot])));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "list-container" },
+    });
+
+    expect(result.success).toBe(true);
+    // Overlay avoidance must not have been abandoned via the fallback.
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    expect(call.x1).toBe(call.x2);
+    // Both ends stay above the bottom bar (1700) minus the 8px overlay padding.
+    expect(Math.max(call.y1, call.y2)).toBeLessThanOrEqual(1692);
+  });
+
+  test("handles a nested container inside a clickable card under a focusable root (#6128)", async () => {
+    const containerNode = createContainerNode(b(0, 500, 1000, 1500), "nested-list");
+    const card = {
+      $: { bounds: b(0, 500, 1000, 1500), "resource-id": "card", clickable: "true" },
+      node: [containerNode],
+    };
+    const focusableRoot = {
+      $: { bounds: b(0, 0, 1000, 2000), "resource-id": "root", focusable: "true" },
+      node: [card],
+    };
+
+    fakeObserveScreen.setObserveResult(createObserveResult(createHierarchy([focusableRoot])));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "nested-list" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    expect(call.x1).toBe(500);
+    expect(call.y1).toBeGreaterThanOrEqual(500);
+    expect(call.y2).toBeLessThanOrEqual(1500);
   });
 
   test("keeps the larger overlay when overlap is partial", async () => {

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -321,6 +321,84 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     expect(overlays).toHaveLength(1);
     expect(overlays[0].bounds).toEqual(b(0, 0, 1000, 2000));
   });
+
+  test("a container selected from the MAIN hierarchy has its clickable ancestor exempted even when window hierarchies also exist (terminal #6128 follow-up: ancestor walk source-tree fix)", () => {
+    // The container resolves from the MAIN hierarchy (resolveSelectedContainerNode's
+    // main-first precedence), but the ancestor walk used to always run over
+    // `rootGroups`, which is window-only once ANY window exists — excluding
+    // the main hierarchy the identified node actually lives in. The node was
+    // therefore never found by identity in that walk, so its real clickable
+    // ancestor (a full-screen app-root) went unexempted and was reported as
+    // a full-cover overlay, reproducing the exact blocked-swipe bug this PR
+    // removes, just for main-hierarchy-selected containers specifically.
+    const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
+    const toastBounds = b(0, 1800, 1000, 2000);
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "appRoot", clickable: "true" }, [
+            realListNode,
+          ]),
+        ],
+      },
+      windows: [
+        {
+          windowLayer: 5,
+          hierarchy: {
+            node: [node(toastBounds, { "resource-id": "toast", clickable: "true" })],
+          },
+        },
+      ],
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    // appRoot (the real, main-hierarchy ancestor) must be exempted; only the
+    // genuine, unrelated window overlay (the toast) is reported.
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(toastBounds);
+  });
+
+  test("a same-bounds sibling sharing only an incidental resource-id (different text) does not cause ambiguity (terminal #6128 follow-up: AND, not OR, identity matching)", () => {
+    // containerElement carries BOTH a resource-id and text. A sibling node
+    // happens to share the same resource-id and even the same bounds, but
+    // has different text. Under OR-matching (any single populated field is
+    // enough) that sibling would count as a second match, making identity
+    // resolution "ambiguous" and forcing the safe empty-ancestor fallback —
+    // resurfacing the full-cover-overlay/blocked-swipe bug for a case that
+    // isn't actually ambiguous once the full identity (id AND text) must
+    // agree.
+    const selected: Element = {
+      bounds: LIST_BOUNDS,
+      "resource-id": "list",
+      text: "Groceries",
+    } as unknown as Element;
+
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
+            node(LIST_BOUNDS, { "resource-id": "list", text: "Groceries", scrollable: "true" }),
+            node(LIST_BOUNDS, { "resource-id": "list", text: "Recents", scrollable: "true" }),
+          ]),
+        ],
+      },
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list", text: "Groceries" },
+      selected,
+    );
+
+    // root is the real, uniquely-identified target's genuine ancestor and
+    // must be exempted — not reported as a full-cover overlay.
+    expect(overlays).toEqual([]);
+  });
 });
 
 describe("SwipeOn container overlays", () => {

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -10,9 +10,9 @@ import { FakeWindow } from "../../../fakes/FakeWindow";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import type { Element, ElementBounds } from "../../../../src/models";
 import { OverlayDetector } from "../../../../src/features/action/swipeon/OverlayDetector";
-import { DefaultElementFinder } from "../../../../src/features/utility/ElementFinder";
-import { DefaultElementGeometry } from "../../../../src/features/utility/ElementGeometry";
-import { DefaultElementParser } from "../../../../src/features/utility/ElementParser";
+import { FakeElementFinder } from "../../../fakes/FakeElementFinder";
+import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
+import { FakeElementParser } from "../../../fakes/FakeElementParser";
 
 describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)", () => {
   const b = (left: number, top: number, right: number, bottom: number): ElementBounds => ({
@@ -31,27 +31,30 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     "resource-id": "list",
     scrollable: true,
   } as unknown as Element;
-  const detector = () =>
-    new OverlayDetector(
-      new DefaultElementFinder(),
-      new DefaultElementGeometry(),
-      new DefaultElementParser(),
-    );
+  // The finder is faked so the test controls exactly which parsed hierarchy
+  // node it hands back as the selected container — that reference is what
+  // the ancestor walk now anchors to via strict identity (`===`). Geometry
+  // and the bounds parser are not exercised by collectOverlayCandidates (the
+  // internal tree walk always uses a real DefaultElementParser instance for
+  // traversal), so plain fakes stand in for them per the repo's
+  // interfaces-and-fakes convention.
+  const detector = (containerNode: object | null) => {
+    const finder = new FakeElementFinder();
+    finder.nextContainerNode = containerNode as any;
+    return new OverlayDetector(finder, new FakeElementGeometry(), new FakeElementParser());
+  };
 
   test("a clickable ancestor of the container is not an overlay (issue repro: root(clickable) > list > row(clickable))", () => {
+    const listNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }, [
+      node(b(0, 0, 1000, 100), { "resource-id": "row", clickable: "true" }),
+    ]);
     const hierarchy = {
       hierarchy: {
-        node: [
-          node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
-            node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }, [
-              node(b(0, 0, 1000, 100), { "resource-id": "row", clickable: "true" }),
-            ]),
-          ]),
-        ],
+        node: [node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [listNode])],
       },
     };
 
-    const overlays = detector().collectOverlayCandidates(
+    const overlays = detector(listNode).collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -62,20 +65,19 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
 
   test("a genuine clickable sibling under a clickable root is still an overlay, and only it", () => {
     const fabBounds = b(800, 1700, 1000, 1900);
+    const listNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
     const hierarchy = {
       hierarchy: {
         node: [
           node(b(0, 0, 1000, 2000), { "resource-id": "root", focusable: "true" }, [
-            node(b(0, 0, 1000, 2000), { "resource-id": "card", clickable: "true" }, [
-              node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
-            ]),
+            node(b(0, 0, 1000, 2000), { "resource-id": "card", clickable: "true" }, [listNode]),
             node(fabBounds, { "resource-id": "fab", clickable: "true" }),
           ]),
         ],
       },
     };
 
-    const overlays = detector().collectOverlayCandidates(
+    const overlays = detector(listNode).collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -92,17 +94,14 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     // the selected container — otherwise the clickable popup root (a genuine
     // overlay covering the list) would be suppressed as an "ancestor".
     const popupBounds = b(100, 600, 900, 1400);
+    const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
     const hierarchy = {
       hierarchy: { node: [] },
       windows: [
         {
           windowLayer: 0,
           hierarchy: {
-            node: [
-              node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [
-                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
-              ]),
-            ],
+            node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
           },
         },
         {
@@ -118,7 +117,7 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       ],
     };
 
-    const overlays = detector().collectOverlayCandidates(
+    const overlays = detector(realListNode).collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -130,38 +129,44 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
   });
 
   test("a same-id look-alike with missing or malformed bounds is not taken as the container either", () => {
-    // Unparseable bounds must not fall through to the id/text match: the
+    // Unparseable bounds must not fall through to an id-only match: the
     // popup's clickable root is still the one overlay in both variants.
     const popupBounds = b(100, 600, 900, 1400);
-    const makeHierarchy = (lookAlikeAttrs: Record<string, string>) => ({
-      hierarchy: { node: [] },
-      windows: [
-        {
-          windowLayer: 0,
-          hierarchy: {
-            node: [
-              node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [
-                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
-              ]),
-            ],
-          },
+    const makeHierarchy = (lookAlikeAttrs: Record<string, string>) => {
+      const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
+      return {
+        realListNode,
+        hierarchy: {
+          hierarchy: { node: [] },
+          windows: [
+            {
+              windowLayer: 0,
+              hierarchy: {
+                node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
+              },
+            },
+            {
+              windowLayer: 5,
+              hierarchy: {
+                node: [
+                  node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
+                    {
+                      $: { "resource-id": "list", scrollable: "true", ...lookAlikeAttrs },
+                      node: [],
+                    },
+                  ]),
+                ],
+              },
+            },
+          ],
         },
-        {
-          windowLayer: 5,
-          hierarchy: {
-            node: [
-              node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
-                { $: { "resource-id": "list", scrollable: "true", ...lookAlikeAttrs }, node: [] },
-              ]),
-            ],
-          },
-        },
-      ],
-    });
+      };
+    };
 
     for (const lookAlike of [{}, { bounds: "not-a-rect" }]) {
-      const overlays = detector().collectOverlayCandidates(
-        makeHierarchy(lookAlike) as any,
+      const { realListNode, hierarchy } = makeHierarchy(lookAlike);
+      const overlays = detector(realListNode).collectOverlayCandidates(
+        hierarchy as any,
         { elementId: "list" },
         listElement,
       );
@@ -169,6 +174,74 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       expect(overlays).toHaveLength(1);
       expect(overlays[0].bounds).toEqual(popupBounds);
     }
+  });
+
+  test("a same-id, same-bounds look-alike in a topmost popup still yields the genuine popup overlay (identity, not selector+bounds)", () => {
+    // The popup's clickable root shares the real container's resource-id AND
+    // exact bounds. A selector+bounds heuristic would accept it as "the
+    // container" and donate the popup's own clickable root to the ancestor
+    // skip set, silently suppressing a genuine overlay so the swipe would
+    // pass through it. Only object identity to the finder-resolved node must
+    // decide this: the popup's look-alike is a different parsed object, so
+    // it can never match, and the popup's clickable root remains a detected
+    // overlay (the finder — faked here — is what a real ElementFinder would
+    // resolve to the main-hierarchy `list`, not the popup look-alike).
+    const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
+    const hierarchy = {
+      hierarchy: { node: [] },
+      windows: [
+        {
+          windowLayer: 0,
+          hierarchy: {
+            node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
+          },
+        },
+        {
+          windowLayer: 5,
+          hierarchy: {
+            node: [
+              node(LIST_BOUNDS, { "resource-id": "popup", clickable: "true" }, [
+                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+              ]),
+            ],
+          },
+        },
+      ],
+    };
+
+    const overlays = detector(realListNode).collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(LIST_BOUNDS);
+  });
+
+  test("returns no ancestor skip set when the finder cannot resolve the container node", () => {
+    // No identity to anchor the walk to: a clickable ancestor of a
+    // same-selector node elsewhere in the tree must not be silently
+    // exempted, so it is still reported as an overlay candidate rather than
+    // risking suppression of a genuine one.
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
+            node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+          ]),
+        ],
+      },
+    };
+
+    const overlays = detector(null).collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(b(0, 0, 1000, 2000));
   });
 });
 

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -85,6 +85,49 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     expect(overlays[0].bounds).toEqual(fabBounds);
     expect(overlays[0].overlapBounds).toEqual(fabBounds);
   });
+
+  test("a same-id node inside a topmost popup window does not donate its clickable ancestors to the skip set", () => {
+    // The popup window is walked first (topmost-first). Its `list` shares the
+    // container's resource-id but not its bounds, so it must not be taken as
+    // the selected container — otherwise the clickable popup root (a genuine
+    // overlay covering the list) would be suppressed as an "ancestor".
+    const popupBounds = b(100, 600, 900, 1400);
+    const hierarchy = {
+      hierarchy: { node: [] },
+      windows: [
+        {
+          windowLayer: 0,
+          hierarchy: {
+            node: [
+              node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [
+                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+              ]),
+            ],
+          },
+        },
+        {
+          windowLayer: 5,
+          hierarchy: {
+            node: [
+              node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
+                node(b(100, 700, 900, 1300), { "resource-id": "list", scrollable: "true" }),
+              ]),
+            ],
+          },
+        },
+      ],
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(popupBounds);
+    expect(overlays[0].overlapBounds).toEqual(popupBounds);
+  });
 });
 
 describe("SwipeOn container overlays", () => {

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -31,18 +31,21 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     "resource-id": "list",
     scrollable: true,
   } as unknown as Element;
-  // The finder is faked so the test controls exactly which parsed hierarchy
-  // node it hands back as the selected container — that reference is what
-  // the ancestor walk now anchors to via strict identity (`===`). Geometry
-  // and the bounds parser are not exercised by collectOverlayCandidates (the
-  // internal tree walk always uses a real DefaultElementParser instance for
-  // traversal), so plain fakes stand in for them per the repo's
-  // interfaces-and-fakes convention.
-  const detector = (containerNode: object | null) => {
-    const finder = new FakeElementFinder();
-    finder.nextContainerNode = containerNode as any;
-    return new OverlayDetector(finder, new FakeElementGeometry(), new FakeElementParser());
-  };
+  // OverlayDetector resolves the selected container node itself (by
+  // requiring a unique selector+exact-bounds match against the passed-in
+  // containerElement — see resolveSelectedContainerNode) rather than
+  // consulting the finder, so the finder is a bare, unconfigured fake here.
+  // The bounds parser is faked too but delegates to the real, pure
+  // src/utils/bounds parseBounds by default (see FakeElementParser), since
+  // that logic is exactly what's under test. Geometry is never exercised by
+  // collectOverlayCandidates. Per the repo's interfaces-and-fakes
+  // convention, OverlayDetector remains the only concrete collaborator.
+  const detector = () =>
+    new OverlayDetector(
+      new FakeElementFinder(),
+      new FakeElementGeometry(),
+      new FakeElementParser(),
+    );
 
   test("a clickable ancestor of the container is not an overlay (issue repro: root(clickable) > list > row(clickable))", () => {
     const listNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }, [
@@ -54,7 +57,7 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       },
     };
 
-    const overlays = detector(listNode).collectOverlayCandidates(
+    const overlays = detector().collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -77,7 +80,7 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       },
     };
 
-    const overlays = detector(listNode).collectOverlayCandidates(
+    const overlays = detector().collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -117,7 +120,7 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       ],
     };
 
-    const overlays = detector(realListNode).collectOverlayCandidates(
+    const overlays = detector().collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -132,41 +135,35 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     // Unparseable bounds must not fall through to an id-only match: the
     // popup's clickable root is still the one overlay in both variants.
     const popupBounds = b(100, 600, 900, 1400);
-    const makeHierarchy = (lookAlikeAttrs: Record<string, string>) => {
-      const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
-      return {
-        realListNode,
-        hierarchy: {
-          hierarchy: { node: [] },
-          windows: [
-            {
-              windowLayer: 0,
-              hierarchy: {
-                node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
-              },
-            },
-            {
-              windowLayer: 5,
-              hierarchy: {
-                node: [
-                  node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
-                    {
-                      $: { "resource-id": "list", scrollable: "true", ...lookAlikeAttrs },
-                      node: [],
-                    },
-                  ]),
-                ],
-              },
-            },
-          ],
+    const makeHierarchy = (lookAlikeAttrs: Record<string, string>) => ({
+      hierarchy: { node: [] },
+      windows: [
+        {
+          windowLayer: 0,
+          hierarchy: {
+            node: [
+              node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [
+                node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
+              ]),
+            ],
+          },
         },
-      };
-    };
+        {
+          windowLayer: 5,
+          hierarchy: {
+            node: [
+              node(popupBounds, { "resource-id": "popup", clickable: "true" }, [
+                { $: { "resource-id": "list", scrollable: "true", ...lookAlikeAttrs }, node: [] },
+              ]),
+            ],
+          },
+        },
+      ],
+    });
 
     for (const lookAlike of [{}, { bounds: "not-a-rect" }]) {
-      const { realListNode, hierarchy } = makeHierarchy(lookAlike);
-      const overlays = detector(realListNode).collectOverlayCandidates(
-        hierarchy as any,
+      const overlays = detector().collectOverlayCandidates(
+        makeHierarchy(lookAlike) as any,
         { elementId: "list" },
         listElement,
       );
@@ -209,7 +206,7 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
       ],
     };
 
-    const overlays = detector(realListNode).collectOverlayCandidates(
+    const overlays = detector().collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,
@@ -219,22 +216,106 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     expect(overlays[0].bounds).toEqual(LIST_BOUNDS);
   });
 
-  test("returns no ancestor skip set when the finder cannot resolve the container node", () => {
-    // No identity to anchor the walk to: a clickable ancestor of a
-    // same-selector node elsewhere in the tree must not be silently
-    // exempted, so it is still reported as an overlay candidate rather than
-    // risking suppression of a genuine one.
+  test("anchors identity to the area-sorted selected match, not the first traversal match, when two `list` nodes share the id (terminal #6128 follow-up)", () => {
+    // Two `list` nodes share the resource-id. The real ElementFinder resolves
+    // the swipe target by AREA-SORTING matches and picking the smallest — here
+    // listB, under cardB — while a first-match traversal (the earlier,
+    // now-removed reliance on finder.findContainerNode) would instead land on
+    // listA, under cardA, which is visited first and is larger.
+    //
+    // Anchoring ancestor-collection to the wrong node (listA) would exempt
+    // cardA — a stranger to listB, not really its ancestor — while leaving
+    // cardB, listB's REAL and fully-covering parent, unexempted: exactly the
+    // "full-cover overlay blocks the whole swipe" bug this file exists to
+    // prevent, just reintroduced via node-identity instead of selector+bounds.
+    const cardABounds = b(0, 0, 1000, 1000);
+    const listABounds = b(0, 0, 1000, 1000);
+    const cardBBounds = b(0, 900, 1000, 1300);
+    const listBBounds = b(100, 950, 900, 1250);
+
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(cardABounds, { "resource-id": "cardA", clickable: "true" }, [
+            node(listABounds, { "resource-id": "list", scrollable: "true" }),
+          ]),
+          node(cardBBounds, { "resource-id": "cardB", clickable: "true" }, [
+            node(listBBounds, { "resource-id": "list", scrollable: "true" }),
+          ]),
+        ],
+      },
+    };
+
+    // Mirrors what the real, area-sorted ElementFinder.findElementByResourceId
+    // hands back as the swipe target: the smaller of the two `list` matches
+    // (listB, area 640,000 vs listA's 1,000,000) — not the first one visited.
+    const selectedListElement: Element = {
+      bounds: listBBounds,
+      "resource-id": "list",
+      scrollable: true,
+    } as unknown as Element;
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      selectedListElement,
+    );
+
+    // cardB truly contains listB and must be exempted as its ancestor, not
+    // reported as a full-cover overlay that would block the swipe outright.
+    // cardA is a stranger to listB (not its ancestor) and clips the top of
+    // its bounds; it must still be reported as a genuine overlay, not wrongly
+    // exempted because identity was anchored to listA instead of listB.
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].overlapBounds).toEqual(b(100, 950, 900, 1000));
+  });
+
+  test("returns no ancestor skip set when no node has both the selector and the target's exact bounds", () => {
+    // The `list` node's bounds don't match containerElement's bounds — as if
+    // the resolved target and this hierarchy snapshot diverged. With no node
+    // satisfying both the selector and the exact bounds, identity cannot be
+    // anchored, so the safe fallback (no ancestor skip set) applies: the
+    // clickable root is still reported as an overlay candidate rather than
+    // risking exemption of the wrong node's ancestors.
+    const mismatchedBounds = b(0, 0, 500, 500);
     const hierarchy = {
       hierarchy: {
         node: [
           node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
+            node(mismatchedBounds, { "resource-id": "list", scrollable: "true" }),
+          ]),
+        ],
+      },
+    };
+
+    const overlays = detector().collectOverlayCandidates(
+      hierarchy as any,
+      { elementId: "list" },
+      listElement,
+    );
+
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].bounds).toEqual(b(0, 0, 1000, 2000));
+  });
+
+  test("returns no ancestor skip set when two nodes tie on the selector and the target's exact bounds", () => {
+    // Two `list` nodes share both the resource-id and the exact bounds of
+    // containerElement: resolveSelectedContainerNode cannot pick one over the
+    // other, so identity is ambiguous. The safe fallback applies — no
+    // ancestor is exempted — rather than risking anchoring to whichever tied
+    // node happens to be visited.
+    const hierarchy = {
+      hierarchy: {
+        node: [
+          node(b(0, 0, 1000, 2000), { "resource-id": "root", clickable: "true" }, [
+            node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
             node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" }),
           ]),
         ],
       },
     };
 
-    const overlays = detector(null).collectOverlayCandidates(
+    const overlays = detector().collectOverlayCandidates(
       hierarchy as any,
       { elementId: "list" },
       listElement,

--- a/test/features/action/swipeon/OverlayDetector.test.ts
+++ b/test/features/action/swipeon/OverlayDetector.test.ts
@@ -181,18 +181,15 @@ describe("OverlayDetector.collectOverlayCandidates container ancestors (#6128)",
     // pass through it. Only object identity to the finder-resolved node must
     // decide this: the popup's look-alike is a different parsed object, so
     // it can never match, and the popup's clickable root remains a detected
-    // overlay (the finder — faked here — is what a real ElementFinder would
-    // resolve to the main-hierarchy `list`, not the popup look-alike).
+    // overlay. The real container lives in the MAIN hierarchy, which a real
+    // ElementFinder always searches before any window — see
+    // resolveSelectedContainerNode's main-first precedence.
     const realListNode = node(LIST_BOUNDS, { "resource-id": "list", scrollable: "true" });
     const hierarchy = {
-      hierarchy: { node: [] },
+      hierarchy: {
+        node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
+      },
       windows: [
-        {
-          windowLayer: 0,
-          hierarchy: {
-            node: [node(b(0, 0, 1000, 2000), { "resource-id": "root" }, [realListNode])],
-          },
-        },
         {
           windowLayer: 5,
           hierarchy: {


### PR DESCRIPTION
## Summary

`OverlayDetector.collectOverlayCandidates` walks the hierarchy pre-order and recorded every clickable/focusable node visited *before* the container as an overlay. A container's ancestors are always visited first and always geometrically contain it, so a `clickable`/`focusable` parent (clickable card, Compose root) was pushed as an overlay with `overlapBounds == containerBounds`; `computeSafeSwipeCoordinates` then found no gap, returned `null`, and `resolveContainerSwipeCoordinates` fell back to the raw container bounds with `warning: "No unobstructed swipe area found; using container bounds."` — abandoning avoidance of any real overlay (FAB, bottom bar) in the process. This PR precomputes the container's ancestor chain and skips those nodes; sibling / other-window detection is unchanged.

## Linked Issue

Closes #6128

Related: #3587 (previous swipeOn geometry bug in the same coordinate pipeline).

## Bug / Regression Context

- **Prior attempts:** none. `OverlayDetector.test.ts` only used root-level containers, so the ancestor case was never covered.
- **Observed symptom:** `swipeOn { container }` / `lookFor` on a scrollable nested inside a `clickable="true"` or `focusable="true"` parent always emitted the "No unobstructed swipe area" warning and swiped over real overlays it should have avoided.
- **Repro steps / conditions:** hierarchy `root(clickable) > list(scrollable) > row(clickable)`; `collectOverlayCandidates` returned `[{ bounds: root, overlapBounds: containerBounds }]`, `computeSafeSwipeCoordinates(...)` returned `null`.

## Changes

- `src/features/action/swipeon/OverlayDetector.ts`: new private `collectContainerAncestors` does a pre-order pass over the same root groups with a depth-indexed path stack and records the ancestors of the first node that matches the container. It reuses `isContainerNode`, so the resource-id / text / content-desc / bounds fallbacks apply identically to the main walk. Because windows are walked topmost-first and a popup can carry a node sharing the container's id/text, a candidate is accepted only when its parsed bounds equal the selected element's bounds; unequal, missing, or malformed bounds are rejected, and the finder's own `containerNode` is deliberately not treated as a substitute (it is resolved topmost-first too and can itself be the look-alike). Otherwise the popup's clickable root — a genuine overlay — would be suppressed as an "ancestor" (two Codex review findings). The main walk now skips any node in that set (`insideContainer || containerAncestors.has(node)`). Nothing else in the pipeline changes.

## Tests

All seven new tests are red with the corresponding guard disabled and green with it (5 fail → 0 fail for the ancestor skip; 1 fail → 0 fail each for the bounds discriminator and the unparseable-bounds rejection; 24/24 across `OverlayDetector.test.ts` + the property suite).

- `test/features/action/swipeon/OverlayDetector.test.ts` — direct `collectOverlayCandidates` block with the real `DefaultElementFinder` / `DefaultElementGeometry` / `DefaultElementParser`:
  - the issue repro (`root(clickable) > list > row(clickable)`) yields `[]`;
  - a genuine clickable FAB sibling under a focusable root + clickable card yields exactly one overlay with the FAB's bounds (ancestors excluded, sibling kept);
  - a topmost popup window whose clickable root contains a same-id `list` with different bounds: the popup root is still reported as the one overlay (the look-alike does not donate its ancestors to the skip set);
  - the same popup with a same-id look-alike whose bounds are missing or malformed (`"not-a-rect"`): the popup root is still the one overlay in both variants.
- `SwipeOn container overlays` (end-to-end through `SwipeOn.execute`):
  - container inside a clickable root: success, no warning, coordinates identical to an unobstructed container (`x1 = 500`, `y1 = 200`);
  - clickable root with a real full-width bottom-bar sibling: no warning and both swipe endpoints stay above `1700 - 8px` padding, i.e. avoidance still works instead of falling back;
  - nested container inside a clickable card under a focusable root: no warning, center x, swipe stays inside the container.

Acceptance criteria from the issue:

- [x] Clickable/focusable ancestors are not reported as overlays.
- [x] A sibling FAB under a clickable root is still avoided (safe coordinates ≠ null).
- [x] Red before / green after.

## Validation

- [x] `turbo run lint build test` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Tests use the existing fakes (`FakeObserveScreen`, `FakeGestureExecutor`, `FakeTimer`, …); each new test runs in well under 100ms
- [x] No new helpers beyond the private ancestor walk; no new dependencies
- [x] Based on latest `main`
