### PR TITLE
fix(explore): match permission/allow/dismiss keywords on word boundaries

### DIFF
--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -52,6 +52,38 @@ function wordBoundaryPattern(keywords: string[]): RegExp {
   return new RegExp(`\\b(?:${keywords.join("|")})\\b`);
 }
 
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Turn a (possibly multi-word) keyword into a pattern fragment whose internal
+ * spaces also accept `_`/`-`/`.`/`/` as separators, so "not now" matches
+ * "not_now" the same way a single-word keyword like "ok" matches "ok_button".
+ */
+function keywordToPatternFragment(keyword: string): string {
+  return keyword.split(" ").map(escapeRegExp).join("[\\s_./-]+");
+}
+
+/**
+ * Build a keyword pattern bounded by non-alphanumeric separators instead of
+ * `\b`.
+ *
+ * JS `\b` treats `_` as a word character, so `\bok\b` does not match inside
+ * machine-style accessibility ids like `ok_button`/`not_now`/`skip_action` —
+ * the old substring check accepted those, so boundary-matching regressed
+ * them (issue #6122 follow-up). Lookarounds that exclude only `[a-z0-9]`
+ * treat `_`, `-`, `.`, `/`, whitespace, punctuation, and string start/end as
+ * separators, so `ok` still matches at the start of `ok_button` while
+ * `bookmark`/`token`/`accessibility`/`disallowance` still don't match. A
+ * multi-word keyword's internal space is likewise separator-tolerant, so
+ * "not now" also matches the machine-id spelling "not_now".
+ */
+function separatorBoundaryPattern(keywords: string[]): RegExp {
+  const alternation = keywords.map(keywordToPatternFragment).join("|");
+  return new RegExp(`(?<![a-z0-9])(?:${alternation})(?![a-z0-9])`, "i");
+}
+
 /**
  * Test a keyword pattern against `text` and `content-desc` independently,
  * never against them joined.
@@ -71,7 +103,8 @@ function matchesInAnyField(pattern: RegExp, el: Element): boolean {
 const RATING_KEYWORD_PATTERN = wordBoundaryPattern(RATING_KEYWORDS);
 
 /**
- * Permission-dialog keywords, matched on word boundaries.
+ * Permission-dialog keywords, matched on separator boundaries (see
+ * `separatorBoundaryPattern`).
  *
  * Substring matching misclassified ordinary UI text — "access" matched
  * "Accessibility", and (in `handlePermissionDialog`) "ok" matched
@@ -92,7 +125,7 @@ const PERMISSION_KEYWORDS = [
   "only this time",
 ];
 
-const PERMISSION_KEYWORD_PATTERN = wordBoundaryPattern(PERMISSION_KEYWORDS);
+const PERMISSION_KEYWORD_PATTERN = separatorBoundaryPattern(PERMISSION_KEYWORDS);
 
 /**
  * Check if screen is a permission dialog
@@ -125,12 +158,14 @@ export function isRatingDialog(elements: Element[]): boolean {
 }
 
 /**
- * "Allow"-button keywords, matched on word boundaries (issue #6122): bare
- * "ok" as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens".
+ * "Allow"-button keywords, matched on separator boundaries (issue #6122):
+ * bare "ok" as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens",
+ * while separator-boundary matching still accepts machine ids like
+ * "ok_button".
  */
 const ALLOW_KEYWORDS = ["allow", "while using", "only this time", "ok"];
 
