### PR TITLE
fix: preserve observation evidence

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -70,6 +70,21 @@ enable/disable conflicts fail startup. Repeatable `--enable-tool` and
 `--disable-tool` flags override these environment values; persisted
 `setToolEnabled` choices override startup defaults.
 
+## Automatic observation screenshots
+
+Explicit `observe` calls retain their existing screenshot behavior. Automatic
+observations taken after an action or while resolving `observe.waitFor` skip
+screenshots by default. Opt in to one screenshot from the final result by
+setting either skip flag to `false` (or `0`):
+
+```bash
+export AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT=false
+export AUTOMOBILE_OBSERVE_WAIT_FOR_SKIP_SCREENSHOT=false
+```
+
+`observe.waitFor` suppresses screenshots for all intermediate polls; enabling
+its flag captures only once, after the condition resolves or times out.
+
 ## Device behavior
 
 AutoMobile does not create an emulator or simulator by default. The legacy

--- a/ios/control-proxy/Tests/CtrlProxyUITests/CtrlProxyUITests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyUITests/CtrlProxyUITests.swift
@@ -133,6 +133,11 @@ final class CtrlProxyUITests: XCTestCase {
         let gestures = GesturePerformer(application: app, elementLocator: locator)
         try gestures.performAction("tap", label: "Message #sample")
         try gestures.typeText(text: "hello")
+        let typedTextExpectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "hello"),
+            object: messageTextView
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [typedTextExpectation], timeout: 5), .completed)
         XCTAssertEqual(messageTextView.value as? String, "hello")
 
         let secureField = app.secureTextFields["secure-field"]

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -45,6 +45,7 @@ interface ObservedChangeOptions {
   overrideMinTimestamp?: number;
   signal?: AbortSignal;
   deferPredictionOutcome?: boolean;
+  deferPostActionScreenshot?: boolean;
   predictionContext?: {
     toolName: string;
     toolArgs: Record<string, any>;
@@ -65,7 +66,7 @@ export class BaseVisualChange {
   >();
   protected timer: Timer;
 
-  private shouldCapturePostActionScreenshot(): boolean {
+  protected shouldCapturePostActionScreenshot(): boolean {
     // Preserve the pre-existing live-view behavior, while allowing other
     // clients to opt in with AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT=0.
     return (
@@ -271,6 +272,7 @@ export class BaseVisualChange {
       actionStartTime: options.overrideMinTimestamp ?? observationStartTime,
       predictionContext: options.deferPredictionOutcome ? undefined : predictionContext,
       signal: options.signal,
+      deferPostActionScreenshot: options.deferPostActionScreenshot,
     });
     if (options.deferPredictionOutcome && predictionContext && typeof observed === "object") {
       this.deferredPredictionOutcomes.set(observed, async (finalObservation) => {
@@ -326,6 +328,20 @@ export class BaseVisualChange {
     await recordOutcome(finalObservation);
   }
 
+  /**
+   * Capture exactly one fresh screenshot after any subclass-specific
+   * observation reconciliation has selected the result returned to the caller.
+   */
+  protected async captureTerminalObservationScreenshot(
+    observation: ObserveResult | undefined,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (observation && this.shouldCapturePostActionScreenshot()) {
+      await this.observeScreen.captureScreenshot?.(perf, signal, observation);
+    }
+  }
+
   private static buildDeviceLockWarning(lock: DeviceLockState): string {
     const preamble = "Device is locked; this interaction likely did not reach the app under test.";
     if (lock.secure === true) {
@@ -349,6 +365,7 @@ export class BaseVisualChange {
       actionStartTime?: number;
       predictionContext?: PredictionActionContext;
       signal?: AbortSignal;
+      deferPostActionScreenshot?: boolean;
     },
   ): Promise<any> {
     const perf = options.perf ?? new NoOpPerformanceTracker();
@@ -374,6 +391,7 @@ export class BaseVisualChange {
       // Retries collect hierarchy only. If enabled, visual evidence is captured
       // once from the final observation below.
       skipScreenshot: true,
+      skipAccessibilityAudit: true,
     });
     perf.end();
 
@@ -409,6 +427,7 @@ export class BaseVisualChange {
         minTimestamp,
         signal: options.signal,
         skipScreenshot: true,
+        skipAccessibilityAudit: true,
       });
       perf.end();
     }
@@ -428,8 +447,8 @@ export class BaseVisualChange {
       logger.warn(`[BaseVisualChange] ${warning}`);
     }
 
-    if (capturePostActionScreenshot) {
-      await this.observeScreen.captureScreenshot?.(perf, options.signal);
+    if (capturePostActionScreenshot && !options.deferPostActionScreenshot) {
+      await this.captureTerminalObservationScreenshot(latestObservation, perf, options.signal);
     }
 
     if (

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -25,6 +25,7 @@ import { PredictionAnalyzer, PredictionActionContext } from "../observe/Predicti
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { sequenceBackoff } from "../../utils/Backoff";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
+import { shouldSkipActionObservationScreenshot } from "../observe/automaticScreenshotPolicy";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -63,6 +64,15 @@ export class BaseVisualChange {
     (observation: ObserveResult) => Promise<void>
   >();
   protected timer: Timer;
+
+  private shouldCapturePostActionScreenshot(): boolean {
+    // Preserve the pre-existing live-view behavior, while allowing other
+    // clients to opt in with AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT=0.
+    return (
+      !shouldSkipActionObservationScreenshot() ||
+      (getDeviceDataStreamServer()?.hasSubscriberForDevice(this.device.deviceId) ?? false)
+    );
+  }
 
   /**
    * Create an BaseVisualChange instance
@@ -327,14 +337,6 @@ export class BaseVisualChange {
     return `${preamble} Unlock or dismiss the keyguard before continuing.`;
   }
 
-  /**
-   * True when a live-view IDE subscriber is attached for this device, meaning a
-   * device screenshot is still worth capturing on internal re-observes.
-   */
-  private hasLiveViewSubscriber(): boolean {
-    return getDeviceDataStreamServer()?.hasSubscriberForDevice(this.device.deviceId) ?? false;
-  }
-
   private async takeObservation(
     blockResult: any,
     previousObserveResult: ObserveResult | null,
@@ -358,12 +360,7 @@ export class BaseVisualChange {
     const maxRetryAttempts = 4;
     const previousHash = this.hashViewHierarchy(previousObserveResult?.viewHierarchy);
 
-    // Internal post-action re-observes don't need a device screenshot: the PNG is
-    // only consumed by a live-view subscriber (fed separately by the
-    // subscriber-gated screenshot stream) or by tools that return the image.
-    // Skipping the capture here avoids a device round-trip per action, but stays
-    // enabled while a live view is attached (#5472, AC#3).
-    const skipScreenshot = !this.hasLiveViewSubscriber();
+    const capturePostActionScreenshot = this.shouldCapturePostActionScreenshot();
 
     perf.serial("finalObserve");
     // Wait for fresh data from accessibility service (skipWaitForFresh=false)
@@ -374,7 +371,9 @@ export class BaseVisualChange {
       skipWaitForFresh: false,
       minTimestamp,
       signal: options.signal,
-      skipScreenshot,
+      // Retries collect hierarchy only. If enabled, visual evidence is captured
+      // once from the final observation below.
+      skipScreenshot: true,
     });
     perf.end();
 
@@ -409,7 +408,7 @@ export class BaseVisualChange {
         skipWaitForFresh: false,
         minTimestamp,
         signal: options.signal,
-        skipScreenshot,
+        skipScreenshot: true,
       });
       perf.end();
     }
@@ -427,6 +426,10 @@ export class BaseVisualChange {
         ? { ...latestObservation.freshness, warning }
         : { isFresh: false, warning };
       logger.warn(`[BaseVisualChange] ${warning}`);
+    }
+
+    if (capturePostActionScreenshot) {
+      await this.observeScreen.captureScreenshot?.(perf, options.signal);
     }
 
     if (

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -26,6 +26,7 @@ import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { sequenceBackoff } from "../../utils/Backoff";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { shouldSkipActionObservationScreenshot } from "../observe/automaticScreenshotPolicy";
+import { serverConfig } from "../../utils/ServerConfig";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -337,9 +338,14 @@ export class BaseVisualChange {
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     signal?: AbortSignal,
   ): Promise<void> {
-    if (observation && this.shouldCapturePostActionScreenshot()) {
-      await this.observeScreen.captureScreenshot?.(perf, signal, observation);
+    if (!observation) {
+      return;
     }
+    if (this.shouldCapturePostActionScreenshot() || serverConfig.isAccessibilityAuditEnabled()) {
+      await this.observeScreen.captureScreenshot?.(perf, signal, observation);
+      return;
+    }
+    await this.observeScreen.runAccessibilityAudit?.(observation, perf);
   }
 
   private static buildDeviceLockWarning(lock: DeviceLockState): string {
@@ -376,8 +382,6 @@ export class BaseVisualChange {
     const retryBackoff = sequenceBackoff([50, 100, 200, 400]);
     const maxRetryAttempts = 4;
     const previousHash = this.hashViewHierarchy(previousObserveResult?.viewHierarchy);
-
-    const capturePostActionScreenshot = this.shouldCapturePostActionScreenshot();
 
     perf.serial("finalObserve");
     // Wait for fresh data from accessibility service (skipWaitForFresh=false)
@@ -447,7 +451,7 @@ export class BaseVisualChange {
       logger.warn(`[BaseVisualChange] ${warning}`);
     }
 
-    if (capturePostActionScreenshot && !options.deferPostActionScreenshot) {
+    if (!options.deferPostActionScreenshot) {
       await this.captureTerminalObservationScreenshot(latestObservation, perf, options.signal);
     }
 

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -553,18 +553,21 @@ export class LaunchApp extends BaseVisualChange {
         // iOS hierarchy timestamps (Swift Date) and TS timestamps (Date.now) are from
         // different clocks, causing minTimestamp checks to fail and force ~130ms round-trips.
         overrideMinTimestamp: 0,
+        deferPostActionScreenshot: true,
         signal,
       },
     );
 
     signal?.throwIfAborted();
-    return this.ensureLaunchObservationMatchesPackage(
+    const settledResult = await this.ensureLaunchObservationMatchesPackage(
       result,
       bundleId,
       undefined,
       undefined,
       signal,
     );
+    await this.captureTerminalObservationScreenshot(settledResult.observation, perf, signal);
+    return settledResult;
   }
 
   private async waitForIosHierarchyReady(
@@ -891,6 +894,7 @@ export class LaunchApp extends BaseVisualChange {
         skipUiStability: skipUiStability ?? false,
         packageName,
         observationTimestampProvider: () => observationTimestampMs,
+        deferPostActionScreenshot: true,
         signal,
       },
     );
@@ -903,6 +907,7 @@ export class LaunchApp extends BaseVisualChange {
       undefined,
       signal,
     );
+    await this.captureTerminalObservationScreenshot(settledLaunchResult.observation, perf, signal);
 
     logger.info(
       `[LaunchApp] TTI capture check: collector=${!!displayedMetricsCollector}, startMs=${displayedMetricsStartMs}, hasObservation=${!!settledLaunchResult?.observation}`,
@@ -1009,6 +1014,8 @@ export class LaunchApp extends BaseVisualChange {
       latestObservation = await this.observeScreen.execute({
         skipWaitForFresh: false,
         signal,
+        skipScreenshot: true,
+        skipAccessibilityAudit: true,
       });
       signal?.throwIfAborted();
       if (this.launchObservationMatchesPackage(latestObservation, expectedPackageName)) {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1722,6 +1722,7 @@ export class TapOnElement extends BaseVisualChange {
           perf,
           signal,
           deferPredictionOutcome: true,
+          deferPostActionScreenshot: true,
           predictionContext: {
             toolName: "tapOn",
             toolArgs: {
@@ -1751,6 +1752,7 @@ export class TapOnElement extends BaseVisualChange {
         // The observation that established the effect must be returned and become
         // the caller's diff baseline, rather than the earlier source capture.
         result.observation = postTap.observation;
+        await this.captureTerminalObservationScreenshot(result.observation, perf, signal);
         await this.recordDeferredPredictionOutcome(result, result.observation);
         const selectedElements = await this.selectionStateTracker.finalize({
           action: options.action,

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -31,6 +31,7 @@ import {
 import { resolveContainerSwipeCoordinates } from "./resolveContainerSwipeCoordinates";
 import { getScreenBounds } from "../../../utils/screenBounds";
 import { exponentialBackoff } from "../../../utils/Backoff";
+import type { ProgressCallback } from "../BaseVisualChange";
 
 function oppositeDirection(dir: SwipeDirection): SwipeDirection {
   switch (dir) {
@@ -65,8 +66,8 @@ interface ScrollUntilVisibleDependencies {
     action: (observeResult: ObserveResult) => Promise<T>,
     options: {
       changeExpected: boolean;
-      timeoutMs: number;
-      progress?: unknown;
+      timeoutMs?: number;
+      progress?: ProgressCallback;
       perf?: PerformanceTracker;
       skipPreviousObserve?: boolean;
       queryOptions?: {
@@ -78,8 +79,13 @@ interface ScrollUntilVisibleDependencies {
         toolName: string;
         toolArgs: Record<string, unknown>;
       };
+      deferPostActionScreenshot?: boolean;
     },
   ) => Promise<T & { observation?: ObserveResult }>;
+  captureTerminalObservationScreenshot?: (
+    observation: ObserveResult | undefined,
+    perf: PerformanceTracker,
+  ) => Promise<void>;
 }
 
 export class ScrollUntilVisible {
@@ -89,7 +95,7 @@ export class ScrollUntilVisible {
 
   async execute(
     options: SwipeOnResolvedOptions,
-    progress?: unknown,
+    progress?: ProgressCallback,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<SwipeOnResult> {
     logger.info(
@@ -98,7 +104,10 @@ export class ScrollUntilVisible {
 
     // Get initial observation
     let lastObservation = await perf.track("initialObserve", () =>
-      this.deps.observeScreen.execute(),
+      this.deps.observeScreen.execute({
+        skipScreenshot: true,
+        skipAccessibilityAudit: true,
+      }),
     );
     if (!lastObservation.viewHierarchy || !lastObservation.screenSize) {
       throw new Error("Failed to get initial observation for scrolling until visible.");
@@ -196,6 +205,7 @@ export class ScrollUntilVisible {
       }
 
       perf.end();
+      await this.deps.captureTerminalObservationScreenshot?.(lastObservation, perf);
       return {
         success: true,
         targetType: "element",
@@ -300,6 +310,7 @@ export class ScrollUntilVisible {
           progress,
           perf,
           skipPreviousObserve: scrollIteration > 1,
+          deferPostActionScreenshot: true,
           predictionContext: {
             toolName: "swipeOn",
             toolArgs: this.deps.buildPredictionArgs(options),
@@ -307,8 +318,13 @@ export class ScrollUntilVisible {
         },
       );
 
+      if (swipeResult.observation?.viewHierarchy) {
+        lastObservation = swipeResult.observation;
+      }
+
       if (!swipeResult.success && this.deps.device.platform === "ios") {
         perf.end();
+        await this.deps.captureTerminalObservationScreenshot?.(lastObservation, perf);
         return {
           ...swipeResult,
           targetType: "screen",
@@ -319,9 +335,7 @@ export class ScrollUntilVisible {
       }
 
       // Update observation
-      if (swipeResult.observation && swipeResult.observation.viewHierarchy) {
-        lastObservation = swipeResult.observation;
-      } else {
+      if (!swipeResult.observation?.viewHierarchy) {
         throw new Error("Lost observation after swipe during scroll until visible.");
       }
 
@@ -424,6 +438,7 @@ export class ScrollUntilVisible {
     }
 
     perf.end();
+    await this.deps.captureTerminalObservationScreenshot?.(lastObservation, perf);
     return {
       success: true,
       targetType: "element",
@@ -690,7 +705,10 @@ export class ScrollUntilVisible {
     let latestObservation = currentObservation;
 
     while (this.deps.timer.now() - startTime < maxWaitMs) {
-      const newObservation = await this.deps.observeScreen.execute();
+      const newObservation = await this.deps.observeScreen.execute({
+        skipScreenshot: true,
+        skipAccessibilityAudit: true,
+      });
       if (!newObservation.viewHierarchy) {
         break;
       }

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -141,6 +141,7 @@ export class SwipeOn extends BaseVisualChange {
       resolveBoomerangConfig: this.resolveBoomerangConfig.bind(this),
       buildPredictionArgs: this.buildPredictionArgs.bind(this),
       observedInteraction: this.observedInteraction.bind(this),
+      captureTerminalObservationScreenshot: this.captureTerminalObservationScreenshot.bind(this),
     });
   }
 

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -100,6 +100,7 @@ export async function pollObserveUntil(
       // Polls are intermediate state only. Public callers that opt into
       // automatic evidence capture it once after this loop completes.
       skipScreenshot: true,
+      skipAccessibilityAudit: true,
     });
     polls++;
     throwIfAborted(options.signal);

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -97,6 +97,9 @@ export async function pollObserveUntil(
       minTimestamp,
       skipWaitForFresh: false,
       signal: options.signal,
+      // Polls are intermediate state only. Public callers that opt into
+      // automatic evidence capture it once after this loop completes.
+      skipScreenshot: true,
     });
     polls++;
     throwIfAborted(options.signal);

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -748,6 +748,18 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   /**
+   * Capture visual evidence without re-reading the hierarchy. Automatic
+   * post-action and waitFor flows use this after their final observation so a
+   * retry/poll loop creates at most one screenshot.
+   */
+  async captureScreenshot(
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.screenshotRecorder.capture(perf, signal);
+  }
+
+  /**
    * Attach a windowed performance snapshot to the result when the
    * `AUTOMOBILE_OBSERVE_PERF_SNAPSHOT` opt-in is enabled. Ensures per-device
    * sampling is running (so the window fills across successive observes) and

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -631,7 +631,9 @@ export class RealObserveScreen implements ObserveScreen {
 
       // Audits + accessibility state detection (each is config-gated; failures don't propagate)
       await this.performanceAuditor.run(result, perf);
-      await this.accessibilityAuditor.run(result, perf);
+      if (!options?.skipAccessibilityAudit) {
+        await this.accessibilityAuditor.run(result, perf);
+      }
       await this.accessibilityStateDetector.run(result, perf, signal);
 
       // Predictive UI (opt-in via config)
@@ -755,8 +757,12 @@ export class RealObserveScreen implements ObserveScreen {
   async captureScreenshot(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     signal?: AbortSignal,
+    observation?: ObserveResult,
   ): Promise<void> {
-    await this.screenshotRecorder.capture(perf, signal);
+    await this.screenshotRecorder.captureFresh(perf, signal);
+    if (observation) {
+      await this.accessibilityAuditor.run(observation, perf);
+    }
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -761,8 +761,15 @@ export class RealObserveScreen implements ObserveScreen {
   ): Promise<void> {
     await this.screenshotRecorder.captureFresh(perf, signal);
     if (observation) {
-      await this.accessibilityAuditor.run(observation, perf);
+      await this.runAccessibilityAudit(observation, perf);
     }
+  }
+
+  async runAccessibilityAudit(
+    observation: ObserveResult,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+  ): Promise<void> {
+    await this.accessibilityAuditor.run(observation, perf);
   }
 
   /**

--- a/src/features/observe/automaticScreenshotPolicy.ts
+++ b/src/features/observe/automaticScreenshotPolicy.ts
@@ -1,0 +1,25 @@
+/**
+ * Automatic screenshots are intentionally opt-in for observations AutoMobile
+ * performs on a caller's behalf. Explicit `observe` calls keep their existing
+ * screenshot behavior.
+ *
+ * The flags use "skip" semantics so their default is backwards compatible:
+ * absent (or any value other than `false`/`0`) means skip automatic capture.
+ */
+export const ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV =
+  "AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT";
+export const OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV = "AUTOMOBILE_OBSERVE_WAIT_FOR_SKIP_SCREENSHOT";
+
+function isSkipEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() !== "false" && value?.trim() !== "0";
+}
+
+export function shouldSkipActionObservationScreenshot(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isSkipEnabled(env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV]);
+}
+
+export function shouldSkipObserveWaitForScreenshot(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isSkipEnabled(env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV]);
+}

--- a/src/features/observe/interfaces/ObserveScreen.ts
+++ b/src/features/observe/interfaces/ObserveScreen.ts
@@ -37,6 +37,12 @@ export interface ObserveScreen {
   ): Promise<void>;
 
   /**
+   * Run the configured accessibility audit for an already-collected observation
+   * without capturing a screenshot.
+   */
+  runAccessibilityAudit?(observation: ObserveResult, perf?: PerformanceTracker): Promise<void>;
+
+  /**
    * Fetch raw (unfiltered) view hierarchy from the device and attach it to an existing
    * ObserveResult. Safe to call after execute() — does not re-observe the screen.
    * @param result - Existing observe result to augment with raw hierarchy data

--- a/src/features/observe/interfaces/ObserveScreen.ts
+++ b/src/features/observe/interfaces/ObserveScreen.ts
@@ -23,6 +23,14 @@ export interface ObserveScreen {
   execute(options?: ObserveScreenExecuteOptions): Promise<ObserveResult>;
 
   /**
+   * Capture a screenshot without taking another hierarchy observation.
+   *
+   * Optional while fakes and narrow test doubles migrate. The production
+   * implementation supplies it for automatic action/waitFor evidence capture.
+   */
+  captureScreenshot?(perf?: PerformanceTracker, signal?: AbortSignal): Promise<void>;
+
+  /**
    * Fetch raw (unfiltered) view hierarchy from the device and attach it to an existing
    * ObserveResult. Safe to call after execute() — does not re-observe the screen.
    * @param result - Existing observe result to augment with raw hierarchy data

--- a/src/features/observe/interfaces/ObserveScreen.ts
+++ b/src/features/observe/interfaces/ObserveScreen.ts
@@ -10,6 +10,8 @@ export interface ObserveScreenExecuteOptions {
   signal?: AbortSignal;
   skipBackStack?: boolean;
   skipScreenshot?: boolean;
+  /** Skip screenshot-dependent accessibility auditing for intermediate observations. */
+  skipAccessibilityAudit?: boolean;
 }
 
 /**
@@ -28,7 +30,11 @@ export interface ObserveScreen {
    * Optional while fakes and narrow test doubles migrate. The production
    * implementation supplies it for automatic action/waitFor evidence capture.
    */
-  captureScreenshot?(perf?: PerformanceTracker, signal?: AbortSignal): Promise<void>;
+  captureScreenshot?(
+    perf?: PerformanceTracker,
+    signal?: AbortSignal,
+    observation?: ObserveResult,
+  ): Promise<void>;
 
   /**
    * Fetch raw (unfiltered) view hierarchy from the device and attach it to an existing

--- a/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
+++ b/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
@@ -46,6 +46,13 @@ export interface ObserveScreenshotRecorder {
    * (successfully or not) and state has been updated.
    */
   capture(perf?: PerformanceTracker, signal?: AbortSignal): Promise<void>;
+
+  /**
+   * Await a fresh capture after any already-pending capture. Terminal evidence
+   * must reflect the completed action or wait condition rather than an earlier
+   * in-flight observation.
+   */
+  captureFresh(perf?: PerformanceTracker, signal?: AbortSignal): Promise<void>;
 }
 
 /**
@@ -112,15 +119,28 @@ export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecord
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     signal?: AbortSignal,
   ): Promise<void> {
+    await this.captureWithOptions(perf, signal, { coalesceWithPending: true });
+  }
+
+  async captureFresh(
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.captureWithOptions(perf, signal, { queueAfterPending: true });
+  }
+
+  private async captureWithOptions(
+    perf: PerformanceTracker,
+    signal: AbortSignal | undefined,
+    trackerOptions: Pick<ScreenshotJobOptions, "coalesceWithPending" | "queueAfterPending">,
+  ): Promise<void> {
     try {
       await perf.track("screenshot", async () => {
         const { promise } = this.screenshotUtil.startTrackedCapture(
           {},
           {
             parentSignal: signal,
-            // Awaitable observe captures share an ordinary in-flight capture,
-            // but queue behind a non-coalescible fresh resource capture.
-            coalesceWithPending: true,
+            ...trackerOptions,
             onComplete: async (completion) => {
               if (!completion.isLatest) {
                 return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ async function main() {
     if (noWaitForPollingOverhead) {
       serverConfig.setWaitForPollingOverheadEnabled(false);
       logger.info(
-        "WaitFor polling overhead disabled (--no-waitfor-polling-overhead): screenshots and back stack skipped during observe waitFor polling",
+        "WaitFor polling overhead disabled (--no-waitfor-polling-overhead): back stack skipped during observe waitFor polling",
       );
     }
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -105,6 +105,7 @@ import {
   resolveSystemTrayAwaitTimeout,
   ensureSystemTrayOpen,
   ensureSystemTrayClosed,
+  captureSystemTrayTerminalEvidence,
   resolveNotificationTapElement,
   resolveNotificationSwipeElement,
   tapElement,
@@ -1452,6 +1453,7 @@ export function registerInteractionTools() {
 
       if (args.action === "open") {
         const result = await ensureSystemTrayOpen(device, awaitTimeoutMs, progress);
+        await captureSystemTrayTerminalEvidence(device, result.observation);
         return createJSONToolResponse({
           message: result.skipped
             ? "System tray already open; no swipe needed"
@@ -1464,6 +1466,7 @@ export function registerInteractionTools() {
 
       if (args.action === "close") {
         const result = await ensureSystemTrayClosed(device, awaitTimeoutMs, progress);
+        await captureSystemTrayTerminalEvidence(device, result.observation);
         return createJSONToolResponse({
           message: result.skipped
             ? "System tray already closed; no collapse needed"
@@ -1502,6 +1505,7 @@ export function registerInteractionTools() {
           throw new ActionableError(`Notification not found after ${awaitTimeoutMs}ms.`);
         }
 
+        await captureSystemTrayTerminalEvidence(device, observation);
         return createJSONToolResponse({
           message: "Found notification in system tray",
           match: match.match.matches,
@@ -1555,7 +1559,11 @@ export function registerInteractionTools() {
         await tapElement(device, tapMatch.element);
         const { observeScreenFactory } = getSystemTrayDependencies();
         const observeScreen = observeScreenFactory(device);
-        const nextObservation = await observeScreen.execute();
+        const nextObservation = await observeScreen.execute({
+          skipScreenshot: true,
+          skipAccessibilityAudit: true,
+        });
+        await captureSystemTrayTerminalEvidence(device, nextObservation);
 
         return createJSONToolResponse({
           message: notification.tapActionLabel
@@ -1595,7 +1603,11 @@ export function registerInteractionTools() {
         await swipeElement(device, swipeTarget);
         const { observeScreenFactory } = getSystemTrayDependencies();
         const observeScreen = observeScreenFactory(device);
-        const nextObservation = await observeScreen.execute();
+        const nextObservation = await observeScreen.execute({
+          skipScreenshot: true,
+          skipAccessibilityAudit: true,
+        });
+        await captureSystemTrayTerminalEvidence(device, nextObservation);
 
         return createJSONToolResponse({
           message: "Dismissed notification",
@@ -1634,7 +1646,11 @@ export function registerInteractionTools() {
 
         const { observeScreenFactory } = getSystemTrayDependencies();
         const observeScreen = observeScreenFactory(device);
-        const nextObservation = await observeScreen.execute();
+        const nextObservation = await observeScreen.execute({
+          skipScreenshot: true,
+          skipAccessibilityAudit: true,
+        });
+        await captureSystemTrayTerminalEvidence(device, nextObservation);
 
         return createJSONToolResponse({
           message:

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -56,6 +56,7 @@ import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { logger } from "../utils/logger";
 import { serverConfig } from "../utils/ServerConfig";
 import { NodeCryptoService } from "../utils/crypto";
+import { shouldSkipObserveWaitForScreenshot } from "../features/observe/automaticScreenshotPolicy";
 
 // Schema definitions
 // waitFor accepts legacy selectors plus richer predicates. Element predicates are
@@ -1042,10 +1043,19 @@ export const waitForObservation = async (
   timer: Timer = defaultTimer,
   platform?: BootedDevice["platform"],
 ): Promise<WaitForObservationOutcome> => {
+  const complete = async (
+    outcome: WaitForObservationOutcome,
+  ): Promise<WaitForObservationOutcome> => {
+    if (!shouldSkipObserveWaitForScreenshot()) {
+      await observeScreen.captureScreenshot?.(createGlobalPerformanceTracker(), signal);
+    }
+    return outcome;
+  };
+
   // Declarative `for` DSL (issue #4398) routes to the #4389 primitives; the
   // legacy element/textAny/activeWindow path below is unchanged (back-compat).
   if (isConditionDsl(waitFor)) {
-    return runWaitForConditionDsl(observeScreen, waitFor, signal, timer);
+    return complete(await runWaitForConditionDsl(observeScreen, waitFor, signal, timer));
   }
 
   const startTime = timer.now();
@@ -1057,11 +1067,9 @@ export const waitForObservation = async (
     elementId: waitFor.elementId,
   };
 
-  // When overhead is disabled, skip screenshots and back stack during ALL waitFor
-  // observations (including the initial one) to reduce ADB contention. This prevents
-  // slow back stack fetches (dumpsys activity) and screenshots (screencap) from
-  // consuming the timeout budget. Trade-off: LATEST_SCREENSHOT will not reflect the
-  // exact screen state when waitFor resolved.
+  // Back-stack collection may stay disabled during waitFor polling to preserve its
+  // timeout budget. Screenshots always stay suppressed during polls; when opted
+  // in, `complete` captures exactly one screenshot from the terminal state.
   const skipPollingOverhead = !serverConfig.isWaitForPollingOverheadEnabled();
 
   const observeOnce = () =>
@@ -1072,7 +1080,7 @@ export const waitForObservation = async (
       minTimestamp: startTime,
       signal,
       skipBackStack: skipPollingOverhead || skipBackStack,
-      skipScreenshot: skipPollingOverhead,
+      skipScreenshot: true,
     });
 
   // Settle gate (issue #3490 §3): once the predicate matches, hold until the
@@ -1102,7 +1110,7 @@ export const waitForObservation = async (
 
   if (waitEvaluation.matched && settleReady(observation)) {
     const waitMs = timer.now() - startTime;
-    return {
+    return complete({
       observation,
       awaitedElement: waitEvaluation.awaitedElement,
       awaitDuration: waitMs,
@@ -1113,7 +1121,7 @@ export const waitForObservation = async (
       polls,
       waitMs,
       matchedElement: waitEvaluation.awaitedElement,
-    };
+    });
   }
   if (!waitEvaluation.matched) {
     matchedHash = null;
@@ -1121,7 +1129,7 @@ export const waitForObservation = async (
 
   if (timer.now() - startTime >= timeoutMs) {
     const waitMs = timer.now() - startTime;
-    return {
+    return complete({
       observation,
       awaitDuration: waitMs,
       awaitTimeout: true,
@@ -1130,7 +1138,7 @@ export const waitForObservation = async (
       timedOut: true,
       polls,
       waitMs,
-    };
+    });
   }
 
   while (timer.now() - startTime < timeoutMs) {
@@ -1144,7 +1152,7 @@ export const waitForObservation = async (
     if (waitEvaluation.matched) {
       if (settleReady(observation)) {
         const waitMs = timer.now() - startTime;
-        return {
+        return complete({
           observation,
           awaitedElement: waitEvaluation.awaitedElement,
           awaitDuration: waitMs,
@@ -1155,7 +1163,7 @@ export const waitForObservation = async (
           polls,
           waitMs,
           matchedElement: waitEvaluation.awaitedElement,
-        };
+        });
       }
     } else {
       matchedHash = null;
@@ -1163,7 +1171,7 @@ export const waitForObservation = async (
   }
 
   const waitMs = timer.now() - startTime;
-  return {
+  return complete({
     observation,
     awaitDuration: waitMs,
     awaitTimeout: true,
@@ -1172,7 +1180,7 @@ export const waitForObservation = async (
     timedOut: true,
     polls,
     waitMs,
-  };
+  });
 };
 
 // Register tools (this will be called when this file is imported)

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -1046,11 +1046,16 @@ export const waitForObservation = async (
   const complete = async (
     outcome: WaitForObservationOutcome,
   ): Promise<WaitForObservationOutcome> => {
-    if (!shouldSkipObserveWaitForScreenshot()) {
+    if (!shouldSkipObserveWaitForScreenshot() || serverConfig.isAccessibilityAuditEnabled()) {
       await observeScreen.captureScreenshot?.(
         createGlobalPerformanceTracker(),
         signal,
         outcome.observation,
+      );
+    } else {
+      await observeScreen.runAccessibilityAudit?.(
+        outcome.observation,
+        createGlobalPerformanceTracker(),
       );
     }
     return outcome;

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -1047,7 +1047,11 @@ export const waitForObservation = async (
     outcome: WaitForObservationOutcome,
   ): Promise<WaitForObservationOutcome> => {
     if (!shouldSkipObserveWaitForScreenshot()) {
-      await observeScreen.captureScreenshot?.(createGlobalPerformanceTracker(), signal);
+      await observeScreen.captureScreenshot?.(
+        createGlobalPerformanceTracker(),
+        signal,
+        outcome.observation,
+      );
     }
     return outcome;
   };
@@ -1081,6 +1085,7 @@ export const waitForObservation = async (
       signal,
       skipBackStack: skipPollingOverhead || skipBackStack,
       skipScreenshot: true,
+      skipAccessibilityAudit: true,
     });
 
   // Settle gate (issue #3490 §3): once the predicate matches, hold until the

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -1272,7 +1272,7 @@ export const waitForNotificationMatch = async (
     }
 
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+    observation = await observeSystemTray(observeScreen, minTimestamp);
   }
 };
 

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -32,6 +32,10 @@ import type { ProgressCallback } from "./toolRegistry";
 import type { SystemTrayNotificationArgs } from "./interactionToolTypes";
 import { boundsArea } from "../utils/bounds";
 import { logger } from "../utils/logger";
+import { shouldSkipActionObservationScreenshot } from "../features/observe/automaticScreenshotPolicy";
+import { getDeviceDataStreamServer } from "../daemon/deviceDataStreamSocketServer";
+import { serverConfig } from "../utils/ServerConfig";
+import type { PerformanceTracker } from "../utils/PerformanceTracker";
 
 // ============================================================================
 // Interfaces
@@ -39,6 +43,12 @@ import { logger } from "../utils/logger";
 
 export interface SystemTrayObserver {
   execute(options?: ObserveScreenExecuteOptions): Promise<ObserveResult>;
+  captureScreenshot?(
+    perf?: PerformanceTracker,
+    signal?: AbortSignal,
+    observation?: ObserveResult,
+  ): Promise<void>;
+  runAccessibilityAudit?(observation: ObserveResult, perf?: PerformanceTracker): Promise<void>;
 }
 
 export interface SystemTrayAdb {
@@ -212,6 +222,37 @@ const sleep = (ms: number) => getSystemTrayDependencies().timer.sleep(ms);
 
 export const resolveSystemTrayAwaitTimeout = (awaitTimeout?: number): number => {
   return awaitTimeout ?? DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS;
+};
+
+const observeSystemTray = (
+  observeScreen: SystemTrayObserver,
+  minTimestamp: number,
+): Promise<ObserveResult> =>
+  observeScreen.execute({
+    skipWaitForFresh: false,
+    minTimestamp,
+    skipScreenshot: true,
+    skipAccessibilityAudit: true,
+  });
+
+export const captureSystemTrayTerminalEvidence = async (
+  device: BootedDevice,
+  observation: ObserveResult | undefined,
+): Promise<void> => {
+  if (!observation) {
+    return;
+  }
+  const { observeScreenFactory } = getSystemTrayDependencies();
+  const observeScreen = observeScreenFactory(device);
+  const shouldCaptureScreenshot =
+    !shouldSkipActionObservationScreenshot() ||
+    serverConfig.isAccessibilityAuditEnabled() ||
+    (getDeviceDataStreamServer()?.hasSubscriberForDevice(device.deviceId) ?? false);
+  if (shouldCaptureScreenshot) {
+    await observeScreen.captureScreenshot?.(undefined, undefined, observation);
+    return;
+  }
+  await observeScreen.runAccessibilityAudit?.(observation);
 };
 
 const expandSystemTray = async (
@@ -976,14 +1017,14 @@ const waitForSystemTrayOpen = async (
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
-  let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  let observation = await observeSystemTray(observeScreen, minTimestamp);
 
   while (timer.now() - startTime < awaitTimeoutMs) {
     if (detector.isTrayOpen(observation.viewHierarchy)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+    observation = await observeSystemTray(observeScreen, minTimestamp);
   }
 
   return observation;
@@ -997,14 +1038,14 @@ const waitForSystemTrayClosed = async (
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
-  let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  let observation = await observeSystemTray(observeScreen, minTimestamp);
 
   while (timer.now() - startTime < awaitTimeoutMs) {
     if (!detector.isTrayOpen(observation.viewHierarchy)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+    observation = await observeSystemTray(observeScreen, minTimestamp);
   }
 
   return observation;
@@ -1025,7 +1066,7 @@ export const ensureSystemTrayOpen = async (
   const observeScreen = observeScreenFactory(device);
 
   let minTimestamp = await detector.getObservationTimestamp();
-  const observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  const observation = await observeSystemTray(observeScreen, minTimestamp);
   if (detector.isTrayOpen(observation.viewHierarchy)) {
     return { observation, opened: false, skipped: true, minTimestamp };
   }
@@ -1063,7 +1104,7 @@ export const ensureSystemTrayClosed = async (
   const observeScreen = observeScreenFactory(device);
 
   let minTimestamp = await detector.getObservationTimestamp();
-  const observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  const observation = await observeSystemTray(observeScreen, minTimestamp);
   if (!detector.isTrayOpen(observation.viewHierarchy)) {
     return { observation, closed: false, skipped: true, minTimestamp };
   }
@@ -1174,7 +1215,7 @@ export const waitForNotificationMatch = async (
   let observation = result.observation;
   const minTimestamp = result.minTimestamp;
   if (!observation) {
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+    observation = await observeSystemTray(observeScreen, minTimestamp);
   }
 
   let lastInfoDiagSignature = "";

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod/v4";
 import { DeviceSessionManager, type DeviceReadinessLevel } from "../utils/DeviceSessionManager";
-import { ActionableError, BootedDevice, SomePlatform } from "../models";
+import { ActionableError, BootedDevice, SomePlatform, type ViewHierarchyResult } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -34,7 +34,11 @@ import {
 } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
-import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
+import {
+  getStructuredField,
+  getStructuredPayload,
+  StructuredToolResponse,
+} from "../utils/toolUtils";
 import { applyJsonSchemaOverride, isInjectedDeviceIdSchema } from "./toolSchemaHelpers";
 import {
   InternalToolName,
@@ -306,6 +310,38 @@ interface AfterToolCallResult {
 
 interface AfterToolCallHandler {
   handle(input: AfterToolCallInput): Promise<AfterToolCallResult>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isViewHierarchyResult(value: unknown): value is ViewHierarchyResult {
+  return isRecord(value) && isRecord(value.hierarchy);
+}
+
+/**
+ * Read an unprojected observation hierarchy from a completed tool envelope.
+ *
+ * `observe` returns the ObserveResult as its top-level structured payload,
+ * while action tools nest the same snapshot under `.observation`. This runs
+ * before `finalizeToolResponse`, so it preserves the raw hierarchy even when
+ * the client-facing response uses the compact skeleton projection.
+ */
+function getObservedHierarchy(
+  name: string,
+  response: { structuredContent?: unknown } | undefined,
+): ViewHierarchyResult | undefined {
+  const payload = getStructuredPayload<Record<string, unknown>>(response);
+  if (!payload) {
+    return undefined;
+  }
+
+  const observation = name === "observe" ? payload : payload.observation;
+  if (!isRecord(observation) || !isViewHierarchyResult(observation.viewHierarchy)) {
+    return undefined;
+  }
+  return observation.viewHierarchy;
 }
 
 type ObservationArtifactWriterFactory = (
@@ -904,11 +940,9 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
 
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      const observeEnvelope = narrowInternalToolEnvelope("observe", response);
-      const observeHierarchy =
-        name === "observe" ? getStructuredField(observeEnvelope, "viewHierarchy") : undefined;
-      if (observeHierarchy) {
-        sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
+      const observedHierarchy = getObservedHierarchy(name, response);
+      if (observedHierarchy) {
+        sessionManager.setLastHierarchy(sessionUuid, observedHierarchy);
       }
       // NOTE: there is deliberately no `screenshot` read here. Production
       // `observe` never emitted a `screenshot` payload field and the session

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -330,10 +330,11 @@ function isViewHierarchyResult(value: unknown): value is ViewHierarchyResult {
  */
 function getObservedHierarchy(
   name: string,
-  response: { structuredContent?: unknown } | undefined,
+  response: { structuredContent?: unknown; content?: unknown } | undefined,
 ): ViewHierarchyResult | undefined {
-  const payload = getStructuredPayload<Record<string, unknown>>(response);
-  if (!payload) {
+  const structuredPayload = getStructuredPayload<Record<string, unknown>>(response);
+  const payload = structuredPayload ?? unwrapToolResponse(response);
+  if (!isRecord(payload)) {
     return undefined;
   }
 

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -21,6 +21,7 @@ export class FakeObserveScreen implements ObserveScreen {
   private callCounter: number = 0;
   private autoVaryHierarchy: boolean = false;
   private readonly executeOptionsHistory: ObserveScreenExecuteOptions[] = [];
+  private readonly capturedScreenshotObservations: Array<ObserveResult | undefined> = [];
 
   /**
    * Set the observe result to be returned by execute and getMostRecentCachedObserveResult
@@ -147,6 +148,7 @@ export class FakeObserveScreen implements ObserveScreen {
     this.getMostRecentCachedObserveResultCallCount = 0;
     this.callCounter = 0;
     this.executeOptionsHistory.length = 0;
+    this.capturedScreenshotObservations.length = 0;
   }
 
   /**
@@ -159,6 +161,11 @@ export class FakeObserveScreen implements ObserveScreen {
   /** Total captureScreenshot() calls. */
   getCaptureScreenshotCallCount(): number {
     return this.captureScreenshotCallCount;
+  }
+
+  /** Observations associated with terminal screenshot capture, in call order. */
+  getCapturedScreenshotObservations(): Array<ObserveResult | undefined> {
+    return [...this.capturedScreenshotObservations];
   }
 
   /**
@@ -183,9 +190,14 @@ export class FakeObserveScreen implements ObserveScreen {
     return this.getNextObserveResult();
   }
 
-  async captureScreenshot(): Promise<void> {
+  async captureScreenshot(
+    _perf?: unknown,
+    _signal?: AbortSignal,
+    observation?: ObserveResult,
+  ): Promise<void> {
     this.executedOperations.push("captureScreenshot");
     this.captureScreenshotCallCount++;
+    this.capturedScreenshotObservations.push(observation);
 
     const error = this.failures.get("captureScreenshot");
     if (error) {

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -15,6 +15,7 @@ export class FakeObserveScreen implements ObserveScreen {
   private observeResultFactory: ((index: number) => ObserveResult) | null = null;
   private observeSequence: ObserveResult[] | null = null;
   private executeCallCount: number = 0;
+  private captureScreenshotCallCount: number = 0;
   private getMostRecentCachedObserveResultCallCount: number = 0;
   private failures: Map<string, Error> = new Map();
   private callCounter: number = 0;
@@ -142,6 +143,7 @@ export class FakeObserveScreen implements ObserveScreen {
   clearHistory(): void {
     this.executedOperations = [];
     this.executeCallCount = 0;
+    this.captureScreenshotCallCount = 0;
     this.getMostRecentCachedObserveResultCallCount = 0;
     this.callCounter = 0;
     this.executeOptionsHistory.length = 0;
@@ -152,6 +154,11 @@ export class FakeObserveScreen implements ObserveScreen {
    */
   getExecuteCallCount(): number {
     return this.executeCallCount;
+  }
+
+  /** Total captureScreenshot() calls. */
+  getCaptureScreenshotCallCount(): number {
+    return this.captureScreenshotCallCount;
   }
 
   /**
@@ -174,6 +181,16 @@ export class FakeObserveScreen implements ObserveScreen {
     }
 
     return this.getNextObserveResult();
+  }
+
+  async captureScreenshot(): Promise<void> {
+    this.executedOperations.push("captureScreenshot");
+    this.captureScreenshotCallCount++;
+
+    const error = this.failures.get("captureScreenshot");
+    if (error) {
+      throw error;
+    }
   }
 
   /** Options passed to each `execute()` call, in order. */

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -16,6 +16,7 @@ export class FakeObserveScreen implements ObserveScreen {
   private observeSequence: ObserveResult[] | null = null;
   private executeCallCount: number = 0;
   private captureScreenshotCallCount: number = 0;
+  private accessibilityAuditCallCount: number = 0;
   private getMostRecentCachedObserveResultCallCount: number = 0;
   private failures: Map<string, Error> = new Map();
   private callCounter: number = 0;
@@ -145,6 +146,7 @@ export class FakeObserveScreen implements ObserveScreen {
     this.executedOperations = [];
     this.executeCallCount = 0;
     this.captureScreenshotCallCount = 0;
+    this.accessibilityAuditCallCount = 0;
     this.getMostRecentCachedObserveResultCallCount = 0;
     this.callCounter = 0;
     this.executeOptionsHistory.length = 0;
@@ -161,6 +163,11 @@ export class FakeObserveScreen implements ObserveScreen {
   /** Total captureScreenshot() calls. */
   getCaptureScreenshotCallCount(): number {
     return this.captureScreenshotCallCount;
+  }
+
+  /** Total runAccessibilityAudit() calls. */
+  getAccessibilityAuditCallCount(): number {
+    return this.accessibilityAuditCallCount;
   }
 
   /** Observations associated with terminal screenshot capture, in call order. */
@@ -200,6 +207,16 @@ export class FakeObserveScreen implements ObserveScreen {
     this.capturedScreenshotObservations.push(observation);
 
     const error = this.failures.get("captureScreenshot");
+    if (error) {
+      throw error;
+    }
+  }
+
+  async runAccessibilityAudit(_observation: ObserveResult, _perf?: unknown): Promise<void> {
+    this.executedOperations.push("runAccessibilityAudit");
+    this.accessibilityAuditCallCount++;
+
+    const error = this.failures.get("runAccessibilityAudit");
     if (error) {
       throw error;
     }

--- a/test/features/action/BaseVisualChange.postActionObservation.test.ts
+++ b/test/features/action/BaseVisualChange.postActionObservation.test.ts
@@ -7,6 +7,7 @@ import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeWindow } from "../../fakes/FakeWindow";
+import { serverConfig } from "../../../src/utils/ServerConfig";
 import {
   ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV,
   shouldSkipActionObservationScreenshot,
@@ -48,6 +49,7 @@ describe("BaseVisualChange post-action observation", () => {
   beforeEach(() => {
     originalActionScreenshotPolicy = process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV];
     delete process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV];
+    serverConfig.setAccessibilityAuditConfig(null);
     PortManager.reset();
     PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
     fakeAdb = new FakeAdbExecutor();
@@ -65,6 +67,7 @@ describe("BaseVisualChange post-action observation", () => {
     } else {
       process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV] = originalActionScreenshotPolicy;
     }
+    serverConfig.setAccessibilityAuditConfig(null);
     PortManager.reset();
     PortManager.setPortAvailabilityCheckerForTesting(null);
   });
@@ -128,6 +131,7 @@ describe("BaseVisualChange post-action observation", () => {
     expect(options).toHaveLength(1);
     expect(options[0].skipScreenshot).toBe(true);
     expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(0);
+    expect(fakeObserveScreen.getAccessibilityAuditCallCount()).toBe(1);
     expect(shouldSkipActionObservationScreenshot()).toBe(true);
   });
 
@@ -150,6 +154,28 @@ describe("BaseVisualChange post-action observation", () => {
     );
     expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
     expect(shouldSkipActionObservationScreenshot()).toBe(false);
+  });
+
+  test("captures one fresh terminal screenshot when the accessibility audit is enabled", async () => {
+    const instance = createVisualChange("android");
+    serverConfig.setAccessibilityAuditConfig({
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    });
+    fakeObserveScreen.setObserveResult(
+      makeObserve({ activeWindow: { appId: "com.example.app" } }),
+    );
+
+    await instance.observedInteraction(async () => ({ success: true }), {
+      changeExpected: false,
+      skipPreviousObserve: true,
+    });
+
+    expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+      true,
+    );
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
   });
 
   test("takes the cached fast path with a single execute when the cache is valid", async () => {

--- a/test/features/action/BaseVisualChange.postActionObservation.test.ts
+++ b/test/features/action/BaseVisualChange.postActionObservation.test.ts
@@ -163,9 +163,7 @@ describe("BaseVisualChange post-action observation", () => {
       failureMode: "report",
       useBaseline: false,
     });
-    fakeObserveScreen.setObserveResult(
-      makeObserve({ activeWindow: { appId: "com.example.app" } }),
-    );
+    fakeObserveScreen.setObserveResult(makeObserve({ activeWindow: { appId: "com.example.app" } }));
 
     await instance.observedInteraction(async () => ({ success: true }), {
       changeExpected: false,

--- a/test/features/action/BaseVisualChange.postActionObservation.test.ts
+++ b/test/features/action/BaseVisualChange.postActionObservation.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { BaseVisualChange } from "../../../src/features/action/BaseVisualChange";
 import { BootedDevice, ObserveResult } from "../../../src/models";
+import { PortManager } from "../../../src/utils/PortManager";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeWindow } from "../../fakes/FakeWindow";
+import {
+  ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV,
+  shouldSkipActionObservationScreenshot,
+} from "../../../src/features/observe/automaticScreenshotPolicy";
 
 /**
  * Post-action observation contract for BaseVisualChange (issue #4169 items 1-3).
@@ -20,6 +25,7 @@ describe("BaseVisualChange post-action observation", () => {
   let fakeObserveScreen: FakeObserveScreen;
   let fakeTimer: FakeTimer;
   let fakeWindow: FakeWindow;
+  let originalActionScreenshotPolicy: string | undefined;
 
   const makeObserve = (overrides: Record<string, unknown> = {}): ObserveResult =>
     ({
@@ -40,6 +46,10 @@ describe("BaseVisualChange post-action observation", () => {
   }
 
   beforeEach(() => {
+    originalActionScreenshotPolicy = process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV];
+    delete process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV];
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
     fakeAdb = new FakeAdbExecutor();
     fakeAwaitIdle = new FakeAwaitIdle();
     fakeObserveScreen = new FakeObserveScreen();
@@ -47,6 +57,16 @@ describe("BaseVisualChange post-action observation", () => {
     fakeTimer.enableAutoAdvance();
     fakeWindow = new FakeWindow();
     fakeWindow.configureCachedActiveWindow(null);
+  });
+
+  afterEach(() => {
+    if (originalActionScreenshotPolicy === undefined) {
+      delete process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV];
+    } else {
+      process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV] = originalActionScreenshotPolicy;
+    }
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
   test("retries a stale observation on the [50,100,200,400] backoff and caps at four attempts", async () => {
@@ -95,12 +115,10 @@ describe("BaseVisualChange post-action observation", () => {
     expect(fakeTimer.getSleepHistory()).toEqual([]);
   });
 
-  test("defaults the post-action re-observe to skipScreenshot when no live-view subscriber (#5472)", async () => {
+  test("skips automatic post-action screenshots by default", async () => {
     const instance = createVisualChange("ios");
     fakeObserveScreen.setObserveResult(makeObserve());
 
-    // No DeviceDataStream server/subscriber is wired in this unit context, so the
-    // internal re-observe must skip the device PNG capture.
     await instance.observedInteraction(async () => ({ success: true }), {
       changeExpected: false,
       skipPreviousObserve: true,
@@ -109,6 +127,29 @@ describe("BaseVisualChange post-action observation", () => {
     const options = fakeObserveScreen.getExecuteOptions();
     expect(options).toHaveLength(1);
     expect(options[0].skipScreenshot).toBe(true);
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(0);
+    expect(shouldSkipActionObservationScreenshot()).toBe(true);
+  });
+
+  test("opt-in captures exactly one screenshot after the final post-action retry", async () => {
+    process.env[ACTION_OBSERVATION_SKIP_SCREENSHOT_ENV] = "false";
+    const instance = createVisualChange("ios");
+    fakeObserveScreen.setObserveResult((index) =>
+      makeObserve({ freshness: { isFresh: false }, updatedAt: index }),
+    );
+
+    await instance.observedInteraction(async () => ({ success: true }), {
+      changeExpected: false,
+      skipPreviousObserve: true,
+      overrideMinTimestamp: 1000,
+    });
+
+    expect(fakeObserveScreen.getExecuteCallCount()).toBe(5);
+    expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+      true,
+    );
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
+    expect(shouldSkipActionObservationScreenshot()).toBe(false);
   });
 
   test("takes the cached fast path with a single execute when the cache is valid", async () => {

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -18,6 +18,7 @@ import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { IOSCtrlProxyManager } from "../../../src/utils/IOSCtrlProxyManager";
 import { DeviceLostError } from "../../../src/server/deviceLossOutcome";
+import { PortManager } from "../../../src/utils/PortManager";
 
 describe("LaunchApp", () => {
   let device: BootedDevice;
@@ -56,6 +57,8 @@ describe("LaunchApp", () => {
       );
 
   beforeEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
     device = { name: "test-device", platform: "android", deviceId: "device-123" };
     fakeAdb = new FakeAdbExecutor();
     fakeAwaitIdle = new FakeAwaitIdle();
@@ -77,6 +80,11 @@ describe("LaunchApp", () => {
     (launchApp as any).window = fakeWindow;
 
     configureInstalledApp();
+  });
+
+  afterEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
   test("returns observation when app is already in foreground", async () => {
@@ -576,6 +584,43 @@ describe("LaunchApp", () => {
         .getExecuteOptions()
         .every((options) => options.signal === controller.signal),
     ).toBe(true);
+  });
+
+  test("captures only the final launch observation after package reconciliation", async () => {
+    fakeTimer.enableAutoAdvance();
+    const previousPackageName = "com.example.previous";
+    const observations = [
+      createObserveResult(previousPackageName),
+      createObserveResult(packageName),
+    ];
+    const originalPolicy = process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+    process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT = "false";
+
+    try {
+      fakeAdb.setForegroundApp({ packageName, userId: 0 });
+      fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+      fakeObserveScreen.setObserveResult(
+        () => observations.shift() ?? createObserveResult(packageName),
+      );
+
+      const result = await launchApp.execute(packageName, false, false);
+
+      expect(result.observation?.activeWindow?.appId).toBe(packageName);
+      expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+        true,
+      );
+      expect(
+        fakeObserveScreen.getExecuteOptions().every((options) => options.skipAccessibilityAudit),
+      ).toBe(true);
+      expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
+      expect(fakeObserveScreen.getCapturedScreenshotObservations()).toEqual([result.observation]);
+    } finally {
+      if (originalPolicy === undefined) {
+        delete process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+      } else {
+        process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT = originalPolicy;
+      }
+    }
   });
 
   test("re-observes when a matching launch observation is marked unverified", async () => {

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { PortManager } from "../../../src/utils/PortManager";
 import type {
   ConditionPredicate,
   WaitForCondition,
@@ -48,6 +49,16 @@ function createTapOnElement(
 }
 
 describe("retryTapIfNoChange", () => {
+  beforeEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+  });
+
+  afterEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
+  });
+
   test("does not retry when hierarchy changed after tap", async () => {
     const { tap } = createTapOnElement();
     const preHierarchy = makeHierarchy("before");
@@ -212,6 +223,46 @@ describe("deriveTapEffect", () => {
       screenChanged: false,
       basis: "insufficient observation data",
     });
+  });
+
+  test("captures terminal evidence after effect polling selects the destination observation", async () => {
+    const { tap } = createTapOnElement();
+    const source = makeObservation({
+      activeWindow: {
+        appId: "com.example.app",
+        activityName: "SourceActivity",
+        layoutSeqSum: 1,
+      },
+    });
+    const destination = makeObservation({
+      activeWindow: {
+        appId: "com.example.app",
+        activityName: "DestinationActivity",
+        layoutSeqSum: 2,
+      },
+    });
+    const captured: ObserveResult[] = [];
+
+    (tap as any).observedInteraction = async (_interaction: unknown, options: unknown) => {
+      expect((options as { deferPostActionScreenshot?: boolean }).deferPostActionScreenshot).toBe(
+        true,
+      );
+      return { success: true, action: "tap", element: makeElement(), observation: source };
+    };
+    (tap as any).deriveTapEffectAfterPostTapObservation = async () => ({
+      effect: { screenChanged: true, basis: "activeWindow changed" },
+      observation: destination,
+    });
+    (tap as any).captureTerminalObservationScreenshot = async (observation: ObserveResult) => {
+      captured.push(observation);
+    };
+    (tap as any).recordDeferredPredictionOutcome = async () => {};
+    (tap as any).selectionStateTracker = { finalize: async () => [] };
+
+    const result = await tap.execute({ action: "tap", text: "Submit" });
+
+    expect(result.observation).toBe(destination);
+    expect(captured).toEqual([destination]);
   });
 
   test("waits for a changed Android observation before deriving the effect", async () => {

--- a/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
@@ -53,6 +53,9 @@ function makeScrollUntilVisible({
   talkBackExecutor,
   getDuration,
   overlayDetector,
+  observeOptions,
+  observedInteractionOptions,
+  terminalEvidence,
 }: {
   accessibilityDetector: FakeAccessibilityDetector;
   finder: FakeElementFinder;
@@ -62,11 +65,17 @@ function makeScrollUntilVisible({
   talkBackExecutor: FakeTalkBackSwipeExecutor;
   getDuration?: (options: SwipeOnResolvedOptions) => number;
   overlayDetector?: FakeOverlayDetector;
+  observeOptions?: Array<Record<string, unknown> | undefined>;
+  observedInteractionOptions?: Array<Record<string, unknown>>;
+  terminalEvidence?: ObserveResult[];
 }): ScrollUntilVisible {
   let callIdx = 0;
 
   const fakeObserveScreen = {
-    execute: async () => observeResults[Math.min(callIdx, observeResults.length - 1)],
+    execute: async (options?: Record<string, unknown>) => {
+      observeOptions?.push(options);
+      return observeResults[Math.min(callIdx, observeResults.length - 1)];
+    },
     getMostRecentCachedObserveResult: async () =>
       observeResults[Math.min(callIdx, observeResults.length - 1)],
   };
@@ -75,7 +84,8 @@ function makeScrollUntilVisible({
 
   const fakeOverlayDetector = overlayDetector ?? new FakeOverlayDetector();
 
-  const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, _opts: any) => {
+  const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, opts: any) => {
+    observedInteractionOptions?.push(opts);
     const obs = observeResults[Math.min(callIdx, observeResults.length - 1)];
     const result = await action(obs);
     callIdx++;
@@ -98,6 +108,11 @@ function makeScrollUntilVisible({
     resolveBoomerangConfig: () => undefined,
     buildPredictionArgs: () => ({}),
     observedInteraction,
+    captureTerminalObservationScreenshot: async (observation) => {
+      if (observation) {
+        terminalEvidence?.push(observation);
+      }
+    },
   });
 }
 
@@ -202,6 +217,39 @@ describe("ScrollUntilVisible overshoot recovery", () => {
     // Verify that executeSwipeGesture was never called with the reversed direction ("down")
     const allDirections = talkBackExecutor.getDirections();
     expect(allDirections.every((d) => d === "up")).toBe(true);
+  });
+
+  test("suppresses intermediate evidence and captures only the terminal observation", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      return findCount >= 2 ? TARGET_ELEMENT : null;
+    };
+    const observeOptions: Array<Record<string, unknown> | undefined> = [];
+    const observedInteractionOptions: Array<Record<string, unknown>> = [];
+    const terminalEvidence: ObserveResult[] = [];
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [makeObserveResult(0), makeObserveResult(1)],
+      talkBackExecutor,
+      observeOptions,
+      observedInteractionOptions,
+      terminalEvidence,
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(observeOptions).not.toHaveLength(0);
+    expect(observeOptions.every((options) => options?.skipScreenshot === true)).toBe(true);
+    expect(observeOptions.every((options) => options?.skipAccessibilityAudit === true)).toBe(true);
+    expect(
+      observedInteractionOptions.every((options) => options.deferPostActionScreenshot === true),
+    ).toBe(true);
+    expect(terminalEvidence).toEqual([result.observation]);
   });
 
   test("switches to opposite direction after forward end-of-list", async () => {

--- a/test/features/observe/WaitForCondition.test.ts
+++ b/test/features/observe/WaitForCondition.test.ts
@@ -85,6 +85,7 @@ describe("RealWaitForCondition", () => {
     expect(result.timedOut).toBe(false);
     expect(result.polls).toBe(2);
     expect(result.matchedElement!.text).toBe("ready");
+    expect(fake.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(true);
   });
 
   test("on timeout returns the last-seen candidates, not a bare failure", async () => {

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -234,6 +234,15 @@ describe("DefaultObserveScreenshotRecorder.capture", () => {
 
     expect(svc.lastTrackerOptions?.coalesceWithPending).toBe(true);
   });
+
+  test("captureFresh() queues terminal evidence after pending work", async () => {
+    svc.setNextResult({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+
+    await recorder.captureFresh(new NoOpPerformanceTracker());
+
+    expect(svc.lastTrackerOptions?.queueAfterPending).toBe(true);
+    expect(svc.lastTrackerOptions?.coalesceWithPending).toBeUndefined();
+  });
 });
 
 describe("DefaultObserveScreenshotRecorder.start", () => {

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1,6 +1,10 @@
 import Ajv2020 from "ajv/dist/2020";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
+import {
+  OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV,
+  shouldSkipObserveWaitForScreenshot,
+} from "../../src/features/observe/automaticScreenshotPolicy";
 import { DefaultElementFinder } from "../../src/features/utility/ElementFinder";
 import type { ObserveResult, ViewHierarchyResult } from "../../src/models";
 import {
@@ -32,6 +36,16 @@ const makeHierarchy = (
   },
   screenWidth: screenSize.width,
   screenHeight: screenSize.height,
+});
+
+const originalWaitForScreenshotPolicy = process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV];
+
+afterEach(() => {
+  if (originalWaitForScreenshotPolicy === undefined) {
+    delete process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV];
+  } else {
+    process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV] = originalWaitForScreenshotPolicy;
+  }
 });
 
 describe("observeSchema waitFor.container", () => {
@@ -1052,6 +1066,73 @@ describe("waitForObservation activeWindow", () => {
     expect(outcome.awaitTimeout).toBe(false);
     expect(outcome.observation.activeWindow?.appId).toBe("com.example.app");
     expect(observeScreen.getExecuteCallCount()).toBe(2);
+    expect(
+      observeScreen.getExecuteOptions().every((options) => options.skipScreenshot === true),
+    ).toBe(true);
+    expect(observeScreen.getCaptureScreenshotCallCount()).toBe(0);
+    expect(shouldSkipObserveWaitForScreenshot()).toBe(true);
+  });
+
+  test("opt-in captures one terminal screenshot while every poll remains suppressed", async () => {
+    process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV] = "0";
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation("com.browser", "", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+      makeObservation("com.example.app", "com.example.app.HomeActivity", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: { appId: "com.example.app" },
+        className: "UITabBar",
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer,
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+    expect(observeScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(true);
+    expect(observeScreen.getCaptureScreenshotCallCount()).toBe(1);
+    expect(shouldSkipObserveWaitForScreenshot()).toBe(false);
+  });
+
+  test("the declarative waitFor path also captures only its terminal screenshot", async () => {
+    process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV] = "false";
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      makeObservation("com.example.app", "com.example.app.HomeActivity"),
+      makeObservation("com.example.app", "com.example.app.HomeActivity"),
+    ]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        for: "stable",
+        timeout: 500,
+        stableReads: 2,
+      } as any,
+      undefined,
+      false,
+      timer,
+    );
+
+    expect(outcome.settled).toBe(true);
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+    expect(observeScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(true);
+    expect(observeScreen.getCaptureScreenshotCallCount()).toBe(1);
   });
 
   test("keeps polling until Android activityName matches", async () => {

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1103,7 +1103,11 @@ describe("waitForObservation activeWindow", () => {
     expect(outcome.awaitTimeout).toBe(false);
     expect(observeScreen.getExecuteCallCount()).toBe(2);
     expect(observeScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(true);
+    expect(
+      observeScreen.getExecuteOptions().every((options) => options.skipAccessibilityAudit),
+    ).toBe(true);
     expect(observeScreen.getCaptureScreenshotCallCount()).toBe(1);
+    expect(observeScreen.getCapturedScreenshotObservations()).toEqual([outcome.observation]);
     expect(shouldSkipObserveWaitForScreenshot()).toBe(false);
   });
 

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -14,6 +14,7 @@ import {
   waitForObservation,
 } from "../../src/server/observeTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { serverConfig } from "../../src/utils/ServerConfig";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -46,6 +47,7 @@ afterEach(() => {
   } else {
     process.env[OBSERVE_WAIT_FOR_SKIP_SCREENSHOT_ENV] = originalWaitForScreenshotPolicy;
   }
+  serverConfig.setAccessibilityAuditConfig(null);
 });
 
 describe("observeSchema waitFor.container", () => {
@@ -1070,6 +1072,7 @@ describe("waitForObservation activeWindow", () => {
       observeScreen.getExecuteOptions().every((options) => options.skipScreenshot === true),
     ).toBe(true);
     expect(observeScreen.getCaptureScreenshotCallCount()).toBe(0);
+    expect(observeScreen.getAccessibilityAuditCallCount()).toBe(1);
     expect(shouldSkipObserveWaitForScreenshot()).toBe(true);
   });
 
@@ -1109,6 +1112,43 @@ describe("waitForObservation activeWindow", () => {
     expect(observeScreen.getCaptureScreenshotCallCount()).toBe(1);
     expect(observeScreen.getCapturedScreenshotObservations()).toEqual([outcome.observation]);
     expect(shouldSkipObserveWaitForScreenshot()).toBe(false);
+  });
+
+  test("an enabled accessibility audit captures one fresh terminal screenshot", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation("com.browser", "", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+      makeObservation("com.example.app", "com.example.app.HomeActivity", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+    serverConfig.setAccessibilityAuditConfig({
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    });
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: { appId: "com.example.app" },
+        className: "UITabBar",
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer,
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(observeScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(true);
+    expect(observeScreen.getCaptureScreenshotCallCount()).toBe(1);
+    expect(observeScreen.getCapturedScreenshotObservations()).toEqual([outcome.observation]);
   });
 
   test("the declarative waitFor path also captures only its terminal screenshot", async () => {

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -134,12 +134,14 @@ describe("proxy server session ownership errors", () => {
         "heartbeat-timeout",
       );
 
-      await expect(client.listTools()).rejects.toThrow(ownershipLoss);
-      await expect(client.listResources()).rejects.toThrow(ownershipLoss);
-      await expect(client.listResourceTemplates()).rejects.toThrow(ownershipLoss);
-      await expect(client.readResource({ uri: "automobile:devices/booted" })).rejects.toThrow(
-        ownershipLoss,
-      );
+      await Promise.all([
+        expect(client.listTools()).rejects.toThrow(ownershipLoss),
+        expect(client.listResources()).rejects.toThrow(ownershipLoss),
+        expect(client.listResourceTemplates()).rejects.toThrow(ownershipLoss),
+        expect(client.readResource({ uri: "automobile:devices/booted" })).rejects.toThrow(
+          ownershipLoss,
+        ),
+      ]);
     } finally {
       await client.close();
       await server.close();

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   registerInteractionTools,
   resetSystemTrayDependencies,
@@ -20,6 +20,7 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
 import { logger, LogLevel } from "../../src/utils/logger";
+import { serverConfig } from "../../src/utils/ServerConfig";
 import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
 
 const POLL_INTERVAL_MS = 250;
@@ -1344,6 +1345,110 @@ describe("systemTray group expansion", () => {
 
     const reResult = await reMatchPromise;
     expect(reResult.match).toBeNull();
+  });
+});
+
+describe("systemTray automatic terminal evidence", () => {
+  let originalActionScreenshotPolicy: string | undefined;
+
+  beforeEach(() => {
+    originalActionScreenshotPolicy = process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+  });
+
+  afterEach(() => {
+    if (originalActionScreenshotPolicy === undefined) {
+      delete process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+    } else {
+      process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT = originalActionScreenshotPolicy;
+    }
+    serverConfig.setAccessibilityAuditConfig(null);
+    resetSystemTrayDependencies();
+    ToolRegistry.clearTools();
+  });
+
+  test("captures only the final find observation when action screenshots are enabled", async () => {
+    process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT = "false";
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Test Notification")),
+    ]);
+
+    setSystemTrayDependencies({
+      timer: new FakeTimer(),
+      adbFactory: () => new SequencedFakeAdbExecutor([1000]),
+      observeScreenFactory: () => fakeObserveScreen,
+    });
+    registerInteractionTools();
+    const handler = ToolRegistry.getTool("systemTray")?.deviceAwareHandler;
+
+    await handler!(device, {
+      action: "find",
+      notification: { title: "Test Notification" },
+      platform: "android",
+    });
+
+    expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+      true,
+    );
+    expect(
+      fakeObserveScreen.getExecuteOptions().every((options) => options.skipAccessibilityAudit),
+    ).toBe(true);
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
+    expect(fakeObserveScreen.getAccessibilityAuditCallCount()).toBe(0);
+  });
+
+  test("keeps the terminal accessibility audit when automatic screenshots are skipped", async () => {
+    delete process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Test Notification")),
+    ]);
+
+    setSystemTrayDependencies({
+      timer: new FakeTimer(),
+      adbFactory: () => new SequencedFakeAdbExecutor([1000]),
+      observeScreenFactory: () => fakeObserveScreen,
+    });
+    registerInteractionTools();
+    const handler = ToolRegistry.getTool("systemTray")?.deviceAwareHandler;
+
+    await handler!(device, {
+      action: "find",
+      notification: { title: "Test Notification" },
+      platform: "android",
+    });
+
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(0);
+    expect(fakeObserveScreen.getAccessibilityAuditCallCount()).toBe(1);
+  });
+
+  test("an enabled accessibility audit captures one fresh terminal screenshot", async () => {
+    delete process.env.AUTOMOBILE_ACTION_OBSERVATION_SKIP_SCREENSHOT;
+    serverConfig.setAccessibilityAuditConfig({
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    });
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Test Notification")),
+    ]);
+
+    setSystemTrayDependencies({
+      timer: new FakeTimer(),
+      adbFactory: () => new SequencedFakeAdbExecutor([1000]),
+      observeScreenFactory: () => fakeObserveScreen,
+    });
+    registerInteractionTools();
+    const handler = ToolRegistry.getTool("systemTray")?.deviceAwareHandler;
+
+    await handler!(device, {
+      action: "find",
+      notification: { title: "Test Notification" },
+      platform: "android",
+    });
+
+    expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+      true,
+    );
+    expect(fakeObserveScreen.getCaptureScreenshotCallCount()).toBe(1);
   });
 });
 

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -184,6 +184,12 @@ describe("systemTray find", () => {
     const minTimestamps = fakeObserveScreen.getMinTimestamps();
     expect(minTimestamps[0]).toBe(1000);
     expect(minTimestamps[1]).toBe(2000);
+    expect(fakeObserveScreen.getExecuteOptions().every((options) => options.skipScreenshot)).toBe(
+      true,
+    );
+    expect(
+      fakeObserveScreen.getExecuteOptions().every((options) => options.skipAccessibilityAudit),
+    ).toBe(true);
   });
 
   test("does not return matches while the tray is closed", async () => {

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -9,7 +9,11 @@ import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
+import {
+  createJSONToolResponse,
+  createStructuredToolResponse,
+  stringifyToolResponse,
+} from "../../src/utils/toolUtils";
 import type { ObserveResult } from "../../src/models/ObserveResult";
 
 /**
@@ -181,5 +185,30 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
     expect(typeof cacheData.lastObserveTime).toBe("number");
     expect((cacheData as Record<string, unknown>).customData).toBeUndefined();
+  });
+
+  test("caches a text-only action response's nested observation", async () => {
+    const sessionId = await setupAutolockedSession();
+    const observation = makeObserveResult();
+    ToolRegistry.registerDeviceAware("inputText", "inputText", toolSchema, async () =>
+      createJSONToolResponse({
+        success: true,
+        message: "Input complete",
+        observation,
+      }),
+    );
+    const tool = ToolRegistry.getTool("inputText")!;
+
+    await tool.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    const cacheData = daemonSessionManager!.getSession(sessionId)!.cacheData;
+    const cachedHierarchy = cacheData.lastHierarchy as any;
+    expect(cachedHierarchy).toBeDefined();
+    expect(cachedHierarchy.hierarchy.node["view-id"]).toBe("com.example:id/root");
+    expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
+    expect(typeof cacheData.lastObserveTime).toBe("number");
   });
 });

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -13,12 +13,10 @@ import { createStructuredToolResponse, stringifyToolResponse } from "../../src/u
 import type { ObserveResult } from "../../src/models/ObserveResult";
 
 /**
- * Integration coverage for issue #2758: the `lastHierarchy` session-cache write
- * must read the ObserveResult out of the MCP envelope's `structuredContent`
- * (previously it read `response.viewHierarchy`, which never existed on the
- * envelope, so the cache was silently never populated — the #2761 diff baseline
- * depends on it). Also verifies the `finalizeToolResponse` chokepoint sanitizes
- * the observe response while the cache keeps the full untrimmed hierarchy.
+ * Integration coverage for the `lastHierarchy` session-cache write. The
+ * ObserveResult can be the top-level structured payload (`observe`) or nested
+ * under `.observation` on an action result; both must update the full,
+ * untrimmed cache before `finalizeToolResponse` applies any wire projection.
  */
 describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
   const androidA: BootedDevice = {
@@ -177,6 +175,11 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     expect(response.content[0].text).toBe(stringifyToolResponse(response.structuredContent));
 
     const cacheData = daemonSessionManager!.getSession(sessionId)!.cacheData;
+    const cachedHierarchy = cacheData.lastHierarchy as any;
+    expect(cachedHierarchy).toBeDefined();
+    expect(cachedHierarchy.hierarchy.node["view-id"]).toBe("com.example:id/root");
+    expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
+    expect(typeof cacheData.lastObserveTime).toBe("number");
     expect((cacheData as Record<string, unknown>).customData).toBeUndefined();
   });
 });

--- a/test/utils/FileDownloader.test.ts
+++ b/test/utils/FileDownloader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -69,13 +69,14 @@ describe("FakeFileDownloader", function () {
 });
 
 describe("DefaultFileDownloader pipeResponseToFile", function () {
-  let tempDir: string | null = null;
+  let tempDir: string;
 
-  afterEach(async function () {
-    if (tempDir) {
-      await fs.rm(tempDir, { recursive: true, force: true });
-      tempDir = null;
-    }
+  beforeAll(async function () {
+    tempDir = await makeScratchTempDir("pipe-response-");
+  });
+
+  afterAll(async function () {
+    await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   test("rejects promptly and removes the partial file when the response closes mid-body", async function () {
@@ -101,8 +102,7 @@ describe("DefaultFileDownloader pipeResponseToFile", function () {
     const response = createFakeResponse();
     response.push(Buffer.from("partial body"));
 
-    tempDir = await makeScratchTempDir("pipe-response-mid-close-");
-    const destination = path.join(tempDir, "file.bin");
+    const destination = path.join(tempDir, "mid-close.bin");
     const downloader = asPipeResponseToFile(new DefaultFileDownloader());
 
     const result = downloader.pipeResponseToFile(response, destination, "https://example.com/file");
@@ -110,8 +110,6 @@ describe("DefaultFileDownloader pipeResponseToFile", function () {
 
     await expect(result).rejects.toThrow(/premature close/i);
 
-    expect(await fs.stat(destination).catch(() => undefined)).toBeUndefined();
-    // No attempt-unique temp file is left behind either.
     expect(await fs.readdir(tempDir)).toEqual([]);
   }, 100);
 
@@ -125,8 +123,7 @@ describe("DefaultFileDownloader pipeResponseToFile", function () {
     const response = createFakeResponse();
     response.push(Buffer.from("partial body"));
 
-    tempDir = await makeScratchTempDir("pipe-response-mid-close-race-");
-    const destination = path.join(tempDir, "file.bin");
+    const destination = path.join(tempDir, "preserved.bin");
     const existingPayload = Buffer.from("already downloaded by another attempt");
     await fs.writeFile(destination, existingPayload);
     const downloader = asPipeResponseToFile(new DefaultFileDownloader());
@@ -145,15 +142,13 @@ describe("DefaultFileDownloader pipeResponseToFile", function () {
     response.push(payload);
     response.push(null);
 
-    tempDir = await makeScratchTempDir("pipe-response-complete-");
-    const destination = path.join(tempDir, "file.bin");
+    const destination = path.join(tempDir, "complete.bin");
     const downloader = asPipeResponseToFile(new DefaultFileDownloader());
 
     await downloader.pipeResponseToFile(response, destination, "https://example.com/file");
 
     expect(await fs.readFile(destination)).toEqual(payload);
-    // No leftover attempt-unique temp file after a successful rename.
-    expect(await fs.readdir(tempDir)).toEqual(["file.bin"]);
+    expect((await fs.readdir(tempDir)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
   }, 100);
 });
 


### PR DESCRIPTION
## Summary

- Preserve complete view hierarchies from both explicit observations and action observations in the session cache before response sanitization.
- Add opt-in terminal screenshot capture for automatic post-action observations and `observe.waitFor`.
- Keep automatic screenshots skipped by default, preserve explicit `observe` behavior, and suppress every intermediate retry or wait poll.

## Root cause

Action responses carry their observation beneath `structuredContent.observation`, while the session cache only inspected the top-level response. Automatic screenshot requests were also issued by each retry or poll instead of the completed tool call.

## Validation

- `bun run lint`
- `bun run build`
- `bun test test/features/action/BaseVisualChange.postActionObservation.test.ts test/server/observeWaitForSchema.test.ts test/features/observe/WaitForCondition.test.ts test/features/observe/SettleObserve.test.ts test/server/toolRegistry.lastHierarchyCache.test.ts`
- `bun run typecheck`
