### PR TITLE
fix(server): make table-data resource pagination params optional and order-independent

### DIFF
--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -15,8 +15,14 @@ import type { TableDataResult } from "../features/database/DatabaseInspector";
 const DATABASE_RESOURCE_TEMPLATES = {
   DATABASES: "automobile:devices/{deviceId}/databases?appId={appId}",
   TABLES: "automobile:devices/{deviceId}/databases/{databasePath}/tables?appId={appId}",
+  // {?appId,limit,offset} is the RFC 6570 optional-query form: ResourceRegistry's
+  // compileUriTemplate parses it via URLSearchParams, so appId/limit/offset each
+  // match independently of presence or order (issue #6133). A literal
+  // "?appId={appId}&limit={limit}&offset={offset}" query string compiles to
+  // fixed-order, all-required captures instead and only matches when every
+  // param appears, in that exact order.
   TABLE_DATA:
-    "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/data?appId={appId}",
+    "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/data{?appId,limit,offset}",
   TABLE_STRUCTURE:
     "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/structure?appId={appId}",
 } as const;
@@ -288,6 +294,26 @@ async function getTablesResource(params: Record<string, string>): Promise<Resour
 }
 
 /**
+ * Parse an optional pagination query param (limit/offset) as a non-negative
+ * integer. Returns `defaultValue` when the param is absent or empty; throws
+ * a descriptive error for anything else that isn't a non-negative integer
+ * (issue #6133 — previously `parseInt` silently produced `NaN`).
+ */
+function parsePaginationParam(
+  raw: string | undefined,
+  defaultValue: number,
+  paramName: string,
+): number {
+  if (raw === undefined || raw === "") {
+    return defaultValue;
+  }
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ${paramName} "${raw}": must be a non-negative integer`);
+  }
+  return Number.parseInt(raw, 10);
+}
+
+/**
  * Get table data resource content
  */
 async function getTableDataResource(params: Record<string, string>): Promise<ResourceContent> {
@@ -296,11 +322,13 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const decodedTable = decodeURIComponent(table);
   const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId);
 
-  // Parse optional limit and offset from query params
-  const limit = params.limit ? parseInt(params.limit, 10) : 50;
-  const offset = params.offset ? parseInt(params.offset, 10) : 0;
-
   try {
+    // Parse optional limit and offset from query params. Each is validated as
+    // a non-negative integer when present; absent falls back to the
+    // documented default (issue #6133).
+    const limit = parsePaginationParam(params.limit, 50, "limit");
+    const offset = parsePaginationParam(params.offset, 0, "offset");
+
     const device = await findBootedDevice(deviceId);
     if (!device) {
       return {
@@ -470,20 +498,12 @@ export function registerDatabaseResources(): void {
     getTablesResource,
   );
 
-  // Register template for table data
+  // Register template for table data. appId, limit, and offset are all
+  // optional and order-independent (issue #6133) — see the template comment.
   ResourceRegistry.registerTemplate(
     DATABASE_RESOURCE_TEMPLATES.TABLE_DATA,
     "Table Data",
     "Get rows from a database table with pagination (default: 50 rows). Add &limit=N&offset=M for pagination.",
-    "application/json",
-    getTableDataResource,
-  );
-
-  // Also register with limit/offset parameters
-  ResourceRegistry.registerTemplate(
-    "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/data?appId={appId}&limit={limit}&offset={offset}",
-    "Table Data (Paginated)",
-    "Get rows from a database table with explicit pagination.",
     "application/json",
     getTableDataResource,
   );

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -1,4 +1,4 @@
-import { ResourceRegistry, ResourceContent, getRequestedResourceUri } from "./resourceRegistry";
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import {
   DatabaseInspector,
@@ -320,14 +320,17 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const { deviceId, databasePath, table, appId } = params;
   const decodedPath = decodeURIComponent(databasePath);
   const decodedTable = decodeURIComponent(table);
-  // Echo back the URI the client actually requested (limit/offset included)
-  // rather than a canonical one without pagination — otherwise two different
-  // pages come back labeled with the same URI, which a URI-keyed MCP client
-  // would conflate (issue #6188). Falls back to the canonical form only if
-  // this handler is ever invoked outside the registry's template-match path.
-  const uri =
-    getRequestedResourceUri(params) ??
-    buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
+  // Always the canonical URI (no limit/offset), never the exact requested
+  // URI. notifyDatabaseChanged / table-schema invalidation both fire
+  // notifyResourceUpdated against this canonical form, and
+  // ResourceRegistry.notifyResourceUpdated requires an exact
+  // subscriptions.has(uri) match — echoing a per-page URI here would leave a
+  // client subscribed to a paginated URI never notified after a mutating
+  // sqlQuery (issue #6188). limit/offset stay valid, optional read params
+  // (issue #6133); the resource's subscribable identity is just the table,
+  // not a page of it. Distinct per-page subscription identities would need a
+  // broader resource-subscription redesign, tracked separately.
+  const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
 
   try {
     // ResourceRegistry forwards any query key that isn't captured as a path

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -1,4 +1,4 @@
-import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { ResourceRegistry, ResourceContent, getRequestedResourceUri } from "./resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import {
   DatabaseInspector,
@@ -320,7 +320,14 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const { deviceId, databasePath, table, appId } = params;
   const decodedPath = decodeURIComponent(databasePath);
   const decodedTable = decodeURIComponent(table);
-  const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
+  // Echo back the URI the client actually requested (limit/offset included)
+  // rather than a canonical one without pagination — otherwise two different
+  // pages come back labeled with the same URI, which a URI-keyed MCP client
+  // would conflate (issue #6188). Falls back to the canonical form only if
+  // this handler is ever invoked outside the registry's template-match path.
+  const uri =
+    getRequestedResourceUri(params) ??
+    buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
 
   try {
     // ResourceRegistry forwards any query key that isn't captured as a path

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -10,6 +10,7 @@ import { BootedDevice } from "../models";
 import { logger } from "../utils/logger";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { TableDataResult } from "../features/database/DatabaseInspector";
+import { optionalInteger } from "./queryParamValidation";
 
 // Resource URI templates
 const DATABASE_RESOURCE_TEMPLATES = {
@@ -299,32 +300,6 @@ async function getTablesResource(params: Record<string, string>): Promise<Resour
 }
 
 /**
- * Parse an optional pagination query param (limit/offset) as a non-negative
- * safe integer. Returns `defaultValue` when the param is absent or empty;
- * throws a descriptive error for anything else that isn't a non-negative
- * safe integer (issue #6133 — previously `parseInt` silently produced `NaN`;
- * an all-digit string outside Number.MAX_SAFE_INTEGER would otherwise round
- * or overflow to `Infinity`).
- */
-function parsePaginationParam(
-  raw: string | undefined,
-  defaultValue: number,
-  paramName: string,
-): number {
-  if (raw === undefined || raw === "") {
-    return defaultValue;
-  }
-  if (!/^\d+$/.test(raw)) {
-    throw new Error(`Invalid ${paramName} "${raw}": must be a non-negative integer`);
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value)) {
-    throw new Error(`Invalid ${paramName} "${raw}": must be a safe integer`);
-  }
-  return value;
-}
-
-/**
  * Get table data resource content
  */
 async function getTableDataResource(params: Record<string, string>): Promise<ResourceContent> {
@@ -342,11 +317,12 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
     if (!appId) {
       throw new Error("Missing required appId query parameter for table data");
     }
-    // Parse optional limit and offset from query params. Each is validated as
-    // a non-negative integer when present; absent falls back to the
-    // documented default (issue #6133).
-    const limit = parsePaginationParam(params.limit, 50, "limit");
-    const offset = parsePaginationParam(params.offset, 0, "offset");
+    // Parse optional limit and offset from query params using the repo's
+    // centralized query-validation helper (safe-integer + min-bound), rather
+    // than a second hand-rolled parser (issue #6188). Absent/empty falls
+    // back to the documented default (issue #6133).
+    const limit = optionalInteger(params.limit, "limit", { min: 0 }) ?? 50;
+    const offset = optionalInteger(params.offset, "offset", { min: 0 }) ?? 0;
 
     const device = await findBootedDevice(deviceId);
     if (!device) {

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -21,6 +21,11 @@ const DATABASE_RESOURCE_TEMPLATES = {
   // "?appId={appId}&limit={limit}&offset={offset}" query string compiles to
   // fixed-order, all-required captures instead and only matches when every
   // param appears, in that exact order.
+  //
+  // ResourceRegistry has no way to mark one of the template's query variables
+  // required and the others optional, so `appId` matches the template even
+  // when absent/empty (issue #6188) — getTableDataResource rejects a missing
+  // or empty `appId` itself instead of forwarding it to the platform client.
   TABLE_DATA:
     "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/data{?appId,limit,offset}",
   TABLE_STRUCTURE:
@@ -295,9 +300,11 @@ async function getTablesResource(params: Record<string, string>): Promise<Resour
 
 /**
  * Parse an optional pagination query param (limit/offset) as a non-negative
- * integer. Returns `defaultValue` when the param is absent or empty; throws
- * a descriptive error for anything else that isn't a non-negative integer
- * (issue #6133 — previously `parseInt` silently produced `NaN`).
+ * safe integer. Returns `defaultValue` when the param is absent or empty;
+ * throws a descriptive error for anything else that isn't a non-negative
+ * safe integer (issue #6133 — previously `parseInt` silently produced `NaN`;
+ * an all-digit string outside Number.MAX_SAFE_INTEGER would otherwise round
+ * or overflow to `Infinity`).
  */
 function parsePaginationParam(
   raw: string | undefined,
@@ -310,7 +317,11 @@ function parsePaginationParam(
   if (!/^\d+$/.test(raw)) {
     throw new Error(`Invalid ${paramName} "${raw}": must be a non-negative integer`);
   }
-  return Number.parseInt(raw, 10);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`Invalid ${paramName} "${raw}": must be a safe integer`);
+  }
+  return value;
 }
 
 /**
@@ -320,9 +331,17 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const { deviceId, databasePath, table, appId } = params;
   const decodedPath = decodeURIComponent(databasePath);
   const decodedTable = decodeURIComponent(table);
-  const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId);
+  const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
 
   try {
+    // appId is a required identity for the target app/database, unlike
+    // limit/offset — the `{?appId,limit,offset}` query-expansion form makes
+    // every one of its variables optional at the template level, so the
+    // handler must reject a missing or empty appId itself rather than
+    // forwarding `undefined`/"" to the platform inspector (issue #6188).
+    if (!appId) {
+      throw new Error("Missing required appId query parameter for table data");
+    }
     // Parse optional limit and offset from query params. Each is validated as
     // a non-negative integer when present; absent falls back to the
     // documented default (issue #6133).

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -33,6 +33,20 @@ const DATABASE_RESOURCE_TEMPLATES = {
     "automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/structure?appId={appId}",
 } as const;
 
+// Path-captured and declared-query param names for the table-data template,
+// used to reject any other (e.g. typo'd) query key instead of silently
+// ignoring it (issue #6188) — matching the unknown-key validation in
+// parsePerformanceParams/parseTrafficParams/parseAppsQueryParams.
+const TABLE_DATA_PATH_PARAM_NAMES = new Set(["deviceId", "databasePath", "table"]);
+const TABLE_DATA_QUERY_PARAM_NAMES = new Set(["appId", "limit", "offset"]);
+
+// Android's DatabaseInspectorProvider.handleGetTableData parses limit/offset
+// with Kotlin's `toIntOrNull()` (a 32-bit signed int), silently falling back
+// to its own default when a value overflows Int32 — so a JS-safe-integer
+// value like 2147483648 would report success with the wrong effective page
+// instead of the value it claims. Bound both to the Int32 range up front.
+const INT32_MAX = 2_147_483_647;
+
 // Cache entries for change detection
 interface DatabaseCacheEntry {
   databases: DatabaseInfo[];
@@ -309,6 +323,19 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const uri = buildTableDataUri(deviceId, decodedPath, decodedTable, appId ?? "");
 
   try {
+    // ResourceRegistry forwards any query key that isn't captured as a path
+    // param, including a typo'd one (e.g. `limt=10`), rather than silently
+    // dropping it — see extractTemplateParams (issue #6188). Reject one here
+    // instead of silently falling back to defaults, matching the unknown-key
+    // validation in parsePerformanceParams/parseTrafficParams/
+    // parseAppsQueryParams.
+    const unknownKeys = Object.keys(params).filter(
+      (key) => !TABLE_DATA_PATH_PARAM_NAMES.has(key) && !TABLE_DATA_QUERY_PARAM_NAMES.has(key),
+    );
+    if (unknownKeys.length > 0) {
+      throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
+    }
+
     // appId is a required identity for the target app/database, unlike
     // limit/offset — the `{?appId,limit,offset}` query-expansion form makes
     // every one of its variables optional at the template level, so the
@@ -320,9 +347,10 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
     // Parse optional limit and offset from query params using the repo's
     // centralized query-validation helper (safe-integer + min-bound), rather
     // than a second hand-rolled parser (issue #6188). Absent/empty falls
-    // back to the documented default (issue #6133).
-    const limit = optionalInteger(params.limit, "limit", { min: 0 }) ?? 50;
-    const offset = optionalInteger(params.offset, "offset", { min: 0 }) ?? 0;
+    // back to the documented default (issue #6133). Bounded to Int32 max —
+    // see the INT32_MAX comment above.
+    const limit = optionalInteger(params.limit, "limit", { min: 0, max: INT32_MAX }) ?? 50;
+    const offset = optionalInteger(params.offset, "offset", { min: 0, max: INT32_MAX }) ?? 0;
 
     const device = await findBootedDevice(deviceId);
     if (!device) {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -129,6 +129,7 @@ function extractTemplateParams(
   });
   if (template.queryParamNames.length > 0) {
     const declaredQueryParams = new Set(template.queryParamNames);
+    const pathParamNames = new Set(template.paramNames);
     const queryStart = uri.indexOf("?");
     const query = queryStart >= 0 ? uri.slice(queryStart + 1) : "";
     const seen = new Set<string>();
@@ -137,11 +138,15 @@ function extractTemplateParams(
         return null;
       }
       seen.add(name);
-      // Only declared `{?a,b}` query variables are captured. An undeclared
-      // query key (issue #6188) — including one that collides with a
-      // path-captured param name like `deviceId` — is ignored rather than
-      // silently overwriting the path capture.
-      if (!declaredQueryParams.has(name)) {
+      // An undeclared query key that collides with a path-captured param
+      // name (e.g. `deviceId`) is dropped instead of silently overwriting
+      // the path capture (issue #6188). Any other undeclared key — one that
+      // doesn't collide with a path param — is still forwarded: several
+      // resource handlers (parsePerformanceParams, parseTrafficParams,
+      // parseAppsQueryParams) do their own fail-closed validation and need
+      // to see unknown keys (e.g. a typo'd param name) to reject them,
+      // rather than have the registry silently discard them first.
+      if (!declaredQueryParams.has(name) && pathParamNames.has(name)) {
         continue;
       }
       params[name] = value;

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -128,6 +128,7 @@ function extractTemplateParams(
     params[name] = match[index + 1];
   });
   if (template.queryParamNames.length > 0) {
+    const declaredQueryParams = new Set(template.queryParamNames);
     const queryStart = uri.indexOf("?");
     const query = queryStart >= 0 ? uri.slice(queryStart + 1) : "";
     const seen = new Set<string>();
@@ -136,6 +137,13 @@ function extractTemplateParams(
         return null;
       }
       seen.add(name);
+      // Only declared `{?a,b}` query variables are captured. An undeclared
+      // query key (issue #6188) — including one that collides with a
+      // path-captured param name like `deviceId` — is ignored rather than
+      // silently overwriting the path capture.
+      if (!declaredQueryParams.has(name)) {
+        continue;
+      }
       params[name] = value;
     }
   }

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -1,9 +1,33 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { registerDatabaseResources } from "../../src/server/databaseResources";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  notifyDatabaseChanged,
+  registerDatabaseResources,
+} from "../../src/server/databaseResources";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import type { BootedDevice } from "../../src/models";
+
+// Minimal MCP-server stand-in, matching the pattern in
+// resourceRegistryListChanged.test.ts: registerWithServer installs request
+// handlers on `server.server`, and notifyResourceUpdated sends through it.
+class FakeUnderlyingServer {
+  notifications: Array<{ method: string; params?: unknown }> = [];
+  handlersBySchema = new Map<unknown, (request: unknown) => Promise<unknown>>();
+  onclose?: () => void;
+  setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>): void {
+    this.handlersBySchema.set(schema, handler);
+  }
+  async notification(payload: { method: string; params?: unknown }): Promise<void> {
+    this.notifications.push(payload);
+  }
+}
+
+class FakeMcpServer {
+  server = new FakeUnderlyingServer();
+}
 
 // Issue #6133: the table-data resource template previously registered a
 // literal `?appId={appId}&limit={limit}&offset={offset}` query string, which
@@ -24,6 +48,7 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
 
   beforeEach(() => {
     ResourceRegistry.clearResources();
+    ResourceRegistry.clearServersForTesting();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();
     originalGetInstance = IOSCtrlProxyClient.getInstance;
@@ -32,6 +57,7 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
   afterEach(() => {
     IOSCtrlProxyClient.getInstance = originalGetInstance;
     ResourceRegistry.clearResources();
+    ResourceRegistry.clearServersForTesting();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();
   });
@@ -69,10 +95,13 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
 
     expect(payload.limit).toBe(expectedLimit);
     expect(payload.offset).toBe(expectedOffset);
-    // The returned uri echoes the exact request (issue #6188) rather than a
-    // canonical form without pagination, so two different pages don't come
-    // back labeled with the same URI to a URI-keyed MCP client.
-    expect(content.uri).toBe(uri);
+    // The returned uri is always the canonical form (no limit/offset),
+    // never the exact requested URI (issue #6188) — notifyDatabaseChanged
+    // fires notifyResourceUpdated against this canonical URI, and
+    // ResourceRegistry requires an exact subscription match, so a
+    // subscriber must be subscribed to this same canonical form to ever
+    // receive an update.
+    expect(content.uri).toBe(`${base}?appId=com.example.app`);
     expect(getTableDataForIos).toHaveBeenCalledWith(
       "com.example.app",
       "/app/Documents/app.db",
@@ -226,5 +255,48 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
       50,
       0,
     );
+  });
+
+  // Issue #6188: notifyDatabaseChanged fires notifyResourceUpdated against the
+  // canonical table-data URI (no limit/offset), and ResourceRegistry.
+  // notifyResourceUpdated requires an exact subscriptions.has(uri) match. A
+  // client that subscribed to the same canonical URI content.uri now always
+  // returns (rather than a per-page URI) must actually receive the update
+  // after a mutating sqlQuery.
+  test("a client subscribed to the canonical content.uri is notified after a mutating change", async () => {
+    const getTableDataForIos = mock(async () => ({
+      columns: ["id"],
+      rows: [["1"]],
+      total: 1,
+    }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&limit=10&offset=5`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+    const content = await match!.template.handler(match!.params);
+    const canonicalUri = `${base}?appId=com.example.app`;
+    expect(content.uri).toBe(canonicalUri);
+
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+    try {
+      const subscribeHandler = server.server.handlersBySchema.get(SubscribeRequestSchema);
+      expect(subscribeHandler).toBeDefined();
+      // Client subscribes to the exact URI it was handed back.
+      await subscribeHandler!({ params: { uri: content.uri } });
+
+      await notifyDatabaseChanged("ios-1", "com.example.app", "/app/Documents/app.db", ["notes"]);
+
+      const methods = server.server.notifications.map((n) => n.method);
+      const updatedUris = server.server.notifications
+        .filter((n) => n.method === "notifications/resources/updated")
+        .map((n) => (n.params as { uri: string }).uri);
+      expect(methods).toContain("notifications/resources/updated");
+      expect(updatedUris).toContain(canonicalUri);
+    } finally {
+      ResourceRegistry.clearServersForTesting();
+    }
   });
 });

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -109,4 +109,71 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
     expect(payload.error).toContain("Invalid offset");
     expect(getTableDataForIos).not.toHaveBeenCalled();
   });
