### PR TITLE
fix(plan): cancel failure-observation timer via injected Timer seam

### DIFF
--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -266,16 +266,20 @@ export class DefaultPlanExecutor implements PlanExecutor {
       const parsedParams = observeTool.schema.parse(enhancedParams) as Record<string, unknown>;
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-      const response = await Promise.race([
-        ToolRegistry.callInternal(observeTool, parsedParams),
-        new Promise<never>((_, reject) => {
-          timeoutHandle = this.timer.setTimeout(() => {
-            reject(new Error("failure observation timed out"));
-          }, DefaultPlanExecutor.FAILURE_OBSERVATION_TIMEOUT_MS);
-        }),
-      ]);
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle);
+      let response: unknown;
+      try {
+        response = await Promise.race([
+          ToolRegistry.callInternal(observeTool, parsedParams),
+          new Promise<never>((_, reject) => {
+            timeoutHandle = this.timer.setTimeout(() => {
+              reject(new Error("failure observation timed out"));
+            }, DefaultPlanExecutor.FAILURE_OBSERVATION_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeoutHandle) {
+          this.timer.clearTimeout(timeoutHandle);
+        }
       }
 
       const raw = this.parseStructuredToolPayload(response);

--- a/test/plan/planExecutorCaptureFailureObservationTimer.test.ts
+++ b/test/plan/planExecutorCaptureFailureObservationTimer.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerObserveTools } from "../../src/server/observeTools";
+import { z } from "zod/v4";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Regression test for issue #6139: `captureFailureObservation` scheduled its
+ * failure-observation timeout via the injected `Timer` but cancelled it with
+ * the global `clearTimeout`, and the cancel sat after the `Promise.race`
+ * outside a `finally` — so it was skipped whenever the race settled via
+ * rejection (an injected `Timer` such as `FakeTimer` never has the handle
+ * cancelled, leaking a pending timer). The fix cancels through
+ * `this.timer.clearTimeout(...)` inside a `finally` around the race so the
+ * timer is always cancelled, on both the resolve and reject paths.
+ */
+describe("PlanExecutor — captureFailureObservation timer cancellation", () => {
+  let planExecutor: DefaultPlanExecutor;
+  let fakeTimer: FakeTimer;
+
+  const deviceSchema = z.object({
+    platform: z.string().optional(),
+    deviceId: z.string().optional(),
+    sessionUuid: z.string().optional(),
+  });
+
+  const markDevice = (name: string) => {
+    (ToolRegistry.getTool(name) as { requiresDevice: boolean }).requiresDevice = true;
+  };
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    planExecutor = new DefaultPlanExecutor(fakeTimer);
+
+    ToolRegistry.register(
+      "captureTimerFailStep",
+      "always fails, triggering captureFailureObservation",
+      deviceSchema,
+      mock(async () => createStructuredToolResponse({ success: false, error: "boom" })),
+    );
+    markDevice("captureTimerFailStep");
+  });
+
+  afterEach(() => {
+    registerObserveTools();
+  });
+
+  test("cancels the injected timer via this.timer, not global clearTimeout, on the success path", async () => {
+    ToolRegistry.register(
+      "observe",
+      "observe resolves before the failure-observation timeout",
+      deviceSchema,
+      mock(async () =>
+        createStructuredToolResponse({
+          updatedAt: 0,
+          screenSize: { width: 100, height: 100 },
+          systemInsets: { left: 0, top: 0, right: 0, bottom: 0 },
+        }),
+      ),
+    );
+    markDevice("observe");
+
+    const plan: Plan = {
+      name: "capture-failure-observation-success",
+      steps: [{ tool: "captureTimerFailStep", params: {} }],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "android", "emulator-5554");
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.failureObservation).toBeDefined();
+    expect(result.failedStep?.failureObservation?.observeError).toBeUndefined();
+    // The observe tool resolved before the failure-observation timeout fired,
+    // so the `finally` block must have cancelled it through the injected
+    // FakeTimer — no pending timer should remain.
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("cancels the injected timer via this.timer, not global clearTimeout, on the rejection path", async () => {
+    ToolRegistry.register(
+      "observe",
+      "observe rejects before the failure-observation timeout",
+      deviceSchema,
+      mock(async () => {
+        throw new Error("observe blew up");
+      }),
+    );
+    markDevice("observe");
+
+    const plan: Plan = {
+      name: "capture-failure-observation-rejection",
+      steps: [{ tool: "captureTimerFailStep", params: {} }],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "android", "emulator-5554");
+
+    expect(result.success).toBe(false);
+    // captureFailureObservation's own catch turns the rejection into an
+    // observeError summary rather than throwing.
+    expect(result.failedStep?.failureObservation?.observeError).toContain("observe blew up");
+    // Before the fix, the cancel after Promise.race was skipped on this
+    // rejection path (and used the global clearTimeout even when reached),
+    // so the FakeTimer's pending timeout was never removed.
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Root cause

`PlanExecutor.captureFailureObservation` (src/utils/plan/PlanExecutor.ts) scheduled its 3s failure-observation timeout via the injected `this.timer.setTimeout(...)`, but cancelled it with the global `clearTimeout(timeoutHandle)`. Under an injected `Timer` (e.g. `FakeTimer` in tests, or any future non-global-backed Timer implementation) that cancel is a no-op, so the fake's pending timer never clears.

Worse, the cancel sat after the `Promise.race([...])` call, outside any `finally`. When `ToolRegistry.callInternal(observeTool, ...)` rejects, the `catch` block runs and the cancel line is skipped entirely — leaking the scheduled timeout on every rejection path (in production this keeps the event loop alive for up to 3s; under `FakeTimer` it leaves a permanently pending timer, breaking test determinism).

## Fix

Wrap the `Promise.race` in `try { ... } finally { if (timeoutHandle) this.timer.clearTimeout(timeoutHandle); }` so the injected `Timer` seam is always used to cancel the timeout, on both the resolve and reject paths.

## Test

`test/plan/planExecutorCaptureFailureObservationTimer.test.ts` — uses `FakeTimer` injected into `DefaultPlanExecutor` and exercises `captureFailureObservation` (via a plan step that fails, triggering the failure-observation capture):

- success path: the mocked `observe` tool resolves before the timeout fires; asserts `fakeTimer.getPendingTimeoutCount()` is `0` afterward.
- rejection path: the mocked `observe` tool throws; asserts the timer is still cancelled (`getPendingTimeoutCount()` is `0`) and the rejection is captured as an `observeError` summary rather than propagating.

Verified the new test fails against the pre-fix code (both assertions report `Received: 1` pending timeout) and passes with the fix.

Closes #6139
