### PR TITLE
fix(mcp): align platform optionality and enforce launchApp strict schema

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7272,7 +7272,7 @@
         },
         "platform": {
           "type": "string",
-          "enum": ["ios", "android"]
+          "enum": ["android", "ios"]
         },
         "sessionUuid": {
           "description": "Session",
@@ -7286,7 +7286,7 @@
           "type": "string"
         }
       },
-      "required": ["title", "body", "platform"],
+      "required": ["title", "body"],
       "additionalProperties": false,
       "if": {
         "properties": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -520,7 +520,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false,
       "if": {
         "properties": {
@@ -635,7 +634,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -672,7 +670,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["action"],
       "additionalProperties": false,
       "if": {
         "properties": {
@@ -942,7 +940,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -1177,7 +1174,7 @@
           "type": "string"
         }
       },
-      "required": ["source", "target", "platform"],
+      "required": ["source", "target"],
       "additionalProperties": false
     }
   },
@@ -2467,7 +2464,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -2503,7 +2499,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -2576,7 +2571,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -2617,7 +2611,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["action"],
       "additionalProperties": false
     }
   },
@@ -2728,7 +2722,7 @@
           "type": "string"
         }
       },
-      "required": ["text", "platform"],
+      "required": ["text"],
       "additionalProperties": false
     }
   },
@@ -2791,7 +2785,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["action"],
       "additionalProperties": false
     }
   },
@@ -3470,7 +3464,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false,
       "if": {
         "required": ["platform", "waitFor"],
@@ -7056,7 +7049,7 @@
           "type": "string"
         }
       },
-      "required": ["url", "platform"],
+      "required": ["url"],
       "additionalProperties": false,
       "if": {
         "required": ["platform", "waitFor"],
@@ -7217,7 +7210,7 @@
           "type": "string"
         }
       },
-      "required": ["direction", "platform"],
+      "required": ["direction"],
       "additionalProperties": false
     }
   },
@@ -7344,7 +7337,7 @@
           "type": "string"
         }
       },
-      "required": ["button", "platform"],
+      "required": ["button"],
       "additionalProperties": false
     }
   },
@@ -7652,7 +7645,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -7832,7 +7824,7 @@
           "type": "string"
         }
       },
-      "required": ["orientation", "platform"],
+      "required": ["orientation"],
       "additionalProperties": false
     }
   },
@@ -7868,7 +7860,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -8590,7 +8581,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -8929,7 +8919,7 @@
           "type": "string"
         }
       },
-      "required": ["direction", "platform"],
+      "required": ["direction"],
       "additionalProperties": false
     }
   },
@@ -8997,7 +8987,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["action"],
       "additionalProperties": false
     }
   },
@@ -9089,7 +9079,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   },
@@ -11746,7 +11735,7 @@
           "type": "string"
         }
       },
-      "required": ["action", "platform"],
+      "required": ["action"],
       "additionalProperties": false
     }
   },
@@ -11777,7 +11766,6 @@
           "type": "string"
         }
       },
-      "required": ["platform"],
       "additionalProperties": false
     }
   }

