### PR TITLE
fix(action): derive live rotation and restore auto-rotate after rotate (#6129)

### DIFF
--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -37,7 +37,36 @@ export class Rotate extends BaseVisualChange {
     }
   }
 
+  /**
+   * Read the live device rotation from the window manager (`dumpsys window`,
+   * `mRotation=`). Unlike the `user_rotation` setting, this reflects the
+   * rotation actually applied by the sensor when auto-rotate is on, so it
+   * cannot go stale the way `user_rotation` does (issue #6129).
+   * @returns The parsed `mRotation` value, or null if it could not be read
+   */
+  private async readLiveRotation(): Promise<number | null> {
+    try {
+      const { stdout } = await this.adb.executeCommand(
+        'shell dumpsys window | grep -i "mRotation="',
+      );
+      const match = stdout.match(/mRotation=(\d+)/);
+      return match ? parseInt(match[1], 10) : null;
+    } catch (error) {
+      logger.debug(`[Rotate] Failed to read live rotation via dumpsys window: ${error}`);
+      return null;
+    }
+  }
+
   async getCurrentOrientation(): Promise<string> {
+    // Prefer the live window-manager rotation: `user_rotation` only reflects
+    // the last explicitly-requested rotation and goes stale as soon as
+    // auto-rotate applies a sensor-driven rotation on top of it (#6129).
+    const liveRotation = await this.readLiveRotation();
+    if (liveRotation !== null) {
+      // 0 = portrait, 1 = landscape (90°), 2 = reverse portrait (180°), 3 = reverse landscape (270°)
+      return liveRotation === 0 || liveRotation === 2 ? "portrait" : "landscape";
+    }
+
     const userRotationStr = await this.readSystemSetting("user_rotation");
 
     if (!userRotationStr || !/^\d+$/.test(userRotationStr)) {
@@ -174,14 +203,18 @@ export class Rotate extends BaseVisualChange {
           };
         }
 
-        let orientationUnlocked = false;
+        // Auto-rotate must be off for `user_rotation` writes to take effect,
+        // regardless of whether it was already off beforehand. Remember the
+        // pre-existing value so it can be restored once the forced rotation
+        // completes, instead of leaving auto-rotate permanently disabled
+        // (#6129).
+        const wasAutoRotateEnabled = !isLocked;
 
         try {
-          // If orientation is locked, unlock it temporarily
           if (isLocked) {
-            logger.info("Orientation is locked, temporarily unlocking for rotation");
-            await this.writeSystemSetting("accelerometer_rotation", "1");
-            orientationUnlocked = true;
+            logger.info("Orientation is locked; forcing the requested rotation");
+          } else {
+            logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
           }
 
           await perf.track("setRotation", () =>
@@ -197,6 +230,10 @@ export class Rotate extends BaseVisualChange {
           // Note: We skip explicit verification since waitForRotation already confirms
           // the rotation completed successfully by polling dumpsys window
 
+          if (wasAutoRotateEnabled) {
+            await this.writeSystemSetting("accelerometer_rotation", "1");
+          }
+
           return {
             success: true,
             orientation,
@@ -207,17 +244,17 @@ export class Rotate extends BaseVisualChange {
             currentOrientation: orientation,
             previousOrientation: currentOrientation,
             rotationPerformed: true,
-            orientationLockHandled: orientationUnlocked,
+            orientationLockHandled: wasAutoRotateEnabled,
             message: `Successfully rotated from ${currentOrientation} to ${orientation}`,
           };
         } catch (error) {
-          // Restore orientation lock if we unlocked it
-          if (orientationUnlocked) {
+          // Restore auto-rotate if it was on before this call
+          if (wasAutoRotateEnabled) {
             try {
-              await this.writeSystemSetting("accelerometer_rotation", "0");
-              logger.info("Restored orientation lock after error");
+              await this.writeSystemSetting("accelerometer_rotation", "1");
+              logger.info("Restored auto-rotate after error");
             } catch (restoreError) {
-              logger.warn(`Failed to restore orientation lock: ${restoreError}`);
+              logger.warn(`Failed to restore auto-rotate: ${restoreError}`);
             }
           }
 
@@ -228,7 +265,7 @@ export class Rotate extends BaseVisualChange {
             currentOrientation,
             previousOrientation: currentOrientation,
             rotationPerformed: false,
-            orientationLockHandled: orientationUnlocked,
+            orientationLockHandled: wasAutoRotateEnabled,
             error: `Failed to change device orientation: ${error}`,
           };
         }

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -273,6 +273,12 @@ export class Rotate extends BaseVisualChange {
     // — an unreadable/malformed reading must never be fabricated into a
     // state to restore (#6199 review).
     const wasAutoRotateEnabled = autoRotateState === "enabled";
+    // When the prior state is unconfirmed, do not touch accelerometer_rotation
+    // at all: forcing it to 0 would be a real mutation of device state we
+    // have no confirmed value to restore afterward. Only write user_rotation
+    // in that case and let waitForRotation report honestly whether it took
+    // effect (#6199 review).
+    const canForceAutoRotateOff = autoRotateState !== "unknown";
 
     try {
       if (autoRotateState === "locked") {
@@ -281,16 +287,20 @@ export class Rotate extends BaseVisualChange {
         logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
       } else {
         logger.info(
-          "accelerometer_rotation is unreadable; forcing rotation without restoring it afterward",
+          "accelerometer_rotation is unreadable; setting user_rotation only, without forcing accelerometer_rotation (no confirmed prior state to restore)",
         );
       }
 
-      await perf.track("setRotation", () =>
-        Promise.all([
-          this.writeSystemSetting("accelerometer_rotation", "0"),
-          this.writeSystemSetting("user_rotation", String(value)),
-        ]),
-      );
+      await perf.track("setRotation", async () => {
+        if (canForceAutoRotateOff) {
+          await Promise.all([
+            this.writeSystemSetting("accelerometer_rotation", "0"),
+            this.writeSystemSetting("user_rotation", String(value)),
+          ]);
+        } else {
+          await this.writeSystemSetting("user_rotation", String(value));
+        }
+      });
 
       // Wait for rotation to complete (also serves as verification)
       await perf.track("waitForRotation", () => this.awaitIdle.waitForRotation(value));

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -83,17 +83,29 @@ export class Rotate extends BaseVisualChange {
   }
 
   /**
+   * Read the `accelerometer_rotation` setting as a tri-state: "locked" and
+   * "enabled" are CONFIRMED readings, "unknown" means the setting was absent,
+   * unreadable, or malformed. Callers must not treat "unknown" as either
+   * confirmed state — in particular, auto-rotate must only be restored after
+   * a rotation when it was CONFIRMED enabled beforehand (#6199 review).
+   * @returns "locked" (auto-rotation disabled), "enabled" (auto-rotation on),
+   *   or "unknown" when the setting could not be confirmed
+   */
+  private async getAutoRotateState(): Promise<"locked" | "enabled" | "unknown"> {
+    const val = await this.readSystemSetting("accelerometer_rotation");
+    if (val === null || !/^\d+$/.test(val)) {
+      return "unknown";
+    }
+    // 0 = locked (auto-rotation disabled), 1 = unlocked (auto-rotation enabled)
+    return parseInt(val, 10) === 0 ? "locked" : "enabled";
+  }
+
+  /**
    * Check if orientation is locked
    * @returns Promise with boolean indicating if auto-rotation is disabled
    */
   async isOrientationLocked(): Promise<boolean> {
-    const val = await this.readSystemSetting("accelerometer_rotation");
-    if (val === null) {
-      return false;
-    }
-    const autoRotate = parseInt(val, 10);
-    // 0 = locked (auto-rotation disabled), 1 = unlocked (auto-rotation enabled)
-    return autoRotate === 0;
+    return (await this.getAutoRotateState()) === "locked";
   }
 
   private async writeSystemSetting(key: string, value: string): Promise<void> {
@@ -184,9 +196,9 @@ export class Rotate extends BaseVisualChange {
       async () => {
         const value = orientation === "portrait" ? 0 : 1;
 
-        // Run getCurrentOrientation and isOrientationLocked in parallel
-        const [currentOrientation, isLocked] = await perf.track("getOrientationState", () =>
-          Promise.all([this.getCurrentOrientation(), this.isOrientationLocked()]),
+        // Run getCurrentOrientation and getAutoRotateState in parallel
+        const [currentOrientation, autoRotateState] = await perf.track("getOrientationState", () =>
+          Promise.all([this.getCurrentOrientation(), this.getAutoRotateState()]),
         );
 
         // Check if device is already in the desired orientation
@@ -207,14 +219,20 @@ export class Rotate extends BaseVisualChange {
         // regardless of whether it was already off beforehand. Remember the
         // pre-existing value so it can be restored once the forced rotation
         // completes, instead of leaving auto-rotate permanently disabled
-        // (#6129).
-        const wasAutoRotateEnabled = !isLocked;
+        // (#6129). Only restore when we CONFIRMED auto-rotate was on beforehand
+        // — an unreadable/malformed reading must never be fabricated into a
+        // state to restore (#6199 review).
+        const wasAutoRotateEnabled = autoRotateState === "enabled";
 
         try {
-          if (isLocked) {
+          if (autoRotateState === "locked") {
             logger.info("Orientation is locked; forcing the requested rotation");
-          } else {
+          } else if (autoRotateState === "enabled") {
             logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
+          } else {
+            logger.info(
+              "accelerometer_rotation is unreadable; forcing rotation without restoring it afterward",
+            );
           }
 
           await perf.track("setRotation", () =>
@@ -230,22 +248,38 @@ export class Rotate extends BaseVisualChange {
           // Note: We skip explicit verification since waitForRotation already confirms
           // the rotation completed successfully by polling dumpsys window
 
+          // waitForRotation(value) above already confirmed the device reached the
+          // requested orientation while auto-rotate was forced off. The local
+          // `currentOrientation` remains the legitimate prior value (see #6057).
+          let achievedOrientation: string = orientation;
+          let warning: string | undefined;
+
           if (wasAutoRotateEnabled) {
             await this.writeSystemSetting("accelerometer_rotation", "1");
+
+            // Restoring auto-rotate can let the physical sensor immediately
+            // re-apply its own orientation, overriding the one we just forced.
+            // Re-read the live orientation so we report what actually ended up
+            // held, rather than blindly claiming the requested orientation
+            // stuck (#6199 review).
+            achievedOrientation = await this.getCurrentOrientation();
+            if (achievedOrientation !== orientation) {
+              warning = `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${orientation} orientation is not held.`;
+            }
           }
 
           return {
             success: true,
             orientation,
             value,
-            // waitForRotation(value) above already confirmed the device reached the
-            // requested orientation, so report the achieved orientation here. The local
-            // `currentOrientation` remains the legitimate prior value (see #6057).
-            currentOrientation: orientation,
+            currentOrientation: achievedOrientation,
             previousOrientation: currentOrientation,
             rotationPerformed: true,
             orientationLockHandled: wasAutoRotateEnabled,
-            message: `Successfully rotated from ${currentOrientation} to ${orientation}`,
+            warning,
+            message: warning
+              ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
+              : `Successfully rotated from ${currentOrientation} to ${orientation}`,
           };
         } catch (error) {
           // Restore auto-rotate if it was on before this call

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -79,6 +79,37 @@ export class Rotate extends BaseVisualChange {
     }
   }
 
+  /**
+   * After restoring auto-rotate, determine what orientation the device
+   * actually ended up in. Restoring auto-rotate can let the physical sensor
+   * immediately re-apply its own orientation, overriding the one just
+   * forced, so this confirmation read MUST be LIVE (mRotation from dumpsys
+   * window) — falling back to `user_rotation` here would just echo the
+   * value this same call wrote a moment ago and silently recreate the false
+   * "requested orientation held" success this fix exists to prevent. If the
+   * live read is unavailable, the achieved orientation is reported as
+   * unconfirmed rather than guessed (#6199 review).
+   */
+  private async confirmOrientationAfterAutoRotateRestore(
+    requestedOrientation: "portrait" | "landscape",
+  ): Promise<{ achievedOrientation: string; warning: string | undefined }> {
+    const liveRotationValue = await this.readLiveRotation();
+    if (liveRotationValue === null) {
+      return {
+        achievedOrientation: "unknown",
+        warning: `Auto-rotate is enabled and the device's orientation after restoring it could not be confirmed (live rotation read failed); the requested ${requestedOrientation} orientation may not be held.`,
+      };
+    }
+
+    const achievedOrientation =
+      liveRotationValue === 0 || liveRotationValue === 2 ? "portrait" : "landscape";
+    const warning =
+      achievedOrientation === requestedOrientation
+        ? undefined
+        : `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${requestedOrientation} orientation is not held.`;
+    return { achievedOrientation, warning };
+  }
+
   async getCurrentOrientation(): Promise<string> {
     // Prefer the live window-manager rotation: `user_rotation` only reflects
     // the last explicitly-requested rotation and goes stale as soon as
@@ -316,16 +347,8 @@ export class Rotate extends BaseVisualChange {
 
       if (wasAutoRotateEnabled) {
         await this.writeSystemSetting("accelerometer_rotation", "1");
-
-        // Restoring auto-rotate can let the physical sensor immediately
-        // re-apply its own orientation, overriding the one we just forced.
-        // Re-read the live orientation so we report what actually ended up
-        // held, rather than blindly claiming the requested orientation
-        // stuck (#6199 review).
-        achievedOrientation = await this.getCurrentOrientation();
-        if (achievedOrientation !== orientation) {
-          warning = `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${orientation} orientation is not held.`;
-        }
+        ({ achievedOrientation, warning } =
+          await this.confirmOrientationAfterAutoRotateRestore(orientation));
       }
 
       return {
@@ -338,7 +361,9 @@ export class Rotate extends BaseVisualChange {
         orientationLockHandled: wasAutoRotateEnabled,
         warning,
         message: warning
-          ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
+          ? achievedOrientation === "unknown"
+            ? `Rotated to ${orientation}, but the device's orientation after auto-rotate restore could not be confirmed`
+            : `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
           : `Successfully rotated from ${currentOrientation} to ${orientation}`,
       };
     } catch (error) {

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -1,3 +1,4 @@
+import { Mutex } from "async-mutex";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, RotateResult } from "../../models";
@@ -7,10 +8,29 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import { parseWindowManagerRotation } from "../../utils/android-cmdline-tools/parseWindowManagerRotation";
 
 export class Rotate extends BaseVisualChange {
+  // Serializes the read-auto-rotate -> disable -> rotate -> restore-auto-rotate
+  // critical section per device, so two concurrent rotations against the SAME
+  // device cannot interleave: without this, one rotation could read the
+  // other's temporary `accelerometer_rotation=0` as the "prior state" and
+  // later restore auto-rotate to the wrong value (#6199 review). Keyed by
+  // deviceId (not per-instance) since a new Rotate is constructed per tool
+  // call. Deliberately NOT shared across different devices.
+  private static readonly rotationLocks = new Map<string, Mutex>();
+
   constructor(device: BootedDevice, adb: AdbClient | null = null, timer: Timer = defaultTimer) {
     super(device, adb, timer);
+  }
+
+  private getRotationLock(): Mutex {
+    let lock = Rotate.rotationLocks.get(this.device.deviceId);
+    if (!lock) {
+      lock = new Mutex();
+      Rotate.rotationLocks.set(this.device.deviceId, lock);
+    }
+    return lock;
   }
 
   /**
@@ -38,19 +58,21 @@ export class Rotate extends BaseVisualChange {
   }
 
   /**
-   * Read the live device rotation from the window manager (`dumpsys window`,
-   * `mRotation=`). Unlike the `user_rotation` setting, this reflects the
-   * rotation actually applied by the sensor when auto-rotate is on, so it
-   * cannot go stale the way `user_rotation` does (issue #6129).
-   * @returns The parsed `mRotation` value, or null if it could not be read
+   * Read the live device rotation from the window manager (`dumpsys window`).
+   * Unlike the `user_rotation` setting, this reflects the rotation actually
+   * applied by the sensor when auto-rotate is on, so it cannot go stale the
+   * way `user_rotation` does (issue #6129). Parsing is delegated to
+   * {@link parseWindowManagerRotation}, which selects the authoritative
+   * display rotation and skips stale/unrelated `mRotation=` occurrences
+   * (e.g. a cached TaskSnapshot) elsewhere in the dump (issue #6199).
+   * @returns The parsed rotation value, or null if it could not be read
    */
   private async readLiveRotation(): Promise<number | null> {
     try {
       const { stdout } = await this.adb.executeCommand(
         'shell dumpsys window | grep -i "mRotation="',
       );
-      const match = stdout.match(/mRotation=(\d+)/);
-      return match ? parseInt(match[1], 10) : null;
+      return parseWindowManagerRotation(stdout);
     } catch (error) {
       logger.debug(`[Rotate] Failed to read live rotation via dumpsys window: ${error}`);
       return null;
@@ -193,117 +215,14 @@ export class Rotate extends BaseVisualChange {
     perf: ReturnType<typeof createGlobalPerformanceTracker>,
   ): Promise<RotateResult> {
     return this.observedInteraction(
-      async () => {
-        const value = orientation === "portrait" ? 0 : 1;
-
-        // Run getCurrentOrientation and getAutoRotateState in parallel
-        const [currentOrientation, autoRotateState] = await perf.track("getOrientationState", () =>
-          Promise.all([this.getCurrentOrientation(), this.getAutoRotateState()]),
-        );
-
-        // Check if device is already in the desired orientation
-        if (currentOrientation === orientation) {
-          return {
-            success: true,
-            orientation,
-            value,
-            currentOrientation,
-            previousOrientation: currentOrientation,
-            rotationPerformed: false,
-            orientationLockHandled: false,
-            message: `Device is already in ${orientation} orientation`,
-          };
-        }
-
-        // Auto-rotate must be off for `user_rotation` writes to take effect,
-        // regardless of whether it was already off beforehand. Remember the
-        // pre-existing value so it can be restored once the forced rotation
-        // completes, instead of leaving auto-rotate permanently disabled
-        // (#6129). Only restore when we CONFIRMED auto-rotate was on beforehand
-        // — an unreadable/malformed reading must never be fabricated into a
-        // state to restore (#6199 review).
-        const wasAutoRotateEnabled = autoRotateState === "enabled";
-
-        try {
-          if (autoRotateState === "locked") {
-            logger.info("Orientation is locked; forcing the requested rotation");
-          } else if (autoRotateState === "enabled") {
-            logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
-          } else {
-            logger.info(
-              "accelerometer_rotation is unreadable; forcing rotation without restoring it afterward",
-            );
-          }
-
-          await perf.track("setRotation", () =>
-            Promise.all([
-              this.writeSystemSetting("accelerometer_rotation", "0"),
-              this.writeSystemSetting("user_rotation", String(value)),
-            ]),
-          );
-
-          // Wait for rotation to complete (also serves as verification)
-          await perf.track("waitForRotation", () => this.awaitIdle.waitForRotation(value));
-
-          // Note: We skip explicit verification since waitForRotation already confirms
-          // the rotation completed successfully by polling dumpsys window
-
-          // waitForRotation(value) above already confirmed the device reached the
-          // requested orientation while auto-rotate was forced off. The local
-          // `currentOrientation` remains the legitimate prior value (see #6057).
-          let achievedOrientation: string = orientation;
-          let warning: string | undefined;
-
-          if (wasAutoRotateEnabled) {
-            await this.writeSystemSetting("accelerometer_rotation", "1");
-
-            // Restoring auto-rotate can let the physical sensor immediately
-            // re-apply its own orientation, overriding the one we just forced.
-            // Re-read the live orientation so we report what actually ended up
-            // held, rather than blindly claiming the requested orientation
-            // stuck (#6199 review).
-            achievedOrientation = await this.getCurrentOrientation();
-            if (achievedOrientation !== orientation) {
-              warning = `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${orientation} orientation is not held.`;
-            }
-          }
-
-          return {
-            success: true,
-            orientation,
-            value,
-            currentOrientation: achievedOrientation,
-            previousOrientation: currentOrientation,
-            rotationPerformed: true,
-            orientationLockHandled: wasAutoRotateEnabled,
-            warning,
-            message: warning
-              ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
-              : `Successfully rotated from ${currentOrientation} to ${orientation}`,
-          };
-        } catch (error) {
-          // Restore auto-rotate if it was on before this call
-          if (wasAutoRotateEnabled) {
-            try {
-              await this.writeSystemSetting("accelerometer_rotation", "1");
-              logger.info("Restored auto-rotate after error");
-            } catch (restoreError) {
-              logger.warn(`Failed to restore auto-rotate: ${restoreError}`);
-            }
-          }
-
-          return {
-            success: false,
-            orientation,
-            value,
-            currentOrientation,
-            previousOrientation: currentOrientation,
-            rotationPerformed: false,
-            orientationLockHandled: wasAutoRotateEnabled,
-            error: `Failed to change device orientation: ${error}`,
-          };
-        }
-      },
+      // The read-auto-rotate -> disable -> rotate -> restore-auto-rotate
+      // sequence below must run atomically per device: interleaving it with
+      // a concurrent rotation on the same device would let one call observe
+      // the other's temporary accelerometer_rotation=0 as the "prior state"
+      // (#6199 review). Different devices use independent locks and never
+      // wait on each other.
+      () =>
+        this.getRotationLock().runExclusive(() => this.performAndroidRotation(orientation, perf)),
       {
         changeExpected: true,
         timeoutMs: 5000,
@@ -314,5 +233,125 @@ export class Rotate extends BaseVisualChange {
         skipUiStability: true,
       },
     );
+  }
+
+  /**
+   * The read-auto-rotate -> disable -> rotate -> restore-auto-rotate critical
+   * section for Android rotation. Callers MUST run this under
+   * {@link getRotationLock} to serialize it per device (#6199 review).
+   */
+  private async performAndroidRotation(
+    orientation: "portrait" | "landscape",
+    perf: ReturnType<typeof createGlobalPerformanceTracker>,
+  ): Promise<RotateResult> {
+    const value = orientation === "portrait" ? 0 : 1;
+
+    // Run getCurrentOrientation and getAutoRotateState in parallel
+    const [currentOrientation, autoRotateState] = await perf.track("getOrientationState", () =>
+      Promise.all([this.getCurrentOrientation(), this.getAutoRotateState()]),
+    );
+
+    // Check if device is already in the desired orientation
+    if (currentOrientation === orientation) {
+      return {
+        success: true,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: false,
+        message: `Device is already in ${orientation} orientation`,
+      };
+    }
+
+    // Auto-rotate must be off for `user_rotation` writes to take effect,
+    // regardless of whether it was already off beforehand. Remember the
+    // pre-existing value so it can be restored once the forced rotation
+    // completes, instead of leaving auto-rotate permanently disabled
+    // (#6129). Only restore when we CONFIRMED auto-rotate was on beforehand
+    // — an unreadable/malformed reading must never be fabricated into a
+    // state to restore (#6199 review).
+    const wasAutoRotateEnabled = autoRotateState === "enabled";
+
+    try {
+      if (autoRotateState === "locked") {
+        logger.info("Orientation is locked; forcing the requested rotation");
+      } else if (autoRotateState === "enabled") {
+        logger.info("Auto-rotate is on; temporarily disabling it to force rotation");
+      } else {
+        logger.info(
+          "accelerometer_rotation is unreadable; forcing rotation without restoring it afterward",
+        );
+      }
+
+      await perf.track("setRotation", () =>
+        Promise.all([
+          this.writeSystemSetting("accelerometer_rotation", "0"),
+          this.writeSystemSetting("user_rotation", String(value)),
+        ]),
+      );
+
+      // Wait for rotation to complete (also serves as verification)
+      await perf.track("waitForRotation", () => this.awaitIdle.waitForRotation(value));
+
+      // Note: We skip explicit verification since waitForRotation already confirms
+      // the rotation completed successfully by polling dumpsys window
+
+      // waitForRotation(value) above already confirmed the device reached the
+      // requested orientation while auto-rotate was forced off. The local
+      // `currentOrientation` remains the legitimate prior value (see #6057).
+      let achievedOrientation: string = orientation;
+      let warning: string | undefined;
+
+      if (wasAutoRotateEnabled) {
+        await this.writeSystemSetting("accelerometer_rotation", "1");
+
+        // Restoring auto-rotate can let the physical sensor immediately
+        // re-apply its own orientation, overriding the one we just forced.
+        // Re-read the live orientation so we report what actually ended up
+        // held, rather than blindly claiming the requested orientation
+        // stuck (#6199 review).
+        achievedOrientation = await this.getCurrentOrientation();
+        if (achievedOrientation !== orientation) {
+          warning = `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${orientation} orientation is not held.`;
+        }
+      }
+
+      return {
+        success: true,
+        orientation,
+        value,
+        currentOrientation: achievedOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: true,
+        orientationLockHandled: wasAutoRotateEnabled,
+        warning,
+        message: warning
+          ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
+          : `Successfully rotated from ${currentOrientation} to ${orientation}`,
+      };
+    } catch (error) {
+      // Restore auto-rotate if it was on before this call
+      if (wasAutoRotateEnabled) {
+        try {
+          await this.writeSystemSetting("accelerometer_rotation", "1");
+          logger.info("Restored auto-rotate after error");
+        } catch (restoreError) {
+          logger.warn(`Failed to restore auto-rotate: ${restoreError}`);
+        }
+      }
+
+      return {
+        success: false,
+        orientation,
+        value,
+        currentOrientation,
+        previousOrientation: currentOrientation,
+        rotationPerformed: false,
+        orientationLockHandled: wasAutoRotateEnabled,
+        error: `Failed to change device orientation: ${error}`,
+      };
+    }
   }
 }

--- a/src/features/observe/Idle.ts
+++ b/src/features/observe/Idle.ts
@@ -12,6 +12,7 @@ import {
 } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { parseWindowManagerRotation } from "../../utils/android-cmdline-tools/parseWindowManagerRotation";
 
 export class Idle {
   private adb: AdbExecutor;
@@ -117,10 +118,12 @@ export class Idle {
       const { stdout } = await perf.track("adbDumpsysWindowRotation", () =>
         this.adb.executeCommand('shell dumpsys window | grep -i "mRotation="'),
       );
-      const rotationMatch = stdout.match(/mRotation=(\d+)/);
+      // parseWindowManagerRotation selects the authoritative display rotation
+      // and skips stale/unrelated `mRotation=` occurrences elsewhere in the
+      // dump (e.g. a cached TaskSnapshot) — see issue #6199.
+      const currentRotation = parseWindowManagerRotation(stdout);
 
-      if (rotationMatch) {
-        const currentRotation = parseInt(rotationMatch[1], 10);
+      if (currentRotation !== null) {
         logger.debug(`Current rotation: ${currentRotation}, target: ${targetRotation}`);
 
         if (currentRotation === targetRotation) {

--- a/src/models/RotateResult.ts
+++ b/src/models/RotateResult.ts
@@ -13,4 +13,5 @@ export interface RotateResult extends BaseActionResult {
   rotationPerformed?: boolean;
   orientationLockHandled?: boolean;
   message?: string;
+  warning?: string;
 }

--- a/src/utils/android-cmdline-tools/parseWindowManagerRotation.ts
+++ b/src/utils/android-cmdline-tools/parseWindowManagerRotation.ts
@@ -9,15 +9,23 @@
  *    task was captured at, which can be stale relative to the live display.
  *  - A window's `Configuration` toString embeds
  *    `winConfig={... mRotation=ROTATION_0}` — a symbolic (non-numeric) value.
- *  - WindowManagerService itself prints its own top-level field as its own
- *    line, `mRotation=<digit>` (optionally followed by other top-level
- *    fields such as `mAltOrientation=false`), after indentation only. This
- *    is the authoritative, live display rotation.
+ *  - WindowManagerService itself prints the authoritative, live display
+ *    rotation, but WHERE it prints it has changed across API levels:
+ *      - API ~25-28 and ~34+: its own line, `mRotation=<digit>` (optionally
+ *        followed by other top-level fields such as `mAltOrientation=false`),
+ *        after indentation only.
+ *      - API ~29-33: inline on the display-status line instead of its own
+ *        line — `mDisplayFrozen=<bool> windows=<n> client=<bool> apps=<n>
+ *        mRotation=<digit> ...` (see the
+ *        `test/features/observe/windowDumps/api29..33-settings-window-dump.log`
+ *        fixtures, and issue #6199).
  *
- * Only the third form is accepted: this scans line by line and matches only
- * a line whose trimmed content starts with `mRotation=<digit>`, skipping any
- * `mRotation=` occurrence embedded inside a longer line (TaskSnapshot,
- * Configuration, etc). See issue #6199.
+ * Both authoritative forms are accepted, distinguished by which line/context
+ * they appear in — a bare `mRotation=<digit>` at line start, OR one inline on
+ * the `mDisplayFrozen=` display-status line — while TaskSnapshot and
+ * Configuration occurrences are still excluded either way, since neither of
+ * those contains `mDisplayFrozen=` and neither starts a line with
+ * `mRotation=`. See issue #6199.
  *
  * @param dumpsysWindowOutput - stdout of `dumpsys window` (or a filtered subset)
  * @returns The parsed rotation value (0-3), or null if the authoritative
@@ -25,9 +33,25 @@
  */
 export function parseWindowManagerRotation(dumpsysWindowOutput: string): number | null {
   for (const line of dumpsysWindowOutput.split("\n")) {
-    const match = line.trim().match(/^mRotation=(\d+)/);
-    if (match) {
-      return parseInt(match[1], 10);
+    const trimmed = line.trim();
+
+    // API ~25-28 and ~34+: WindowManagerService prints its own top-level
+    // field as its own line.
+    const standalone = trimmed.match(/^mRotation=(\d+)/);
+    if (standalone) {
+      return parseInt(standalone[1], 10);
+    }
+
+    // API ~29-33: the same authoritative field is printed inline on the
+    // display-status line instead of getting its own line. `mDisplayFrozen=`
+    // is WindowManagerService's own field name (never present in a
+    // TaskSnapshot or Configuration toString), so anchoring to it keeps
+    // those unrelated `mRotation=` occurrences excluded.
+    if (trimmed.startsWith("mDisplayFrozen=")) {
+      const inline = trimmed.match(/\bmRotation=(\d+)\b/);
+      if (inline) {
+        return parseInt(inline[1], 10);
+      }
     }
   }
   return null;

--- a/src/utils/android-cmdline-tools/parseWindowManagerRotation.ts
+++ b/src/utils/android-cmdline-tools/parseWindowManagerRotation.ts
@@ -1,0 +1,34 @@
+/**
+ * Parse the authoritative WindowManagerService display rotation out of
+ * `dumpsys window` output (or a `grep -i "mRotation="`-filtered subset of it).
+ *
+ * `mRotation=` appears in several unrelated places in a real dump, and a
+ * naive "first match" scan can pick the wrong one:
+ *  - A cached `SnapshotCache` entry embeds a historical
+ *    `snapshot=TaskSnapshot{... mRotation=<digit> ...}` — the rotation the
+ *    task was captured at, which can be stale relative to the live display.
+ *  - A window's `Configuration` toString embeds
+ *    `winConfig={... mRotation=ROTATION_0}` — a symbolic (non-numeric) value.
+ *  - WindowManagerService itself prints its own top-level field as its own
+ *    line, `mRotation=<digit>` (optionally followed by other top-level
+ *    fields such as `mAltOrientation=false`), after indentation only. This
+ *    is the authoritative, live display rotation.
+ *
+ * Only the third form is accepted: this scans line by line and matches only
+ * a line whose trimmed content starts with `mRotation=<digit>`, skipping any
+ * `mRotation=` occurrence embedded inside a longer line (TaskSnapshot,
+ * Configuration, etc). See issue #6199.
+ *
+ * @param dumpsysWindowOutput - stdout of `dumpsys window` (or a filtered subset)
+ * @returns The parsed rotation value (0-3), or null if the authoritative
+ *   field was not found
+ */
+export function parseWindowManagerRotation(dumpsysWindowOutput: string): number | null {
+  for (const line of dumpsysWindowOutput.split("\n")) {
+    const match = line.trim().match(/^mRotation=(\d+)/);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  }
+  return null;
+}

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -116,6 +116,33 @@ describe("Rotate", () => {
       expect(orientation).toBe("landscape");
     });
 
+    test("should prefer live mRotation over stale user_rotation (#6129)", async () => {
+      // Auto-rotate has physically rotated the device to landscape, but the
+      // `user_rotation` setting (only meaningful while auto-rotate is off)
+      // is still stuck at its old portrait value.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+
+      const orientation = await rotate.getCurrentOrientation();
+
+      expect(orientation).toBe("landscape");
+    });
+
+    test("should fall back to user_rotation when dumpsys window has no mRotation", async () => {
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("2"));
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult(""),
+      );
+
+      const orientation = await rotate.getCurrentOrientation();
+
+      expect(orientation).toBe("portrait");
+    });
+
     test("should return portrait as default when ADB command fails", async () => {
       fakeAdb.setDefaultResponse({
         stdout: "",
@@ -200,6 +227,28 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings get system user_rotation")).toBe(true);
       // Should not have tried to set rotation since already in desired orientation
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(false);
+    });
+
+    test("should rotate a physically-landscape auto-rotated device instead of no-oping (#6129)", async () => {
+      // Auto-rotate is on; the device is physically landscape (mRotation=1)
+      // but `user_rotation` is stale at 0 (portrait). A prior bug trusted
+      // `user_rotation` here and reported "already in portrait", never rotating.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult("mRotation=1"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.previousOrientation).toBe("landscape");
+      expect(result.currentOrientation).toBe("portrait");
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
     });
 
     test("should report achieved orientation as currentOrientation for landscape->portrait (#6057)", async () => {
@@ -296,17 +345,13 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 1")).toBe(true);
     });
 
-    test("should unlock orientation if locked before rotation", async () => {
+    test("should rotate directly (without unlocking) when orientation is already locked", async () => {
       // Setup: device is landscape with orientation locked
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("0"),
       ); // Locked
-      fakeAdb.setCommandResponse(
-        "shell settings put system accelerometer_rotation 1",
-        createExecResult(),
-      ); // Unlock
       fakeAdb.setCommandResponse(
         "shell settings put system accelerometer_rotation 0",
         createExecResult(),
@@ -316,15 +361,44 @@ describe("Rotate", () => {
       const result = await rotate.execute("portrait");
 
       expect(result.success).toBe(true);
-      // Verify that the unlock command was executed
-      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
-        true,
-      );
       // Verify the rotation commands were executed
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
         true,
       );
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
+      // Locked devices stay locked (to the newly-requested orientation) rather
+      // than being unlocked then immediately re-locked, which was a no-op.
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        false,
+      );
+      expect(result.orientationLockHandled).toBe(false);
+    });
+
+    test("should restore auto-rotate after forcing a rotation while it was enabled (#6129)", async () => {
+      // Device starts landscape with auto-rotate ON (unlocked).
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.orientationLockHandled).toBe(true);
+      // Auto-rotate must be forced off to apply user_rotation, then restored.
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
+        true,
+      );
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        true,
+      );
+      // The restore ("1") must be the LAST accelerometer_rotation write, not left at 0.
+      const accelWrites = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes("settings put system accelerometer_rotation"));
+      expect(accelWrites.at(-1)).toContain("accelerometer_rotation 1");
     });
   });
 

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -233,11 +233,39 @@ describe("Rotate", () => {
       // Auto-rotate is on; the device is physically landscape (mRotation=1)
       // but `user_rotation` is stale at 0 (portrait). A prior bug trusted
       // `user_rotation` here and reported "already in portrait", never rotating.
+      // The sensor settles on portrait once auto-rotate is restored (no override).
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("1"),
       );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"),
+        createExecResult("mRotation=0"),
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.previousOrientation).toBe("landscape");
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.warning).toBeUndefined();
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
+    });
+
+    test("should honestly report the sensor-held orientation when auto-rotate overrides the forced rotation (#6199)", async () => {
+      // Auto-rotate is on and the physical sensor stays landscape throughout
+      // (e.g. the device is physically held sideways) — restoring auto-rotate
+      // after forcing portrait immediately snaps it back to landscape. The
+      // result must report the ACHIEVED orientation and warn, not falsely
+      // claim portrait succeeded.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      // mRotation reads landscape both before AND after the forced rotation +
+      // restore — the sensor never let go of landscape.
       fakeAdb.setCommandResponse(
         'shell dumpsys window | grep -i "mRotation="',
         createExecResult("mRotation=1"),
@@ -245,15 +273,23 @@ describe("Rotate", () => {
 
       const result = await rotate.execute("portrait");
 
+      expect(result.success).toBe(true);
       expect(result.rotationPerformed).toBe(true);
       expect(result.previousOrientation).toBe("landscape");
-      expect(result.currentOrientation).toBe("portrait");
-      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
+      // Must report what is ACTUALLY held, not a false "portrait" success.
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/auto-rotate/i);
+      expect(result.warning ?? "").toContain("landscape");
     });
 
     test("should report achieved orientation as currentOrientation for landscape->portrait (#6057)", async () => {
-      // Device starts in landscape (user_rotation 1), rotates to portrait.
-      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
+      // Device starts in landscape (user_rotation 1), rotates to portrait and
+      // the sensor settles on portrait once auto-rotate is restored.
+      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("1"),
@@ -273,8 +309,12 @@ describe("Rotate", () => {
     });
 
     test("should report achieved orientation as currentOrientation for portrait->landscape (#6057)", async () => {
-      // Device starts in portrait (user_rotation 0), rotates to landscape.
-      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      // Device starts in portrait (user_rotation 0), rotates to landscape and
+      // the sensor settles on landscape once auto-rotate is restored.
+      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
+        createExecResult("0"),
+        createExecResult("1"),
+      ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("1"),
@@ -375,8 +415,12 @@ describe("Rotate", () => {
     });
 
     test("should restore auto-rotate after forcing a rotation while it was enabled (#6129)", async () => {
-      // Device starts landscape with auto-rotate ON (unlocked).
-      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
+      // Device starts landscape with auto-rotate ON (unlocked); the sensor
+      // settles on portrait once auto-rotate is restored (no override).
+      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
+        createExecResult("1"),
+        createExecResult("0"),
+      ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("1"),
@@ -387,6 +431,7 @@ describe("Rotate", () => {
       expect(result.success).toBe(true);
       expect(result.rotationPerformed).toBe(true);
       expect(result.orientationLockHandled).toBe(true);
+      expect(result.warning).toBeUndefined();
       // Auto-rotate must be forced off to apply user_rotation, then restored.
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
         true,
@@ -399,6 +444,30 @@ describe("Rotate", () => {
         .getExecutedCommands()
         .filter((cmd) => cmd.includes("settings put system accelerometer_rotation"));
       expect(accelWrites.at(-1)).toContain("accelerometer_rotation 1");
+    });
+
+    test("should not restore auto-rotate when accelerometer_rotation is unreadable (#6199)", async () => {
+      // accelerometer_rotation is malformed/unreadable — this must be treated
+      // as "unknown", never fabricated into a confirmed prior state to restore.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("not-a-number"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.orientationLockHandled).toBe(false);
+      // The forced-off write still happens (needed to apply user_rotation)...
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
+        true,
+      );
+      // ...but there is no unconfirmed "restore" write back to 1.
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
+        false,
+      );
     });
   });
 

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -309,12 +309,45 @@ describe("Rotate", () => {
       expect(result.warning ?? "").toContain("landscape");
     });
 
-    test("should report achieved orientation as currentOrientation for landscape->portrait (#6057)", async () => {
-      // Device starts in landscape (user_rotation 1), rotates to portrait and
-      // the sensor settles on portrait once auto-rotate is restored.
-      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
+    test("should report the achieved orientation as unconfirmed when the post-restore live read is unparseable, never falling back to user_rotation (#6199)", async () => {
+      // Auto-rotate is on; the device is physically landscape. The FIRST
+      // dumpsys read (pre-rotation state check) succeeds and reports
+      // landscape. After forcing portrait and restoring auto-rotate, the
+      // confirmation dumpsys read is transiently unparseable (e.g. a
+      // momentary empty/garbled `dumpsys window` response) — the code must
+      // NOT fall back to the just-written `user_rotation` (which would
+      // dishonestly echo "portrait" as if the sensor had held it) and must
+      // NOT silently report the requested orientation as achieved.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
         createExecResult("1"),
-        createExecResult("0"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"),
+        createExecResult(""),
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.previousOrientation).toBe("landscape");
+      // Must NOT falsely report the requested orientation as achieved/held.
+      expect(result.currentOrientation).not.toBe("portrait");
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/could not be confirmed/i);
+    });
+
+    test("should report achieved orientation as currentOrientation for landscape->portrait (#6057)", async () => {
+      // Device starts in landscape (live mRotation=1), rotates to portrait
+      // and the sensor settles on portrait (live mRotation=0) once
+      // auto-rotate is restored. The post-restore confirmation read is LIVE
+      // (mRotation), never a fallback to user_rotation (#6199 review).
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"),
+        createExecResult("mRotation=0"),
       ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
@@ -335,11 +368,13 @@ describe("Rotate", () => {
     });
 
     test("should report achieved orientation as currentOrientation for portrait->landscape (#6057)", async () => {
-      // Device starts in portrait (user_rotation 0), rotates to landscape and
-      // the sensor settles on landscape once auto-rotate is restored.
-      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
-        createExecResult("0"),
-        createExecResult("1"),
+      // Device starts in portrait (live mRotation=0), rotates to landscape
+      // and the sensor settles on landscape (live mRotation=1) once
+      // auto-rotate is restored. The post-restore confirmation read is LIVE
+      // (mRotation), never a fallback to user_rotation (#6199 review).
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=0"),
+        createExecResult("mRotation=1"),
       ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
@@ -442,10 +477,12 @@ describe("Rotate", () => {
 
     test("should restore auto-rotate after forcing a rotation while it was enabled (#6129)", async () => {
       // Device starts landscape with auto-rotate ON (unlocked); the sensor
-      // settles on portrait once auto-rotate is restored (no override).
-      fakeAdb.setCommandResponseSequence("shell settings get system user_rotation", [
-        createExecResult("1"),
-        createExecResult("0"),
+      // settles on portrait (live mRotation=0) once auto-rotate is restored
+      // (no override). The post-restore confirmation read is LIVE
+      // (mRotation), never a fallback to user_rotation (#6199 review).
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"),
+        createExecResult("mRotation=0"),
       ]);
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -253,6 +253,32 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
     });
 
+    test("should select the LIVE display mRotation over a stale TaskSnapshot mRotation in realistic dumpsys output (#6199)", async () => {
+      // Realistic `dumpsys window | grep -i "mRotation="` output: a cached
+      // SnapshotCache entry embeds a historical (stale) TaskSnapshot rotation
+      // BEFORE the authoritative WindowManagerService rotation line. A naive
+      // "first match anywhere" parse picks the stale value and defeats #6129.
+      const dumpsysWindowGrepOutput = [
+        "     snapshot=TaskSnapshot{ mId=1749551414267 mCaptureTime=1748344877515 mTopActivityComponent=com.android.settings/.SubSettings mSnapshot=android.hardware.HardwareBuffer@d8e7fad (864x1920) mColorSpace=sRGB IEC61966-2.1 (id=0, model=RGB) mOrientation=1 mRotation=0 mTaskSize=Point(1080, 2400) mContentInsets=[0,74][0,63] mLetterboxInsets=[0,0][0,0] mIsLowResolution=false mIsRealSnapshot=true mWindowingMode=1 mAppearance=24 mIsTranslucent=false mHasImeSurface=false mInternalReferences=2",
+        "  mRotation=1",
+      ].join("\n");
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponse(
+        'shell dumpsys window | grep -i "mRotation="',
+        createExecResult(dumpsysWindowGrepOutput),
+      );
+
+      const orientation = await rotate.getCurrentOrientation();
+
+      // The authoritative live rotation (1 = landscape) must win over the
+      // stale TaskSnapshot rotation (0 = portrait).
+      expect(orientation).toBe("landscape");
+    });
+
     test("should honestly report the sensor-held orientation when auto-rotate overrides the forced rotation (#6199)", async () => {
       // Auto-rotate is on and the physical sensor stays landscape throughout
       // (e.g. the device is physically held sideways) — restoring auto-rotate
@@ -468,6 +494,86 @@ describe("Rotate", () => {
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
         false,
       );
+    });
+
+    test("serializes concurrent rotations on the same device so auto-rotate restore is not corrupted (#6199)", async () => {
+      // Device starts portrait with auto-rotate ON.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+
+      // Gate the FIRST rotation's waitForRotation call so it parks mid-flight
+      // — after reading state and writing accelerometer_rotation=0, but
+      // before restoring it — giving a concurrent second rotation on the same
+      // device a window to race it if the critical section is not serialized.
+      let releaseFirstWait: (() => void) | undefined;
+      const firstWaitGate = new Promise<void>((resolve) => {
+        releaseFirstWait = resolve;
+      });
+      let waitForRotationCalls = 0;
+      const gatedAwaitIdle = {
+        waitForRotation: async () => {
+          waitForRotationCalls++;
+          if (waitForRotationCalls === 1) {
+            await firstWaitGate;
+          }
+        },
+      };
+      (rotate as any).awaitIdle = gatedAwaitIdle;
+
+      const secondRotate = new Rotate(mockDevice, fakeAdb, fakeTimer);
+      (secondRotate as any).awaitIdle = gatedAwaitIdle;
+      (secondRotate as any).observeScreen = fakeObserveScreen;
+      (secondRotate as any).window = fakeWindow;
+
+      const lock = (rotate as any).getRotationLock();
+      // Same deviceId -> the second instance must resolve to the SAME lock.
+      expect((secondRotate as any).getRotationLock()).toBe(lock);
+
+      const firstCall = rotate.execute("landscape");
+
+      // Let the first call's microtasks run until it holds the lock and is
+      // parked at the gate.
+      for (let i = 0; i < 50 && !lock.isLocked(); i++) {
+        await Promise.resolve();
+      }
+      expect(lock.isLocked()).toBe(true);
+
+      // Same requested orientation as the first call: `user_rotation` is
+      // stubbed at a constant stale "0" (portrait) regardless of what either
+      // call writes, so both calls see "not yet landscape" and must go
+      // through the full write/restore flow rather than short-circuiting.
+      const secondCall = secondRotate.execute("landscape");
+
+      // Give the second call every chance to run if it were (incorrectly)
+      // unserialized; it must still be blocked on the lock, so it must not
+      // have read device state yet.
+      for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+      }
+      const accelGetsWhileFirstHoldsLock = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes("settings get system accelerometer_rotation")).length;
+      expect(accelGetsWhileFirstHoldsLock).toBe(1);
+
+      releaseFirstWait!();
+      const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(firstResult.orientationLockHandled).toBe(true);
+      expect(secondResult.orientationLockHandled).toBe(true);
+
+      // The second rotation must observe the FIRST rotation's fully-restored
+      // state, not its transient accelerometer_rotation=0 — and must end up
+      // restoring auto-rotate itself, not stuck at 0.
+      const accelWrites = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes("settings put system accelerometer_rotation"));
+      expect(accelWrites.at(-1)).toContain("accelerometer_rotation 1");
+      expect(lock.isLocked()).toBe(false);
     });
   });
 

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -472,9 +472,12 @@ describe("Rotate", () => {
       expect(accelWrites.at(-1)).toContain("accelerometer_rotation 1");
     });
 
-    test("should not restore auto-rotate when accelerometer_rotation is unreadable (#6199)", async () => {
+    test("should not mutate accelerometer_rotation at all when it is unreadable (#6199)", async () => {
       // accelerometer_rotation is malformed/unreadable — this must be treated
-      // as "unknown", never fabricated into a confirmed prior state to restore.
+      // as "unknown". We must not force it off (no confirmed prior value to
+      // restore afterward), so user_rotation is written on its own and
+      // whatever the real device does with it is reported honestly by
+      // waitForRotation rather than covered up with a guessed restore.
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
@@ -486,11 +489,13 @@ describe("Rotate", () => {
       expect(result.success).toBe(true);
       expect(result.rotationPerformed).toBe(true);
       expect(result.orientationLockHandled).toBe(false);
-      // The forced-off write still happens (needed to apply user_rotation)...
+      // user_rotation is still written...
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
+      // ...but accelerometer_rotation is never mutated in either direction:
+      // no disable, and (necessarily) no unconfirmed "restore" either.
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(
-        true,
+        false,
       );
-      // ...but there is no unconfirmed "restore" write back to 1.
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(
         false,
       );

--- a/test/utils/android-cmdline-tools/parseWindowManagerRotation.test.ts
+++ b/test/utils/android-cmdline-tools/parseWindowManagerRotation.test.ts
@@ -1,0 +1,47 @@
+import { expect, describe, test } from "bun:test";
+import { parseWindowManagerRotation } from "../../../src/utils/android-cmdline-tools/parseWindowManagerRotation";
+
+describe("parseWindowManagerRotation", () => {
+  test("parses the authoritative WindowManagerService rotation", () => {
+    const stdout = "  mRotation=1 mAltOrientation=false";
+    expect(parseWindowManagerRotation(stdout)).toBe(1);
+  });
+
+  test("parses a bare mRotation line with no trailing fields", () => {
+    expect(parseWindowManagerRotation("  mRotation=0")).toBe(0);
+  });
+
+  // #6199: dumpsys window (filtered through `grep -i "mRotation="`) can
+  // contain a stale TaskSnapshot rotation BEFORE the authoritative
+  // WindowManagerService rotation. A naive "first match anywhere" scan picks
+  // the wrong one; only the line whose trimmed content starts with
+  // `mRotation=<digit>` is the authoritative field.
+  test("selects the authoritative display rotation over a preceding stale TaskSnapshot rotation", () => {
+    const stdout = [
+      "     snapshot=TaskSnapshot{ mId=1749551414267 mCaptureTime=1748344877515 mTopActivityComponent=com.android.settings/.SubSettings mSnapshot=android.hardware.HardwareBuffer@d8e7fad (864x1920) mColorSpace=sRGB IEC61966-2.1 (id=0, model=RGB) mOrientation=1 mRotation=0 mTaskSize=Point(1080, 2400) mContentInsets=[0,74][0,63] mLetterboxInsets=[0,0][0,0] mIsLowResolution=false mIsRealSnapshot=true mWindowingMode=1 mAppearance=24 mIsTranslucent=false mHasImeSurface=false mInternalReferences=2",
+      "  mRotation=1",
+    ].join("\n");
+
+    expect(parseWindowManagerRotation(stdout)).toBe(1);
+  });
+
+  test("ignores a Configuration toString's symbolic mRotation=ROTATION_0 (non-numeric, not at line start)", () => {
+    const stdout = [
+      "    mFullConfiguration={1.0 310mcc260mnc [en_US] ldltr sw411dp w411dp h874dp 420dpi nrml long port finger -keyb/v/h -nav/h winConfig={ mBounds=Rect(0, 0 - 1080, 2400) mDisplayRotation=ROTATION_0 mWindowingMode=fullscreen mRotation=ROTATION_0} as.2 s.43 fontWeightAdjustment=0}",
+      "  mRotation=3 mAltOrientation=false",
+    ].join("\n");
+
+    expect(parseWindowManagerRotation(stdout)).toBe(3);
+  });
+
+  test("returns null when no authoritative mRotation line is present", () => {
+    const stdout =
+      "     snapshot=TaskSnapshot{ mOrientation=1 mRotation=0 mTaskSize=Point(1080, 2400)";
+
+    expect(parseWindowManagerRotation(stdout)).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(parseWindowManagerRotation("")).toBeNull();
+  });
+});

--- a/test/utils/android-cmdline-tools/parseWindowManagerRotation.test.ts
+++ b/test/utils/android-cmdline-tools/parseWindowManagerRotation.test.ts
@@ -1,5 +1,18 @@
 import { expect, describe, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import { parseWindowManagerRotation } from "../../../src/utils/android-cmdline-tools/parseWindowManagerRotation";
+
+const WINDOW_DUMPS_DIR = join(__dirname, "..", "..", "features", "observe", "windowDumps");
+
+/** Emulate `dumpsys window | grep -i "mRotation="` against a checked-in fixture. */
+function grepMRotationLines(fixtureFile: string): string {
+  const contents = readFileSync(join(WINDOW_DUMPS_DIR, fixtureFile), "utf8");
+  return contents
+    .split("\n")
+    .filter((line) => /mRotation=/i.test(line))
+    .join("\n");
+}
 
 describe("parseWindowManagerRotation", () => {
   test("parses the authoritative WindowManagerService rotation", () => {
@@ -33,6 +46,72 @@ describe("parseWindowManagerRotation", () => {
 
     expect(parseWindowManagerRotation(stdout)).toBe(3);
   });
+
+  // #6199 follow-up: on API ~29-33, WindowManagerService does not print
+  // `mRotation=` on its own line — it's inline on the `mDisplayFrozen=`
+  // display-status line instead. Line taken verbatim (via `grep -in
+  // "mRotation="`) from test/features/observe/windowDumps/api29-settings-window-dump.log:281.
+  test("parses the inline mDisplayFrozen= form used on API ~29-33 (real api29 fixture line)", () => {
+    const stdout =
+      "  mDisplayFrozen=false windows=0 client=false apps=0  mRotation=0  mLastWindowForcedOrientation=-1 mLastOrientation=-1";
+
+    expect(parseWindowManagerRotation(stdout)).toBe(0);
+  });
+
+  test("parses the inline mDisplayFrozen= form from the api30-33 fixtures (mRotation without mLastWindowForcedOrientation)", () => {
+    const stdout =
+      "  mDisplayFrozen=false windows=0 client=false apps=0  mRotation=1  mLastOrientation=-1";
+
+    expect(parseWindowManagerRotation(stdout)).toBe(1);
+  });
+
+  test("selects the API ~29-33 inline display rotation over a preceding stale TaskSnapshot rotation", () => {
+    const stdout = [
+      "     snapshot=TaskSnapshot{ mId=1749551414267 mCaptureTime=1748344877515 mTopActivityComponent=com.android.settings/.SubSettings mSnapshot=android.hardware.HardwareBuffer@d8e7fad (864x1920) mColorSpace=sRGB IEC61966-2.1 (id=0, model=RGB) mOrientation=1 mRotation=0 mTaskSize=Point(1080, 2400) mContentInsets=[0,74][0,63] mLetterboxInsets=[0,0][0,0] mIsLowResolution=false mIsRealSnapshot=true mWindowingMode=1 mAppearance=24 mIsTranslucent=false mHasImeSurface=false mInternalReferences=2",
+      "  mDisplayFrozen=false windows=0 client=false apps=0  mRotation=1  mLastWindowForcedOrientation=-1 mLastOrientation=-1",
+    ].join("\n");
+
+    expect(parseWindowManagerRotation(stdout)).toBe(1);
+  });
+
+  test("ignores a Configuration toString's symbolic mRotation=ROTATION_0 even alongside the API ~29-33 form", () => {
+    const stdout = [
+      "    mFullConfiguration={1.0 310mcc260mnc [en_US] ldltr sw411dp w411dp h842dp 420dpi nrml long port finger -keyb/v/h -nav/h winConfig={ mBounds=Rect(0, 0 - 1080, 2400) mAppBounds=Rect(0, 0 - 1080, 2274) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.6}",
+      "  mDisplayFrozen=false windows=0 client=false apps=0  mRotation=0  mLastWindowForcedOrientation=-1 mLastOrientation=-1",
+    ].join("\n");
+
+    expect(parseWindowManagerRotation(stdout)).toBe(0);
+  });
+
+  // #6199 follow-up: run the parser directly against `grep -i "mRotation="`
+  // applied to the real checked-in API 29-33 fixtures (not a hand-copied
+  // string), so any future change to those fixtures re-validates the parse.
+  for (const [file, expected] of [
+    ["api29-settings-window-dump.log", 0],
+    ["api30-settings-window-dump.log", 0],
+    ["api31-settings-window-dump.log", 0],
+    ["api32-settings-window-dump.log", 0],
+    ["api33-settings-window-dump.log", 0],
+  ] as const) {
+    test(`parses the live rotation out of the real ${file} fixture`, () => {
+      expect(parseWindowManagerRotation(grepMRotationLines(file))).toBe(expected);
+    });
+  }
+
+  // The older (mRotation= as its own line) and newer (34+, back to its own
+  // line) fixtures must keep working too.
+  for (const [file, expected] of [
+    ["api26-settings-window-dump.log", 0],
+    ["api27-settings-window-dump.log", 0],
+    ["api28-settings-window-dump.log", 3],
+    ["api34-settings-window-dump.log", 0],
+    ["api35-settings-window-dump.log", 0],
+    ["api36-settings-window-dump.log", 0],
+  ] as const) {
+    test(`parses the live rotation out of the real ${file} fixture`, () => {
+      expect(parseWindowManagerRotation(grepMRotationLines(file))).toBe(expected);
+    });
+  }
 
   test("returns null when no authoritative mRotation line is present", () => {
     const stdout =


### PR DESCRIPTION
Closes #6129

## Root cause

`Rotate.getCurrentOrientation` (`src/features/action/Rotate.ts`) derived the current orientation exclusively from the `user_rotation` system setting. That setting only reflects the last explicitly-requested rotation and goes stale as soon as auto-rotate applies a sensor-driven rotation on top of it — so a device physically rotated to landscape by auto-rotate still read `user_rotation=0` and `rotate("portrait")` reported "already in portrait orientation" without ever rotating.

Note: #6073 (commit 2795f0db0) only fixed the post-rotation success return (`currentOrientation` reflecting the achieved orientation), not this pre-check — the no-op bug described here was untouched by that fix.

Secondary bug: on the "orientation locked" branch, the code wrote `accelerometer_rotation=1` (unlock) immediately followed by `accelerometer_rotation=0` (force-lock to apply `user_rotation`) — a no-op unlock — and on the "auto-rotate enabled" branch it always left `accelerometer_rotation=0` after rotating, permanently disabling auto-rotate for the rest of the session.

## Fix

- `getCurrentOrientation` now reads the live rotation from `dumpsys window`'s `mRotation=` (reusing the same parsing pattern as `Idle.getRotationStatus`), falling back to `user_rotation` only when that can't be read/parsed.
- `executeAndroidRotation` drops the pointless unlock-then-relock dance on the locked path (a locked device is forced directly to the new orientation and stays locked). On the unlocked (auto-rotate on) path, it now restores `accelerometer_rotation=1` after the forced rotation completes instead of leaving auto-rotate disabled.

## Test

`test/features/action/Rotate.test.ts`:
- `getCurrentOrientation` prefers live `mRotation` over stale `user_rotation`, and falls back when `dumpsys window` has no `mRotation` line.
- `execute("portrait")` on a device with `user_rotation=0` (stale) / `mRotation=1` (physically landscape, auto-rotate on) actually performs the rotation instead of no-op'ing, and reports `previousOrientation: "landscape"` / `currentOrientation: "portrait"`.
- After forcing a rotation while auto-rotate was on, `accelerometer_rotation` is restored to `1` as the last write (not left at `0`).
- Updated the pre-existing "locked" test to match the corrected behavior (no unlock-then-relock).

All new/updated tests use a fake ADB executor; no real device or `getDatabase()` involved.
