### PR TITLE
fix(observe): rename skeleton identifier field id to elementId

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -438,7 +438,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -619,7 +619,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -1161,7 +1161,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -2487,7 +2487,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -2601,7 +2601,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -2712,7 +2712,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -2851,7 +2851,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -3382,7 +3382,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Output projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) in place of viewHierarchy/elements. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Output projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) in place of viewHierarchy/elements. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -4596,7 +4596,7 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": {
+              "elementId": {
                 "type": "string"
               },
               "label": {
@@ -7040,7 +7040,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -7201,7 +7201,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -7328,7 +7328,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -7636,7 +7636,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -7816,7 +7816,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -7852,7 +7852,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -8574,7 +8574,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -8913,7 +8913,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -8981,7 +8981,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -9073,7 +9073,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -9255,7 +9255,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },
@@ -11073,7 +11073,7 @@
           "type": "boolean"
         },
         "project": {
-          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
+          "description": "Observation projection. 'skeleton' (default) returns a flat, actionable-only list (elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
           "type": "string",
           "enum": ["full", "skeleton"]
         },

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -9,7 +9,7 @@ import { ElementProvenance, getElementProvenance, isStrictAncestor } from "./ele
  *
  * `toSkeleton` collapses the already-computed `ObserveResult.elements`
  * (`{ clickable, scrollable, text, media }`) into a flat, actionable-only list —
- * `{ id, label, bounds, affordances }` — dropping layout scaffolding. Embedded
+ * `{ elementId, label, bounds, affordances }` — dropping layout scaffolding. Embedded
  * semantic links and a Compose test tag are retained only when present, because
  * they make otherwise inaccessible link activation discoverable. It is a
  * pure merge + dedup + compaction of that structure: no device I/O, no tree
@@ -23,9 +23,11 @@ import { ElementProvenance, getElementProvenance, isStrictAncestor } from "./ele
  * already-flattened `text` category's geometry, so those rows are no longer
  * `label: null` and non-clickable state text is not lost.
  *