+
+  test("rejects a limit outside the safe integer range instead of overflowing", async () => {
+    const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&limit=99999999999999999999999`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.error).toContain("Invalid limit");
+    expect(getTableDataForIos).not.toHaveBeenCalled();
+  });
+
+  // Issue #6188: `{?appId,limit,offset}` makes every query variable optional
+  // at the template-match level, including appId — which must stay a
+  // required app identity. The handler rejects a missing/empty appId itself.
+  test.each([
+    ["appId omitted entirely", `${base}?limit=10&offset=5`],
+    ["appId present but empty", `${base}?appId=&limit=10&offset=5`],
+  ])("rejects table data request when %s", async (_label, uri) => {
+    const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.error).toContain("Missing required appId");
+    expect(getTableDataForIos).not.toHaveBeenCalled();
+  });
+
+  // Issue #6188: extractTemplateParams previously copied every query pair,
+  // so a query key colliding with a path-captured param name (deviceId,
+  // databasePath, table) silently overrode the path-selected value.
+  test("ignores an undeclared query key that collides with a path parameter", async () => {
+    const getTableDataForIos = mock(async () => ({
+      columns: ["id"],
+      rows: [["1"]],
+      total: 1,
+    }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&deviceId=ios-2`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+    expect(match!.params.deviceId).toBe("ios-1");
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.deviceId).toBe("ios-1");
+    expect(getTableDataForIos).toHaveBeenCalledWith(
+      "com.example.app",
+      "/app/Documents/app.db",
+      "notes",
+      50,
+      0,
+    );
+  });
 });

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -69,6 +69,10 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
 
     expect(payload.limit).toBe(expectedLimit);
     expect(payload.offset).toBe(expectedOffset);
