### PR TITLE
fix(daemon): guard networkCondition TTL expiry with a condition generation

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -2085,8 +2085,24 @@ export class SessionManager {
    * timed-out setup cannot arm or fire a TTL against a same-UUID REPLACEMENT
    * session. The TTL is clamped to `MAX_NETWORK_CONDITION_TTL_SECONDS` so the
    * millisecond product cannot overflow `setTimeout`'s signed 32-bit delay (item 4).
+   *
+   * `generation` MUST be the value the caller's own `bumpNetworkConditionGeneration`
+   * call returned for the mutation this TTL belongs to (issue #6181 review) — NOT
+   * re-read from the session's current generation here. Two mutations (B, C) can
+   * bump the shared counter before either reaches this call (B under `await
+   * trackSessionSetup`, C right behind it), so reading "current" at schedule time
+   * can tag B's timer with C's generation. Comparing against a per-call, per-mutation
+   * value closes that window: a timer only ever matches the generation it actually
+   * belongs to. Callers that don't track their own generation (tests, and any
+   * caller predating this parameter) may omit it, falling back to the session's
+   * current generation at schedule time — safe as long as no concurrent mutation is
+   * in flight for that call.
    */
-  scheduleNetworkConditionExpiry(session: Session, expiresInSeconds: number): void {
+  scheduleNetworkConditionExpiry(
+    session: Session,
+    expiresInSeconds: number,
+    generation?: number,
+  ): void {
     const sessionId = session.sessionId;
     this.cancelNetworkConditionExpiry(sessionId);
     if (!(expiresInSeconds > 0)) {
@@ -2105,14 +2121,13 @@ export class SessionManager {
           `setTimeout limit for session ${sessionId}; clamping to ${effectiveSeconds}s`,
       );
     }
-    // Capture the CURRENT generation into the closure (issue #6177): this is the
-    // generation of the condition this TTL belongs to. If a newer condition
-    // supersedes it before this timer's awaited restore settles, the generation
-    // check in restoreNetworkConditionOnExpiry detects the mismatch and skips
-    // clearing the newer condition's restore slot.
-    const generation = this.currentNetworkConditionGeneration(sessionId);
+    // Capture the OWNING mutation's generation into the closure (issue #6177,
+    // hardened #6181): if a newer condition supersedes it before this timer's
+    // awaited restore settles, the generation check in restoreNetworkConditionOnExpiry
+    // detects the mismatch and skips clearing the newer condition's restore slot.
+    const effectiveGeneration = generation ?? this.currentNetworkConditionGeneration(sessionId);
     const handle = this.timer.setTimeout(() => {
-      this.handleNetworkConditionExpiry(session, generation);
+      this.handleNetworkConditionExpiry(session, effectiveGeneration);
     }, effectiveSeconds * 1000);
     this.networkConditionExpiryTimers.set(sessionId, { handle, session });
   }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -345,6 +345,15 @@ export class SessionManager {
     string,
     { handle: NodeJS.Timeout; session: Session }
   > = new Map();
+  /**
+   * Monotonic per-session network-condition generation (issue #6177). Bumped by
+   * {@link bumpNetworkConditionGeneration} on every apply/reset mutation, and
+   * captured into a TTL expiry's closure when it is scheduled. A stale expiry
+   * (condition A) that is still awaiting its restore when a newer condition
+   * (B) is applied sees, on completion, that the session's generation has moved
+   * on — so it can detect it was superseded and must not clear B's restore slot.
+   */
+  private readonly networkConditionGeneration: Map<string, number> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
   /** Automatic device assignments that have not yet started their creation write. */
@@ -2096,8 +2105,14 @@ export class SessionManager {
           `setTimeout limit for session ${sessionId}; clamping to ${effectiveSeconds}s`,
       );
     }
+    // Capture the CURRENT generation into the closure (issue #6177): this is the
+    // generation of the condition this TTL belongs to. If a newer condition
+    // supersedes it before this timer's awaited restore settles, the generation
+    // check in restoreNetworkConditionOnExpiry detects the mismatch and skips
+    // clearing the newer condition's restore slot.
+    const generation = this.currentNetworkConditionGeneration(sessionId);
     const handle = this.timer.setTimeout(() => {
-      this.handleNetworkConditionExpiry(session);
+      this.handleNetworkConditionExpiry(session, generation);
     }, effectiveSeconds * 1000);
     this.networkConditionExpiryTimers.set(sessionId, { handle, session });
   }
@@ -2129,7 +2144,7 @@ export class SessionManager {
    * REPLACEMENT session (or an already-released one) is a no-op, so it never acts
    * on a freed or replaced device.
    */
-  private handleNetworkConditionExpiry(session: Session): void {
+  private handleNetworkConditionExpiry(session: Session, expectedGeneration: number): void {
     const sessionId = session.sessionId;
     const entry = this.networkConditionExpiryTimers.get(sessionId);
     if (entry && entry.session === session) {
@@ -2150,7 +2165,7 @@ export class SessionManager {
       `Network condition TTL elapsed for session ${sessionId}; resetting device ${target.deviceId} to none`,
     );
     this.trackPendingDeviceCleanup(target.deviceId, [
-      this.restoreNetworkConditionOnExpiry(session, target),
+      this.restoreNetworkConditionOnExpiry(session, target, expectedGeneration),
     ]);
   }
 
@@ -2163,10 +2178,11 @@ export class SessionManager {
   private async restoreNetworkConditionOnExpiry(
     session: Session,
     target: NetworkConditionRestoreTarget,
+    expectedGeneration: number,
   ): Promise<void> {
     try {
       await this.restoreNetworkCondition(target);
-      this.clearNetworkConditionIfOwned(session);
+      this.clearNetworkConditionIfOwned(session, expectedGeneration);
       return;
     } catch (error) {
       logger.warn(
@@ -2175,7 +2191,7 @@ export class SessionManager {
       );
       const succeeded = await this.retryNetworkConditionRestoreUntilSuccess(target, error);
       if (succeeded) {
-        this.clearNetworkConditionIfOwned(session);
+        this.clearNetworkConditionIfOwned(session, expectedGeneration);
       }
       // On exhaustion the slot is intentionally retained so a later release retries.
     }
@@ -2184,10 +2200,21 @@ export class SessionManager {
   /**
    * Drop the network restore slot once a reset has satisfied it (issue #6085),
    * but ONLY while the captured session is still the live one — a same-UUID
-   * replacement must keep its own freshly-published slot.
+   * replacement must keep its own freshly-published slot — AND only while the
+   * session's network-condition generation still matches the one this expiry was
+   * scheduled against (issue #6177). A stale expiry (condition A) that settles
+   * after a newer condition (B) has been applied must not delete B's restore
+   * slot: the generation mismatch is the signal that A has been superseded.
    */
-  private clearNetworkConditionIfOwned(session: Session): void {
+  private clearNetworkConditionIfOwned(session: Session, expectedGeneration: number): void {
     if (this.sessions.get(session.sessionId) !== session) {
+      return;
+    }
+    if (this.currentNetworkConditionGeneration(session.sessionId) !== expectedGeneration) {
+      logger.debug(
+        `Network condition TTL expiry for session ${session.sessionId} settled after a newer ` +
+          `condition superseded it; leaving that condition's restore slot in place`,
+      );
       return;
     }
     if (session.cacheData.networkCondition) {
@@ -2352,6 +2379,22 @@ export class SessionManager {
       return;
     }
     this.updateSessionCache(sessionId, { networkCondition: state });
+  }
+
+  /**
+   * Bump the per-session network-condition generation (issue #6177). Called on
+   * every apply/reset mutation, BEFORE the mutation runs, so a TTL scheduled for
+   * the condition being replaced can never observe the generation it captures as
+   * still current. Returns the new generation for the caller to arm a TTL with.
+   */
+  bumpNetworkConditionGeneration(sessionId: string): number {
+    const next = (this.networkConditionGeneration.get(sessionId) ?? 0) + 1;
+    this.networkConditionGeneration.set(sessionId, next);
+    return next;
+  }
+
+  private currentNetworkConditionGeneration(sessionId: string): number {
+    return this.networkConditionGeneration.get(sessionId) ?? 0;
   }
 
   /** Read the original network condition without recording session activity. */
@@ -2531,6 +2574,7 @@ export class SessionManager {
     }
     this.sessions.delete(sessionId);
     this.sessionDeviceMap.delete(sessionId);
+    this.networkConditionGeneration.delete(sessionId);
     return true;
   }
 

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -34,12 +34,20 @@ export async function runSessionNetworkMutation<T>(
       `Cannot mutate network condition: session ${sessionUuid} is bound to ${session.assignedDevice}, not ${deviceId}.`,
     );
   }
-  // Bump the network-condition generation BEFORE mutating (issue #6177): this
-  // condition (B) may be applied while an earlier condition's (A's) TTL expiry is
-  // still awaiting its restore. Bumping here — and having that expiry re-check the
-  // generation it captured when it fired, after its own restore settles — lets a
-  // stale A detect it has been superseded and skip clearing B's restore slot.
-  sessionManager.bumpNetworkConditionGeneration(sessionUuid);
+  // Bump the network-condition generation BEFORE mutating (issue #6177), and
+  // CAPTURE the value THIS mutation was assigned into a local. This condition
+  // (B) may be applied while an earlier condition's (A's) TTL expiry is still
+  // awaiting its restore — bumping here, and having that expiry re-check the
+  // generation it captured when it fired, lets a stale A detect it has been
+  // superseded and skip clearing B's restore slot.
+  //
+  // The capture matters as much as the bump (issue #6181 review): two mutations
+  // (B, C) can each bump the shared counter before either reaches the `await
+  // trackSessionSetup` below, so `scheduleNetworkConditionExpiry` must be told
+  // THIS call's generation explicitly rather than re-reading "current" once the
+  // mutation settles — by then a third mutation may have bumped it further, and
+  // re-reading would mistag this TTL with a generation it doesn't own.
+  const generation = sessionManager.bumpNetworkConditionGeneration(sessionUuid);
   // Publish the restore slot before mutating, so a release that begins while the
   // emulator command is in flight already knows the device must be restored.
   //
@@ -83,7 +91,7 @@ export async function runSessionNetworkMutation<T>(
   // on it). A reset, or a degrade with no TTL, arms nothing; the pre-mutation
   // cancel above already cleared any prior timer.
   if (registerRestore && expiresInSeconds !== undefined && expiresInSeconds > 0) {
-    sessionManager.scheduleNetworkConditionExpiry(session, expiresInSeconds);
+    sessionManager.scheduleNetworkConditionExpiry(session, expiresInSeconds, generation);
   }
   return result;
 }

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -34,6 +34,12 @@ export async function runSessionNetworkMutation<T>(
       `Cannot mutate network condition: session ${sessionUuid} is bound to ${session.assignedDevice}, not ${deviceId}.`,
     );
   }
+  // Bump the network-condition generation BEFORE mutating (issue #6177): this
+  // condition (B) may be applied while an earlier condition's (A's) TTL expiry is
+  // still awaiting its restore. Bumping here — and having that expiry re-check the
+  // generation it captured when it fired, after its own restore settles — lets a
+  // stale A detect it has been superseded and skip clearing B's restore slot.
+  sessionManager.bumpNetworkConditionGeneration(sessionUuid);
   // Publish the restore slot before mutating, so a release that begins while the
   // emulator command is in flight already knows the device must be restored.
   //

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2356,6 +2356,83 @@ describe("SessionManager", () => {
         manager.stopCleanupTimer();
       }
     });
+
+    test("a TTL captures the OWNING mutation's generation, not the shared counter re-read after a later mutation bumps it, across a three-way A/B/C overlap (#6181 review)", async () => {
+      const timer = new FakeTimer();
+      const restoreCalls: string[] = [];
+      let releaseDeferredRestore: (() => void) | undefined;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        noopBiometric,
+        (): NetworkConditionRestorer => ({
+          restore: async (profile) => {
+            restoreCalls.push(profile);
+            if (restoreCalls.length === 1) {
+              // Condition B's TTL-expiry restore: deferred so condition C can be
+              // applied while it is still in flight.
+              await new Promise<void>((resolve) => {
+                releaseDeferredRestore = resolve;
+              });
+            }
+          },
+        }),
+      );
+      try {
+        const sessionId = "net-ttl-three-way-generation";
+        const session = await manager.createSession(sessionId, "emulator-5554", "android");
+
+        // Condition A: establishes the restore slot at generation 1.
+        manager.bumpNetworkConditionGeneration(sessionId);
+        manager.setNetworkCondition(sessionId, { initialProfile: "none" });
+
+        // Condition B's mutation begins: it bumps to generation 2 and captures
+        // that value — exactly as runSessionNetworkMutation does — BEFORE its
+        // own (slow) mutation resolves.
+        const genB = manager.bumpNetworkConditionGeneration(sessionId);
+        expect(genB).toBe(2);
+
+        // Condition C's mutation ALSO begins and bumps to generation 3 while
+        // B's mutation is still conceptually in flight — the exact interleaving
+        // the review flagged: the shared counter has moved past B's own value
+        // before B ever reaches its schedule call.
+        const genC = manager.bumpNetworkConditionGeneration(sessionId);
+        expect(genC).toBe(3);
+
+        // B's mutation resolves first and arms a short TTL. It must be tagged
+        // with B's OWN captured generation (2) — a re-read of "current" here
+        // would wrongly pick up 3.
+        manager.scheduleNetworkConditionExpiry(session, 10, genB);
+
+        // B's TTL fires: its restore starts but hangs (deferred above). This
+        // also removes B's timer entry, so there is nothing left to cancel.
+        timer.advanceTime(10_000);
+        const bCleanup = manager.getPendingDeviceCleanup("emulator-5554");
+        expect(bCleanup).not.toBeNull();
+        expect(restoreCalls).toEqual(["none"]);
+
+        // C's mutation resolves after B's TTL has already fired and is still
+        // awaiting its restore, and arms its own TTL at its own generation.
+        manager.scheduleNetworkConditionExpiry(session, 100, genC);
+
+        // B's deferred restore now settles. With the OWNING generation (2)
+        // correctly captured, it must detect the mismatch against the current
+        // generation (3) and NOT clear C's restore slot.
+        releaseDeferredRestore?.();
+        await bCleanup;
+        expect(manager.getNetworkCondition(sessionId)).toEqual({ initialProfile: "none" });
+
+        // A later release must still restore the device — C's slot survived, so
+        // the device is not handed back to the pool still shaped.
+        await manager.releaseSession(sessionId);
+        expect(restoreCalls).toEqual(["none", "none"]);
+        expect(manager.getNetworkCondition(sessionId)).toBeUndefined();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
   });
 
   describe("statistics", () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2295,6 +2295,67 @@ describe("SessionManager", () => {
         manager.stopCleanupTimer();
       }
     });
+
+    test("a stale TTL (A) whose restore is still pending must not clobber a newer condition's (B's) restore slot (#6177)", async () => {
+      const timer = new FakeTimer();
+      const restoreCalls: string[] = [];
+      let releaseFirstRestore: (() => void) | undefined;
+      const manager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {} }),
+        noopBiometric,
+        (): NetworkConditionRestorer => ({
+          restore: async (profile) => {
+            restoreCalls.push(profile);
+            if (restoreCalls.length === 1) {
+              // Condition A's TTL-expiry restore: deferred so the test can apply
+              // condition B while it is still in flight.
+              await new Promise<void>((resolve) => {
+                releaseFirstRestore = resolve;
+              });
+            }
+          },
+        }),
+      );
+      try {
+        const sessionId = "net-ttl-generation";
+        const session = await manager.createSession(sessionId, "emulator-5554", "android");
+
+        // Apply condition A with a 60s TTL.
+        manager.bumpNetworkConditionGeneration(sessionId);
+        manager.setNetworkCondition(sessionId, { initialProfile: "none" });
+        manager.scheduleNetworkConditionExpiry(session, 60);
+
+        // A's TTL fires: its restore starts but hangs (deferred above).
+        timer.advanceTime(60_000);
+        const aCleanup = manager.getPendingDeviceCleanup("emulator-5554");
+        expect(aCleanup).not.toBeNull();
+        expect(restoreCalls).toEqual(["none"]);
+
+        // While A's restore is still pending, condition B is applied on the same
+        // session — bumping the generation and arming its own TTL, exactly as
+        // runSessionNetworkMutation does for a real setDeviceState call.
+        manager.bumpNetworkConditionGeneration(sessionId);
+        manager.cancelNetworkConditionExpiry(sessionId);
+        manager.scheduleNetworkConditionExpiry(session, 60);
+
+        // A's deferred restore now settles. Its completion must detect it was
+        // superseded and must NOT clear B's restore slot.
+        releaseFirstRestore?.();
+        await aCleanup;
+        expect(manager.getNetworkCondition(sessionId)).toEqual({ initialProfile: "none" });
+
+        // A later release must still restore the device — B's slot survived, so
+        // the device is not handed back to the pool still shaped.
+        await manager.releaseSession(sessionId);
+        expect(restoreCalls).toEqual(["none", "none"]);
+        expect(manager.getNetworkCondition(sessionId)).toBeUndefined();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
   });
 
   describe("statistics", () => {


### PR DESCRIPTION
Closes #6177

## Root cause

`src/daemon/sessionManager.ts` schedules a per-condition `networkCondition`
TTL (issue #6085 item 2). When it fires (`handleNetworkConditionExpiry`), the
timer entry is removed from `networkConditionExpiryTimers` immediately, but
the actual device reset (`restoreNetworkConditionOnExpiry`) is asynchronous
and awaited separately.

The earlier timer-overlap fix (#6113) only guarded against an *un-fired*
timer being superseded — `cancelNetworkConditionExpiry` runs before a new
mutation applies. It did not give the *awaited restore* of an already-fired
timer any per-condition identity. So the sequence:

1. Condition A applied, TTL A armed.
2. TTL A fires; its restore call starts (e.g. an emulator console command)
   but has not resolved yet.
3. While A's restore is still pending, the same session applies condition B
   (a new `setDeviceState` network mutation). `cancelNetworkConditionExpiry`
   is a no-op here — A's timer entry was already removed when it fired — so
   nothing stops B's mutation, and B publishes its own TTL.
4. A's restore finally resolves. `clearNetworkConditionIfOwned` only checked
   that the *session* was still live (identity-guarded against a same-UUID
   replacement session) — it had no way to know a *newer condition* had since
   been applied to that same session. It deleted the restore slot B had just
   published.
5. A later `release` reads `networkCondition` for the restore target, finds
   nothing, and hands the device back to the pool **without restoring it** —
   the device is left shaped by B.

## Fix

Add a monotonic per-session `networkCondition` generation
(`SessionManager.bumpNetworkConditionGeneration`), bumped by
`runSessionNetworkMutation` (`src/server/sessionNetworkCondition.ts`) on
every apply/reset mutation, BEFORE the mutation runs.

`scheduleNetworkConditionExpiry` captures the *current* generation into the
TTL's timer closure. When that TTL later fires and its restore settles,
`clearNetworkConditionIfOwned` re-checks the session's *current* generation
against the one captured at schedule time. A mismatch means a newer
condition has since been applied — the stale expiry now skips clearing the
slot (and skips it in both the immediate-success path and the
retry-until-success path), leaving the newer condition's restore slot intact
for a later release to act on. This matches the identity-guard pattern
already used for the session instance itself, just keyed one level finer
(per-condition rather than per-session).

The `networkConditionGeneration` map entry is cleaned up in `removeSession`
alongside the other per-session maps.

## Test

`test/daemon/sessionManager.test.ts`: new test "a stale TTL (A) whose restore
is still pending must not clobber a newer condition's (B's) restore slot
(#6177)", using `FakeTimer` and a restorer whose first call is deferred via
an externally-resolved promise. It drives exactly the A-fires →
(restore-pending) → apply-B → A-restore-completes interleaving and asserts:

- A's late completion does NOT clear B's restore slot
  (`getNetworkCondition` still returns B's baseline).
- A subsequent `release` still restores the device (second restore call
  fires, slot is cleared afterward) — the device is not left shaped.

**Red before / green after**: reverting just the generation check in
`clearNetworkConditionIfOwned` (`if (false && ...)`) while keeping the rest
of the fix reproduces the bug — the test fails with
`expect(manager.getNetworkCondition(sessionId)).toEqual({ initialProfile:
"none" })` receiving `undefined` (B's slot got cleared by A). Restoring the
check makes the test pass again.

## Validation

- `./node_modules/.bin/turbo run lint build test` — all pass (964 tests)
- `bun run format:check` — clean
- `bun run typecheck` — no new errors vs. baseline (163 known)
- `bun test test/daemon/sessionManager.test.ts` — 123 pass
- `bun test test/server/sessionNetworkCondition.test.ts` — 9 pass
