### PR TITLE
fix(ios): classify kill -0 EPERM as running in isRunning

### DIFF
--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -3,6 +3,12 @@ import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
 import type { Timer } from "../SystemTimer";
 import { defaultTimer } from "../SystemTimer";
 import { logger } from "../logger";
+import { errorMessage } from "../describeUnknownError";
+
+/** Matches a `kill -0` failure caused by the target being owned by another
+ * user/process (EPERM), not by it being gone (ESRCH). The process exists in
+ * this case, so callers must not treat the failure as "not running". */
+const PERMISSION_DENIED_PATTERN = /operation not permitted|permission denied/i;
 
 export interface CtrlProxyProcessInfo {
   readonly ppid?: number;
@@ -128,14 +134,18 @@ export class IOSCtrlProxyProcessClient {
   async isRunning(pid: number, deadline?: number): Promise<boolean> {
     try {
       const result = await this.executeCommand("kill", ["-0", String(pid)], deadline);
-      return !/operation not permitted|permission denied/i.test(result.stderr);
+      return !PERMISSION_DENIED_PATTERN.test(result.stderr);
     } catch (error) {
       // A command error means the process is unavailable only while the
       // caller's cleanup budget remains. Do not turn deadline expiry into a
       // successful exit observation.
       this.remainingTimeoutMs(deadline);
       logger.debug(`[IOSCtrlProxy] Failed to check PID ${pid}: ${error}`);
-      return false;
+      // `kill -0` exits non-zero for both EPERM (process exists, owned by
+      // another user) and ESRCH (no such process), so the exec seam's throw
+      // path can't be told apart by exit code alone. Classify from the
+      // wrapped error text: EPERM means the process is alive (#6137).
+      return PERMISSION_DENIED_PATTERN.test(errorMessage(error));
     }
   }
 

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -152,4 +152,38 @@ describe("IOSCtrlProxyProcessClient", () => {
     await expect(client.isRunning(77)).resolves.toBe(false);
     expect(host.getExecutedCommands()).toEqual(["kill -0 77"]);
   });
+
+  test("treats a kill -0 EPERM rejection as the process still running (#6137)", async () => {
+    const host: HostCommandExecutor = {
+      async executeCommand() {
+        throw new Error(
+          "Command failed: kill -0 77\nexit code: 1\nstderr: (last 4000 chars)\nOperation not permitted",
+        );
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await expect(client.isRunning(77)).resolves.toBe(true);
+  });
+
+  test("treats a kill -0 ESRCH rejection as the process not running", async () => {
+    const host: HostCommandExecutor = {
+      async executeCommand() {
+        throw new Error(
+          "Command failed: kill -0 77\nexit code: 1\nstderr: (last 4000 chars)\nNo such process",
+        );
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await expect(client.isRunning(77)).resolves.toBe(false);
+  });
+
+  test("treats a clean kill -0 exit as the process running", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("kill -0 77", result());
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await expect(client.isRunning(77)).resolves.toBe(true);
+  });
 });


### PR DESCRIPTION
## Root cause

`IOSCtrlProxyProcessClient.isRunning` (`src/utils/ios/IOSCtrlProxyProcessClient.ts`)
ran `kill -0 <pid>` through `executeCommand` → `runExecSeam`
(`src/utils/ExecSeam.ts`), which throws on any non-zero exit. `/bin/kill -0`
exits 1 both for EPERM (process exists, owned by another user) and ESRCH (no
such process), so both cases landed in the `catch` and returned `false`. The
`stderr` regex guard in the `try` branch that was meant to detect EPERM text
was therefore unreachable — a successful, zero-exit `kill -0` never carries
"Operation not permitted" in `stderr`.

Consequences: `waitForExit`/`haveExited` reported a process tree as exited
right after `TERM` even though it was alive under another user,
`terminateProcessTree` returned success prematurely, and `isOwnedRunnerAlive`
falsely reported `false` for such a runner.

## Fix

In the `catch`, classify the wrapped error's message for the EPERM/permission
text (`operation not permitted` / `permission denied`, case-insensitive) and
return `true` (process exists) when it matches — mirroring the existing
correct pattern in `src/utils/logPruner.ts`'s `defaultIsProcessAlive`, which
checks `error.code === "EPERM"` on a direct `process.kill` call. Genuine
"no such process" / ESRCH failures still return `false`. The shared regex
also backs the pre-existing `try`-branch stderr guard, unifying the constant.

## Test

`test/utils/ios/IOSCtrlProxyProcessClient.test.ts` adds:

- a `kill -0` rejection whose wrapped error text contains
  "Operation not permitted" → `isRunning` resolves `true`
- a `kill -0` rejection whose wrapped error text contains "No such process"
  → `isRunning` resolves `false`
- a clean `kill -0` exit → `isRunning` resolves `true`

All new tests use a fake exec seam (`HostCommandExecutor`/`FakeHostCommandExecutor`)
and run well under 100ms; no real `getDatabase()` is touched.

Closes #6137