+    // The returned uri echoes the exact request (issue #6188) rather than a
+    // canonical form without pagination, so two different pages don't come
+    // back labeled with the same URI to a URI-keyed MCP client.
+    expect(content.uri).toBe(uri);
     expect(getTableDataForIos).toHaveBeenCalledWith(
       "com.example.app",
       "/app/Documents/app.db",

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -20,13 +20,17 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
 
   const base = "automobile:devices/ios-1/databases/%2Fapp%2FDocuments%2Fapp.db/tables/notes/data";
 
+  let originalGetInstance: typeof IOSCtrlProxyClient.getInstance;
+
   beforeEach(() => {
     ResourceRegistry.clearResources();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();
+    originalGetInstance = IOSCtrlProxyClient.getInstance;
   });
 
   afterEach(() => {
+    IOSCtrlProxyClient.getInstance = originalGetInstance;
     ResourceRegistry.clearResources();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { registerDatabaseResources } from "../../src/server/databaseResources";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import type { BootedDevice } from "../../src/models";
+
+// Issue #6133: the table-data resource template previously registered a
+// literal `?appId={appId}&limit={limit}&offset={offset}` query string, which
+// ResourceRegistry.compileUriTemplate compiles into fixed-order, all-required
+// captures. That silently broke every URI that omitted limit or offset, or
+// supplied them out of order, even though the handler documents both as
+// optional. The fix switches to the RFC 6570 `{?appId,limit,offset}` form.
+describe("table-data resource template optional pagination (issue #6133)", () => {
+  const device: BootedDevice = {
+    deviceId: "ios-1",
+    platform: "ios",
+    name: "iPhone 16 Simulator",
+  };
+
+  const base = "automobile:devices/ios-1/databases/%2Fapp%2FDocuments%2Fapp.db/tables/notes/data";
+
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+    PlatformDeviceManagerFactory.reset();
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  afterEach(() => {
+    ResourceRegistry.clearResources();
+    PlatformDeviceManagerFactory.reset();
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  function setupDevice(getTableDataForIos: (...args: unknown[]) => Promise<unknown>): void {
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      getTableDataForIos,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevices: mock(async (platform: string) => (platform === "ios" ? [device] : [])),
+    } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+  }
+
+  test.each([
+    ["neither limit nor offset present", `${base}?appId=com.example.app`, 50, 0],
+    ["only limit present", `${base}?appId=com.example.app&limit=10`, 10, 0],
+    ["only offset present", `${base}?appId=com.example.app&offset=5`, 50, 5],
+    ["both present, documented order", `${base}?appId=com.example.app&limit=10&offset=5`, 10, 5],
+    ["both present, offset before limit", `${base}?appId=com.example.app&offset=5&limit=10`, 10, 5],
+    ["appId after limit/offset", `${base}?limit=10&offset=5&appId=com.example.app`, 10, 5],
+  ])("matches and parses params: %s", async (_label, uri, expectedLimit, expectedOffset) => {
+    const getTableDataForIos = mock(async () => ({
+      columns: ["id"],
+      rows: [["1"]],
+      total: 1,
+    }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.limit).toBe(expectedLimit);
+    expect(payload.offset).toBe(expectedOffset);
+    expect(getTableDataForIos).toHaveBeenCalledWith(
+      "com.example.app",
+      "/app/Documents/app.db",
+      "notes",
+      expectedLimit,
+      expectedOffset,
+    );
+  });
+
+  test("rejects a non-numeric limit with an actionable error instead of NaN", async () => {
+    const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&limit=abc`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.error).toContain("Invalid limit");
+    expect(getTableDataForIos).not.toHaveBeenCalled();
+  });
+
+  test("rejects a negative offset with an actionable error instead of NaN", async () => {
+    const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&offset=-5`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.error).toContain("Invalid offset");
+    expect(getTableDataForIos).not.toHaveBeenCalled();
+  });
+});

--- a/test/server/databaseResourcesPagination.test.ts
+++ b/test/server/databaseResourcesPagination.test.ts
@@ -147,6 +147,53 @@ describe("table-data resource template optional pagination (issue #6133)", () =>
     expect(getTableDataForIos).not.toHaveBeenCalled();
   });
 
+  // Issue #6188: ResourceRegistry.extractTemplateParams forwards any query
+  // key that isn't a path capture — including a typo like `limt` — instead
+  // of silently dropping it, so getTableDataResource must reject unknown
+  // keys itself rather than silently falling back to defaults.
+  test("rejects an unknown/typo'd query parameter instead of silently defaulting", async () => {
+    const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+    setupDevice(getTableDataForIos);
+    registerDatabaseResources();
+
+    const uri = `${base}?appId=com.example.app&limt=10`;
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+    expect(match!.params.limt).toBe("10");
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.error).toContain("Unknown query parameters");
+    expect(payload.error).toContain("limt");
+    expect(getTableDataForIos).not.toHaveBeenCalled();
+  });
+
+  // Issue #6188: Android's DatabaseInspectorProvider.handleGetTableData
+  // parses limit/offset with Kotlin's `toIntOrNull()` (32-bit signed), so a
+  // JS-safe-integer value beyond Int32 max would silently fall back to the
+  // Android-side default instead of the value the resource response claims.
+  test.each([
+    ["limit", `${base}?appId=com.example.app&limit=2147483648`],
+    ["offset", `${base}?appId=com.example.app&offset=2147483648`],
+  ])(
+    "rejects an out-of-Int32-range %s instead of silently mismatching Android",
+    async (paramName, uri) => {
+      const getTableDataForIos = mock(async () => ({ columns: [], rows: [], total: 0 }));
+      setupDevice(getTableDataForIos);
+      registerDatabaseResources();
+
+      const match = ResourceRegistry.matchTemplate(uri);
+      expect(match).toBeDefined();
+
+      const content = await match!.template.handler(match!.params);
+      const payload = JSON.parse(content.text!);
+
+      expect(payload.error).toContain(`Invalid ${paramName}`);
+      expect(getTableDataForIos).not.toHaveBeenCalled();
+    },
+  );
+
   // Issue #6188: extractTemplateParams previously copied every query pair,
   // so a query key colliding with a path-captured param name (deviceId,
   // databasePath, table) silently overrode the path-selected value.

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -195,6 +195,20 @@ describe("ResourceRegistry URI-template matching", () => {
     });
   });
 
