### PR TITLE
fix(logPruner): stop daemon own-file cap from claiming daemon-launch-<pid>.log

### DIFF
--- a/src/utils/logPruner.ts
+++ b/src/utils/logPruner.ts
@@ -30,11 +30,24 @@ function defaultIsProcessAlive(pid: number): boolean {
 
 /**
  * Whether `file` belongs to `ownPrefix`, matched on an exact PID boundary so
- * `stdio-12` never claims `stdio-123`'s files. Filenames are
- * `<prefix>.log` (active) and `<prefix>-<ts>.log` (rotated).
+ * `stdio-12` never claims `stdio-123`'s files. Filenames are `<prefix>.log`
+ * (active) and `<prefix>-<rotation suffix>.log` (rotated).
+ *
+ * `daemon-launch-<pid>.log` is the manager's launch-capture log — owned by
+ * whichever process spawned it, not the daemon — but it textually starts with
+ * `daemon-` too, so a bare `startsWith(\`${ownPrefix}-\`)` wrongly claims it for
+ * the `daemon` owner. Excluding that one named sub-role keeps the exact-PID-
+ * boundary match for everything else (issue #6120).
  */
 function isOwnedBy(file: string, ownPrefix: string): boolean {
-  return file === `${ownPrefix}.log` || file.startsWith(`${ownPrefix}-`);
+  if (file === `${ownPrefix}.log`) {
+    return true;
+  }
+  if (!file.startsWith(`${ownPrefix}-`)) {
+    return false;
+  }
+  const rest = file.slice(ownPrefix.length + 1);
+  return !/^launch-\d+\.log$/.test(rest);
 }
 
 /**

--- a/test/utils/logPruner.test.ts
+++ b/test/utils/logPruner.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pruneLogFiles } from "../../src/utils/logPruner";
+
+async function withTempLogDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "logpruner-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("logPruner isOwnedBy (via pruneLogFiles)", () => {
+  test("daemon own-file cap does not count daemon-launch-<pid>.log and does not delete them", async () => {
+    await withTempLogDir(async (dir) => {
+      // 3 rotated daemon backups + active + 9 daemon-launch capture logs, matching
+      // the issue's repro shape (issue #6120).
+      const rotated = [
+        "daemon-2026-01-01T00-00-00.000Z.log",
+        "daemon-2026-01-02T00-00-00.000Z.log",
+        "daemon-2026-01-03T00-00-00.000Z.log",
+      ];
+      const launchLogs = Array.from({ length: 9 }, (_, i) => `daemon-launch-${100 + i}.log`);
+      const active = "daemon.log";
+      for (const file of [...rotated, ...launchLogs, active]) {
+        await writeFile(path.join(dir, file), "x");
+      }
+
+      await pruneLogFiles({
+        dir,
+        ownPrefix: "daemon",
+        maxOwnFiles: 10,
+        abandonedMaxAgeMs: 1000 * 60 * 60,
+        // Treat every launch-log PID as alive so sweep (b) never removes them —
+        // isolating this assertion to the own-file cap (a) under test.
+        isProcessAlive: () => true,
+      });
+
+      const after = await readdir(dir);
+
+      // The daemon's own rotated backups must survive the cap — they must not be
+      // pushed out by peer daemon-launch-<pid>.log files counting against it.
+      for (const file of rotated) {
+        expect(after).toContain(file);
+      }
+      expect(after).toContain(active);
+      // Launch logs are a different owner's files, untouched by the daemon's cap.
+      for (const file of launchLogs) {
+        expect(after).toContain(file);
+      }
+    });
+  });
+
+  test("daemon own-file cap still prunes the daemon's own excess rotated backups", async () => {
+    await withTempLogDir(async (dir) => {
+      const rotated = Array.from(
+        { length: 5 },
+        (_, i) => `daemon-2026-01-0${i + 1}T00-00-00.000Z.log`,
+      );
+      const active = "daemon.log";
+      for (const file of [...rotated, active]) {
+        await writeFile(path.join(dir, file), "x");
+      }
+
+      await pruneLogFiles({
+        dir,
+        ownPrefix: "daemon",
+        maxOwnFiles: 3,
+        abandonedMaxAgeMs: 1000 * 60 * 60,
+      });
+
+      const after = await readdir(dir);
+      // 6 own files total, cap 3 -> oldest 3 (lexically first) pruned.
+      expect(after).not.toContain(rotated[0]);
+      expect(after).not.toContain(rotated[1]);
+      expect(after).not.toContain(rotated[2]);
+      expect(after).toContain(rotated[3]);
+      expect(after).toContain(rotated[4]);
+      expect(after).toContain(active);
+    });
+  });
+
+  test("daemon-launch-<dead pid>.log older than the stale threshold is swept once its owner has exited", async () => {
+    await withTempLogDir(async (dir) => {
+      const staleLaunchLog = "daemon-launch-4242.log";
+      await writeFile(path.join(dir, staleLaunchLog), "x");
+      await writeFile(path.join(dir, "daemon.log"), "x");
+
+      await pruneLogFiles({
+        dir,
+        ownPrefix: "daemon",
+        maxOwnFiles: 10,
+        abandonedMaxAgeMs: -1, // treat every file as already stale
+        isProcessAlive: () => false, // owner pid 4242 has exited
+      });
+
+      const after = await readdir(dir);
+      expect(after).not.toContain(staleLaunchLog);
+    });
+  });
+
+  test("a live peer's daemon-launch-<pid>.log is never removed by the daemon's sweep", async () => {
+    await withTempLogDir(async (dir) => {
+      const liveLaunchLog = "daemon-launch-9999.log";
+      await writeFile(path.join(dir, liveLaunchLog), "x");
+      await writeFile(path.join(dir, "daemon.log"), "x");
+
+      await pruneLogFiles({
+        dir,
+        ownPrefix: "daemon",
+        maxOwnFiles: 10,
+        abandonedMaxAgeMs: -1,
+        isProcessAlive: () => true, // owner pid 9999 still running
+      });
+
+      const after = await readdir(dir);
+      expect(after).toContain(liveLaunchLog);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `isOwnedBy("daemon", ...)` in `src/utils/logPruner.ts` wrongly matching
peer `daemon-launch-<pid>.log` files as owned by the `daemon` process.

## Root cause

`isOwnedBy` matched any file that merely `startsWith(\`${ownPrefix}-\`)`. The
daemon's log prefix is the bare string `daemon`, and the manager writes
launch-capture logs named `daemon-launch-<pid>.log` (owned by the spawning
manager, not the daemon). `"daemon-launch-123.log".startsWith("daemon-")` is
`true`, so:

1. **Own-file cap**: every manager's launch log counted toward the daemon's
   `maxOwnFiles` cap. Sorted lexically, the daemon's genuinely-owned rotated
   backups (`daemon-<timestamp>.log`) sort before `daemon-launch-*.log`, so
   the backups were the files evicted while launch logs survived.
2. **Sweep**: the sweep step `continue`s on anything "owned", so the daemon
   never reaped stale `daemon-launch-*.log` files via its own pruning pass
   even after `ownerPid()` recognized their owning PID had exited.

## Fix

`isOwnedBy` now excludes the one named sub-role that collides with the
prefix boundary — `<prefix>-launch-<pid>.log` — while keeping the existing
exact-PID-boundary match (`stdio-12` never claims `stdio-123`) for every
other rotated-file shape used elsewhere in the suite.

## Testing

- `test/utils/logPruner.test.ts` (new): reproduces the issue's exact repro
  shape (3 rotated daemon backups + 9 `daemon-launch-*.log` + active,
  `maxOwnFiles: 10`) and asserts the rotated backups survive the cap and the
  launch logs are untouched by it; also covers the daemon's own-file cap
  still pruning its own excess backups, and the sweep both removing a dead
  launch log past the stale threshold and never removing a live peer's.
- `test/daemon/loggerPrune.test.ts` (pre-existing, unmodified): still green,
  confirming the fix preserves the exact-PID-boundary behavior for
  `stdio-<pid>` and the existing `daemon-launch-<pid>.log` sweep coverage
  from #2724.
- Full suite: `turbo run lint build test`, `bun run typecheck`,
  `bun run format:check` all green locally.

## Acceptance criteria

- [x] Daemon rotated backups are retained up to `maxOwnFiles`; launch logs
      are not counted.
- [x] `daemon-launch-<dead pid>.log` older than the stale threshold is
      removed by the daemon's sweep.
- [x] Red before / green after.

Closes #6120
