### PR TITLE
fix(plan-schema): gate doNotDisturb/biometrics inline validation on params absence

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -683,12 +683,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/setDeviceStateParams"
-              },
-              "doNotDisturb": {
-                "$ref": "#/$defs/doNotDisturbStateInput"
-              },
-              "biometrics": {
-                "$ref": "#/$defs/biometricStateInput"
               }
             },
             "anyOf": [
@@ -721,6 +715,44 @@
                   "properties": {
                     "networkCondition": {
                       "$ref": "#/$defs/networkConditionStateInput"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.doNotDisturb (when present) fully overrides an inline doNotDisturb at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict doNotDisturbStateInput rules to the inline form ONLY when params.doNotDisturb is absent, otherwise a valid params override would false-reject the discarded inline value (#6112).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["doNotDisturb"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "doNotDisturb": {
+                      "$ref": "#/$defs/doNotDisturbStateInput"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.biometrics (when present) fully overrides an inline biometrics at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict biometricStateInput rules to the inline form ONLY when params.biometrics is absent, otherwise a valid params override would false-reject the discarded inline value (#6112).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["biometrics"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "biometrics": {
+                      "$ref": "#/$defs/biometricStateInput"
                     }
                   }
                 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -683,12 +683,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/setDeviceStateParams"
-              },
-              "doNotDisturb": {
-                "$ref": "#/$defs/doNotDisturbStateInput"
-              },
-              "biometrics": {
-                "$ref": "#/$defs/biometricStateInput"
               }
             },
             "anyOf": [
@@ -721,6 +715,44 @@
                   "properties": {
                     "networkCondition": {
                       "$ref": "#/$defs/networkConditionStateInput"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.doNotDisturb (when present) fully overrides an inline doNotDisturb at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict doNotDisturbStateInput rules to the inline form ONLY when params.doNotDisturb is absent, otherwise a valid params override would false-reject the discarded inline value (#6112).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["doNotDisturb"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "doNotDisturb": {
+                      "$ref": "#/$defs/doNotDisturbStateInput"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.biometrics (when present) fully overrides an inline biometrics at normalization (PlanNormalizer, params precedence), so the inline value is discarded at execution. Apply the strict biometricStateInput rules to the inline form ONLY when params.biometrics is absent, otherwise a valid params override would false-reject the discarded inline value (#6112).",
+                "if": {
+                  "required": ["params"],
+                  "properties": {
+                    "params": {
+                      "required": ["biometrics"]
+                    }
+                  }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "biometrics": {
+                      "$ref": "#/$defs/biometricStateInput"
                     }
                   }
                 }

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -172,6 +172,38 @@ steps:
       expect(validator.validateYaml(offline).valid).toBe(true);
     });
 
+    it("should accept an inline doNotDisturb that params.doNotDisturb overrides (#6112)", () => {
+      // PlanNormalizer gives params precedence, so at execution this step receives
+      // ONLY the valid params form — the malformed inline `{}` (neither `enabled`
+      // nor `mode`) is discarded. Schema validation must not false-reject it.
+      const yaml = `
+name: dnd-inline-overridden
+steps:
+  - tool: setDeviceState
+    doNotDisturb: {}
+    params:
+      doNotDisturb:
+        mode: priority
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(true);
+    });
+
+    it("should accept an inline biometrics that params.biometrics overrides (#6112)", () => {
+      // Same duality: params.biometrics discards the malformed inline enrollment
+      // value at normalization, so schema validation must not false-reject it.
+      const yaml = `
+name: biometrics-inline-overridden
+steps:
+  - tool: setDeviceState
+    biometrics:
+      enrollment: sometimes
+    params:
+      biometrics:
+        enrollment: enrolled
+`;
+      expect(validator.validateYaml(yaml).valid).toBe(true);
+    });
+
     it("should validate cross-platform permission / appop steps in sequence", () => {
       const yaml = `
 name: grant-explicit
@@ -712,6 +744,51 @@ steps:
   - tool: setDeviceState
     biometrics:
       enrollment: sometimes
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should still reject a standalone inline biometrics with no params override (#6112)", () => {
+      // Guards against weakening the standalone-inline validation: with no
+      // overriding params.biometrics, a malformed inline enrollment value must
+      // still be rejected.
+      const yaml = `
+name: bad-biometric-enrollment-standalone
+steps:
+  - tool: setDeviceState
+    biometrics:
+      enrollment: sometimes
+    params:
+      networkCondition:
+        cancel: true
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject a standalone inline doNotDisturb with neither enabled nor mode (#6112)", () => {
+      const yaml = `
+name: bad-dnd-standalone
+steps:
+  - tool: setDeviceState
+    doNotDisturb: {}
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should still reject a standalone inline doNotDisturb when an unrelated params field is set (#6112)", () => {
+      // A present `params` without `params.doNotDisturb` must not gate off the
+      // inline doNotDisturb validation.
+      const yaml = `
+name: bad-dnd-standalone-unrelated-params
+steps:
+  - tool: setDeviceState
+    doNotDisturb: {}
+    params:
+      biometrics:
+        enrollment: enrolled
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(false);


### PR DESCRIPTION
## Summary

Completes the audit from #6112: `setDeviceState`'s `doNotDisturb` and `biometrics` fields carried the same inline-vs-params duality already fixed for `networkCondition` in #6107.

`PlanNormalizer.normalizeStep` (`src/utils/plan/PlanNormalizer.ts:44-50`) gives `params` precedence and discards the inline value at normalization, so execution only ever sees the params form. But `PlanSchemaValidator` runs strict inline-field constraints on the un-normalized step, so a step with a malformed/discarded inline `doNotDisturb` or `biometrics` value overridden by a valid `params.<field>` was false-rejected at schema validation even though it would execute correctly.

## Fix

Mirrored the #6107 `allOf`/if-params-present-then-true-else-strict-ref gate onto **both** `doNotDisturb` and `biometrics` in **both** schema copies:
- `schemas/test-plan.schema.json`
- `android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json`

Verified drift-identical with `scripts/check-schema-copy-drift.ts`. `networkCondition`'s existing gate is untouched.

## Tests

Added to `test/plan/PlanSchemaValidator.test.ts`, mirroring the `networkCondition` coverage from #6107:
- Inline `doNotDisturb` (malformed, `{}`) + `params.doNotDisturb` override → accepted
- Inline `biometrics` (malformed enrollment) + `params.biometrics` override → accepted
- Standalone inline `doNotDisturb` with neither `enabled` nor `mode` (no params override) → still rejected
- Standalone inline `doNotDisturb` with an unrelated `params` field present (no `params.doNotDisturb`) → still rejected (guards the gate is keyed on the specific field, not `params` presence generally)
- Standalone inline `biometrics` with malformed enrollment + an unrelated `params.networkCondition` → still rejected

All 61 tests in the file pass in ~280ms.

## Validation

- `turbo run lint build test` — pass
- `bun run format:check` — pass
- `bun run typecheck` — pass (163 baseline, no new errors)
- `scripts/check-schema-copy-drift.ts` — identical

Closes #6112