+  test("ignores an undeclared query key instead of overwriting a path-captured param (issue #6188)", () => {
+    ResourceRegistry.registerTemplate(
+      "automobile:test/{id}/data{?first}",
+      "Test",
+      "Test path/query collision",
+      "application/json",
+      async () => ({ uri: "automobile:test", text: "{}" }),
+    );
+
+    const match = ResourceRegistry.matchTemplate("automobile:test/one/data?first=a&id=two");
+
+    expect(match).toMatchObject({ params: { id: "one", first: "a" } });
+  });
+
   test("retains the requested URI for an RFC 6570 template handler", async () => {
     const server = new FakeMcpServer();
     let handlerUri = "";

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -209,6 +209,23 @@ describe("ResourceRegistry URI-template matching", () => {
     expect(match).toMatchObject({ params: { id: "one", first: "a" } });
   });
 
+  test("forwards an undeclared query key that does not collide with a path param, for handler-side validation (issue #6188)", () => {
+    ResourceRegistry.registerTemplate(
+      "automobile:test{?first}",
+      "Test",
+      "Test unknown-key passthrough",
+      "application/json",
+      async () => ({ uri: "automobile:test", text: "{}" }),
+    );
+
+    // e.g. a typo'd `limt=10` — sibling handlers (parsePerformanceParams,
+    // parseTrafficParams, parseAppsQueryParams) reject unknown keys
+    // themselves and need to see them in `params` to do so.
+    const match = ResourceRegistry.matchTemplate("automobile:test?first=a&limt=10");
+
+    expect(match).toMatchObject({ params: { first: "a", limt: "10" } });
+  });
+
   test("retains the requested URI for an RFC 6570 template handler", async () => {
     const server = new FakeMcpServer();
     let handlerUri = "";


### PR DESCRIPTION
## Root cause

`src/server/databaseResources.ts:482-489` registered the table-data
pagination resource with a *literal* query string:

```
automobile:devices/{deviceId}/databases/{databasePath}/tables/{table}/data?appId={appId}&limit={limit}&offset={offset}
```

`ResourceRegistry.compileUriTemplate` (`src/server/resourceRegistry.ts:81-113`)
only recognizes the RFC 6570 `{?a,b}` query-expansion form for
order-independent, optional query captures. A literal `?a={a}&b={b}` string
instead compiles to ordinary fixed-order path captures, so the template only
matched a URI that supplied **both** `limit` and `offset`, in that **exact
order** — even though the resource description ("Add &limit=N&offset=M for
pagination") and the handler (`getTableDataResource`, defaulting each
independently) both document them as optional.

## Fix

- Replaced the literal query string with the supported
  `.../data{?appId,limit,offset}` form, so `extractTemplateParams` parses the
  query via `URLSearchParams` — order-independent, each param optional,
  properly decoded.
- Dropped the now-redundant duplicate "Table Data (Paginated)" template
  registration.
- `limit`/`offset` are now validated as non-negative integers when present
  (`parsePaginationParam`); a non-numeric or negative value returns an
  actionable `Invalid limit/offset "..."` error instead of silently producing
  `NaN` inspector calls. Absent params still default to `limit=50`/`offset=0`
  as documented.

## Test

Added `test/server/databaseResourcesPagination.test.ts` (runs in ~5ms per
test, no real device/DB): a `test.each` table asserts the template matches
and the handler parses the right `limit`/`offset` for all six URI forms from
the issue (neither param, only limit, only offset, both in documented order,
both reversed, `appId` after limit/offset), plus two tests asserting a
non-numeric limit and a negative offset are rejected with an actionable
error rather than `NaN`.

Closes #6133

## Follow-up (review thread)

The returned `content.uri` for table-data reads is always the canonical
form (no `limit`/`offset`) so a subscriber's URI matches what
`notifyDatabaseChanged` / table-schema invalidation fire
`notifyResourceUpdated` against — `ResourceRegistry` requires an exact
`subscriptions.has(uri)` match. Richer per-page subscription identities
are tracked separately in #6198.