- * `id` / `label` map directly onto the `tapOn` selector union (`elementId` /
- * `text`), so a skeleton row is issued as `tapOn({ elementId })` with no new
- * selector semantics (issue #4388 acceptance criterion 2).
+ * `elementId` / `label` map directly onto the `tapOn` selector union
+ * (`elementId` / `text`), so a skeleton row is issued as `tapOn({ elementId })`
+ * with no new selector semantics (issue #4388 acceptance criterion 2). The
+ * emitted key is named `elementId` (not `id`) to literally match the selector
+ * field name — see issue #6153.
  */
 
 type ObserveElements = NonNullable<ObserveResult["elements"]>;
@@ -39,10 +41,10 @@ function nonEmptyString(value: unknown): string | undefined {
 }
 
 /**
- * `id = resource-id ?? view-id`. The `view-id` slot is the stable content-hash
- * id from `assignStableViewIds` (`s-…`, #3228), so a row keeps its id across a
- * scroll. A test tag is carried separately for Compose owners that do not enable
- * `testTagsAsResourceId`.
+ * `elementId = resource-id ?? view-id`. The `view-id` slot is the stable
+ * content-hash id from `assignStableViewIds` (`s-…`, #3228), so a row keeps its
+ * elementId across a scroll. A test tag is carried separately for Compose
+ * owners that do not enable `testTagsAsResourceId`.
  */
 function deriveId(el: Element): string | undefined {
   return nonEmptyString(el["resource-id"]) ?? nonEmptyString(el["view-id"]);
@@ -113,9 +115,9 @@ function boundsTuple(el: Element): SkeletonElement["bounds"] | undefined {
   return [left, top, right, bottom];
 }
 
-/** Working accumulator for one merged skeleton row, keyed by `(id, label, bounds)`. */
+/** Working accumulator for one merged skeleton row, keyed by `(elementId, label, bounds)`. */
 interface SkeletonAccumulator {
-  id?: string;
+  elementId?: string;
   label?: string;
   sublabel?: string;
   testTag?: string;
@@ -131,13 +133,13 @@ interface SkeletonAccumulator {
   provenance?: ElementProvenance;
 }
 
-/** NUL-joined identity so `(id, label, bounds)` triples dedup without straddling. */
+/** NUL-joined identity so `(elementId, label, bounds)` triples dedup without straddling. */
 function identityKey(
-  id: string | undefined,
+  elementId: string | undefined,
   label: string | undefined,
   bounds: SkeletonElement["bounds"],
 ): string {
-  return [id ?? "", label ?? "", bounds.join(",")].join("\0");
+  return [elementId ?? "", label ?? "", bounds.join(",")].join("\0");
 }
 
 function area(bounds: SkeletonElement["bounds"]): number {
@@ -159,7 +161,7 @@ function strictlyContains(
 }
 
 /**
- * Merge overlapping element categories into one accumulator per `(id, label,
+ * Merge overlapping element categories into one accumulator per `(elementId, label,
  * bounds)` triple, unioning affordances. `text` overlaps `clickable`/`scrollable`
  * on real captures (a clickable node that carries text is in both), so the
  * identity key dedups them. `media` carries no actionable affordance and is
@@ -172,14 +174,14 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
     if (!bounds) {
       continue;
     }
-    const id = deriveId(el);
+    const elementId = deriveId(el);
     const label = deriveLabel(el);
     const affordances = deriveAffordances(el);
-    const key = identityKey(id, label, bounds);
+    const key = identityKey(elementId, label, bounds);
 
     let acc = byIdentity.get(key);
     if (!acc) {
-      acc = { id, label, bounds, affordances: new Set<Affordance>() };
+      acc = { elementId, label, bounds, affordances: new Set<Affordance>() };
       byIdentity.set(key, acc);
     }
     if (acc.provenance === undefined) {
@@ -384,8 +386,8 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
     bounds: acc.bounds,
     affordances: AFFORDANCE_ORDER.filter((affordance) => acc.affordances.has(affordance)),
   };
-  if (acc.id !== undefined) {
-    entry.id = acc.id;
+  if (acc.elementId !== undefined) {
+    entry.elementId = acc.elementId;
   }
   if (acc.label !== undefined) {
     entry.label = acc.label;
@@ -408,7 +410,7 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
 /**
  * Project the flattened `elements` block into an actionable-only skeleton
  * (issue #4388): merge + dedup the categories, apply the keep rule, and emit
- * `{ id, label, bounds, affordances }` rows with compact tuple bounds.
+ * `{ elementId, label, bounds, affordances }` rows with compact tuple bounds.
  */
 export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
   const accumulators = accumulateByIdentity(elements);

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -69,14 +69,15 @@ export type Affordance = "tap" | "long-press" | "input" | "scroll" | "toggle";
 
 /**
  * One row of the Interactable Skeleton Projection (issue #4388): a flat,
- * actionable-only summary of a screen. `id` / `label` map directly onto the
- * `tapOn` selector union (`elementId` / `text`), so an agent reads the skeleton
- * and issues `tapOn({ elementId })` with no new selector semantics. Bounds are
- * always the compact `[left, top, right, bottom]` tuple.
+ * actionable-only summary of a screen. `elementId` / `label` map directly onto
+ * the `tapOn` selector union (`elementId` / `text`), so an agent reads the
+ * skeleton and issues `tapOn({ elementId })` with no new selector semantics
+ * and no key rename (issue #6153). Bounds are always the compact
+ * `[left, top, right, bottom]` tuple.
  */
 export interface SkeletonElement {
   /** `resource-id ?? view-id` (the stable content-hash id from #3228). */
-  id?: string;
+  elementId?: string;
   /**
    * `text ?? content-desc`, else the hoisted primary text of descendants (issue
    * #5869). A clickable container whose own node carries no text/content-desc

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -530,8 +530,8 @@ const observeBaseSchema = withJsonSchemaOverride(
         .optional()
         .describe(
           "Output projection. 'skeleton' (default) returns a flat, actionable-only list " +
-            "(id/label/bounds/affordances) in place of viewHierarchy/elements. Each skeleton " +
-            "id/label is directly usable " +
+            "(elementId/label/bounds/affordances) in place of viewHierarchy/elements. Each skeleton " +
+            "elementId/label is directly usable " +
             "as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
         ),
       skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling"),

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -570,7 +570,7 @@ export const deviceLockSchema = z.object({
  */
 export const skeletonElementSchema = z
   .object({
-    id: z.string().optional(),
+    elementId: z.string().optional(),
     label: z.string().optional(),
     sublabel: z.string().optional(),
     testTag: z.string().optional(),

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -23,8 +23,8 @@ export const responseShapeControlFields = {
     .optional()
     .describe(
       "Observation projection. 'skeleton' (default) returns a flat, actionable-only list " +
-        "(id/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' " +
-        "returns the raw view hierarchy under `viewHierarchy`. Each skeleton id/label is " +
+        "(elementId/label/bounds/affordances) under `skeleton` in place of `viewHierarchy`; 'full' " +
+        "returns the raw view hierarchy under `viewHierarchy`. Each skeleton elementId/label is " +
         "directly usable as a tapOn selector; re-request with raw/project:'full' to disambiguate.",
     ),
 } as const;

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -990,7 +990,7 @@ describe("sanitizeObserveResult", () => {
 
       const out = sanitizeObserveResult(observe, { dropElements: true, project: "skeleton" });
 
-      const card = out.skeleton?.find((entry) => entry.id === "long_press_card");
+      const card = out.skeleton?.find((entry) => entry.elementId === "long_press_card");
       expect(card).toBeDefined();
       expect(card?.label).toBe("Basic long press card");
       expect(card?.sublabel).toContain("Long press me");

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { toSkeleton } from "../../../../src/features/observe/output/SkeletonProjection";
 import { setElementProvenance } from "../../../../src/features/observe/output/elementProvenance";
 import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
+import { tapOnSchema } from "../../../../src/server/interactionTools";
 import type { Element } from "../../../../src/models/Element";
 import type { ObserveResult } from "../../../../src/models/ObserveResult";
 import type { SkeletonElement } from "../../../../src/models/ObserveResult";
@@ -29,7 +30,7 @@ function bounds(left: number, top: number, right: number, bottom: number): Eleme
 }
 
 function findById(skeleton: SkeletonElement[], id: string): SkeletonElement | undefined {
-  return skeleton.find((entry) => entry.id === id);
+  return skeleton.find((entry) => entry.elementId === id);
 }
 
 describe("toSkeleton — acceptance criteria", () => {
@@ -55,13 +56,36 @@ describe("toSkeleton — acceptance criteria", () => {
       const submit = findById(skeleton, "com.app:id/submit");
       expect(submit).toBeDefined();
       // resource-id wins over view-id; text wins over content-desc.
-      expect(submit?.id).toBe("com.app:id/submit");
+      expect(submit?.elementId).toBe("com.app:id/submit");
       expect(submit?.label).toBe("Submit");
 
       const row = findById(skeleton, "s-def456");
       expect(row).toBeDefined();
       // No resource-id: falls back to the stable view-id; no text: content-desc.
       expect(row?.label).toBe("Compose row");
+    });
+
+    test("a skeleton entry's elementId round-trips through tapOnSelectorSchema (issue #6153)", () => {
+      const node: Element = {
+        bounds: bounds(0, 0, 100, 50),
+        "resource-id": "com.app:id/submit",
+        text: "Submit",
+        clickable: "true",
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [node] }));
+      const entry = skeleton[0];
+      expect(entry.elementId).toBe("com.app:id/submit");
+      // No stray `id` key survives the rename.
+      expect((entry as Record<string, unknown>).id).toBeUndefined();
+
+      // The docs promise a skeleton entry's elementId is "directly usable as a
+      // tapOn selector" — verify that promise against the real selector schema.
+      const parsed = tapOnSchema.parse({
+        platform: "android",
+        selector: { elementId: entry.elementId },
+      });
+      expect(parsed.selector).toEqual({ elementId: "com.app:id/submit" });
     });
   });
 
@@ -259,7 +283,7 @@ describe("toSkeleton — acceptance criteria", () => {
 
       // The clickable row survives; the redundant inner label is suppressed.
       expect(skeleton).toHaveLength(1);
-      expect(skeleton[0].id).toBe("row");
+      expect(skeleton[0].elementId).toBe("row");
       expect(skeleton[0].affordances).toEqual(["tap"]);
     });
 
@@ -308,7 +332,7 @@ describe("toSkeleton — acceptance criteria", () => {
       const skeleton = toSkeleton(makeElements({ clickable: [a, b], scrollable: [c] }));
 
       expect(skeleton).toHaveLength(1);
-      expect(skeleton[0].id).toBe("dup");
+      expect(skeleton[0].elementId).toBe("dup");
       expect(skeleton[0].label).toBe("Row");
       expect(skeleton[0].affordances).toEqual(["tap", "scroll"]);
     });
@@ -642,7 +666,7 @@ describe("toSkeleton — acceptance criteria", () => {
       expect(elements).toBeDefined();
 
       const skeleton = toSkeleton(elements!);
-      const card = skeleton.find((entry) => entry.id === "long_press_card");
+      const card = skeleton.find((entry) => entry.elementId === "long_press_card");
       expect(card).toBeDefined();
       // Without ancestry provenance the exact-fill child is dropped and the card
       // stays label:null; with it, the label lands on the tappable row.


### PR DESCRIPTION
## What

`observe`'s skeleton projection emitted each row's identifier under the key
`id`, but every `tapOn`/`tapAny` selector union accepts only `elementId`
(plus `testTag`/`text`/`accessibilityLink`/`textAny`). Copying a skeleton
`id` straight into a selector — the workflow the docs explicitly promised
("directly usable as a tapOn selector") — was rejected with
`Unrecognized key: "id"`.

This renames the emitted skeleton field `id` -> `elementId` so the wire
output literally matches the selector name, and updates the tool
descriptions so the existing "directly usable" claim is now true.

## Breaking change

**This is a breaking wire-format change.** Any client reading a skeleton
entry's `id` field must switch to `elementId`. No `id` alias was added to
the `tapOn`/`tapAny` selector schemas (the selectors already only accepted
`elementId`, unchanged).

## Files changed

- `src/features/observe/output/SkeletonProjection.ts` — internal
  `SkeletonAccumulator.id` -> `elementId`, `identityKey`/`accumulateByIdentity`
  param renamed, emitted `entry.id` -> `entry.elementId`, doc comments updated.
- `src/models/ObserveResult.ts` — `SkeletonElement.id` -> `elementId`.
- `src/server/toolOutputSchemas.ts` — `skeletonElementSchema.id` -> `elementId`.
- `src/server/toolSchemaHelpers.ts` / `src/server/observeTools.ts` — the
  `project` param description now says "elementId/label" instead of
  "id/label", making the "directly usable as a tapOn selector" claim
  accurate.
- `schemas/tool-definitions.json` — regenerated via
  `scripts/update-tool-definitions.sh` for the description text change.

### Consumers/tests updated

- `test/features/observe/output/skeletonProjection.test.ts` — every
  `entry.id` / `skeleton[0].id` assertion switched to `elementId`; added a
  new test asserting a skeleton entry's `elementId` round-trips through
  `tapOnSchema.parse({ selector: { elementId } })` (the docs' promise) and
  that no stray `id` key survives on the emitted entry.
- `test/features/observe/output/ObserveResultOutput.test.ts` — the
  `long_press_card` lookup switched from `entry.id` to `entry.elementId`.

Grepped broadly across `src/`, `test/`, and `docs/` for any other reader of
a skeleton entry's `.id` (including `ObserveResultOutput.ts`,
`ObserveScopeExperiments.ts`, `ObserveElementCollector.ts`,
`finalizeToolResponse.ts`, `appTools.ts`, `interactionToolTypes.ts`) — none
remained.

## Test evidence

```
bun test test/features/observe/output/skeletonProjection.test.ts
 37 pass, 0 fail

turbo run lint build test
 875 pass, 0 fail (64 files)

bun run typecheck
 typecheck gate: no new type errors (163 known error(s) in baseline)

bun run format:check
 All matched files use the correct format.
```

Closes #6153
