### PR TITLE
fix(daemon): answer daemon/heartbeat out-of-band, never queued behind tools/call

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -226,6 +226,16 @@ export const DAEMON_BOUND_SESSION_REPLAY_TTL_MS = 30 * 60 * 1000;
 export const DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD = "daemon/subscribe-notifications";
 
 /**
+ * Bound-session keepalive method. Must be answered immediately, never queued
+ * behind an in-flight `tools/call` on the same socket: the MCP proxy's keeper
+ * sends this over the same `DaemonClient` socket used for tool forwarding, so
+ * head-of-line blocking behind a long acquisition call (e.g. `startDevice` for
+ * a second device) can starve the heartbeat past the session's
+ * heartbeat-timeout and get it reaped (issue #6135).
+ */
+export const DAEMON_HEARTBEAT_METHOD = "daemon/heartbeat";
+
+/**
  * Control-socket method returning the current `deviceId (serial/UDID) ↔
  * deviceSessionUuid` map from the daemon's `DeviceSessionRegistry`. Lets a
  * stream consumer resolve a serial to its stable connection-epoch identity

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -2,7 +2,7 @@ import { DaemonRequest } from "./types";
 import { DeviceLabelMap, Session } from "./sessionManager";
 import type { DeviceRecoveryEligibility, DeviceRecoveryPolicy, PooledDevice } from "./devicePool";
 import type { DeviceSessionRecord } from "./deviceSessionRegistry";
-import { DAEMON_LIST_DEVICE_SESSIONS_METHOD } from "./constants";
+import { DAEMON_HEARTBEAT_METHOD, DAEMON_LIST_DEVICE_SESSIONS_METHOD } from "./constants";
 
 /** Socket endpoint clients may query before sending optional newer parameters. */
 export const DAEMON_CAPABILITIES_METHOD = "daemon/capabilities";
