### PR TITLE
fix(a11y): scale WCAG touch-target check by density

### DIFF
--- a/src/features/accessibility/WcagAudit.ts
+++ b/src/features/accessibility/WcagAudit.ts
@@ -235,9 +235,13 @@ export class WcagAudit {
 
       if (widthPx < minSizePx || heightPx < minSizePx) {
         // Report the measured size in dp, not raw px, so the message is
-        // labeled correctly regardless of device density.
-        const widthDp = Math.round((widthPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
-        const heightDp = Math.round((heightPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
+        // labeled correctly regardless of device density. Round DOWN rather
+        // than to nearest: a violation's exact dp size is always < minSizeDp
+        // (that's why it violated), and rounding to nearest can carry a
+        // fractional dp (e.g. 43.81dp) up to display as the minimum itself
+        // (44dp), which reads as passing next to "minimum: 44x44dp".
+        const widthDp = Math.floor((widthPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
+        const heightDp = Math.floor((heightPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
 
         violations.push({
           type: "touch-target-too-small",

--- a/src/features/accessibility/WcagAudit.ts
+++ b/src/features/accessibility/WcagAudit.ts
@@ -68,7 +68,7 @@ export class WcagAudit {
     }
 
     // Check for touch target size violations
-    violations.push(...this.checkTouchTargetSizes(elements, config.level));
+    violations.push(...this.checkTouchTargetSizes(elements, config.level, density));
 
     // Check for unlabeled form inputs
     violations.push(...this.checkFormInputLabels(elements, viewHierarchy, density));
@@ -206,12 +206,23 @@ export class WcagAudit {
   /**
    * Check for touch targets that are too small
    */
-  private checkTouchTargetSizes(elements: Element[], wcagLevel: string): WcagViolation[] {
+  private checkTouchTargetSizes(
+    elements: Element[],
+    wcagLevel: string,
+    density?: number,
+  ): WcagViolation[] {
     const violations: WcagViolation[] = [];
 
-    // WCAG 2.1 Level AA: minimum 44x44 CSS pixels (approx 44 dp on Android)
-    // WCAG 2.1 Level AAA: no additional requirement beyond AA
-    const minSize = 44;
+    // WCAG 2.1 Level AA: minimum 44x44 dp on Android.
+    // WCAG 2.1 Level AAA: no additional requirement beyond AA.
+    const minSizeDp = 44;
+
+    // `bounds` are physical pixels (see Element.ts / ViewHierarchyNode), so the
+    // dp gate must be scaled by density the same way checkFormInputLabels
+    // scales its gap gate (labelGapThresholdPx) — otherwise a 33dp target on an
+    // xxhdpi device (~100px) is compared against a raw 44px and wrongly passes.
+    const dpi = density && density > 0 ? density : WcagAudit.FALLBACK_DENSITY_DPI;
+    const minSizePx = minSizeDp * (dpi / WcagAudit.BASELINE_DENSITY_DPI);
 
     for (const element of elements) {
       // Only check clickable elements
@@ -219,19 +230,24 @@ export class WcagAudit {
         continue;
       }
 
-      const width = element.bounds.right - element.bounds.left;
-      const height = element.bounds.bottom - element.bounds.top;
+      const widthPx = element.bounds.right - element.bounds.left;
+      const heightPx = element.bounds.bottom - element.bounds.top;
 
-      if (width < minSize || height < minSize) {
+      if (widthPx < minSizePx || heightPx < minSizePx) {
+        // Report the measured size in dp, not raw px, so the message is
+        // labeled correctly regardless of device density.
+        const widthDp = Math.round((widthPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
+        const heightDp = Math.round((heightPx * WcagAudit.BASELINE_DENSITY_DPI) / dpi);
+
         violations.push({
           type: "touch-target-too-small",
           severity: wcagLevel === "AAA" ? "error" : "warning",
           criterion: "2.5.5", // Target Size (Level AAA in WCAG 2.1, AA in WCAG 2.2)
-          message: `Touch target is too small: ${width}x${height}dp (minimum: ${minSize}x${minSize}dp)`,
+          message: `Touch target is too small: ${widthDp}x${heightDp}dp (minimum: ${minSizeDp}x${minSizeDp}dp)`,
           element,
           details: {
-            actualSize: { width, height },
-            requiredSize: { width: minSize, height: minSize },
+            actualSize: { width: widthDp, height: heightDp },
+            requiredSize: { width: minSizeDp, height: minSizeDp },
             explanation: "Touch targets should be at least 44x44 dp to be easily tappable",
           },
           fingerprint: this.generateFingerprint(element, "touch-target-too-small"),

--- a/test/features/accessibility/WcagAudit.test.ts
+++ b/test/features/accessibility/WcagAudit.test.ts
@@ -598,6 +598,28 @@ describe("WcagAudit", function () {
 
       expect(sizeViolations).toHaveLength(0);
     });
+
+    it("never rounds a failing dimension's reported dp up to the minimum", async function () {
+      // 115px at 420 DPI is 43.81dp — under the 44dp gate (115.5px), so this
+      // must violate. Rounding to nearest would display "44x44dp", which
+      // reads as meeting "minimum: 44x44dp" right next to it.
+      const elements: Element[] = [
+        {
+          bounds: { left: 0, top: 0, right: 115, bottom: 115 },
+          clickable: true,
+          text: "Borderline",
+        },
+      ];
+
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 420);
+      const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
+
+      expect(sizeViolations).toHaveLength(1);
+      expect(sizeViolations[0].message).toBe(
+        "Touch target is too small: 43x43dp (minimum: 44x44dp)",
+      );
+      expect(sizeViolations[0].details.actualSize).toEqual({ width: 43, height: 43 });
+    });
   });
 
   describe("Heading Hierarchy", function () {

--- a/test/features/accessibility/WcagAudit.test.ts
+++ b/test/features/accessibility/WcagAudit.test.ts
@@ -177,7 +177,8 @@ describe("WcagAudit", function () {
         useBaseline: false,
       };
 
-      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+      // mdpi (160 DPI): 1dp == 1px, so bounds-as-dp assumptions below hold exactly.
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 160);
 
       const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
       expect(sizeViolations).toHaveLength(1);
@@ -199,7 +200,7 @@ describe("WcagAudit", function () {
         useBaseline: false,
       };
 
-      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 160);
 
       const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
       expect(sizeViolations).toHaveLength(0);
@@ -221,7 +222,7 @@ describe("WcagAudit", function () {
         useBaseline: false,
       };
 
-      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 160);
 
       const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
       expect(sizeViolations).toHaveLength(0);
@@ -507,7 +508,8 @@ describe("WcagAudit", function () {
           useBaseline: false,
         };
 
-        const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+        // mdpi (160 DPI): 1dp == 1px, so bounds-as-dp labels above hold exactly.
+        const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 160);
         const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
 
         if (expectViolation) {
@@ -519,6 +521,83 @@ describe("WcagAudit", function () {
         }
       },
     );
+  });
+
+  describe("Touch Target Size (density scaling)", function () {
+    const hierarchy: ViewHierarchyNode = { class: "View", children: [] };
+    const config: AccessibilityAuditConfig = {
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    };
+
+    // 44dp minimum, scaled by density/160. At xxhdpi (480 DPI) that is 132px.
+    it("flags a 100x100px target on an xxhdpi (480 DPI) device (33dp, below the 44dp gate)", async function () {
+      const elements: Element[] = [
+        {
+          bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+          clickable: true,
+          text: "Small",
+        },
+      ];
+
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 480);
+      const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
+
+      expect(sizeViolations).toHaveLength(1);
+      // 100px at 480 DPI is 33dp (100 * 160 / 480), not 100dp.
+      expect(sizeViolations[0].message).toContain("33x33dp");
+      expect(sizeViolations[0].message).not.toContain("100x100dp");
+    });
+
+    it("passes a 140x140px target on an xxhdpi (480 DPI) device (>= the 132px/44dp gate)", async function () {
+      const elements: Element[] = [
+        {
+          bounds: { left: 0, top: 0, right: 140, bottom: 140 },
+          clickable: true,
+          text: "Big enough",
+        },
+      ];
+
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 480);
+      const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
+
+      expect(sizeViolations).toHaveLength(0);
+    });
+
+    it("treats mdpi (160 DPI) as 1dp == 1px", async function () {
+      const elements: Element[] = [
+        {
+          bounds: { left: 0, top: 0, right: 40, bottom: 40 },
+          clickable: true,
+          text: "Small",
+        },
+      ];
+
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config, 160);
+      const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
+
+      expect(sizeViolations).toHaveLength(1);
+      expect(sizeViolations[0].message).toContain("40x40dp");
+    });
+
+    it("falls back to a sensible default density when none is reported, consistent with checkFormInputLabels", async function () {
+      // No density passed at all — exercises the same fallback path as
+      // labelGapThresholdPx's FALLBACK_DENSITY_DPI (320 == xhdpi/2x), so a
+      // 44dp target on that assumed density is ~88px.
+      const elements: Element[] = [
+        {
+          bounds: { left: 0, top: 0, right: 88, bottom: 88 }, // exactly 44dp at 320 DPI
+          clickable: true,
+          text: "Perfect",
+        },
+      ];
+
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+      const sizeViolations = result.violations.filter((v) => v.type === "touch-target-too-small");
+
+      expect(sizeViolations).toHaveLength(0);
+    });
   });
 
   describe("Heading Hierarchy", function () {


### PR DESCRIPTION
## Summary

`WcagAudit.checkTouchTargetSizes` compared physical-pixel `bounds` against a
raw 44 (dp) threshold with no density scaling, so on higher-density devices
(e.g. xxhdpi, 480 DPI) a target well under the real 44dp minimum could pass,
and the reported size was pixels mislabeled as dp. The sibling
`checkFormInputLabels` already scaled its gap gate by `density / 160`
(`labelGapThresholdPx`) — this brings the touch-target check in line with it.

## Linked Issue

Closes #6127

## Bug / Regression Context

- **Prior attempts:** none.
- **Observed symptom:** a 100x100px (33dp) clickable on a 480 dpi device
  produced no `touch-target-too-small` violation, and any violation that was
  reported showed raw pixel counts labeled `dp`.
- **Repro steps / conditions:** run `WcagAudit.audit` with `density: 480` and
  a clickable element sized 100x100 physical px (33dp) — no violation was
  raised prior to this fix.

## Fix

Scale the 44dp minimum to pixels using `minSizeDp * (dpi / 160)`, and convert
the measured px size back to dp for the violation message. Falls back to the
existing `FALLBACK_DENSITY_DPI` (320) when density is unavailable, matching
`checkFormInputLabels`'s default.

## Testing

- Added `Touch Target Size (density scaling)` describe block in
  `test/features/accessibility/WcagAudit.test.ts`:
  - 100x100px @ 480 dpi (33dp) is flagged, and the message reports `33x33dp`
    (not `100x100dp`).
  - 140x140px @ 480 dpi is not flagged (>= the 132px/44dp gate).
  - mdpi (160 dpi) behaves as 1dp == 1px.
  - No density reported falls back to the 320 dpi default, consistent with
    the sibling label check.
- Updated the existing density-less touch-target tests (single-case and
  parameterized) to pass an explicit `density: 160` (mdpi), since the
  no-density fallback changed from "treat px as dp" to the shared
  `FALLBACK_DENSITY_DPI` (320) default — those tests were asserting 1:1 dp
  math and needed an explicit mdpi density to keep pinning that.
- Confirmed red before the implementation change (100x100px @ 480 dpi case
  failed to flag), green after.
- `turbo run lint build test`, `bun run typecheck`, `bun run format:check`
  all pass locally.

## Validation

- [x] `scripts/all_fast_validate_checks.sh`-equivalent (`turbo run lint build test`) passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [ ] Android/iOS changes: N/A (TypeScript-only change)
- [x] New/changed tests use interfaces + fakes + FakeTimer where relevant; unit tests run in <100ms
- [x] No new dependency added
- [x] Rebased onto latest `main`

## Kotlin Reuse Check

N/A — no Kotlin changed.

## Device Verification

N/A — pure computation fix in `WcagAudit`, covered by unit tests.

## Follow-ups

None identified beyond this issue's scope.