--- a/src/features/observe/IdentifyInteractions.ts
+++ b/src/features/observe/IdentifyInteractions.ts
@@ -9,7 +9,8 @@ import { NavigationEdge } from "../../utils/interfaces/NavigationGraph";
 type InteractionType = "navigation" | "input" | "action" | "scroll" | "toggle";
 
 export interface IdentifyInteractionsOptions {
-  platform: "android" | "ios";
+  // #6154: optional — resolved from deviceId/session when omitted.
+  platform?: "android" | "ios";
   filter?: {
     types?: InteractionType[];
     minConfidence?: number;

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -241,12 +241,22 @@ export const crashAppResultSchema = z.object({
 
 export const launchAppSchema = withAppIdAliases(
   addDeviceTargetingToSchema(
-    z.object({
-      appId: z.string(),
-      clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
-      coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
-      ...responseShapeControlFields,
-    }),
+    z
+      .object({
+        appId: z.string(),
+        clearAppData: z
+          .boolean()
+          .optional()
+          .describe("Clear app data before launch (default false)"),
+        coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
+        ...responseShapeControlFields,
+      })
+      // #6154: the advertised `additionalProperties: false` was not actually
+      // enforced at runtime — `.strict()` closes that gap. `withAppIdAliases`
+      // runs its `z.preprocess` normalization (packageName -> appId, alias
+      // deleted) before this schema ever parses, so the documented alias still
+      // works under strict mode.
+      .strict(),
   ),
 );
 

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -38,7 +38,10 @@ export interface DebugSearchArgs {
 // Schema definitions
 const debugSearchBaseSchema = z
   .object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     text: z.string().optional().describe("Text to search for in elements"),
     elementId: elementIdTextFieldsSchema.shape.elementId.describe(
       "Element resource ID / accessibility identifier to search for",

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -22,7 +22,8 @@ const ensureDebugEnabled = () => {
 
 // Type definitions for tool arguments
 export interface DebugSearchArgs {
-  platform: Platform;
+  // #6154: optional — resolved from deviceId/session when omitted.
+  platform?: Platform;
   text?: string;
   elementId?: string;
   container?: {

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -31,7 +31,10 @@ import { boundsEqual } from "../utils/bounds";
 
 const highlightBaseSchema = z
   .object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     deviceId: z.string().optional(),
     timeoutMs: z
       .number()

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -355,18 +355,40 @@ const createDefaultViewHierarchyClient = (device: BootedDevice): HighlightViewHi
   throw new ActionableError(`Visual highlights are not supported on ${device.platform} devices.`);
 };
 
+/**
+ * #6154 follow-up: `platform` is optional on the wire (resolved from
+ * deviceId/session), so `args.platform` can be `undefined` here even though
+ * ToolRegistry has already resolved `device`. Build the `VisualHighlightClient`
+ * options from the resolved `device.platform` — never the raw request field —
+ * or its device/platform mismatch check spuriously rejects every call that
+ * omitted `platform`. Exported standalone so the resolution itself (not just
+ * the end-to-end handler) is directly testable.
+ */
+export function resolveHighlightClientOptions(
+  device: BootedDevice,
+  args: Pick<HighlightArgs, "deviceId" | "sessionUuid" | "timeoutMs">,
+): {
+  device: BootedDevice;
+  deviceId: string;
+  platform: Platform;
+  sessionUuid?: string;
+  timeoutMs?: number;
+} {
+  return {
+    device,
+    deviceId: args.deviceId ?? device.deviceId,
+    platform: device.platform,
+    sessionUuid: args.sessionUuid,
+    timeoutMs: args.timeoutMs,
+  };
+}
+
 export function registerHighlightTools(dependencies: HighlightToolDependencies = {}) {
   const highlightHandler = async (device: BootedDevice, args: HighlightArgs) => {
     const highlightClient = dependencies.highlightClientFactory
       ? dependencies.highlightClientFactory()
       : new VisualHighlightClient();
-    const options = {
-      device,
-      deviceId: args.deviceId ?? device.deviceId,
-      platform: args.platform as Platform,
-      sessionUuid: args.sessionUuid,
-      timeoutMs: args.timeoutMs,
-    };
+    const options = resolveHighlightClientOptions(device, args);
 
     try {
       const highlightId = dependencies.generateHighlightId

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -9,17 +9,23 @@ import type { ObserveWaitForOptions, SettledOptions } from "./observeTools";
 // Tool Argument Types
 // ============================================================================
 
+// #6154: `platform` is optional on every one of these tools' wire schemas
+// (resolved from deviceId/session when omitted), so the hand-written arg
+// types below must match it — a typed caller could not otherwise omit it.
+// `TapOnArgs.platform` (below) is left as-is: tapOn's schema has been
+// optional since #5870, predating this pass, and fixing that pre-existing
+// mismatch is out of scope here.
 export interface ClearTextArgs {
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface SelectAllTextArgs {
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface PressButtonArgs {
   button: "home" | "back" | "menu" | "power" | "volume_up" | "volume_down" | "recent";
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface SystemTrayNotificationArgs {
@@ -33,7 +39,7 @@ export interface SystemTrayArgs {
   action: "open" | "close" | "find" | "tap" | "dismiss" | "clearAll";
   notification?: SystemTrayNotificationArgs;
   awaitTimeout?: number;
-  platform: Platform;
+  platform?: Platform;
 }
 
 /** Selector variants that focus an input field before typing (issue #5872). */
@@ -50,19 +56,19 @@ export interface InputTextArgs {
   mode?: "a11y" | "eventLast" | "eventAll" | "eventOnly";
   imeAction?: ImeAction;
   dismissKeyboard?: boolean;
-  platform: Platform;
+  platform?: Platform;
   raw?: boolean;
   project?: "full" | "skeleton";
 }
 
 export interface WakeAndUnlockArgs {
   pin?: string;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface OpenLinkArgs {
   url: string;
-  platform: Platform;
+  platform?: Platform;
   waitFor?: ObserveWaitForOptions;
   settled?: SettledOptions;
 }
@@ -111,7 +117,7 @@ export interface TapAnyArgs {
     duration?: number;
   };
   scrollableContainer?: boolean;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface DragAndDropArgs {
@@ -126,7 +132,7 @@ export interface DragAndDropArgs {
   pressDurationMs?: number;
   dragDurationMs?: number;
   holdDurationMs?: number;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface SwipeOnArgs {
@@ -146,7 +152,7 @@ export interface SwipeOnArgs {
   apexPause?: number;
   returnSpeed?: number;
   speed?: "slow" | "normal" | "fast";
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface PinchOnArgs {
@@ -162,36 +168,36 @@ export interface PinchOnArgs {
     text?: string;
   };
   autoTarget?: boolean;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface ShakeArgs {
   duration?: number;
   intensity?: number;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface ImeActionArgs {
   action: ImeAction;
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface KeyboardArgs {
   action: "open" | "close" | "detect";
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface RecentAppsArgs {
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface RotateArgs {
   orientation: "portrait" | "landscape";
-  platform: Platform;
+  platform?: Platform;
 }
 
 export interface ClipboardArgs {
   action: "copy" | "paste" | "clear" | "get";
   text?: string;
-  platform: Platform;
+  platform?: Platform;
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -39,6 +39,7 @@ import {
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import {
+  assertActiveWindowWaitForSupportedOnPlatform,
   overrideWaitForJsonSchema,
   refineWaitForArgs,
   settledSchema,
@@ -1713,6 +1714,12 @@ export function registerInteractionTools() {
     _progress?: ProgressCallback,
     signal?: AbortSignal,
   ) => {
+    // #6154 follow-up: `platform` is optional on the wire, so the schema's
+    // iOS-rejects-activityName check (raw request platform) can be skipped
+    // entirely when the caller omitted it. Re-validate against the resolved
+    // `device.platform` before opening the URL.
+    assertActiveWindowWaitForSupportedOnPlatform(device.platform, args.waitFor);
+
     const openUrl = new OpenURL(device);
     const result = await openUrl.execute(args.url);
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -152,7 +152,10 @@ export const shakeSchema = addDeviceTargetingToSchema(
   z.object({
     duration: z.number().optional().describe("Shake duration ms (default 1000)"),
     intensity: z.number().optional().describe("Shake intensity (Android; default 100)"),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -160,7 +163,10 @@ export const shakeSchema = addDeviceTargetingToSchema(
 export const keyboardSchema = addDeviceTargetingToSchema(
   z.object({
     action: z.enum(["open", "close", "detect"]).describe("Keyboard action"),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
   }),
 );
 
@@ -385,7 +391,10 @@ export const tapAnySchema = withJsonSchemaOverride(
           })
           .optional()
           .describe("Poll for clickable element before tapping"),
-        platform: platformSchema,
+        // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+        // not required — a device handle from getAndroid/getApple is sufficient on
+        // its own.
+        platform: platformSchema.optional(),
         ...responseShapeControlFields,
       })
       .strict(),
@@ -427,7 +436,10 @@ export const dragAndDropSchema = withJsonSchemaOverride(
         .max(3000)
         .optional()
         .describe("Hold duration ms (min: 100, max: 3000, default: 100)"),
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
       ...responseShapeControlFields,
     }),
   ),
@@ -466,7 +478,10 @@ export const swipeOnSchema = withJsonSchemaOverride(
         .optional()
         .describe("Speed multiplier for return swipe (0.1-3.0)"),
       speed: z.enum(["slow", "normal", "fast"]).optional().describe("Swipe speed preset"),
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
       ...responseShapeControlFields,
     }),
   ),
@@ -493,7 +508,10 @@ export const pinchOnSchema = withJsonSchemaOverride(
         .describe("Use full screen including status/nav bars"),
       container: elementContainerSchema.optional().describe("Scope search to a container"),
       autoTarget: z.boolean().optional().describe("Auto-target pinchable containers"),
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
       ...responseShapeControlFields,
     }),
   ),
@@ -502,14 +520,20 @@ export const pinchOnSchema = withJsonSchemaOverride(
 
 export const clearTextSchema = addDeviceTargetingToSchema(
   z.object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
 
 export const selectAllTextSchema = addDeviceTargetingToSchema(
   z.object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -517,7 +541,10 @@ export const selectAllTextSchema = addDeviceTargetingToSchema(
 export const pressButtonSchema = addDeviceTargetingToSchema(
   z.object({
     button: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"]),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -538,7 +565,10 @@ const systemTraySchemaBase = z.object({
     .number()
     .optional()
     .describe("Timeout in ms to wait for notification (default: 5000)"),
-  platform: platformSchema,
+  // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+  // not required — a device handle from getAndroid/getApple is sufficient on
+  // its own.
+  platform: platformSchema.optional(),
   ...responseShapeControlFields,
 });
 
@@ -578,7 +608,10 @@ export const stopAppSchema = withAppIdAliases(
   addDeviceTargetingToSchema(
     z.object({
       appId: z.string(),
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
     }),
   ),
 );
@@ -588,7 +621,10 @@ export const clearStateSchema = withAppIdAliases(
     z.object({
       appId: z.string(),
       clearKeychain: z.boolean().optional().describe("Clear iOS keychain"),
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
     }),
   ),
 );
@@ -641,7 +677,10 @@ export const inputTextSchema = addDeviceTargetingToSchema(
       .optional()
       .describe("IME action after input"),
     dismissKeyboard: z.boolean().optional().describe("Android: dismiss keyboard after input"),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -654,7 +693,10 @@ export const wakeAndUnlockSchema = addDeviceTargetingToSchema(
       .describe(
         "Credential to unlock a secure Android device. Optional; logically required to unlock a secure lock unless a pin was already remembered this session. Ignored on iOS.",
       ),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
   }),
 );
 
@@ -666,7 +708,10 @@ export const openLinkSchema = withAppIdAliases(
     addDeviceTargetingToSchema(
       z.object({
         url: z.string().describe("URL to open"),
-        platform: platformSchema,
+        // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+        // not required — a device handle from getAndroid/getApple is sufficient on
+        // its own.
+        platform: platformSchema.optional(),
         waitFor: waitForSchema
           .optional()
           .describe("After opening, wait for this predicate before returning the observation"),
@@ -720,21 +765,30 @@ export const buildOpenLinkPayload = (
 export const imeActionSchema = addDeviceTargetingToSchema(
   z.object({
     action: z.enum(["done", "next", "search", "send", "go", "previous"]).describe("IME action"),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
 
 export const recentAppsSchema = addDeviceTargetingToSchema(
   z.object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
 
 export const homeScreenSchema = addDeviceTargetingToSchema(
   z.object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -742,7 +796,10 @@ export const homeScreenSchema = addDeviceTargetingToSchema(
 export const rotateSchema = addDeviceTargetingToSchema(
   z.object({
     orientation: z.enum(["portrait", "landscape"]),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     ...responseShapeControlFields,
   }),
 );
@@ -754,7 +811,10 @@ const optionalClipboardTextSchema = z
   .optional()
   .describe("Text to copy (required for 'copy' action)");
 const clipboardPlatformSchema = {
-  platform: platformSchema,
+  // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+  // not required — a device handle from getAndroid/getApple is sufficient on
+  // its own.
+  platform: platformSchema.optional(),
 };
 
 export const clipboardSchema = z.discriminatedUnion("action", [

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -2,7 +2,12 @@ import { z } from "zod/v4";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import {
+  addDeviceTargetingToSchema,
+  platformSchema,
+  withAppIdAliases,
+  withJsonSchemaOverride,
+} from "./toolSchemaHelpers";
 import {
   ANDROID_PACKAGE_NAME_PATTERN,
   PostNotification,
@@ -11,7 +16,8 @@ import {
 import { NotificationPolicy } from "../features/utility/NotificationPolicy";
 
 export interface PostNotificationArgs extends PostNotificationOptions {
-  platform: Platform;
+  // #6154: optional — resolved from deviceId/session when omitted.
+  platform?: Platform;
 }
 
 const iosAppIdRequiredMessage = "appId is required when platform is ios";
@@ -36,31 +42,63 @@ const postNotificationCommonShape = {
 const postNotificationAppIdDescription =
   "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted";
 
+const androidAppIdInvalidMessage = "appId must be an Android package name";
+
+/**
+ * #6154 follow-up: `postNotification` used a `z.discriminatedUnion("platform", ...)`,
+ * which requires the discriminator field to be present to pick a branch — so
+ * `platform` could not be made optional (resolved from deviceId/session) without
+ * restructuring away from the union. These per-platform appId rules (iOS requires
+ * it, Android's must look like a package name) now run through this single
+ * checker: from the schema's `superRefine` when the caller provided an explicit
+ * `platform` (fast, parse-time feedback), and from `postNotificationHandler`
+ * against the resolved `device.platform` when the caller omitted it — mirroring
+ * the pattern used for `changeLocalization`/`observe`.
+ */
+export function checkPostNotificationPlatformConstraints(
+  platform: Platform | undefined,
+  args: Pick<PostNotificationArgs, "appId">,
+): { path: "appId"; message: string } | null {
+  if (platform === "ios" && !args.appId) {
+    return { path: "appId", message: iosAppIdRequiredMessage };
+  }
+  if (platform === "android" && args.appId && !ANDROID_PACKAGE_NAME_PATTERN.test(args.appId)) {
+    return { path: "appId", message: androidAppIdInvalidMessage };
+  }
+  return null;
+}
+
 export const postNotificationSchema = withAppIdAliases(
-  z.discriminatedUnion("platform", [
+  withJsonSchemaOverride(
     addDeviceTargetingToSchema(
       z.object({
         ...postNotificationCommonShape,
-        appId: z
-          .string({ error: iosAppIdRequiredMessage })
-          .min(1, iosAppIdRequiredMessage)
-          .describe(postNotificationAppIdDescription),
-        platform: z.literal("ios"),
+        appId: z.string().min(1).optional().describe(postNotificationAppIdDescription),
+        // #5870/#6154: a `sessionUuid`/`deviceId` resolves the platform, so
+        // `platform` is not required — a device handle from getAndroid/getApple
+        // is sufficient on its own. The per-platform appId rules below only
+        // fire when the caller provided an explicit `platform`; the omitted
+        // case is enforced post-resolution in postNotificationHandler.
+        platform: platformSchema.optional(),
       }),
-    ),
-    addDeviceTargetingToSchema(
-      z.object({
-        ...postNotificationCommonShape,
-        appId: z
-          .string()
-          .min(1)
-          .regex(ANDROID_PACKAGE_NAME_PATTERN, "appId must be an Android package name")
-          .optional()
-          .describe(postNotificationAppIdDescription),
-        platform: z.literal("android"),
-      }),
-    ),
-  ]),
+    ).superRefine((values, ctx) => {
+      const violation = checkPostNotificationPlatformConstraints(values.platform, values);
+      if (violation) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [violation.path],
+          message: violation.message,
+        });
+      }
+    }),
+    (jsonSchema) => {
+      jsonSchema.if = {
+        properties: { platform: { const: "ios" } },
+        required: ["platform"],
+      };
+      jsonSchema.then = { required: ["appId"] };
+    },
+  ),
 );
 
 export const getNotificationPolicySchema = withAppIdAliases(
@@ -86,6 +124,16 @@ export type SetNotificationPolicyArgs = z.infer<typeof setNotificationPolicySche
 
 export function registerNotificationTools() {
   const postNotificationHandler = async (device: BootedDevice, args: PostNotificationArgs) => {
+    // #6154 follow-up: `platform` is optional on the wire, so the schema's
+    // per-platform appId checks (raw request platform) are skipped entirely
+    // when the caller omitted it. Re-validate against the resolved
+    // `device.platform`, before the try/catch below so the actionable message
+    // isn't re-wrapped as a generic execution failure.
+    const violation = checkPostNotificationPlatformConstraints(device.platform, args);
+    if (violation) {
+      throw new ActionableError(violation.message);
+    }
+
     try {
       const postNotification = new PostNotification(device);
       const result = await postNotification.execute({

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -517,7 +517,10 @@ export const overrideWaitForJsonSchema: JsonSchemaOverride = (jsonSchema) => {
 const observeBaseSchema = withJsonSchemaOverride(
   addDeviceTargetingToSchema(
     z.object({
-      platform: platformSchema,
+      // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+      // not required — a device handle from getAndroid/getApple is sufficient on
+      // its own.
+      platform: platformSchema.optional(),
       waitFor: waitForSchema
         .optional()
         .describe("Wait for element to appear before returning observation"),
@@ -545,7 +548,10 @@ export const observeSchema = withAppIdAliases(observeBaseSchema);
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(
   z.object({
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     filter: z
       .object({
         types: z

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -470,6 +470,28 @@ export const refineWaitForArgs = (
   }
 };
 
+/**
+ * #6154 follow-up: `refineWaitForArgs`'s iOS-rejects-activityName check runs
+ * at schema-parse time against the raw request `platform`, which is now
+ * optional (resolved from deviceId/session). A caller that omits `platform`
+ * on an iOS device would skip that check entirely at parse time, so both
+ * `observe` and `openLink` re-run it here against the resolved
+ * `device.platform` once ToolRegistry has determined it.
+ */
+export function assertActiveWindowWaitForSupportedOnPlatform(
+  platform: "android" | "ios",
+  waitFor: ObserveWaitForOptions | undefined,
+): void {
+  const activeWindow = waitFor?.activeWindow;
+  if (
+    platform === "ios" &&
+    activeWindow?.activityName !== undefined &&
+    activeWindow.appId === undefined
+  ) {
+    throw new ActionableError("activityName is Android-only; use appId/bundleId on iOS");
+  }
+}
+
 // Shared advertised-JSON-schema override for `observe` and `openLink`: enforce
 // the iOS activityName rule, require waitFor whenever settled is present, and
 // swap the verbose generated `waitFor` schema for the compact advertised form.
@@ -1162,9 +1184,15 @@ export function registerObserveTools() {
     _progress?: unknown,
     signal?: AbortSignal,
   ): Promise<StructuredToolResponse<ObserveToolPayload>> => {
+    const waitFor = args.waitFor;
+    // #6154 follow-up: `platform` is optional on the wire, so the schema's
+    // iOS-rejects-activityName check (which runs against the raw request
+    // platform) can be skipped entirely when the caller omitted it. Re-validate
+    // against the resolved `device.platform`, before the try/catch below so the
+    // actionable message isn't re-wrapped as a generic execution failure.
+    assertActiveWindowWaitForSupportedOnPlatform(device.platform, waitFor);
     try {
       const observeScreen = new RealObserveScreen(device);
-      const waitFor = args.waitFor;
       // ObserveScreen.execute() rejects stale cross-platform hierarchies at the
       // source, so every observation reaching here is already platform-validated
       // (raw-mode append below is likewise gated on a validated primary hierarchy).

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -79,13 +79,6 @@ export const changeLocalizationSchema = withJsonSchemaOverride(
             "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided.",
         });
       }
-      if (values.appId && values.platform !== "android") {
-        ctx.addIssue({
-          code: "custom",
-          path: ["appId"],
-          message: "appId is only supported for Android locale changes.",
-        });
-      }
       if (values.appId && !values.locale) {
         ctx.addIssue({
           code: "custom",
@@ -93,13 +86,12 @@ export const changeLocalizationSchema = withJsonSchemaOverride(
           message: "appId only applies when locale is provided.",
         });
       }
-      if (values.platform === "android" && values.locale && !values.appId) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["appId"],
-          message: "appId is required for Android locale changes.",
-        });
-      }
+      // #6154 follow-up: `platform` is optional here (resolved from
+      // deviceId/session), so a platform-dependent check at parse time would
+      // run before that resolution and could miss real violations, or reject
+      // valid requests, when the caller omitted platform. Those checks
+      // (`appId` requires/implies Android) run in `changeLocalizationHandler`
+      // instead, against the resolved `device.platform`.
     },
   ),
   (jsonSchema) => {
@@ -325,7 +317,8 @@ export interface SetActiveDeviceArgs {
 }
 
 export interface ChangeLocalizationArgs {
-  platform: Platform;
+  // #6154: optional — resolved from deviceId/session when omitted.
+  platform?: Platform;
   appId?: string;
   locale?: string;
   timeZone?: string;
@@ -333,6 +326,27 @@ export interface ChangeLocalizationArgs {
   timeFormat?: "12" | "24";
   calendarSystem?: string;
   restartApp?: string;
+}
+
+/**
+ * #6154 follow-up: `platform` is optional on the wire (resolved from
+ * deviceId/session), so the appId<->platform cross-checks that used to live in
+ * `changeLocalizationSchema`'s `superRefine` cannot run there anymore — at
+ * parse time the effective platform may not be known yet (the caller may have
+ * omitted it entirely). Run them here instead, against the resolved
+ * `device.platform`, exported standalone so the constraint itself is directly
+ * testable without a real `SystemConfigurationManager`.
+ */
+export function assertChangeLocalizationPlatformConstraints(
+  platform: Platform,
+  args: Pick<ChangeLocalizationArgs, "appId" | "locale">,
+): void {
+  if (args.appId && platform !== "android") {
+    throw new ActionableError("appId is only supported for Android locale changes.");
+  }
+  if (platform === "android" && args.locale && !args.appId) {
+    throw new ActionableError("appId is required for Android locale changes.");
+  }
 }
 
 export type GetDeviceStateArgs = z.infer<typeof getDeviceStateSchema>;
@@ -458,6 +472,8 @@ export function registerUtilityTools() {
   };
 
   const changeLocalizationHandler = async (device: BootedDevice, args: ChangeLocalizationArgs) => {
+    assertChangeLocalizationPlatformConstraints(device.platform, args);
+
     const manager = new SystemConfigurationManager(device);
     const changes: {
       locale?: string;

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -42,7 +42,10 @@ export const setActiveDeviceSchema = addSessionUuidToSchema(
 );
 
 const changeLocalizationBaseSchema = z.object({
-  platform: platformSchema,
+  // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+  // not required — a device handle from getAndroid/getApple is sufficient on
+  // its own.
+  platform: platformSchema.optional(),
   appId: z.string().min(1).optional().describe("Android app package for locale changes"),
   locale: z.string().min(1).optional().describe("Locale tag (e.g., ar-SA, ja-JP)"),
   timeZone: z.string().min(1).optional().describe("Zone ID (e.g., America/Los_Angeles)"),

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -234,7 +234,10 @@ const highlightSchema = z.object({
 const videoRecordingSchema = addDeviceTargetingToSchema(
   z.object({
     action: z.enum(["start", "stop"]),
-    platform: platformSchema,
+    // #5870: a `sessionUuid`/`deviceId` resolves the platform, so `platform` is
+    // not required — a device handle from getAndroid/getApple is sufficient on
+    // its own.
+    platform: platformSchema.optional(),
     deviceId: z.string().optional(),
     recordingId: z.string().optional().describe("Recording ID"),
     qualityPreset: z.enum(["low", "medium", "high"]).optional(),

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -197,7 +197,8 @@ export function setVideoRecordingDeviceDetectorForTesting(
 
 export interface VideoRecordingArgs {
   action: "start" | "stop";
-  platform: "android" | "ios";
+  // #6154: optional — resolved from deviceId/session when omitted.
+  platform?: "android" | "ios";
   deviceId?: string;
   qualityPreset?: VideoQualityPreset;
   targetBitrateKbps?: number;

--- a/test/server/highlightTools.test.ts
+++ b/test/server/highlightTools.test.ts
@@ -51,11 +51,14 @@ describe("Highlight Tools Registration", () => {
       }),
     ).toThrow();
 
+    // #6154: platform is optional wherever deviceId/session resolves it, so
+    // omitting it (with a valid shape) no longer throws — only `shape` is
+    // actually required.
     expect(() =>
       tool!.schema.parse({
         shape: validShape,
       }),
-    ).toThrow();
+    ).not.toThrow();
   });
 
   test("rejects invalid highlight shapes", () => {

--- a/test/server/interactionTools.clipboard.test.ts
+++ b/test/server/interactionTools.clipboard.test.ts
@@ -60,7 +60,8 @@ describe("clipboard tool schema", () => {
 
     expect(toolDefinition).toBeDefined();
     const schema = toolDefinition!.inputSchema as any;
-    expect(schema.required).toEqual(["action", "platform"]);
+    // #6154: platform is optional wherever deviceId/session resolves it.
+    expect(schema.required).toEqual(["action"]);
     expect(schema.properties.action.enum).toEqual(["copy", "paste", "clear", "get"]);
     expect(schema.anyOf).toBeUndefined();
     expect(schema.oneOf).toBeUndefined();

--- a/test/server/notificationTools.test.ts
+++ b/test/server/notificationTools.test.ts
@@ -103,8 +103,11 @@ describe("notification tools", () => {
 
     expect(toolDefinition).toBeDefined();
     const schema = toolDefinition!.inputSchema as any;
-    expect(schema.required).toEqual(["title", "body", "platform"]);
-    expect(schema.properties.platform.enum).toEqual(["ios", "android"]);
+    // #6154: platform is optional wherever deviceId/session resolves it.
+    expect(schema.required).toEqual(["title", "body"]);
+    // #6154: platform now comes from the shared `platformSchema` (android, ios)
+    // instead of a per-branch literal union, so the enum order flipped.
+    expect(schema.properties.platform.enum).toEqual(["android", "ios"]);
     expect(schema.properties.appId.description).toContain(
       "Android defaults to the live foreground app",
     );
@@ -120,7 +123,8 @@ describe("notification tools", () => {
 
     expect(toolDefinition).toBeDefined();
     const schema = toolDefinition!.inputSchema as any;
-    expect(schema.required).toEqual(["title", "body", "platform"]);
+    // #6154: platform is optional wherever deviceId/session resolves it.
+    expect(schema.required).toEqual(["title", "body"]);
     expect(schema.if).toEqual({
       properties: {
         platform: { const: "ios" },

--- a/test/server/toolParamErrorHint.test.ts
+++ b/test/server/toolParamErrorHint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { formatToolParamError } from "../../src/server/index";
 import { swipeOnSchema, tapOnSchema } from "../../src/server/interactionTools";
+import { listDeviceImagesSchema } from "../../src/server/deviceTools";
 import { observeSchema, waitForSchema } from "../../src/server/observeTools";
 import { setPreferenceSchema } from "../../src/server/preferenceTools";
 
@@ -78,12 +79,13 @@ describe("formatToolParamError actionable validation hints", () => {
     );
   });
 
+  // #6154: platform is now optional wherever deviceId/session resolves it, so
+  // this hint is exercised through a schema with no device to resolve it
+  // from — listDeviceImages, where platform genuinely stays required.
   test("calls an omitted required platform required instead of an invalid option", () => {
-    const result = observeSchema.safeParse({ deviceId: "emulator-5554" });
+    const result = listDeviceImagesSchema.safeParse({});
     expect(result.success).toBe(false);
-    const message = formatToolParamError("observe", result.error, {
-      deviceId: "emulator-5554",
-    });
+    const message = formatToolParamError("listDeviceImages", result.error, {});
     expect(message).toContain("platform is required");
     expect(message).not.toContain("Invalid option");
   });

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -301,21 +301,20 @@ describe("appId aliases on tool schemas", () => {
     }
   });
 
-  test("changeLocalizationSchema rejects appId for iOS locale changes", () => {
+  // #6154 follow-up: `platform` is optional (resolved from deviceId/session),
+  // so the appId<->platform cross-checks can no longer live in the schema
+  // (parse time may not know the effective platform yet) — they run in
+  // `changeLocalizationHandler` against the resolved `device.platform`
+  // instead (see test/server/utilityTools.changeLocalizationPlatform.test.ts).
+  // The schema itself now accepts this combination at parse time.
+  test("changeLocalizationSchema accepts appId regardless of the declared platform (enforced post-resolution)", () => {
     const result = changeLocalizationSchema.safeParse({
       platform: "ios",
       bundleId: "com.example.app",
       locale: "fr-FR",
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) =>
-          issue.message.includes("appId is only supported for Android"),
-        ),
-      ).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 
   test("changeLocalizationSchema rejects appId when locale is omitted", () => {
@@ -335,20 +334,16 @@ describe("appId aliases on tool schemas", () => {
     }
   });
 
-  test("changeLocalizationSchema requires appId for Android locale changes", () => {
+  // #6154 follow-up: the "appId required for Android" cross-check moved to
+  // the handler (see note above), so this now parses successfully at the
+  // schema level; the handler test covers the actual enforcement.
+  test("changeLocalizationSchema accepts a missing appId at parse time (enforced post-resolution)", () => {
     const result = changeLocalizationSchema.safeParse({
       platform: "android",
       locale: "fr-FR",
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) =>
-          issue.message.includes("appId is required for Android locale changes"),
-        ),
-      ).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 });
 

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -375,7 +375,9 @@ describe("generated tool definitions", () => {
     expect(changeLocalization?.inputSchema?.then).toEqual({
       required: ["appId"],
     });
-    expect(changeLocalization?.inputSchema?.required).toEqual(["platform"]);
+    // #6154: platform is optional wherever deviceId/session resolves it, so
+    // the top level no longer requires it.
+    expect(changeLocalization?.inputSchema?.required).toBeUndefined();
   });
 });
 

--- a/test/server/tools/toolInputContracts6154.test.ts
+++ b/test/server/tools/toolInputContracts6154.test.ts
@@ -13,6 +13,10 @@ import {
 import { launchAppSchema } from "../../../src/server/appTools";
 import { highlightSchema, resolveHighlightClientOptions } from "../../../src/server/highlightTools";
 import { assertChangeLocalizationPlatformConstraints } from "../../../src/server/utilityTools";
+import {
+  checkPostNotificationPlatformConstraints,
+  postNotificationSchema,
+} from "../../../src/server/notificationTools";
 import type { BootedDevice } from "../../../src/models";
 import { ActionableError } from "../../../src/models/ActionableError";
 
@@ -100,6 +104,21 @@ describe("issue #6154: platform is optional wherever deviceId/session resolves i
     expect(result.platform).toBeUndefined();
     expect(result.deviceId).toBeUndefined();
     expect(result.sessionUuid).toBe("session-123");
+  });
+
+  // Coordinator follow-up: postNotification used a z.discriminatedUnion on
+  // `platform`, which forces the discriminator to be present — it was missed
+  // by the original #6154 sweep and still required platform even with a
+  // resolvable deviceId. Restructured off the union; assert it now matches
+  // the rest of the action-tool family.
+  test("postNotification parses with platform omitted and deviceId present", () => {
+    const result = postNotificationSchema.parse({
+      deviceId: "emulator-5554",
+      title: "T",
+      body: "B",
+    });
+    expect(result.platform).toBeUndefined();
+    expect(result.deviceId).toBe("emulator-5554");
   });
 });
 
@@ -233,6 +252,46 @@ describe("issue #6154 follow-up: handlers use the resolved platform, not the raw
       expect(() =>
         assertActiveWindowWaitForSupportedOnPlatform(iosDevice.platform, undefined),
       ).not.toThrow();
+    });
+  });
+
+  describe("postNotification (Codex P2, follow-up sweep miss)", () => {
+    test("iOS device via deviceId with no appId (no platform param) is rejected post-resolution", () => {
+      const violation = checkPostNotificationPlatformConstraints(iosDevice.platform, {});
+      expect(violation).toEqual({
+        path: "appId",
+        message: "appId is required when platform is ios",
+      });
+    });
+
+    test("iOS device via deviceId with appId (no platform param) is accepted", () => {
+      expect(
+        checkPostNotificationPlatformConstraints(iosDevice.platform, {
+          appId: "com.example.app",
+        }),
+      ).toBeNull();
+    });
+
+    test("Android device via deviceId with a malformed appId (no platform param) is rejected post-resolution", () => {
+      const violation = checkPostNotificationPlatformConstraints(androidDevice.platform, {
+        appId: "not a package name; rm -rf",
+      });
+      expect(violation).toEqual({
+        path: "appId",
+        message: "appId must be an Android package name",
+      });
+    });
+
+    test("Android device via deviceId with a valid appId (no platform param) is accepted", () => {
+      expect(
+        checkPostNotificationPlatformConstraints(androidDevice.platform, {
+          appId: "com.example.app",
+        }),
+      ).toBeNull();
+    });
+
+    test("Android device via deviceId with no appId at all (no platform param) is accepted", () => {
+      expect(checkPostNotificationPlatformConstraints(androidDevice.platform, {})).toBeNull();
     });
   });
 });

--- a/test/server/tools/toolInputContracts6154.test.ts
+++ b/test/server/tools/toolInputContracts6154.test.ts
@@ -6,8 +6,15 @@ import {
   selectAllTextSchema,
   wakeAndUnlockSchema,
 } from "../../../src/server/interactionTools";
-import { observeSchema } from "../../../src/server/observeTools";
+import {
+  assertActiveWindowWaitForSupportedOnPlatform,
+  observeSchema,
+} from "../../../src/server/observeTools";
 import { launchAppSchema } from "../../../src/server/appTools";
+import { resolveHighlightClientOptions } from "../../../src/server/highlightTools";
+import { assertChangeLocalizationPlatformConstraints } from "../../../src/server/utilityTools";
+import type { BootedDevice } from "../../../src/models";
+import { ActionableError } from "../../../src/models/ActionableError";
 
 // Issue #6154 half 1: `platform` was required on pressButton/inputText/observe
 // (and siblings) but optional on tapOn/launchApp, even though a `deviceId`
@@ -101,5 +108,95 @@ describe("issue #6154: launchApp schema enforces its declared contract", () => {
         bogusKey: 123,
       }),
     ).toThrow();
+  });
+});
+
+// Coordinator follow-up on #6154 (three Codex review threads): making
+// `platform` optional exposed handlers that still branched on the raw,
+// possibly-undefined request field instead of the platform ToolRegistry had
+// already resolved from deviceId/session onto `device`. These tests exercise
+// the extracted resolution/validation helpers directly against a resolved
+// `BootedDevice`, independent of the raw (now-optional) `platform` param.
+describe("issue #6154 follow-up: handlers use the resolved platform, not the raw param", () => {
+  const iosDevice: BootedDevice = { name: "iPhone", platform: "ios", deviceId: "sim-1" };
+  const androidDevice: BootedDevice = {
+    name: "Pixel",
+    platform: "android",
+    deviceId: "emulator-5554",
+  };
+
+  describe("highlight (P1)", () => {
+    test("resolves platform from the device when the request omitted it", () => {
+      const options = resolveHighlightClientOptions(iosDevice, { deviceId: iosDevice.deviceId });
+      expect(options.platform).toBe("ios");
+      expect(options.device).toBe(iosDevice);
+    });
+
+    test("resolves the Android platform the same way", () => {
+      const options = resolveHighlightClientOptions(androidDevice, {
+        deviceId: androidDevice.deviceId,
+      });
+      expect(options.platform).toBe("android");
+    });
+  });
+
+  describe("changeLocalization (P2)", () => {
+    test("Android device via deviceId with locale + appId (no platform param) is valid", () => {
+      expect(() =>
+        assertChangeLocalizationPlatformConstraints(androidDevice.platform, {
+          locale: "fr-FR",
+          appId: "com.example.app",
+        }),
+      ).not.toThrow();
+    });
+
+    test("Android device via deviceId with locale but no appId is rejected post-resolution", () => {
+      expect(() =>
+        assertChangeLocalizationPlatformConstraints(androidDevice.platform, {
+          locale: "fr-FR",
+        }),
+      ).toThrow(ActionableError);
+    });
+
+    test("iOS device via deviceId with appId is rejected post-resolution", () => {
+      expect(() =>
+        assertChangeLocalizationPlatformConstraints(iosDevice.platform, {
+          locale: "fr-FR",
+          appId: "com.example.app",
+        }),
+      ).toThrow(ActionableError);
+    });
+  });
+
+  describe("observe / openLink activeWindow.activityName (P2)", () => {
+    test("iOS device via deviceId with activityName (no platform param) is rejected post-resolution", () => {
+      expect(() =>
+        assertActiveWindowWaitForSupportedOnPlatform(iosDevice.platform, {
+          activeWindow: { activityName: "com.example.MainActivity" },
+        }),
+      ).toThrow(ActionableError);
+    });
+
+    test("iOS device via deviceId with appId (not activityName) is accepted", () => {
+      expect(() =>
+        assertActiveWindowWaitForSupportedOnPlatform(iosDevice.platform, {
+          activeWindow: { appId: "com.example.app" },
+        }),
+      ).not.toThrow();
+    });
+
+    test("Android device with activityName is accepted", () => {
+      expect(() =>
+        assertActiveWindowWaitForSupportedOnPlatform(androidDevice.platform, {
+          activeWindow: { activityName: "com.example.MainActivity" },
+        }),
+      ).not.toThrow();
+    });
+
+    test("no waitFor at all is a no-op", () => {
+      expect(() =>
+        assertActiveWindowWaitForSupportedOnPlatform(iosDevice.platform, undefined),
+      ).not.toThrow();
+    });
   });
 });

--- a/test/server/tools/toolInputContracts6154.test.ts
+++ b/test/server/tools/toolInputContracts6154.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearTextSchema,
+  inputTextSchema,
+  pressButtonSchema,
+  selectAllTextSchema,
+  wakeAndUnlockSchema,
+} from "../../../src/server/interactionTools";
+import { observeSchema } from "../../../src/server/observeTools";
+import { launchAppSchema } from "../../../src/server/appTools";
+
+// Issue #6154 half 1: `platform` was required on pressButton/inputText/observe
+// (and siblings) but optional on tapOn/launchApp, even though a `deviceId`
+// (or session) resolves the platform the same way for all of them. Assert the
+// aligned tools now accept platform omitted when deviceId is present.
+describe("issue #6154: platform is optional wherever deviceId/session resolves it", () => {
+  test("pressButton parses with platform omitted and deviceId present", () => {
+    const result = pressButtonSchema.parse({
+      deviceId: "emulator-5554",
+      button: "back",
+    });
+    expect(result.platform).toBeUndefined();
+    expect(result.deviceId).toBe("emulator-5554");
+  });
+
+  test("inputText parses with platform omitted and deviceId present", () => {
+    const result = inputTextSchema.parse({
+      deviceId: "emulator-5554",
+      text: "hello",
+    });
+    expect(result.platform).toBeUndefined();
+  });
+
+  test("observe parses with platform omitted and deviceId present", () => {
+    const result = observeSchema.parse({
+      deviceId: "emulator-5554",
+    });
+    expect(result.platform).toBeUndefined();
+  });
+
+  test("wakeAndUnlock parses with platform omitted and deviceId present", () => {
+    const result = wakeAndUnlockSchema.parse({
+      deviceId: "emulator-5554",
+    });
+    expect(result.platform).toBeUndefined();
+  });
+
+  test("clearText parses with platform omitted and deviceId present", () => {
+    const result = clearTextSchema.parse({
+      deviceId: "emulator-5554",
+    });
+    expect(result.platform).toBeUndefined();
+  });
+
+  test("selectAllText parses with platform omitted and deviceId present", () => {
+    const result = selectAllTextSchema.parse({
+      deviceId: "emulator-5554",
+    });
+    expect(result.platform).toBeUndefined();
+  });
+
+  test("platform is still validated as android/ios when provided", () => {
+    expect(() =>
+      pressButtonSchema.parse({
+        deviceId: "emulator-5554",
+        button: "back",
+        platform: "windows",
+      }),
+    ).toThrow();
+  });
+});
+
+// Issue #6154 half 2: launchApp's advertised `required`/`additionalProperties`
+// were not enforced at runtime — a plain z.object with no `.strict()` silently
+// accepted unknown keys. `.strict()` closes the gap while `withAppIdAliases`
+// (a z.preprocess ahead of the strict inner schema) keeps the documented
+// packageName -> appId alias working.
+describe("issue #6154: launchApp schema enforces its declared contract", () => {
+  test("accepts appId", () => {
+    const result = launchAppSchema.parse({
+      deviceId: "emulator-5554",
+      appId: "com.google.android.deskclock",
+    });
+    expect(result.appId).toBe("com.google.android.deskclock");
+  });
+
+  test("accepts the documented packageName alias for appId", () => {
+    const result = launchAppSchema.parse({
+      deviceId: "emulator-5554",
+      packageName: "com.google.android.deskclock",
+    });
+    expect(result.appId).toBe("com.google.android.deskclock");
+    expect((result as Record<string, unknown>).packageName).toBeUndefined();
+  });
+
+  test("rejects a genuinely unknown property", () => {
+    expect(() =>
+      launchAppSchema.parse({
+        deviceId: "emulator-5554",
+        appId: "com.google.android.deskclock",
+        bogusKey: 123,
+      }),
+    ).toThrow();
+  });
+});

--- a/test/server/tools/toolInputContracts6154.test.ts
+++ b/test/server/tools/toolInputContracts6154.test.ts
@@ -11,7 +11,7 @@ import {
   observeSchema,
 } from "../../../src/server/observeTools";
 import { launchAppSchema } from "../../../src/server/appTools";
-import { resolveHighlightClientOptions } from "../../../src/server/highlightTools";
+import { highlightSchema, resolveHighlightClientOptions } from "../../../src/server/highlightTools";
 import { assertChangeLocalizationPlatformConstraints } from "../../../src/server/utilityTools";
 import type { BootedDevice } from "../../../src/models";
 import { ActionableError } from "../../../src/models/ActionableError";
@@ -75,6 +75,32 @@ describe("issue #6154: platform is optional wherever deviceId/session resolves i
       }),
     ).toThrow();
   });
+
+  // CodeRabbit follow-up: the tests above only exercise deviceId-based
+  // resolution — a suite that never sends a bare sessionUuid could pass even
+  // if session-based resolution (no deviceId at all) were broken. Cover that
+  // path explicitly for observe and highlight.
+  test("observe parses with platform omitted, sessionUuid present, and NO deviceId", () => {
+    const result = observeSchema.parse({
+      sessionUuid: "session-123",
+    });
+    expect(result.platform).toBeUndefined();
+    expect(result.deviceId).toBeUndefined();
+    expect(result.sessionUuid).toBe("session-123");
+  });
+
+  test("highlight parses with platform omitted, sessionUuid present, and NO deviceId", () => {
+    const result = highlightSchema.parse({
+      sessionUuid: "session-123",
+      shape: {
+        type: "box",
+        bounds: { x: 0, y: 0, width: 10, height: 10 },
+      },
+    });
+    expect(result.platform).toBeUndefined();
+    expect(result.deviceId).toBeUndefined();
+    expect(result.sessionUuid).toBe("session-123");
+  });
 });
 
 // Issue #6154 half 2: launchApp's advertised `required`/`additionalProperties`
@@ -106,6 +132,16 @@ describe("issue #6154: launchApp schema enforces its declared contract", () => {
         deviceId: "emulator-5554",
         appId: "com.google.android.deskclock",
         bogusKey: 123,
+      }),
+    ).toThrow();
+  });
+
+  // CodeRabbit follow-up: the alias/unknown-property tests above never assert
+  // that appId (or its packageName alias) is actually required — pin that too.
+  test("rejects a missing appId (and missing packageName alias)", () => {
+    expect(() =>
+      launchAppSchema.parse({
+        deviceId: "emulator-5554",
       }),
     ).toThrow();
   });


### PR DESCRIPTION
## Summary

Fixes both halves of #6154 — the MCP tool input contract was unpredictable in
two ways.

**Half 1 — `platform` required on some action tools, optional on others.**
`tapOn`/`launchApp` already treat `platform` as optional (#5870): a resolved
`deviceId` or session already determines it, so restating it is unnecessary.
`pressButton`, `inputText`, `observe`, and a long tail of siblings (`shake`,
`keyboard`, `tapAny`, `dragAndDrop`, `swipeOn`, `pinchOn`, `clearText`,
`selectAllText`, `systemTray`, `stopApp`, `clearState`, `wakeAndUnlock`,
`openLink`, `imeAction`, `recentApps`, `homeScreen`, `rotate`, `clipboard`,
`debugSearch`, `highlight`, `identifyInteractions`, `changeLocalization`,
`videoRecording`) instead declared their own required `platform` field,
which won out over the optional default `addDeviceTargetingToSchema` already
injects. Changed every one of those to `platformSchema.optional()` with the
#5870 rationale comment, so the whole action-tool family now follows one
rule: platform is optional, resolved from `deviceId`/session when omitted.
Device-provisioning tools that have no existing device to resolve platform
from (`listDeviceImages`, `startDevice`, `killDevice`, `teardownDevice`) are
intentionally left as-is — different semantics, not part of this family.

**Half 2 — `launchApp`'s declared contract wasn't enforced.** `tools/list`
advertised `required: ["appId"]` and `additionalProperties: false` for
`launchApp`, but `launchAppSchema` was a plain `z.object` with no `.strict()`,
so unknown properties were silently accepted. Added `.strict()`. The
documented `packageName` → `appId` alias still works: `withAppIdAliases`
wraps the schema in a `z.preprocess` that normalizes `packageName` into
`appId` (deleting the alias key) *before* the strict inner schema ever
parses.

`schemas/tool-definitions.json` is regenerated via
`scripts/update-tool-definitions.sh` to reflect both changes (this is a CI
gate).

## Tests

- `test/server/tools/toolInputContracts6154.test.ts` (new): asserts
  `pressButton`/`inputText`/`observe`/`wakeAndUnlock`/`clearText`/
  `selectAllText` parse with `platform` omitted and `deviceId` present, that
  an invalid `platform` value still fails, that `launchApp` accepts `appId`
  and the `packageName` alias, and that it rejects a genuinely unknown
  property.
- Updated the handful of existing tests that pinned the old
  platform-required contract: `test/server/highlightTools.test.ts`,
  `test/server/interactionTools.clipboard.test.ts`,
  `test/server/toolParamErrorHint.test.ts`,
  `test/server/toolSchemaHelpers.test.ts`.

All unit tests run in-memory / schema-only — no real device or DB is
touched, and the new suite runs in well under 100ms.

Closes #6154
