### PR TITLE
fix(logger): degrade to stderr and preserve NDJSON on file-sink open failure

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,7 +6,11 @@ import path from "path";
 import { statAsync, renameAsync } from "./io";
 import { ensureSecureLogsDirSync } from "./tempDir";
 import { pruneLogFiles } from "./logPruner";
-import { resolveAutomobileLogFormat, resolveAutomobileLogSink } from "./loggingConfig";
+import {
+  resolveAutomobileLogFormat,
+  resolveAutomobileLogSink,
+  writeEmergencyLog,
+} from "./loggingConfig";
 
 export {
   parseAutomobileLogFormat,
@@ -177,8 +181,11 @@ const openLogStream = (target: string): fs.WriteStream | undefined => {
   try {
     return fs.createWriteStream(target, { flags: "a" });
   } catch (error) {
-    // Logger init is the thing failing, so it cannot log itself — warn to stderr.
-    process.stderr.write(`Failed to open log stream ${target}: ${String(error)}\n`);
+    // Logger init is the thing failing, so it cannot log itself — route the
+    // diagnostic through the JSON-aware emergency helper so this line stays
+    // valid NDJSON in `AUTOMOBILE_LOG_FORMAT=json` mode instead of a raw-text
+    // line breaking an otherwise-NDJSON stderr stream (issue #6179).
+    writeEmergencyLog(`Failed to open log stream ${target}`, error);
     return undefined;
   }
 };
@@ -430,12 +437,27 @@ const reportLogFailure = async (context: string, error: unknown): Promise<void> 
 };
 
 const writeToFile = async (line: string): Promise<void> => {
-  if (!logStream) {
+  if (!logFilePath) {
+    // Stderr-only sink: no file stream is ever expected here.
     return;
   }
-  await checkAndRotateLog();
+  if (!logStream) {
+    // A prior open attempt failed — e.g. bun's transient EEXIST/epoll race
+    // (#5930 family). Retry lazily on the next write instead of leaving the
+    // sink permanently dead: the failure that killed it may have cleared.
+    logStream = openLogStream(logFilePath);
+  }
+  if (logStream) {
+    await checkAndRotateLog();
+  }
   const stream = logStream;
   if (!stream) {
+    // Still unavailable. When file is the only configured sink, degrade to
+    // stderr rather than silently discarding the record (issue #6179);
+    // `stderr`/`both` sinks already emit this line via writeToConfiguredStderr.
+    if (logSink === "file") {
+      await writeToStderr(line);
+    }
     return;
   }
   await new Promise<void>((resolve, reject) => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -173,23 +173,26 @@ const logFilePath = logsDir ? path.join(logsDir, `${ownLogPrefix}.log`) : undefi
 
 interface FailureProneStream {
   on(event: "error", listener: (error: Error) => void): void;
-  on(event: "close", listener: () => void): void;
 }
 
 // A stream that opened successfully can still fail later — e.g. EACCES/ENOSPC
 // surfacing asynchronously once bun/node actually touches the fd. An 'error'
 // event with no listener throws and crashes the process, the exact failure
 // mode #6111/#6179 exists to prevent (just reached via the async path instead
-// of the synchronous constructor throw). Attach handlers so that instead: (a)
+// of the synchronous constructor throw). Attach a handler so that instead: (a)
 // the error never goes unhandled, (b) the broken stream is dropped so the next
 // write retries opening it (or degrades to stderr, same as the sync path), and
 // (c) the diagnostic stays valid NDJSON in json mode (issue #6179).
+//
+// Deliberately NOT listening for 'close': checkAndRotateLog() ends the active
+// stream on purpose at the size cap and immediately opens its replacement —
+// a normal, expected close with no error. Clearing `logStream` on every close
+// (regardless of cause) raced that legitimate rotation and could drop the
+// freshly-opened replacement stream right after rotating, breaking logging
+// for the rest of the process. An unexpected close without a preceding
+// 'error' is rare enough (and self-healing via the next write's lazy retry
+// once a subsequent write actually fails) that it doesn't need a handler here.
 const attachStreamFailureHandlers = (stream: FailureProneStream, target: string): void => {
-  const dropIfCurrent = (): void => {
-    if (logStream === stream) {
-      logStream = undefined;
-    }
-  };
   stream.on("error", (error) => {
     try {
       writeEmergencyLog(`Log stream error on ${target}`, error);
@@ -198,9 +201,10 @@ const attachStreamFailureHandlers = (stream: FailureProneStream, target: string)
       // event emitter — that would just relocate the crash.
       void loggingError;
     }
-    dropIfCurrent();
+    if (logStream === stream) {
+      logStream = undefined;
+    }
   });
-  stream.on("close", dropIfCurrent);
 };
 
 // Constructing an appending WriteStream can throw synchronously — e.g. bun's

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -171,6 +171,38 @@ const logsDir = logSink === "stderr" ? undefined : ensureSecureLogsDirSync();
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = logsDir ? path.join(logsDir, `${ownLogPrefix}.log`) : undefined;
 
+interface FailureProneStream {
+  on(event: "error", listener: (error: Error) => void): void;
+  on(event: "close", listener: () => void): void;
+}
+
+// A stream that opened successfully can still fail later — e.g. EACCES/ENOSPC
+// surfacing asynchronously once bun/node actually touches the fd. An 'error'
+// event with no listener throws and crashes the process, the exact failure
+// mode #6111/#6179 exists to prevent (just reached via the async path instead
+// of the synchronous constructor throw). Attach handlers so that instead: (a)
+// the error never goes unhandled, (b) the broken stream is dropped so the next
+// write retries opening it (or degrades to stderr, same as the sync path), and
+// (c) the diagnostic stays valid NDJSON in json mode (issue #6179).
+const attachStreamFailureHandlers = (stream: FailureProneStream, target: string): void => {
+  const dropIfCurrent = (): void => {
+    if (logStream === stream) {
+      logStream = undefined;
+    }
+  };
+  stream.on("error", (error) => {
+    try {
+      writeEmergencyLog(`Log stream error on ${target}`, error);
+    } catch (loggingError) {
+      // The emergency helper itself must never throw back into the stream's
+      // event emitter — that would just relocate the crash.
+      void loggingError;
+    }
+    dropIfCurrent();
+  });
+  stream.on("close", dropIfCurrent);
+};
+
 // Constructing an appending WriteStream can throw synchronously — e.g. bun's
 // internal fast path occasionally races its epoll registration and throws
 // `EEXIST: ... epoll_ctl` (issue #5930 family). At module load this crashes the
@@ -179,7 +211,9 @@ const logFilePath = logsDir ? path.join(logsDir, `${ownLogPrefix}.log`) : undefi
 // fall back to console-only logging rather than taking the process down.
 const openLogStream = (target: string): fs.WriteStream | undefined => {
   try {
-    return fs.createWriteStream(target, { flags: "a" });
+    const stream = fs.createWriteStream(target, { flags: "a" });
+    attachStreamFailureHandlers(stream, target);
+    return stream;
   } catch (error) {
     // Logger init is the thing failing, so it cannot log itself — route the
     // diagnostic through the JSON-aware emergency helper so this line stays

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -494,15 +494,33 @@ const writeToFile = async (line: string): Promise<void> => {
     }
     return;
   }
-  await new Promise<void>((resolve, reject) => {
-    stream.write(line + "\n", (error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
+  try {
+    await new Promise<void>((resolve, reject) => {
+      stream.write(line + "\n", (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
     });
-  });
+  } catch (error) {
+    // The write itself failed (e.g. EISDIR/ENOSPC surfacing on write rather
+    // than at open). The stream's own 'error' listener (attachStreamFailureHandlers)
+    // will also fire and drop `logStream` so later writes retry/degrade, but
+    // THIS record must not vanish too. `reportLogFailure` intentionally
+    // suppresses its diagnostic for the `file` sink, so degrade the record
+    // itself to stderr here rather than relying on that path (issue #6179).
+    // `stderr`/`both` sinks already have this line on stderr via
+    // writeToConfiguredStderr, so only handle it here for `file`; otherwise
+    // rethrow and let the existing writeToLogFile/reportLogFailure diagnostic
+    // stand, avoiding a duplicate of the same line.
+    if (logSink === "file") {
+      await writeToStderr(line);
+      return;
+    }
+    throw error;
+  }
 };
 
 const writeToConfiguredStderr = async (line: string): Promise<void> => {

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, spyOn } from "bun:test";
-import fs, { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import fs, { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -356,5 +356,48 @@ describe("logger degrades the record itself under a persistent write failure (Co
     // duplicate that exact line.
     const matches = stderr.lines.filter((line) => line.includes("both-mode record"));
     expect(matches.length).toBe(1);
+  });
+});
+
+describe("size-based rotation is not broken by the stream-error handler (Codex P2 on #6210)", () => {
+  test("logging still works after a normal rotation — the freshly-opened stream survives the old stream's close", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-rotate-"));
+    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
+    // Pre-seed the target past the 10MiB rotation threshold so the very first
+    // write triggers checkAndRotateLog's real rotation path (end() the old
+    // stream, rename it to a backup, open a fresh stream) without having to
+    // push 10MiB of traffic through the logger itself.
+    writeFileSync(targetLogFile, Buffer.alloc(11 * 1024 * 1024, "x"));
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("text", "file", logDir);
+
+      mod.logger.info("first record after rotation");
+      await mod.logger.flush();
+      // A previous buggy 'close' handler cleared `logStream` whenever ANY
+      // stream closed, including the old stream's normal post-rotation close
+      // — which could race the freshly-opened replacement and silently break
+      // every write after the first one. Prove a second write also lands.
+      mod.logger.info("second record after rotation");
+      await mod.logger.flush();
+      await mod.logger.closeAfterFlush();
+
+      const files = fs.readdirSync(logDir);
+      // The pre-seeded 11MiB file must have been rotated out to a timestamped
+      // backup, and a fresh (small) active log file created in its place.
+      const backups = files.filter((f) => f !== `stdio-${process.pid}.log`);
+      expect(backups.length).toBeGreaterThan(0);
+
+      const activeContents = fs.readFileSync(targetLogFile, "utf-8");
+      expect(activeContents).toContain("first record after rotation");
+      expect(activeContents).toContain("second record after rotation");
+      // The active file should be tiny — proof the writes landed in the new
+      // post-rotation stream, not silently dropped nor appended to the old
+      // (now-renamed) 11MiB file.
+      expect(activeContents.length).toBeLessThan(1024);
+    } finally {
+      rmSync(logDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import fs, { mkdtempSync, rmSync } from "node:fs";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** A stream that constructs successfully but can be made to fail later, the
+ * way a real fd surfaces EACCES/ENOSPC asynchronously after open(). */
+class AsyncFailStream extends EventEmitter {
+  destroyed = false;
+  writable = true;
+
+  write(_chunk: unknown, callback?: (error: Error | null) => void): boolean {
+    queueMicrotask(() => callback?.(null));
+    return true;
+  }
+
+  end(callback?: () => void): void {
+    queueMicrotask(() => callback?.());
+  }
+}
 
 let importCounter = 0;
 
@@ -45,6 +62,35 @@ async function loggerWithEnv(
       delete process.env.AUTOMOBILE_LOG_DIR;
     } else {
       process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+    }
+  }
+}
+
+/**
+ * `writeEmergencyLog` re-reads `AUTOMOBILE_LOG_FORMAT` from the live
+ * environment on every call rather than a module-cached value, so a
+ * diagnostic emitted *after* `loggerWithEnv`'s import has returned (and
+ * already restored the env) would otherwise see the pre-test format. Restore
+ * the env for the duration of `fn`, matching what the running process would
+ * actually have configured.
+ */
+function withRestoredEnv<T>(format: string, sink: string, fn: () => T): T {
+  const previousFormat = process.env.AUTOMOBILE_LOG_FORMAT;
+  const previousSink = process.env.AUTOMOBILE_LOG_SINK;
+  process.env.AUTOMOBILE_LOG_FORMAT = format;
+  process.env.AUTOMOBILE_LOG_SINK = sink;
+  try {
+    return fn();
+  } finally {
+    if (previousFormat === undefined) {
+      delete process.env.AUTOMOBILE_LOG_FORMAT;
+    } else {
+      process.env.AUTOMOBILE_LOG_FORMAT = previousFormat;
+    }
+    if (previousSink === undefined) {
+      delete process.env.AUTOMOBILE_LOG_SINK;
+    } else {
+      process.env.AUTOMOBILE_LOG_SINK = previousSink;
     }
   }
 }
@@ -148,6 +194,100 @@ describe("logger sink degradation on open failure (#6179)", () => {
         return (
           record.event === "log.emergency" &&
           String(record.message).includes("Failed to open log stream")
+        );
+      }),
+    ).toBeTrue();
+  });
+});
+
+describe("logger sink degradation on async stream error (Codex P1 on #6210)", () => {
+  test("an async 'error' after successful open does not crash, and degrades subsequent logs to stderr", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-async-error-"));
+    let opened: AsyncFailStream | undefined;
+    const createWriteStream = spyOn(fs, "createWriteStream");
+    createWriteStream.mockImplementationOnce(() => {
+      opened = new AsyncFailStream();
+      return opened as unknown as fs.WriteStream;
+    });
+    createWriteStream.mockImplementation(() => {
+      // The stream stays broken after the async failure: every retry also fails.
+      throw new Error("EACCES: still unavailable");
+    });
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    let emitThrew = false;
+    try {
+      mod = await loggerWithEnv("text", "file", logDir);
+      expect(opened).toBeDefined();
+
+      // Emitting 'error' with no listener would throw synchronously and crash
+      // the process. Assert it does not.
+      try {
+        opened?.emit("error", new Error("EACCES: async open failure"));
+      } catch {
+        emitThrew = true;
+      }
+
+      // The diagnostic from the async error is not what we're asserting on
+      // here; isolate the next write.
+      stderr.lines.length = 0;
+      mod.logger.info("after async stream error");
+      await mod.logger.flush();
+    } finally {
+      stderr.restore();
+      createWriteStream.mockRestore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    expect(emitThrew).toBeFalse();
+    // The broken stream must have been cleared so the next write retried (and,
+    // since every retry fails here, degraded to stderr) instead of silently
+    // dropping the record.
+    expect(stderr.lines.some((line) => line.includes("after async stream error"))).toBeTrue();
+  });
+
+  test("async stream error diagnostic stays valid NDJSON in json+both mode", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-async-error-json-"));
+    let opened: AsyncFailStream | undefined;
+    const createWriteStream = spyOn(fs, "createWriteStream").mockImplementation(() => {
+      opened = new AsyncFailStream();
+      return opened as unknown as fs.WriteStream;
+    });
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("json", "both", logDir);
+      expect(opened).toBeDefined();
+      stderr.lines.length = 0;
+
+      // The handler's diagnostic write goes through process.stderr.write
+      // synchronously (writeEmergencyLog is sync), no need to await anything.
+      // Restore the env for the duration of the emit: writeEmergencyLog reads
+      // it live, and loggerWithEnv already reverted it once the import above
+      // resolved, same as it would still be live in a real long-running process.
+      withRestoredEnv("json", "both", () => {
+        opened?.emit("error", new Error("ENOSPC: async open failure"));
+      });
+    } finally {
+      stderr.restore();
+      createWriteStream.mockRestore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    expect(stderr.lines.length).toBeGreaterThan(0);
+    for (const line of stderr.lines) {
+      const record = JSON.parse(line);
+      expect(typeof record).toBe("object");
+    }
+    expect(
+      stderr.lines.some((line) => {
+        const record = JSON.parse(line);
+        return (
+          record.event === "log.emergency" && String(record.message).includes("Log stream error")
         );
       }),
     ).toBeTrue();

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, spyOn } from "bun:test";
-import fs, { mkdtempSync, rmSync } from "node:fs";
+import fs, { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -291,5 +291,70 @@ describe("logger sink degradation on async stream error (Codex P1 on #6210)", ()
         );
       }),
     ).toBeTrue();
+  });
+});
+
+describe("logger degrades the record itself under a persistent write failure (Codex P2 on #6210)", () => {
+  test("every ordinary record reaches stderr — not just the emergency diagnostic — when the log target is a directory (EISDIR on every write)", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-eisdir-"));
+    // Reproduce the reviewer's exact repro without mocking fs at all: the
+    // resolved log file path IS a directory, so every real open/write against
+    // it fails with a genuine EISDIR — asynchronously, matching real EACCES/
+    // ENOSPC failures rather than a synchronous constructor throw.
+    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
+    mkdirSync(targetLogFile);
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("text", "file", logDir);
+      stderr.lines.length = 0;
+
+      // Repeated writes: the no-silent-loss guarantee must hold for every
+      // record, not just the first one after the failure is discovered.
+      mod.logger.info("first record");
+      await mod.logger.flush();
+      mod.logger.info("second record");
+      await mod.logger.flush();
+      mod.logger.info("third record");
+      await mod.logger.flush();
+    } finally {
+      stderr.restore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    // Each actual log line must degrade to stderr, not just an emergency
+    // diagnostic (`log.emergency`/"Log stream error") that says something
+    // failed without preserving what was actually logged.
+    expect(stderr.lines.some((line) => line.includes("first record"))).toBeTrue();
+    expect(stderr.lines.some((line) => line.includes("second record"))).toBeTrue();
+    expect(stderr.lines.some((line) => line.includes("third record"))).toBeTrue();
+  });
+
+  test("does not double-emit the same record to stderr in `both` mode when the file write also fails", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-eisdir-both-"));
+    const targetLogFile = join(logDir, `stdio-${process.pid}.log`);
+    mkdirSync(targetLogFile);
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("text", "both", logDir);
+      stderr.lines.length = 0;
+
+      mod.logger.info("both-mode record");
+      await mod.logger.flush();
+    } finally {
+      stderr.restore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    // `both` already emits every record via writeToConfiguredStderr regardless
+    // of file-sink health; the failed file write must not additionally
+    // duplicate that exact line.
+    const matches = stderr.lines.filter((line) => line.includes("both-mode record"));
+    expect(matches.length).toBe(1);
   });
 });

