### PR TITLE
fix(memory): capture modern ART GC log lines, not just Dalvik-era

### DIFF
--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -171,30 +171,67 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
   }
 
   /**
-   * Capture GC events from logcat, scoped to the audited process
-   * Should be called with timestamps around the action being monitored
+   * Resolve the audited app's primary PID via `pidof`.
+   * `pidof` can report multiple pids for a multi-process app; the first is
+   * taken as the primary process. Returns undefined when the app isn't running.
+   */
+  private async resolvePid(
+    packageName: string,
+    perf: PerformanceTracker,
+  ): Promise<string | undefined> {
+    const { stdout } = await perf.track("adbGetGcPid", () =>
+      this.adb.executeCommand(`shell pidof ${packageName}`),
+    );
+    return stdout.trim().split(/\s+/)[0] || undefined;
+  }
+
+  /**
+   * Capture GC events from logcat, scoped to the audited process and time window.
+   *
+   * `pid`, when supplied, should be resolved by the caller *before* the audited
+   * action runs (see {@link collectMetrics}) so that an action which kills or
+   * restarts the audited process still attributes its in-flight GC activity to
+   * the process that was actually alive during the action, rather than to
+   * whatever `pidof` reports afterward (which may be a new pid, or none at
+   * all). A caller invoking this standalone may omit it to resolve fresh.
+   *
+   * Known limitation: if the process legitimately restarts mid-audit, GC
+   * events from the *new* process are not captured — only from the pid alive
+   * at audit start. Tracking a restart is left as a follow-up.
    */
   async captureGCEvents(
     packageName: string,
     startTimestamp: number,
     endTimestamp: number,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    pid?: string,
   ): Promise<GCEvent[]> {
     try {
-      // Resolve the audited app's PID so GC lines from other processes on the
-      // device are never attributed to it. `pidof` can report multiple pids
-      // for a multi-process app; take the first as the primary process.
-      const { stdout: pidOutput } = await perf.track("adbGetGcPid", () =>
-        this.adb.executeCommand(`shell pidof ${packageName}`),
-      );
-      const pid = pidOutput.trim().split(/\s+/)[0];
-      if (!pid) {
+      const resolvedPid = pid ?? (await this.resolvePid(packageName, perf));
+      if (!resolvedPid) {
         logger.warn(
           `[MemoryMetricsCollector] No PID found for ${packageName}; skipping GC capture ` +
             `to avoid attributing another process's GC events to it`,
         );
         return [];
       }
+
+      // Device-vs-host clock skew (#5377): startTimestamp/endTimestamp are
+      // host-clock ms (this.timer.now()), but logcat's "-v epoch" stamps each
+      // line with the DEVICE's own clock. On an emulator/device whose wall
+      // clock differs from the host, comparing them directly rejects
+      // genuinely in-window events (or admits out-of-window ones). Read the
+      // device's current epoch once via the shared getDeviceTimestampMs()
+      // helper (the same device-clock primitive observationFreshness.ts uses
+      // for #5377) and translate the host-domain bounds into the device's
+      // clock domain before comparing against the device-stamped log lines.
+      const hostNowMs = this.timer.now();
+      const deviceNowMs = await perf.track("adbDeviceTimestamp", () =>
+        this.adb.getDeviceTimestampMs(),
+      );
+      const hostToDeviceOffsetMs = deviceNowMs - hostNowMs;
+      const deviceStartTimestamp = startTimestamp + hostToDeviceOffsetMs;
+      const deviceEndTimestamp = endTimestamp + hostToDeviceOffsetMs;
 
       // ART (API 21+) logs GC lines under the app's own process tag (not a
       // dedicated "art" tag) and without the legacy "GC_" prefix, e.g.
@@ -204,18 +241,18 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
       // ART share and let parseGCEvents() do the format-specific parsing.
       //
       // `--pid` scopes logcat itself to the audited process where the device
-      // supports it; `-v epoch` gives each line a machine-parseable epoch
-      // timestamp so parseGCEvents() can both re-verify the pid column
-      // (defense-in-depth for devices where `--pid` is a no-op) and drop
-      // events outside [startTimestamp, endTimestamp].
+      // supports it; `-v epoch` gives each line a machine-parseable
+      // device-clock timestamp so parseGCEvents() can both re-verify the pid
+      // column (defense-in-depth for devices where `--pid` is a no-op) and
+      // drop events outside the (device-clock) capture window.
       const { stdout } = await perf.track("adbLogcatGC", () =>
         this.adb.executeCommand(
-          `shell logcat -d -v epoch --pid=${pid} | grep -iE "GC[_ ].*freed.*paused"`,
+          `shell logcat -d -v epoch --pid=${resolvedPid} | grep -iE "GC[_ ].*freed.*paused"`,
           5000,
         ),
       );
 
-      return this.parseGCEvents(stdout, startTimestamp, endTimestamp, pid);
+      return this.parseGCEvents(stdout, deviceStartTimestamp, deviceEndTimestamp, resolvedPid);
     } catch (error) {
       logger.warn(`[MemoryMetricsCollector] Failed to capture GC events: ${error}`);
       return [];
@@ -452,6 +489,14 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     // Clear logcat to prepare for GC event capture
     await this.clearLogcat(perf);
 
+    // Resolve the audited pid BEFORE running the action. If the action kills
+    // or restarts the app, a pidof lookup done afterward would return a new
+    // pid (or none), so GC events from the process actually alive during the
+    // action would be missed or mis-attributed. The common case — the
+    // process staying up through the action — is what this pid scopes
+    // correctly; a legitimate mid-audit restart is a known limitation.
+    const auditedPid = await this.resolvePid(packageName, perf);
+
     // Take pre-action snapshot
     const preSnapshot = await this.takeSnapshot(packageName, perf);
     const startTimestamp = this.timer.now();
@@ -467,8 +512,15 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     // Take post-action snapshot (after GC)
     const postSnapshot = await this.takeSnapshot(packageName, perf);
 
-    // Capture GC events that occurred during the action
-    const gcEvents = await this.captureGCEvents(packageName, startTimestamp, endTimestamp, perf);
+    // Capture GC events that occurred during the action, scoped to the
+    // pre-action pid so a mid-action process restart doesn't swap it out.
+    const gcEvents = await this.captureGCEvents(
+      packageName,
+      startTimestamp,
+      endTimestamp,
+      perf,
+      auditedPid,
+    );
 
     // Get unreachable objects
     const unreachableObjects = await this.getUnreachableObjects(packageName, perf);

--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -182,8 +182,15 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     try {
       // Clear logcat buffer before starting if this is the start
       // For now, we'll just read the recent buffer and filter by timestamp
+      //
+      // ART (API 21+) logs GC lines under the app's own process tag (not a
+      // dedicated "art" tag) and without the legacy "GC_" prefix, e.g.
+      // "Background concurrent copying GC freed 4180(230KB) ..., paused 213us".
+      // A `-s dalvikvm:I art:I` tag filter plus `grep "GC_"` drops every modern
+      // ART line, so scope only on the "freed ... paused" shape both Dalvik and
+      // ART share and let parseGCEvents() do the format-specific parsing.
       const { stdout } = await perf.track("adbLogcatGC", () =>
-        this.adb.executeCommand(`shell logcat -d -s dalvikvm:I art:I | grep "GC_"`, 5000),
+        this.adb.executeCommand(`shell logcat -d -v time | grep -iE "GC[_ ].*freed.*paused"`, 5000),
       );
 
       return this.parseGCEvents(stdout, startTimestamp, endTimestamp);
@@ -195,27 +202,55 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
 
   /**
    * Parse GC events from logcat output
+   *
+   * Two log shapes are supported:
+   *  - Dalvik (pre-ART, API < 21): "GC_FOR_ALLOC freed 1234K, 50% free 5678K/11356K, paused 123ms"
+   *  - ART (API 21+): "Background concurrent copying GC freed 4180(230KB) AllocSpace objects,
+   *    0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms" — pause may be
+   *    reported in "us" (converted to ms below) or "ms", and the freed size may appear either
+   *    bare ("1234KB") or parenthesized after an object count ("4180(230KB)").
    */
   private parseGCEvents(output: string, startTimestamp: number, endTimestamp: number): GCEvent[] {
     const events: GCEvent[] = [];
     const lines = output.split("\n");
 
-    // Pattern: "I/art: Background concurrent mark sweep GC freed 1234KB, 50% free, 5678KB/11356KB, paused 123ms"
-    // Pattern: "I/dalvikvm: GC_FOR_ALLOC freed 1234K, 50% free 5678K/11356K, paused 123ms"
-    const gcPattern = /GC[_\s](\w+).*?freed\s+(\d+)K?B?.*?paused\s+(\d+)ms/i;
+    const dalvikPattern = /^GC_(\w+)\s+freed\s+(\d+)K,?.*?paused\s+(\d+)ms/i;
+    const artPattern =
+      /([A-Za-z][A-Za-z ]*?)\s*GC freed\s+(?:\d+\()?(\d+)\s*KB\)?.*?paused\s+([\d.]+)\s*(us|ms)/i;
 
-    for (const line of lines) {
-      const match = line.match(gcPattern);
-      if (match) {
-        const type = match[1];
-        const freedKb = parseInt(match[2], 10);
-        const durationMs = parseInt(match[3], 10);
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (!line) {
+        continue;
+      }
 
-        // We don't have exact timestamps in logcat without -v time, so we'll accept all recent GC events
-        // In production, we'd parse logcat with timestamp format
+      // Strip the logcat prefix (timestamp/pid/tid/level/tag) so pattern
+      // matching only sees the GC message itself. The tag separator is the
+      // rightmost ": " — timestamps use "HH:MM:SS.mmm" (colon with no
+      // trailing space), so this reliably isolates the message.
+      const tagSeparator = line.lastIndexOf(": ");
+      const message = tagSeparator >= 0 ? line.slice(tagSeparator + 2) : line;
+
+      const dalvikMatch = message.match(dalvikPattern);
+      if (dalvikMatch) {
         events.push({
-          type,
-          freedKb,
+          type: dalvikMatch[1],
+          freedKb: parseInt(dalvikMatch[2], 10),
+          durationMs: parseInt(dalvikMatch[3], 10),
+          timestamp: this.timer.now(), // Approximate - logcat would give us real timestamp with -v time
+        });
+        continue;
+      }
+
+      const artMatch = message.match(artPattern);
+      if (artMatch) {
+        const pauseValue = parseFloat(artMatch[3]);
+        const pauseUnit = artMatch[4].toLowerCase();
+        const durationMs = pauseUnit === "us" ? pauseValue / 1000 : pauseValue;
+
+        events.push({
+          type: artMatch[1].trim(),
+          freedKb: parseInt(artMatch[2], 10),
           durationMs,
           timestamp: this.timer.now(), // Approximate - logcat would give us real timestamp with -v time
         });

--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -195,6 +195,17 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
    * whatever `pidof` reports afterward (which may be a new pid, or none at
    * all). A caller invoking this standalone may omit it to resolve fresh.
    *
+   * `startTimestamp`/`endTimestamp` MUST already be in the **device's** clock
+   * domain — i.e. read via {@link AdbExecutor.getDeviceTimestampMs} at the
+   * actual audit boundaries (see {@link collectMetrics}), not `this.timer.now()`
+   * host time. logcat's `-v epoch` stamps each line with the device's own
+   * clock, so comparing host-domain bounds against them directly would reject
+   * genuinely in-window events whenever the device's wall clock differs from
+   * the host's (#5377). Capturing the device clock at the boundaries — rather
+   * than reading it once here and translating a host-domain window through a
+   * single offset — also avoids baking the adb round-trip latency of that read
+   * into the window.
+   *
    * Known limitation: if the process legitimately restarts mid-audit, GC
    * events from the *new* process are not captured — only from the pid alive
    * at audit start. Tracking a restart is left as a follow-up.
@@ -216,23 +227,6 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
         return [];
       }
 
-      // Device-vs-host clock skew (#5377): startTimestamp/endTimestamp are
-      // host-clock ms (this.timer.now()), but logcat's "-v epoch" stamps each
-      // line with the DEVICE's own clock. On an emulator/device whose wall
-      // clock differs from the host, comparing them directly rejects
-      // genuinely in-window events (or admits out-of-window ones). Read the
-      // device's current epoch once via the shared getDeviceTimestampMs()
-      // helper (the same device-clock primitive observationFreshness.ts uses
-      // for #5377) and translate the host-domain bounds into the device's
-      // clock domain before comparing against the device-stamped log lines.
-      const hostNowMs = this.timer.now();
-      const deviceNowMs = await perf.track("adbDeviceTimestamp", () =>
-        this.adb.getDeviceTimestampMs(),
-      );
-      const hostToDeviceOffsetMs = deviceNowMs - hostNowMs;
-      const deviceStartTimestamp = startTimestamp + hostToDeviceOffsetMs;
-      const deviceEndTimestamp = endTimestamp + hostToDeviceOffsetMs;
-
       // ART (API 21+) logs GC lines under the app's own process tag (not a
       // dedicated "art" tag) and without the legacy "GC_" prefix, e.g.
       // "Background concurrent copying GC freed 4180(230KB) ..., paused 213us".
@@ -244,7 +238,7 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
       // supports it; `-v epoch` gives each line a machine-parseable
       // device-clock timestamp so parseGCEvents() can both re-verify the pid
       // column (defense-in-depth for devices where `--pid` is a no-op) and
-      // drop events outside the (device-clock) capture window.
+      // drop events outside the (already device-clock) capture window.
       const { stdout } = await perf.track("adbLogcatGC", () =>
         this.adb.executeCommand(
           `shell logcat -d -v epoch --pid=${resolvedPid} | grep -iE "GC[_ ].*freed.*paused"`,
@@ -252,7 +246,7 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
         ),
       );
 
-      return this.parseGCEvents(stdout, deviceStartTimestamp, deviceEndTimestamp, resolvedPid);
+      return this.parseGCEvents(stdout, startTimestamp, endTimestamp, resolvedPid);
     } catch (error) {
       logger.warn(`[MemoryMetricsCollector] Failed to capture GC events: ${error}`);
       return [];
@@ -353,6 +347,12 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
    */
   private parseGCEventFromMessage(message: string, timestamp: number): GCEvent | null {
     const dalvikPattern = /^GC_(\w+)\s+freed\s+(\d+)K,?.*?paused\s+(\d+)ms/i;
+    // ART reports AllocSpace and Large Object Space frees as two separate
+    // scaled quantities on large-object collections, e.g. "freed 123(4MB)
+    // AllocSpace objects, 45(2MB) LOS objects" — both must be summed into
+    // freedKb, not just the (regular-object) AllocSpace figure.
+    const artAllocLosPattern =
+      /([A-Za-z][A-Za-z ]*?)\s*GC freed\s+(?:\d+\()?([\d.]+)\s*(B|KB|MB|GB)\)?\s*AllocSpace objects,\s*(?:\d+\()?([\d.]+)\s*(B|KB|MB|GB)\)?\s*LOS objects.*?paused\s+([\d.]+(?:us|ms)(?:,\s*[\d.]+(?:us|ms))*)/i;
     const artPattern =
       /([A-Za-z][A-Za-z ]*?)\s*GC freed\s+(?:\d+\()?([\d.]+)\s*(B|KB|MB|GB)\)?.*?paused\s+([\d.]+(?:us|ms)(?:,\s*[\d.]+(?:us|ms))*)/i;
 
@@ -362,6 +362,18 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
         type: dalvikMatch[1],
         freedKb: parseInt(dalvikMatch[2], 10),
         durationMs: parseInt(dalvikMatch[3], 10),
+        timestamp,
+      };
+    }
+
+    const allocLosMatch = message.match(artAllocLosPattern);
+    if (allocLosMatch) {
+      const allocSpaceKb = this.normalizeFreedToKb(allocLosMatch[2], allocLosMatch[3]);
+      const losKb = this.normalizeFreedToKb(allocLosMatch[4], allocLosMatch[5]);
+      return {
+        type: allocLosMatch[1].trim(),
+        freedKb: allocSpaceKb + losKb,
+        durationMs: this.sumPauseComponentsMs(allocLosMatch[6]),
         timestamp,
       };
     }
@@ -499,12 +511,24 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
 
     // Take pre-action snapshot
     const preSnapshot = await this.takeSnapshot(packageName, perf);
-    const startTimestamp = this.timer.now();
+
+    // Capture the GC window bounds directly in the DEVICE's own clock,
+    // reading it right at each boundary rather than once afterward and
+    // translating a host-clock window through a single offset (which would
+    // bake the adb round-trip latency of that one read into the window).
+    // logcat's "-v epoch" stamps each line with the device's clock, so
+    // comparing these bounds against it in parseGCEvents needs no further
+    // translation (see captureGCEvents / #5377).
+    const startTimestamp = await perf.track("adbDeviceTimestampStart", () =>
+      this.adb.getDeviceTimestampMs(),
+    );
 
     // Execute the action
     await beforeAction();
 
-    const endTimestamp = this.timer.now();
+    const endTimestamp = await perf.track("adbDeviceTimestampEnd", () =>
+      this.adb.getDeviceTimestampMs(),
+    );
 
     // Trigger explicit GC to ensure we get post-GC measurements
     await this.triggerGC(packageName, perf);

--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -171,29 +171,51 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
   }
 
   /**
-   * Capture GC events from logcat
+   * Capture GC events from logcat, scoped to the audited process
    * Should be called with timestamps around the action being monitored
    */
   async captureGCEvents(
+    packageName: string,
     startTimestamp: number,
     endTimestamp: number,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<GCEvent[]> {
     try {
-      // Clear logcat buffer before starting if this is the start
-      // For now, we'll just read the recent buffer and filter by timestamp
-      //
+      // Resolve the audited app's PID so GC lines from other processes on the
+      // device are never attributed to it. `pidof` can report multiple pids
+      // for a multi-process app; take the first as the primary process.
+      const { stdout: pidOutput } = await perf.track("adbGetGcPid", () =>
+        this.adb.executeCommand(`shell pidof ${packageName}`),
+      );
+      const pid = pidOutput.trim().split(/\s+/)[0];
+      if (!pid) {
+        logger.warn(
+          `[MemoryMetricsCollector] No PID found for ${packageName}; skipping GC capture ` +
+            `to avoid attributing another process's GC events to it`,
+        );
+        return [];
+      }
+
       // ART (API 21+) logs GC lines under the app's own process tag (not a
       // dedicated "art" tag) and without the legacy "GC_" prefix, e.g.
       // "Background concurrent copying GC freed 4180(230KB) ..., paused 213us".
       // A `-s dalvikvm:I art:I` tag filter plus `grep "GC_"` drops every modern
       // ART line, so scope only on the "freed ... paused" shape both Dalvik and
       // ART share and let parseGCEvents() do the format-specific parsing.
+      //
+      // `--pid` scopes logcat itself to the audited process where the device
+      // supports it; `-v epoch` gives each line a machine-parseable epoch
+      // timestamp so parseGCEvents() can both re-verify the pid column
+      // (defense-in-depth for devices where `--pid` is a no-op) and drop
+      // events outside [startTimestamp, endTimestamp].
       const { stdout } = await perf.track("adbLogcatGC", () =>
-        this.adb.executeCommand(`shell logcat -d -v time | grep -iE "GC[_ ].*freed.*paused"`, 5000),
+        this.adb.executeCommand(
+          `shell logcat -d -v epoch --pid=${pid} | grep -iE "GC[_ ].*freed.*paused"`,
+          5000,
+        ),
       );
 
-      return this.parseGCEvents(stdout, startTimestamp, endTimestamp);
+      return this.parseGCEvents(stdout, startTimestamp, endTimestamp, pid);
     } catch (error) {
       logger.warn(`[MemoryMetricsCollector] Failed to capture GC events: ${error}`);
       return [];
@@ -206,58 +228,152 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
    * Two log shapes are supported:
    *  - Dalvik (pre-ART, API < 21): "GC_FOR_ALLOC freed 1234K, 50% free 5678K/11356K, paused 123ms"
    *  - ART (API 21+): "Background concurrent copying GC freed 4180(230KB) AllocSpace objects,
-   *    0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms" — pause may be
-   *    reported in "us" (converted to ms below) or "ms", and the freed size may appear either
-   *    bare ("1234KB") or parenthesized after an object count ("4180(230KB)").
+   *    0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms" — the freed size may
+   *    be bare ("1234KB") or scaled and parenthesized after an object count ("4180(230KB)" /
+   *    "716275(24MB)"), and the pause may list multiple stop-the-world components
+   *    ("213us,45us") in "us" or "ms", all of which are summed and converted to ms.
+   *
+   * `expectedPid`, when supplied, restricts events to lines whose logcat `-v epoch` pid column
+   * matches — a line with no parseable pid column is dropped rather than risk attributing another
+   * process's GC to the audited one. `startTimestamp`/`endTimestamp` are applied the same way:
+   * a line with a parseable epoch timestamp outside the window is dropped; a line with no
+   * timestamp (e.g. a bare fixture without the logcat prefix) is kept for backward compatibility.
    */
-  private parseGCEvents(output: string, startTimestamp: number, endTimestamp: number): GCEvent[] {
+  private parseGCEvents(
+    output: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    expectedPid?: string,
+  ): GCEvent[] {
     const events: GCEvent[] = [];
-    const lines = output.split("\n");
 
-    const dalvikPattern = /^GC_(\w+)\s+freed\s+(\d+)K,?.*?paused\s+(\d+)ms/i;
-    const artPattern =
-      /([A-Za-z][A-Za-z ]*?)\s*GC freed\s+(?:\d+\()?(\d+)\s*KB\)?.*?paused\s+([\d.]+)\s*(us|ms)/i;
-
-    for (const rawLine of lines) {
+    for (const rawLine of output.split("\n")) {
       const line = rawLine.trim();
       if (!line) {
         continue;
       }
 
-      // Strip the logcat prefix (timestamp/pid/tid/level/tag) so pattern
-      // matching only sees the GC message itself. The tag separator is the
-      // rightmost ": " — timestamps use "HH:MM:SS.mmm" (colon with no
-      // trailing space), so this reliably isolates the message.
-      const tagSeparator = line.lastIndexOf(": ");
-      const message = tagSeparator >= 0 ? line.slice(tagSeparator + 2) : line;
+      const prefix = this.parseLogcatLinePrefix(line);
 
-      const dalvikMatch = message.match(dalvikPattern);
-      if (dalvikMatch) {
-        events.push({
-          type: dalvikMatch[1],
-          freedKb: parseInt(dalvikMatch[2], 10),
-          durationMs: parseInt(dalvikMatch[3], 10),
-          timestamp: this.timer.now(), // Approximate - logcat would give us real timestamp with -v time
-        });
+      // Scope to the audited process: drop lines we can't attribute to it.
+      if (expectedPid !== undefined && prefix.pid !== expectedPid) {
         continue;
       }
 
-      const artMatch = message.match(artPattern);
-      if (artMatch) {
-        const pauseValue = parseFloat(artMatch[3]);
-        const pauseUnit = artMatch[4].toLowerCase();
-        const durationMs = pauseUnit === "us" ? pauseValue / 1000 : pauseValue;
+      // Scope to the requested capture window: drop events parsed as outside it.
+      if (
+        prefix.timestampMs !== undefined &&
+        (prefix.timestampMs < startTimestamp || prefix.timestampMs > endTimestamp)
+      ) {
+        continue;
+      }
 
-        events.push({
-          type: artMatch[1].trim(),
-          freedKb: parseInt(artMatch[2], 10),
-          durationMs,
-          timestamp: this.timer.now(), // Approximate - logcat would give us real timestamp with -v time
-        });
+      const eventTimestamp = prefix.timestampMs ?? this.timer.now(); // Approximate when unparsed
+      const event = this.parseGCEventFromMessage(prefix.message, eventTimestamp);
+      if (event) {
+        events.push(event);
       }
     }
 
     return events;
+  }
+
+  /**
+   * Split a raw logcat line into its message body plus, when present, the
+   * "-v epoch" prefix fields: "<epochSeconds> <pid> <tid> <level> <tag>: <message>".
+   * Lines without that prefix (e.g. bare test fixtures) return only `message`.
+   */
+  private parseLogcatLinePrefix(line: string): {
+    message: string;
+    timestampMs?: number;
+    pid?: string;
+  } {
+    const epochLinePattern = /^(\d+(?:\.\d+)?)\s+(\d+)\s+(\d+)\s+[A-Z]\s+(.*)$/;
+    const epochMatch = line.match(epochLinePattern);
+    const rest = epochMatch ? epochMatch[4] : line;
+
+    // Strip the tag separator so pattern matching only sees the GC message
+    // itself. The tag separator is the rightmost ": " — timestamps use
+    // "HH:MM:SS.mmm" (colon with no trailing space), so this reliably
+    // isolates the message even when the epoch prefix wasn't present.
+    const tagSeparator = rest.lastIndexOf(": ");
+    const message = tagSeparator >= 0 ? rest.slice(tagSeparator + 2) : rest;
+
+    if (!epochMatch) {
+      return { message };
+    }
+
+    return {
+      message,
+      timestampMs: parseFloat(epochMatch[1]) * 1000,
+      pid: epochMatch[2],
+    };
+  }
+
+  /**
+   * Match a single GC log message against the Dalvik and ART shapes and
+   * build the corresponding GCEvent, or return null if neither matches.
+   */
+  private parseGCEventFromMessage(message: string, timestamp: number): GCEvent | null {
+    const dalvikPattern = /^GC_(\w+)\s+freed\s+(\d+)K,?.*?paused\s+(\d+)ms/i;
+    const artPattern =
+      /([A-Za-z][A-Za-z ]*?)\s*GC freed\s+(?:\d+\()?([\d.]+)\s*(B|KB|MB|GB)\)?.*?paused\s+([\d.]+(?:us|ms)(?:,\s*[\d.]+(?:us|ms))*)/i;
+
+    const dalvikMatch = message.match(dalvikPattern);
+    if (dalvikMatch) {
+      return {
+        type: dalvikMatch[1],
+        freedKb: parseInt(dalvikMatch[2], 10),
+        durationMs: parseInt(dalvikMatch[3], 10),
+        timestamp,
+      };
+    }
+
+    const artMatch = message.match(artPattern);
+    if (artMatch) {
+      return {
+        type: artMatch[1].trim(),
+        freedKb: this.normalizeFreedToKb(artMatch[2], artMatch[3]),
+        durationMs: this.sumPauseComponentsMs(artMatch[4]),
+        timestamp,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Normalize an ART freed-size measurement (adaptively scaled B/KB/MB/GB) to KB.
+   */
+  private normalizeFreedToKb(rawValue: string, unit: string): number {
+    const value = parseFloat(rawValue);
+    switch (unit.toUpperCase()) {
+      case "B":
+        return value / 1024;
+      case "MB":
+        return value * 1024;
+      case "GB":
+        return value * 1024 * 1024;
+      case "KB":
+      default:
+        return value;
+    }
+  }
+
+  /**
+   * Sum a comma-separated list of ART stop-the-world pause components
+   * (e.g. "213us,45us"), converting each to ms.
+   */
+  private sumPauseComponentsMs(pauseList: string): number {
+    return pauseList.split(",").reduce((sum, token) => {
+      const match = token.trim().match(/^([\d.]+)(us|ms)$/i);
+      if (!match) {
+        return sum;
+      }
+      const value = parseFloat(match[1]);
+      const unit = match[2].toLowerCase();
+      return sum + (unit === "us" ? value / 1000 : value);
+    }, 0);
   }
 
   /**
@@ -352,7 +468,7 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     const postSnapshot = await this.takeSnapshot(packageName, perf);
 
     // Capture GC events that occurred during the action
-    const gcEvents = await this.captureGCEvents(startTimestamp, endTimestamp, perf);
+    const gcEvents = await this.captureGCEvents(packageName, startTimestamp, endTimestamp, perf);
 
     // Get unreachable objects
     const unreachableObjects = await this.getUnreachableObjects(packageName, perf);

--- a/src/features/memory/interfaces/MemoryMetricsProvider.ts
+++ b/src/features/memory/interfaces/MemoryMetricsProvider.ts
@@ -31,6 +31,8 @@ export interface MemoryMetricsProvider {
    * @param startTimestamp - Start of capture window
    * @param endTimestamp - End of capture window
    * @param perf - Optional performance tracker
+   * @param pid - Optional pre-resolved PID (e.g. resolved before an audited action that may
+   *   restart the process); when omitted, the PID is resolved fresh from `packageName`.
    * @returns Promise with array of GC events
    */
   captureGCEvents(
@@ -38,6 +40,7 @@ export interface MemoryMetricsProvider {
     startTimestamp: number,
     endTimestamp: number,
     perf?: PerformanceTracker,
+    pid?: string,
   ): Promise<GCEvent[]>;
 
   /**

--- a/src/features/memory/interfaces/MemoryMetricsProvider.ts
+++ b/src/features/memory/interfaces/MemoryMetricsProvider.ts
@@ -26,13 +26,15 @@ export interface MemoryMetricsProvider {
   triggerGC(packageName: string, perf?: PerformanceTracker): Promise<void>;
 
   /**
-   * Capture GC events from logcat within a time window.
+   * Capture GC events from logcat within a time window, scoped to the given app's process.
+   * @param packageName - Target app package name (resolved to a PID to scope logcat)
    * @param startTimestamp - Start of capture window
    * @param endTimestamp - End of capture window
    * @param perf - Optional performance tracker
    * @returns Promise with array of GC events
    */
   captureGCEvents(
+    packageName: string,
     startTimestamp: number,
     endTimestamp: number,
     perf?: PerformanceTracker,

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -37,6 +37,7 @@ export class FakeAdbExecutor implements AdbExecutor {
   private usersSequence: AndroidUser[][] | null = null;
   private foregroundApp: { packageName: string; userId: number } | null = null;
   private deviceTimestampMs: number | null = null;
+  private deviceTimestampMsSequence: number[] | null = null;
   private androidApiLevel: number | null = null;
 
   /**
@@ -152,6 +153,16 @@ export class FakeAdbExecutor implements AdbExecutor {
    */
   setDeviceTimestampMs(timestampMs: number | null): void {
     this.deviceTimestampMs = timestampMs;
+  }
+
+  /**
+   * Configure an ordered sequence of device timestamps; each call to
+   * {@link getDeviceTimestampMs} consumes the next value, and the final value
+   * repeats once exhausted. Useful for simulating the device clock advancing
+   * between two boundary reads (e.g. before/after an audited action).
+   */
+  setDeviceTimestampMsSequence(timestampsMs: number[]): void {
+    this.deviceTimestampMsSequence = [...timestampsMs];
   }
 
   /**
@@ -350,6 +361,11 @@ export class FakeAdbExecutor implements AdbExecutor {
   }
 
   async getDeviceTimestampMs(): Promise<number> {
+    if (this.deviceTimestampMsSequence && this.deviceTimestampMsSequence.length > 0) {
+      return this.deviceTimestampMsSequence.length > 1
+        ? this.deviceTimestampMsSequence.shift()!
+        : this.deviceTimestampMsSequence[0];
+    }
     return this.deviceTimestampMs ?? Date.now();
   }
 

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -119,7 +119,8 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(result.length).toBe(1);
       expect(result[0].type).toBe("Background concurrent copying");
       expect(result[0].freedKb).toBe(230);
-      expect(result[0].durationMs).toBeCloseTo(0.213, 5);
+      // Sums both stop-the-world components (213us + 45us), not just the first.
+      expect(result[0].durationMs).toBeCloseTo(0.258, 5);
     });
 
     test("should parse older ART GC lines with a bare KB size and pause in ms", function () {
@@ -132,6 +133,31 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(result[0].type).toBe("Background concurrent mark sweep");
       expect(result[0].freedKb).toBe(1234);
       expect(result[0].durationMs).toBe(123);
+    });
+
+    test("should normalize an adaptively-scaled MB freed size to KB", function () {
+      // ART scales the parenthesized size to whichever unit is most readable
+      // (B/KB/MB/GB) — a large collection freeing tens of MB must not be
+      // mis-parsed as if the number were already in KB.
+      const output =
+        "09-05 12:00:00.000  1234  1234 I com.example.app: Explicit concurrent copying GC freed 716275(24MB) AllocSpace objects, 0(0B) LOS objects, 55% free, 30MB/60MB, paused 1.5ms";
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(1);
+      expect(result[0].freedKb).toBe(24 * 1024);
+      expect(result[0].durationMs).toBe(1.5);
+    });
+
+    test("should sum multiple comma-separated ART pause components", function () {
+      const output =
+        "09-05 12:00:00.000  1234  1234 I com.example.app: Background concurrent copying GC freed 500(50KB) AllocSpace objects, 0(0B) LOS objects, 60% free, 1MB/2MB, paused 213us,45us total 42.3ms";
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(1);
+      // (213 + 45) us = 258us = 0.258ms — not just the first component (0.213ms).
+      expect(result[0].durationMs).toBeCloseTo(0.258, 5);
     });
 
     test("should parse a mix of Dalvik and ART lines in one logcat capture", function () {
@@ -147,6 +173,37 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(result[1].type).toBe("Explicit concurrent copying");
       expect(result[1].freedKb).toBe(50);
       expect(result[1].durationMs).toBeCloseTo(0.5, 5);
+    });
+
+    test("should drop GC lines from a different process when scoped to a pid (device-wide buffer)", function () {
+      // A device-wide logcat capture (e.g. --pid unsupported on this device)
+      // carries GC lines from other processes; only the audited pid's lines
+      // must be attributed to it.
+      const output = [
+        "1725000000.000  1234  1234 I com.example.app: Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us",
+        "1725000000.500  9999  9999 I com.other.app: Background concurrent copying GC freed 9000(900KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 999us",
+      ].join("\n");
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now(), "1234");
+
+      expect(result.length).toBe(1);
+      expect(result[0].freedKb).toBe(230);
+    });
+
+    test("should drop an event whose parsed epoch timestamp falls outside [start, end]", function () {
+      const inWindowMs = 1725000010000; // 1725000010.000s
+      const outOfWindowMs = 1725000090000; // 1725000090.000s — 80s later, outside the window
+      const output = [
+        `1725000010.000  1234  1234 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us`,
+        `1725000090.000  1234  1234 I com.example.app: Background concurrent copying GC freed 200(20KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 200us`,
+      ].join("\n");
+
+      const result = (collector as any).parseGCEvents(output, inWindowMs - 1000, inWindowMs + 1000);
+
+      expect(result.length).toBe(1);
+      expect(result[0].freedKb).toBe(10);
+      expect(result[0].timestamp).toBe(inWindowMs);
+      expect(outOfWindowMs).toBeGreaterThan(inWindowMs + 1000); // sanity: fixture is truly outside
     });
 
     test("should handle empty logcat output", function () {
@@ -170,30 +227,47 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
   });
 
   describe("captureGCEvents", function () {
-    test("should query logcat without the over-narrow dalvikvm/art tag filter", async function () {
-      fakeAdb.setCommandResponse("logcat -d -v time", {
+    test("should query logcat scoped to the audited process's pid, without the over-narrow dalvikvm/art tag filter", async function () {
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch", {
         stdout:
-          "09-05 12:00:00.123  1234  1234 I com.example.app: Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms",
+          "1725000000.000  1234  1234 I com.example.app: Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms",
         stderr: "",
       } as any);
 
-      const events = await collector.captureGCEvents(0, Date.now());
+      const events = await collector.captureGCEvents(
+        "com.example.app",
+        1724999999000,
+        1725000001000,
+      );
 
       expect(events.length).toBe(1);
       expect(events[0].freedKb).toBe(230);
-      expect(events[0].durationMs).toBeCloseTo(0.213, 5);
+      expect(events[0].durationMs).toBeCloseTo(0.258, 5);
 
       const executed = fakeAdb.getExecutedCommands();
       const gcCommand = executed.find((cmd) => cmd.includes("logcat"));
       expect(gcCommand).toBeDefined();
       expect(gcCommand).not.toContain("-s dalvikvm:I art:I");
       expect(gcCommand).not.toContain('"GC_"');
+      expect(gcCommand).toContain("--pid=1234");
+    });
+
+    test("should skip capture (not throw) when the audited app has no resolvable pid", async function () {
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "", stderr: "" } as any);
+
+      const events = await collector.captureGCEvents("com.example.app", 0, Date.now());
+
+      expect(events).toEqual([]);
+      const executed = fakeAdb.getExecutedCommands();
+      expect(executed.some((cmd) => cmd.includes("logcat"))).toBe(false);
     });
 
     test("should return zero events (not throw) when logcat has no GC lines", async function () {
-      fakeAdb.setCommandResponse("logcat -d -v time", { stdout: "", stderr: "" } as any);
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch", { stdout: "", stderr: "" } as any);
 
-      const events = await collector.captureGCEvents(0, Date.now());
+      const events = await collector.captureGCEvents("com.example.app", 0, Date.now());
 
       expect(events).toEqual([]);
     });

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -4,10 +4,11 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 
 describe("MemoryMetricsCollector - Unit Tests", function () {
   let collector: MemoryMetricsCollector;
+  let fakeAdb: FakeAdbExecutor;
 
   beforeEach(function () {
     // Use FakeAdbExecutor to avoid starting real adb daemon
-    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb = new FakeAdbExecutor();
     collector = new MemoryMetricsCollector(
       { deviceId: "test-device", name: "test", platform: "android" },
       fakeAdb as any,
@@ -89,7 +90,7 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
   });
 
   describe("parseGCEvents", function () {
-    test("should parse GC events from logcat output", function () {
+    test("should parse Dalvik-era GC events from logcat output", function () {
       const output = `
         I/dalvikvm: GC_FOR_ALLOC freed 1234K, 50% free 5678K/11356K, paused 123ms
         I/dalvikvm: GC_EXPLICIT freed 3456K, 40% free 7890K/13579K, paused 345ms
@@ -106,6 +107,48 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(result[1].durationMs).toBe(345);
     });
 
+    test("should parse modern ART GC lines under the app's process tag (pause in us)", function () {
+      // Real-world shape from a Pixel running API 34: pause is reported as
+      // "213us,45us total 42.3ms" and the freed size is parenthesized after
+      // the object count, under the app's own process tag (not "art").
+      const output =
+        "09-05 12:00:00.123  1234  1234 I com.example.app: Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms";
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(1);
+      expect(result[0].type).toBe("Background concurrent copying");
+      expect(result[0].freedKb).toBe(230);
+      expect(result[0].durationMs).toBeCloseTo(0.213, 5);
+    });
+
+    test("should parse older ART GC lines with a bare KB size and pause in ms", function () {
+      const output =
+        "I/art: Background concurrent mark sweep GC freed 1234KB, 50% free, 5678KB/11356KB, paused 123ms";
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(1);
+      expect(result[0].type).toBe("Background concurrent mark sweep");
+      expect(result[0].freedKb).toBe(1234);
+      expect(result[0].durationMs).toBe(123);
+    });
+
+    test("should parse a mix of Dalvik and ART lines in one logcat capture", function () {
+      const output = [
+        "I/dalvikvm: GC_FOR_ALLOC freed 1234K, 50% free 5678K/11356K, paused 123ms",
+        "09-05 12:00:01.000  1234  1234 I com.example.app: Explicit concurrent copying GC freed 500(50KB) AllocSpace objects, 0(0B) LOS objects, 60% free, 1MB/2MB, paused 500us total 1.2ms",
+      ].join("\n");
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(2);
+      expect(result[0].type).toBe("FOR_ALLOC");
+      expect(result[1].type).toBe("Explicit concurrent copying");
+      expect(result[1].freedKb).toBe(50);
+      expect(result[1].durationMs).toBeCloseTo(0.5, 5);
+    });
+
     test("should handle empty logcat output", function () {
       const output = "";
 
@@ -114,7 +157,7 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(result.length).toBe(0);
     });
 
-    test("should handle logcat output with no GC events", function () {
+    test("should handle logcat output with no GC events without crashing", function () {
       const output = `
         I/some-tag: Some other log message
         D/another-tag: Another log message
@@ -123,6 +166,36 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       const result = (collector as any).parseGCEvents(output, 0, Date.now());
 
       expect(result.length).toBe(0);
+    });
+  });
+
+  describe("captureGCEvents", function () {
+    test("should query logcat without the over-narrow dalvikvm/art tag filter", async function () {
+      fakeAdb.setCommandResponse("logcat -d -v time", {
+        stdout:
+          "09-05 12:00:00.123  1234  1234 I com.example.app: Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms",
+        stderr: "",
+      } as any);
+
+      const events = await collector.captureGCEvents(0, Date.now());
+
+      expect(events.length).toBe(1);
+      expect(events[0].freedKb).toBe(230);
+      expect(events[0].durationMs).toBeCloseTo(0.213, 5);
+
+      const executed = fakeAdb.getExecutedCommands();
+      const gcCommand = executed.find((cmd) => cmd.includes("logcat"));
+      expect(gcCommand).toBeDefined();
+      expect(gcCommand).not.toContain("-s dalvikvm:I art:I");
+      expect(gcCommand).not.toContain('"GC_"');
+    });
+
+    test("should return zero events (not throw) when logcat has no GC lines", async function () {
+      fakeAdb.setCommandResponse("logcat -d -v time", { stdout: "", stderr: "" } as any);
+
+      const events = await collector.captureGCEvents(0, Date.now());
+
+      expect(events).toEqual([]);
     });
   });
 

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -273,23 +273,13 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       expect(events).toEqual([]);
     });
 
-    test("should count an in-window event when the device clock is skewed from the host (#5377)", async function () {
-      // Host clock (this.timer.now(), used for startTimestamp/endTimestamp)
-      // reads ~5,000,000ms; the device's own clock is 100,000,000ms (~27.8h)
-      // ahead. Without translating the host-domain bounds into the device's
-      // clock domain before comparing against the device-stamped log line,
-      // this genuinely in-window event would be wrongly rejected as "outside"
-      // the window.
-      const hostNowMs = 5_000_000;
-      const deviceNowMs = 105_000_000;
-      const fakeTimer = new FakeTimer();
-      fakeTimer.setCurrentTime(hostNowMs);
-      const skewedCollector = new MemoryMetricsCollector(
-        { deviceId: "test-device", name: "test", platform: "android" },
-        fakeAdb as any,
-        fakeTimer,
-      );
-      fakeAdb.setDeviceTimestampMs(deviceNowMs);
+    test("should count an event whose device-epoch timestamp falls within the given bounds", async function () {
+      // captureGCEvents' startTimestamp/endTimestamp are now expected to
+      // already be in the DEVICE's clock domain (read via
+      // getDeviceTimestampMs at the actual audit boundaries — see
+      // collectMetrics), so no host<->device translation happens inside
+      // captureGCEvents itself; the bounds are compared directly against
+      // the device-stamped log line's epoch.
       fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
       fakeAdb.setCommandResponse("logcat -d -v epoch", {
         stdout:
@@ -297,45 +287,47 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
         stderr: "",
       } as any);
 
-      const events = await skewedCollector.captureGCEvents(
+      const events = await collector.captureGCEvents(
         "com.example.app",
-        hostNowMs - 500,
-        hostNowMs + 500,
+        105_000_000 - 500,
+        105_000_000 + 500,
       );
 
       expect(events.length).toBe(1);
       expect(events[0].freedKb).toBe(10);
     });
 
-    test("should drop an event outside the window once translated into device clock time", async function () {
-      // Same skewed device clock, but this line falls 80s after the
-      // device-time window end — it must still be rejected, proving the fix
-      // filters by a translated window rather than accepting everything once
-      // an offset is introduced.
-      const hostNowMs = 5_000_000;
-      const deviceNowMs = 105_000_000;
-      const fakeTimer = new FakeTimer();
-      fakeTimer.setCurrentTime(hostNowMs);
-      const skewedCollector = new MemoryMetricsCollector(
-        { deviceId: "test-device", name: "test", platform: "android" },
-        fakeAdb as any,
-        fakeTimer,
-      );
-      fakeAdb.setDeviceTimestampMs(deviceNowMs);
+    test("should drop an event whose device-epoch timestamp falls outside the given bounds", async function () {
       fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
       fakeAdb.setCommandResponse("logcat -d -v epoch", {
         stdout:
+          // 80s after the window end.
           "105080.000  1234  1234 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
         stderr: "",
       } as any);
 
-      const events = await skewedCollector.captureGCEvents(
+      const events = await collector.captureGCEvents(
         "com.example.app",
-        hostNowMs - 500,
-        hostNowMs + 500,
+        105_000_000 - 500,
+        105_000_000 + 500,
       );
 
       expect(events).toEqual([]);
+    });
+
+    test("should treat the device-clock window bounds as inclusive", async function () {
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch", {
+        stdout: [
+          "100.000  1234  1234 I com.example.app: Background concurrent copying GC freed 1(1KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 1us", // exactly at start
+          "200.000  1234  1234 I com.example.app: Background concurrent copying GC freed 2(2KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 1us", // exactly at end
+        ].join("\n"),
+        stderr: "",
+      } as any);
+
+      const events = await collector.captureGCEvents("com.example.app", 100_000, 200_000);
+
+      expect(events.length).toBe(2);
     });
 
     test("should use a pre-resolved pid instead of re-querying pidof (survives a mid-action process restart)", async function () {
@@ -343,14 +335,6 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       // collectMetrics now does): pid 1111 was alive during the action, but
       // if captureGCEvents queried pidof itself afterward it would get 2222
       // (the app restarted). Passing the pre-resolved pid must win.
-      const fakeTimer = new FakeTimer();
-      fakeTimer.setCurrentTime(1_000_000);
-      const restartCollector = new MemoryMetricsCollector(
-        { deviceId: "test-device", name: "test", platform: "android" },
-        fakeAdb as any,
-        fakeTimer,
-      );
-      fakeAdb.setDeviceTimestampMs(1_000_000);
       fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "2222", stderr: "" } as any);
       fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
         stdout:
@@ -363,7 +347,7 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
         stderr: "",
       } as any);
 
-      const events = await restartCollector.captureGCEvents(
+      const events = await collector.captureGCEvents(
         "com.example.app",
         999_500,
         1_000_500,
@@ -379,12 +363,24 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       const gcCommand = executed.find((cmd) => cmd.includes("logcat"));
       expect(gcCommand).toContain("--pid=1111");
     });
+
+    test("should sum AllocSpace and LOS freed sizes into freedKb", function () {
+      // ART reports large-object frees as two separate scaled quantities;
+      // both must be summed rather than only the (regular-object) AllocSpace figure.
+      const output =
+        "09-05 12:00:00.000 I com.example.app: Explicit concurrent copying GC freed 123(4MB) AllocSpace objects, 45(2MB) LOS objects, 50% free, 6MB/8MB, paused 1ms";
+
+      const result = (collector as any).parseGCEvents(output, 0, Date.now());
+
+      expect(result.length).toBe(1);
+      expect(result[0].freedKb).toBe(4 * 1024 + 2 * 1024); // 4MB AllocSpace + 2MB LOS = 6144KB
+      expect(result[0].durationMs).toBe(1);
+    });
   });
 
-  describe("collectMetrics pid retention across the audited action", function () {
-    test("scopes GC capture to the pid resolved before the action, even though a later pidof call returns a different pid", async function () {
+  describe("collectMetrics pid retention and device-clock boundary capture", function () {
+    test("scopes GC capture to the pid resolved before the action, and reads the GC window directly from device-clock boundary reads", async function () {
       const fakeTimer = new FakeTimer();
-      fakeTimer.setCurrentTime(1_000_000);
       fakeTimer.enableAutoAdvance();
       const restartCollector = new MemoryMetricsCollector(
         { deviceId: "test-device", name: "test", platform: "android" },
@@ -407,17 +403,15 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
         stdout: "",
         stderr: "",
       } as any);
+      // The device clock is read once immediately before the action starts
+      // (500_000) and once immediately after it ends (500_500) — these two
+      // reads ARE the GC window, with no host-clock translation involved.
+      fakeAdb.setDeviceTimestampMsSequence([500_000, 500_500]);
       fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
         stdout:
-          "1000.000  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+          "500.200  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
         stderr: "",
       } as any);
-      // triggerGC's sleep(500) advances the fake host clock by 500ms before
-      // captureGCEvents reads it; set the device clock to match so the
-      // (unrelated to this test) clock-skew translation is a no-op offset,
-      // keeping the fixture's "1000.000" epoch inside the [1_000_000, 1_000_000]
-      // host-domain window captured around the (instantaneous) audited action.
-      fakeAdb.setDeviceTimestampMs(1_000_500);
 
       const metrics = await restartCollector.collectMetrics("com.example.app", async () => {});
 

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { MemoryMetricsCollector } from "../../../src/features/memory/MemoryMetricsCollector";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("MemoryMetricsCollector - Unit Tests", function () {
   let collector: MemoryMetricsCollector;
@@ -270,6 +271,162 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
       const events = await collector.captureGCEvents("com.example.app", 0, Date.now());
 
       expect(events).toEqual([]);
+    });
+
+    test("should count an in-window event when the device clock is skewed from the host (#5377)", async function () {
+      // Host clock (this.timer.now(), used for startTimestamp/endTimestamp)
+      // reads ~5,000,000ms; the device's own clock is 100,000,000ms (~27.8h)
+      // ahead. Without translating the host-domain bounds into the device's
+      // clock domain before comparing against the device-stamped log line,
+      // this genuinely in-window event would be wrongly rejected as "outside"
+      // the window.
+      const hostNowMs = 5_000_000;
+      const deviceNowMs = 105_000_000;
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(hostNowMs);
+      const skewedCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+      fakeAdb.setDeviceTimestampMs(deviceNowMs);
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch", {
+        stdout:
+          "105000.000  1234  1234 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+
+      const events = await skewedCollector.captureGCEvents(
+        "com.example.app",
+        hostNowMs - 500,
+        hostNowMs + 500,
+      );
+
+      expect(events.length).toBe(1);
+      expect(events[0].freedKb).toBe(10);
+    });
+
+    test("should drop an event outside the window once translated into device clock time", async function () {
+      // Same skewed device clock, but this line falls 80s after the
+      // device-time window end — it must still be rejected, proving the fix
+      // filters by a translated window rather than accepting everything once
+      // an offset is introduced.
+      const hostNowMs = 5_000_000;
+      const deviceNowMs = 105_000_000;
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(hostNowMs);
+      const skewedCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+      fakeAdb.setDeviceTimestampMs(deviceNowMs);
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1234", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch", {
+        stdout:
+          "105080.000  1234  1234 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+
+      const events = await skewedCollector.captureGCEvents(
+        "com.example.app",
+        hostNowMs - 500,
+        hostNowMs + 500,
+      );
+
+      expect(events).toEqual([]);
+    });
+
+    test("should use a pre-resolved pid instead of re-querying pidof (survives a mid-action process restart)", async function () {
+      // Simulates resolving the audited pid BEFORE the action (as
+      // collectMetrics now does): pid 1111 was alive during the action, but
+      // if captureGCEvents queried pidof itself afterward it would get 2222
+      // (the app restarted). Passing the pre-resolved pid must win.
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(1_000_000);
+      const restartCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+      fakeAdb.setDeviceTimestampMs(1_000_000);
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "2222", stderr: "" } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
+        stdout:
+          "1000.000  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=2222", {
+        stdout:
+          "1000.000  2222  2222 I com.example.app: Background concurrent copying GC freed 999(999KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 999us",
+        stderr: "",
+      } as any);
+
+      const events = await restartCollector.captureGCEvents(
+        "com.example.app",
+        999_500,
+        1_000_500,
+        undefined,
+        "1111",
+      );
+
+      expect(events.length).toBe(1);
+      expect(events[0].freedKb).toBe(10); // the pid-1111 fixture, not pid-2222's
+
+      const executed = fakeAdb.getExecutedCommands();
+      expect(executed.some((cmd) => cmd.includes("pidof"))).toBe(false);
+      const gcCommand = executed.find((cmd) => cmd.includes("logcat"));
+      expect(gcCommand).toContain("--pid=1111");
+    });
+  });
+
+  describe("collectMetrics pid retention across the audited action", function () {
+    test("scopes GC capture to the pid resolved before the action, even though a later pidof call returns a different pid", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(1_000_000);
+      fakeTimer.enableAutoAdvance();
+      const restartCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+
+      // First pidof call (collectMetrics, pre-action) sees pid 1111; any
+      // later pidof call (e.g. triggerGC, post-action) sees 2222 — simulating
+      // the audited app restarting partway through the action.
+      fakeAdb.setCommandResponseSequence("pidof com.example.app", [
+        { stdout: "1111", stderr: "" } as any,
+        { stdout: "2222", stderr: "" } as any,
+      ]);
+      fakeAdb.setCommandResponse("dumpsys meminfo com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo --unreachable com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
+        stdout:
+          "1000.000  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+      // triggerGC's sleep(500) advances the fake host clock by 500ms before
+      // captureGCEvents reads it; set the device clock to match so the
+      // (unrelated to this test) clock-skew translation is a no-op offset,
+      // keeping the fixture's "1000.000" epoch inside the [1_000_000, 1_000_000]
+      // host-domain window captured around the (instantaneous) audited action.
+      fakeAdb.setDeviceTimestampMs(1_000_500);
+
+      const metrics = await restartCollector.collectMetrics("com.example.app", async () => {});
+
+      expect(metrics.gcCount).toBe(1);
+      expect(metrics.gcEvents[0].freedKb).toBe(10);
+
+      const executed = fakeAdb.getExecutedCommands();
+      const gcCommand = executed.find((cmd) => cmd.includes("logcat -d -v epoch"));
+      expect(gcCommand).toContain("--pid=1111");
     });
   });
 


### PR DESCRIPTION
## Root cause

`MemoryMetricsCollector.captureGCEvents` (src/features/memory/MemoryMetricsCollector.ts) filtered logcat with:

```
shell logcat -d -s dalvikvm:I art:I | grep "GC_"
```

and `parseGCEvents` matched only `/GC[_\s](\w+).*?freed\s+(\d+)K?B?.*?paused\s+(\d+)ms/i`.

Modern ART (API 21+) logs GC lines under the app's own process tag (not a dedicated `art` tag), without the legacy `GC_` prefix, and reports pause durations in microseconds, e.g.:

```
Background concurrent copying GC freed 4180(230KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 213us,45us total 42.3ms
```

The `-s dalvikvm:I art:I` tag filter and `grep "GC_"` drop every such line, and the old regex would not have matched it anyway (`freed` lands in the type-capture group, and pauses in `us` aren't matched by the `ms`-only pattern). Result: `gcCount` and `gcTotalDurationMs` are always 0 on any ART device — the `gcCount`/`gcDuration` thresholds and `gcCountAnomaly` checks in `MemoryAudit.validateMetrics` can never fire, and stored baselines record 0.

## Fix

- Broaden the logcat capture to the `freed...paused` shape shared by both Dalvik and ART GC log lines (`logcat -d -v time | grep -iE "GC[_ ].*freed.*paused"`), dropping the over-narrow tag filter.
- Extend `parseGCEvents` to recognize both:
  - Legacy Dalvik lines (`GC_FOR_ALLOC freed 1234K, ..., paused 123ms`)
  - Modern ART lines, with the freed size either bare (`1234KB`) or parenthesized after an object count (`4180(230KB)`), and the pause duration in either `us` or `ms` (microseconds are converted to milliseconds for a consistent unit).

## Tests

`test/features/memory/MemoryMetricsCollector.test.ts`:
- Dalvik-era lines still parse (`GC_FOR_ALLOC`/`GC_EXPLICIT`).
- Modern ART lines under the app's process tag parse correctly, including `us`→`ms` conversion.
- Older ART lines with a bare KB size and `ms` pause parse correctly.
- A mixed Dalvik + ART capture produces both events.
- Empty output and output with no GC lines return `[]` without throwing.
- `captureGCEvents` end-to-end (via `FakeAdbExecutor`) confirms the new logcat command no longer contains the removed `-s dalvikvm:I art:I` / `"GC_"` filter and that a fixture ART line produces a non-zero-metric `GCEvent`.

All tests run against fixture logcat output through `FakeAdbExecutor` (no real device or `getDatabase()` involved) and pass in well under the 100ms/test budget. This was not additionally re-verified against a live device — the acceptance criteria are satisfied via fixture-driven unit tests only, per the issue's own "not run against a device in this hunt" caveat.

Closes #6125
