### PR TITLE
fix(mcp): action-tool handlers return isError on failure

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -265,6 +265,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["predictive-ui", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
+# swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
 # swap-fp: 7,7,11,13,13 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
@@ -273,7 +274,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
 # swap-fp: 9 :: src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 9 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type 'null | undefined' is not assignable to type 'NormalizedHighlightBounds | undefined'.
-# swap-fp: 9 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
 # swap-fp: 9 :: src/server/networkGraph.ts: error TS2322: Type 'null | string | undefined' is not assignable to type 'null | string'.
 # swap-fp: 9,9,11,11 :: src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
 # swap-fp: 9,9,9 :: src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -28,6 +28,11 @@ import {
   PinchOnResult,
   SendTextResult,
   SwipeOnToolPayload,
+  type ClearTextResult,
+  type DragAndDropResult,
+  type ImeActionResult,
+  type PressButtonResult,
+  type SelectAllTextResult,
   type TapOnElementResult,
   type TapOnSelectedElement,
 } from "../models";
@@ -826,6 +831,59 @@ export function formatSwipeOnMessage(
     : `Swiped ${direction}`;
 }
 
+// Injection seam for the swipeOn handler (mirrors the pinchOn/tapOn factory
+// seams). Lets a unit test exercise the registered handler wiring with a fake
+// SwipeOn whose execute() returns a failure, so a revert of the `isError`
+// gating below is caught by a test — not just the formatter (#6163).
+export type SwipeOnLike = Pick<SwipeOn, "execute">;
+
+let swipeOnFactory: (device: BootedDevice) => SwipeOnLike = (device) => new SwipeOn(device);
+
+export function setSwipeOnFactory(factory: (device: BootedDevice) => SwipeOnLike): void {
+  swipeOnFactory = factory;
+}
+
+export function resetSwipeOnFactory(): void {
+  swipeOnFactory = (device) => new SwipeOn(device);
+}
+
+export async function swipeOnHandler(
+  device: BootedDevice,
+  args: SwipeOnArgs,
+  progress?: ProgressCallback,
+): Promise<StructuredToolResponse<SwipeOnToolPayload> & { isError?: true }> {
+  RecompositionTracker.getInstance().recordInteraction();
+  const swipeOn = swipeOnFactory(device);
+  const resolvedDirection = resolveSwipeDirection({
+    direction: args.direction,
+    gestureType: args.gestureType,
+  });
+  const result = await swipeOn.execute(
+    {
+      container: args.container,
+      autoTarget: args.autoTarget ?? true,
+      direction: resolvedDirection.direction,
+      lookFor: args.lookFor,
+      speed: args.speed,
+      includeSystemInsets: args.includeSystemInsets ?? false,
+      boomerang: args.boomerang,
+      apexPause: args.apexPause,
+      returnSpeed: args.returnSpeed,
+    },
+    progress,
+  );
+
+  const response = createStructuredToolResponse({
+    message: formatSwipeOnMessage(result, args.direction),
+    observation: result.observation,
+    ...result,
+  });
+  // formatSwipeOnMessage already gates the message on `result.success`; the MCP
+  // envelope must agree, exactly as tapOn/inputText do (#6152, #5902), so a
+  // conforming client can't mistake a failed swipe for a completed one (#6163).
+  return result.success ? response : { ...response, isError: true };
+}
+
 export function formatPinchOnMessage(
   result: Pick<PinchOnResult, "success" | "error">,
   direction: string,
@@ -877,11 +935,15 @@ export async function pinchOnHandler(
     progress,
   );
 
-  return createJSONToolResponse({
+  const response = createJSONToolResponse({
     message: formatPinchOnMessage(result, args.direction),
     observation: result.observation,
     ...result,
   });
+  // formatPinchOnMessage already gates the message on `result.success`; the MCP
+  // envelope must agree, exactly as tapOn/inputText do (#6152, #5902), so a
+  // conforming client can't mistake a failed pinch for a completed one (#6163).
+  return result.success ? response : { ...response, isError: true };
 }
 
 export function buildInputTextResultMessage(
@@ -1042,137 +1104,281 @@ export async function tapOnHandler(
   return result.success ? response : { ...response, isError: true as const };
 }
 
+// Injection seam for the tapAny handler (mirrors the tapOn factory seam above).
+// Lets a unit test exercise the registered handler wiring with a fake
+// TapAnyElement whose execute() returns a failure (#6163).
+export type TapAnyElementLike = Pick<TapAnyElement, "execute">;
+
+let tapAnyElementFactory: (device: BootedDevice) => TapAnyElementLike = (device) =>
+  new TapAnyElement(device);
+
+export function setTapAnyElementFactory(
+  factory: (device: BootedDevice) => TapAnyElementLike,
+): void {
+  tapAnyElementFactory = factory;
+}
+
+export function resetTapAnyElementFactory(): void {
+  tapAnyElementFactory = (device) => new TapAnyElement(device);
+}
+
+function buildTapAnySearchSummary(
+  result: Pick<TapOnElementResult, "searchUntil">,
+): string | undefined {
+  const searchStats = result.searchUntil;
+  const shouldIncludeSearchSummary =
+    Boolean(searchStats) && (searchStats!.requestCount > 0 || searchStats!.changeCount > 0);
+  return shouldIncludeSearchSummary && searchStats
+    ? `${searchStats.changeCount} view hierarchy changes over ${searchStats.requestCount} requests within ${searchStats.durationMs}ms`
+    : undefined;
+}
+
+export async function tapAnyHandler(
+  device: BootedDevice,
+  args: TapAnyArgs,
+  progress?: ProgressCallback,
+) {
+  RecompositionTracker.getInstance().recordInteraction();
+  const tapAnyCommand = tapAnyElementFactory(device);
+  const result = await tapAnyCommand.execute(
+    {
+      container: args.container,
+      selectionStrategy: args.selectionStrategy,
+      scrollableContainer: args.scrollableContainer,
+      action: args.action,
+      duration: args.duration,
+      searchUntil: args.searchUntil,
+    },
+    progress,
+  );
+
+  const searchSummary = buildTapAnySearchSummary(result);
+  // A miss must not read as a completed tap: gate the message on the outcome
+  // and mark the MCP envelope `isError`, exactly as tapOn does (#6152, #6163).
+  const message = result.success
+    ? searchSummary
+      ? `Tapped clickable element (${searchSummary})`
+      : "Tapped clickable element"
+    : `Failed to tap clickable element: ${result.error || "unknown error"}`;
+  const response = createStructuredToolResponse({
+    message,
+    observation: result.observation,
+    ...result,
+  });
+  return result.success ? response : { ...response, isError: true as const };
+}
+
+// Injection seam for the dragAndDrop handler. Lets a unit test exercise the
+// registered handler wiring with a fake DragAndDrop whose execute() returns a
+// failure (#6163).
+export type DragAndDropLike = Pick<DragAndDrop, "execute">;
+
+let dragAndDropFactory: (device: BootedDevice) => DragAndDropLike = (device) =>
+  new DragAndDrop(device);
+
+export function setDragAndDropFactory(factory: (device: BootedDevice) => DragAndDropLike): void {
+  dragAndDropFactory = factory;
+}
+
+export function resetDragAndDropFactory(): void {
+  dragAndDropFactory = (device) => new DragAndDrop(device);
+}
+
+export async function dragAndDropHandler(
+  device: BootedDevice,
+  args: DragAndDropArgs,
+  progress?: ProgressCallback,
+) {
+  RecompositionTracker.getInstance().recordInteraction();
+  const dragAndDrop = dragAndDropFactory(device);
+  const result: DragAndDropResult = await dragAndDrop.execute(
+    {
+      source: args.source,
+      target: args.target,
+      pressDurationMs: args.pressDurationMs,
+      dragDurationMs: args.dragDurationMs,
+      holdDurationMs: args.holdDurationMs,
+    },
+    progress,
+  );
+
+  const message = result.success
+    ? "Dragged element to target"
+    : `Failed to drag element to target: ${result.error || "unknown error"}`;
+  const response = createJSONToolResponse({
+    message,
+    observation: result.observation,
+    ...result,
+  });
+  return result.success ? response : { ...response, isError: true as const };
+}
+
+// Injection seam for the clearText handler. Lets a unit test exercise the
+// registered handler wiring with a fake ClearText whose execute() returns a
+// failure (#6163).
+export type ClearTextLike = Pick<ClearText, "execute">;
+
+let clearTextFactory: (device: BootedDevice) => ClearTextLike = (device) => new ClearText(device);
+
+export function setClearTextFactory(factory: (device: BootedDevice) => ClearTextLike): void {
+  clearTextFactory = factory;
+}
+
+export function resetClearTextFactory(): void {
+  clearTextFactory = (device) => new ClearText(device);
+}
+
+export async function clearTextHandler(
+  device: BootedDevice,
+  _args: ClearTextArgs,
+  progress?: ProgressCallback,
+) {
+  try {
+    const clearText = clearTextFactory(device);
+    const result: ClearTextResult = await clearText.execute(progress);
+
+    const message = result.success
+      ? "Cleared text from input field"
+      : `Failed to clear text: ${result.error || "unknown error"}`;
+    const response = createJSONToolResponse({
+      message,
+      observation: result.observation,
+      ...result,
+    });
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to clear text: ${error}`);
+  }
+}
+
+// Injection seam for the selectAllText handler. Lets a unit test exercise the
+// registered handler wiring with a fake SelectAllText whose execute() returns
+// a failure (#6163).
+export type SelectAllTextLike = Pick<SelectAllText, "execute">;
+
+let selectAllTextFactory: (device: BootedDevice) => SelectAllTextLike = (device) =>
+  new SelectAllText(device);
+
+export function setSelectAllTextFactory(
+  factory: (device: BootedDevice) => SelectAllTextLike,
+): void {
+  selectAllTextFactory = factory;
+}
+
+export function resetSelectAllTextFactory(): void {
+  selectAllTextFactory = (device) => new SelectAllText(device);
+}
+
+export async function selectAllTextHandler(
+  device: BootedDevice,
+  _args: SelectAllTextArgs,
+  progress?: ProgressCallback,
+) {
+  try {
+    const selectAllText = selectAllTextFactory(device);
+    const result: SelectAllTextResult = await selectAllText.execute(progress);
+
+    const message = result.success
+      ? "Selected all text in focused input field"
+      : `Failed to select all text: ${result.error || "unknown error"}`;
+    const response = createJSONToolResponse({
+      message,
+      observation: result.observation,
+      ...result,
+    });
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to select all text: ${error}`);
+  }
+}
+
+// Injection seam for the pressButton handler. Lets a unit test exercise the
+// registered handler wiring with a fake PressButton whose execute() returns a
+// failure (#6163).
+export type PressButtonLike = Pick<PressButton, "execute">;
+
+let pressButtonFactory: (device: BootedDevice) => PressButtonLike = (device) =>
+  new PressButton(device);
+
+export function setPressButtonFactory(factory: (device: BootedDevice) => PressButtonLike): void {
+  pressButtonFactory = factory;
+}
+
+export function resetPressButtonFactory(): void {
+  pressButtonFactory = (device) => new PressButton(device);
+}
+
+export async function pressButtonHandler(
+  device: BootedDevice,
+  args: PressButtonArgs,
+  progress?: ProgressCallback,
+) {
+  RecompositionTracker.getInstance().recordInteraction();
+  try {
+    const pressButton = pressButtonFactory(device);
+    const result: PressButtonResult = await pressButton.execute(args.button, progress);
+
+    const message = result.success
+      ? `Pressed button ${args.button}`
+      : `Failed to press button ${args.button}: ${result.error || "unknown error"}`;
+    const response = createJSONToolResponse({
+      message,
+      observation: result.observation,
+      ...result,
+    });
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to press button: ${error}`);
+  }
+}
+
+// Injection seam for the imeAction handler. Lets a unit test exercise the
+// registered handler wiring with a fake ImeAction whose execute() returns a
+// failure (#6163).
+export type ImeActionLike = Pick<ImeAction, "execute">;
+
+let imeActionFactory: (device: BootedDevice) => ImeActionLike = (device) => new ImeAction(device);
+
+export function setImeActionFactory(factory: (device: BootedDevice) => ImeActionLike): void {
+  imeActionFactory = factory;
+}
+
+export function resetImeActionFactory(): void {
+  imeActionFactory = (device) => new ImeAction(device);
+}
+
+export async function imeActionHandler(
+  device: BootedDevice,
+  args: ImeActionArgs,
+  progress?: ProgressCallback,
+) {
+  try {
+    const imeAction = imeActionFactory(device);
+    const result: ImeActionResult = await imeAction.execute(args.action, progress);
+
+    const message = result.success
+      ? `Executed IME action "${args.action}"`
+      : `Failed to execute IME action "${args.action}": ${result.error || "unknown error"}`;
+    const response = createJSONToolResponse({
+      message,
+      observation: result.observation,
+      ...result,
+    });
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to execute IME action: ${error}`);
+  }
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
 
 export function registerInteractionTools() {
-  // tapOn handler is defined at module scope (with an injectable TapOnElement
-  // factory) so a unit test can exercise the registered handler wiring (#6152).
-
-  // TapAny handler
-  const tapAnyHandler = async (
-    device: BootedDevice,
-    args: TapAnyArgs,
-    progress?: ProgressCallback,
-  ) => {
-    RecompositionTracker.getInstance().recordInteraction();
-    const tapAnyCommand = new TapAnyElement(device);
-    const result = await tapAnyCommand.execute(
-      {
-        container: args.container,
-        selectionStrategy: args.selectionStrategy,
-        scrollableContainer: args.scrollableContainer,
-        action: args.action,
-        duration: args.duration,
-        searchUntil: args.searchUntil,
-      },
-      progress,
-    );
-
-    const searchStats = result.searchUntil;
-    const shouldIncludeSearchSummary =
-      Boolean(searchStats) && (searchStats!.requestCount > 0 || searchStats!.changeCount > 0);
-    const searchSummary =
-      shouldIncludeSearchSummary && searchStats
-        ? `${searchStats.changeCount} view hierarchy changes over ${searchStats.requestCount} requests within ${searchStats.durationMs}ms`
-        : undefined;
-
-    return createStructuredToolResponse({
-      message: searchSummary
-        ? `Tapped clickable element (${searchSummary})`
-        : "Tapped clickable element",
-      observation: result.observation,
-      ...result,
-    });
-  };
-
-  // Drag and drop handler
-  const dragAndDropHandler = async (
-    device: BootedDevice,
-    args: DragAndDropArgs,
-    progress?: ProgressCallback,
-  ) => {
-    RecompositionTracker.getInstance().recordInteraction();
-    const dragAndDrop = new DragAndDrop(device);
-    const result = await dragAndDrop.execute(
-      {
-        source: args.source,
-        target: args.target,
-        pressDurationMs: args.pressDurationMs,
-        dragDurationMs: args.dragDurationMs,
-        holdDurationMs: args.holdDurationMs,
-      },
-      progress,
-    );
-
-    return createJSONToolResponse({
-      message: "Dragged element to target",
-      observation: result.observation,
-      ...result,
-    });
-  };
-
-  // Clear text handler
-  const clearTextHandler = async (
-    device: BootedDevice,
-    args: ClearTextArgs,
-    progress?: ProgressCallback,
-  ) => {
-    try {
-      const clearText = new ClearText(device);
-      const result = await clearText.execute(progress);
-
-      return createJSONToolResponse({
-        message: "Cleared text from input field",
-        observation: result.observation,
-        ...result,
-      });
-    } catch (error) {
-      throw new ActionableError(`Failed to clear text: ${error}`);
-    }
-  };
-
-  // Select all text handler
-  const selectAllTextHandler = async (
-    device: BootedDevice,
-    args: SelectAllTextArgs,
-    progress?: ProgressCallback,
-  ) => {
-    try {
-      const selectAllText = new SelectAllText(device);
-      const result = await selectAllText.execute(progress);
-
-      return createJSONToolResponse({
-        message: "Selected all text in focused input field",
-        observation: result.observation,
-        ...result,
-      });
-    } catch (error) {
-      throw new ActionableError(`Failed to select all text: ${error}`);
-    }
-  };
-
-  // Press button handler
-  const pressButtonHandler = async (
-    device: BootedDevice,
-    args: PressButtonArgs,
-    progress?: ProgressCallback,
-  ) => {
-    RecompositionTracker.getInstance().recordInteraction();
-    try {
-      const pressButton = new PressButton(device);
-      const result = await pressButton.execute(args.button, progress);
-
-      return createJSONToolResponse({
-        message: `Pressed button ${args.button}`,
-        observation: result.observation,
-        ...result,
-      });
-    } catch (error) {
-      throw new ActionableError(`Failed to press button: ${error}`);
-    }
-  };
+  // tapOn, tapAny, dragAndDrop, clearText, selectAllText, pressButton,
+  // imeAction, and swipeOn handlers are defined at module scope (each with an
+  // injectable factory) so a unit test can exercise the registered handler
+  // wiring (#6152, #6163).
 
   // System tray handler
   const systemTrayHandler = async (
@@ -1389,39 +1595,8 @@ export function registerInteractionTools() {
     }
   };
 
-  // Swipe on handler
-  const swipeOnHandler = async (
-    device: BootedDevice,
-    args: SwipeOnArgs,
-    progress?: ProgressCallback,
-  ): Promise<StructuredToolResponse<SwipeOnToolPayload>> => {
-    RecompositionTracker.getInstance().recordInteraction();
-    const swipeOn = new SwipeOn(device);
-    const resolvedDirection = resolveSwipeDirection({
-      direction: args.direction,
-      gestureType: args.gestureType,
-    });
-    const result = await swipeOn.execute(
-      {
-        container: args.container,
-        autoTarget: args.autoTarget ?? true,
-        direction: resolvedDirection.direction,
-        lookFor: args.lookFor,
-        speed: args.speed,
-        includeSystemInsets: args.includeSystemInsets ?? false,
-        boomerang: args.boomerang,
-        apexPause: args.apexPause,
-        returnSpeed: args.returnSpeed,
-      },
-      progress,
-    );
-
-    return createStructuredToolResponse({
-      message: formatSwipeOnMessage(result, args.direction),
-      observation: result.observation,
-      ...result,
-    });
-  };
+  // swipeOn handler is defined at module scope (with an injectable SwipeOn
+  // factory) so a unit test can exercise the registered handler wiring (#6163).
 
   // Pinch on handler
   // pinchOn handler is defined at module scope (with an injectable PinchOn
@@ -1526,25 +1701,8 @@ export function registerInteractionTools() {
     }
   };
 
-  // IME action handler
-  const imeActionHandler = async (
-    device: BootedDevice,
-    args: ImeActionArgs,
-    progress?: ProgressCallback,
-  ) => {
-    try {
-      const imeAction = new ImeAction(device);
-      const result = await imeAction.execute(args.action, progress);
-
-      return createJSONToolResponse({
-        message: `Executed IME action "${args.action}"`,
-        observation: result.observation,
-        ...result,
-      });
-    } catch (error) {
-      throw new ActionableError(`Failed to execute IME action: ${error}`);
-    }
-  };
+  // imeAction handler is defined at module scope (with an injectable ImeAction
+  // factory) so a unit test can exercise the registered handler wiring (#6163).
 
   // Keyboard handler
   const keyboardHandler = async (device: BootedDevice, args: KeyboardArgs) => {

--- a/test/server/interactionTools.actionHandlersIsError.test.ts
+++ b/test/server/interactionTools.actionHandlersIsError.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearTextHandler,
+  dragAndDropHandler,
+  imeActionHandler,
+  pressButtonHandler,
+  resetClearTextFactory,
+  resetDragAndDropFactory,
+  resetImeActionFactory,
+  resetPressButtonFactory,
+  resetSelectAllTextFactory,
+  resetTapAnyElementFactory,
+  selectAllTextHandler,
+  setClearTextFactory,
+  setDragAndDropFactory,
+  setImeActionFactory,
+  setPressButtonFactory,
+  setSelectAllTextFactory,
+  setTapAnyElementFactory,
+  tapAnyHandler,
+} from "../../src/server/interactionTools";
+import type {
+  ClearTextArgs,
+  DragAndDropArgs,
+  ImeActionArgs,
+  PressButtonArgs,
+  SelectAllTextArgs,
+  TapAnyArgs,
+} from "../../src/server/interactionToolTypes";
+import type {
+  BootedDevice,
+  ClearTextResult,
+  DragAndDropResult,
+  ImeActionResult,
+  PressButtonResult,
+  SelectAllTextResult,
+  TapOnElementResult,
+} from "../../src/models";
+
+// #6163: the tapOn (#6152) and inputText (#5902) fix — gate the message on
+// `result.success` and set `isError: true` on the MCP envelope when the
+// underlying execute() reports a failure — generalized to the rest of the
+// action-tool family. Each suite below exercises the REGISTERED handler (not
+// just a formatter) through an injected fake so a revert of the gating is
+// caught by a test.
+//
+// These handlers return either `createJSONToolResponse` (no `structuredContent`)
+// or `createStructuredToolResponse` (payload under `structuredContent`); both
+// always serialize the full payload into `content[0].text`, so parsing that
+// text is the one accessor that works for every handler here.
+
+type ToolResponse = { isError?: true; content: Array<{ type: string; text: string }> };
+
+const parsePayload = (response: ToolResponse): { message: string; success: boolean } =>
+  JSON.parse(response.content[0].text) as { message: string; success: boolean };
+
+const fakeDevice = { deviceId: "fake", platform: "android" } as unknown as BootedDevice;
+
+describe("tapAnyHandler (registered handler wiring)", () => {
+  const args: TapAnyArgs = { action: "tap", platform: "android" };
+
+  afterEach(() => {
+    resetTapAnyElementFactory();
+  });
+
+  const fakeResult = (overrides: Partial<TapOnElementResult>): TapOnElementResult =>
+    ({
+      success: false,
+      action: "tap",
+      element: { bounds: { left: 0, top: 0, right: 0, bottom: 0 } },
+      ...overrides,
+    }) as TapOnElementResult;
+
+  test("a failure sets isError and reports the failure, not a completed tap", async () => {
+    setTapAnyElementFactory(() => ({
+      execute: async () => fakeResult({ error: "No clickable element found" }),
+    }));
+
+    const response = (await tapAnyHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe(
+      "Failed to tap clickable element: No clickable element found",
+    );
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setTapAnyElementFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await tapAnyHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe("Tapped clickable element");
+  });
+});
+
+describe("dragAndDropHandler (registered handler wiring)", () => {
+  const args: DragAndDropArgs = {
+    source: { text: "Item" },
+    target: { text: "Trash" },
+    platform: "android",
+  };
+
+  afterEach(() => {
+    resetDragAndDropFactory();
+  });
+
+  const fakeResult = (overrides: Partial<DragAndDropResult>): DragAndDropResult =>
+    ({ success: false, duration: 0, distance: 0, ...overrides }) as DragAndDropResult;
+
+  test("a failure sets isError and reports the failure, not a completed drag", async () => {
+    setDragAndDropFactory(() => ({
+      execute: async () =>
+        fakeResult({ error: "Unable to get view hierarchy, cannot drag and drop" }),
+    }));
+
+    const response = (await dragAndDropHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe(
+      "Failed to drag element to target: Unable to get view hierarchy, cannot drag and drop",
+    );
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setDragAndDropFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await dragAndDropHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe("Dragged element to target");
+  });
+});
+
+describe("clearTextHandler (registered handler wiring)", () => {
+  const args: ClearTextArgs = { platform: "android" };
+
+  afterEach(() => {
+    resetClearTextFactory();
+  });
+
+  const fakeResult = (overrides: Partial<ClearTextResult>): ClearTextResult => ({
+    success: false,
+    ...overrides,
+  });
+
+  test("a failure sets isError and reports the failure, not a completed clear", async () => {
+    setClearTextFactory(() => ({
+      execute: async () => fakeResult({ error: "Failed to clear text" }),
+    }));
+
+    const response = (await clearTextHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe("Failed to clear text: Failed to clear text");
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setClearTextFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await clearTextHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe("Cleared text from input field");
+  });
+});
+
+describe("selectAllTextHandler (registered handler wiring)", () => {
+  const args: SelectAllTextArgs = { platform: "android" };
+
+  afterEach(() => {
+    resetSelectAllTextFactory();
+  });
+
+  const fakeResult = (overrides: Partial<SelectAllTextResult>): SelectAllTextResult => ({
+    success: false,
+    ...overrides,
+  });
+
+  test("a failure sets isError and reports the failure, not a completed selection", async () => {
+    setSelectAllTextFactory(() => ({
+      execute: async () => fakeResult({ error: "No focused input field" }),
+    }));
+
+    const response = (await selectAllTextHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe(
+      "Failed to select all text: No focused input field",
+    );
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setSelectAllTextFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await selectAllTextHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe("Selected all text in focused input field");
+  });
+});
+
+describe("pressButtonHandler (registered handler wiring)", () => {
+  const args: PressButtonArgs = { button: "back", platform: "android" };
+
+  afterEach(() => {
+    resetPressButtonFactory();
+  });
+
+  const fakeResult = (overrides: Partial<PressButtonResult>): PressButtonResult =>
+    ({ success: false, button: "back", keyCode: 4, ...overrides }) as PressButtonResult;
+
+  test("a failure sets isError and reports the failure, not a completed press", async () => {
+    setPressButtonFactory(() => ({
+      execute: async () => fakeResult({ error: "Unsupported button: back" }),
+    }));
+
+    const response = (await pressButtonHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe(
+      "Failed to press button back: Unsupported button: back",
+    );
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setPressButtonFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await pressButtonHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe("Pressed button back");
+  });
+});
+
+describe("imeActionHandler (registered handler wiring)", () => {
+  const args: ImeActionArgs = { action: "done", platform: "android" };
+
+  afterEach(() => {
+    resetImeActionFactory();
+  });
+
+  const fakeResult = (overrides: Partial<ImeActionResult>): ImeActionResult => ({
+    success: false,
+    action: "done",
+    ...overrides,
+  });
+
+  test("a failure sets isError and reports the failure, not a completed action", async () => {
+    setImeActionFactory(() => ({
+      execute: async () => fakeResult({ error: "No focused input field" }),
+    }));
+
+    const response = (await imeActionHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBe(true);
+    expect(parsePayload(response).message).toBe(
+      'Failed to execute IME action "done": No focused input field',
+    );
+    expect(parsePayload(response).success).toBe(false);
+  });
+
+  test("a success has no isError and the unchanged success message", async () => {
+    setImeActionFactory(() => ({
+      execute: async () => fakeResult({ success: true }),
+    }));
+
+    const response = (await imeActionHandler(fakeDevice, args)) as ToolResponse;
+    expect(response.isError).toBeUndefined();
+    expect(parsePayload(response).message).toBe('Executed IME action "done"');
+  });
+});

--- a/test/server/interactionTools.pinchOn.test.ts
+++ b/test/server/interactionTools.pinchOn.test.ts
@@ -89,9 +89,15 @@ describe("pinchOnHandler (registered handler wiring)", () => {
       execute: async () => fakeResult({ success: false, error: "scale must be greater than 0" }),
     }));
 
-    const message = parseMessage(await pinchOnHandler(fakeDevice, args));
+    const response = await pinchOnHandler(fakeDevice, args);
+    const message = parseMessage(response);
     expect(message).toBe("scale must be greater than 0");
     expect(message).not.toBe("Pinched in");
+    // The MCP envelope must agree with the message (#6163): a failed pinch must
+    // not read as an ordinary successful result to a conforming client.
+    expect(response.isError).toBe(true);
+    const payload = JSON.parse(response.content[0].text) as { success: boolean };
+    expect(payload.success).toBe(false);
   });
 
   test("serialized response reports a success message on a successful pinch", async () => {
@@ -99,6 +105,8 @@ describe("pinchOnHandler (registered handler wiring)", () => {
       execute: async () => fakeResult({ success: true }),
     }));
 
-    expect(parseMessage(await pinchOnHandler(fakeDevice, args))).toBe("Pinched in");
+    const response = await pinchOnHandler(fakeDevice, args);
+    expect(parseMessage(response)).toBe("Pinched in");
+    expect(response.isError).toBeUndefined();
   });
 });

--- a/test/server/interactionTools.swipeOn.test.ts
+++ b/test/server/interactionTools.swipeOn.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from "bun:test";
-import { formatSwipeOnMessage } from "../../src/server/interactionTools";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  formatSwipeOnMessage,
+  resetSwipeOnFactory,
+  setSwipeOnFactory,
+  swipeOnHandler,
+} from "../../src/server/interactionTools";
+import type { SwipeOnArgs } from "../../src/server/interactionToolTypes";
+import type { BootedDevice, SwipeOnToolPayload } from "../../src/models";
+import { getStructuredField } from "../../src/utils/toolUtils";
 
 describe("formatSwipeOnMessage", () => {
   test("reports non-throwing swipe failures instead of a completed swipe", () => {
@@ -46,5 +54,46 @@ describe("formatSwipeOnMessage", () => {
     [{ success: true as const, found: true }, "up", "Swiped up and found element after 1 swipe(s)"],
   ])("success %o yields %p", (result, direction, expected) => {
     expect(formatSwipeOnMessage(result, direction)).toBe(expected);
+  });
+});
+
+// Handler-level coverage: exercise the REGISTERED swipeOn handler path (not
+// just the formatter) with an injected fake SwipeOn, and assert the serialized
+// envelope carries `isError: true` on failure. Before #6163 the message was
+// already outcome-gated but the envelope never set `isError`, so a conforming
+// client still saw an ordinary result on a failed swipe.
+describe("swipeOnHandler (registered handler wiring)", () => {
+  const fakeDevice = { deviceId: "fake", platform: "android" } as unknown as BootedDevice;
+  const args: SwipeOnArgs = { direction: "up", platform: "android" };
+
+  afterEach(() => {
+    resetSwipeOnFactory();
+  });
+
+  const fakeResult = (overrides: Partial<SwipeOnToolPayload>): SwipeOnToolPayload =>
+    ({
+      success: false,
+      ...overrides,
+    }) as SwipeOnToolPayload;
+
+  test("a failed swipe sets isError and reports the failure, not a completed swipe", async () => {
+    setSwipeOnFactory(() => ({
+      execute: async () => fakeResult({ error: "VoiceOver scrolling is not supported" }),
+    }));
+
+    const response = await swipeOnHandler(fakeDevice, args);
+    expect(response.isError).toBe(true);
+    expect(getStructuredField(response, "message")).toBe("VoiceOver scrolling is not supported");
+    expect(getStructuredField(response, "success")).toBe(false);
+  });
+
+  test("a successful swipe has no isError and an unchanged message", async () => {
+    setSwipeOnFactory(() => ({
+      execute: async () => fakeResult({ success: true, found: false }),
+    }));
+
+    const response = await swipeOnHandler(fakeDevice, args);
+    expect(response.isError).toBeUndefined();
+    expect(getStructuredField(response, "message")).toBe("Swiped up");
   });
 });


### PR DESCRIPTION
## Summary

#6152 (PR #6162) fixed the success-shaped-failure envelope for `tapOn` only, mirroring the #5902 `inputText` fix. #6163 audited the rest of the action-tool family in `src/server/interactionTools.ts` and asked for the same treatment. This PR applies it.

## Linked Issue

Closes #6163

## Changes

`src/server/interactionTools.ts` — each handler below is hoisted to module scope with an injectable factory (mirroring the `setTapOnElementFactory`/`setPinchOnFactory` seam), and its message is gated on `result.success` with `isError: true` set on the MCP envelope on failure:

- `swipeOnHandler` — message was already outcome-gated (`formatSwipeOnMessage`), but the envelope never set `isError`.
- `pinchOnHandler` — same gap: message already gated (`formatPinchOnMessage`), envelope now sets `isError`.
- `tapAnyHandler` — was hard-coded `"Tapped clickable element"` regardless of outcome; now `"Failed to tap clickable element: <error>"` on failure.
- `dragAndDropHandler` — was hard-coded `"Dragged element to target"`; now `"Failed to drag element to target: <error>"` on failure.
- `clearTextHandler` — was hard-coded `"Cleared text from input field"`; now `"Failed to clear text: <error>"` on failure.
- `selectAllTextHandler` — was hard-coded `"Selected all text in focused input field"`; now `"Failed to select all text: <error>"` on failure.
- `pressButtonHandler` — was hard-coded `"Pressed button <b>"`; now `"Failed to press button <b>: <error>"` on failure.
- `imeActionHandler` — was hard-coded `Executed IME action "<action>"`; now `Failed to execute IME action "<action>": <error>` on failure.

All failure messages use `result.error || "unknown error"` (`||` not `??`, matching the #4183 P4 precedent so an empty-string error still yields a non-empty message). Successful responses are byte-for-byte unchanged.

`scripts/typecheck-baseline.txt`: column-shift-only update (`bun run typecheck:update`); error count unchanged (163).

## Tests

New `test/server/interactionTools.actionHandlersIsError.test.ts` covers `tapAnyHandler`, `dragAndDropHandler`, `clearTextHandler`, `selectAllTextHandler`, `pressButtonHandler`, and `imeActionHandler` — one failure test + one success test per handler, each through the registered handler with an injected fake (no device, no DB).

Extended `test/server/interactionTools.swipeOn.test.ts` and `test/server/interactionTools.pinchOn.test.ts` with handler-wiring tests asserting `isError: true` on failure and `undefined` on success.

All new/changed tests run in well under 100ms with no device or DB.

## Acceptance criteria (from #6163)

- [x] Every handler above sets `isError: true` and a `Failed to ...: <error>` message when `execute()` returns `success: false`.
- [x] Successful responses are byte-for-byte unchanged.
- [x] One unit test per handler through an injected fake (no device), <100ms.

## Validation

- [x] `turbo run lint build test` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` reports no new errors (baseline unchanged at 163, column-shift-only update)
- [x] `schemas/tool-definitions.json` regenerated and confirmed up to date (no schema/description text changed)