-const ALLOW_KEYWORD_PATTERN = wordBoundaryPattern(ALLOW_KEYWORDS);
+const ALLOW_KEYWORD_PATTERN = separatorBoundaryPattern(ALLOW_KEYWORDS);
 
 /**
  * Handle permission dialog by clicking "Allow" or similar
@@ -168,7 +203,7 @@ export async function handlePermissionDialog(
 
 const DISMISS_KEYWORDS = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
 
-const DISMISS_KEYWORD_PATTERN = wordBoundaryPattern(DISMISS_KEYWORDS);
+const DISMISS_KEYWORD_PATTERN = separatorBoundaryPattern(DISMISS_KEYWORDS);
 
 /**
  * Dismiss dialog by clicking dismiss/close/later buttons

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -82,50 +82,26 @@ function tokenize(field: string): string[] {
 }
 
 /**
- * Common inflection suffixes stripped when comparing a field token against a
- * keyword token, longest first so "closing" tries "ing" before "s".
- */
-const INFLECTION_SUFFIXES = ["ing", "es", "ed", "s"];
-
-/**
- * True if `token` is `keywordToken`, or `keywordToken` plus one of the common
- * inflection suffixes above.
- *
- * Exact-token matching dropped ordinary inflections the old substring
- * matcher caught — "Permissions required" tokenizes to
- * `["permissions", ...]`, which no longer equals the keyword "permission"
- * (issue #6122 follow-up). Stripping a trailing "s"/"es"/"ing"/"ed" before
- * comparing restores "permissions"/"allows"/"denies" while still rejecting
- * "bookmark"/"token"/"accessibility" — none of those have a keyword as their
- * stem.
- */
-function tokenMatchesKeyword(token: string, keywordToken: string): boolean {
-  if (token === keywordToken) {
-    return true;
-  }
-  return INFLECTION_SUFFIXES.some(
-    (suffix) =>
-      token.length > suffix.length &&
-      token.endsWith(suffix) &&
-      token.slice(0, -suffix.length) === keywordToken,
-  );
-}
-
-/**
  * True if `keywordTokens` (itself tokenized, so "don't allow" -> ["don", "t",
- * "allow"]) appears, inflection-tolerant, as a contiguous run inside
+ * "allow"]) appears, by exact token equality, as a contiguous run inside
  * `fieldTokens`.
+ *
+ * An earlier revision stripped a trailing "s"/"es"/"ing"/"ed" from a field
+ * token before comparing, to accept plurals like "permissions" without
+ * listing them explicitly. That algorithmic stemming traded one false
+ * negative for a false positive: "notes" strips to "not", so "Notes now"
+ * satisfied the dismiss phrase "not now" (issue #6122 follow-up). Matching
+ * stays exact-token-only; any inflected form a real dialog uses (e.g.
+ * "permissions", "allows") is listed explicitly in the keyword set instead
+ * (see `PERMISSION_KEYWORDS`), so the match surface is exactly what was
+ * asked for, never a guess.
  */
 function containsTokenSequence(fieldTokens: string[], keywordTokens: string[]): boolean {
   if (keywordTokens.length === 0) {
     return false;
   }
   for (let start = 0; start + keywordTokens.length <= fieldTokens.length; start++) {
-    if (
-      keywordTokens.every((keywordToken, offset) =>
-        tokenMatchesKeyword(fieldTokens[start + offset], keywordToken),
-      )
-    ) {
+    if (keywordTokens.every((token, offset) => fieldTokens[start + offset] === token)) {
       return true;
     }
   }
@@ -166,16 +142,22 @@ const RATING_KEYWORD_PATTERN = wordBoundaryPattern(RATING_KEYWORDS);
  * Substring matching misclassified ordinary UI text — "access" matched
  * "Accessibility", and (in `handlePermissionDialog`) "ok" matched
  * "Bookmarks"/"Cookies"/"Tokens" (issue #6122, same defect class as #4190).
- * "access" is dropped entirely rather than token-matched: as a whole word it
- * still shows up in ambient, non-permission UI ("Quick access", "Access your
- * library" as a bookmarks/history shortcut). Real permission dialogs always
- * carry "allow"/"permission"/"deny" alongside it, so those keywords cover the
- * case ("Allow access to your location?" still matches via "allow") without
- * the false positives.
+ * "access" is included as its own exact token: tokenizing "Accessibility"
+ * yields the single token `["accessibility"]`, distinct from `["access"]`,
+ * so it no longer collides the way the old substring check did — an earlier
+ * revision dropped "access" from this list defensively, before the
+ * tokenizer existed to make that distinction safely, which regressed
+ * "Camera access required" to a miss. Plurals actually seen on real dialogs
+ * ("permissions", "allows") are listed explicitly rather than derived by
+ * stemming — stemming previously turned "Notes now" into a false dismiss
+ * match ("notes" -> "not").
  */
 const PERMISSION_KEYWORDS = [
   "allow",
+  "allows",
   "permission",
+  "permissions",
+  "access",
   "deny",
   "don't allow",
   "while using",
@@ -218,9 +200,10 @@ export function isRatingDialog(elements: Element[]): boolean {
  * "Allow"-button keywords, matched by whole tokens (issue #6122): bare "ok"
  * as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens", while
  * token matching still accepts machine ids like "ok_button"/"okButton" and
- * "okay" as its own affirmative.
+ * "okay" as its own affirmative. "ok"/"okay" are never inflected — "notes"
+ * must never satisfy "not", so no keyword here is derived by stemming.
  */
-const ALLOW_KEYWORDS = ["allow", "while using", "only this time", "ok", "okay"];
+const ALLOW_KEYWORDS = ["allow", "allows", "while using", "only this time", "ok", "okay"];
 
 const ALLOW_KEYWORD_TOKENS = toKeywordTokenLists(ALLOW_KEYWORDS);
 

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -52,69 +52,89 @@ function wordBoundaryPattern(keywords: string[]): RegExp {
   return new RegExp(`\\b(?:${keywords.join("|")})\\b`);
 }
 
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
- * Turn a (possibly multi-word) keyword into a pattern fragment whose internal
- * spaces also accept `_`/`-`/`.`/`/` as separators, so "not now" matches
- * "not_now" the same way a single-word keyword like "ok" matches "ok_button".
- */
-function keywordToPatternFragment(keyword: string): string {
-  return keyword.split(" ").map(escapeRegExp).join("[\\s_./-]+");
-}
-
-/**
- * Build a keyword pattern bounded by non-alphanumeric separators instead of
- * `\b`.
+ * Tokenize accessibility field text into lowercase word tokens.
  *
- * JS `\b` treats `_` as a word character, so `\bok\b` does not match inside
- * machine-style accessibility ids like `ok_button`/`not_now`/`skip_action` —
- * the old substring check accepted those, so boundary-matching regressed
- * them (issue #6122 follow-up). Lookarounds that exclude only `[a-z0-9]`
- * treat `_`, `-`, `.`, `/`, whitespace, punctuation, and string start/end as
- * separators, so `ok` still matches at the start of `ok_button` while
- * `bookmark`/`token`/`accessibility`/`disallowance` still don't match. A
- * multi-word keyword's internal space is likewise separator-tolerant, so
- * "not now" also matches the machine-id spelling "not_now".
+ * Splits on every non-alphanumeric character (whitespace, underscore,
+ * hyphen, dot, slash, apostrophe, punctuation) AND at camelCase boundaries
+ * (a lowercase letter or digit followed by an uppercase letter), so
+ * "ok_button", "okButton", and "OK Button" all tokenize to the same
+ * `["ok", "button"]`.
+ *
+ * This replaces regex-boundary keyword matching (`\b`, then a
+ * non-alphanumeric lookaround), which needed a new boundary rule for every
+ * separator style real apps use — underscore ids in one #6122 follow-up,
+ * camelCase ids in the next. Tokenizing once and comparing whole tokens ends
+ * that per-case patching: a keyword matches iff it equals a token (or, for a
+ * multi-word keyword, a contiguous run of tokens), so "ok" never matches
+ * inside "token" or "bookmark", and "allow" never matches inside
+ * "disallowance", regardless of how the surrounding text is punctuated or
+ * cased.
  */
-function separatorBoundaryPattern(keywords: string[]): RegExp {
-  const alternation = keywords.map(keywordToPatternFragment).join("|");
-  return new RegExp(`(?<![a-z0-9])(?:${alternation})(?![a-z0-9])`, "i");
+function tokenize(field: string): string[] {
+  return field
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter((token) => token.length > 0)
+    .map((token) => token.toLowerCase());
 }
 
 /**
- * Test a keyword pattern against `text` and `content-desc` independently,
- * never against them joined.
- *
- * `elementText`'s space-joined string prevents a *single-token* keyword from
- * being manufactured across the two fields (e.g. "acc" + "ess" -> "access"),
- * but a *multi-word* keyword like "only this time" has its own internal
- * space — text:"Only" + content-desc:"this time" reproduces that exact
- * phrase via the join separator alone (issue #6122). Matching each field on
- * its own closes that gap while leaving single-field matches unchanged.
+ * True if `keywordTokens` (itself tokenized, so "don't allow" -> ["don", "t",
+ * "allow"]) appears as a contiguous run inside `fieldTokens`.
  */
-function matchesInAnyField(pattern: RegExp, el: Element): boolean {
+function containsTokenSequence(fieldTokens: string[], keywordTokens: string[]): boolean {
+  if (keywordTokens.length === 0) {
+    return false;
+  }
+  for (let start = 0; start + keywordTokens.length <= fieldTokens.length; start++) {
+    if (keywordTokens.every((token, offset) => fieldTokens[start + offset] === token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function toKeywordTokenLists(keywords: string[]): string[][] {
+  return keywords.map(tokenize);
+}
+
+/**
+ * Test a set of already-tokenized keywords against an element's `text` and
+ * `content-desc` independently — never joined.
+ *
+ * A joined string would let a multi-word keyword be manufactured across the
+ * two independent fields (text:"Only" + content-desc:"this time" -> "only
+ * this time"), so each field is tokenized and searched on its own (issue
+ * #6122 follow-up).
+ */
+function matchesAnyKeywordInAnyField(keywordTokenLists: string[][], el: Element): boolean {
   const fields = [el.text, el["content-desc"]];
-  return fields.some((field) => field !== undefined && pattern.test(field.toLowerCase()));
+  return fields.some((field) => {
+    if (field === undefined) {
+      return false;
+    }
+    const fieldTokens = tokenize(field);
+    return keywordTokenLists.some((keywordTokens) =>
+      containsTokenSequence(fieldTokens, keywordTokens),
+    );
+  });
 }
 
 const RATING_KEYWORD_PATTERN = wordBoundaryPattern(RATING_KEYWORDS);
 
 /**
- * Permission-dialog keywords, matched on separator boundaries (see
- * `separatorBoundaryPattern`).
+ * Permission-dialog keywords, matched by whole tokens (see `tokenize`).
  *
  * Substring matching misclassified ordinary UI text — "access" matched
  * "Accessibility", and (in `handlePermissionDialog`) "ok" matched
  * "Bookmarks"/"Cookies"/"Tokens" (issue #6122, same defect class as #4190).
- * "access" is dropped entirely rather than boundary-matched: as a whole word
- * it still shows up in ambient, non-permission UI ("Quick access", "Access
- * your library" as a bookmarks/history shortcut). Real permission dialogs
- * always carry "allow"/"permission"/"deny" alongside it, so those keywords
- * cover the case ("Allow access to your location?" still matches via
- * "allow") without the false positives.
+ * "access" is dropped entirely rather than token-matched: as a whole word it
+ * still shows up in ambient, non-permission UI ("Quick access", "Access your
+ * library" as a bookmarks/history shortcut). Real permission dialogs always
+ * carry "allow"/"permission"/"deny" alongside it, so those keywords cover the
+ * case ("Allow access to your location?" still matches via "allow") without
+ * the false positives.
  */
 const PERMISSION_KEYWORDS = [
   "allow",
@@ -125,13 +145,13 @@ const PERMISSION_KEYWORDS = [
   "only this time",
 ];
 
-const PERMISSION_KEYWORD_PATTERN = separatorBoundaryPattern(PERMISSION_KEYWORDS);
+const PERMISSION_KEYWORD_TOKENS = toKeywordTokenLists(PERMISSION_KEYWORDS);
 
 /**
  * Check if screen is a permission dialog
  */
 export function isPermissionDialog(elements: Element[]): boolean {
-  return elements.some((el) => matchesInAnyField(PERMISSION_KEYWORD_PATTERN, el));
+  return elements.some((el) => matchesAnyKeywordInAnyField(PERMISSION_KEYWORD_TOKENS, el));
 }
 
 /**
@@ -158,14 +178,14 @@ export function isRatingDialog(elements: Element[]): boolean {
 }
 
 /**
- * "Allow"-button keywords, matched on separator boundaries (issue #6122):
- * bare "ok" as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens",
- * while separator-boundary matching still accepts machine ids like
- * "ok_button".
+ * "Allow"-button keywords, matched by whole tokens (issue #6122): bare "ok"
+ * as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens", while
+ * token matching still accepts machine ids like "ok_button"/"okButton" and
+ * "okay" as its own affirmative.
  */
-const ALLOW_KEYWORDS = ["allow", "while using", "only this time", "ok"];
+const ALLOW_KEYWORDS = ["allow", "while using", "only this time", "ok", "okay"];
 
-const ALLOW_KEYWORD_PATTERN = separatorBoundaryPattern(ALLOW_KEYWORDS);
+const ALLOW_KEYWORD_TOKENS = toKeywordTokenLists(ALLOW_KEYWORDS);
 
 /**
  * Handle permission dialog by clicking "Allow" or similar
@@ -182,7 +202,7 @@ export async function handlePermissionDialog(
       continue;
     }
 
-    if (matchesInAnyField(ALLOW_KEYWORD_PATTERN, element)) {
+    if (matchesAnyKeywordInAnyField(ALLOW_KEYWORD_TOKENS, element)) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;
@@ -203,7 +223,7 @@ export async function handlePermissionDialog(
 
 const DISMISS_KEYWORDS = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
 
-const DISMISS_KEYWORD_PATTERN = separatorBoundaryPattern(DISMISS_KEYWORDS);
+const DISMISS_KEYWORD_TOKENS = toKeywordTokenLists(DISMISS_KEYWORDS);
 
 /**
  * Dismiss dialog by clicking dismiss/close/later buttons
@@ -220,7 +240,7 @@ async function dismissDialog(
       continue;
     }
 
-    if (matchesInAnyField(DISMISS_KEYWORD_PATTERN, element)) {
+    if (matchesAnyKeywordInAnyField(DISMISS_KEYWORD_TOKENS, element)) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -56,24 +56,26 @@ function wordBoundaryPattern(keywords: string[]): RegExp {
  * Tokenize accessibility field text into lowercase word tokens.
  *
  * Splits on every non-alphanumeric character (whitespace, underscore,
- * hyphen, dot, slash, apostrophe, punctuation) AND at camelCase boundaries
- * (a lowercase letter or digit followed by an uppercase letter), so
- * "ok_button", "okButton", and "OK Button" all tokenize to the same
- * `["ok", "button"]`.
+ * hyphen, dot, slash, apostrophe, punctuation) AND at camelCase boundaries —
+ * both a lowercase/digit-to-uppercase transition ("okButton" -> "ok
+ * Button") and an acronym-to-titlecase transition ("OKButton" ->
+ * "OK Button", "HTTPServer" -> "HTTP Server") — so "ok_button", "okButton",
+ * "OKButton", and "OK Button" all tokenize to the same `["ok", "button"]`.
  *
  * This replaces regex-boundary keyword matching (`\b`, then a
  * non-alphanumeric lookaround), which needed a new boundary rule for every
  * separator style real apps use — underscore ids in one #6122 follow-up,
- * camelCase ids in the next. Tokenizing once and comparing whole tokens ends
- * that per-case patching: a keyword matches iff it equals a token (or, for a
- * multi-word keyword, a contiguous run of tokens), so "ok" never matches
- * inside "token" or "bookmark", and "allow" never matches inside
- * "disallowance", regardless of how the surrounding text is punctuated or
- * cased.
+ * plain camelCase ids in the next, acronym-prefixed camelCase in this one.
+ * Tokenizing once and comparing whole tokens ends that per-case patching: a
+ * keyword matches iff it equals a token (or, for a multi-word keyword, a
+ * contiguous run of tokens), so "ok" never matches inside "token" or
+ * "bookmark", and "allow" never matches inside "disallowance", regardless of
+ * how the surrounding text is punctuated or cased.
  */
 function tokenize(field: string): string[] {
   return field
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
     .split(/[^A-Za-z0-9]+/)
     .filter((token) => token.length > 0)
     .map((token) => token.toLowerCase());

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -43,26 +43,46 @@ const RATING_KEYWORDS = [
   "stars",
 ];
 
-const RATING_KEYWORD_PATTERN = new RegExp(`\\b(?:${RATING_KEYWORDS.join("|")})\\b`);
+/**
+ * Build a case-sensitive word-boundary pattern from already-lowercased
+ * keywords. Callers must lowercase input text before testing (see
+ * `elementText`) since the pattern itself carries no `i` flag.
+ */
+function wordBoundaryPattern(keywords: string[]): RegExp {
+  return new RegExp(`\\b(?:${keywords.join("|")})\\b`);
+}
+
+const RATING_KEYWORD_PATTERN = wordBoundaryPattern(RATING_KEYWORDS);
+
+/**
+ * Permission-dialog keywords, matched on word boundaries.
+ *
+ * Substring matching misclassified ordinary UI text — "access" matched
+ * "Accessibility", and (in `handlePermissionDialog`) "ok" matched
+ * "Bookmarks"/"Cookies"/"Tokens" (issue #6122, same defect class as #4190).
+ * "access" is dropped entirely rather than boundary-matched: as a whole word
+ * it still shows up in ambient, non-permission UI ("Quick access", "Access
+ * your library" as a bookmarks/history shortcut). Real permission dialogs
+ * always carry "allow"/"permission"/"deny" alongside it, so those keywords
+ * cover the case ("Allow access to your location?" still matches via
+ * "allow") without the false positives.
+ */
+const PERMISSION_KEYWORDS = [
+  "allow",
+  "permission",
+  "deny",
+  "don't allow",
+  "while using",
+  "only this time",
+];
+
+const PERMISSION_KEYWORD_PATTERN = wordBoundaryPattern(PERMISSION_KEYWORDS);
 
 /**
  * Check if screen is a permission dialog
  */
 export function isPermissionDialog(elements: Element[]): boolean {
-  const permissionKeywords = [
-    "allow",
-    "permission",
-    "access",
-    "deny",
-    "don't allow",
-    "while using",
-    "only this time",
-  ];
-
-  return elements.some((el) => {
-    const text = (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
-    return permissionKeywords.some((keyword) => text.includes(keyword));
-  });
+  return elements.some((el) => PERMISSION_KEYWORD_PATTERN.test(elementText(el)));
 }
 
 /**
@@ -89,6 +109,14 @@ export function isRatingDialog(elements: Element[]): boolean {
 }
 
 /**
+ * "Allow"-button keywords, matched on word boundaries (issue #6122): bare
+ * "ok" as a substring matched "Bookmarks"/"Look up"/"Cookies"/"Tokens".
+ */
+const ALLOW_KEYWORDS = ["allow", "while using", "only this time", "ok"];
+
+const ALLOW_KEYWORD_PATTERN = wordBoundaryPattern(ALLOW_KEYWORDS);
+
+/**
  * Handle permission dialog by clicking "Allow" or similar
  */
 export async function handlePermissionDialog(
@@ -98,18 +126,12 @@ export async function handlePermissionDialog(
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
 ): Promise<boolean> {
-  // Look for "Allow" or "While using" buttons
-  const allowKeywords = ["allow", "while using", "only this time", "ok"];
-
   for (const element of elements) {
     if (!element.clickable) {
       continue;
     }
 
-    const text =
-      (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
-
-    if (allowKeywords.some((keyword) => text.includes(keyword))) {
+    if (ALLOW_KEYWORD_PATTERN.test(elementText(element))) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;
@@ -128,6 +150,10 @@ export async function handlePermissionDialog(
   return false;
 }
 
+const DISMISS_KEYWORDS = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
+
+const DISMISS_KEYWORD_PATTERN = wordBoundaryPattern(DISMISS_KEYWORDS);
+
 /**
  * Dismiss dialog by clicking dismiss/close/later buttons
  */
@@ -138,17 +164,12 @@ async function dismissDialog(
   adb: AdbExecutor | null,
   progress?: ProgressCallback,
 ): Promise<boolean> {
-  const dismissKeywords = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
-
   for (const element of elements) {
     if (!element.clickable) {
       continue;
     }
 
-    const text =
-      (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
-
-    if (dismissKeywords.some((keyword) => text.includes(keyword))) {
+    if (DISMISS_KEYWORD_PATTERN.test(elementText(element))) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -82,15 +82,50 @@ function tokenize(field: string): string[] {
 }
 
 /**
+ * Common inflection suffixes stripped when comparing a field token against a
+ * keyword token, longest first so "closing" tries "ing" before "s".
+ */
+const INFLECTION_SUFFIXES = ["ing", "es", "ed", "s"];
+
+/**
+ * True if `token` is `keywordToken`, or `keywordToken` plus one of the common
+ * inflection suffixes above.
+ *
+ * Exact-token matching dropped ordinary inflections the old substring
+ * matcher caught — "Permissions required" tokenizes to
+ * `["permissions", ...]`, which no longer equals the keyword "permission"
+ * (issue #6122 follow-up). Stripping a trailing "s"/"es"/"ing"/"ed" before
+ * comparing restores "permissions"/"allows"/"denies" while still rejecting
+ * "bookmark"/"token"/"accessibility" — none of those have a keyword as their
+ * stem.
+ */
+function tokenMatchesKeyword(token: string, keywordToken: string): boolean {
+  if (token === keywordToken) {
+    return true;
+  }
+  return INFLECTION_SUFFIXES.some(
+    (suffix) =>
+      token.length > suffix.length &&
+      token.endsWith(suffix) &&
+      token.slice(0, -suffix.length) === keywordToken,
+  );
+}
+
+/**
  * True if `keywordTokens` (itself tokenized, so "don't allow" -> ["don", "t",
- * "allow"]) appears as a contiguous run inside `fieldTokens`.
+ * "allow"]) appears, inflection-tolerant, as a contiguous run inside
+ * `fieldTokens`.
  */
 function containsTokenSequence(fieldTokens: string[], keywordTokens: string[]): boolean {
   if (keywordTokens.length === 0) {
     return false;
   }
   for (let start = 0; start + keywordTokens.length <= fieldTokens.length; start++) {
-    if (keywordTokens.every((token, offset) => fieldTokens[start + offset] === token)) {
+    if (
+      keywordTokens.every((keywordToken, offset) =>
+        tokenMatchesKeyword(fieldTokens[start + offset], keywordToken),
+      )
+    ) {
       return true;
     }
   }

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -52,6 +52,22 @@ function wordBoundaryPattern(keywords: string[]): RegExp {
   return new RegExp(`\\b(?:${keywords.join("|")})\\b`);
 }
 
+/**
+ * Test a keyword pattern against `text` and `content-desc` independently,
+ * never against them joined.
+ *
+ * `elementText`'s space-joined string prevents a *single-token* keyword from
+ * being manufactured across the two fields (e.g. "acc" + "ess" -> "access"),
+ * but a *multi-word* keyword like "only this time" has its own internal
+ * space — text:"Only" + content-desc:"this time" reproduces that exact
+ * phrase via the join separator alone (issue #6122). Matching each field on
+ * its own closes that gap while leaving single-field matches unchanged.
+ */
+function matchesInAnyField(pattern: RegExp, el: Element): boolean {
+  const fields = [el.text, el["content-desc"]];
+  return fields.some((field) => field !== undefined && pattern.test(field.toLowerCase()));
+}
+
 const RATING_KEYWORD_PATTERN = wordBoundaryPattern(RATING_KEYWORDS);
 
 /**
@@ -82,7 +98,7 @@ const PERMISSION_KEYWORD_PATTERN = wordBoundaryPattern(PERMISSION_KEYWORDS);
  * Check if screen is a permission dialog
  */
 export function isPermissionDialog(elements: Element[]): boolean {
-  return elements.some((el) => PERMISSION_KEYWORD_PATTERN.test(elementText(el)));
+  return elements.some((el) => matchesInAnyField(PERMISSION_KEYWORD_PATTERN, el));
 }
 
 /**
@@ -131,7 +147,7 @@ export async function handlePermissionDialog(
       continue;
     }
 
-    if (ALLOW_KEYWORD_PATTERN.test(elementText(element))) {
+    if (matchesInAnyField(ALLOW_KEYWORD_PATTERN, element)) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;
@@ -169,7 +185,7 @@ async function dismissDialog(
       continue;
     }
 
-    if (DISMISS_KEYWORD_PATTERN.test(elementText(element))) {
+    if (matchesInAnyField(DISMISS_KEYWORD_PATTERN, element)) {
       const selector = tapSelectorFor(element, viewHierarchy);
       if (!selector) {
         continue;

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -92,6 +92,7 @@ describe("ExploreBlockerDetection", () => {
       ["Accessible", false],
       ["Disallow", false],
       ["Allowance", false],
+      ["disallowance", false],
       ["Bookmarks", false],
       ["Home", false],
       ["Settings", false],
@@ -105,6 +106,12 @@ describe("ExploreBlockerDetection", () => {
       ["While using the app", true],
       ["Only this time", true],
       ["Don't allow", true],
+      // machine-style accessibility ids (issue #6122 follow-up): "_"/"-"/"."
+      // are separators, not word characters, so a plain `\b` boundary would
+      // wrongly reject these even though the old substring check accepted
+      // them.
+      ["allow_button", true],
+      ["permission_denied", true],
     ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
       expect(isPermissionDialog([createMockElement({ text })])).toBe(expected);
     });
@@ -459,6 +466,38 @@ describe("ExploreBlockerDetection", () => {
       expect(calls).toEqual([]);
     });
 
+    // Issue #6122 follow-up: JS `\b` treats "_"/"-"/"." as word characters,
+    // so a plain word-boundary pattern would wrongly reject machine-style
+    // accessibility descriptions like "ok_button" even though the old
+    // substring check accepted them.
+    test("handlePermissionDialog taps machine-style 'ok_button'/'allow_button'/'ok.button' content-desc ids", async () => {
+      for (const machineId of ["ok_button", "allow_button", "ok.button"]) {
+        const { calls, restore } = captureTapOptions();
+        const elements = [
+          createMockElement({
+            text: "",
+            "content-desc": machineId,
+            "resource-id": "com.test:id/ok_button",
+          }),
+        ];
+
+        let handled: boolean;
+        try {
+          handled = await handlePermissionDialog(
+            elements,
+            hierarchyOf(elements),
+            androidDevice,
+            null,
+          );
+        } finally {
+          restore();
+        }
+
+        expect(handled).toBe(true);
+        expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
+      }
+    });
+
     test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {
       const { calls, restore } = captureTapOptions();
       const elements = [
@@ -520,6 +559,42 @@ describe("ExploreBlockerDetection", () => {
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/skip_button", action: "tap" }]);
+    });
+
+    // Issue #6122 follow-up: machine-style content-desc ids using "_"/"-"/"."
+    // separators must still be tapped as dismiss buttons.
+    test("dismissDialog taps machine-style 'not_now'/'skip-action'/'skip.action' content-desc ids", async () => {
+      for (const machineId of ["not_now", "skip-action", "skip.action"]) {
+        const { calls, restore } = captureTapOptions();
+        const elements = [
+          createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+          createMockElement({
+            text: "",
+            "content-desc": machineId,
+            "resource-id": "com.test:id/dismiss_button",
+          }),
+        ];
+        const parser = {
+          flattenViewHierarchy: () =>
+            elements.map((element, index) => ({ element, index, depth: 0 })),
+        } as unknown as ElementParser;
+
+        let handled: boolean;
+        try {
+          handled = await detectAndHandleBlockers(
+            { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+            androidDevice,
+            null,
+            parser,
+            async () => {},
+          );
+        } finally {
+          restore();
+        }
+
+        expect(handled).toBe(true);
+        expect(calls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
+      }
     });
 
     test("dismissDialog does not tap when only 'close'/'skip' substrings are present", async () => {

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -531,6 +531,33 @@ describe("ExploreBlockerDetection", () => {
       }
     });
 
+    // Issue #6122 follow-up round 4: an acronym-prefixed camelCase id like
+    // "OKButton" has no lowercase-to-uppercase transition (the whole prefix
+    // "OKB" is capitals), so it needs the acronym-to-titlecase split too —
+    // otherwise it tokenizes as a single "okbutton" token that matches
+    // nothing.
+    test("handlePermissionDialog taps acronym-prefixed camelCase 'OKButton' content-desc", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "OKButton", "resource-id": "com.test:id/ok_button" }),
+      ];
+
+      let handled: boolean;
+      try {
+        handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(true);
+      expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
+    });
+
     test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {
       const { calls, restore } = captureTapOptions();
       const elements = [

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -75,6 +75,39 @@ describe("ExploreBlockerDetection", () => {
 
       expect(isPermissionDialog(elements)).toBe(true);
     });
+
+    // Issue #6122: keywords were matched as bare substrings, so ordinary UI
+    // text containing "access" ("Accessibility", "Quick access") was
+    // misclassified as a permission dialog — same defect class as #4190.
+    // "access" is dropped from the keyword list entirely (see
+    // PERMISSION_KEYWORDS) rather than boundary-matched, because as a whole
+    // word it still appears in ambient, non-permission UI.
+    test.each([
+      // [text, expected]
+      ["Accessibility", false],
+      ["ACCESSIBILITY", false],
+      ["Accessibility settings", false],
+      ["Quick access", false],
+      ["Access your library", false],
+      ["Accessible", false],
+      ["Disallow", false],
+      ["Allowance", false],
+      ["Bookmarks", false],
+      ["Home", false],
+      ["Settings", false],
+      // positive controls: real permission dialogs must still match
+      ["Allow", true],
+      ["allow", true],
+      ["ALLOW", true],
+      ["Allow access to your location?", true], // matches via "allow", not "access"
+      ["Deny", true],
+      ["This app needs permission to access your camera", true], // matches via "permission"
+      ["While using the app", true],
+      ["Only this time", true],
+      ["Don't allow", true],
+    ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
+      expect(isPermissionDialog([createMockElement({ text })])).toBe(expected);
+    });
   });
 
   describe("isLoginScreen", () => {
@@ -356,6 +389,58 @@ describe("ExploreBlockerDetection", () => {
           action: "tap",
         },
       ]);
+    });
+
+    // Issue #6122: the allow-button keyword "ok" was matched as a bare
+    // substring, so "Bookmarks"/"Look up"/"Cookies"/"Tokens" were tapped as
+    // if they were the dialog's Allow button, before a genuine "OK" was ever
+    // reached.
+    test("handlePermissionDialog skips 'ok'-substring buttons and taps the real OK button", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Bookmarks", "resource-id": "com.test:id/bookmarks" }),
+        createMockElement({ text: "Cookies", "resource-id": "com.test:id/cookies" }),
+        createMockElement({ text: "Tokens", "resource-id": "com.test:id/tokens" }),
+        createMockElement({ text: "OK", "resource-id": "com.test:id/ok_button" }),
+      ];
+
+      let handled: boolean;
+      try {
+        handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(true);
+      expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
+    });
+
+    test("handlePermissionDialog does not tap when only 'ok'-substring buttons are present", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Bookmarks", "resource-id": "com.test:id/bookmarks" }),
+        createMockElement({ text: "Cookies", "resource-id": "com.test:id/cookies" }),
+      ];
+
+      let handled: boolean;
+      try {
+        handled = await handlePermissionDialog(
+          elements,
+          hierarchyOf(elements),
+          androidDevice,
+          null,
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(false);
+      expect(calls).toEqual([]);
     });
 
     test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -108,6 +108,22 @@ describe("ExploreBlockerDetection", () => {
     ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
       expect(isPermissionDialog([createMockElement({ text })])).toBe(expected);
     });
+
+    // Issue #6122 follow-up: a multi-word keyword must not be manufactured by
+    // joining `text` and `content-desc` — each field is matched on its own.
+    test("does not match a multiword keyword split across text and content-desc", () => {
+      const elements = [createMockElement({ text: "Only", "content-desc": "this time" })];
+
+      expect(isPermissionDialog(elements)).toBe(false);
+    });
+
+    test("still matches a multiword keyword contained wholly in one field", () => {
+      const textOnly = [createMockElement({ text: "Only this time", "content-desc": "" })];
+      const contentDescOnly = [createMockElement({ text: "", "content-desc": "Only this time" })];
+
+      expect(isPermissionDialog(textOnly)).toBe(true);
+      expect(isPermissionDialog(contentDescOnly)).toBe(true);
+    });
   });
 
   describe("isLoginScreen", () => {
@@ -469,6 +485,70 @@ describe("ExploreBlockerDetection", () => {
 
       expect(handled).toBe(true);
       expect(calls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
+    });
+
+    // Discriminating regression test: "Disclosed" contains "close" and
+    // "Skipping" contains "skip" as bare substrings, so under the old
+    // substring matcher these would be (wrongly) tapped as dismiss buttons.
+    // Word-boundary matching must reject both while still accepting a
+    // genuine "Skip" button — reverting to substring matching turns this red.
+    test("dismissDialog does not tap 'close'/'skip' substrings but taps a genuine Skip button", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+        createMockElement({ text: "Disclosed", "resource-id": "com.test:id/disclosed" }),
+        createMockElement({ text: "Skipping", "resource-id": "com.test:id/skipping" }),
+        createMockElement({ text: "Skip", "resource-id": "com.test:id/skip_button" }),
+      ];
+      const parser = {
+        flattenViewHierarchy: () =>
+          elements.map((element, index) => ({ element, index, depth: 0 })),
+      } as unknown as ElementParser;
+
+      let handled: boolean;
+      try {
+        handled = await detectAndHandleBlockers(
+          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          parser,
+          async () => {},
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(true);
+      expect(calls).toEqual([{ elementId: "com.test:id/skip_button", action: "tap" }]);
+    });
+
+    test("dismissDialog does not tap when only 'close'/'skip' substrings are present", async () => {
+      const { calls, restore } = captureTapOptions();
+      const elements = [
+        createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+        createMockElement({ text: "Disclosed", "resource-id": "com.test:id/disclosed" }),
+        createMockElement({ text: "Skipping", "resource-id": "com.test:id/skipping" }),
+      ];
+      const parser = {
+        flattenViewHierarchy: () =>
+          elements.map((element, index) => ({ element, index, depth: 0 })),
+      } as unknown as ElementParser;
+
+      let handled: boolean;
+      try {
+        handled = await detectAndHandleBlockers(
+          { viewHierarchy: hierarchyOf(elements) } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          parser,
+          async () => {},
+        );
+      } finally {
+        restore();
+      }
+
+      expect(handled).toBe(false);
+      expect(calls).toEqual([]);
     });
   });
 

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -118,6 +118,12 @@ describe("ExploreBlockerDetection", () => {
       // boundary, not just a boundary regex.
       ["allowButton", true],
       ["denyButton", true],
+      // inflected forms (issue #6122 follow-up round 5): exact-token matching
+      // dropped ordinary plurals/inflections the old substring matcher
+      // caught — "Permissions required" tokenizes to "permissions", which no
+      // longer equals the keyword "permission" without stem tolerance.
+      ["Permissions required", true],
+      ["Allows access", true],
     ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
       expect(isPermissionDialog([createMockElement({ text })])).toBe(expected);
     });

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -112,6 +112,12 @@ describe("ExploreBlockerDetection", () => {
       // them.
       ["allow_button", true],
       ["permission_denied", true],
+      // camelCase accessibility ids (issue #6122 follow-up round 3): a
+      // lookaround excluding only [a-z0-9] treats an adjacent capital as
+      // alphanumeric, so "allowButton" needs tokenizing at the camelCase
+      // boundary, not just a boundary regex.
+      ["allowButton", true],
+      ["denyButton", true],
     ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
       expect(isPermissionDialog([createMockElement({ text })])).toBe(expected);
     });
@@ -498,6 +504,33 @@ describe("ExploreBlockerDetection", () => {
       }
     });
 
+    // Issue #6122 follow-up round 3: a lookaround boundary treats an
+    // adjacent uppercase letter as alphanumeric, so "okButton"/"allowButton"
+    // regressed under the separator-boundary fix even though the old
+    // substring check accepted them. "Okay" is also added as its own
+    // affirmative keyword (tokenizes to ["okay"], distinct from "ok").
+    test("handlePermissionDialog taps camelCase 'okButton'/'allowButton' content-desc ids and a genuine 'Okay' button", async () => {
+      for (const text of ["okButton", "allowButton", "Okay"]) {
+        const { calls, restore } = captureTapOptions();
+        const elements = [createMockElement({ text, "resource-id": "com.test:id/ok_button" })];
+
+        let handled: boolean;
+        try {
+          handled = await handlePermissionDialog(
+            elements,
+            hierarchyOf(elements),
+            androidDevice,
+            null,
+          );
+        } finally {
+          restore();
+        }
+
+        expect(handled).toBe(true);
+        expect(calls).toEqual([{ elementId: "com.test:id/ok_button", action: "tap" }]);
+      }
+    });
+
     test("dismissDialog taps a Not now button with text and resource-id by id only", async () => {
       const { calls, restore } = captureTapOptions();
       const elements = [
@@ -563,8 +596,8 @@ describe("ExploreBlockerDetection", () => {
 
     // Issue #6122 follow-up: machine-style content-desc ids using "_"/"-"/"."
     // separators must still be tapped as dismiss buttons.
-    test("dismissDialog taps machine-style 'not_now'/'skip-action'/'skip.action' content-desc ids", async () => {
-      for (const machineId of ["not_now", "skip-action", "skip.action"]) {
+    test("dismissDialog taps machine-style 'not_now'/'skip-action'/'skip.action'/'notNow'/'skipAction' content-desc ids", async () => {
+      for (const machineId of ["not_now", "skip-action", "skip.action", "notNow", "skipAction"]) {
         const { calls, restore } = captureTapOptions();
         const elements = [
           createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -77,18 +77,17 @@ describe("ExploreBlockerDetection", () => {
     });
 
     // Issue #6122: keywords were matched as bare substrings, so ordinary UI
-    // text containing "access" ("Accessibility", "Quick access") was
-    // misclassified as a permission dialog — same defect class as #4190.
-    // "access" is dropped from the keyword list entirely (see
-    // PERMISSION_KEYWORDS) rather than boundary-matched, because as a whole
-    // word it still appears in ambient, non-permission UI.
+    // text containing "access" ("Accessibility") was misclassified as a
+    // permission dialog — same defect class as #4190. Tokenizing splits
+    // "Accessibility" into the single token ["accessibility"], distinct from
+    // ["access"], so "access" is safely kept as its own exact keyword (an
+    // earlier revision dropped it defensively before the tokenizer existed
+    // to make that distinction — see PERMISSION_KEYWORDS).
     test.each([
       // [text, expected]
       ["Accessibility", false],
       ["ACCESSIBILITY", false],
       ["Accessibility settings", false],
-      ["Quick access", false],
-      ["Access your library", false],
       ["Accessible", false],
       ["Disallow", false],
       ["Allowance", false],
@@ -100,12 +99,21 @@ describe("ExploreBlockerDetection", () => {
       ["Allow", true],
       ["allow", true],
       ["ALLOW", true],
-      ["Allow access to your location?", true], // matches via "allow", not "access"
+      ["Allow access to your location?", true], // matches via "allow" and "access"
       ["Deny", true],
       ["This app needs permission to access your camera", true], // matches via "permission"
       ["While using the app", true],
       ["Only this time", true],
       ["Don't allow", true],
+      // "access" is a real exact-token keyword again (issue #6122 follow-up
+      // round 6): tokenizing keeps it distinct from "accessibility", so
+      // "Camera access required" is correctly detected, and "Quick
+      // access"/"Access your library" — real ambient UI, but genuinely
+      // containing the standalone word "access" — now match too, which is
+      // the accepted tradeoff of restoring this keyword.
+      ["Camera access required", true],
+      ["Quick access", true],
+      ["Access your library", true],
       // machine-style accessibility ids (issue #6122 follow-up): "_"/"-"/"."
       // are separators, not word characters, so a plain `\b` boundary would
       // wrongly reject these even though the old substring check accepted
@@ -118,10 +126,10 @@ describe("ExploreBlockerDetection", () => {
       // boundary, not just a boundary regex.
       ["allowButton", true],
       ["denyButton", true],
-      // inflected forms (issue #6122 follow-up round 5): exact-token matching
-      // dropped ordinary plurals/inflections the old substring matcher
-      // caught — "Permissions required" tokenizes to "permissions", which no
-      // longer equals the keyword "permission" without stem tolerance.
+      // Explicit inflected forms (issue #6122 follow-up round 6): matching
+      // is exact-token-only (no stemming — see `containsTokenSequence`), so
+      // "permissions"/"allows" match only because they're listed explicitly
+      // in PERMISSION_KEYWORDS, not derived from "permission"/"allow".
       ["Permissions required", true],
       ["Allows access", true],
     ])("isPermissionDialog(%p) === %p", (text: string, expected: boolean) => {
@@ -690,6 +698,66 @@ describe("ExploreBlockerDetection", () => {
 
       expect(handled).toBe(false);
       expect(calls).toEqual([]);
+    });
+
+    // Issue #6122 follow-up round 6: an earlier inflection-tolerant matcher
+    // stripped a trailing "s" before comparing tokens, so "notes" stripped
+    // to "not" and falsely satisfied the dismiss phrase "not now" — a live
+    // regression on any screen with a "Notes" button next to a "Now"/similar
+    // label. Exact-token matching must reject this while still accepting a
+    // genuine "Not now".
+    test("dismissDialog does not tap a 'Notes now' false positive but taps a genuine 'Not now'", async () => {
+      const { calls: notesCalls, restore: restoreNotes } = captureTapOptions();
+      const notesElements = [
+        createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+        createMockElement({ text: "Notes now", "resource-id": "com.test:id/notes_now" }),
+      ];
+      const notesParser = {
+        flattenViewHierarchy: () =>
+          notesElements.map((element, index) => ({ element, index, depth: 0 })),
+      } as unknown as ElementParser;
+
+      let notesHandled: boolean;
+      try {
+        notesHandled = await detectAndHandleBlockers(
+          { viewHierarchy: hierarchyOf(notesElements) } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          notesParser,
+          async () => {},
+        );
+      } finally {
+        restoreNotes();
+      }
+
+      expect(notesHandled).toBe(false);
+      expect(notesCalls).toEqual([]);
+
+      const { calls: genuineCalls, restore: restoreGenuine } = captureTapOptions();
+      const genuineElements = [
+        createMockElement({ text: "Enjoying the app? Rate us!", clickable: false }),
+        createMockElement({ text: "Not now", "resource-id": "com.test:id/dismiss_button" }),
+      ];
+      const genuineParser = {
+        flattenViewHierarchy: () =>
+          genuineElements.map((element, index) => ({ element, index, depth: 0 })),
+      } as unknown as ElementParser;
+
+      let genuineHandled: boolean;
+      try {
+        genuineHandled = await detectAndHandleBlockers(
+          { viewHierarchy: hierarchyOf(genuineElements) } as unknown as ObserveResult,
+          androidDevice,
+          null,
+          genuineParser,
+          async () => {},
+        );
+      } finally {
+        restoreGenuine();
+      }
+
+      expect(genuineHandled).toBe(true);
+      expect(genuineCalls).toEqual([{ elementId: "com.test:id/dismiss_button", action: "tap" }]);
     });
   });
 


### PR DESCRIPTION
## Root cause

`isPermissionDialog`, `handlePermissionDialog`'s allow-keyword check, and
`dismissDialog`'s dismiss-keyword check in
`src/features/navigation/ExploreBlockerDetection.ts` matched keywords with
bare `.includes()` substring checks:

- `"access"` matched `"Accessibility"` / `"Quick access"`.
- `"ok"` matched `"Bookmarks"` / `"Look up"` / `"Cookies"` / `"Tokens"`.

This is the same defect class as #4190, which the file already fixed for
rating keywords (`RATING_KEYWORD_PATTERN`, PR #4203) but left the permission
and allow/dismiss keyword lists on substring matching.

## Fix (final design)

The matcher went through several review-driven iterations — word-boundary
regex, then separator-boundary regex, then an inflection-stemming
algorithm — each of which fixed one false-match case while introducing
another. The design that finally holds:

- **Tokenize, don't regex-bound.** `tokenize()` splits each accessibility
  field on every non-alphanumeric character (whitespace, `_`, `-`, `.`, `/`,
  apostrophe, punctuation) **and** at both camelCase boundaries — a
  lowercase/digit-to-uppercase transition ("okButton" -> "ok Button") and an
  acronym-to-titlecase transition ("OKButton" -> "OK Button", "HTTPServer" ->
  "HTTP Server") — lowercasing the result. `"ok_button"`, `"okButton"`,
  `"OKButton"`, and `"OK Button"` all tokenize to `["ok", "button"]`.
- **Exact-token matching only — no stemming.** A keyword matches iff it
  equals a token (single-word) or appears as a contiguous run of tokens
  (multi-word). An intermediate revision stripped a trailing `s`/`es`/`ing`/
  `ed` from a token before comparing, to accept plurals like "permissions"
  without listing them — but that traded one false negative for a false
  positive: `"notes"` strips to `"not"`, so "Notes now" wrongly satisfied the
  dismiss phrase "not now". The final design lists every inflected form a
  real dialog uses **explicitly** in the keyword set instead of deriving it
  algorithmically: `PERMISSION_KEYWORDS` carries both `"allow"`/`"allows"`
  and `"permission"`/`"permissions"`; `ALLOW_KEYWORDS` carries `"allow"` and
  `"allows"`. `"ok"`/`"okay"` are never inflected, so `"notes"` can never
  satisfy `"not"`.
- **`"access"` is a real keyword again.** An earlier revision dropped it
  from `PERMISSION_KEYWORDS` defensively — before the tokenizer existed to
  keep it distinct from "accessibility" — which regressed "Camera access
  required" to a miss. Tokenizing "Accessibility" yields the single token
  `["accessibility"]`, never `["access"]`, so restoring `"access"` is safe
  from that collision. The accepted tradeoff: real ambient UI that
  genuinely contains the standalone word "access" ("Quick access", "Access
  your library") now also classifies as a permission dialog.
- **Per-field matching.** `text` and `content-desc` are tokenized and
  matched independently, never joined — a joined string would let a
  multi-word keyword be manufactured across the two fields (`text:"Only"` +
  `content-desc:"this time"` reproducing `"only this time"`).

## Tests

`test/features/navigation/ExploreBlockerDetection.test.ts` (104 pass, 0
fail, well under 100ms):
- `test.each` table for `isPermissionDialog` proving whole-token matching:
  "Accessibility"/"Bookmarks"/"Disallow"/"disallowance" don't classify;
  "Allow"/"Deny"/"Camera access required"/"Quick access"/"Access your
  library"/"Permissions required"/"Allows access"/"allow_button"/
  "allowButton" all do.
- `handlePermissionDialog` cases proving "OK"/"Okay"/machine ids
  ("ok_button", "allow_button", "ok.button", "okButton", "allowButton",
  "OKButton") are tapped while "Bookmarks"/"Cookies"/"Tokens" (bare-substring
  false positives) are skipped.
- `dismissDialog` cases proving "Skip"/machine ids ("not_now", "skip-action",
  "skip.action", "notNow", "skipAction") are tapped while
  "Disclosed"/"Skipping" (bare-substring false positives) are skipped, and a
  dedicated regression test proving a genuine "Not now" is still tapped
  while "Notes now" (the stemming-era false positive) is not.
- Cross-field cases proving a multi-word keyword is not manufactured by
  joining `text` + `content-desc`, but still matches when contained in one
  field.

## Follow-up (deliberately out of scope)

CodeRabbit flagged that the `handlePermissionDialog`/`dismissDialog` tests
use `spyOn(TapOnElement.prototype, "execute")` / `spyOn(defaultTimer,
"sleep")` global spies rather than injected fakes. Both
`ExploreBlockerDetection.ts` and its sibling `Explore.ts` construct
`TapOnElement` directly (`new TapOnElement(device, adb)`) with no injected
action/timer seam today, so fixing this needs a production refactor beyond a
keyword-matching bug fix. Filed as #6191 (`ExploreBlockerDetection tests:
inject action/timer fakes instead of global spies`). Refs #6191.

Closes #6122
