### PR TITLE
test: harden nav-graph session-uuid bats + snapshot-name property domain

### DIFF
--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -41,6 +41,13 @@ make_mock() {
   make_executable "${MOCK_BIN}/$1" "$2"
 }
 
+# Sentinel returned by the getAndroid mock below. It is deliberately distinct
+# from the fabricated UUID removed from the production script by #6104
+# ("52150000-0000-4000-8000-000000000000") so the assertions in this test can
+# tell a genuinely-forwarded acquired session apart from a regression that
+# keeps forwarding the old hardcoded value.
+export ACQUIRED_SESSION_UUID="9f860000-0000-4000-8000-000000000000"
+
 @test "binds the Android graph session before emitting and polling an SDK navigation event" {
   make_mock adb '
 printf "%s\n" "$*" >> "$ADB_LOG"
@@ -97,10 +104,14 @@ if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && 
     echo "getAndroid acquired without target deviceId" >&2
     exit 1
   }
-  printf "{\"sessionUuid\":\"52150000-0000-4000-8000-000000000000\"}\n"
+  printf "{\"sessionUuid\":\"%s\"}\n" "$ACQUIRED_SESSION_UUID"
   exit 0
 fi
 if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ]; then
+  [ "$5" = "$ACQUIRED_SESSION_UUID" ] || {
+    echo "session-scoped call forwarded an unexpected --session-uuid: $5" >&2
+    exit 1
+  }
   case "$6" in
     launchApp)
       [ -f "$DEVICE_READY_FILE" ] || {
@@ -153,6 +164,14 @@ exit 1
   # Regression for issue #4579: scope the graph read to the fixture package so a
   # concurrent hierarchy push cannot redirect the query to another app's graph.
   grep -q -- "getNavigationGraph --platform android --deviceId emulator-5554 --appId dev.jasonpearson.automobile.playground" "$AUTO_MOBILE_LOG"
+  # Regression for #6180: every session-scoped call must forward the UUID that
+  # getAndroid actually acquired, not a fabricated one. The session-scoped mock
+  # above already fails the run if a forwarded UUID does not match
+  # ACQUIRED_SESSION_UUID; this asserts at least one such call was made and none
+  # of them carried the old hardcoded UUID that #6104 removed from the script.
+  session_uuid_calls="$(grep -c -- "--session-uuid ${ACQUIRED_SESSION_UUID}" "$AUTO_MOBILE_LOG")"
+  [ "$session_uuid_calls" -ge 3 ]
+  ! grep -q -- '--session-uuid 52150000-0000-4000-8000-000000000000' "$AUTO_MOBILE_LOG"
 }
 
 @test "uses the workspace CLI entrypoint when the global auto-mobile install is unavailable" {

--- a/test/utils/snapshotNameValidation.property.test.ts
+++ b/test/utils/snapshotNameValidation.property.test.ts
@@ -70,13 +70,31 @@ const hostileUnit = fc.oneof(
 );
 const hostileName = fc.string({ unit: hostileUnit, maxLength: 24 });
 
+// The guard's *documented* forbidden cases (see assertSafeSnapshotName's
+// doc comment and reject() call sites): a NUL byte, a path separator, the
+// bare traversal segments, or an empty/whitespace-only name. Everything else
+// — including non-ASCII text like "é", spaces inside the name, emoji, and
+// other unicode — is accepted. This is restated independently of the
+// implementation (rather than calling assertSafeSnapshotName itself) so a
+// regression that narrows the guard's real accepted domain shows up here.
+function isDocumentedlyForbidden(name: string): boolean {
+  return (
+    name.trim().length === 0 ||
+    name.includes("\0") ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name === "." ||
+    name === ".."
+  );
+}
+
 // Ordinary single-segment names — the accepted domain the store relies on.
-const safeUnit = fc.constantFrom(..."abcdefghijABCDEFGHIJ0123456789 ._-".split(""));
+// Drawn from full printable-grapheme unicode (not just ASCII) so the
+// "acceptance" property below actually exercises non-ASCII names such as
+// "é" rather than only ever sampling a small hand-picked alphabet.
 const safeName = fc
-  .string({ unit: safeUnit, minLength: 1, maxLength: 20 })
-  // Exclude the strings the guard legitimately rejects even under a safe
-  // alphabet: whitespace-only names and the bare traversal segments.
-  .filter((s) => s.trim().length > 0 && s !== "." && s !== "..");
+  .string({ unit: "grapheme", minLength: 1, maxLength: 20 })
+  .filter((s) => !isDocumentedlyForbidden(s));
 
 describe("assertSafeSnapshotName (property-based, #5705)", () => {
   test("soundness: every accepted name joins to a direct child of the base directory", () => {


### PR DESCRIPTION
Two post-merge P2 test-quality findings from #6104 and #6071 that were never addressed. Closes #6180.

## 1. Assert the forwarded session UUID (`test/bats/android-navigation-graph-sdk-event-integration.bats`)

The success fixture returned the same fabricated UUID (`52150000-0000-4000-8000-000000000000`) that #6104 removed from the production script, and the session-scoped mock dispatched on `$6` (the subcommand) without checking `$5` (the forwarded `--session-uuid` value). An implementation that calls `getAndroid` but keeps forwarding the old fabricated UUID would pass all three tests yet fail against the real daemon.

Fix: the `getAndroid` mock now returns a distinct sentinel UUID (`9f860000-0000-4000-8000-000000000000`), the session-scoped mock rejects any `--session-uuid` that doesn't match it, and the test asserts every forwarded call used the sentinel and none used the old fabricated value.

Verified the new assertion actually catches the gap: temporarily made the production script overwrite `session_uuid` with the old fabricated value after acquisition (simulating the exact regression this hardens against) and confirmed the test fails; reverted and confirmed it's green again with no diff to the production script.

## 2. Broaden the accepted-name generator (`test/utils/snapshotNameValidation.property.test.ts`)

`safeName` was drawn from a small hand-picked ASCII alphabet, so a regression that rejects a currently-valid name (e.g. `é`) still satisfied every property — soundness discards rejected samples and the error-contract property treats rejection as valid, so nothing actually exercised non-ASCII names.

Fix: `safeName` now draws from full printable-grapheme unicode and filters only the guard's documented forbidden cases (NUL byte, path separators, bare `.`/`..` segments, empty/whitespace-only names) — restated independently of `assertSafeSnapshotName` rather than by calling it, so the acceptance property can actually detect over-rejection.

Verified by temporarily tightening the guard to reject any non-ASCII character and confirming the acceptance property fails with a genuine non-ASCII counterexample (a U+00A0 no-break space); reverted with no diff to the guard.

## Validation
- `bats test/bats/android-navigation-graph-sdk-event-integration.bats` — 3/3 green
- `bun test test/utils/snapshotNameValidation.property.test.ts` — 7/7 green
- `turbo run lint build test` — 846 pass, 0 fail
- `bun run format:check` — clean
- `bun run typecheck` — no new errors (163 known baseline)
