### PR TITLE
fix(server): echo client progressToken instead of fabricating one

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -476,13 +476,24 @@ export class DaemonClient {
   }
 
   /**
-   * Call a tool on the daemon
+   * Call a tool on the daemon. `progressToken` echoes the MCP client's own
+   * `params._meta.progressToken` (issue #6205) so the daemon can relay
+   * `notifications/progress` ticks back tagged with that SAME token — omit it
+   * to request no progress relay, never fabricate one downstream.
    */
-  async callTool(toolName: string, params: Record<string, any>): Promise<any> {
-    return this.sendRequest("tools/call", {
-      name: toolName,
-      arguments: params,
-    });
+  async callTool(
+    toolName: string,
+    params: Record<string, any>,
+    progressToken?: string | number,
+  ): Promise<any> {
+    return this.sendRequest(
+      "tools/call",
+      {
+        name: toolName,
+        arguments: params,
+      },
+      progressToken,
+    );
   }
 
   /**
@@ -492,7 +503,11 @@ export class DaemonClient {
     return this.sendRequest("resources/read", { uri, ...params });
   }
 
-  private async sendRequest(method: string, params: Record<string, any>): Promise<any> {
+  private async sendRequest(
+    method: string,
+    params: Record<string, any>,
+    progressToken?: string | number,
+  ): Promise<any> {
     // Ensure we're connected
     if (!this.connected) {
       await this.connect();
@@ -505,6 +520,7 @@ export class DaemonClient {
       type: "mcp_request",
       method,
       params,
+      ...(progressToken !== undefined ? { progressToken } : {}),
       ...this.handshakeFields(),
     };
 
@@ -617,7 +633,11 @@ export class DaemonClient {
 export interface DaemonClientLike {
   connect(timeoutMs?: number, signal?: AbortSignal): Promise<void>;
   close(): Promise<void>;
-  callTool(toolName: string, params: Record<string, any>): Promise<any>;
+  callTool(
+    toolName: string,
+    params: Record<string, any>,
+    progressToken?: string | number,
+  ): Promise<any>;
   readResource(uri: string, params?: Record<string, any>): Promise<any>;
   callDaemonMethod(method: string, params: Record<string, any>): Promise<any>;
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -19,7 +19,7 @@ import {
   DAEMON_BOUND_SESSION_PARAM,
   DAEMON_RELEASED_SESSION_PARAM,
 } from "./constants";
-import type { DaemonNotification, DaemonOptions } from "./types";
+import { PROGRESS_NOTIFICATION_METHOD, type DaemonNotification, type DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBroadcast";
 import {
@@ -273,6 +273,17 @@ export class DaemonToolUnavailableError extends Error {
     this.daemonBuildId = params.daemon.buildId;
   }
 }
+
+/**
+ * Callback for a relayed `notifications/progress` tick (issue #6205), mirroring
+ * `ProgressCallback` in `src/server/toolRegistry.ts` without importing the
+ * server's tool-registry module from the daemon layer.
+ */
+export type DaemonProxyProgressCallback = (
+  progress: number,
+  total?: number,
+  message?: string,
+) => void;
 
 /**
  * Configuration for the DaemonMcpProxy
@@ -732,6 +743,12 @@ export class DaemonMcpProxy {
   // Listeners for daemon-forwarded list-changed notifications (issue #3223),
   // fired after the matching cache is invalidated so a re-fetch is never stale.
   private readonly listChangedListeners = new Set<(kind: ListChangedKind) => void>();
+  // In-flight `callTool` progress callbacks keyed by the client's own
+  // progressToken (issue #6205) — registered just before forwarding and
+  // removed in the call's `finally`, so a relayed `notifications/progress`
+  // frame is routed to the right caller purely by echoing that token, with no
+  // daemon-fabricated correlation id needed.
+  private readonly progressListeners = new Map<string | number, DaemonProxyProgressCallback>();
   // Releases this proxy's handler on the current client. Needed because a
   // clientFactory may return a shared/reused client (test fakes do); without it
   // every reconnect would stack another handler on that client.
@@ -964,6 +981,11 @@ export class DaemonMcpProxy {
       return;
     }
 
+    if (notification.method === PROGRESS_NOTIFICATION_METHOD) {
+      this.handleProgressNotification(notification);
+      return;
+    }
+
     const kind = listChangedKindForMethod(notification.method);
     if (kind === undefined) {
       // Unknown pushed methods are expected as the daemon grows new
@@ -991,6 +1013,30 @@ export class DaemonMcpProxy {
         // break cache invalidation or sibling listeners.
         logger.warn(`[DaemonMcpProxy] list_changed listener failed for ${kind}: ${error}`);
       }
+    }
+  }
+
+  // Route a relayed `notifications/progress` frame to the caller that
+  // registered for its token (issue #6205). A token with no registered
+  // listener (the call already completed, or a stray/unexpected frame) is
+  // silently dropped — never surfaced as an error, since a race between the
+  // final tick and call completion is expected.
+  private handleProgressNotification(notification: DaemonNotification): void {
+    if (notification.progressToken === undefined || notification.progress === undefined) {
+      return;
+    }
+    const listener = this.progressListeners.get(notification.progressToken);
+    if (!listener) {
+      return;
+    }
+    try {
+      listener(notification.progress, notification.total, notification.message);
+    } catch (error) {
+      // Best-effort: a throwing progress consumer must never break the
+      // notification channel or the in-flight tool call it belongs to.
+      logger.warn(
+        `[DaemonMcpProxy] progress listener failed for token ${notification.progressToken}: ${error}`,
+      );
     }
   }
 
@@ -1633,9 +1679,18 @@ export class DaemonMcpProxy {
   }
 
   /**
-   * Call a tool on the daemon
+   * Call a tool on the daemon. `progressToken` echoes the external MCP
+   * client's own `params._meta.progressToken` (issue #6205); when present it
+   * is forwarded to the daemon so `notifications/progress` ticks relayed back
+   * over the socket can be routed to `onProgress`, tagged with that SAME
+   * token. Omit both to request no progress relay — nothing is fabricated.
    */
-  async callTool(name: string, args: Record<string, unknown>): Promise<any> {
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+    progressToken?: string | number,
+    onProgress?: DaemonProxyProgressCallback,
+  ): Promise<any> {
     // Device-session acquisition (getAndroid/getApple/startDevice) mints a NEW
     // session in its RESULT and is never routed to — or fenced by — the connection's
     // bound session: it must be admitted even on a terminally fenced connection so
@@ -1659,11 +1714,14 @@ export class DaemonMcpProxy {
     // UNRELATED session bumps the global epoch but not the forwarded UUID's entry,
     // so it does not block remembering the session this call forwarded.
     const callReleaseEpoch = this.releaseEpoch;
+    if (progressToken !== undefined && onProgress) {
+      this.progressListeners.set(progressToken, onProgress);
+    }
     try {
       const result = await this.withRecoverableReconnect(
         () => {
           this.throwIfForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch);
-          return this.client!.callTool(name, forwardedArgs);
+          return this.client!.callTool(name, forwardedArgs, progressToken);
         },
         forwardedSessionUuid,
         // Acquisition is admitted while fenced; the terminal fence is cleared once
@@ -1713,6 +1771,9 @@ export class DaemonMcpProxy {
       throw error;
     } finally {
       this.releaseReleaseEpochReference(forwardedSessionUuid);
+      if (progressToken !== undefined) {
+        this.progressListeners.delete(progressToken);
+      }
     }
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -13,7 +13,13 @@ import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS } from "../utils/deviceTimeouts";
 import { errorMessage } from "../utils/describeUnknownError";
-import { DaemonNotification, DaemonRequest, DaemonResponse, SessionContext } from "./types";
+import {
+  DaemonNotification,
+  DaemonRequest,
+  DaemonResponse,
+  PROGRESS_NOTIFICATION_METHOD,
+  SessionContext,
+} from "./types";
 import {
   SOCKET_PATH,
   DAEMON_HANDSHAKE_ENABLED,
@@ -603,6 +609,41 @@ export class UnixSocketServer {
       }
       this.writeFrame(socket, sessionId, notification);
     }
+  }
+
+  /**
+   * Push one `notifications/progress` tick to the SINGLE socket session that
+   * requested it (issue #6205), carrying the SAME `progressToken` that
+   * session's `tools/call` request declared. Unlike the broadcast helpers
+   * above, this targets exactly one socket rather than every subscriber — the
+   * per-session request queue serializes `tools/call`s, so at most one call is
+   * ever in flight per session and no correlation beyond the token is needed.
+   * Best-effort and gated on the opt-in subscription, matching the broadcast
+   * helpers: an unsubscribed or already-torn-down socket is silently skipped.
+   */
+  private pushProgressNotification(
+    sessionId: string,
+    progressToken: string | number,
+    progress: number,
+    total?: number,
+    message?: string,
+  ): void {
+    if (!this.notificationSubscribers.has(sessionId)) {
+      return;
+    }
+    const socket = this.clientSockets.get(sessionId);
+    if (!socket) {
+      return;
+    }
+    const notification: DaemonNotification = {
+      type: "daemon_notification",
+      method: PROGRESS_NOTIFICATION_METHOD,
+      progressToken,
+      progress,
+      ...(total !== undefined ? { total } : {}),
+      ...(message !== undefined ? { message } : {}),
+    };
+    this.writeFrame(socket, sessionId, notification);
   }
 
   private writeFrame(
@@ -3910,6 +3951,7 @@ export class UnixSocketServer {
         return await mcpClient.listTools();
       }
       case "tools/call": {
+        const progressToken = request.progressToken;
         return await mcpClient.callTool(
           {
             name: request.params.name,
@@ -3920,7 +3962,28 @@ export class UnixSocketServer {
             ),
           },
           undefined,
-          requestOptions,
+          {
+            ...requestOptions,
+            // Relay progress ticks back to the ORIGINATING socket session,
+            // tagged with the client's own token — never a daemon-fabricated
+            // one, and never sent when the client asked for none (#6205).
+            ...(progressToken !== undefined
+              ? {
+                  onprogress: (notification: {
+                    progress: number;
+                    total?: number;
+                    message?: string;
+                  }) =>
+                    this.pushProgressNotification(
+                      socketSessionId,
+                      progressToken,
+                      notification.progress,
+                      notification.total,
+                      notification.message,
+                    ),
+                }
+              : {}),
+          },
         );
       }
       case "resources/list": {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -28,6 +28,14 @@ export interface DaemonRequest {
   clientBuildId?: string;
   /** Absolute path to the client's entry script (build-identity fallback). */
   clientEntryScript?: string;
+  /**
+   * Echo of the MCP client's own `params._meta.progressToken` for a `tools/call`
+   * request (issue #6205). When present the daemon relays `notifications/progress`
+   * ticks for this call back to the requesting socket session carrying this SAME
+   * token, mirroring the direct-server fix (#6118); when absent no progress is
+   * relayed, never fabricated.
+   */
+  progressToken?: string | number;
 }
 
 /**
@@ -59,6 +67,13 @@ export interface DaemonResponse {
 }
 
 /**
+ * Wire method for a relayed progress tick (issue #6205). Shared by the socket
+ * server's push (`pushProgressNotification`) and the proxy's inbound dispatch
+ * (`handleDaemonNotification`) so the two ends can never drift.
+ */
+export const PROGRESS_NOTIFICATION_METHOD = "notifications/progress";
+
+/**
  * Server-pushed notification frame sent from daemon to a subscribed CLI client
  * over the control socket (issue #3223). Unlike {@link DaemonResponse} it has no
  * `id` — it does not correlate to a request. Clients discriminate on `type`.
@@ -79,6 +94,19 @@ export interface DaemonNotification {
   reason?: string;
   /** Authoritative terminal state captured before SessionManager removed it. */
   release?: SessionReleaseSnapshot;
+  /**
+   * The client-supplied progress token this tick belongs to, for
+   * `notifications/progress` frames (issue #6205) — echoed verbatim from the
+   * `tools/call` {@link DaemonRequest.progressToken} that requested it, never a
+   * daemon-fabricated value. Absent for every other notification method.
+   */
+  progressToken?: string | number;
+  /** Progress value for `notifications/progress` frames. */
+  progress?: number;
+  /** Optional total for `notifications/progress` frames. */
+  total?: number;
+  /** Optional human-readable status for `notifications/progress` frames. */
+  message?: string;
 }
 
 /** Discriminates a daemon socket frame as a server-pushed notification. */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -631,25 +631,32 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           }
         : parsedParams;
 
-    // Create progress callback if tool supports progress
-    const progressCallback = tool.supportsProgress
-      ? async (progress: number, total?: number, message?: string) => {
-          try {
-            await server.server.notification({
-              method: "notifications/progress",
-              params: {
-                progressToken: `${name}-${defaultTimer.now()}`,
-                progress,
-                total,
-                ...(message && { message }),
-              },
-            });
-          } catch (error) {
-            // Log progress notification errors but don't fail the tool execution
-            logger.warn(`Failed to send progress notification: ${error}`);
+    // Create progress callback if the tool supports progress AND the client
+    // asked for it. Per the MCP spec, progress notifications must echo the
+    // token the client supplied in `params._meta.progressToken` — a
+    // server-fabricated token has no registered handler on the client, so
+    // sending one for a request that never asked is worse than sending none
+    // (issue #6118).
+    const requestProgressToken = extra._meta?.progressToken;
+    const progressCallback =
+      tool.supportsProgress && requestProgressToken !== undefined
+        ? async (progress: number, total?: number, message?: string) => {
+            try {
+              await extra.sendNotification({
+                method: "notifications/progress",
+                params: {
+                  progressToken: requestProgressToken,
+                  progress,
+                  total,
+                  ...(message && { message }),
+                },
+              });
+            } catch (error) {
+              // Log progress notification errors but don't fail the tool execution
+              logger.warn(`Failed to send progress notification: ${error}`);
+            }
           }
-        }
-      : undefined;
+        : undefined;
 
     try {
       if (

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -211,7 +211,7 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
   });
 
   // Register tools/call handler - forward to daemon
-  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const name = request.params.name;
     const args = (request.params.arguments || {}) as Record<string, unknown>;
 
@@ -221,8 +221,32 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
 
     logger.info(`[ProxyServer] Forwarding tool call: ${name}`);
 
+    // Echo the CLIENT's own progress token through the daemon round trip
+    // (issue #6205) — the direct server (#6118) already refuses to fabricate
+    // one, and the proxy must not either: relay a tick only when the client
+    // asked, tagged with that SAME token.
+    const requestProgressToken = extra._meta?.progressToken;
+    const onProgress =
+      requestProgressToken !== undefined
+        ? (progress: number, total?: number, message?: string): void => {
+            extra
+              .sendNotification({
+                method: "notifications/progress",
+                params: {
+                  progressToken: requestProgressToken,
+                  progress,
+                  total,
+                  ...(message && { message }),
+                },
+              })
+              .catch((error: unknown) => {
+                logger.warn(`[ProxyServer] Failed to relay progress notification: ${error}`);
+              });
+          }
+        : undefined;
+
     try {
-      const result = await proxy.callTool(name, args);
+      const result = await proxy.callTool(name, args, requestProgressToken, onProgress);
       return result;
     } catch (error) {
       if (error instanceof DaemonBoundSessionExpiredError) {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1452,8 +1452,11 @@ export class ToolRegistryClass {
       const wrappedHandler = async (args: any, extra: any) => {
         const signal: AbortSignal | undefined = extra?.signal;
 
-        if (tool.supportsProgress) {
-          const progressToken = extra?._meta?.progressToken ?? `${tool.name}-${this.timer.now()}`;
+        // Only echo the client's own token (issue #6118) — never fabricate
+        // one, since the client has no handler registered for a token it
+        // never sent and would surface a spurious protocol error.
+        const progressToken: string | number | undefined = extra?._meta?.progressToken;
+        if (tool.supportsProgress && progressToken !== undefined) {
           const progressCallback: ProgressCallback = async (
             progress: number,
             total?: number,

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -67,10 +67,17 @@ export class FakeDaemonClient implements DaemonClientLike {
     this.connected = false;
   }
 
-  async callTool(toolName: string, params: Record<string, any>): Promise<any> {
+  readonly callToolProgressTokens: Array<string | number | undefined> = [];
+
+  async callTool(
+    toolName: string,
+    params: Record<string, any>,
+    progressToken?: string | number,
+  ): Promise<any> {
     const recordedParams = { ...params };
     delete recordedParams[DAEMON_BOUND_SESSION_PARAM];
     this.callToolCalls.push({ toolName, params: recordedParams });
+    this.callToolProgressTokens.push(progressToken);
     if (this.onCallTool) {
       await this.onCallTool(toolName, params);
     }
@@ -125,6 +132,30 @@ export class FakeDaemonClient implements DaemonClientLike {
     this.subscribeToNotificationsCalls += 1;
     if (this.shouldFailSubscribe) {
       throw new Error("Unsupported daemon method: daemon/subscribe-notifications");
+    }
+  }
+
+  /**
+   * Test hook (issue #6205): simulate the daemon relaying a
+   * `notifications/progress` tick for an in-flight `callTool`, tagged with the
+   * SAME `progressToken` the fake received — mirrors what
+   * `UnixSocketServer.pushProgressNotification` does for real.
+   */
+  emitProgress(
+    progressToken: string | number,
+    progress: number,
+    total?: number,
+    message?: string,
+  ): void {
+    for (const handler of this.notificationHandlers) {
+      handler({
+        type: "daemon_notification",
+        method: "notifications/progress",
+        progressToken,
+        progress,
+        ...(total !== undefined ? { total } : {}),
+        ...(message !== undefined ? { message } : {}),
+      });
     }
   }
 

--- a/test/server/index.progress.test.ts
+++ b/test/server/index.progress.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import type { ProgressCallback } from "../../src/server/toolRegistry";
+
+/**
+ * Proves the fix for issue #6118 at the real MCP CallTool boundary
+ * (`src/server/index.ts`'s `CallToolRequestSchema` handler, not the dead
+ * `ToolRegistry.registerWithServer` path): progress notifications must echo
+ * the client-supplied `_meta.progressToken`, and none must be sent when the
+ * client didn't ask for progress at all.
+ */
+describe("CallTool progress notifications echo the client's token (issue #6118)", () => {
+  let fixture: McpTestFixture;
+  const TOOL = "__progress_probe_6118__";
+
+  beforeAll(async () => {
+    ToolRegistry.register(
+      TOOL,
+      "probe tool that reports two progress ticks",
+      z.object({}).passthrough(),
+      async (_args: unknown, progress?: ProgressCallback) => {
+        await progress?.(1, 2, "tick one");
+        await progress?.(2, 2, "tick two");
+        return createStructuredToolResponse({ success: true });
+      },
+      { supportsProgress: true },
+    );
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(TOOL);
+  });
+
+  test("client onprogress receives ticks carrying the client's own token", async () => {
+    const { client } = fixture.getContext();
+    const received: Array<{ progressToken?: unknown; progress: number; total?: number }> = [];
+    const errors: string[] = [];
+    client.onerror = (error) => {
+      errors.push(String(error));
+    };
+
+    await client.callTool({ name: TOOL, arguments: {} }, undefined, {
+      onprogress: (notification) => {
+        received.push(notification as unknown as { progress: number; total?: number });
+      },
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].progress).toBe(1);
+    expect(received[1].progress).toBe(2);
+    // The SDK client strips progressToken off before handing the notification
+    // to onprogress (it uses it internally to route the callback), so the
+    // absence of an "unknown token" error IS the proof the server echoed the
+    // token the client registered rather than fabricating its own.
+    expect(errors).toHaveLength(0);
+  });
+
+  test("no progress notification is sent when the client did not request one", async () => {
+    const { client } = fixture.getContext();
+    const errors: string[] = [];
+    client.onerror = (error) => {
+      errors.push(String(error));
+    };
+
+    // No `onprogress` option: the SDK client sends no `_meta.progressToken`.
+    const result = await client.callTool({ name: TOOL, arguments: {} });
+
+    expect(result).toBeDefined();
+    // No fabricated token means the client never gets an "unknown token"
+    // protocol error even though the tool called progress() twice server-side.
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/test/server/proxyServerProgress.test.ts
+++ b/test/server/proxyServerProgress.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+
+/**
+ * Proves the fix for issue #6205 (the proxy-mode half of #6118): the DEFAULT
+ * deployment forwards `tools/call` through `createProxyMcpServer` /
+ * `DaemonMcpProxy`, not the direct server, so it needs its own echo of the
+ * client's `_meta.progressToken` across the daemon round trip.
+ */
+describe("Proxy tools/call relays progress tagged with the client's own token (issue #6205)", () => {
+  let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+  afterEach(() => {
+    isAvailableSpy?.mockRestore();
+    isAvailableSpy = null;
+  });
+
+  async function setup(fakeClient: FakeDaemonClient) {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = { ...daemonManager.statusResult, version: DAEMON_VERSION };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => fakeClient,
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "progress-test-client", version: "0.0.1" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return { server, proxy, client };
+  }
+
+  test("client onprogress receives a tick carrying the client's own token", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      onCallTool: () => {
+        // Simulate the daemon relaying one progress tick WHILE the call is in
+        // flight, tagged with whatever token this exact call forwarded —
+        // mirrors the real socket server echoing the SAME token end to end.
+        const token = fakeClient.callToolProgressTokens.at(-1);
+        if (token !== undefined) {
+          fakeClient.emitProgress(token, 1, 2, "halfway");
+        }
+      },
+    });
+    const { proxy, client } = await setup(fakeClient);
+
+    const received: Array<{ progress: number; total?: number }> = [];
+    const errors: string[] = [];
+    client.onerror = (error) => {
+      errors.push(String(error));
+    };
+
+    try {
+      await client.callTool({ name: "someTool", arguments: {} }, undefined, {
+        onprogress: (notification) => {
+          received.push(notification as unknown as { progress: number; total?: number });
+        },
+      });
+
+      expect(received).toHaveLength(1);
+      expect(received[0].progress).toBe(1);
+      expect(received[0].total).toBe(2);
+      // No "unknown token" client error is the proof the proxy echoed the same
+      // token the client's SDK registered, rather than a daemon/proxy-fabricated
+      // one going astray.
+      expect(errors).toHaveLength(0);
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
+
+  test("no progress notification reaches the client when it did not request one", async () => {
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+    });
+    const { proxy, client } = await setup(fakeClient);
+
+    const errors: string[] = [];
+    client.onerror = (error) => {
+      errors.push(String(error));
+    };
+
+    try {
+      const result = await client.callTool({ name: "someTool", arguments: {} });
+
+      expect(result).toBeDefined();
+      // No client-supplied token: the proxy must forward `undefined`, never a
+      // fabricated one, so the daemon relays nothing back.
+      expect(fakeClient.callToolProgressTokens).toEqual([undefined]);
+      expect(errors).toHaveLength(0);
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
+});

--- a/test/server/toolRegistry.registerWithServer.test.ts
+++ b/test/server/toolRegistry.registerWithServer.test.ts
@@ -124,8 +124,8 @@ describe("ToolRegistry.registerWithServer", () => {
     });
   });
 
-  test("progress callback uses generated token when _meta.progressToken is absent", async () => {
-    let capturedProgress: ProgressCallback | undefined;
+  test("does not fabricate a token or pass a progress callback when _meta.progressToken is absent", async () => {
+    let capturedProgress: ProgressCallback | undefined = undefined;
     const sentNotifications: any[] = [];
 
     ToolRegistry.register(
@@ -152,17 +152,11 @@ describe("ToolRegistry.registerWithServer", () => {
     };
 
     await handler!({}, fakeExtra);
-    await capturedProgress!(10, 50);
 
-    expect(sentNotifications).toHaveLength(1);
-    const params = sentNotifications[0].params;
-    expect(params.progress).toBe(10);
-    expect(params.total).toBe(50);
-    // Token should be a generated string starting with tool name
-    expect(typeof params.progressToken).toBe("string");
-    expect(params.progressToken).toMatch(/^noTokenTool-/);
-    // message should not be present when not provided
-    expect(params.message).toBeUndefined();
+    // No client-supplied token: the handler must not fabricate one (#6118),
+    // so the tool never receives a progress callback to invoke.
+    expect(capturedProgress).toBeUndefined();
+    expect(sentNotifications).toHaveLength(0);
   });
 
   test("does not pass progress callback for tools without supportsProgress", async () => {


### PR DESCRIPTION
## Root cause

Per the MCP spec, a `notifications/progress` message must carry the SAME
`progressToken` the client sent in `params._meta.progressToken`. The
production `tools/call` handler in `src/server/index.ts` fabricated its own
token (`` `${name}-${defaultTimer.now()}` ``) instead of reading the client's,
so an SDK client had no registered handler for that token and routed every
tick to `onerror` — `onprogress` was never invoked.

`ToolRegistry.registerWithServer` (`src/server/toolRegistry.ts`) already read
`extra?._meta?.progressToken` correctly, but that path is dead in production:
`index.ts` overwrites the `CallToolRequestSchema` handler after
`ToolRegistry.registerWithServer` runs, so its `server.registerTool(...)`
wrapper never actually handles a call. It also fell back to the same
fabrication when no token was present, so it wasn't a template for the right
behavior either.

## Fix

- `src/server/index.ts`: read `extra._meta?.progressToken`. Build the
  progress callback only when the tool supports progress AND the client
  supplied a token; otherwise skip creating one entirely (no fabrication, no
  progress sent for requests that didn't ask). Send via `extra.sendNotification`
  (transport-scoped, matching the SDK's own related-notification pattern)
  instead of `server.server.notification`.
- `src/server/toolRegistry.ts`: applied the same fix to
  `registerWithServer`'s wrapper so the dead duplicate no longer disagrees
  with the live path.

## Test

`test/server/index.progress.test.ts` (new) drives the real `createMcpServer`
handler through an `InMemoryTransport` client/server pair:
- a `tools/call` with `onprogress` set (client auto-registers
  `_meta.progressToken`) receives both progress ticks and produces zero
  client errors — proof the server echoed the client's own token rather than
  a fabricated one (an unrecognized token surfaces as a client `onerror`).
- a `tools/call` with no `onprogress` produces zero client errors even though
  the tool calls `progress()` twice server-side — proof nothing is fabricated
  or sent when the client didn't ask.

`test/server/toolRegistry.registerWithServer.test.ts` updated: the case that
previously asserted a generated fallback token now asserts no token is
fabricated and no progress callback is handed to the tool when
`_meta.progressToken` is absent.

Closes #6118
