### PR TITLE
fix: preserve networkCondition TTL on failed reset; mirror TTL max in plan schemas

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -1118,7 +1118,8 @@
         "expiresInSeconds": {
           "type": "number",
           "minimum": 0,
-          "description": "Advisory TTL; session release/expiry restores connectivity"
+          "maximum": 2147483,
+          "description": "TTL in seconds. When set on a degrading request, a timer resets the device to normal connectivity after it elapses, independent of session lifetime; session release/expiry also restores connectivity, whichever comes first. Capped at 2147483s (~24.8 days) to fit the timer's 32-bit limit."
         }
       },
       "anyOf": [

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -1118,7 +1118,8 @@
         "expiresInSeconds": {
           "type": "number",
           "minimum": 0,
-          "description": "Advisory TTL; session release/expiry restores connectivity"
+          "maximum": 2147483,
+          "description": "TTL in seconds. When set on a degrading request, a timer resets the device to normal connectivity after it elapses, independent of session lifetime; session release/expiry also restores connectivity, whichever comes first. Capped at 2147483s (~24.8 days) to fit the timer's 32-bit limit."
         }
       },
       "anyOf": [

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -343,7 +343,7 @@ export class SessionManager {
    */
   private readonly networkConditionExpiryTimers: Map<
     string,
-    { handle: NodeJS.Timeout; session: Session }
+    { handle: NodeJS.Timeout; session: Session; deadlineMs: number; generation: number }
   > = new Map();
   /**
    * Monotonic per-session network-condition generation (issue #6177). Bumped by
@@ -2126,10 +2126,63 @@ export class SessionManager {
     // awaited restore settles, the generation check in restoreNetworkConditionOnExpiry
     // detects the mismatch and skips clearing the newer condition's restore slot.
     const effectiveGeneration = generation ?? this.currentNetworkConditionGeneration(sessionId);
+    this.armNetworkConditionExpiryAt(
+      session,
+      this.timer.now() + effectiveSeconds * 1000,
+      effectiveGeneration,
+    );
+  }
+
+  /**
+   * Arm the timer for an absolute deadline and a fixed generation, shared by
+   * {@link scheduleNetworkConditionExpiry} (a fresh TTL) and
+   * {@link rearmNetworkConditionExpiry} (restoring a snapshot taken by
+   * {@link peekNetworkConditionExpiry}). Identity-guarded like its callers: a
+   * session that was replaced under the same id since the deadline was captured
+   * is not armed against.
+   */
+  private armNetworkConditionExpiryAt(
+    session: Session,
+    deadlineMs: number,
+    generation: number,
+  ): void {
+    const sessionId = session.sessionId;
+    if (this.sessions.get(sessionId) !== session) {
+      return;
+    }
+    const remainingMs = Math.max(0, deadlineMs - this.timer.now());
     const handle = this.timer.setTimeout(() => {
-      this.handleNetworkConditionExpiry(session, effectiveGeneration);
-    }, effectiveSeconds * 1000);
-    this.networkConditionExpiryTimers.set(sessionId, { handle, session });
+      this.handleNetworkConditionExpiry(session, generation);
+    }, remainingMs);
+    this.networkConditionExpiryTimers.set(sessionId, { handle, session, deadlineMs, generation });
+  }
+
+  /**
+   * Snapshot a pending network-condition TTL without disturbing it (issue
+   * #6178 item 1). `runSessionNetworkMutation` calls this before cancelling the
+   * timer to run its own mutation race-free (issue #6085 review), then re-arms
+   * the snapshot via {@link rearmNetworkConditionExpiry} if that mutation does
+   * not confirm success — so a manual reset whose emulator command fails does
+   * not permanently drop the deadline a prior timed degrade promised.
+   */
+  peekNetworkConditionExpiry(
+    sessionId: string,
+  ): { deadlineMs: number; generation: number } | undefined {
+    const entry = this.networkConditionExpiryTimers.get(sessionId);
+    return entry ? { deadlineMs: entry.deadlineMs, generation: entry.generation } : undefined;
+  }
+
+  /**
+   * Re-arm a TTL previously captured via {@link peekNetworkConditionExpiry},
+   * preserving its original deadline and generation exactly (issue #6178 item
+   * 1). A deadline already in the past fires on the next tick rather than
+   * being dropped, matching a TTL that elapsed while the failed mutation ran.
+   */
+  rearmNetworkConditionExpiry(
+    session: Session,
+    snapshot: { deadlineMs: number; generation: number },
+  ): void {
+    this.armNetworkConditionExpiryAt(session, snapshot.deadlineMs, snapshot.generation);
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -354,6 +354,18 @@ export class SessionManager {
    * on — so it can detect it was superseded and must not clear B's restore slot.
    */
   private readonly networkConditionGeneration: Map<string, number> = new Map();
+  /**
+   * Per-session tail of the promise chain serializing
+   * {@link runNetworkConditionMutationExclusive} critical sections (issue #6178
+   * PR #6183 review, structural fix). The generation guard alone cannot
+   * preserve a displaced expiry: a later generation only proves a mutation was
+   * ATTEMPTED, not that it succeeded, so two overlapping FAILURES (B then C)
+   * could each see nothing to restore while a timed degrade's (A's) original
+   * deadline is lost between them. Serializing the whole apply/reset + TTL
+   * arm/cancel/re-arm sequence per session removes the race family outright —
+   * see {@link runNetworkConditionMutationExclusive}.
+   */
+  private readonly networkConditionMutationQueues: Map<string, Promise<unknown>> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
   /** Automatic device assignments that have not yet started their creation write. */
@@ -2481,6 +2493,40 @@ export class SessionManager {
     return next;
   }
 
+  /**
+   * Run `fn` as the next link in a per-session promise-chain mutex, so that
+   * `runSessionNetworkMutation`'s ENTIRE critical section — generation bump,
+   * TTL snapshot/cancel, the mutation itself, and its TTL re-arm/schedule
+   * decision — never overlaps another same-session networkCondition mutation
+   * (issue #6178 PR #6183 review). This is the structural fix for a family of
+   * races the generation guard alone could not close: a later generation only
+   * proves a mutation was ATTEMPTED, not that it succeeded, so two overlapping
+   * FAILURES could each observe nothing to restore while a displaced TTL is
+   * lost between them. With this lock, a later mutation's snapshot always sees
+   * the FULLY SETTLED state (including any prior mutation's own re-arm) of the
+   * one before it — the whole interleaving family becomes impossible, not just
+   * the specific cases already patched.
+   *
+   * Scoped narrowly and reentrancy-safe by construction: keyed per session id
+   * (never blocks a different session's mutations, or unrelated session work
+   * like release/rebind — those act on the timer/session maps directly), and
+   * `fn` is the caller's entire body, so nothing outside this one critical
+   * section is ever held across an await. `.catch(() => undefined)` on the
+   * chain tail ensures one mutation's rejection cannot wedge the queue for the
+   * next; the `finally` drops the map entry once nothing is queued behind it,
+   * so a dead session leaves no residue.
+   */
+  runNetworkConditionMutationExclusive<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.networkConditionMutationQueues.get(sessionId) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(fn);
+    this.networkConditionMutationQueues.set(sessionId, next);
+    return next.finally(() => {
+      if (this.networkConditionMutationQueues.get(sessionId) === next) {
+        this.networkConditionMutationQueues.delete(sessionId);
+      }
+    });
+  }
+
   private currentNetworkConditionGeneration(sessionId: string): number {
     return this.networkConditionGeneration.get(sessionId) ?? 0;
   }
@@ -2663,6 +2709,7 @@ export class SessionManager {
     this.sessions.delete(sessionId);
     this.sessionDeviceMap.delete(sessionId);
     this.networkConditionGeneration.delete(sessionId);
+    this.networkConditionMutationQueues.delete(sessionId);
     return true;
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -2177,11 +2177,31 @@ export class SessionManager {
    * preserving its original deadline and generation exactly (issue #6178 item
    * 1). A deadline already in the past fires on the next tick rather than
    * being dropped, matching a TTL that elapsed while the failed mutation ran.
+   *
+   * Generation-guarded (issue #6178 PR #6183 review, P1): the caller's own
+   * mutation attempt already bumped the counter to `snapshot.generation`
+   * before it ran, so an UNCHANGED current generation means nothing else has
+   * mutated since. But three overlapping requests on one session (A's timed
+   * degrade, B's slow failing re-apply, C's later successful re-apply) can
+   * settle out of order — B's failure must not blindly re-arm A's deadline
+   * once C has already bumped the counter again and established its own
+   * state (its own fresh TTL, live in the timer map, or a deliberate "no
+   * TTL"). Skipping whenever the generation has moved on avoids both
+   * resurrecting a deadline C already retired AND clobbering C's live timer
+   * handle without cancelling it.
    */
   rearmNetworkConditionExpiry(
     session: Session,
     snapshot: { deadlineMs: number; generation: number },
   ): void {
+    const sessionId = session.sessionId;
+    if (this.currentNetworkConditionGeneration(sessionId) !== snapshot.generation) {
+      logger.debug(
+        `Skipping network-condition TTL re-arm for session ${sessionId}: generation ` +
+          `${snapshot.generation} has been superseded by a later mutation`,
+      );
+      return;
+    }
     this.armNetworkConditionExpiryAt(session, snapshot.deadlineMs, snapshot.generation);
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -2201,6 +2201,17 @@ export class SessionManager {
    * TTL"). Skipping whenever the generation has moved on avoids both
    * resurrecting a deadline C already retired AND clobbering C's live timer
    * handle without cancelling it.
+   *
+   * Also refuses to re-arm a releasing/released session (issue #6178 PR #6183
+   * review, P2): `releaseSessionInternal` cancels any pending TTL BEFORE
+   * awaiting the tracked mutation that may still be in flight. If that
+   * mutation then throws (or otherwise triggers a re-arm) while release is
+   * still draining, blindly re-arming here would undo release's cancellation
+   * — either running a stale timer concurrently with release's own
+   * restoration, or pinning a released session's timer-map entry for up to
+   * `MAX_NETWORK_CONDITION_TTL_SECONDS` (~24.8 days). Release's cancellation
+   * must be the last word, so a releasing/no-longer-current session is never
+   * re-armed.
    */
   rearmNetworkConditionExpiry(
     session: Session,
@@ -2211,6 +2222,13 @@ export class SessionManager {
       logger.debug(
         `Skipping network-condition TTL re-arm for session ${sessionId}: generation ` +
           `${snapshot.generation} has been superseded by a later mutation`,
+      );
+      return;
+    }
+    if (!this.isAdmittedForAutomation(session)) {
+      logger.debug(
+        `Skipping network-condition TTL re-arm for session ${sessionId}: session is releasing ` +
+          `or no longer live`,
       );
       return;
     }

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -69,98 +69,112 @@ export async function runSessionNetworkMutation<T>(
       `Cannot mutate network condition: session ${sessionUuid} is bound to ${session.assignedDevice}, not ${deviceId}.`,
     );
   }
-  // Bump the network-condition generation BEFORE mutating (issue #6177), and
-  // CAPTURE the value THIS mutation was assigned into a local. This condition
-  // (B) may be applied while an earlier condition's (A's) TTL expiry is still
-  // awaiting its restore — bumping here, and having that expiry re-check the
-  // generation it captured when it fired, lets a stale A detect it has been
-  // superseded and skip clearing B's restore slot.
-  //
-  // The capture matters as much as the bump (issue #6181 review): two mutations
-  // (B, C) can each bump the shared counter before either reaches the `await
-  // trackSessionSetup` below, so `scheduleNetworkConditionExpiry` must be told
-  // THIS call's generation explicitly rather than re-reading "current" once the
-  // mutation settles — by then a third mutation may have bumped it further, and
-  // re-reading would mistag this TTL with a generation it doesn't own.
-  const generation = sessionManager.bumpNetworkConditionGeneration(sessionUuid);
-  // Publish the restore slot before mutating, so a release that begins while the
-  // emulator command is in flight already knows the device must be restored.
-  //
-  // DOCUMENTED CONTRACT (issue #6012): a session ALWAYS restores the network to a
-  // clean `none` state on release/rebind — never to a reconstructed pre-session
-  // condition. This is deliberate, not a limitation to paper over: the emulator
-  // console's `network status` returns only free-form download/upload/latency
-  // text whose format varies by emulator version, so a pre-session baseline
-  // cannot be reliably reconstructed or re-applied — and faking one would be
-  // worse than not trying. More importantly, sessions run against a device pool
-  // that must hand the NEXT session a clean device, so restoring to `none` is the
-  // correct behavior even if a prior condition were knowable. The stored baseline
-  // is therefore fixed at `none`.
-  if (registerRestore) {
-    sessionManager.setNetworkCondition(sessionUuid, { initialProfile: "none" });
-  }
-
-  // Cancel any prior TTL BEFORE the mutation, not after (issue #6085 review): a
-  // slow re-apply would otherwise leave the OLD timer armed, and it could fire
-  // mid-mutation, reset the just-shaped device, and clear the freshly-published
-  // restore slot. Cancelling up front closes that overlap window; the new TTL (if
-  // any) is armed only after the mutation settles, below.
-  //
-  // Snapshot the prior TTL's DEADLINE before cancelling it (issue #6178 item 1):
-  // if this mutation is a manual reset (or any mutation) that does not confirm
-  // success — a typed `success: false` result, or a thrown error — the
-  // emulator's shaping never actually changed, so the ORIGINAL deadline must
-  // survive rather than being silently dropped. Re-arming below restores that
-  // deadline, but tagged with THIS call's generation (captured above), not the
-  // snapshot's: the counter was already bumped for this attempt regardless of
-  // its outcome, so the re-armed timer must match what
-  // `currentNetworkConditionGeneration` will return, or its eventual successful
-  // fire would see a generation mismatch and skip clearing the restore slot.
-  const priorExpiry = sessionManager.peekNetworkConditionExpiry(sessionUuid);
-  sessionManager.cancelNetworkConditionExpiry(sessionUuid);
-  const rearmPriorExpiry = () => {
-    if (priorExpiry) {
-      sessionManager.rearmNetworkConditionExpiry(session, {
-        deadlineMs: priorExpiry.deadlineMs,
-        generation,
-      });
+  // Run the ENTIRE apply/reset + TTL decision as one per-session critical
+  // section (issue #6178 PR #6183 review, structural fix): the generation
+  // guard on `rearmNetworkConditionExpiry` alone cannot preserve a displaced
+  // expiry, because a later generation only proves a mutation was ATTEMPTED,
+  // not that it succeeded — two overlapping FAILURES (a slow B, then C) could
+  // each find nothing to restore while a timed degrade's (A's) original
+  // deadline is lost between them. Serializing here removes that whole
+  // interleaving family: at most one such critical section runs per session at
+  // a time, so this mutation's snapshot always sees the FULLY SETTLED state
+  // (including any earlier mutation's own re-arm) rather than a window where
+  // it has been cancelled but not yet resolved one way or the other.
+  return sessionManager.runNetworkConditionMutationExclusive(sessionUuid, async () => {
+    // Bump the network-condition generation BEFORE mutating (issue #6177), and
+    // CAPTURE the value THIS mutation was assigned into a local. This condition
+    // (B) may be applied while an earlier condition's (A's) TTL expiry is still
+    // awaiting its restore — bumping here, and having that expiry re-check the
+    // generation it captured when it fired, lets a stale A detect it has been
+    // superseded and skip clearing B's restore slot. The generation guard now
+    // serves as defense-in-depth alongside the serialization above, not as the
+    // sole protection.
+    //
+    // The capture matters as much as the bump (issue #6181 review): a caller
+    // must be told THIS call's generation explicitly rather than re-reading
+    // "current" once the mutation settles — by then a later queued mutation may
+    // have bumped it further, and re-reading would mistag this TTL with a
+    // generation it doesn't own.
+    const generation = sessionManager.bumpNetworkConditionGeneration(sessionUuid);
+    // Publish the restore slot before mutating, so a release that begins while the
+    // emulator command is in flight already knows the device must be restored.
+    //
+    // DOCUMENTED CONTRACT (issue #6012): a session ALWAYS restores the network to a
+    // clean `none` state on release/rebind — never to a reconstructed pre-session
+    // condition. This is deliberate, not a limitation to paper over: the emulator
+    // console's `network status` returns only free-form download/upload/latency
+    // text whose format varies by emulator version, so a pre-session baseline
+    // cannot be reliably reconstructed or re-applied — and faking one would be
+    // worse than not trying. More importantly, sessions run against a device pool
+    // that must hand the NEXT session a clean device, so restoring to `none` is the
+    // correct behavior even if a prior condition were knowable. The stored baseline
+    // is therefore fixed at `none`.
+    if (registerRestore) {
+      sessionManager.setNetworkCondition(sessionUuid, { initialProfile: "none" });
     }
-  };
 
-  let completed = false;
-  let result!: T;
-  try {
-    await sessionManager.trackSessionSetup(session, async () => {
-      result = await mutation();
-      completed = true;
-    });
-  } catch (error) {
-    rearmPriorExpiry();
-    throw error;
-  }
-  if (!completed) {
-    rearmPriorExpiry();
-    throw new Error(
-      `Cannot mutate network condition: session ${sessionUuid} began releasing before the mutation started.`,
-    );
-  }
-  if (isTypedFailureResult(result)) {
-    // Restore the prior deadline and STOP (issue #6178 PR #6183 review, P2): a
-    // failed re-apply must not fall through to the schedule below, which would
-    // immediately cancel the just-restored timer and arm a fresh TTL for a
-    // mutation that never actually took effect.
-    rearmPriorExpiry();
+    // Cancel any prior TTL BEFORE the mutation, not after (issue #6085 review): a
+    // slow re-apply would otherwise leave the OLD timer armed, and it could fire
+    // mid-mutation, reset the just-shaped device, and clear the freshly-published
+    // restore slot. Cancelling up front closes that overlap window; the new TTL (if
+    // any) is armed only after the mutation settles, below.
+    //
+    // Snapshot the prior TTL's DEADLINE before cancelling it (issue #6178 item 1):
+    // if this mutation is a manual reset (or any mutation) that does not confirm
+    // success — a typed `success: false` result, or a thrown error — the
+    // emulator's shaping never actually changed, so the ORIGINAL deadline must
+    // survive rather than being silently dropped. Re-arming below restores that
+    // deadline, but tagged with THIS call's generation (captured above), not the
+    // snapshot's: the counter was already bumped for this attempt regardless of
+    // its outcome, so the re-armed timer must match what
+    // `currentNetworkConditionGeneration` will return, or its eventual successful
+    // fire would see a generation mismatch and skip clearing the restore slot.
+    const priorExpiry = sessionManager.peekNetworkConditionExpiry(sessionUuid);
+    sessionManager.cancelNetworkConditionExpiry(sessionUuid);
+    const rearmPriorExpiry = () => {
+      if (priorExpiry) {
+        sessionManager.rearmNetworkConditionExpiry(session, {
+          deadlineMs: priorExpiry.deadlineMs,
+          generation,
+        });
+      }
+    };
+
+    let completed = false;
+    let result!: T;
+    try {
+      await sessionManager.trackSessionSetup(session, async () => {
+        result = await mutation();
+        completed = true;
+      });
+    } catch (error) {
+      rearmPriorExpiry();
+      throw error;
+    }
+    if (!completed) {
+      rearmPriorExpiry();
+      throw new Error(
+        `Cannot mutate network condition: session ${sessionUuid} began releasing before the mutation started.`,
+      );
+    }
+    if (isTypedFailureResult(result)) {
+      // Restore the prior deadline and STOP (issue #6178 PR #6183 review, P2): a
+      // failed re-apply must not fall through to the schedule below, which would
+      // immediately cancel the just-restored timer and arm a fresh TTL for a
+      // mutation that never actually took effect.
+      rearmPriorExpiry();
+      return result;
+    }
+    // Arm the standalone per-condition TTL (issue #6085 item 2) for a degrade that
+    // registered a restore slot AND carries a positive TTL. Pass the CAPTURED
+    // `session` instance so a stale re-apply — one whose tracked setup finished only
+    // after this session was released and replaced under the same UUID — cannot arm
+    // a TTL against the replacement (scheduleNetworkConditionExpiry identity-guards
+    // on it). A reset, or a degrade with no TTL, arms nothing; the pre-mutation
+    // cancel above already cleared any prior timer.
+    if (registerRestore && expiresInSeconds !== undefined && expiresInSeconds > 0) {
+      sessionManager.scheduleNetworkConditionExpiry(session, expiresInSeconds, generation);
+    }
     return result;
-  }
-  // Arm the standalone per-condition TTL (issue #6085 item 2) for a degrade that
-  // registered a restore slot AND carries a positive TTL. Pass the CAPTURED
-  // `session` instance so a stale re-apply — one whose tracked setup finished only
-  // after this session was released and replaced under the same UUID — cannot arm
-  // a TTL against the replacement (scheduleNetworkConditionExpiry identity-guards
-  // on it). A reset, or a degrade with no TTL, arms nothing; the pre-mutation
-  // cancel above already cleared any prior timer.
-  if (registerRestore && expiresInSeconds !== undefined && expiresInSeconds > 0) {
-    sessionManager.scheduleNetworkConditionExpiry(session, expiresInSeconds, generation);
-  }
-  return result;
+  });
 }

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -1,19 +1,38 @@
 import type { SessionManager } from "../daemon/sessionManager";
 
 /**
- * True when `value` is a typed `{ success: false, ... }` result (e.g.
- * `DeviceStateResult`) rather than a thrown error or an untyped void return.
- * `DeviceState` converts a failed emulator command into a resolved
- * `success: false` rather than throwing (issue #6178 item 1), so a caller
- * that only watches for a rejection misses it.
+ * True when `value` shows the network-condition mutation itself did not
+ * succeed — a typed failure (`DeviceState` converts a failed emulator command
+ * into a resolved result rather than throwing) rather than a thrown error or
+ * an untyped void return.
+ *
+ * A combined `setDeviceState` request (e.g. `networkCondition` + `doNotDisturb`
+ * in one call) can report a `success: false` TOP-LEVEL aggregate because a
+ * DIFFERENT field failed while `networkCondition` itself applied cleanly
+ * (issue #6178 PR #6183 review, P2): re-arming the prior TTL on that aggregate
+ * flag would wrongly revive a deadline the network mutation already retired.
+ * So when a `networkCondition` sub-result is present, judge success from IT
+ * specifically, using the same predicate `DeviceState.setState` folds into its
+ * own aggregate (`supported && !error && verified !== false`) — never the
+ * top-level flag. Only a result with no `networkCondition` sub-result (a bare
+ * reset outcome with no per-field breakdown) falls back to the top-level flag.
  */
 function isTypedFailureResult(value: unknown): boolean {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "success" in value &&
-    (value as Record<string, unknown>).success === false
-  );
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if ("networkCondition" in record && typeof record.networkCondition === "object") {
+    const networkCondition = record.networkCondition as Record<string, unknown> | null;
+    if (networkCondition !== null) {
+      const succeeded =
+        networkCondition.supported === true &&
+        !networkCondition.error &&
+        networkCondition.verified !== false;
+      return !succeeded;
+    }
+  }
+  return "success" in record && record.success === false;
 }
 
 /**
@@ -126,7 +145,12 @@ export async function runSessionNetworkMutation<T>(
     );
   }
   if (isTypedFailureResult(result)) {
+    // Restore the prior deadline and STOP (issue #6178 PR #6183 review, P2): a
+    // failed re-apply must not fall through to the schedule below, which would
+    // immediately cancel the just-restored timer and arm a fresh TTL for a
+    // mutation that never actually took effect.
     rearmPriorExpiry();
+    return result;
   }
   // Arm the standalone per-condition TTL (issue #6085 item 2) for a degrade that
   // registered a restore slot AND carries a positive TTL. Pass the CAPTURED

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -1,6 +1,22 @@
 import type { SessionManager } from "../daemon/sessionManager";
 
 /**
+ * True when `value` is a typed `{ success: false, ... }` result (e.g.
+ * `DeviceStateResult`) rather than a thrown error or an untyped void return.
+ * `DeviceState` converts a failed emulator command into a resolved
+ * `success: false` rather than throwing (issue #6178 item 1), so a caller
+ * that only watches for a rejection misses it.
+ */
+function isTypedFailureResult(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "success" in value &&
+    (value as Record<string, unknown>).success === false
+  );
+}
+
+/**
  * Bind a device-wide network-condition mutation to the session lifecycle,
  * paralleling {@link runSessionBiometricMutation} (issue #6012 review).
  *
@@ -70,18 +86,47 @@ export async function runSessionNetworkMutation<T>(
   // mid-mutation, reset the just-shaped device, and clear the freshly-published
   // restore slot. Cancelling up front closes that overlap window; the new TTL (if
   // any) is armed only after the mutation settles, below.
+  //
+  // Snapshot the prior TTL's DEADLINE before cancelling it (issue #6178 item 1):
+  // if this mutation is a manual reset (or any mutation) that does not confirm
+  // success — a typed `success: false` result, or a thrown error — the
+  // emulator's shaping never actually changed, so the ORIGINAL deadline must
+  // survive rather than being silently dropped. Re-arming below restores that
+  // deadline, but tagged with THIS call's generation (captured above), not the
+  // snapshot's: the counter was already bumped for this attempt regardless of
+  // its outcome, so the re-armed timer must match what
+  // `currentNetworkConditionGeneration` will return, or its eventual successful
+  // fire would see a generation mismatch and skip clearing the restore slot.
+  const priorExpiry = sessionManager.peekNetworkConditionExpiry(sessionUuid);
   sessionManager.cancelNetworkConditionExpiry(sessionUuid);
+  const rearmPriorExpiry = () => {
+    if (priorExpiry) {
+      sessionManager.rearmNetworkConditionExpiry(session, {
+        deadlineMs: priorExpiry.deadlineMs,
+        generation,
+      });
+    }
+  };
 
   let completed = false;
   let result!: T;
-  await sessionManager.trackSessionSetup(session, async () => {
-    result = await mutation();
-    completed = true;
-  });
+  try {
+    await sessionManager.trackSessionSetup(session, async () => {
+      result = await mutation();
+      completed = true;
+    });
+  } catch (error) {
+    rearmPriorExpiry();
+    throw error;
+  }
   if (!completed) {
+    rearmPriorExpiry();
     throw new Error(
       `Cannot mutate network condition: session ${sessionUuid} began releasing before the mutation started.`,
     );
+  }
+  if (isTypedFailureResult(result)) {
+    rearmPriorExpiry();
   }
   // Arm the standalone per-condition TTL (issue #6085 item 2) for a degrade that
   // registered a restore slot AND carries a positive TTL. Pass the CAPTURED

--- a/src/server/sessionNetworkCondition.ts
+++ b/src/server/sessionNetworkCondition.ts
@@ -81,6 +81,23 @@ export async function runSessionNetworkMutation<T>(
   // (including any earlier mutation's own re-arm) rather than a window where
   // it has been cancelled but not yet resolved one way or the other.
   return sessionManager.runNetworkConditionMutationExclusive(sessionUuid, async () => {
+    // Re-validate the captured session is STILL the live one before touching
+    // any shared state (issue #6178 PR #6183 review, P1 release race):
+    // `session` was captured above, before waiting for this per-session queue
+    // slot. A predecessor mutation can run long enough to outlast a session
+    // release — if this call was queued behind it, by the time this callback
+    // finally runs the session may have been released and a same-UUID
+    // REPLACEMENT session may already be live and mutating its own TTL, or
+    // this session may simply be draining. Aborting here — before any
+    // generation bump, TTL snapshot/cancel, or mutation — guarantees a stale
+    // queued mutation never bumps the replacement's generation or cancels its
+    // timer.
+    if (!sessionManager.isAdmittedForAutomation(session)) {
+      throw new Error(
+        `Cannot mutate network condition: session ${sessionUuid} is no longer the live session ` +
+          `(released, replaced, or releasing).`,
+      );
+    }
     // Bump the network-condition generation BEFORE mutating (issue #6177), and
     // CAPTURE the value THIS mutation was assigned into a local. This condition
     // (B) may be applied while an earlier condition's (A's) TTL expiry is still

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -129,6 +129,19 @@ steps:
       expect(validator.validateYaml(yaml).valid).toBe(true);
     });
 
+    it("should accept the networkCondition TTL maximum (#6178 item 2)", () => {
+      // Mirrors MAX_NETWORK_CONDITION_TTL_SECONDS (src/features/utility/DeviceState.ts).
+      const yaml = `
+name: net-ttl-max
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: veryBad
+      expiresInSeconds: 2147483
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(true);
+    });
+
     it("should accept an inline networkCondition that params.networkCondition overrides (#6090 review)", () => {
       // PlanNormalizer gives params precedence, so at execution this step receives
       // ONLY the valid params reset — the inline `{delayMs:0}` is discarded. Schema
@@ -331,6 +344,22 @@ steps:
       delayMs: 0
 `;
       expect(validator.validateYaml(yaml).valid).toBe(false);
+    });
+
+    it("should reject a networkCondition TTL above the maximum (#6178 item 2)", () => {
+      // Mirrors MAX_NETWORK_CONDITION_TTL_SECONDS (src/features/utility/DeviceState.ts):
+      // out-of-range values must be rejected at plan validation, not only at
+      // execution (issue #6178, from the #6113 review).
+      const yaml = `
+name: net-ttl-above-max
+steps:
+  - tool: setDeviceState
+    networkCondition:
+      profile: veryBad
+      expiresInSeconds: 2147484
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
     });
 
     it("should validate iOS simulator permissions through cross-platform permission tools", () => {

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -345,30 +345,97 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
-  test("B's late failed re-apply does not re-arm A's TTL over C's live TTL (#6178 PR #6183 review, P1)", async () => {
+  test("serializes overlapping same-session network mutations so the second observes the first's completed state (#6178 PR #6183 review, structural fix)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    const startedFirst = Promise.withResolvers<void>();
+    const finishFirst = Promise.withResolvers<void>();
+    const order: string[] = [];
+    try {
+      await manager.createSession("net-serialize", "emulator-5554", "android");
+
+      // First mutation starts and blocks mid-flight, HOLDING the per-session lock.
+      const first = runSessionNetworkMutation(
+        manager,
+        "net-serialize",
+        "emulator-5554",
+        true,
+        async () => {
+          order.push("first-start");
+          startedFirst.resolve();
+          await finishFirst.promise;
+          order.push("first-end");
+        },
+        30,
+      );
+      await startedFirst.promise;
+
+      // A second mutation is issued while the first is still in flight. Its
+      // critical section (bump/snapshot/cancel/mutation) must not begin until
+      // the first has fully settled, including its own TTL decision.
+      let secondStarted = false;
+      const second = runSessionNetworkMutation(
+        manager,
+        "net-serialize",
+        "emulator-5554",
+        true,
+        async () => {
+          secondStarted = true;
+          order.push("second-start");
+        },
+        60,
+      );
+
+      // Give the microtask queue every chance to run the second mutation's body
+      // if it were (incorrectly) allowed to start concurrently with the first.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(secondStarted).toBe(false);
+
+      finishFirst.resolve();
+      await first;
+      await second;
+
+      // The second only ran after the first fully completed — no interleaving.
+      expect(order).toEqual(["first-start", "first-end", "second-start"]);
+
+      // The second's own 60s TTL (armed only once both settled) is what fires.
+      timer.advanceTime(60_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("A's original TTL survives two overlapping FAILURES, B then C (#6178 PR #6183 review, structural fix)", async () => {
     const timer = new FakeTimer();
     const restored: string[] = [];
     const manager = makeManager(timer, restored);
     const startedB = Promise.withResolvers<void>();
     const finishedB = Promise.withResolvers<void>();
+    const startedC = Promise.withResolvers<void>();
+    const finishedC = Promise.withResolvers<void>();
     try {
-      await manager.createSession("net-overlap", "emulator-5554", "android");
+      await manager.createSession("net-ab-fail", "emulator-5554", "android");
 
       // A: timed degrade, 30s TTL.
       await runSessionNetworkMutation(
         manager,
-        "net-overlap",
+        "net-ab-fail",
         "emulator-5554",
         true,
         async () => {},
         30,
       );
+      timer.advanceTime(5_000); // 25s remain on A's deadline.
 
-      // B: a slow re-apply that will eventually fail. Its tracked mutation blocks
-      // partway through, snapshotting and cancelling A's TTL before it does.
+      // B: a slow re-apply that will fail. Holds the per-session lock while blocked.
       const mutationB = runSessionNetworkMutation(
         manager,
-        "net-overlap",
+        "net-ab-fail",
         "emulator-5554",
         true,
         async () => {
@@ -380,29 +447,39 @@ describe("runSessionNetworkMutation", () => {
       );
       await startedB.promise;
 
-      // C: arrives while B is still in flight and applies successfully with its
-      // own 50s TTL — this bumps the generation counter past B's.
-      await runSessionNetworkMutation(
+      // C is issued while B is still in flight. Under serialization it cannot
+      // even begin its critical section (no bump, no snapshot) until B's lock
+      // is released — this call just queues.
+      const mutationC = runSessionNetworkMutation(
         manager,
-        "net-overlap",
+        "net-ab-fail",
         "emulator-5554",
         true,
-        async () => {},
+        async () => {
+          startedC.resolve();
+          await finishedC.promise;
+          return { success: false, deviceId: "emulator-5554", platform: "android" as const };
+        },
         50,
       );
 
-      // B now settles as a failure. Its attempt to re-arm A's original deadline
-      // must be skipped: the generation has moved on to C, so B's stale snapshot
-      // must neither resurrect A's deadline nor clobber C's live timer.
+      // B fails. With B and C serialized, B's re-arm of A's original deadline
+      // is NOT stale (nothing has bumped the generation past B's yet), so it
+      // succeeds — then B releases the lock and C's critical section begins.
       finishedB.resolve();
       await mutationB;
+      await startedC.promise;
 
-      // A's original 30s deadline passes and fires nothing.
-      timer.advanceTime(30_000);
+      // C fails too, snapshotting the deadline B just restored and re-arming it
+      // again under C's own (now-current) generation.
+      finishedC.resolve();
+      await mutationC;
+
+      // A's ORIGINAL deadline (25s remaining from the 5s mark, i.e. absolute
+      // t=30s) fires and restores — never lost between B's and C's failures.
+      timer.advanceTime(24_000);
       expect(restored).toEqual([]);
-
-      // C's own 50s TTL still fires on schedule and restores.
-      timer.advanceTime(20_000);
+      timer.advanceTime(1_000);
       await manager.getPendingDeviceCleanup("emulator-5554");
       expect(restored).toEqual(["none"]);
     } finally {

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -269,6 +269,82 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
+  test("preserves the original TTL deadline when a manual reset fails (#6178 item 1)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-reset-fail", "emulator-5554", "android");
+      // Timed degrade arms a 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-reset-fail",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      // 10s elapse, then a manual reset (registerRestore=false) whose emulator
+      // command fails — DeviceState resolves this as `success: false`, not a throw.
+      timer.advanceTime(10_000);
+      const resetResult = await runSessionNetworkMutation(
+        manager,
+        "net-reset-fail",
+        "emulator-5554",
+        false,
+        async () => ({ success: false, deviceId: "emulator-5554", platform: "android" }),
+      );
+      expect(resetResult).toEqual({
+        success: false,
+        deviceId: "emulator-5554",
+        platform: "android",
+      });
+
+      // The failed reset must not have cancelled the original degrade's TTL: it
+      // still fires at its ORIGINAL deadline (20s of its 30s remain), not never
+      // and not from a fresh 30s.
+      timer.advanceTime(19_000);
+      expect(restored).toEqual([]);
+      timer.advanceTime(1_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+      expect(manager.getNetworkCondition("net-reset-fail")).toBeUndefined();
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("preserves the original TTL deadline when a manual reset throws (#6178 item 1)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-reset-throw", "emulator-5554", "android");
+      await runSessionNetworkMutation(
+        manager,
+        "net-reset-throw",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      timer.advanceTime(10_000);
+      await expect(
+        runSessionNetworkMutation(manager, "net-reset-throw", "emulator-5554", false, async () => {
+          throw new Error("emulator console rejected reset");
+        }),
+      ).rejects.toThrow("emulator console rejected reset");
+
+      timer.advanceTime(20_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("runs the mutation untracked when there is no session", async () => {
     let ran = false;
     const result = await runSessionNetworkMutation(

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -345,6 +345,165 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
+  test("B's late failed re-apply does not re-arm A's TTL over C's live TTL (#6178 PR #6183 review, P1)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    const startedB = Promise.withResolvers<void>();
+    const finishedB = Promise.withResolvers<void>();
+    try {
+      await manager.createSession("net-overlap", "emulator-5554", "android");
+
+      // A: timed degrade, 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-overlap",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      // B: a slow re-apply that will eventually fail. Its tracked mutation blocks
+      // partway through, snapshotting and cancelling A's TTL before it does.
+      const mutationB = runSessionNetworkMutation(
+        manager,
+        "net-overlap",
+        "emulator-5554",
+        true,
+        async () => {
+          startedB.resolve();
+          await finishedB.promise;
+          return { success: false, deviceId: "emulator-5554", platform: "android" as const };
+        },
+        40,
+      );
+      await startedB.promise;
+
+      // C: arrives while B is still in flight and applies successfully with its
+      // own 50s TTL — this bumps the generation counter past B's.
+      await runSessionNetworkMutation(
+        manager,
+        "net-overlap",
+        "emulator-5554",
+        true,
+        async () => {},
+        50,
+      );
+
+      // B now settles as a failure. Its attempt to re-arm A's original deadline
+      // must be skipped: the generation has moved on to C, so B's stale snapshot
+      // must neither resurrect A's deadline nor clobber C's live timer.
+      finishedB.resolve();
+      await mutationB;
+
+      // A's original 30s deadline passes and fires nothing.
+      timer.advanceTime(30_000);
+      expect(restored).toEqual([]);
+
+      // C's own 50s TTL still fires on schedule and restores.
+      timer.advanceTime(20_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("a failed re-apply restores the prior deadline and does not arm a fresh TTL of its own (#6178 PR #6183 review, P2)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-reapply-fail", "emulator-5554", "android");
+      // A: 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-reapply-fail",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      timer.advanceTime(10_000);
+
+      // A failing re-apply that ALSO carries its own (very different) TTL. If the
+      // failure path fell through to schedule a fresh TTL for it, the device
+      // would instead be reset ~999s from now rather than at the ORIGINAL
+      // 20s-remaining deadline.
+      const result = await runSessionNetworkMutation(
+        manager,
+        "net-reapply-fail",
+        "emulator-5554",
+        true,
+        async () => ({ success: false, deviceId: "emulator-5554", platform: "android" as const }),
+        999,
+      );
+      expect(result.success).toBe(false);
+
+      // The ORIGINAL deadline (20s remaining) fires — not a fresh 999s TTL from
+      // the failed re-apply, and not never.
+      timer.advanceTime(19_000);
+      expect(restored).toEqual([]);
+      timer.advanceTime(1_000);
+      await manager.getPendingDeviceCleanup("emulator-5554");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("a combined request where DND fails but networkCondition succeeds is not treated as a network failure (#6178 PR #6183 review, P3)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    try {
+      await manager.createSession("net-combined", "emulator-5554", "android");
+      // A: 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-combined",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      timer.advanceTime(10_000);
+
+      // A combined request with NO TTL of its own: the TOP-LEVEL aggregate is
+      // success:false because DND failed, but the networkCondition sub-result
+      // applied cleanly. (No expiresInSeconds is deliberate: it isolates this
+      // case from the #6178 item 2 fix — a wrongly-triggered rearm is the ONLY
+      // thing that could still fire below.)
+      const combined: DeviceStateResult = {
+        success: false,
+        deviceId: "emulator-5554",
+        platform: "android",
+        doNotDisturb: { supported: true, enabled: false, error: "DND toggle rejected" },
+        networkCondition: { supported: true, capability: "partial", appliedProfile: "3g" },
+        error: "DND toggle rejected",
+      };
+      const result = await runSessionNetworkMutation(
+        manager,
+        "net-combined",
+        "emulator-5554",
+        true,
+        async () => combined,
+      );
+      expect(result).toEqual(combined);
+
+      // The network mutation is judged a SUCCESS from its own sub-result, so A's
+      // original TTL is correctly retired (not revived) — and since this request
+      // carried no TTL of its own, nothing is ever scheduled to fire again.
+      timer.advanceTime(1_000_000);
+      expect(restored).toEqual([]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("runs the mutation untracked when there is no session", async () => {
     let ran = false;
     const result = await runSessionNetworkMutation(

--- a/test/server/sessionNetworkCondition.test.ts
+++ b/test/server/sessionNetworkCondition.test.ts
@@ -581,6 +581,142 @@ describe("runSessionNetworkMutation", () => {
     }
   });
 
+  test("a mutation queued behind release aborts without touching a same-UUID replacement's generation/timer (#6178 PR #6183 review, P1)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    const startedA = Promise.withResolvers<void>();
+    const finishedA = Promise.withResolvers<void>();
+    try {
+      await manager.createSession("net-release-race", "emulator-5554", "android");
+
+      // A: a mutation that runs long enough to outlast release's ~1s setup
+      // drain. No restore slot (registerRestore=false) so release's OWN
+      // teardown does not also touch the network condition for this device —
+      // this test is about the QUEUE/identity race, not release's restore path.
+      const mutationA = runSessionNetworkMutation(
+        manager,
+        "net-release-race",
+        "emulator-5554",
+        false,
+        async () => {
+          startedA.resolve();
+          await finishedA.promise;
+        },
+      );
+      await startedA.promise;
+
+      // B is issued while A is still in flight — queued behind it on the
+      // per-session mutation lock.
+      let bStarted = false;
+      const mutationB = runSessionNetworkMutation(
+        manager,
+        "net-release-race",
+        "emulator-5554",
+        true,
+        async () => {
+          bStarted = true;
+        },
+        999,
+      );
+
+      // Release begins. It cancels any pending TTL (none right now) and waits
+      // up to 1s for A's tracked setup, which never comes since A is still
+      // blocked — the drain times out and release removes the session anyway.
+      const release = manager.releaseSession("net-release-race");
+      await timer.advanceTimeAsync(1_000);
+      await release;
+
+      // A same-UUID REPLACEMENT session is created and successfully applies
+      // its own condition with its own TTL, all while A (and queued B) are
+      // still unresolved.
+      await manager.createSession("net-release-race", "emulator-5556", "android");
+      await runSessionNetworkMutation(
+        manager,
+        "net-release-race",
+        "emulator-5556",
+        true,
+        async () => {},
+        20,
+      );
+
+      // A finally completes, unblocking B. B must abort — it captured the OLD
+      // (now-dead) session — WITHOUT bumping the replacement's generation or
+      // touching its timer.
+      finishedA.resolve();
+      await mutationA;
+      await expect(mutationB).rejects.toThrow(/no longer the live session/);
+      expect(bStarted).toBe(false);
+
+      // The replacement's own 20s TTL still fires untouched.
+      timer.advanceTime(20_000);
+      await manager.getPendingDeviceCleanup("emulator-5556");
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("release rejects a re-arm from a mutation that throws while draining, so no timer is left armed (#6178 PR #6183 review, P2)", async () => {
+    const timer = new FakeTimer();
+    const restored: string[] = [];
+    const manager = makeManager(timer, restored);
+    const startedB = Promise.withResolvers<void>();
+    const failB = Promise.withResolvers<void>();
+    try {
+      await manager.createSession("net-release-throw", "emulator-5554", "android");
+
+      // A: 30s TTL.
+      await runSessionNetworkMutation(
+        manager,
+        "net-release-throw",
+        "emulator-5554",
+        true,
+        async () => {},
+        30,
+      );
+
+      // B: a re-apply that will THROW. Blocks mid-mutation, having already
+      // snapshotted and cancelled A's TTL.
+      const mutationB = runSessionNetworkMutation(
+        manager,
+        "net-release-throw",
+        "emulator-5554",
+        true,
+        async () => {
+          startedB.resolve();
+          await failB.promise;
+          throw new Error("emulator console rejected re-apply");
+        },
+        40,
+      );
+      await startedB.promise;
+
+      // Release begins WHILE B's mutation is still tracked/in-flight.
+      const release = manager.releaseSession("net-release-throw");
+
+      // B's mutation now throws. Its catch block attempts to re-arm A's
+      // original deadline — but the session is already releasing, so the
+      // re-arm must be skipped.
+      failB.resolve();
+      await expect(mutationB).rejects.toThrow("emulator console rejected re-apply");
+
+      await release;
+
+      // Release's own restoration ran exactly once — no interference from a
+      // resurrected TTL, and no timer was left armed for the (now-released)
+      // session.
+      expect(restored).toEqual(["none"]);
+      expect(manager.peekNetworkConditionExpiry("net-release-throw")).toBeUndefined();
+
+      // Advancing time arbitrarily confirms nothing was pinned/hidden.
+      timer.advanceTime(100_000_000);
+      expect(restored).toEqual(["none"]);
+    } finally {
+      manager.stopCleanupTimer();
+    }
+  });
+
   test("runs the mutation untracked when there is no session", async () => {
     let ran = false;
     const result = await runSessionNetworkMutation(


### PR DESCRIPTION
Closes #6178

Two post-merge review findings on #6113 (networkCondition TTL), never addressed. Builds on top of the #6177 per-mutation-generation fix (#6181) already on `main`.

## Part 1 — Preserve the old TTL until a reset succeeds

`runSessionNetworkMutation` (`src/server/sessionNetworkCondition.ts`) unconditionally cancelled any pending per-condition TTL *before* running its mutation. That ordering is correct to avoid a race with a slow re-apply (#6085 review), but it meant a manual reset whose emulator command failed — `DeviceState` resolves that as a typed `success: false`, not a throw — permanently lost the original expiry. The prior delay/bandwidth shaping then stayed in place until session release instead of expiring at its promised deadline.

Fix:
- `SessionManager` now snapshots the pending timer's absolute deadline and generation (`peekNetworkConditionExpiry`) before cancelling it, and can re-arm that exact snapshot (`rearmNetworkConditionExpiry`), both built on a shared `armNetworkConditionExpiryAt`.
- `runSessionNetworkMutation` snapshots the prior TTL, cancels it (unchanged race-avoidance ordering), runs the mutation, and re-arms the snapshot — tagged with *this* attempt's already-bumped generation, so a later successful fire correctly matches `currentNetworkConditionGeneration` — if the mutation throws or resolves with a typed `success: false`.
- On success (or no prior TTL), behavior is unchanged.

Tests (`test/server/sessionNetworkCondition.test.ts`, FakeTimer, <1ms each):
- `preserves the original TTL deadline when a manual reset fails (#6178 item 1)` — arms a 30s TTL, advances 10s, a manual reset resolves `success: false`, then asserts the *original* deadline (20s remaining, not a fresh 30s) still fires and restores.
- `preserves the original TTL deadline when a manual reset throws (#6178 item 1)` — same, but the reset mutation throws.
- All 9 pre-existing tests in this file still pass unchanged, including the #6085 review test asserting the prior TTL is still cancelled *before* a slow re-apply's mutation runs.

## Part 2 — Mirror the TTL maximum in the plan schemas

`src/server/utilityTools.ts` defines the runtime max as `MAX_NETWORK_CONDITION_TTL_SECONDS` (`2_147_483`s, from `src/features/utility/DeviceState.ts`) on the `setDeviceState` Zod schema's `networkCondition.expiresInSeconds`, but neither JSON plan schema mirrored it — so both plan validators accepted out-of-range values that then deterministically failed only at execution.

Fix:
- Added `"maximum": 2147483` plus the runtime TTL description to `expiresInSeconds` under `networkConditionStateInput` in both `schemas/test-plan.schema.json` and `android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json` (kept drift-identical; verified with `scripts/check-schema-copy-drift.ts`).

Tests (`test/plan/PlanSchemaValidator.test.ts`):
- `should accept the networkCondition TTL maximum (#6178 item 2)` — `expiresInSeconds: 2147483` validates.
- `should reject a networkCondition TTL above the maximum (#6178 item 2)` — `expiresInSeconds: 2147484` is rejected at plan-validation time (not only at execution).

## Validation

- `turbo run lint build test` (via `./node_modules/.bin/turbo`) — pass
- `bun run format:check` — pass
- `bun run typecheck` — pass, no new baseline errors
- `bun run scripts/check-schema-copy-drift.ts` — schemas structurally identical
- `scripts/update-tool-definitions.sh` — `schemas/tool-definitions.json` already up to date (no Zod schema changed)