@@ -88,7 +88,7 @@ export async function handleDaemonRequest(
   }
 
   switch (request.method) {
-    case "daemon/heartbeat": {
+    case DAEMON_HEARTBEAT_METHOD: {
       const sessionId = (request.params as { sessionId?: string } | undefined)?.sessionId;
       if (!sessionId) {
         return {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -18,6 +18,7 @@ import {
   SOCKET_PATH,
   DAEMON_HANDSHAKE_ENABLED,
   DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
+  DAEMON_HEARTBEAT_METHOD,
   DAEMON_SESSION_TOOL_BINDING_HEADER,
   DAEMON_RELEASED_SESSION_HEADER,
   DAEMON_TOOL_SELECTION_PROFILE_HEADER,
@@ -659,6 +660,21 @@ export class UnixSocketServer {
         type: "mcp_response",
         success: true,
         result: { subscribed: true },
+      };
+    }
+
+    // Bound-session keepalive must never wait behind an in-flight tools/call on the same
+    // socket: a queued heartbeat can lose the race with the session's heartbeat-timeout
+    // during a long unattributed acquisition (e.g. startDevice for a second device), and the
+    // session gets reaped out from under a still-live client (issue #6135). It touches only
+    // SessionManager's heartbeat bookkeeping, so answering it out-of-band here does not
+    // reorder anything tool calls observe.
+    if (request.method === DAEMON_HEARTBEAT_METHOD) {
+      const daemonResponse = await handleDaemonRequest(request, this.daemonState);
+      return {
+        id: request.id,
+        type: "mcp_response",
+        ...daemonResponse,
       };
     }
 

--- a/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
@@ -53,6 +53,7 @@ function createFakeDaemonState(
   sessionDevices: Map<string, string>,
   sessionDeviceLabels: Map<string, DeviceLabelMap>,
   mcpAutolockSessions: Map<string, string>,
+  onHeartbeat?: (sessionId: string) => void,
 ) {
   return {
     isInitialized: () => true,
@@ -65,6 +66,7 @@ function createFakeDaemonState(
       },
       getDeviceLabels: (sessionId: string) => sessionDeviceLabels.get(sessionId),
       releaseSession: async () => null,
+      recordHeartbeat: (sessionId: string) => onHeartbeat?.(sessionId),
     }),
     getDevicePool: () => ({
       refreshDevices: async () => 0,
@@ -308,6 +310,72 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(b.success).toBe(true);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
+  });
+
+  test("answers daemon/heartbeat immediately instead of queueing it behind an in-flight tools/call on the same socket (issue #6135)", async () => {
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-heartbeat-hol-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    sessionDevices.set("session-a", "device-a");
+    const order: string[] = [];
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions, (sessionId) =>
+        order.push(`heartbeat:${sessionId}`),
+      ),
+      fakeTimer,
+    );
+    await server.start();
+
+    const toolCallStarted = Promise.withResolvers<void>();
+    const releaseToolCall = Promise.withResolvers<void>();
+    server.mcpClientFactory = async () => ({
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        order.push("toolCall:start");
+        toolCallStarted.resolve();
+        await releaseToolCall.promise;
+        order.push("toolCall:end");
+        return { content: [] };
+      },
+      listResources: async () => ({ resources: [] }),
+      readResource: async () => ({ contents: [] }),
+      listResourceTemplates: async () => ({ resourceTemplates: [] }),
+      close: async () => {},
+    });
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      // A long-running tools/call occupies this socket's request queue — the
+      // same socket the MCP proxy's bound-session heartbeat keeper uses.
+      const longCall = client.request("tools/call", {
+        name: "startDevice",
+        arguments: { sessionUuid: "session-a", deviceId: "device-b" },
+      });
+      await toolCallStarted.promise;
+
+      // A heartbeat sent while that call is still in flight must be answered
+      // (and recorded) right away, not after the tools/call finishes.
+      const heartbeat = await client.request("daemon/heartbeat", {
+        sessionId: "session-a",
+      });
+
+      expect(heartbeat.success).toBe(true);
+      // The heartbeat was recorded BEFORE the blocked tools/call released —
+      // proving it was not queued behind it (pre-fix, this order would be
+      // toolCall:start, toolCall:end, heartbeat:session-a).
+      expect(order).toEqual(["toolCall:start", "heartbeat:session-a"]);
+
+      releaseToolCall.resolve();
+      const longResult = await longCall;
+      expect(longResult.success).toBe(true);
+      expect(order).toEqual(["toolCall:start", "heartbeat:session-a", "toolCall:end"]);
+    } finally {
+      releaseToolCall.resolve();
+      client.close();
+    }
   });
 
   test("forwards the socket timeout budget to IDE navigation graph calls", async () => {


### PR DESCRIPTION
## Root cause

`UnixSocketServer.handleRequest` (`src/daemon/socketServer.ts`) special-cased
only `daemon/subscribe-notifications` to answer immediately; every other
method, including `daemon/heartbeat`, was routed through the per-socket
`enqueueRequest` queue, which processes one request at a time per socket.

The MCP proxy's bound-session heartbeat keeper (`sendBoundSessionHeartbeat` in
`daemonMcpProxy.ts`) sends `daemon/heartbeat` over the *same* `DaemonClient`
socket used for `tools/call` forwarding. So a heartbeat issued while a long
`tools/call` was already in flight on that socket (e.g. `startDevice` for a
second device right after `getAndroid`) sat behind it in the queue until the
tool call returned.

The only thing that keeps a bound session alive during that wait is
`hasActiveSessionExecution` — which requires the in-flight execution to be
*attributed* to that session. It isn't attributed in the cases traced in
#6135 (no `boundRoute` yet, or an autolock session that doesn't resolve for
the second platform). With nothing keeping the session's heartbeat clock
fresh, a cold boot (30-180s) routinely outlasts the default 10s / autolock
60s heartbeat timeout, and `SessionHeartbeatMonitor` reaps the session
(`heartbeat-timeout`) while the client is still alive and waiting on it.

## Fix

Answer `daemon/heartbeat` immediately, outside `enqueueRequest`, the same way
`daemon/subscribe-notifications` already is (`src/daemon/socketServer.ts`).
It only touches `SessionManager`'s heartbeat bookkeeping (`recordHeartbeat`),
so answering out-of-band cannot reorder anything an actual `tools/call`
observes — ordering for tool calls on a socket is unchanged.

Added a `DAEMON_HEARTBEAT_METHOD` constant in `src/daemon/constants.ts`
(mirroring `DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD`) and used it at both the
socket-server bypass and the `daemon/heartbeat` case in
`daemonRequestHandlers.ts`.

## Test

`test/daemon/socketServerMcpForwardSerialization.integration.test.ts`: new
test with a fake `tools/call` blocked in flight on a socket. Asserts a
`daemon/heartbeat` on the *same* socket is answered (and recorded via
`SessionManager.recordHeartbeat`) before the blocked `tools/call` completes —
proving the heartbeat is not head-of-line blocked behind it. Verified the
test fails against the pre-fix code path (heartbeat routed through
`enqueueRequest`) and passes with the fix.

Full validation: `turbo run lint build test`, `bun run format:check`,
`bun run typecheck` all pass.

Closes #6135