--- a/test/utils/logger-sink-degradation.test.ts
+++ b/test/utils/logger-sink-degradation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, spyOn } from "bun:test";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let importCounter = 0;
+
+async function loggerWithEnv(
+  format: string | undefined,
+  sink: string | undefined,
+  logDir?: string,
+): Promise<typeof import("../../src/utils/logger")> {
+  const previousFormat = process.env.AUTOMOBILE_LOG_FORMAT;
+  const previousSink = process.env.AUTOMOBILE_LOG_SINK;
+  const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+  if (format === undefined) {
+    delete process.env.AUTOMOBILE_LOG_FORMAT;
+  } else {
+    process.env.AUTOMOBILE_LOG_FORMAT = format;
+  }
+  if (sink === undefined) {
+    delete process.env.AUTOMOBILE_LOG_SINK;
+  } else {
+    process.env.AUTOMOBILE_LOG_SINK = sink;
+  }
+  if (logDir === undefined) {
+    delete process.env.AUTOMOBILE_LOG_DIR;
+  } else {
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
+  }
+  try {
+    return await import(`../../src/utils/logger.ts?sink-degradation-${importCounter++}`);
+  } finally {
+    if (previousFormat === undefined) {
+      delete process.env.AUTOMOBILE_LOG_FORMAT;
+    } else {
+      process.env.AUTOMOBILE_LOG_FORMAT = previousFormat;
+    }
+    if (previousSink === undefined) {
+      delete process.env.AUTOMOBILE_LOG_SINK;
+    } else {
+      process.env.AUTOMOBILE_LOG_SINK = previousSink;
+    }
+    if (previousLogDir === undefined) {
+      delete process.env.AUTOMOBILE_LOG_DIR;
+    } else {
+      process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+    }
+  }
+}
+
+function spyStderr(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = spyOn(process.stderr, "write").mockImplementation(((
+    chunk: unknown,
+    callback?: (error?: Error | null) => void,
+  ) => {
+    lines.push(String(chunk));
+    queueMicrotask(() => callback?.());
+    return true;
+  }) as typeof process.stderr.write);
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+describe("logger sink degradation on open failure (#6179)", () => {
+  test("does not silently discard logs after the default file sink fails to open", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-open-fail-"));
+    const createWriteStream = spyOn(fs, "createWriteStream").mockImplementation(() => {
+      throw new Error("EEXIST: epoll_ctl race");
+    });
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("text", "file", logDir);
+      // Module load already hit the open-failure diagnostic; clear it so we can
+      // isolate the assertion to what a subsequent ordinary log record does.
+      stderr.lines.length = 0;
+
+      mod.logger.info("should not be lost");
+      await mod.logger.flush();
+    } finally {
+      stderr.restore();
+      createWriteStream.mockRestore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    // The record must reach a sink (degraded to stderr) rather than vanish —
+    // the file sink stays unavailable for the whole test because
+    // createWriteStream keeps throwing on every retry attempt.
+    expect(stderr.lines.some((line) => line.includes("should not be lost"))).toBeTrue();
+  });
+
+  test("recovers file logging once a transient open failure clears", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-open-recover-"));
+    const createWriteStream = spyOn(fs, "createWriteStream");
+    createWriteStream.mockImplementationOnce(() => {
+      throw new Error("EEXIST: epoll_ctl race");
+    });
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("text", "file", logDir);
+      // Module load's open attempt failed; the next write should retry and,
+      // since the mock now delegates to the real implementation, succeed.
+      mod.logger.info("recovered after retry");
+      await mod.logger.flush();
+      await mod.logger.closeAfterFlush();
+
+      const files = fs.readdirSync(logDir);
+      expect(files.length).toBeGreaterThan(0);
+      const contents = fs.readFileSync(join(logDir, files[0]), "utf-8");
+      expect(contents).toContain("recovered after retry");
+    } finally {
+      createWriteStream.mockRestore();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+
+  test("open-failure diagnostic stays valid NDJSON in json+both mode", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-open-fail-json-"));
+    const createWriteStream = spyOn(fs, "createWriteStream").mockImplementation(() => {
+      throw new Error("EEXIST: epoll_ctl race");
+    });
+    const stderr = spyStderr();
+
+    let mod: typeof import("../../src/utils/logger") | undefined;
+    try {
+      mod = await loggerWithEnv("json", "both", logDir);
+    } finally {
+      stderr.restore();
+      createWriteStream.mockRestore();
+      await mod?.logger.closeAfterFlush();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    expect(stderr.lines.length).toBeGreaterThan(0);
+    for (const line of stderr.lines) {
+      // Every stderr line must parse as JSON — a raw-text diagnostic would
+      // break collectors that parse each line as an independent NDJSON record.
+      const record = JSON.parse(line);
+      expect(typeof record).toBe("object");
+    }
+    expect(
+      stderr.lines.some((line) => {
+        const record = JSON.parse(line);
+        return (
+          record.event === "log.emergency" &&
+          String(record.message).includes("Failed to open log stream")
+        );
+      }),
+    ).toBeTrue();
+  });
+});


### PR DESCRIPTION
Fixes two unaddressed post-merge review findings on #6111 (logger survives WriteStream construction throw), tracked in #6179.

## Findings addressed

1. **Retain a log sink after a transient open failure.** With the default `file` sink, one transient `fs.createWriteStream` throw at module load previously left `logStream` `undefined` permanently: `writeToFile` returned without writing, `checkAndRotateLog` exited early (never retried), and stderr was not enabled for ordinary records — so every subsequent log record was silently discarded instead of the intended console-only degradation.

   Fix: `writeToFile` now retries the open lazily on the next write (a transient failure clearing on its own recovers file logging), and if the file sink is still unavailable and `file` is the only configured sink, degrades that record to stderr instead of dropping it. `stderr`/`both` sinks were already unaffected since `writeToConfiguredStderr` covers them independently.

2. **Preserve NDJSON in the open-failure diagnostic.** When `AUTOMOBILE_LOG_FORMAT=json` (sink `both` or otherwise), a synchronous stream-construction failure previously wrote a raw-text warning straight to `process.stderr`, breaking an otherwise-NDJSON stream for collectors parsing each line as JSON.

   Fix: route that diagnostic through the existing JSON-aware `writeEmergencyLog` helper (`src/utils/loggingConfig.ts`), which already picks JSON vs. plain text based on `AUTOMOBILE_LOG_FORMAT`.

## Tests

Added `test/utils/logger-sink-degradation.test.ts` (module-reimport pattern matching the existing `logger-structured.test.ts` harness), injecting a `fs.createWriteStream` mock that throws:

- a persistent open failure no longer silently discards records — a subsequent `logger.info(...)` reaches stderr instead of vanishing
- a transient failure (mocked once) recovers on the next write and file logging resumes
- in `AUTOMOBILE_LOG_FORMAT=json` + `both` sink, the open-failure diagnostic is valid, parseable NDJSON (`event: "log.emergency"`), not raw text

All new tests run in well under 100ms and never touch the real `getDatabase()`.

Closes #6179
