### PR TITLE
fix(cli): stop --port/--host/--initial-session-uuid from swallowing the next flag

### DIFF
--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -268,29 +268,30 @@ export function parseArgs(
       break;
     }
     if (arg === "--port") {
-      const port = parseInt(args[i + 1], 10);
+      const nextArg = args[i + 1];
+      const port = parseInt(nextArg, 10);
       if (!isNaN(port) && port > 0 && port < 65536) {
         daemonPort = port;
+        i++;
       } else {
-        log.warn(`Invalid port: ${args[i + 1]}`);
+        log.warn(`Invalid port: ${nextArg}`);
       }
-      i++;
     } else if (arg === "--host") {
       const host = args[i + 1];
       if (host && !host.startsWith("--")) {
         daemonHost = host;
+        i++;
       } else {
         log.warn(`Invalid host: ${host}`);
       }
-      i++;
     } else if (arg === "--initial-session-uuid") {
       const sessionUuid = args[i + 1];
       if (sessionUuid && !sessionUuid.startsWith("--")) {
         initialSessionUuid = sessionUuid;
+        i++;
       } else {
         log.warn(`Invalid initial session UUID: ${sessionUuid}`);
       }
-      i++;
     } else if (arg === "--a11y-level") {
       a11yLevel = args[++i];
     } else if (arg === "--a11y-failure-mode") {

--- a/test/cli/parseArgs.test.ts
+++ b/test/cli/parseArgs.test.ts
@@ -75,4 +75,57 @@ describe("parseArgs (#4277)", () => {
     expect(parsed.enabledTools).toEqual(["observe"]);
     expect(parsed.disabledTools).toEqual(["clipboard"]);
   });
+
+  // #6168: --port / --host / --initial-session-uuid must not swallow the
+  // following flag when given no value (proxy-mode sibling of #6136).
+  describe("value-taking options do not consume a following flag when given no value", () => {
+    test.each([
+      {
+        name: "--host with no value preserves the following --port",
+        args: ["--host", "--port", "9999"],
+        expected: { daemonHost: undefined, daemonPort: 9999 },
+      },
+      {
+        name: "--port with no value preserves the following --host",
+        args: ["--port", "--host", "0.0.0.0"],
+        expected: { daemonPort: undefined, daemonHost: "0.0.0.0" },
+      },
+      {
+        name: "--initial-session-uuid with no value preserves the following --debug",
+        args: ["--initial-session-uuid", "--debug"],
+        expected: { initialSessionUuid: undefined, debug: true },
+      },
+    ])("$name", ({ args, expected }) => {
+      const parsed = parseArgs(args, logger);
+
+      for (const [key, value] of Object.entries(expected)) {
+        expect(parsed[key as keyof typeof parsed]).toBe(value);
+      }
+    });
+
+    test.each([
+      {
+        name: "--host with a valid value",
+        args: ["--host", "0.0.0.0"],
+        key: "daemonHost",
+        value: "0.0.0.0",
+      },
+      {
+        name: "--port with a valid value",
+        args: ["--port", "9999"],
+        key: "daemonPort",
+        value: 9999,
+      },
+      {
+        name: "--initial-session-uuid with a valid value",
+        args: ["--initial-session-uuid", "device-session-a"],
+        key: "initialSessionUuid",
+        value: "device-session-a",
+      },
+    ])("$name still parses correctly", ({ args, key, value }) => {
+      const parsed = parseArgs(args, logger);
+
+      expect(parsed[key as keyof typeof parsed]).toBe(value);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`src/cli/parseArgs.ts` ran an unconditional `i++` after `--port`, `--host`, and `--initial-session-uuid`, so when one of them was given no value the following flag was consumed and silently dropped (e.g. `--host --port 9999` dropped the port). This is the proxy-mode sibling of #6136, which fixed the same shape in `parseDaemonArgs` (#6160).

## Fix

Moved `i++` inside the accepted-value branch for all three options, mirroring the fix pattern used for `parseDaemonArgs` and the already-correct branches in this same file (`--a11y-level`, `--plan-execution-lock-scope`, etc.). A rejected value (missing, or a `--`-prefixed token) is now left unconsumed instead of being swallowed along with the flag that should have followed it.

## Tests

Added `test.each` coverage in `test/cli/parseArgs.test.ts`:
- `--host --port 9999` → host stays default, port 9999 preserved
- `--port --host 0.0.0.0` → port stays default, host preserved
- `--initial-session-uuid --debug` → uuid unset, debug true
- Valid-value rows for each of the three flags, confirming normal parsing is unaffected

Closes #6168
