### PR TITLE
fix(plan): bring barrier to parity with criticalSection in plan validation

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
@@ -35,7 +35,7 @@ object TestPlanToolCategories {
             "deleteDevice",
           ),
         "Device configuration" to setOf("rotate", "shake", "systemTray", "changeLocalization"),
-        "Plan execution" to setOf("executePlan", "criticalSection"),
+        "Plan execution" to setOf("executePlan", "criticalSection", "barrier"),
         "Deep links" to setOf("getDeepLinks"),
         "Navigation graph" to setOf("getNavigationGraph", "explore", "identifyInteractions"),
         "Snapshots" to

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/PlanSchemaValidatorTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/PlanSchemaValidatorTest.kt
@@ -299,6 +299,7 @@ class PlanSchemaValidatorTest {
       steps:
         - tool: criticalSection
           params:
+            device: A
             lock: sync-point
             deviceCount: 2
             steps:

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -95,19 +95,21 @@ object TestPlanValidator {
 
     // Validate multi-device requirements (a plan using criticalSection/barrier
     // or any step-level device label must declare top-level 'devices') and
-    // barrier-lock distinct-device-count feasibility -- mirrors the daemon's
-    // PlanValidator.validateMultiDeviceRequirements /
-    // validateBarrierDistinctDeviceCounts so a plan that validates here also
-    // survives daemon-side load instead of passing IDE/JUnit validation and
-    // then failing at execution (#6215 review).
+    // barrier-lock coordination feasibility (declared-device membership,
+    // distinct-device count, generation completeness) -- mirrors the
+    // daemon's PlanValidator.validateMultiDeviceRequirements /
+    // validateBarrierDistinctDeviceCounts / validateBarrierGenerationCompleteness
+    // so a plan that validates here also survives daemon-side load instead
+    // of passing IDE/JUnit validation and then failing at execution (#6215
+    // review).
     val multiDeviceErrors = validateMultiDeviceRequirements(parsedObject)
-    val barrierDeviceCountErrors = validateBarrierDistinctDeviceCounts(parsedObject)
+    val barrierCoordinationErrors = validateBarrierCoordination(parsedObject)
 
     if (
       validationErrors.isEmpty() &&
         toolNameErrors.isEmpty() &&
         multiDeviceErrors.isEmpty() &&
-        barrierDeviceCountErrors.isEmpty()
+        barrierCoordinationErrors.isEmpty()
     ) {
       return ValidationResult(valid = true)
     }
@@ -118,7 +120,7 @@ object TestPlanValidator {
     // Add tool name and coordination validation errors
     errors.addAll(toolNameErrors)
     errors.addAll(multiDeviceErrors)
-    errors.addAll(barrierDeviceCountErrors)
+    errors.addAll(barrierCoordinationErrors)
 
     return ValidationResult(valid = false, errors = errors)
   }
@@ -231,28 +233,42 @@ object TestPlanValidator {
     return step[field]
   }
 
-  private class BarrierLockUsage {
-    val devices = mutableSetOf<String>()
-    val deviceCounts = mutableSetOf<Int>()
+  /**
+   * The plan's declared top-level 'devices' labels, or null when the plan declares none. Accepts
+   * both the plain-label and label/platform-definition forms.
+   */
+  private fun declaredDeviceLabels(parsedObject: Any?): Set<String>? {
+    val devices = (parsedObject as? Map<*, *>)?.get("devices") as? List<*> ?: return null
+    if (devices.isEmpty()) {
+      return null
+    }
+    return devices
+      .mapNotNull { entry ->
+        when (entry) {
+          is String -> entry
+          is Map<*, *> -> entry["label"] as? String
+          else -> null
+        }
+      }
+      .toSet()
   }
 
-  /**
-   * Validates that every barrier lock is populated by enough distinct devices to ever satisfy its
-   * declared deviceCount -- mirrors the daemon's PlanValidator.validateBarrierDistinctDeviceCounts.
-   * Sound without reconstructing rounds: a single round needs deviceCount distinct arrivals, so if
-   * fewer distinct devices ever target a given lock across the whole plan, no round can ever
-   * complete.
-   */
-  private fun validateBarrierDistinctDeviceCounts(parsedObject: Any?): List<ValidationError> {
-    if (parsedObject !is Map<*, *>) {
-      return emptyList()
-    }
-    val steps = parsedObject["steps"]
-    if (steps !is List<*>) {
-      return emptyList()
-    }
+  private class BarrierLockUsage {
+    val devices = mutableSetOf<String>()
+    // Long, not Int: a schema-valid deviceCount can exceed Int.MAX_VALUE, and narrowing it with
+    // Int.toInt() would silently wrap/truncate instead of rejecting it (#6215 review).
+    val deviceCounts = mutableSetOf<Long>()
+    var arrivals = 0
+  }
 
+  /** Collects each barrier step's lock/device/deviceCount usage, keyed by lock name. */
+  private fun collectBarrierLockUsage(
+    steps: List<*>,
+    declaredDevices: Set<String>?,
+  ): Pair<Map<String, BarrierLockUsage>, List<ValidationError>> {
     val usageByLock = mutableMapOf<String, BarrierLockUsage>()
+    val errors = mutableListOf<ValidationError>()
+
     for (step in steps) {
       if (step !is Map<*, *> || step["tool"] as? String != "barrier") {
         continue
@@ -263,18 +279,44 @@ object TestPlanValidator {
         continue
       }
       val usage = usageByLock.getOrPut(lock) { BarrierLockUsage() }
+      usage.arrivals += 1
 
       val device = effectiveCoordinationField(step, "device") as? String
       if (!device.isNullOrEmpty()) {
-        usage.devices.add(device)
+        if (declaredDevices != null && device !in declaredDevices) {
+          errors.add(
+            ValidationError(
+              field = "steps",
+              message =
+                "barrier step references device \"$device\" for lock \"$lock\", but the plan's declared devices are [${declaredDevices.joinToString(", ")}]. Every barrier device must be a declared device label.",
+              severity = ValidationSeverity.ERROR,
+            )
+          )
+        } else {
+          usage.devices.add(device)
+        }
       }
 
-      val deviceCount = (effectiveCoordinationField(step, "deviceCount") as? Number)?.toInt()
+      val deviceCount = (effectiveCoordinationField(step, "deviceCount") as? Number)?.toLong()
       if (deviceCount != null && deviceCount >= 1) {
         usage.deviceCounts.add(deviceCount)
       }
     }
 
+    return usageByLock to errors
+  }
+
+  /**
+   * Validates that every barrier lock is populated by enough distinct, declared devices to ever
+   * satisfy its declared deviceCount -- mirrors the daemon's
+   * PlanValidator.validateBarrierDistinctDeviceCounts (plus PlanValidator's generic device-label
+   * check, which the daemon runs separately via validateDeviceLabelsPresent). Sound without
+   * reconstructing rounds: a single round needs deviceCount distinct arrivals, so if fewer distinct
+   * devices ever target a given lock across the whole plan, no round can ever complete.
+   */
+  private fun validateBarrierDistinctDeviceCounts(
+    usageByLock: Map<String, BarrierLockUsage>
+  ): List<ValidationError> {
     val errors = mutableListOf<ValidationError>()
     for ((lock, usage) in usageByLock) {
       for (deviceCount in usage.deviceCounts) {
@@ -291,8 +333,60 @@ object TestPlanValidator {
         }
       }
     }
-
     return errors
+  }
+
+  /**
+   * Validates that a reused barrier lock's total arrivals form complete generations -- mirrors the
+   * daemon's PlanValidator.validateBarrierGenerationCompleteness. Sound without reconstructing
+   * rounds: only checked when a lock has a single consistent deviceCount N (an inconsistent
+   * deviceCount across reuses of the same lock is legitimate, and there is no single N to divide
+   * by); for that N, the total arrival count must be an exact multiple of N or a trailing
+   * generation is necessarily incomplete and would deadlock forever.
+   */
+  private fun validateBarrierGenerationCompleteness(
+    usageByLock: Map<String, BarrierLockUsage>
+  ): List<ValidationError> {
+    val errors = mutableListOf<ValidationError>()
+    for ((lock, usage) in usageByLock) {
+      if (usage.deviceCounts.size != 1) {
+        continue
+      }
+      val deviceCount = usage.deviceCounts.first()
+      if (deviceCount < 1 || usage.arrivals % deviceCount == 0L) {
+        continue
+      }
+      errors.add(
+        ValidationError(
+          field = "steps",
+          message =
+            "barrier lock \"$lock\" has ${usage.arrivals} total arrival(s) across the plan, which is not a multiple of its deviceCount=$deviceCount. At least one generation is necessarily incomplete and would deadlock waiting for a device that never arrives.",
+          severity = ValidationSeverity.ERROR,
+        )
+      )
+    }
+    return errors
+  }
+
+  /**
+   * Runs all barrier-lock coordination checks (declared-device membership, distinct-device count,
+   * generation completeness) in one pass over the plan's steps.
+   */
+  private fun validateBarrierCoordination(parsedObject: Any?): List<ValidationError> {
+    if (parsedObject !is Map<*, *>) {
+      return emptyList()
+    }
+    val steps = parsedObject["steps"]
+    if (steps !is List<*>) {
+      return emptyList()
+    }
+
+    val declaredDevices = declaredDeviceLabels(parsedObject)
+    val (usageByLock, membershipErrors) = collectBarrierLockUsage(steps, declaredDevices)
+
+    return membershipErrors +
+      validateBarrierDistinctDeviceCounts(usageByLock) +
+      validateBarrierGenerationCompleteness(usageByLock)
   }
 
   /** Find the line number of a tool name in a specific step */

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -290,19 +290,32 @@ object TestPlanValidator {
   }
 
   /**
-   * Validates that every declared device label is non-blank after trimming -- mirrors the daemon's
-   * PlanValidator.validateDevicesField. The schema's minLength:1 (plus the pattern requiring a
-   * non-whitespace character) already rejects most blank labels, but this is a defense-in-depth
-   * semantic check matching the daemon's own trim-then-check logic exactly (#6215 review).
+   * Validates the declared 'devices' field's structure -- mirrors the daemon's
+   * PlanValidator.validateDevicesField:
+   * - Every label is non-blank after trimming (the schema's minLength:1 plus the non-whitespace
+   *   pattern already rejects most blank labels; this is defense in depth matching the daemon's own
+   *   trim-then-check logic exactly).
+   * - The list does not mix plain-string labels with label/platform definitions -- the daemon
+   *   rejects any such mix outright (#6215 review).
    */
   private fun validateDevicesField(parsedObject: Any?): List<ValidationError> {
     val devices = (parsedObject as? Map<*, *>)?.get("devices") as? List<*> ?: return emptyList()
     val errors = mutableListOf<ValidationError>()
+
+    var hasLabelEntries = false
+    var hasDefinitionEntries = false
+
     for (entry in devices) {
       val label =
         when (entry) {
-          is String -> entry
-          is Map<*, *> -> entry["label"] as? String
+          is String -> {
+            hasLabelEntries = true
+            entry
+          }
+          is Map<*, *> -> {
+            hasDefinitionEntries = true
+            entry["label"] as? String
+          }
           else -> null
         } ?: continue
       if (label.trim().isEmpty()) {
@@ -315,6 +328,18 @@ object TestPlanValidator {
         )
       }
     }
+
+    if (hasLabelEntries && hasDefinitionEntries) {
+      errors.add(
+        ValidationError(
+          field = "devices",
+          message =
+            "Plan 'devices' must be a list of labels or a list of objects with label/platform (do not mix formats).",
+          severity = ValidationSeverity.ERROR,
+        )
+      )
+    }
+
     return errors
   }
 
@@ -686,9 +711,51 @@ object TestPlanValidator {
   }
 
   /**
+   * Validates that no lock name is shared between a criticalSection step and a barrier step --
+   * mirrors the daemon's PlanValidator.validateNoCrossToolLockSharing. Both tools share the runtime
+   * coordinator's lock namespace and expected-device-count state (keyed by lock name alone), so
+   * mixing tool types on one lock name is racy: e.g. a criticalSection A/B pair and a barrier C/D
+   * pair both using lock "shared" with deviceCount=2 can pair mismatched participants (A with C)
+   * and overwrite each other's expected count. Each tool type must use a distinct lock name.
+   */
+  private fun validateNoCrossToolLockSharing(steps: List<*>): List<ValidationError> {
+    val criticalSectionLocks = mutableSetOf<String>()
+    val barrierLocks = mutableSetOf<String>()
+
+    for (step in steps) {
+      if (step !is Map<*, *>) {
+        continue
+      }
+      val tool = step["tool"] as? String
+      if (tool != "criticalSection" && tool != "barrier") {
+        continue
+      }
+      val lock = effectiveCoordinationField(step, "lock") as? String
+      if (lock.isNullOrEmpty()) {
+        continue
+      }
+      if (tool == "criticalSection") criticalSectionLocks.add(lock) else barrierLocks.add(lock)
+    }
+
+    val shared = criticalSectionLocks.filter { it in barrierLocks }
+    if (shared.isEmpty()) {
+      return emptyList()
+    }
+    val names = shared.joinToString(", ") { "\"$it\"" }
+    return listOf(
+      ValidationError(
+        field = "steps",
+        message =
+          "lock name(s) $names are used by both a criticalSection step and a barrier step. Both tools share the runtime coordinator's lock namespace and expected-count state, so mixing tool types on the same lock name is racy and can pair mismatched participants or overwrite the expected count. Use a distinct lock name per tool type.",
+        severity = ValidationSeverity.ERROR,
+      )
+    )
+  }
+
+  /**
    * Runs all barrier-lock coordination checks (declared-device membership, deviceCount range and
-   * consistency, distinct-device count, generation completeness, excess single-device arrivals) in
-   * one pass over the plan's steps.
+   * consistency, distinct-device count, generation completeness, excess single-device arrivals,
+   * cross-tool lock sharing) in one pass over the plan's steps.
    */
   private fun validateBarrierCoordination(parsedObject: Any?): List<ValidationError> {
     if (parsedObject !is Map<*, *>) {
@@ -703,6 +770,7 @@ object TestPlanValidator {
     val (usageByLock, membershipErrors) = collectBarrierLockUsage(steps, declaredDevices)
 
     return membershipErrors +
+      validateNoCrossToolLockSharing(steps) +
       validateBarrierConsistentDeviceCount(usageByLock) +
       validateBarrierDistinctDeviceCounts(usageByLock) +
       validateBarrierGenerationCompleteness(usageByLock) +

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -304,6 +304,12 @@ object TestPlanValidator {
 
     var hasLabelEntries = false
     var hasDefinitionEntries = false
+    // Raw label occurrences (NOT deduped) so a duplicate is caught even when the two entries are
+    // structurally different definitions (e.g. Android "A" + iOS "A") -- JSON Schema's
+    // uniqueItems only compares whole entries, so two different definitions sharing a label pass
+    // it, and declaredDeviceLabels()'s Set collapses them before any membership/feasibility check
+    // ever sees the duplicate (#6215 review).
+    val rawLabels = mutableListOf<String>()
 
     for (entry in devices) {
       val label =
@@ -318,6 +324,7 @@ object TestPlanValidator {
           }
           else -> null
         } ?: continue
+      rawLabels.add(label)
       if (label.trim().isEmpty()) {
         errors.add(
           ValidationError(
@@ -335,6 +342,18 @@ object TestPlanValidator {
           field = "devices",
           message =
             "Plan 'devices' must be a list of labels or a list of objects with label/platform (do not mix formats).",
+          severity = ValidationSeverity.ERROR,
+        )
+      )
+    }
+
+    val duplicates = rawLabels.groupingBy { it }.eachCount().filter { it.value > 1 }.keys
+    if (duplicates.isNotEmpty()) {
+      errors.add(
+        ValidationError(
+          field = "devices",
+          message =
+            "Plan 'devices' array contains duplicate labels: [${rawLabels.joinToString(", ")}]",
           severity = ValidationSeverity.ERROR,
         )
       )

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -730,6 +730,36 @@ object TestPlanValidator {
   }
 
   /**
+   * Validates that no step authors the reserved '__lockNamespace' field (inline or under params) --
+   * mirrors the daemon's PlanValidator.validateNoAuthoredLockNamespace. It is injected internally
+   * by PlanExecutor at runtime to scope a plan's lock state, and an authored plan must never set
+   * it: two participants authoring different truthy __lockNamespace values for the same lock would
+   * pass every per-lock feasibility check yet wait in separate namespaced barriers/critical
+   * sections at runtime until timeout, since CriticalSectionCoordinator keys runtime state by
+   * namespace+lock while the checks above aggregate by lock name alone.
+   */
+  private fun validateNoAuthoredLockNamespace(steps: List<*>): List<ValidationError> {
+    val errors = mutableListOf<ValidationError>()
+    for ((index, step) in steps.withIndex()) {
+      if (step !is Map<*, *>) {
+        continue
+      }
+      if (effectiveCoordinationField(step, "__lockNamespace") != null) {
+        val tool = step["tool"] as? String ?: "unknown"
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message =
+              "step $index ($tool) sets '__lockNamespace', which is a reserved field injected internally by the plan executor. Authored plans must not set it.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+    }
+    return errors
+  }
+
+  /**
    * Validates that no lock name is shared between a criticalSection step and a barrier step --
    * mirrors the daemon's PlanValidator.validateNoCrossToolLockSharing. Both tools share the runtime
    * coordinator's lock namespace and expected-device-count state (keyed by lock name alone), so
@@ -789,6 +819,7 @@ object TestPlanValidator {
     val (usageByLock, membershipErrors) = collectBarrierLockUsage(steps, declaredDevices)
 
     return membershipErrors +
+      validateNoAuthoredLockNamespace(steps) +
       validateNoCrossToolLockSharing(steps) +
       validateBarrierConsistentDeviceCount(usageByLock) +
       validateBarrierDistinctDeviceCounts(usageByLock) +

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -123,12 +123,20 @@ object TestPlanValidator {
     // of passing IDE/JUnit validation and then failing at execution (#6215
     // review).
     val multiDeviceErrors = validateMultiDeviceRequirements(parsedObject)
+    // Every step (not just barrier/criticalSection) must target a declared
+    // device label once the plan declares 'devices' -- mirrors the daemon's
+    // PlanValidator.validateDeviceLabelsPresent, which checks every step
+    // generically. Without this, a barrier plan with valid A/B barriers
+    // plus e.g. a device-less or undeclared-device tapOn step passed here
+    // while the daemon rejects it (#6215 review).
+    val deviceLabelErrors = validateDeviceLabelsPresent(parsedObject)
     val barrierCoordinationErrors = validateBarrierCoordination(parsedObject)
 
     if (
       validationErrors.isEmpty() &&
         toolNameErrors.isEmpty() &&
         multiDeviceErrors.isEmpty() &&
+        deviceLabelErrors.isEmpty() &&
         barrierCoordinationErrors.isEmpty()
     ) {
       return ValidationResult(valid = true)
@@ -140,6 +148,7 @@ object TestPlanValidator {
     // Add tool name and coordination validation errors
     errors.addAll(toolNameErrors)
     errors.addAll(multiDeviceErrors)
+    errors.addAll(deviceLabelErrors)
     errors.addAll(barrierCoordinationErrors)
 
     return ValidationResult(valid = false, errors = errors)
@@ -272,6 +281,100 @@ object TestPlanValidator {
       }
       .toSet()
   }
+
+  /**
+   * Validates that EVERY step (not just barrier/criticalSection) targets a declared device label
+   * once the plan declares 'devices' -- mirrors the daemon's
+   * PlanValidator.validateDeviceLabelsPresent, which checks every step generically rather than only
+   * the coordination tools. Without this, a barrier plan with valid A/B barriers plus e.g. a
+   * device-less or undeclared-device tapOn step passes here while the daemon rejects it (#6215
+   * review). Also validates each criticalSection sub-step's device, matching the daemon's nested
+   * check.
+   */
+  private fun validateDeviceLabelsPresent(parsedObject: Any?): List<ValidationError> {
+    val declaredDevices = declaredDeviceLabels(parsedObject) ?: return emptyList()
+    val steps = (parsedObject as? Map<*, *>)?.get("steps") as? List<*> ?: return emptyList()
+
+    val errors = mutableListOf<ValidationError>()
+    steps.forEachIndexed { index, step ->
+      if (step !is Map<*, *>) {
+        return@forEachIndexed
+      }
+      val tool = step["tool"] as? String ?: "unknown"
+      checkStepDeviceLabel(step, "step $index ($tool)", declaredDevices, errors)
+
+      if (tool == "criticalSection") {
+        val subSteps = effectiveCoordinationField(step, "steps") as? List<*>
+        subSteps?.forEachIndexed { subIndex, sub ->
+          if (sub !is Map<*, *>) {
+            return@forEachIndexed
+          }
+          val subTool = sub["tool"] as? String ?: "unknown"
+          checkStepDeviceLabel(
+            sub,
+            "step $index.steps[$subIndex] ($subTool)",
+            declaredDevices,
+            errors,
+          )
+        }
+      }
+    }
+    return errors
+  }
+
+  /** Checks one step's effective device label against the declared devices set. */
+  private fun checkStepDeviceLabel(
+    step: Map<*, *>,
+    label: String,
+    declaredDevices: Set<String>,
+    errors: MutableList<ValidationError>,
+  ) {
+    val device = effectiveCoordinationField(step, "device")
+    when {
+      device == null || (device as? String)?.isEmpty() == true -> {
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message = "$label is missing a 'device' parameter, but the plan declares 'devices'.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+      device !is String || device !in declaredDevices -> {
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message =
+              "$label targets device \"$device\", which is not in the plan's declared devices [${declaredDevices.joinToString(", ")}].",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Barrier coordination checks below enforce NECESSARY conditions for a
+  // barrier plan to be executable -- they do not prove full deadlock-freedom.
+  // Specifically NOT checked (tracked in issue #6231):
+  //   - Generation-boundary stranding within one lock: e.g. deviceCount=3
+  //     with arrivals A,A/B,B/C/D passes every check below (4 distinct
+  //     devices, 6 arrivals divisible by 3, no device exceeds its
+  //     2-generation budget), but if A/C/D happen to complete generation 1
+  //     first, B's two arrivals can never both be scheduled into the same
+  //     generation and it deadlocks. Proving this requires reasoning about
+  //     which subsets of arrivals can complete each generation -- a
+  //     scheduling-feasibility problem, not a simple count check.
+  //   - Cross-lock ordering cycles: device A doing barrier(X) then
+  //     barrier(Y), and device B doing barrier(Y) then barrier(X), with
+  //     both locks needing exactly {A, B} -- A blocks at X waiting for B, B
+  //     blocks at Y waiting for A. Every per-lock check below passes
+  //     because each lock individually has enough distinct arrivals and no
+  //     device exceeds its generation budget. A sound version of this
+  //     check is possible but only for locks with zero population slack
+  //     (evaluated and deferred during the #6215 review -- see issue #6231
+  //     for why).
+  // -----------------------------------------------------------------------
 
   private class BarrierLockUsage {
     val devices = mutableSetOf<String>()

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -87,8 +87,28 @@ object TestPlanValidator {
         )
       }
 
-    // Validate against schema
-    val validationErrors: List<Error> = schema.validate(jsonString, InputFormat.JSON)
+    // Validate against schema. A numeric value far outside the 64-bit long
+    // range (e.g. a SnakeYAML BigInteger deviceCount) can make the
+    // underlying JSON-schema library's own minimum/maximum keyword
+    // validators throw instead of reporting a validation error -- treat that
+    // the same as any other schema-validation failure rather than letting it
+    // crash validateYaml (#6215 review).
+    val validationErrors: List<Error> =
+      try {
+        schema.validate(jsonString, InputFormat.JSON)
+      } catch (e: Exception) {
+        return ValidationResult(
+          valid = false,
+          errors =
+            listOf(
+              ValidationError(
+                field = "root",
+                message = "Schema validation failed: ${e.message}",
+                severity = ValidationSeverity.ERROR,
+              )
+            ),
+        )
+      }
 
     // Validate tool names
     val toolNameErrors = validateToolNames(parsedObject, yamlContent)
@@ -261,6 +281,96 @@ object TestPlanValidator {
     var arrivals = 0
   }
 
+  /**
+   * Converts a coordination field's raw value to an exact positive Long, or null if it isn't one
+   * (including a value that is numerically out of the supported range, e.g. a SnakeYAML BigInteger
+   * beyond Long.MAX_VALUE). Never wraps/truncates a value that doesn't fit -- callers must treat a
+   * non-null raw value that maps to null here as an explicit rejection, not an absence (#6215
+   * review: a schema-valid but off-range deviceCount must be rejected, not silently narrowed).
+   */
+  private fun exactPositiveLong(raw: Any?): Long? =
+    when (raw) {
+      is Long -> raw.takeIf { it >= 1 }
+      is Int -> raw.toLong().takeIf { it >= 1 }
+      is java.math.BigInteger ->
+        try {
+          raw.longValueExact().takeIf { it >= 1 }
+        } catch (e: ArithmeticException) {
+          null
+        }
+      is Number -> {
+        val value = raw.toDouble()
+        if (
+          value.isFinite() &&
+            value >= 1.0 &&
+            value <= Long.MAX_VALUE.toDouble() &&
+            value == kotlin.math.floor(value)
+        ) {
+          value.toLong()
+        } else {
+          null
+        }
+      }
+      else -> null
+    }
+
+  /** Records one barrier step's device (membership-checked) against its lock's usage. */
+  private fun recordBarrierDevice(
+    usage: BarrierLockUsage,
+    lock: String,
+    step: Map<*, *>,
+    declaredDevices: Set<String>?,
+    errors: MutableList<ValidationError>,
+  ) {
+    val device = effectiveCoordinationField(step, "device") as? String
+    when {
+      device.isNullOrEmpty() -> {
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message =
+              "barrier step for lock \"$lock\" is missing a 'device' parameter. Every barrier step must target a specific device.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+      declaredDevices != null && device !in declaredDevices -> {
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message =
+              "barrier step references device \"$device\" for lock \"$lock\", but the plan's declared devices are [${declaredDevices.joinToString(", ")}]. Every barrier device must be a declared device label.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+      else -> usage.devices.add(device)
+    }
+  }
+
+  /** Records one barrier step's deviceCount against its lock's usage. */
+  private fun recordBarrierDeviceCount(
+    usage: BarrierLockUsage,
+    lock: String,
+    step: Map<*, *>,
+    errors: MutableList<ValidationError>,
+  ) {
+    val raw = effectiveCoordinationField(step, "deviceCount") ?: return
+    val deviceCount = exactPositiveLong(raw)
+    if (deviceCount != null) {
+      usage.deviceCounts.add(deviceCount)
+      return
+    }
+    errors.add(
+      ValidationError(
+        field = "steps",
+        message =
+          "barrier step for lock \"$lock\" declares deviceCount=$raw, which is outside the supported range (a positive integer representable in 64 bits). This is rejected rather than silently narrowed.",
+        severity = ValidationSeverity.ERROR,
+      )
+    )
+  }
+
   /** Collects each barrier step's lock/device/deviceCount usage, keyed by lock name. */
   private fun collectBarrierLockUsage(
     steps: List<*>,
@@ -281,29 +391,40 @@ object TestPlanValidator {
       val usage = usageByLock.getOrPut(lock) { BarrierLockUsage() }
       usage.arrivals += 1
 
-      val device = effectiveCoordinationField(step, "device") as? String
-      if (!device.isNullOrEmpty()) {
-        if (declaredDevices != null && device !in declaredDevices) {
-          errors.add(
-            ValidationError(
-              field = "steps",
-              message =
-                "barrier step references device \"$device\" for lock \"$lock\", but the plan's declared devices are [${declaredDevices.joinToString(", ")}]. Every barrier device must be a declared device label.",
-              severity = ValidationSeverity.ERROR,
-            )
-          )
-        } else {
-          usage.devices.add(device)
-        }
-      }
-
-      val deviceCount = (effectiveCoordinationField(step, "deviceCount") as? Number)?.toLong()
-      if (deviceCount != null && deviceCount >= 1) {
-        usage.deviceCounts.add(deviceCount)
-      }
+      recordBarrierDevice(usage, lock, step, declaredDevices, errors)
+      recordBarrierDeviceCount(usage, lock, step, errors)
     }
 
     return usageByLock to errors
+  }
+
+  /**
+   * Validates that a reused barrier lock declares the same deviceCount every time it's used --
+   * mirrors the daemon's PlanValidator.validateBarrierConsistentDeviceCount. The runtime
+   * coordinator keys a single shared expected-device-count per lock name (every arrival's
+   * registerExpectedDevices call overwrites it), so mixed-count reuse of the same lock is racy:
+   * whether the barrier ever releases depends on arrival order, and it can deadlock to the barrier
+   * timeout nondeterministically.
+   */
+  private fun validateBarrierConsistentDeviceCount(
+    usageByLock: Map<String, BarrierLockUsage>
+  ): List<ValidationError> {
+    val errors = mutableListOf<ValidationError>()
+    for ((lock, usage) in usageByLock) {
+      if (usage.deviceCounts.size <= 1) {
+        continue
+      }
+      val counts = usage.deviceCounts.sorted().joinToString(", ")
+      errors.add(
+        ValidationError(
+          field = "steps",
+          message =
+            "barrier lock \"$lock\" is reused with inconsistent deviceCount values ($counts). The runtime coordinator keeps a single shared expected count per lock name, so mixed-count reuse is racy and can deadlock depending on arrival order. Use a distinct lock name for each deviceCount instead.",
+          severity = ValidationSeverity.ERROR,
+        )
+      )
+    }
+    return errors
   }
 
   /**
@@ -339,10 +460,11 @@ object TestPlanValidator {
   /**
    * Validates that a reused barrier lock's total arrivals form complete generations -- mirrors the
    * daemon's PlanValidator.validateBarrierGenerationCompleteness. Sound without reconstructing
-   * rounds: only checked when a lock has a single consistent deviceCount N (an inconsistent
-   * deviceCount across reuses of the same lock is legitimate, and there is no single N to divide
-   * by); for that N, the total arrival count must be an exact multiple of N or a trailing
-   * generation is necessarily incomplete and would deadlock forever.
+   * rounds: only meaningful when a lock has a single consistent deviceCount N
+   * (validateBarrierConsistentDeviceCount already rejects a lock with more than one, so this
+   * defensively skips that case too rather than picking an arbitrary N); for that N, the total
+   * arrival count must be an exact multiple of N or a trailing generation is necessarily incomplete
+   * and would deadlock forever.
    */
   private fun validateBarrierGenerationCompleteness(
     usageByLock: Map<String, BarrierLockUsage>
@@ -369,8 +491,8 @@ object TestPlanValidator {
   }
 
   /**
-   * Runs all barrier-lock coordination checks (declared-device membership, distinct-device count,
-   * generation completeness) in one pass over the plan's steps.
+   * Runs all barrier-lock coordination checks (declared-device membership, deviceCount range and
+   * consistency, distinct-device count, generation completeness) in one pass over the plan's steps.
    */
   private fun validateBarrierCoordination(parsedObject: Any?): List<ValidationError> {
     if (parsedObject !is Map<*, *>) {
@@ -385,6 +507,7 @@ object TestPlanValidator {
     val (usageByLock, membershipErrors) = collectBarrierLockUsage(steps, declaredDevices)
 
     return membershipErrors +
+      validateBarrierConsistentDeviceCount(usageByLock) +
       validateBarrierDistinctDeviceCounts(usageByLock) +
       validateBarrierGenerationCompleteness(usageByLock)
   }

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -16,10 +16,12 @@ object TestPlanValidator {
   private val yaml = Yaml()
 
   /**
-   * JS Number.MAX_SAFE_INTEGER (2^53 - 1) -- the upper bound the runtime's z.number().int() timeout
-   * contract implicitly enforces for barrier/criticalSection steps.
+   * setTimeout's real usable range: Node/Bun clamp any delay >= 2^31 (2147483648) to 1ms with a
+   * TimeoutOverflowWarning instead of honoring it, so a coordination timeout at or above that value
+   * times out almost immediately rather than waiting as requested. 2^31 - 1 = 2147483647ms (~24.8
+   * days).
    */
-  private const val JS_MAX_SAFE_INTEGER = 9007199254740991L
+  private const val MAX_SETTIMEOUT_DELAY_MS = 2147483647L
 
   /** Load the JSON schema from resources */
   @Synchronized
@@ -737,11 +739,13 @@ object TestPlanValidator {
 
   /**
    * Validates that an optional 'timeout' on a criticalSection or barrier step, when declared, is a
-   * positive integer that does not exceed JS's Number.MAX_SAFE_INTEGER -- mirrors the daemon's
+   * positive integer that does not exceed MAX_SETTIMEOUT_DELAY_MS -- mirrors the daemon's
    * PlanValidator.validateCoordinationTimeouts. Both tools' runtime schemas
-   * (criticalSectionTools.ts / barrierTools.ts) declare z.number().int().positive() for timeout, so
-   * a value beyond the IEEE-754 safe-integer range passes the authoring schema's simple
-   * exclusiveMinimum check yet fails the runtime contract, and the plan only fails at execution.
+   * (criticalSectionTools.ts / barrierTools.ts) declare z.number().int().positive() for timeout,
+   * and CriticalSectionCoordinator.waitAtBarrier passes the value straight to production setTimeout
+   * -- Node/Bun clamp any delay >= 2^31 to 1ms instead of honoring it, so a value at or beyond that
+   * range passes the authoring schema's simple exclusiveMinimum check yet times out almost
+   * instantly at runtime instead of honoring the requested wait.
    */
   private fun validateCoordinationTimeouts(steps: List<*>): List<ValidationError> {
     val errors = mutableListOf<ValidationError>()
@@ -755,14 +759,14 @@ object TestPlanValidator {
       }
       val raw = effectiveCoordinationField(step, "timeout") ?: continue
       val timeout = exactPositiveLong(raw)
-      if (timeout != null && timeout <= JS_MAX_SAFE_INTEGER) {
+      if (timeout != null && timeout <= MAX_SETTIMEOUT_DELAY_MS) {
         continue
       }
       errors.add(
         ValidationError(
           field = "steps",
           message =
-            "$tool step $index declares 'timeout' of $raw, which must be a positive integer no greater than Number.MAX_SAFE_INTEGER ($JS_MAX_SAFE_INTEGER).",
+            "$tool step $index declares 'timeout' of $raw, which must be a positive integer no greater than setTimeout's usable range (${MAX_SETTIMEOUT_DELAY_MS}ms, ~24.8 days) -- Node/Bun clamp larger delays to 1ms instead of honoring them.",
           severity = ValidationSeverity.ERROR,
         )
       )

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -93,15 +93,32 @@ object TestPlanValidator {
     // Validate tool names
     val toolNameErrors = validateToolNames(parsedObject, yamlContent)
 
-    if (validationErrors.isEmpty() && toolNameErrors.isEmpty()) {
+    // Validate multi-device requirements (a plan using criticalSection/barrier
+    // or any step-level device label must declare top-level 'devices') and
+    // barrier-lock distinct-device-count feasibility -- mirrors the daemon's
+    // PlanValidator.validateMultiDeviceRequirements /
+    // validateBarrierDistinctDeviceCounts so a plan that validates here also
+    // survives daemon-side load instead of passing IDE/JUnit validation and
+    // then failing at execution (#6215 review).
+    val multiDeviceErrors = validateMultiDeviceRequirements(parsedObject)
+    val barrierDeviceCountErrors = validateBarrierDistinctDeviceCounts(parsedObject)
+
+    if (
+      validationErrors.isEmpty() &&
+        toolNameErrors.isEmpty() &&
+        multiDeviceErrors.isEmpty() &&
+        barrierDeviceCountErrors.isEmpty()
+    ) {
       return ValidationResult(valid = true)
     }
 
     // Format validation errors
     val errors = validationErrors.map { error -> formatError(error, yamlContent) }.toMutableList()
 
-    // Add tool name validation errors
+    // Add tool name and coordination validation errors
     errors.addAll(toolNameErrors)
+    errors.addAll(multiDeviceErrors)
+    errors.addAll(barrierDeviceCountErrors)
 
     return ValidationResult(valid = false, errors = errors)
   }
@@ -131,6 +148,144 @@ object TestPlanValidator {
               severity = ValidationSeverity.ERROR,
               line = lineInfo?.line,
               column = lineInfo?.column,
+            )
+          )
+        }
+      }
+    }
+
+    return errors
+  }
+
+  /**
+   * A plan uses multi-device features if it declares any criticalSection/barrier step (both are
+   * plan-only multi-device coordination primitives) or any step targets a device label -- mirrors
+   * the daemon's PlanValidator.hasMultiDeviceFeatures.
+   */
+  private fun hasMultiDeviceFeatures(parsedObject: Any?): Boolean {
+    if (parsedObject !is Map<*, *>) {
+      return false
+    }
+
+    val devices = parsedObject["devices"]
+    if (devices is List<*> && devices.isNotEmpty()) {
+      return true
+    }
+
+    val steps = parsedObject["steps"]
+    if (steps !is List<*>) {
+      return false
+    }
+
+    return steps.any { step ->
+      if (step !is Map<*, *>) {
+        false
+      } else {
+        val tool = step["tool"] as? String
+        tool == "criticalSection" ||
+          tool == "barrier" ||
+          step["device"] != null ||
+          (step["params"] as? Map<*, *>)?.get("device") != null
+      }
+    }
+  }
+
+  /**
+   * Validates that a plan using multi-device features (device labels, or a criticalSection/barrier
+   * step) declares a non-empty top-level 'devices' field -- mirrors the daemon's
+   * PlanValidator.validateMultiDeviceRequirements. Without this, a plan can pass IDE/JUnit
+   * validation here yet be rejected when the daemon loads it for execution (#6215 review).
+   */
+  private fun validateMultiDeviceRequirements(parsedObject: Any?): List<ValidationError> {
+    if (!hasMultiDeviceFeatures(parsedObject)) {
+      return emptyList()
+    }
+
+    val devices = (parsedObject as? Map<*, *>)?.get("devices")
+    val hasDevices = devices is List<*> && devices.isNotEmpty()
+    if (hasDevices) {
+      return emptyList()
+    }
+
+    return listOf(
+      ValidationError(
+        field = "devices",
+        message =
+          "Plan uses multi-device features (device labels or criticalSection/barrier) but does not declare 'devices' field. Add a 'devices' array at the top level of your plan.",
+        severity = ValidationSeverity.ERROR,
+      )
+    )
+  }
+
+  /**
+   * Resolves the effective value of a coordination field (lock/device/deviceCount) for a step,
+   * honoring PlanNormalizer's params-wins precedence: when the field is present under params, that
+   * value wins even if a different value also sits inline on the step -- mirrors the daemon's
+   * PlanValidator.effectiveField.
+   */
+  private fun effectiveCoordinationField(step: Map<*, *>, field: String): Any? {
+    val params = step["params"] as? Map<*, *>
+    if (params != null && params.containsKey(field)) {
+      return params[field]
+    }
+    return step[field]
+  }
+
+  private class BarrierLockUsage {
+    val devices = mutableSetOf<String>()
+    val deviceCounts = mutableSetOf<Int>()
+  }
+
+  /**
+   * Validates that every barrier lock is populated by enough distinct devices to ever satisfy its
+   * declared deviceCount -- mirrors the daemon's PlanValidator.validateBarrierDistinctDeviceCounts.
+   * Sound without reconstructing rounds: a single round needs deviceCount distinct arrivals, so if
+   * fewer distinct devices ever target a given lock across the whole plan, no round can ever
+   * complete.
+   */
+  private fun validateBarrierDistinctDeviceCounts(parsedObject: Any?): List<ValidationError> {
+    if (parsedObject !is Map<*, *>) {
+      return emptyList()
+    }
+    val steps = parsedObject["steps"]
+    if (steps !is List<*>) {
+      return emptyList()
+    }
+
+    val usageByLock = mutableMapOf<String, BarrierLockUsage>()
+    for (step in steps) {
+      if (step !is Map<*, *> || step["tool"] as? String != "barrier") {
+        continue
+      }
+
+      val lock = effectiveCoordinationField(step, "lock") as? String
+      if (lock.isNullOrEmpty()) {
+        continue
+      }
+      val usage = usageByLock.getOrPut(lock) { BarrierLockUsage() }
+
+      val device = effectiveCoordinationField(step, "device") as? String
+      if (!device.isNullOrEmpty()) {
+        usage.devices.add(device)
+      }
+
+      val deviceCount = (effectiveCoordinationField(step, "deviceCount") as? Number)?.toInt()
+      if (deviceCount != null && deviceCount >= 1) {
+        usage.deviceCounts.add(deviceCount)
+      }
+    }
+
+    val errors = mutableListOf<ValidationError>()
+    for ((lock, usage) in usageByLock) {
+      for (deviceCount in usage.deviceCounts) {
+        if (usage.devices.size < deviceCount) {
+          val deviceList = usage.devices.joinToString(", ").ifEmpty { "none" }
+          errors.add(
+            ValidationError(
+              field = "steps",
+              message =
+                "barrier lock \"$lock\" declares deviceCount=$deviceCount but only ${usage.devices.size} distinct device(s) ($deviceList) ever target it in this plan. No round can ever complete.",
+              severity = ValidationSeverity.ERROR,
             )
           )
         }

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -279,6 +279,9 @@ object TestPlanValidator {
     // Int.toInt() would silently wrap/truncate instead of rejecting it (#6215 review).
     val deviceCounts = mutableSetOf<Long>()
     var arrivals = 0
+    // Per-device occurrence count, used to catch a device scheduled more times than there are
+    // generations for it to participate in.
+    val deviceOccurrences = mutableMapOf<String, Int>()
   }
 
   /**
@@ -344,7 +347,10 @@ object TestPlanValidator {
           )
         )
       }
-      else -> usage.devices.add(device)
+      else -> {
+        usage.devices.add(device)
+        usage.deviceOccurrences[device] = (usage.deviceOccurrences[device] ?: 0) + 1
+      }
     }
   }
 
@@ -491,8 +497,59 @@ object TestPlanValidator {
   }
 
   /**
+   * Validates that no single device is scheduled to arrive at a barrier lock more times than there
+   * are generations for it to participate in -- mirrors the daemon's
+   * PlanValidator.validateBarrierExcessDeviceArrivals.
+   *
+   * PlanPartitioner executes each device's track sequentially, so a device can only ever occupy one
+   * "slot" per generation -- it cannot re-enter the same lock a second time within a generation
+   * it's already part of. For a lock with a single consistent deviceCount N and T total arrivals (T
+   * divisible by N, per validateBarrierGenerationCompleteness), there are G = T / N generations
+   * available in total. A device appearing more than G times can never be scheduled into a
+   * generation it hasn't already used, so it deadlocks waiting at an arrival no generation will
+   * ever admit.
+   *
+   * Sound: a device appearing at most G times is exactly the necessary condition for a feasible
+   * one-arrival-per-generation assignment to exist (e.g. A,A,B,B with deviceCount=2 has G=2 and
+   * each device appears exactly 2 times -- feasible, and correctly accepted).
+   */
+  private fun validateBarrierExcessDeviceArrivals(
+    usageByLock: Map<String, BarrierLockUsage>
+  ): List<ValidationError> {
+    val errors = mutableListOf<ValidationError>()
+    for ((lock, usage) in usageByLock) {
+      if (usage.deviceCounts.size != 1) {
+        continue
+      }
+      val deviceCount = usage.deviceCounts.first()
+      if (deviceCount < 1 || usage.arrivals % deviceCount != 0L) {
+        // Inconsistent-count and incomplete-generation cases are already reported by the other
+        // checks; skip here to avoid a meaningless generation count.
+        continue
+      }
+      val generations = usage.arrivals / deviceCount
+
+      for ((device, occurrences) in usage.deviceOccurrences) {
+        if (occurrences <= generations) {
+          continue
+        }
+        errors.add(
+          ValidationError(
+            field = "steps",
+            message =
+              "barrier lock \"$lock\" has $generations generation(s) available (deviceCount=$deviceCount, ${usage.arrivals} total arrivals), but device \"$device\" arrives $occurrences times. A device can participate in a lock at most once per generation, since each device's track executes sequentially, so this device would deadlock waiting for a generation that never admits it again.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+    }
+    return errors
+  }
+
+  /**
    * Runs all barrier-lock coordination checks (declared-device membership, deviceCount range and
-   * consistency, distinct-device count, generation completeness) in one pass over the plan's steps.
+   * consistency, distinct-device count, generation completeness, excess single-device arrivals) in
+   * one pass over the plan's steps.
    */
   private fun validateBarrierCoordination(parsedObject: Any?): List<ValidationError> {
     if (parsedObject !is Map<*, *>) {
@@ -509,7 +566,8 @@ object TestPlanValidator {
     return membershipErrors +
       validateBarrierConsistentDeviceCount(usageByLock) +
       validateBarrierDistinctDeviceCounts(usageByLock) +
-      validateBarrierGenerationCompleteness(usageByLock)
+      validateBarrierGenerationCompleteness(usageByLock) +
+      validateBarrierExcessDeviceArrivals(usageByLock)
   }
 
   /** Find the line number of a tool name in a specific step */

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -123,6 +123,11 @@ object TestPlanValidator {
     // of passing IDE/JUnit validation and then failing at execution (#6215
     // review).
     val multiDeviceErrors = validateMultiDeviceRequirements(parsedObject)
+    // Every declared device label must be non-blank after trimming -- mirrors
+    // the daemon's PlanValidator.validateDevicesField. The schema's
+    // minLength:1 accepts a whitespace-only label like " ", which the
+    // daemon rejects after trimming (#6215 review).
+    val devicesFieldErrors = validateDevicesField(parsedObject)
     // Every step (not just barrier/criticalSection) must target a declared
     // device label once the plan declares 'devices' -- mirrors the daemon's
     // PlanValidator.validateDeviceLabelsPresent, which checks every step
@@ -136,6 +141,7 @@ object TestPlanValidator {
       validationErrors.isEmpty() &&
         toolNameErrors.isEmpty() &&
         multiDeviceErrors.isEmpty() &&
+        devicesFieldErrors.isEmpty() &&
         deviceLabelErrors.isEmpty() &&
         barrierCoordinationErrors.isEmpty()
     ) {
@@ -148,6 +154,7 @@ object TestPlanValidator {
     // Add tool name and coordination validation errors
     errors.addAll(toolNameErrors)
     errors.addAll(multiDeviceErrors)
+    errors.addAll(devicesFieldErrors)
     errors.addAll(deviceLabelErrors)
     errors.addAll(barrierCoordinationErrors)
 
@@ -280,6 +287,35 @@ object TestPlanValidator {
         }
       }
       .toSet()
+  }
+
+  /**
+   * Validates that every declared device label is non-blank after trimming -- mirrors the daemon's
+   * PlanValidator.validateDevicesField. The schema's minLength:1 (plus the pattern requiring a
+   * non-whitespace character) already rejects most blank labels, but this is a defense-in-depth
+   * semantic check matching the daemon's own trim-then-check logic exactly (#6215 review).
+   */
+  private fun validateDevicesField(parsedObject: Any?): List<ValidationError> {
+    val devices = (parsedObject as? Map<*, *>)?.get("devices") as? List<*> ?: return emptyList()
+    val errors = mutableListOf<ValidationError>()
+    for (entry in devices) {
+      val label =
+        when (entry) {
+          is String -> entry
+          is Map<*, *> -> entry["label"] as? String
+          else -> null
+        } ?: continue
+      if (label.trim().isEmpty()) {
+        errors.add(
+          ValidationError(
+            field = "devices",
+            message = "Invalid device label: \"$label\". Device labels must be non-empty strings.",
+            severity = ValidationSeverity.ERROR,
+          )
+        )
+      }
+    }
+    return errors
   }
 
   /**

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidator.kt
@@ -15,6 +15,12 @@ object TestPlanValidator {
   private var schema: Schema? = null
   private val yaml = Yaml()
 
+  /**
+   * JS Number.MAX_SAFE_INTEGER (2^53 - 1) -- the upper bound the runtime's z.number().int() timeout
+   * contract implicitly enforces for barrier/criticalSection steps.
+   */
+  private const val JS_MAX_SAFE_INTEGER = 9007199254740991L
+
   /** Load the JSON schema from resources */
   @Synchronized
   private fun loadSchema(): Schema {
@@ -730,6 +736,41 @@ object TestPlanValidator {
   }
 
   /**
+   * Validates that an optional 'timeout' on a criticalSection or barrier step, when declared, is a
+   * positive integer that does not exceed JS's Number.MAX_SAFE_INTEGER -- mirrors the daemon's
+   * PlanValidator.validateCoordinationTimeouts. Both tools' runtime schemas
+   * (criticalSectionTools.ts / barrierTools.ts) declare z.number().int().positive() for timeout, so
+   * a value beyond the IEEE-754 safe-integer range passes the authoring schema's simple
+   * exclusiveMinimum check yet fails the runtime contract, and the plan only fails at execution.
+   */
+  private fun validateCoordinationTimeouts(steps: List<*>): List<ValidationError> {
+    val errors = mutableListOf<ValidationError>()
+    for ((index, step) in steps.withIndex()) {
+      if (step !is Map<*, *>) {
+        continue
+      }
+      val tool = step["tool"] as? String
+      if (tool != "criticalSection" && tool != "barrier") {
+        continue
+      }
+      val raw = effectiveCoordinationField(step, "timeout") ?: continue
+      val timeout = exactPositiveLong(raw)
+      if (timeout != null && timeout <= JS_MAX_SAFE_INTEGER) {
+        continue
+      }
+      errors.add(
+        ValidationError(
+          field = "steps",
+          message =
+            "$tool step $index declares 'timeout' of $raw, which must be a positive integer no greater than Number.MAX_SAFE_INTEGER ($JS_MAX_SAFE_INTEGER).",
+          severity = ValidationSeverity.ERROR,
+        )
+      )
+    }
+    return errors
+  }
+
+  /**
    * Validates that no step authors the reserved '__lockNamespace' field (inline or under params) --
    * mirrors the daemon's PlanValidator.validateNoAuthoredLockNamespace. It is injected internally
    * by PlanExecutor at runtime to scope a plan's lock state, and an authored plan must never set
@@ -820,6 +861,7 @@ object TestPlanValidator {
 
     return membershipErrors +
       validateNoAuthoredLockNamespace(steps) +
+      validateCoordinationTimeouts(steps) +
       validateNoCrossToolLockSharing(steps) +
       validateBarrierConsistentDeviceCount(usageByLock) +
       validateBarrierDistinctDeviceCounts(usageByLock) +

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
@@ -9,6 +9,7 @@ object ValidTools {
     setOf(
       "accessibility",
       "accessibilityFocus",
+      "barrier",
       "biometricAuth",
       "captureDeviceSnapshot",
       "changeLocalization",

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -761,7 +761,7 @@
           }
         },
         {
-          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target) or nested under params -- PlanNormalizer merges both into params before execution, so either authoring style must validate (#6215 review).",
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -800,18 +800,33 @@
                 "default": 30000
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": ["lock", "deviceCount", "steps"]
+                "anyOf": [
+                  { "required": ["lock"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                ]
               },
               {
-                "required": ["params"]
+                "anyOf": [
+                  { "required": ["deviceCount"] },
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "required": ["deviceCount"] } }
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  { "required": ["steps"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
+                ]
               }
             ]
           }
         },
         {
-          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step or nested under params, same as criticalSection (#6215 review).",
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations rule as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -842,12 +857,21 @@
                 "default": 30000
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": ["lock", "deviceCount"]
+                "anyOf": [
+                  { "required": ["lock"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                ]
               },
               {
-                "required": ["params"]
+                "anyOf": [
+                  { "required": ["deviceCount"] },
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "required": ["deviceCount"] } }
+                  }
+                ]
               }
             ]
           }
@@ -1536,7 +1560,6 @@
     },
     "criticalSectionParams": {
       "type": "object",
-      "required": ["lock", "steps", "deviceCount"],
       "additionalProperties": true,
       "properties": {
         "lock": {
@@ -1564,11 +1587,10 @@
           "default": 30000
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected."
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected. lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation (#6215 review)."
     },
     "barrierParams": {
       "type": "object",
-      "required": ["lock", "deviceCount"],
       "additionalProperties": true,
       "properties": {
         "lock": {
@@ -1588,7 +1610,7 @@
           "default": 30000
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected. lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block (#6215 review)."
     }
   }
 }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -201,18 +201,32 @@
       "description": "A step can have tool-specific parameters either in a 'params' object or as top-level properties (e.g., 'id', 'text', 'appId', 'direction', etc.)",
       "allOf": [
         {
-          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
+          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected. Conversely, when params DOES declare device, its own value must still be validated (non-blank string) -- most tools have no tool-specific params schema to catch an invalid params.device otherwise, so a plan with e.g. params.device: 456 would normalize to an invalid device and only fail at the daemon (#6215 review).",
           "if": {
             "required": ["params"],
             "properties": { "params": { "type": "object", "required": ["device"] } }
           },
-          "then": true,
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "device": {
+                    "type": "string",
+                    "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
+                    "minLength": 1,
+                    "pattern": "\\S"
+                  }
+                }
+              }
+            }
+          },
           "else": {
             "properties": {
               "device": {
                 "type": "string",
                 "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
-                "minLength": 1
+                "minLength": 1,
+                "pattern": "\\S"
               }
             }
           }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -173,9 +173,7 @@
           "description": "Tool-specific parameters (can also be specified as top-level properties)"
         },
         "device": {
-          "type": "string",
-          "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
-          "minLength": 1
+          "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools). Type-constrained in allOf below, gated on whether params.device overrides it (params-wins precedence)."
         },
         "label": {
           "type": "string",
@@ -199,6 +197,23 @@
       },
       "description": "A step can have tool-specific parameters either in a 'params' object or as top-level properties (e.g., 'id', 'text', 'appId', 'direction', etc.)",
       "allOf": [
+        {
+          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
+          "if": {
+            "required": ["params"],
+            "properties": { "params": { "required": ["device"] } }
+          },
+          "then": true,
+          "else": {
+            "properties": {
+              "device": {
+                "type": "string",
+                "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
+                "minLength": 1
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {
@@ -869,6 +884,71 @@
                     }
                   }
                 }
+              },
+              {
+                "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["platform"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": ["android", "ios"],
+                      "description": "Platform"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.sessionUuid override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["sessionUuid"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "sessionUuid": {
+                      "type": "string",
+                      "description": "Session UUID for device targeting"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.keepScreenAwake override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "keepScreenAwake": {
+                      "type": "boolean",
+                      "description": "Keep physical Android devices awake during the session (default: true)"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceId override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceId"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceId": {
+                      "type": "string",
+                      "description": "Device ID override"
+                    }
+                  }
+                }
               }
             ]
           }
@@ -953,6 +1033,71 @@
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
                       "default": 30000
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["platform"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": ["android", "ios"],
+                      "description": "Platform"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.sessionUuid override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["sessionUuid"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "sessionUuid": {
+                      "type": "string",
+                      "description": "Session UUID for device targeting"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.keepScreenAwake override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "keepScreenAwake": {
+                      "type": "boolean",
+                      "description": "Keep physical Android devices awake during the session (default: true)"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceId override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceId"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceId": {
+                      "type": "string",
+                      "description": "Device ID override"
                     }
                   }
                 }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -926,7 +926,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
-                      "maximum": 9007199254740991,
+                      "maximum": 2147483647,
                       "default": 30000
                     }
                   }
@@ -1105,7 +1105,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
-                      "maximum": 9007199254740991,
+                      "maximum": 2147483647,
                       "default": 30000
                     }
                   }
@@ -1887,7 +1887,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
+          "maximum": 2147483647,
           "default": 30000
         },
         "platform": {
@@ -1932,7 +1932,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
+          "maximum": 2147483647,
           "default": 30000
         },
         "platform": {

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -926,6 +926,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
                       "default": 30000
                     }
                   }
@@ -1104,6 +1105,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
                       "default": 30000
                     }
                   }
@@ -1885,6 +1887,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "default": 30000
         },
         "platform": {
@@ -1929,6 +1932,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "default": 30000
         },
         "platform": {

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -819,6 +819,20 @@
                 }
               },
               {
+                "$comment": "__lockNamespace is a reserved internal field injected by PlanExecutor at runtime to scope a plan's lock state -- an authored plan must never set it, inline or under params. Rejected explicitly here because criticalSectionParams' additionalProperties stays true, so simply omitting it from the declared properties would not block it. The params branch requires params to be an object before trusting its 'required' check -- required vacuously passes against a non-object value like params: null, which would otherwise misfire this rejection on every step with params: null (#6215 review).",
+                "not": {
+                  "anyOf": [
+                    { "required": ["__lockNamespace"] },
+                    {
+                      "required": ["params"],
+                      "properties": {
+                        "params": { "type": "object", "required": ["__lockNamespace"] }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "anyOf": [
                   { "required": ["lock"] },
                   {
@@ -1009,6 +1023,20 @@
                       "$ref": "#/$defs/barrierParams"
                     }
                   }
+                }
+              },
+              {
+                "$comment": "__lockNamespace is a reserved internal field injected by PlanExecutor at runtime to scope a plan's lock state -- an authored plan must never set it, inline or under params. Rejected explicitly here because barrierParams' additionalProperties stays true, so simply omitting it from the declared properties would not block it. The params branch requires params to be an object before trusting its 'required' check -- required vacuously passes against a non-object value like params: null, which would otherwise misfire this rejection on every step with params: null (#6215 review).",
+                "not": {
+                  "anyOf": [
+                    { "required": ["__lockNamespace"] },
+                    {
+                      "required": ["params"],
+                      "properties": {
+                        "params": { "type": "object", "required": ["__lockNamespace"] }
+                      }
+                    }
+                  ]
                 }
               },
               {
@@ -1923,13 +1951,9 @@
         "deviceId": {
           "type": "string",
           "description": "Device ID override"
-        },
-        "__lockNamespace": {
-          "type": "string",
-          "description": "Internal plan-scoped lock namespace (injected)"
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block. __lockNamespace is deliberately NOT declared here (and is explicitly rejected in the criticalSection/barrier if/then blocks below): it is injected internally by PlanExecutor at runtime to scope a plan's lock state, and an authored plan must never set it -- two participants authoring different truthy __lockNamespace values for the same lock would pass every per-lock feasibility check yet wait in separate namespaced barriers at runtime until timeout."
     }
   }
 }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -28,7 +28,9 @@
         "oneOf": [
           {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Device label; must contain at least one non-whitespace character (a whitespace-only label like \" \" satisfies minLength but is rejected by the daemon's validateDevicesField, which trims labels before checking emptiness -- #6215 review)."
           },
           {
             "$ref": "#/$defs/planDevice"
@@ -141,8 +143,9 @@
       "properties": {
         "label": {
           "type": "string",
-          "description": "Device label for multi-device routing",
-          "minLength": 1
+          "description": "Device label for multi-device routing; must contain at least one non-whitespace character.",
+          "minLength": 1,
+          "pattern": "\\S"
         },
         "platform": {
           "type": "string",
@@ -201,7 +204,7 @@
           "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
           "if": {
             "required": ["params"],
-            "properties": { "params": { "required": ["device"] } }
+            "properties": { "params": { "type": "object", "required": ["device"] } }
           },
           "then": true,
           "else": {
@@ -795,7 +798,10 @@
               {
                 "anyOf": [
                   { "required": ["lock"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["lock"] } }
+                  }
                 ]
               },
               {
@@ -803,21 +809,24 @@
                   { "required": ["deviceCount"] },
                   {
                     "required": ["params"],
-                    "properties": { "params": { "required": ["deviceCount"] } }
+                    "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                   }
                 ]
               },
               {
                 "anyOf": [
                   { "required": ["steps"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["steps"] } }
+                  }
                 ]
               },
               {
                 "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["lock"] } }
+                  "properties": { "params": { "type": "object", "required": ["lock"] } }
                 },
                 "then": true,
                 "else": {
@@ -834,7 +843,7 @@
                 "$comment": "params.deviceCount override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceCount"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                 },
                 "then": true,
                 "else": {
@@ -851,7 +860,7 @@
                 "$comment": "params.steps override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["steps"] } }
+                  "properties": { "params": { "type": "object", "required": ["steps"] } }
                 },
                 "then": true,
                 "else": {
@@ -871,7 +880,7 @@
                 "$comment": "params.timeout override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["timeout"] } }
+                  "properties": { "params": { "type": "object", "required": ["timeout"] } }
                 },
                 "then": true,
                 "else": {
@@ -889,7 +898,7 @@
                 "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["platform"] } }
+                  "properties": { "params": { "type": "object", "required": ["platform"] } }
                 },
                 "then": true,
                 "else": {
@@ -906,7 +915,7 @@
                 "$comment": "params.sessionUuid override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["sessionUuid"] } }
+                  "properties": { "params": { "type": "object", "required": ["sessionUuid"] } }
                 },
                 "then": true,
                 "else": {
@@ -922,7 +931,7 @@
                 "$comment": "params.keepScreenAwake override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                  "properties": { "params": { "type": "object", "required": ["keepScreenAwake"] } }
                 },
                 "then": true,
                 "else": {
@@ -938,7 +947,7 @@
                 "$comment": "params.deviceId override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceId"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceId"] } }
                 },
                 "then": true,
                 "else": {
@@ -973,7 +982,10 @@
               {
                 "anyOf": [
                   { "required": ["lock"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["lock"] } }
+                  }
                 ]
               },
               {
@@ -981,7 +993,7 @@
                   { "required": ["deviceCount"] },
                   {
                     "required": ["params"],
-                    "properties": { "params": { "required": ["deviceCount"] } }
+                    "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                   }
                 ]
               },
@@ -989,7 +1001,7 @@
                 "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["lock"] } }
+                  "properties": { "params": { "type": "object", "required": ["lock"] } }
                 },
                 "then": true,
                 "else": {
@@ -1006,7 +1018,7 @@
                 "$comment": "params.deviceCount override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceCount"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                 },
                 "then": true,
                 "else": {
@@ -1023,7 +1035,7 @@
                 "$comment": "params.timeout override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["timeout"] } }
+                  "properties": { "params": { "type": "object", "required": ["timeout"] } }
                 },
                 "then": true,
                 "else": {
@@ -1041,7 +1053,7 @@
                 "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["platform"] } }
+                  "properties": { "params": { "type": "object", "required": ["platform"] } }
                 },
                 "then": true,
                 "else": {
@@ -1058,7 +1070,7 @@
                 "$comment": "params.sessionUuid override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["sessionUuid"] } }
+                  "properties": { "params": { "type": "object", "required": ["sessionUuid"] } }
                 },
                 "then": true,
                 "else": {
@@ -1074,7 +1086,7 @@
                 "$comment": "params.keepScreenAwake override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                  "properties": { "params": { "type": "object", "required": ["keepScreenAwake"] } }
                 },
                 "then": true,
                 "else": {
@@ -1090,7 +1102,7 @@
                 "$comment": "params.deviceId override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceId"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceId"] } }
                 },
                 "then": true,
                 "else": {

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -761,6 +761,7 @@
           }
         },
         {
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target) or nested under params -- PlanNormalizer merges both into params before execution, so either authoring style must validate (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -773,12 +774,44 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/criticalSectionParams"
+              },
+              "lock": {
+                "type": "string",
+                "description": "Global lock identifier for synchronization across devices",
+                "minLength": 1
+              },
+              "steps": {
+                "type": "array",
+                "description": "Steps to execute serially within the critical section",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/planStep"
+                }
+              },
+              "deviceCount": {
+                "type": "integer",
+                "description": "Expected number of devices that must reach the barrier before execution proceeds",
+                "minimum": 1
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                "exclusiveMinimum": 0,
+                "default": 30000
               }
             },
-            "required": ["params"]
+            "anyOf": [
+              {
+                "required": ["lock", "deviceCount", "steps"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
           }
         },
         {
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step or nested under params, same as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -791,9 +824,32 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/barrierParams"
+              },
+              "lock": {
+                "type": "string",
+                "description": "Shared barrier name; all devices using the same name synchronize together",
+                "minLength": 1
+              },
+              "deviceCount": {
+                "type": "integer",
+                "description": "Number of devices that must arrive before the barrier lifts",
+                "minimum": 1
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                "exclusiveMinimum": 0,
+                "default": 30000
               }
             },
-            "required": ["params"]
+            "anyOf": [
+              {
+                "required": ["lock", "deviceCount"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
           }
         }
       ]
@@ -1504,7 +1560,7 @@
         "timeout": {
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
-          "minimum": 0,
+          "exclusiveMinimum": 0,
           "default": 30000
         }
       },
@@ -1528,7 +1584,7 @@
         "timeout": {
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
-          "minimum": 0,
+          "exclusiveMinimum": 0,
           "default": 30000
         }
       },

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -759,6 +759,42 @@
               }
             ]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "criticalSection"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/criticalSectionParams"
+              }
+            },
+            "required": ["params"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "barrier"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/barrierParams"
+              }
+            },
+            "required": ["params"]
+          }
         }
       ]
     },
@@ -1445,7 +1481,7 @@
     "criticalSectionParams": {
       "type": "object",
       "required": ["lock", "steps", "deviceCount"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "lock": {
           "type": "string",
@@ -1472,7 +1508,31 @@
           "default": 30000
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices"
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected."
+    },
+    "barrierParams": {
+      "type": "object",
+      "required": ["lock", "deviceCount"],
+      "additionalProperties": true,
+      "properties": {
+        "lock": {
+          "type": "string",
+          "description": "Shared barrier name; all devices using the same name synchronize together",
+          "minLength": 1
+        },
+        "deviceCount": {
+          "type": "integer",
+          "description": "Number of devices that must arrive before the barrier lifts",
+          "minimum": 1
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Barrier timeout in milliseconds (default: 30000ms)",
+          "minimum": 0,
+          "default": 30000
+        }
+      },
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected."
     }
   }
 }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -1669,9 +1669,30 @@
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
           "default": 30000
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected. lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation (#6215 review)."
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation."
     },
     "barrierParams": {
       "type": "object",
@@ -1692,9 +1713,34 @@
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
           "default": 30000
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
+        },
+        "__lockNamespace": {
+          "type": "string",
+          "description": "Internal plan-scoped lock namespace (injected)"
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected. lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block (#6215 review)."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block."
     }
   }
 }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -761,7 +761,7 @@
           }
         },
         {
-          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice (#6215 review).",
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice. Additionally, when params declares a field, params WINS at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, same precedence #6090/#6107 established for networkCondition/doNotDisturb) -- so the inline sibling is discarded and must NOT be type-checked in that case, or a plan with an invalid-but-overridden inline value would be false-rejected (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -774,30 +774,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/criticalSectionParams"
-              },
-              "lock": {
-                "type": "string",
-                "description": "Global lock identifier for synchronization across devices",
-                "minLength": 1
-              },
-              "steps": {
-                "type": "array",
-                "description": "Steps to execute serially within the critical section",
-                "minItems": 1,
-                "items": {
-                  "$ref": "#/$defs/planStep"
-                }
-              },
-              "deviceCount": {
-                "type": "integer",
-                "description": "Expected number of devices that must reach the barrier before execution proceeds",
-                "minimum": 1
-              },
-              "timeout": {
-                "type": "integer",
-                "description": "Barrier timeout in milliseconds (default: 30000ms)",
-                "exclusiveMinimum": 0,
-                "default": 30000
               }
             },
             "allOf": [
@@ -821,12 +797,84 @@
                   { "required": ["steps"] },
                   { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
                 ]
+              },
+              {
+                "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["lock"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "lock": {
+                      "type": "string",
+                      "description": "Global lock identifier for synchronization across devices",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceCount override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceCount"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceCount": {
+                      "type": "integer",
+                      "description": "Expected number of devices that must reach the barrier before execution proceeds",
+                      "minimum": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.steps override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["steps"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "steps": {
+                      "type": "array",
+                      "description": "Steps to execute serially within the critical section",
+                      "minItems": 1,
+                      "items": {
+                        "$ref": "#/$defs/planStep"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.timeout override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["timeout"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                      "exclusiveMinimum": 0,
+                      "default": 30000
+                    }
+                  }
+                }
               }
             ]
           }
         },
         {
-          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations rule as criticalSection (#6215 review).",
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations and params-wins-override rules as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -839,22 +887,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/barrierParams"
-              },
-              "lock": {
-                "type": "string",
-                "description": "Shared barrier name; all devices using the same name synchronize together",
-                "minLength": 1
-              },
-              "deviceCount": {
-                "type": "integer",
-                "description": "Number of devices that must arrive before the barrier lifts",
-                "minimum": 1
-              },
-              "timeout": {
-                "type": "integer",
-                "description": "Barrier timeout in milliseconds (default: 30000ms)",
-                "exclusiveMinimum": 0,
-                "default": 30000
               }
             },
             "allOf": [
@@ -872,6 +904,58 @@
                     "properties": { "params": { "required": ["deviceCount"] } }
                   }
                 ]
+              },
+              {
+                "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["lock"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "lock": {
+                      "type": "string",
+                      "description": "Shared barrier name; all devices using the same name synchronize together",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceCount override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceCount"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceCount": {
+                      "type": "integer",
+                      "description": "Number of devices that must arrive before the barrier lifts",
+                      "minimum": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.timeout override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["timeout"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                      "exclusiveMinimum": 0,
+                      "default": 30000
+                    }
+                  }
+                }
               }
             ]
           }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -789,12 +789,21 @@
             "required": ["tool"]
           },
           "then": {
-            "properties": {
-              "params": {
-                "$ref": "#/$defs/criticalSectionParams"
-              }
-            },
             "allOf": [
+              {
+                "$comment": "Apply criticalSectionParams' shape ONLY when params is actually an object. PlanNormalizer.isRecord treats a non-object params (e.g. null) as absent ({}), so an inline-form step with params: null must still validate via its inline fields below, not fail the unconditional object-shaped $ref (#6215 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "type": "object" } }
+                },
+                "then": {
+                  "properties": {
+                    "params": {
+                      "$ref": "#/$defs/criticalSectionParams"
+                    }
+                  }
+                }
+              },
               {
                 "anyOf": [
                   { "required": ["lock"] },
@@ -973,12 +982,21 @@
             "required": ["tool"]
           },
           "then": {
-            "properties": {
-              "params": {
-                "$ref": "#/$defs/barrierParams"
-              }
-            },
             "allOf": [
+              {
+                "$comment": "Apply barrierParams' shape ONLY when params is actually an object. PlanNormalizer.isRecord treats a non-object params (e.g. null) as absent ({}), so an inline-form step with params: null must still validate via its inline fields below, not fail the unconditional object-shaped $ref (#6215 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "type": "object" } }
+                },
+                "then": {
+                  "properties": {
+                    "params": {
+                      "$ref": "#/$defs/barrierParams"
+                    }
+                  }
+                }
+              },
               {
                 "anyOf": [
                   { "required": ["lock"] },

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -841,6 +841,128 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects two structurally-different device definitions sharing a label`() {
+    // JSON Schema's uniqueItems only compares whole entries, so an Android
+    // "A" and an iOS "A" definition pass it -- but they collapse to the
+    // same label, and the daemon's validateDevicesField rejects the
+    // duplicate regardless of the definitions' other fields (#6215 review).
+    val yaml =
+      """
+      name: duplicate-label-across-definitions
+      devices:
+        - label: A
+          platform: android
+        - label: A
+          platform: ios
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "Two structurally-different device definitions sharing a label should be invalid",
+    )
+  }
+
+  @Test
+  fun `rejects a non-coordination step's params device when it is not a string`() {
+    // For a tool with no tool-specific params schema (e.g. tapOn), an
+    // invalid inline device is skipped once params declares device (params
+    // wins at normalization), but nothing previously validated params.device
+    // itself -- a plan with params.device: 456 would normalize to an
+    // invalid device and only fail at the daemon (#6215 review).
+    val yaml =
+      """
+      name: tapon-invalid-params-device-number
+      devices:
+        - A
+      steps:
+        - tool: tapOn
+          device: 123
+          params:
+            device: 456
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A non-string params.device should be invalid")
+  }
+
+  @Test
+  fun `rejects a non-coordination step's params device when it is whitespace-only`() {
+    val yaml =
+      """
+      name: tapon-blank-params-device
+      devices:
+        - A
+      steps:
+        - tool: tapOn
+          params:
+            device: " "
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A whitespace-only params.device should be invalid")
+  }
+
+  @Test
+  fun `accepts a valid params device overriding an invalid inline device`() {
+    val yaml =
+      """
+      name: tapon-valid-params-device
+      devices:
+        - A
+      steps:
+        - tool: tapOn
+          device: 123
+          params:
+            device: A
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "A valid params.device overriding an invalid inline device should be valid",
+    )
+  }
+
+  @Test
+  fun `rejects a barrier step's params device when it is whitespace-only`() {
+    val yaml =
+      """
+      name: barrier-blank-params-device
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: " "
+            lock: sync1
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync1
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A whitespace-only barrier params.device should be invalid")
+  }
+
+  @Test
   fun `rejects a barrier with an inline malformed platform value`() {
     // The inline form must be constrained the same as the nested-params
     // form, or PlanNormalizer moving it into params later would make the

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -258,6 +258,124 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `accepts barrier with inline coordination params (no nested params object)`() {
+    // Plans may place lock/deviceCount/device directly on the step, the same
+    // inline-vs-params shape criticalSection (and most other tools) accept.
+    val yaml =
+      """
+      name: barrier-inline-test
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync-point
+          deviceCount: 2
+        - tool: barrier
+          device: B
+          lock: sync-point
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "Inline-form barrier plan should be valid")
+  }
+
+  @Test
+  fun `accepts criticalSection with inline coordination params`() {
+    val yaml =
+      """
+      name: critical-section-inline-test
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          lock: sync-point
+          deviceCount: 1
+          steps:
+            - tool: tapOn
+              params:
+                device: A
+                text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "Inline-form criticalSection plan should be valid")
+  }
+
+  @Test
+  fun `rejects barrier with a zero timeout`() {
+    val yaml =
+      """
+      name: barrier-zero-timeout
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+            timeout: 0
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "barrier with timeout=0 should be invalid")
+  }
+
+  @Test
+  fun `accepts barrier with a positive timeout`() {
+    val yaml =
+      """
+      name: barrier-positive-timeout
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+            timeout: 5000
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "barrier with a positive timeout should be valid")
+  }
+
+  @Test
+  fun `rejects criticalSection with a zero timeout`() {
+    val yaml =
+      """
+      name: critical-section-zero-timeout
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            lock: sync-point
+            deviceCount: 1
+            timeout: 0
+            steps:
+              - tool: tapOn
+                params:
+                  device: A
+                  text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "criticalSection with timeout=0 should be invalid")
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -128,6 +128,32 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `validates barrier parameters`() {
+    val yaml =
+      """
+      name: barrier-test
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "Barrier plan should be valid")
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -544,6 +544,146 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects a barrier plan targeting device labels outside the declared devices set`() {
+    // devices=[A,B] but the barrier steps target C/D: the distinct-device
+    // count (2) would otherwise satisfy deviceCount=2, but C/D are not
+    // declared devices at all, so this must be rejected regardless --
+    // mirrors the daemon's PlanValidator.validateDeviceLabelsPresent.
+    val yaml =
+      """
+      name: barrier-targets-undeclared-devices
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: C
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: D
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier targeting undeclared device labels should be invalid")
+  }
+
+  @Test
+  fun `rejects a barrier deviceCount that overflows Int instead of silently truncating it`() {
+    // 4294967298 = 2^32 + 2, which truncates to 2 via a naive Int narrowing
+    // -- that would make this A/B plan pass. The declared count must be
+    // honored at its real magnitude (held as Long) and rejected as
+    // underpopulated, not silently truncated to something satisfiable.
+    val yaml =
+      """
+      name: barrier-devicecount-overflows-int
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 4294967298
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 4294967298
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A deviceCount exceeding Int range must not be silently truncated into a satisfiable value",
+    )
+  }
+
+  @Test
+  fun `rejects a reused barrier lock whose total arrivals are not a multiple of deviceCount`() {
+    // A, B, A with deviceCount=2: 2 distinct devices satisfies the
+    // distinct-device check, but 3 total arrivals is not a multiple of 2 --
+    // generation 1 {A,B} completes and clears, then the trailing A waits
+    // alone forever. Mirrors the daemon's
+    // PlanValidator.validateBarrierGenerationCompleteness.
+    val yaml =
+      """
+      name: barrier-incomplete-trailing-generation
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "3 total arrivals is not a multiple of deviceCount=2, so this should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a reused barrier lock whose total arrivals form complete generations`() {
+    // A, B, A, B with deviceCount=2: 4 total arrivals is a multiple of 2,
+    // so both generations complete cleanly.
+    val yaml =
+      """
+      name: barrier-complete-generations
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "4 total arrivals is a multiple of deviceCount=2, so this is valid")
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -778,6 +778,121 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects an authored __lockNamespace on a barrier step's params`() {
+    // __lockNamespace is a reserved field injected internally by
+    // PlanExecutor at runtime to scope a plan's lock state. If two
+    // participants authored different truthy values for the same lock,
+    // every per-lock feasibility check would pass yet they'd wait in
+    // separate namespaced barriers at runtime until timeout (#6215 review).
+    val yaml =
+      """
+      name: barrier-authored-lock-namespace
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 2
+            __lockNamespace: one
+        - tool: barrier
+          params:
+            device: B
+            lock: sync1
+            deviceCount: 2
+            __lockNamespace: two
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "An authored __lockNamespace on a barrier step should be invalid")
+  }
+
+  @Test
+  fun `rejects an authored inline __lockNamespace on a barrier step`() {
+    val yaml =
+      """
+      name: barrier-authored-lock-namespace-inline
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync1
+          deviceCount: 2
+          __lockNamespace: one
+        - tool: barrier
+          device: B
+          lock: sync1
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "An authored inline __lockNamespace on a barrier step should be invalid",
+    )
+  }
+
+  @Test
+  fun `rejects an authored __lockNamespace on a criticalSection step's params`() {
+    val yaml =
+      """
+      name: critical-section-authored-lock-namespace
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 1
+            __lockNamespace: one
+            steps:
+              - tool: observe
+                params:
+                  device: A
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "An authored __lockNamespace on a criticalSection step should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a normal barrier plan that does not author __lockNamespace`() {
+    val yaml =
+      """
+      name: barrier-normal-no-lock-namespace
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync1
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "A normal barrier plan without __lockNamespace should be valid")
+  }
+
+  @Test
   fun `rejects devices mixing a plain-string label with a label platform definition`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -624,6 +624,223 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `accepts an inline barrier with params null and valid inline lock deviceCount device`() {
+    // PlanNormalizer.isRecord treats a non-object params (e.g. null) as
+    // absent ({}), so an inline-form barrier step with params: null is a
+    // previously-supported normalized form -- the unconditional
+    // barrierParams $ref (which requires an object) must not reject it;
+    // only the inline fields should be validated (#6215 review).
+    val yaml =
+      """
+      name: barrier-inline-null-params
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync1
+          deviceCount: 2
+          params: null
+        - tool: barrier
+          device: B
+          lock: sync1
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "An inline barrier with params: null and valid inline fields should be valid",
+    )
+  }
+
+  @Test
+  fun `rejects an inline barrier with params null and an invalid inline field`() {
+    val yaml =
+      """
+      name: barrier-inline-null-params-invalid
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync1
+          deviceCount: not-a-number
+          params: null
+        - tool: barrier
+          device: B
+          lock: sync1
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "An invalid inline deviceCount with params: null should be invalid")
+  }
+
+  @Test
+  fun `rejects the same lock name used by both a criticalSection and a barrier step`() {
+    // Both tools share the runtime coordinator's lock namespace and
+    // expected-count state, so a criticalSection A/B pair and a barrier
+    // C/D pair both using lock "shared" with deviceCount=2 can pair
+    // mismatched participants and overwrite each other's expected count.
+    val yaml =
+      """
+      name: lock-shared-across-tool-types
+      devices:
+        - A
+        - B
+        - C
+        - D
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: shared
+            deviceCount: 2
+            steps:
+              - tool: observe
+                params:
+                  device: A
+        - tool: criticalSection
+          params:
+            device: B
+            lock: shared
+            deviceCount: 2
+            steps:
+              - tool: observe
+                params:
+                  device: B
+        - tool: barrier
+          params:
+            device: C
+            lock: shared
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: D
+            lock: shared
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A lock shared between criticalSection and barrier should be invalid")
+  }
+
+  @Test
+  fun `accepts criticalSection and barrier using distinct lock names`() {
+    val yaml =
+      """
+      name: distinct-locks-per-tool-type
+      devices:
+        - A
+        - B
+        - C
+        - D
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: cs-lock
+            deviceCount: 2
+            steps:
+              - tool: observe
+                params:
+                  device: A
+        - tool: criticalSection
+          params:
+            device: B
+            lock: cs-lock
+            deviceCount: 2
+            steps:
+              - tool: observe
+                params:
+                  device: B
+        - tool: barrier
+          params:
+            device: C
+            lock: barrier-lock
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: D
+            lock: barrier-lock
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "Distinct lock names per tool type should be valid")
+  }
+
+  @Test
+  fun `rejects devices mixing a plain-string label with a label platform definition`() {
+    val yaml =
+      """
+      name: mixed-device-formats
+      devices:
+        - A
+        - label: B
+          platform: android
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Mixed device declaration formats should be invalid")
+  }
+
+  @Test
+  fun `accepts devices that are all plain-string labels`() {
+    val yaml =
+      """
+      name: all-label-devices
+      devices:
+        - A
+        - B
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "All plain-string device labels should be valid")
+  }
+
+  @Test
+  fun `accepts devices that are all label platform definitions`() {
+    val yaml =
+      """
+      name: all-definition-devices
+      devices:
+        - label: A
+          platform: android
+        - label: B
+          platform: ios
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: hi
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "All label/platform device definitions should be valid")
+  }
+
+  @Test
   fun `rejects a barrier with an inline malformed platform value`() {
     // The inline form must be constrained the same as the nested-params
     // form, or PlanNormalizer moving it into params later would make the

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -284,6 +284,48 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `accepts barrier with coordination fields split across inline and params`() {
+    // PlanNormalizer merges inline fields and params together before
+    // execution, so a field counts as present wherever it appears -- lock
+    // inline + deviceCount in params must validate.
+    val yaml =
+      """
+      name: barrier-split-fields-test
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          lock: sync-point
+          params:
+            device: A
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "Split-field barrier plan should be valid")
+  }
+
+  @Test
+  fun `rejects barrier missing deviceCount from both inline and params`() {
+    val yaml =
+      """
+      name: barrier-split-fields-missing-devicecount
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          lock: sync-point
+          params:
+            device: A
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier missing deviceCount from both locations should be invalid")
+  }
+
+  @Test
   fun `accepts criticalSection with inline coordination params`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -563,6 +563,67 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects an invalid inline device when params is null`() {
+    // JSON Schema's "required" keyword vacuously passes against a
+    // non-object value, so a naive "params has device" guard would treat
+    // params: null as if it declared 'device', wrongly skipping the inline
+    // check. The guard must require params to be an object before
+    // trusting its presence (#6215 review).
+    val yaml =
+      """
+      name: tapon-null-params-invalid-device
+      devices:
+        - A
+      steps:
+        - tool: tapOn
+          device: 123
+          params: null
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "An invalid inline device with params: null should be invalid")
+  }
+
+  @Test
+  fun `accepts a valid inline device when params is null`() {
+    val yaml =
+      """
+      name: tapon-null-params-valid-device
+      devices:
+        - A
+      steps:
+        - tool: tapOn
+          device: A
+          params: null
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "A valid inline device with params: null should be valid")
+  }
+
+  @Test
+  fun `rejects a whitespace-only declared device label`() {
+    // A whitespace-only label like " " satisfies the schema's minLength:1
+    // (and now the non-whitespace pattern too), but the daemon trims
+    // labels before checking emptiness -- mirrors
+    // PlanValidator.validateDevicesField (#6215 review).
+    val yaml =
+      """
+      name: whitespace-only-device-label
+      devices:
+        - " "
+      steps:
+        - tool: observe
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A whitespace-only device label should be invalid")
+  }
+
+  @Test
   fun `rejects a barrier with an inline malformed platform value`() {
     // The inline form must be constrained the same as the nested-params
     // form, or PlanNormalizer moving it into params later would make the

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -684,6 +684,91 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects a single device arriving more times than there are generations`() {
+    // A, B, A, A with deviceCount=2: 4 arrivals is divisible by 2 (G=2), but
+    // device A appears 3 times (greater than G=2) -- after generation 1
+    // {A,B} releases, A's second arrival starts generation 2, but its third
+    // arrival has no generation left to join.
+    val yaml =
+      """
+      name: barrier-excess-single-device-arrivals
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "Device A arriving 3 times with only 2 generations available should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a barrier lock where every device arrives at most once per available generation`() {
+    // A, A, B, B with deviceCount=2: G=2, and each device appears exactly 2
+    // times (<= G) -- feasible, since generation 1 can be {A,B} and
+    // generation 2 can be {A,B} using the second arrival of each.
+    val yaml =
+      """
+      name: barrier-feasible-repeated-arrivals
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "Each device arriving exactly as many times as there are generations should be valid",
+    )
+  }
+
+  @Test
   fun `rejects a reused barrier lock declared with more than one distinct deviceCount`() {
     // A/B at deviceCount=2, then A/B/C at deviceCount=3 for the SAME lock
     // name: the runtime coordinator keeps one shared expected count per

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -418,6 +418,62 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `accepts barrier with invalid inline deviceCount overridden by a valid params deviceCount`() {
+    // PlanNormalizer's params-wins merge discards the inline sibling, so the
+    // effective (params) value is what must be validated.
+    val yaml =
+      """
+      name: barrier-inline-invalid-params-valid
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync-point
+          deviceCount: not-a-number
+          params:
+            deviceCount: 2
+        - tool: barrier
+          device: B
+          lock: sync-point
+          params:
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "Effective (params) deviceCount should be validated, not the discarded inline value",
+    )
+  }
+
+  @Test
+  fun `rejects barrier with a valid inline deviceCount overridden by an invalid params deviceCount`() {
+    val yaml =
+      """
+      name: barrier-inline-valid-params-invalid
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync-point
+          deviceCount: 2
+          params:
+            deviceCount: 0
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "Effective (params) deviceCount=0 should be rejected even though inline is valid",
+    )
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -893,6 +893,121 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects a barrier timeout exceeding Number MAX_SAFE_INTEGER`() {
+    val yaml =
+      """
+      name: barrier-timeout-over-cap
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 2
+            timeout: 9007199254740992
+        - tool: barrier
+          params:
+            device: B
+            lock: sync1
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A barrier timeout exceeding Number.MAX_SAFE_INTEGER should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a barrier timeout at exactly Number MAX_SAFE_INTEGER`() {
+    val yaml =
+      """
+      name: barrier-timeout-at-cap
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 2
+            timeout: 9007199254740991
+        - tool: barrier
+          params:
+            device: B
+            lock: sync1
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "A barrier timeout at exactly Number.MAX_SAFE_INTEGER should be valid")
+  }
+
+  @Test
+  fun `rejects a criticalSection timeout exceeding Number MAX_SAFE_INTEGER`() {
+    val yaml =
+      """
+      name: critical-section-timeout-over-cap
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 1
+            timeout: 9007199254740992
+            steps:
+              - tool: tapOn
+                params:
+                  device: A
+                  text: OK
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A criticalSection timeout exceeding Number.MAX_SAFE_INTEGER should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a criticalSection timeout at exactly Number MAX_SAFE_INTEGER`() {
+    val yaml =
+      """
+      name: critical-section-timeout-at-cap
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: sync1
+            deviceCount: 1
+            timeout: 9007199254740991
+            steps:
+              - tool: tapOn
+                params:
+                  device: A
+                  text: OK
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "A criticalSection timeout at exactly Number.MAX_SAFE_INTEGER should be valid",
+    )
+  }
+
+  @Test
   fun `rejects devices mixing a plain-string label with a label platform definition`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -504,6 +504,119 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `accepts a criticalSection sub-step with a discarded invalid inline device overridden by a valid params device`() {
+    // PlanNormalizer.normalizeSteps merges params over inline fields for
+    // EVERY step, not just the outer criticalSection/barrier step -- a
+    // nested sub-step is itself validated as a planStep (via the
+    // criticalSectionParams.steps $ref), so this precedence must be
+    // honored there too (#6215 review).
+    val yaml =
+      """
+      name: critical-section-substep-device-override
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 1
+            steps:
+              - tool: tapOn
+                device: 123
+                params:
+                  device: A
+                  text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(
+      result.valid,
+      "A discarded invalid inline device overridden by a valid params.device should be valid",
+    )
+  }
+
+  @Test
+  fun `rejects a criticalSection sub-step with an invalid inline device when params does not override it`() {
+    val yaml =
+      """
+      name: critical-section-substep-invalid-device
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 1
+            steps:
+              - tool: tapOn
+                device: 123
+                params:
+                  text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "An un-overridden invalid inline device should be invalid")
+  }
+
+  @Test
+  fun `rejects a barrier with an inline malformed platform value`() {
+    // The inline form must be constrained the same as the nested-params
+    // form, or PlanNormalizer moving it into params later would make the
+    // runtime addDeviceTargetingToSchema reject a plan this authoring
+    // schema accepted (#6215 review).
+    val yaml =
+      """
+      name: barrier-inline-malformed-platform
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync-point
+          deviceCount: 2
+          platform: windows
+        - tool: barrier
+          device: B
+          lock: sync-point
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "An inline platform=windows should be invalid")
+  }
+
+  @Test
+  fun `accepts a barrier with an inline valid platform value`() {
+    val yaml =
+      """
+      name: barrier-inline-valid-platform
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          device: A
+          lock: sync-point
+          deviceCount: 2
+          platform: android
+        - tool: barrier
+          device: B
+          lock: sync-point
+          deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "An inline platform=android should be valid")
+  }
+
+  @Test
   fun `accepts barrier with a positive timeout`() {
     // Both A and B arrive so the declared deviceCount=2 is satisfiable by 2
     // distinct devices.

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -154,6 +154,110 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects barrier missing lock`() {
+    val yaml =
+      """
+      name: barrier-missing-lock
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier missing 'lock' should be invalid")
+  }
+
+  @Test
+  fun `rejects barrier missing deviceCount`() {
+    val yaml =
+      """
+      name: barrier-missing-devicecount
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier missing 'deviceCount' should be invalid")
+  }
+
+  @Test
+  fun `rejects barrier with wrong-typed deviceCount`() {
+    val yaml =
+      """
+      name: barrier-bad-devicecount-type
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: "two"
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier with a non-numeric deviceCount should be invalid")
+  }
+
+  @Test
+  fun `rejects criticalSection missing lock`() {
+    val yaml =
+      """
+      name: critical-section-missing-lock
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            deviceCount: 2
+            steps:
+              - tool: tapOn
+                params:
+                  device: A
+                  text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "criticalSection missing 'lock' should be invalid")
+  }
+
+  @Test
+  fun `rejects criticalSection missing deviceCount`() {
+    val yaml =
+      """
+      name: critical-section-missing-devicecount
+      devices:
+        - A
+      steps:
+        - tool: criticalSection
+          params:
+            lock: sync-point
+            steps:
+              - tool: tapOn
+                params:
+                  device: A
+                  text: Button
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "criticalSection missing 'deviceCount' should be invalid")
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -684,6 +684,164 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects a reused barrier lock declared with more than one distinct deviceCount`() {
+    // A/B at deviceCount=2, then A/B/C at deviceCount=3 for the SAME lock
+    // name: the runtime coordinator keeps one shared expected count per
+    // lock, so mixed-count reuse is racy and must be rejected regardless of
+    // whether the distinct-device/divisibility checks would otherwise pass
+    // it.
+    val yaml =
+      """
+      name: barrier-mixed-devicecount-reuse
+      devices:
+        - A
+        - B
+        - C
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: C
+            lock: sync-point
+            deviceCount: 3
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A lock reused with two different deviceCount values should be invalid",
+    )
+  }
+
+  @Test
+  fun `accepts a reused barrier lock whose deviceCount stays consistent across every use`() {
+    val yaml =
+      """
+      name: barrier-consistent-devicecount-reuse
+      devices:
+        - A
+        - B
+        - C
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: C
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 3
+        - tool: barrier
+          params:
+            device: C
+            lock: sync-point
+            deviceCount: 3
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "A lock reused with a consistent deviceCount should be valid")
+  }
+
+  @Test
+  fun `rejects a barrier step that omits device entirely under a declared devices set`() {
+    // devices=[A]: one deviceCount=1 barrier step for this lock omits
+    // 'device' altogether while another targets A. The device-less step
+    // must be rejected, not silently ignored -- mirrors the daemon's
+    // PlanValidator.validateDeviceLabelsPresent.
+    val yaml =
+      """
+      name: barrier-missing-device
+      devices:
+        - A
+      steps:
+        - tool: barrier
+          params:
+            lock: sync-point
+            deviceCount: 1
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 1
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "A barrier step with no device label should be invalid")
+  }
+
+  @Test
+  fun `rejects a barrier deviceCount that overflows Long instead of wrapping it`() {
+    // 18446744073709551618 = 2^64 + 2, a SnakeYAML BigInteger. A naive
+    // Long.toLong() (or BigInteger.toLong()) narrowing wraps this to 2,
+    // which would make this A/B plan pass. The value must be rejected at
+    // its real magnitude, not silently wrapped into something satisfiable.
+    val yaml =
+      """
+      name: barrier-devicecount-overflows-long
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 18446744073709551618
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 18446744073709551618
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A deviceCount exceeding Long range must not be silently wrapped into a satisfiable value",
+    )
+  }
+
+  @Test
   fun `validates expectations array`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -893,7 +893,7 @@ class TestPlanValidatorTest {
   }
 
   @Test
-  fun `rejects a barrier timeout exceeding Number MAX_SAFE_INTEGER`() {
+  fun `rejects a barrier timeout exceeding setTimeout's usable range`() {
     val yaml =
       """
       name: barrier-timeout-over-cap
@@ -906,7 +906,7 @@ class TestPlanValidatorTest {
             device: A
             lock: sync1
             deviceCount: 2
-            timeout: 9007199254740992
+            timeout: 2147483648
         - tool: barrier
           params:
             device: B
@@ -918,12 +918,12 @@ class TestPlanValidatorTest {
     val result = TestPlanValidator.validateYaml(yaml)
     assertFalse(
       result.valid,
-      "A barrier timeout exceeding Number.MAX_SAFE_INTEGER should be invalid",
+      "A barrier timeout exceeding setTimeout's usable range should be invalid",
     )
   }
 
   @Test
-  fun `accepts a barrier timeout at exactly Number MAX_SAFE_INTEGER`() {
+  fun `accepts a barrier timeout at exactly setTimeout's usable range`() {
     val yaml =
       """
       name: barrier-timeout-at-cap
@@ -936,7 +936,7 @@ class TestPlanValidatorTest {
             device: A
             lock: sync1
             deviceCount: 2
-            timeout: 9007199254740991
+            timeout: 2147483647
         - tool: barrier
           params:
             device: B
@@ -946,11 +946,14 @@ class TestPlanValidatorTest {
         .trimIndent()
 
     val result = TestPlanValidator.validateYaml(yaml)
-    assertTrue(result.valid, "A barrier timeout at exactly Number.MAX_SAFE_INTEGER should be valid")
+    assertTrue(
+      result.valid,
+      "A barrier timeout at exactly setTimeout's usable range should be valid",
+    )
   }
 
   @Test
-  fun `rejects a criticalSection timeout exceeding Number MAX_SAFE_INTEGER`() {
+  fun `rejects a criticalSection timeout exceeding setTimeout's usable range`() {
     val yaml =
       """
       name: critical-section-timeout-over-cap
@@ -962,7 +965,7 @@ class TestPlanValidatorTest {
             device: A
             lock: sync1
             deviceCount: 1
-            timeout: 9007199254740992
+            timeout: 2147483648
             steps:
               - tool: tapOn
                 params:
@@ -974,12 +977,12 @@ class TestPlanValidatorTest {
     val result = TestPlanValidator.validateYaml(yaml)
     assertFalse(
       result.valid,
-      "A criticalSection timeout exceeding Number.MAX_SAFE_INTEGER should be invalid",
+      "A criticalSection timeout exceeding setTimeout's usable range should be invalid",
     )
   }
 
   @Test
-  fun `accepts a criticalSection timeout at exactly Number MAX_SAFE_INTEGER`() {
+  fun `accepts a criticalSection timeout at exactly setTimeout's usable range`() {
     val yaml =
       """
       name: critical-section-timeout-at-cap
@@ -991,7 +994,7 @@ class TestPlanValidatorTest {
             device: A
             lock: sync1
             deviceCount: 1
-            timeout: 9007199254740991
+            timeout: 2147483647
             steps:
               - tool: tapOn
                 params:
@@ -1003,7 +1006,7 @@ class TestPlanValidatorTest {
     val result = TestPlanValidator.validateYaml(yaml)
     assertTrue(
       result.valid,
-      "A criticalSection timeout at exactly Number.MAX_SAFE_INTEGER should be valid",
+      "A criticalSection timeout at exactly setTimeout's usable range should be valid",
     )
   }
 

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -113,6 +113,7 @@ class TestPlanValidatorTest {
       steps:
         - tool: criticalSection
           params:
+            device: A
             lock: sync-point
             deviceCount: 2
             steps:
@@ -151,6 +152,76 @@ class TestPlanValidatorTest {
 
     val result = TestPlanValidator.validateYaml(yaml)
     assertTrue(result.valid, "Barrier plan should be valid")
+  }
+
+  @Test
+  fun `rejects a plan with valid barriers plus a device-less non-coordination step`() {
+    // devices=[A,B] and both barrier steps are individually valid, but the
+    // trailing tapOn step declares no device at all. The daemon's
+    // PlanValidator.validateDeviceLabelsPresent checks every step
+    // generically, not just barrier/criticalSection -- this must be
+    // rejected here too (#6215 review).
+    val yaml =
+      """
+      name: barrier-plan-with-device-less-tapon
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: tapOn
+          params:
+            text: Continue
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A device-less tapOn step under a plan that declares devices should be invalid",
+    )
+  }
+
+  @Test
+  fun `rejects a plan with valid barriers plus a non-coordination step targeting an undeclared device`() {
+    val yaml =
+      """
+      name: barrier-plan-with-undeclared-device-tapon
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+        - tool: tapOn
+          params:
+            device: C
+            text: Continue
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "A tapOn step targeting an undeclared device should be invalid",
+    )
   }
 
   @Test
@@ -342,6 +413,7 @@ class TestPlanValidatorTest {
         - A
       steps:
         - tool: criticalSection
+          device: A
           lock: sync-point
           deviceCount: 1
           steps:
@@ -376,6 +448,59 @@ class TestPlanValidatorTest {
 
     val result = TestPlanValidator.validateYaml(yaml)
     assertFalse(result.valid, "barrier with timeout=0 should be invalid")
+  }
+
+  @Test
+  fun `rejects barrier with a malformed platform value`() {
+    // addDeviceTargetingToSchema restricts platform to android/ios at
+    // execution; the authoring schema must reject an invalid value too,
+    // instead of only failing at execution (#6215 review).
+    val yaml =
+      """
+      name: barrier-malformed-platform
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+            platform: windows
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "barrier with platform=windows should be invalid")
+  }
+
+  @Test
+  fun `accepts barrier with a valid platform value`() {
+    val yaml =
+      """
+      name: barrier-valid-platform
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+            platform: android
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+            platform: android
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertTrue(result.valid, "barrier with platform=android should be valid")
   }
 
   @Test

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -287,17 +287,25 @@ class TestPlanValidatorTest {
   fun `accepts barrier with coordination fields split across inline and params`() {
     // PlanNormalizer merges inline fields and params together before
     // execution, so a field counts as present wherever it appears -- lock
-    // inline + deviceCount in params must validate.
+    // inline + deviceCount in params must validate. A second device's
+    // arrival is included so the lock's declared deviceCount=2 is
+    // satisfiable by 2 distinct devices.
     val yaml =
       """
       name: barrier-split-fields-test
       devices:
         - A
+        - B
       steps:
         - tool: barrier
           lock: sync-point
           params:
             device: A
+            deviceCount: 2
+        - tool: barrier
+          lock: sync-point
+          params:
+            device: B
             deviceCount: 2
       """
         .trimIndent()
@@ -372,6 +380,8 @@ class TestPlanValidatorTest {
 
   @Test
   fun `accepts barrier with a positive timeout`() {
+    // Both A and B arrive so the declared deviceCount=2 is satisfiable by 2
+    // distinct devices.
     val yaml =
       """
       name: barrier-positive-timeout
@@ -382,6 +392,12 @@ class TestPlanValidatorTest {
         - tool: barrier
           params:
             device: A
+            lock: sync-point
+            deviceCount: 2
+            timeout: 5000
+        - tool: barrier
+          params:
+            device: B
             lock: sync-point
             deviceCount: 2
             timeout: 5000
@@ -470,6 +486,60 @@ class TestPlanValidatorTest {
     assertFalse(
       result.valid,
       "Effective (params) deviceCount=0 should be rejected even though inline is valid",
+    )
+  }
+
+  @Test
+  fun `rejects a barrier plan with no top-level devices declaration`() {
+    // Mirrors the daemon's PlanValidator.validateMultiDeviceRequirements: a
+    // barrier step is a multi-device coordination primitive, so a plan using
+    // it must declare 'devices'. Without this check, IDE/JUnit validation
+    // would bless a plan the daemon rejects at load time (#6215 review).
+    val yaml =
+      """
+      name: barrier-no-devices-declared
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+        - tool: barrier
+          params:
+            device: B
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(result.valid, "Barrier plan without a 'devices' declaration should be invalid")
+  }
+
+  @Test
+  fun `rejects a barrier lock reachable by fewer distinct devices than its declared deviceCount`() {
+    // Only device A ever arrives at this lock, so the declared
+    // deviceCount=2 can never be satisfied -- mirrors the daemon's
+    // PlanValidator.validateBarrierDistinctDeviceCounts.
+    val yaml =
+      """
+      name: barrier-underpopulated-lock
+      devices:
+        - A
+        - B
+      steps:
+        - tool: barrier
+          params:
+            device: A
+            lock: sync-point
+            deviceCount: 2
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+    assertFalse(
+      result.valid,
+      "Barrier lock reachable by only 1 distinct device but declaring deviceCount=2 should be invalid",
     )
   }
 

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -761,7 +761,7 @@
           }
         },
         {
-          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target) or nested under params -- PlanNormalizer merges both into params before execution, so either authoring style must validate (#6215 review).",
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -800,18 +800,33 @@
                 "default": 30000
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": ["lock", "deviceCount", "steps"]
+                "anyOf": [
+                  { "required": ["lock"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                ]
               },
               {
-                "required": ["params"]
+                "anyOf": [
+                  { "required": ["deviceCount"] },
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "required": ["deviceCount"] } }
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  { "required": ["steps"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
+                ]
               }
             ]
           }
         },
         {
-          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step or nested under params, same as criticalSection (#6215 review).",
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations rule as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -842,12 +857,21 @@
                 "default": 30000
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": ["lock", "deviceCount"]
+                "anyOf": [
+                  { "required": ["lock"] },
+                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                ]
               },
               {
-                "required": ["params"]
+                "anyOf": [
+                  { "required": ["deviceCount"] },
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "required": ["deviceCount"] } }
+                  }
+                ]
               }
             ]
           }
@@ -1536,7 +1560,6 @@
     },
     "criticalSectionParams": {
       "type": "object",
-      "required": ["lock", "steps", "deviceCount"],
       "additionalProperties": true,
       "properties": {
         "lock": {
@@ -1564,11 +1587,10 @@
           "default": 30000
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected."
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected. lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation (#6215 review)."
     },
     "barrierParams": {
       "type": "object",
-      "required": ["lock", "deviceCount"],
       "additionalProperties": true,
       "properties": {
         "lock": {
@@ -1588,7 +1610,7 @@
           "default": 30000
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected. lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block (#6215 review)."
     }
   }
 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -201,18 +201,32 @@
       "description": "A step can have tool-specific parameters either in a 'params' object or as top-level properties (e.g., 'id', 'text', 'appId', 'direction', etc.)",
       "allOf": [
         {
-          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
+          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected. Conversely, when params DOES declare device, its own value must still be validated (non-blank string) -- most tools have no tool-specific params schema to catch an invalid params.device otherwise, so a plan with e.g. params.device: 456 would normalize to an invalid device and only fail at the daemon (#6215 review).",
           "if": {
             "required": ["params"],
             "properties": { "params": { "type": "object", "required": ["device"] } }
           },
-          "then": true,
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "device": {
+                    "type": "string",
+                    "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
+                    "minLength": 1,
+                    "pattern": "\\S"
+                  }
+                }
+              }
+            }
+          },
           "else": {
             "properties": {
               "device": {
                 "type": "string",
                 "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
-                "minLength": 1
+                "minLength": 1,
+                "pattern": "\\S"
               }
             }
           }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -173,9 +173,7 @@
           "description": "Tool-specific parameters (can also be specified as top-level properties)"
         },
         "device": {
-          "type": "string",
-          "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
-          "minLength": 1
+          "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools). Type-constrained in allOf below, gated on whether params.device overrides it (params-wins precedence)."
         },
         "label": {
           "type": "string",
@@ -199,6 +197,23 @@
       },
       "description": "A step can have tool-specific parameters either in a 'params' object or as top-level properties (e.g., 'id', 'text', 'appId', 'direction', etc.)",
       "allOf": [
+        {
+          "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
+          "if": {
+            "required": ["params"],
+            "properties": { "params": { "required": ["device"] } }
+          },
+          "then": true,
+          "else": {
+            "properties": {
+              "device": {
+                "type": "string",
+                "description": "Device label indicating which device this step runs on (required in multi-device plans for non-device-agnostic tools)",
+                "minLength": 1
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {
@@ -869,6 +884,71 @@
                     }
                   }
                 }
+              },
+              {
+                "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["platform"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": ["android", "ios"],
+                      "description": "Platform"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.sessionUuid override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["sessionUuid"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "sessionUuid": {
+                      "type": "string",
+                      "description": "Session UUID for device targeting"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.keepScreenAwake override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "keepScreenAwake": {
+                      "type": "boolean",
+                      "description": "Keep physical Android devices awake during the session (default: true)"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceId override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceId"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceId": {
+                      "type": "string",
+                      "description": "Device ID override"
+                    }
+                  }
+                }
               }
             ]
           }
@@ -953,6 +1033,71 @@
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
                       "default": 30000
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["platform"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": ["android", "ios"],
+                      "description": "Platform"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.sessionUuid override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["sessionUuid"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "sessionUuid": {
+                      "type": "string",
+                      "description": "Session UUID for device targeting"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.keepScreenAwake override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "keepScreenAwake": {
+                      "type": "boolean",
+                      "description": "Keep physical Android devices awake during the session (default: true)"
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceId override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceId"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceId": {
+                      "type": "string",
+                      "description": "Device ID override"
                     }
                   }
                 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -926,7 +926,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
-                      "maximum": 9007199254740991,
+                      "maximum": 2147483647,
                       "default": 30000
                     }
                   }
@@ -1105,7 +1105,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
-                      "maximum": 9007199254740991,
+                      "maximum": 2147483647,
                       "default": 30000
                     }
                   }
@@ -1887,7 +1887,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
+          "maximum": 2147483647,
           "default": 30000
         },
         "platform": {
@@ -1932,7 +1932,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
+          "maximum": 2147483647,
           "default": 30000
         },
         "platform": {

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -926,6 +926,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
                       "default": 30000
                     }
                   }
@@ -1104,6 +1105,7 @@
                       "type": "integer",
                       "description": "Barrier timeout in milliseconds (default: 30000ms)",
                       "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
                       "default": 30000
                     }
                   }
@@ -1885,6 +1887,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "default": 30000
         },
         "platform": {
@@ -1929,6 +1932,7 @@
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "default": 30000
         },
         "platform": {

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -819,6 +819,20 @@
                 }
               },
               {
+                "$comment": "__lockNamespace is a reserved internal field injected by PlanExecutor at runtime to scope a plan's lock state -- an authored plan must never set it, inline or under params. Rejected explicitly here because criticalSectionParams' additionalProperties stays true, so simply omitting it from the declared properties would not block it. The params branch requires params to be an object before trusting its 'required' check -- required vacuously passes against a non-object value like params: null, which would otherwise misfire this rejection on every step with params: null (#6215 review).",
+                "not": {
+                  "anyOf": [
+                    { "required": ["__lockNamespace"] },
+                    {
+                      "required": ["params"],
+                      "properties": {
+                        "params": { "type": "object", "required": ["__lockNamespace"] }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "anyOf": [
                   { "required": ["lock"] },
                   {
@@ -1009,6 +1023,20 @@
                       "$ref": "#/$defs/barrierParams"
                     }
                   }
+                }
+              },
+              {
+                "$comment": "__lockNamespace is a reserved internal field injected by PlanExecutor at runtime to scope a plan's lock state -- an authored plan must never set it, inline or under params. Rejected explicitly here because barrierParams' additionalProperties stays true, so simply omitting it from the declared properties would not block it. The params branch requires params to be an object before trusting its 'required' check -- required vacuously passes against a non-object value like params: null, which would otherwise misfire this rejection on every step with params: null (#6215 review).",
+                "not": {
+                  "anyOf": [
+                    { "required": ["__lockNamespace"] },
+                    {
+                      "required": ["params"],
+                      "properties": {
+                        "params": { "type": "object", "required": ["__lockNamespace"] }
+                      }
+                    }
+                  ]
                 }
               },
               {
@@ -1923,13 +1951,9 @@
         "deviceId": {
           "type": "string",
           "description": "Device ID override"
-        },
-        "__lockNamespace": {
-          "type": "string",
-          "description": "Internal plan-scoped lock namespace (injected)"
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block. __lockNamespace is deliberately NOT declared here (and is explicitly rejected in the criticalSection/barrier if/then blocks below): it is injected internally by PlanExecutor at runtime to scope a plan's lock state, and an authored plan must never set it -- two participants authoring different truthy __lockNamespace values for the same lock would pass every per-lock feasibility check yet wait in separate namespaced barriers at runtime until timeout."
     }
   }
 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -28,7 +28,9 @@
         "oneOf": [
           {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Device label; must contain at least one non-whitespace character (a whitespace-only label like \" \" satisfies minLength but is rejected by the daemon's validateDevicesField, which trims labels before checking emptiness -- #6215 review)."
           },
           {
             "$ref": "#/$defs/planDevice"
@@ -141,8 +143,9 @@
       "properties": {
         "label": {
           "type": "string",
-          "description": "Device label for multi-device routing",
-          "minLength": 1
+          "description": "Device label for multi-device routing; must contain at least one non-whitespace character.",
+          "minLength": 1,
+          "pattern": "\\S"
         },
         "platform": {
           "type": "string",
@@ -201,7 +204,7 @@
           "$comment": "Generic (all tools): params.device (when present) overrides inline device at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, params precedence), so the inline sibling is discarded and must NOT be type-checked in that case -- e.g. a nested criticalSection/barrier sub-step with an invalid inline device but a valid params.device must not be false-rejected (#6215 review).",
           "if": {
             "required": ["params"],
-            "properties": { "params": { "required": ["device"] } }
+            "properties": { "params": { "type": "object", "required": ["device"] } }
           },
           "then": true,
           "else": {
@@ -795,7 +798,10 @@
               {
                 "anyOf": [
                   { "required": ["lock"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["lock"] } }
+                  }
                 ]
               },
               {
@@ -803,21 +809,24 @@
                   { "required": ["deviceCount"] },
                   {
                     "required": ["params"],
-                    "properties": { "params": { "required": ["deviceCount"] } }
+                    "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                   }
                 ]
               },
               {
                 "anyOf": [
                   { "required": ["steps"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["steps"] } }
+                  }
                 ]
               },
               {
                 "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["lock"] } }
+                  "properties": { "params": { "type": "object", "required": ["lock"] } }
                 },
                 "then": true,
                 "else": {
@@ -834,7 +843,7 @@
                 "$comment": "params.deviceCount override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceCount"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                 },
                 "then": true,
                 "else": {
@@ -851,7 +860,7 @@
                 "$comment": "params.steps override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["steps"] } }
+                  "properties": { "params": { "type": "object", "required": ["steps"] } }
                 },
                 "then": true,
                 "else": {
@@ -871,7 +880,7 @@
                 "$comment": "params.timeout override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["timeout"] } }
+                  "properties": { "params": { "type": "object", "required": ["timeout"] } }
                 },
                 "then": true,
                 "else": {
@@ -889,7 +898,7 @@
                 "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["platform"] } }
+                  "properties": { "params": { "type": "object", "required": ["platform"] } }
                 },
                 "then": true,
                 "else": {
@@ -906,7 +915,7 @@
                 "$comment": "params.sessionUuid override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["sessionUuid"] } }
+                  "properties": { "params": { "type": "object", "required": ["sessionUuid"] } }
                 },
                 "then": true,
                 "else": {
@@ -922,7 +931,7 @@
                 "$comment": "params.keepScreenAwake override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                  "properties": { "params": { "type": "object", "required": ["keepScreenAwake"] } }
                 },
                 "then": true,
                 "else": {
@@ -938,7 +947,7 @@
                 "$comment": "params.deviceId override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceId"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceId"] } }
                 },
                 "then": true,
                 "else": {
@@ -973,7 +982,10 @@
               {
                 "anyOf": [
                   { "required": ["lock"] },
-                  { "required": ["params"], "properties": { "params": { "required": ["lock"] } } }
+                  {
+                    "required": ["params"],
+                    "properties": { "params": { "type": "object", "required": ["lock"] } }
+                  }
                 ]
               },
               {
@@ -981,7 +993,7 @@
                   { "required": ["deviceCount"] },
                   {
                     "required": ["params"],
-                    "properties": { "params": { "required": ["deviceCount"] } }
+                    "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                   }
                 ]
               },
@@ -989,7 +1001,7 @@
                 "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["lock"] } }
+                  "properties": { "params": { "type": "object", "required": ["lock"] } }
                 },
                 "then": true,
                 "else": {
@@ -1006,7 +1018,7 @@
                 "$comment": "params.deviceCount override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceCount"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceCount"] } }
                 },
                 "then": true,
                 "else": {
@@ -1023,7 +1035,7 @@
                 "$comment": "params.timeout override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["timeout"] } }
+                  "properties": { "params": { "type": "object", "required": ["timeout"] } }
                 },
                 "then": true,
                 "else": {
@@ -1041,7 +1053,7 @@
                 "$comment": "params.platform override, same rule as lock above -- addDeviceTargetingToSchema restricts this to android/ios at runtime, so the inline form must be validated only when params does not override it.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["platform"] } }
+                  "properties": { "params": { "type": "object", "required": ["platform"] } }
                 },
                 "then": true,
                 "else": {
@@ -1058,7 +1070,7 @@
                 "$comment": "params.sessionUuid override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["sessionUuid"] } }
+                  "properties": { "params": { "type": "object", "required": ["sessionUuid"] } }
                 },
                 "then": true,
                 "else": {
@@ -1074,7 +1086,7 @@
                 "$comment": "params.keepScreenAwake override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["keepScreenAwake"] } }
+                  "properties": { "params": { "type": "object", "required": ["keepScreenAwake"] } }
                 },
                 "then": true,
                 "else": {
@@ -1090,7 +1102,7 @@
                 "$comment": "params.deviceId override, same rule as lock above.",
                 "if": {
                   "required": ["params"],
-                  "properties": { "params": { "required": ["deviceId"] } }
+                  "properties": { "params": { "type": "object", "required": ["deviceId"] } }
                 },
                 "then": true,
                 "else": {

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -761,6 +761,7 @@
           }
         },
         {
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target) or nested under params -- PlanNormalizer merges both into params before execution, so either authoring style must validate (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -773,12 +774,44 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/criticalSectionParams"
+              },
+              "lock": {
+                "type": "string",
+                "description": "Global lock identifier for synchronization across devices",
+                "minLength": 1
+              },
+              "steps": {
+                "type": "array",
+                "description": "Steps to execute serially within the critical section",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/planStep"
+                }
+              },
+              "deviceCount": {
+                "type": "integer",
+                "description": "Expected number of devices that must reach the barrier before execution proceeds",
+                "minimum": 1
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                "exclusiveMinimum": 0,
+                "default": 30000
               }
             },
-            "required": ["params"]
+            "anyOf": [
+              {
+                "required": ["lock", "deviceCount", "steps"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
           }
         },
         {
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step or nested under params, same as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -791,9 +824,32 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/barrierParams"
+              },
+              "lock": {
+                "type": "string",
+                "description": "Shared barrier name; all devices using the same name synchronize together",
+                "minLength": 1
+              },
+              "deviceCount": {
+                "type": "integer",
+                "description": "Number of devices that must arrive before the barrier lifts",
+                "minimum": 1
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                "exclusiveMinimum": 0,
+                "default": 30000
               }
             },
-            "required": ["params"]
+            "anyOf": [
+              {
+                "required": ["lock", "deviceCount"]
+              },
+              {
+                "required": ["params"]
+              }
+            ]
           }
         }
       ]
@@ -1504,7 +1560,7 @@
         "timeout": {
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
-          "minimum": 0,
+          "exclusiveMinimum": 0,
           "default": 30000
         }
       },
@@ -1528,7 +1584,7 @@
         "timeout": {
           "type": "integer",
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
-          "minimum": 0,
+          "exclusiveMinimum": 0,
           "default": 30000
         }
       },

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -759,6 +759,42 @@
               }
             ]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "criticalSection"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/criticalSectionParams"
+              }
+            },
+            "required": ["params"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "barrier"
+              }
+            },
+            "required": ["tool"]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/barrierParams"
+              }
+            },
+            "required": ["params"]
+          }
         }
       ]
     },
@@ -1445,7 +1481,7 @@
     "criticalSectionParams": {
       "type": "object",
       "required": ["lock", "steps", "deviceCount"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "lock": {
           "type": "string",
@@ -1472,7 +1508,31 @@
           "default": 30000
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices"
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected."
+    },
+    "barrierParams": {
+      "type": "object",
+      "required": ["lock", "deviceCount"],
+      "additionalProperties": true,
+      "properties": {
+        "lock": {
+          "type": "string",
+          "description": "Shared barrier name; all devices using the same name synchronize together",
+          "minLength": 1
+        },
+        "deviceCount": {
+          "type": "integer",
+          "description": "Number of devices that must arrive before the barrier lifts",
+          "minimum": 1
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Barrier timeout in milliseconds (default: 30000ms)",
+          "minimum": 0,
+          "default": 30000
+        }
+      },
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected."
     }
   }
 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -1669,9 +1669,30 @@
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
           "default": 30000
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
         }
       },
-      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are not rejected. lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation (#6215 review)."
+      "description": "Parameters for criticalSection tool that provides barrier synchronization and mutex-based serial execution across multiple devices. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/steps/deviceCount are intentionally NOT required here: a plan may declare any of them inline on the step instead of nested here, and PlanNormalizer merges the two -- the planStep if/then block enforces required-ness against that merged union, not against this def in isolation."
     },
     "barrierParams": {
       "type": "object",
@@ -1692,9 +1713,34 @@
           "description": "Barrier timeout in milliseconds (default: 30000ms)",
           "exclusiveMinimum": 0,
           "default": 30000
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
+        },
+        "__lockNamespace": {
+          "type": "string",
+          "description": "Internal plan-scoped lock namespace (injected)"
         }
       },
-      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true so the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) and the internally-injected __lockNamespace are not rejected. lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block (#6215 review)."
+      "description": "Parameters for barrier tool: a pure synchronization point with no serialized section. additionalProperties stays true for any genuinely-unknown extra field, but the device-targeting fields injected by addDeviceTargetingToSchema (device, sessionUuid, platform, deviceId, keepScreenAwake) are explicitly typed so a malformed value (e.g. platform: windows) is rejected here instead of only failing at execution (#6215 review). lock/deviceCount are intentionally NOT required here for the same reason as criticalSectionParams -- required-ness is enforced against the inline+params union in the planStep if/then block."
     }
   }
 }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -761,7 +761,7 @@
           }
         },
         {
-          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice (#6215 review).",
+          "$comment": "criticalSection accepts lock/deviceCount/steps/timeout either inline on the step (like dragAndDrop's source/target), nested under params, or SPLIT across both (e.g. lock inline, deviceCount in params) -- PlanNormalizer merges inline fields and params together before execution, so a field counts as present wherever it appears. Each required field is validated against that merged union independently, not as an all-inline-or-all-params choice. Additionally, when params declares a field, params WINS at normalization (PlanNormalizer's `{ ...inlineParams, ...paramsFromStep }` merge, same precedence #6090/#6107 established for networkCondition/doNotDisturb) -- so the inline sibling is discarded and must NOT be type-checked in that case, or a plan with an invalid-but-overridden inline value would be false-rejected (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -774,30 +774,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/criticalSectionParams"
-              },
-              "lock": {
-                "type": "string",
-                "description": "Global lock identifier for synchronization across devices",
-                "minLength": 1
-              },
-              "steps": {
-                "type": "array",
-                "description": "Steps to execute serially within the critical section",
-                "minItems": 1,
-                "items": {
-                  "$ref": "#/$defs/planStep"
-                }
-              },
-              "deviceCount": {
-                "type": "integer",
-                "description": "Expected number of devices that must reach the barrier before execution proceeds",
-                "minimum": 1
-              },
-              "timeout": {
-                "type": "integer",
-                "description": "Barrier timeout in milliseconds (default: 30000ms)",
-                "exclusiveMinimum": 0,
-                "default": 30000
               }
             },
             "allOf": [
@@ -821,12 +797,84 @@
                   { "required": ["steps"] },
                   { "required": ["params"], "properties": { "params": { "required": ["steps"] } } }
                 ]
+              },
+              {
+                "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["lock"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "lock": {
+                      "type": "string",
+                      "description": "Global lock identifier for synchronization across devices",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceCount override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceCount"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceCount": {
+                      "type": "integer",
+                      "description": "Expected number of devices that must reach the barrier before execution proceeds",
+                      "minimum": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.steps override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["steps"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "steps": {
+                      "type": "array",
+                      "description": "Steps to execute serially within the critical section",
+                      "minItems": 1,
+                      "items": {
+                        "$ref": "#/$defs/planStep"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.timeout override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["timeout"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                      "exclusiveMinimum": 0,
+                      "default": 30000
+                    }
+                  }
+                }
               }
             ]
           }
         },
         {
-          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations rule as criticalSection (#6215 review).",
+          "$comment": "barrier accepts lock/deviceCount/timeout either inline on the step, nested under params, or split across both, same union-of-locations and params-wins-override rules as criticalSection (#6215 review).",
           "if": {
             "properties": {
               "tool": {
@@ -839,22 +887,6 @@
             "properties": {
               "params": {
                 "$ref": "#/$defs/barrierParams"
-              },
-              "lock": {
-                "type": "string",
-                "description": "Shared barrier name; all devices using the same name synchronize together",
-                "minLength": 1
-              },
-              "deviceCount": {
-                "type": "integer",
-                "description": "Number of devices that must arrive before the barrier lifts",
-                "minimum": 1
-              },
-              "timeout": {
-                "type": "integer",
-                "description": "Barrier timeout in milliseconds (default: 30000ms)",
-                "exclusiveMinimum": 0,
-                "default": 30000
               }
             },
             "allOf": [
@@ -872,6 +904,58 @@
                     "properties": { "params": { "required": ["deviceCount"] } }
                   }
                 ]
+              },
+              {
+                "$comment": "params.lock (when present) overrides inline lock at normalization; validate the inline form only when params.lock is absent, otherwise a valid params override would false-reject the discarded inline value.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["lock"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "lock": {
+                      "type": "string",
+                      "description": "Shared barrier name; all devices using the same name synchronize together",
+                      "minLength": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.deviceCount override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["deviceCount"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "deviceCount": {
+                      "type": "integer",
+                      "description": "Number of devices that must arrive before the barrier lifts",
+                      "minimum": 1
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "params.timeout override, same rule as lock above.",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "required": ["timeout"] } }
+                },
+                "then": true,
+                "else": {
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "Barrier timeout in milliseconds (default: 30000ms)",
+                      "exclusiveMinimum": 0,
+                      "default": 30000
+                    }
+                  }
+                }
               }
             ]
           }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -789,12 +789,21 @@
             "required": ["tool"]
           },
           "then": {
-            "properties": {
-              "params": {
-                "$ref": "#/$defs/criticalSectionParams"
-              }
-            },
             "allOf": [
+              {
+                "$comment": "Apply criticalSectionParams' shape ONLY when params is actually an object. PlanNormalizer.isRecord treats a non-object params (e.g. null) as absent ({}), so an inline-form step with params: null must still validate via its inline fields below, not fail the unconditional object-shaped $ref (#6215 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "type": "object" } }
+                },
+                "then": {
+                  "properties": {
+                    "params": {
+                      "$ref": "#/$defs/criticalSectionParams"
+                    }
+                  }
+                }
+              },
               {
                 "anyOf": [
                   { "required": ["lock"] },
@@ -973,12 +982,21 @@
             "required": ["tool"]
           },
           "then": {
-            "properties": {
-              "params": {
-                "$ref": "#/$defs/barrierParams"
-              }
-            },
             "allOf": [
+              {
+                "$comment": "Apply barrierParams' shape ONLY when params is actually an object. PlanNormalizer.isRecord treats a non-object params (e.g. null) as absent ({}), so an inline-form step with params: null must still validate via its inline fields below, not fail the unconditional object-shaped $ref (#6215 review).",
+                "if": {
+                  "required": ["params"],
+                  "properties": { "params": { "type": "object" } }
+                },
+                "then": {
+                  "properties": {
+                    "params": {
+                      "$ref": "#/$defs/barrierParams"
+                    }
+                  }
+                }
+              },
               {
                 "anyOf": [
                   { "required": ["lock"] },

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -254,6 +254,7 @@ export class PlanValidator {
   private static validateCoordinationLocks(plan: Plan): void {
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
+    this.validateBarrierConsistentDeviceCount(plan);
     this.validateBarrierDistinctDeviceCounts(plan);
     this.validateBarrierGenerationCompleteness(plan);
   }
@@ -424,6 +425,40 @@ export class PlanValidator {
   }
 
   /**
+   * Validates that a reused barrier lock declares the same `deviceCount`
+   * every time it's used.
+   *
+   * The runtime coordinator (CriticalSectionCoordinator) keys a single
+   * shared expected-device-count per lock name: every arrival's
+   * `registerExpectedDevices` call overwrites it, so whichever arrival
+   * happens to run last wins. Mixed-count reuse of the same lock therefore
+   * makes whether the barrier ever releases depend on arrival order — it
+   * can deadlock to the barrier timeout nondeterministically. A plan that
+   * legitimately wants different participant counts per phase must use a
+   * distinct lock name per count instead.
+   */
+  private static validateBarrierConsistentDeviceCount(plan: Plan): void {
+    const usageByLock = this.collectBarrierLockUsage(plan);
+    const errors: string[] = [];
+
+    for (const [lock, usage] of usageByLock.entries()) {
+      if (usage.deviceCounts.size <= 1) {
+        continue;
+      }
+      const counts = Array.from(usage.deviceCounts)
+        .sort((a, b) => a - b)
+        .join(", ");
+      errors.push(
+        `barrier lock "${lock}" is reused with inconsistent deviceCount values (${counts}). The runtime coordinator keeps a single shared expected count per lock name, so mixed-count reuse is racy and can deadlock depending on arrival order. Use a distinct lock name for each deviceCount instead.`,
+      );
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
+  /**
    * Validates that a reused barrier lock's total arrivals form complete
    * generations, catching a class of deadlock the distinct-device check
    * above cannot: e.g. arrivals A, B, A with deviceCount=2 has 2 distinct
@@ -431,15 +466,14 @@ export class PlanValidator {
    * generation that only ever gets 1 of the 2 devices it needs, so it waits
    * forever.
    *
-   * Sound WITHOUT reconstructing rounds: only checked when a lock has a
-   * single consistent deviceCount N (an inconsistent lock isn't itself an
-   * error here — barrier legitimately allows different deviceCount values
-   * across its reuses — but there's no single N to divide by, so this
-   * check is skipped for it). For that N, the total number of barrier steps
-   * referencing the lock must be an exact multiple of N: each generation
-   * consumes exactly N arrivals, so a non-multiple total necessarily leaves
-   * an incomplete trailing generation that can never complete. This never
-   * false-rejects a valid plan.
+   * Sound WITHOUT reconstructing rounds: only meaningful when a lock has a
+   * single consistent deviceCount N (validateBarrierConsistentDeviceCount
+   * already rejects a lock with more than one, so this defensively skips
+   * that case too rather than picking an arbitrary N). For that N, the
+   * total number of barrier steps referencing the lock must be an exact
+   * multiple of N: each generation consumes exactly N arrivals, so a
+   * non-multiple total necessarily leaves an incomplete trailing generation
+   * that can never complete. This never false-rejects a valid plan.
    */
   private static validateBarrierGenerationCompleteness(plan: Plan): void {
     const usageByLock = this.collectBarrierLockUsage(plan);

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -271,10 +271,44 @@ export class PlanValidator {
   private static validateCoordinationLocks(plan: Plan): void {
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
+    this.validateNoCrossToolLockSharing(plan);
     this.validateBarrierConsistentDeviceCount(plan);
     this.validateBarrierDistinctDeviceCounts(plan);
     this.validateBarrierGenerationCompleteness(plan);
     this.validateBarrierExcessDeviceArrivals(plan);
+  }
+
+  /**
+   * Validates that no lock name is shared between a criticalSection step
+   * and a barrier step. Both tools share the runtime coordinator's lock
+   * namespace and expected-device-count state (CriticalSectionCoordinator
+   * keys both by the same lock name), so mixing tool types on one lock name
+   * is racy: e.g. a criticalSection A/B pair and a barrier C/D pair both
+   * using lock "shared" with deviceCount=2 can pair A with C instead of the
+   * intended A-with-B / C-with-D, and cross-tool arrivals can overwrite each
+   * other's expected count. Each tool type must use a distinct lock name.
+   */
+  private static validateNoCrossToolLockSharing(plan: Plan): void {
+    const criticalSectionLocks = new Set<string>();
+    const barrierLocks = new Set<string>();
+
+    for (const step of plan.steps) {
+      if (step.tool !== "criticalSection" && step.tool !== "barrier") {
+        continue;
+      }
+      const lock = this.effectiveField(step, "lock");
+      if (typeof lock !== "string" || lock.length === 0) {
+        continue;
+      }
+      (step.tool === "criticalSection" ? criticalSectionLocks : barrierLocks).add(lock);
+    }
+
+    const shared = Array.from(criticalSectionLocks).filter((lock) => barrierLocks.has(lock));
+    if (shared.length > 0) {
+      throw new ActionableError(
+        `lock name${shared.length === 1 ? "" : "s"} ${shared.map((l) => `"${l}"`).join(", ")} ${shared.length === 1 ? "is" : "are"} used by both a criticalSection step and a barrier step. Both tools share the runtime coordinator's lock namespace and expected-count state, so mixing tool types on the same lock name is racy and can pair mismatched participants or overwrite the expected count. Use a distinct lock name per tool type.`,
+      );
+    }
   }
 
   /**

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -2,6 +2,11 @@ import { Plan } from "../../models/Plan";
 import { ActionableError } from "../../models";
 import { normalizePlanDevices } from "./PlanDevices";
 
+interface BarrierOccurrence {
+  stepIndex: number;
+  deviceCount: unknown;
+}
+
 /**
  * Validates a plan structure and enforces multi-device rules.
  */
@@ -219,21 +224,31 @@ export class PlanValidator {
   }
 
   /**
-   * Validates that every criticalSection/barrier lock has a consistent
-   * contract across the steps that share it:
+   * Validates cross-step consistency for both coordination tools:
+   * criticalSection locks (a lock is entered at most once per plan) and
+   * barrier locks (a lock may recur across multiple synchronization rounds).
+   */
+  private static validateCoordinationLocks(plan: Plan): void {
+    this.validateCriticalSectionLocks(plan);
+    this.validateBarrierRounds(plan);
+  }
+
+  /**
+   * Validates that every criticalSection lock has a consistent contract
+   * across the steps that share it:
    *   - All steps sharing a lock declare the same deviceCount.
    *   - The number of steps sharing a lock equals that deviceCount (otherwise
-   *     the barrier will deadlock waiting for a device that never arrives).
+   *     the section will deadlock waiting for a device that never arrives).
    *   - Each participating step targets a distinct device (no device can
    *     enter the same lock twice — it would re-acquire and deadlock).
    *
-   * barrier gets the same treatment as criticalSection here: both share the
-   * lock/deviceCount/device contract (barrier just has no nested steps).
+   * Unlike barrier, a criticalSection lock is a single-use rendezvous within
+   * a plan, so every occurrence of a given lock name is validated together.
    *
    * These checks catch coordination bugs at validation time instead of
-   * surfacing them as a 30-second barrier timeout at runtime.
+   * surfacing them as a 30-second timeout at runtime.
    */
-  private static validateCoordinationLocks(plan: Plan): void {
+  private static validateCriticalSectionLocks(plan: Plan): void {
     interface LockOccurrence {
       stepIndex: number;
       device: unknown;
@@ -243,7 +258,7 @@ export class PlanValidator {
 
     for (let i = 0; i < plan.steps.length; i++) {
       const step = plan.steps[i];
-      if (step.tool !== "criticalSection" && step.tool !== "barrier") {
+      if (step.tool !== "criticalSection") {
         continue;
       }
       const params = step.params;
@@ -276,7 +291,7 @@ export class PlanValidator {
           .map((o) => `step ${o.stepIndex} deviceCount=${String(o.deviceCount)}`)
           .join(", ");
         errors.push(
-          `lock "${lock}" has inconsistent deviceCount values: ${detail}. All steps sharing a lock must declare the same deviceCount.`,
+          `criticalSection lock "${lock}" has inconsistent deviceCount values: ${detail}. All steps sharing a lock must declare the same deviceCount.`,
         );
         continue;
       }
@@ -286,7 +301,7 @@ export class PlanValidator {
 
       if (declaredCount !== undefined && occurrences.length !== declaredCount) {
         errors.push(
-          `lock "${lock}" declares deviceCount=${declaredCount} but ${occurrences.length} step${occurrences.length === 1 ? "" : "s"} reference${occurrences.length === 1 ? "s" : ""} it. Every participating device needs its own criticalSection/barrier step with this lock.`,
+          `criticalSection lock "${lock}" declares deviceCount=${declaredCount} but ${occurrences.length} step${occurrences.length === 1 ? "" : "s"} reference${occurrences.length === 1 ? "s" : ""} it. Every participating device needs its own criticalSection step with this lock.`,
         );
       }
 
@@ -302,7 +317,7 @@ export class PlanValidator {
       for (const [device, indices] of devicesSeen.entries()) {
         if (indices.length > 1) {
           errors.push(
-            `lock "${lock}" is entered twice by device "${device}" (steps ${indices.join(", ")}). Each device can participate in a given lock at most once.`,
+            `criticalSection lock "${lock}" is entered twice by device "${device}" (steps ${indices.join(", ")}). Each device can participate in a given lock at most once.`,
           );
         }
       }
@@ -311,6 +326,127 @@ export class PlanValidator {
     if (errors.length > 0) {
       throw new ActionableError(errors.join("\n"));
     }
+  }
+
+  /**
+   * Validates that every barrier lock has a consistent contract *per round*.
+   *
+   * Unlike criticalSection, the same barrier lock name is meant to be reused
+   * across multiple synchronization phases within a plan: the runtime
+   * coordinator (CriticalSectionCoordinator.waitAtBarrier) clears its arrival
+   * set once a round's deviceCount is reached, so each device can arrive at
+   * the same lock again for a later round. Collapsing every occurrence of a
+   * lock name into one bucket (as criticalSection does) would false-reject a
+   * plan that legitimately reuses a barrier across phases, since the total
+   * occurrence count would outnumber deviceCount.
+   *
+   * Rounds are inferred positionally: for a given lock, a device's Nth
+   * barrier step (in plan step order) belongs to round N, and round N across
+   * devices is validated as one group — same deviceCount declared, and
+   * exactly deviceCount devices participate in that round.
+   */
+  private static validateBarrierRounds(plan: Plan): void {
+    const perLockPerDevice = this.collectBarrierOccurrencesByLockAndDevice(plan);
+
+    const errors: string[] = [];
+    for (const [lock, byDevice] of perLockPerDevice.entries()) {
+      errors.push(...this.validateBarrierLockRounds(lock, byDevice));
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
+  private static collectBarrierOccurrencesByLockAndDevice(
+    plan: Plan,
+  ): Map<string, Map<string, BarrierOccurrence[]>> {
+    // lock -> device -> ordered occurrences (index within the array is the round)
+    const perLockPerDevice = new Map<string, Map<string, BarrierOccurrence[]>>();
+
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      if (step.tool !== "barrier") {
+        continue;
+      }
+      const params = step.params;
+      if (!params || typeof params !== "object") {
+        continue;
+      }
+      const lock = (params as { lock?: unknown }).lock;
+      if (typeof lock !== "string" || lock.length === 0) {
+        // Schema-level requirements are validated elsewhere; skip silently.
+        continue;
+      }
+      const device = (params as { device?: unknown }).device;
+      if (typeof device !== "string" || device.length === 0) {
+        // Missing/invalid device labels are reported by validateDeviceLabelsPresent.
+        continue;
+      }
+
+      const byDevice = perLockPerDevice.get(lock) ?? new Map<string, BarrierOccurrence[]>();
+      const occurrences = byDevice.get(device) ?? [];
+      occurrences.push({
+        stepIndex: i,
+        deviceCount: (params as { deviceCount?: unknown }).deviceCount,
+      });
+      byDevice.set(device, occurrences);
+      perLockPerDevice.set(lock, byDevice);
+    }
+
+    return perLockPerDevice;
+  }
+
+  /**
+   * Validates every round of a single barrier lock: a device's Nth barrier
+   * step (in plan step order) belongs to round N, and round N across devices
+   * is validated as one group.
+   */
+  private static validateBarrierLockRounds(
+    lock: string,
+    byDevice: Map<string, BarrierOccurrence[]>,
+  ): string[] {
+    const roundCounts = Array.from(byDevice.values()).map((o) => o.length);
+    const maxRounds = roundCounts.length > 0 ? Math.max(...roundCounts) : 0;
+    const rounds = Array.from({ length: maxRounds }, (_, round) =>
+      Array.from(byDevice.values())
+        .map((occurrences) => occurrences[round])
+        .filter((occurrence): occurrence is BarrierOccurrence => occurrence !== undefined),
+    );
+
+    return rounds.flatMap((roundOccurrences, round) =>
+      this.validateBarrierRound(lock, round, roundOccurrences),
+    );
+  }
+
+  private static validateBarrierRound(
+    lock: string,
+    round: number,
+    roundOccurrences: BarrierOccurrence[],
+  ): string[] {
+    const deviceCounts = new Set(
+      roundOccurrences.map((o) => o.deviceCount).filter((c) => typeof c === "number"),
+    );
+
+    if (deviceCounts.size > 1) {
+      const detail = roundOccurrences
+        .map((o) => `step ${o.stepIndex} deviceCount=${String(o.deviceCount)}`)
+        .join(", ");
+      return [
+        `barrier lock "${lock}" round ${round + 1} has inconsistent deviceCount values: ${detail}. All steps sharing a barrier round must declare the same deviceCount.`,
+      ];
+    }
+
+    const declaredCount =
+      deviceCounts.size === 1 ? (deviceCounts.values().next().value as number) : undefined;
+
+    if (declaredCount !== undefined && roundOccurrences.length !== declaredCount) {
+      return [
+        `barrier lock "${lock}" round ${round + 1} declares deviceCount=${declaredCount} but ${roundOccurrences.length} step${roundOccurrences.length === 1 ? "" : "s"} reference${roundOccurrences.length === 1 ? "s" : ""} it. Every participating device needs its own barrier step for this round.`,
+      ];
+    }
+
+    return [];
   }
 
   /**

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -35,10 +35,10 @@ export class PlanValidator {
       this.validateDeviceLabelsPresent(plan);
     }
 
-    // Validate cross-step consistency for criticalSection locks. Runs even
-    // when devices aren't declared so callers get a useful error rather than
-    // a deadlock at the barrier.
-    this.validateCriticalSectionLocks(plan);
+    // Validate cross-step consistency for criticalSection/barrier locks. Runs
+    // even when devices aren't declared so callers get a useful error rather
+    // than a deadlock at runtime.
+    this.validateCoordinationLocks(plan);
   }
 
   /**
@@ -219,18 +219,21 @@ export class PlanValidator {
   }
 
   /**
-   * Validates that every criticalSection lock has a consistent contract
-   * across the steps that share it:
+   * Validates that every criticalSection/barrier lock has a consistent
+   * contract across the steps that share it:
    *   - All steps sharing a lock declare the same deviceCount.
    *   - The number of steps sharing a lock equals that deviceCount (otherwise
    *     the barrier will deadlock waiting for a device that never arrives).
    *   - Each participating step targets a distinct device (no device can
    *     enter the same lock twice — it would re-acquire and deadlock).
    *
+   * barrier gets the same treatment as criticalSection here: both share the
+   * lock/deviceCount/device contract (barrier just has no nested steps).
+   *
    * These checks catch coordination bugs at validation time instead of
    * surfacing them as a 30-second barrier timeout at runtime.
    */
-  private static validateCriticalSectionLocks(plan: Plan): void {
+  private static validateCoordinationLocks(plan: Plan): void {
     interface LockOccurrence {
       stepIndex: number;
       device: unknown;
@@ -240,7 +243,7 @@ export class PlanValidator {
 
     for (let i = 0; i < plan.steps.length; i++) {
       const step = plan.steps[i];
-      if (step.tool !== "criticalSection") {
+      if (step.tool !== "criticalSection" && step.tool !== "barrier") {
         continue;
       }
       const params = step.params;
@@ -273,7 +276,7 @@ export class PlanValidator {
           .map((o) => `step ${o.stepIndex} deviceCount=${String(o.deviceCount)}`)
           .join(", ");
         errors.push(
-          `criticalSection lock "${lock}" has inconsistent deviceCount values: ${detail}. All steps sharing a lock must declare the same deviceCount.`,
+          `lock "${lock}" has inconsistent deviceCount values: ${detail}. All steps sharing a lock must declare the same deviceCount.`,
         );
         continue;
       }
@@ -283,7 +286,7 @@ export class PlanValidator {
 
       if (declaredCount !== undefined && occurrences.length !== declaredCount) {
         errors.push(
-          `criticalSection lock "${lock}" declares deviceCount=${declaredCount} but ${occurrences.length} step${occurrences.length === 1 ? "" : "s"} reference${occurrences.length === 1 ? "s" : ""} it. Every participating device needs its own criticalSection step with this lock.`,
+          `lock "${lock}" declares deviceCount=${declaredCount} but ${occurrences.length} step${occurrences.length === 1 ? "" : "s"} reference${occurrences.length === 1 ? "s" : ""} it. Every participating device needs its own criticalSection/barrier step with this lock.`,
         );
       }
 
@@ -299,7 +302,7 @@ export class PlanValidator {
       for (const [device, indices] of devicesSeen.entries()) {
         if (indices.length > 1) {
           errors.push(
-            `criticalSection lock "${lock}" is entered twice by device "${device}" (steps ${indices.join(", ")}). Each device can participate in a given lock at most once.`,
+            `lock "${lock}" is entered twice by device "${device}" (steps ${indices.join(", ")}). Each device can participate in a given lock at most once.`,
           );
         }
       }
@@ -320,9 +323,9 @@ export class PlanValidator {
       return true;
     }
 
-    // Check if any step uses device parameter or criticalSection
+    // Check if any step uses device parameter or criticalSection/barrier
     for (const step of plan.steps) {
-      if (step.tool === "criticalSection") {
+      if (step.tool === "criticalSection" || step.tool === "barrier") {
         return true;
       }
       if (step.params?.device !== undefined) {
@@ -339,10 +342,10 @@ export class PlanValidator {
   static validateMultiDeviceRequirements(plan: Plan): void {
     const hasFeatures = this.hasMultiDeviceFeatures(plan);
 
-    // If plan uses device labels or criticalSection, it must declare devices
+    // If plan uses device labels or criticalSection/barrier, it must declare devices
     if (hasFeatures && (!plan.devices || plan.devices.length === 0)) {
       throw new ActionableError(
-        "Plan uses multi-device features (device labels or criticalSection) but does not declare 'devices' field. " +
+        "Plan uses multi-device features (device labels or criticalSection/barrier) but does not declare 'devices' field. " +
           "Add a 'devices' array at the top level of your plan.",
       );
     }

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -269,6 +269,7 @@ export class PlanValidator {
    * own per-step params.
    */
   private static validateCoordinationLocks(plan: Plan): void {
+    this.validateNoAuthoredLockNamespace(plan);
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
     this.validateNoCrossToolLockSharing(plan);
@@ -276,6 +277,34 @@ export class PlanValidator {
     this.validateBarrierDistinctDeviceCounts(plan);
     this.validateBarrierGenerationCompleteness(plan);
     this.validateBarrierExcessDeviceArrivals(plan);
+  }
+
+  /**
+   * Validates that no step authors the reserved `__lockNamespace` field
+   * (inline or under `params`). It is injected internally by PlanExecutor
+   * at runtime to scope a plan's lock state, and an authored plan must
+   * never set it: two participants authoring different truthy
+   * `__lockNamespace` values for the same lock would pass every per-lock
+   * feasibility check yet wait in separate namespaced barriers/critical
+   * sections at runtime until timeout, since CriticalSectionCoordinator
+   * keys runtime state by namespace+lock while the checks above aggregate
+   * by lock name alone.
+   */
+  private static validateNoAuthoredLockNamespace(plan: Plan): void {
+    const errors: string[] = [];
+
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      if (this.effectiveField(step, "__lockNamespace") !== undefined) {
+        errors.push(
+          `step ${i} (${step.tool}) sets '__lockNamespace', which is a reserved field injected internally by the plan executor. Authored plans must not set it.`,
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
   }
 
   /**

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -281,14 +281,24 @@ export class PlanValidator {
   }
 
   /**
+   * setTimeout's real usable range: Bun/Node clamp any delay >= 2^31
+   * (2147483648) to 1ms with a `TimeoutOverflowWarning` instead of honoring
+   * it, so a coordination timeout at or above that value times out almost
+   * immediately rather than waiting as requested.
+   */
+  private static readonly MAX_SETTIMEOUT_DELAY_MS = 2147483647;
+
+  /**
    * Validates that an optional `timeout` on a criticalSection or barrier
    * step, when declared, is a positive integer that does not exceed
-   * `Number.MAX_SAFE_INTEGER`. Both tools' runtime schemas
-   * (criticalSectionTools.ts / barrierTools.ts) declare
-   * `z.number().int().positive()` for timeout, so a value beyond the
-   * IEEE-754 safe-integer range passes the authoring schema's simple
-   * `exclusiveMinimum` check yet fails the runtime contract, and the plan
-   * only fails at execution.
+   * `MAX_SETTIMEOUT_DELAY_MS` (2^31 - 1, ~24.8 days). Both tools' runtime
+   * schemas (criticalSectionTools.ts / barrierTools.ts) declare
+   * `z.number().int().positive()` for timeout, and `CriticalSectionCoordinator
+   * .waitAtBarrier` passes the value straight to production `setTimeout` --
+   * Node/Bun's `setTimeout` silently clamps any delay >= 2^31 to 1ms, so a
+   * value beyond that range passes the authoring schema's simple
+   * `exclusiveMinimum` check yet times out almost instantly at runtime
+   * instead of honoring the requested wait.
    */
   private static validateCoordinationTimeouts(plan: Plan): void {
     const errors: string[] = [];
@@ -306,10 +316,10 @@ export class PlanValidator {
         typeof timeout !== "number" ||
         !Number.isInteger(timeout) ||
         timeout < 1 ||
-        timeout > Number.MAX_SAFE_INTEGER
+        timeout > this.MAX_SETTIMEOUT_DELAY_MS
       ) {
         errors.push(
-          `${step.tool} step ${i} declares 'timeout' of ${JSON.stringify(timeout)}, which must be a positive integer no greater than Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}).`,
+          `${step.tool} step ${i} declares 'timeout' of ${JSON.stringify(timeout)}, which must be a positive integer no greater than setTimeout's usable range (${this.MAX_SETTIMEOUT_DELAY_MS}ms, ~24.8 days) -- Node/Bun clamp larger delays to 1ms instead of honoring them.`,
         );
       }
     }

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -1,4 +1,4 @@
-import { Plan } from "../../models/Plan";
+import { Plan, PlanStep } from "../../models/Plan";
 import { ActionableError } from "../../models";
 import { normalizePlanDevices } from "./PlanDevices";
 
@@ -219,6 +219,34 @@ export class PlanValidator {
   }
 
   /**
+   * Resolves the effective value of a coordination field (`lock`/`device`/
+   * `deviceCount`) for a step, honoring PlanNormalizer's params-wins
+   * precedence: when a field is present under `params`, that value wins even
+   * if a different value also sits inline on the step — PlanNormalizer's
+   * `{ ...inlineParams, ...paramsFromStep }` merge discards the inline one at
+   * normalization, the same precedence the #6090/#6107 networkCondition/
+   * doNotDisturb inline-vs-params handling established. Falling back to the
+   * inline value only when `params` doesn't declare the field also keeps this
+   * correct for a step that reaches this validator before normalization.
+   */
+  private static effectiveField(step: PlanStep, field: string): unknown {
+    const params = step.params;
+    if (
+      params &&
+      typeof params === "object" &&
+      Object.prototype.hasOwnProperty.call(params, field)
+    ) {
+      return (params as Record<string, unknown>)[field];
+    }
+    // A step reaching this validator before PlanNormalizer runs may carry
+    // coordination fields as plain siblings of `tool`/`params` -- outside
+    // PlanStep's declared shape, but present on the underlying object.
+    // oxlint-disable-next-line auto-mobile/no-unknown-cast
+    const inlineFields = step as unknown as Record<string, unknown>;
+    return inlineFields[field];
+  }
+
+  /**
    * Validates coordination-tool params: criticalSection's cross-step lock
    * consistency (a lock is entered at most once per plan), and barrier's
    * own per-step params.
@@ -257,11 +285,7 @@ export class PlanValidator {
       if (step.tool !== "criticalSection") {
         continue;
       }
-      const params = step.params;
-      if (!params || typeof params !== "object") {
-        continue;
-      }
-      const lock = (params as { lock?: unknown }).lock;
+      const lock = this.effectiveField(step, "lock");
       if (typeof lock !== "string" || lock.length === 0) {
         // Schema-level requirements are validated elsewhere; skip silently.
         continue;
@@ -269,8 +293,8 @@ export class PlanValidator {
       const occurrences = lockUsage.get(lock) ?? [];
       occurrences.push({
         stepIndex: i,
-        device: (params as { device?: unknown }).device,
-        deviceCount: (params as { deviceCount?: unknown }).deviceCount,
+        device: this.effectiveField(step, "device"),
+        deviceCount: this.effectiveField(step, "deviceCount"),
       });
       lockUsage.set(lock, occurrences);
     }
@@ -348,18 +372,13 @@ export class PlanValidator {
       if (step.tool !== "barrier") {
         continue;
       }
-      const params = step.params;
-      if (!params || typeof params !== "object") {
-        errors.push(`barrier step ${i} is missing its params object.`);
-        continue;
-      }
 
-      const lock = (params as { lock?: unknown }).lock;
+      const lock = this.effectiveField(step, "lock");
       if (typeof lock !== "string" || lock.length === 0) {
         errors.push(`barrier step ${i} is missing a non-empty 'lock' parameter.`);
       }
 
-      const deviceCount = (params as { deviceCount?: unknown }).deviceCount;
+      const deviceCount = this.effectiveField(step, "deviceCount");
       if (typeof deviceCount !== "number" || !Number.isInteger(deviceCount) || deviceCount < 1) {
         errors.push(
           `barrier step ${i} must declare a positive integer 'deviceCount', got ${JSON.stringify(deviceCount)}.`,
@@ -410,7 +429,7 @@ export class PlanValidator {
 
     for (const step of plan.steps) {
       if (step.tool === "barrier") {
-        this.recordBarrierLockUsage(usageByLock, step.params);
+        this.recordBarrierLockUsage(usageByLock, step);
       }
     }
 
@@ -419,12 +438,9 @@ export class PlanValidator {
 
   private static recordBarrierLockUsage(
     usageByLock: Map<string, { devices: Set<string>; deviceCounts: Set<number> }>,
-    params: Record<string, unknown> | undefined,
+    step: PlanStep,
   ): void {
-    if (!params || typeof params !== "object") {
-      return;
-    }
-    const lock = (params as { lock?: unknown }).lock;
+    const lock = this.effectiveField(step, "lock");
     if (typeof lock !== "string" || lock.length === 0) {
       return;
     }
@@ -434,12 +450,12 @@ export class PlanValidator {
       deviceCounts: new Set<number>(),
     };
 
-    const device = (params as { device?: unknown }).device;
+    const device = this.effectiveField(step, "device");
     if (typeof device === "string" && device.length > 0) {
       usage.devices.add(device);
     }
 
-    const deviceCount = (params as { deviceCount?: unknown }).deviceCount;
+    const deviceCount = this.effectiveField(step, "deviceCount");
     if (typeof deviceCount === "number" && Number.isInteger(deviceCount) && deviceCount >= 1) {
       usage.deviceCounts.add(deviceCount);
     }

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -255,6 +255,7 @@ export class PlanValidator {
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
     this.validateBarrierDistinctDeviceCounts(plan);
+    this.validateBarrierGenerationCompleteness(plan);
   }
 
   /**
@@ -422,10 +423,53 @@ export class PlanValidator {
     }
   }
 
+  /**
+   * Validates that a reused barrier lock's total arrivals form complete
+   * generations, catching a class of deadlock the distinct-device check
+   * above cannot: e.g. arrivals A, B, A with deviceCount=2 has 2 distinct
+   * devices (passes that check) but the 3rd (trailing) arrival starts a new
+   * generation that only ever gets 1 of the 2 devices it needs, so it waits
+   * forever.
+   *
+   * Sound WITHOUT reconstructing rounds: only checked when a lock has a
+   * single consistent deviceCount N (an inconsistent lock isn't itself an
+   * error here — barrier legitimately allows different deviceCount values
+   * across its reuses — but there's no single N to divide by, so this
+   * check is skipped for it). For that N, the total number of barrier steps
+   * referencing the lock must be an exact multiple of N: each generation
+   * consumes exactly N arrivals, so a non-multiple total necessarily leaves
+   * an incomplete trailing generation that can never complete. This never
+   * false-rejects a valid plan.
+   */
+  private static validateBarrierGenerationCompleteness(plan: Plan): void {
+    const usageByLock = this.collectBarrierLockUsage(plan);
+    const errors: string[] = [];
+
+    for (const [lock, usage] of usageByLock.entries()) {
+      if (usage.deviceCounts.size !== 1) {
+        continue;
+      }
+      const deviceCount = usage.deviceCounts.values().next().value as number;
+      if (deviceCount < 1 || usage.arrivals % deviceCount === 0) {
+        continue;
+      }
+      errors.push(
+        `barrier lock "${lock}" has ${usage.arrivals} total arrival${usage.arrivals === 1 ? "" : "s"} across the plan, which is not a multiple of its deviceCount=${deviceCount}. At least one generation is necessarily incomplete and would deadlock waiting for a device that never arrives.`,
+      );
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
   private static collectBarrierLockUsage(
     plan: Plan,
-  ): Map<string, { devices: Set<string>; deviceCounts: Set<number> }> {
-    const usageByLock = new Map<string, { devices: Set<string>; deviceCounts: Set<number> }>();
+  ): Map<string, { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }> {
+    const usageByLock = new Map<
+      string,
+      { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }
+    >();
 
     for (const step of plan.steps) {
       if (step.tool === "barrier") {
@@ -437,7 +481,7 @@ export class PlanValidator {
   }
 
   private static recordBarrierLockUsage(
-    usageByLock: Map<string, { devices: Set<string>; deviceCounts: Set<number> }>,
+    usageByLock: Map<string, { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }>,
     step: PlanStep,
   ): void {
     const lock = this.effectiveField(step, "lock");
@@ -448,7 +492,9 @@ export class PlanValidator {
     const usage = usageByLock.get(lock) ?? {
       devices: new Set<string>(),
       deviceCounts: new Set<number>(),
+      arrivals: 0,
     };
+    usage.arrivals += 1;
 
     const device = this.effectiveField(step, "device");
     if (typeof device === "string" && device.length > 0) {

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -226,6 +226,7 @@ export class PlanValidator {
   private static validateCoordinationLocks(plan: Plan): void {
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
+    this.validateBarrierDistinctDeviceCounts(plan);
   }
 
   /**
@@ -369,6 +370,81 @@ export class PlanValidator {
     if (errors.length > 0) {
       throw new ActionableError(errors.join("\n"));
     }
+  }
+
+  /**
+   * Validates that every barrier lock is populated by enough distinct devices
+   * to ever satisfy its declared `deviceCount`.
+   *
+   * This is sound WITHOUT reconstructing rounds: a single round needs
+   * `deviceCount` distinct device arrivals, so if fewer distinct devices ever
+   * target a given lock across the whole plan, no round can ever complete —
+   * regardless of how many times those devices arrive (reused across
+   * rounds). This mirrors the intent of criticalSection's cross-step lock
+   * check without inferring round boundaries.
+   */
+  private static validateBarrierDistinctDeviceCounts(plan: Plan): void {
+    const usageByLock = this.collectBarrierLockUsage(plan);
+    const errors: string[] = [];
+
+    for (const [lock, usage] of usageByLock.entries()) {
+      for (const deviceCount of usage.deviceCounts) {
+        if (usage.devices.size < deviceCount) {
+          const devices = Array.from(usage.devices).join(", ") || "none";
+          errors.push(
+            `barrier lock "${lock}" declares deviceCount=${deviceCount} but only ${usage.devices.size} distinct device${usage.devices.size === 1 ? "" : "s"} (${devices}) ever target it in this plan. No round can ever complete.`,
+          );
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
+  private static collectBarrierLockUsage(
+    plan: Plan,
+  ): Map<string, { devices: Set<string>; deviceCounts: Set<number> }> {
+    const usageByLock = new Map<string, { devices: Set<string>; deviceCounts: Set<number> }>();
+
+    for (const step of plan.steps) {
+      if (step.tool === "barrier") {
+        this.recordBarrierLockUsage(usageByLock, step.params);
+      }
+    }
+
+    return usageByLock;
+  }
+
+  private static recordBarrierLockUsage(
+    usageByLock: Map<string, { devices: Set<string>; deviceCounts: Set<number> }>,
+    params: Record<string, unknown> | undefined,
+  ): void {
+    if (!params || typeof params !== "object") {
+      return;
+    }
+    const lock = (params as { lock?: unknown }).lock;
+    if (typeof lock !== "string" || lock.length === 0) {
+      return;
+    }
+
+    const usage = usageByLock.get(lock) ?? {
+      devices: new Set<string>(),
+      deviceCounts: new Set<number>(),
+    };
+
+    const device = (params as { device?: unknown }).device;
+    if (typeof device === "string" && device.length > 0) {
+      usage.devices.add(device);
+    }
+
+    const deviceCount = (params as { deviceCount?: unknown }).deviceCount;
+    if (typeof deviceCount === "number" && Number.isInteger(deviceCount) && deviceCount >= 1) {
+      usage.deviceCounts.add(deviceCount);
+    }
+
+    usageByLock.set(lock, usage);
   }
 
   /**

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -272,11 +272,51 @@ export class PlanValidator {
     this.validateNoAuthoredLockNamespace(plan);
     this.validateCriticalSectionLocks(plan);
     this.validateBarrierParams(plan);
+    this.validateCoordinationTimeouts(plan);
     this.validateNoCrossToolLockSharing(plan);
     this.validateBarrierConsistentDeviceCount(plan);
     this.validateBarrierDistinctDeviceCounts(plan);
     this.validateBarrierGenerationCompleteness(plan);
     this.validateBarrierExcessDeviceArrivals(plan);
+  }
+
+  /**
+   * Validates that an optional `timeout` on a criticalSection or barrier
+   * step, when declared, is a positive integer that does not exceed
+   * `Number.MAX_SAFE_INTEGER`. Both tools' runtime schemas
+   * (criticalSectionTools.ts / barrierTools.ts) declare
+   * `z.number().int().positive()` for timeout, so a value beyond the
+   * IEEE-754 safe-integer range passes the authoring schema's simple
+   * `exclusiveMinimum` check yet fails the runtime contract, and the plan
+   * only fails at execution.
+   */
+  private static validateCoordinationTimeouts(plan: Plan): void {
+    const errors: string[] = [];
+
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      if (step.tool !== "criticalSection" && step.tool !== "barrier") {
+        continue;
+      }
+      const timeout = this.effectiveField(step, "timeout");
+      if (timeout === undefined) {
+        continue;
+      }
+      if (
+        typeof timeout !== "number" ||
+        !Number.isInteger(timeout) ||
+        timeout < 1 ||
+        timeout > Number.MAX_SAFE_INTEGER
+      ) {
+        errors.push(
+          `${step.tool} step ${i} declares 'timeout' of ${JSON.stringify(timeout)}, which must be a positive integer no greater than Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}).`,
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
   }
 
   /**

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -3,6 +3,19 @@ import { ActionableError } from "../../models";
 import { normalizePlanDevices } from "./PlanDevices";
 
 /**
+ * Aggregated usage of a single barrier lock name across a plan, used by the
+ * coordination checks below.
+ */
+interface BarrierLockUsage {
+  devices: Set<string>;
+  deviceCounts: Set<number>;
+  arrivals: number;
+  // Per-device occurrence count, used to catch a device scheduled more times
+  // than there are generations for it to participate in.
+  deviceOccurrences: Map<string, number>;
+}
+
+/**
  * Validates a plan structure and enforces multi-device rules.
  */
 export class PlanValidator {
@@ -257,6 +270,7 @@ export class PlanValidator {
     this.validateBarrierConsistentDeviceCount(plan);
     this.validateBarrierDistinctDeviceCounts(plan);
     this.validateBarrierGenerationCompleteness(plan);
+    this.validateBarrierExcessDeviceArrivals(plan);
   }
 
   /**
@@ -497,13 +511,57 @@ export class PlanValidator {
     }
   }
 
-  private static collectBarrierLockUsage(
-    plan: Plan,
-  ): Map<string, { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }> {
-    const usageByLock = new Map<
-      string,
-      { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }
-    >();
+  /**
+   * Validates that no single device is scheduled to arrive at a barrier lock
+   * more times than there are generations for it to participate in.
+   *
+   * PlanPartitioner executes each device's track sequentially, so a device
+   * can only ever occupy one "slot" per generation — it cannot re-enter the
+   * same lock a second time within a generation it's already part of. For a
+   * lock with a single consistent deviceCount N and T total arrivals (T
+   * divisible by N, per validateBarrierGenerationCompleteness), there are
+   * G = T / N generations available in total. A device appearing more than G
+   * times can never be scheduled into a generation it hasn't already used,
+   * so it deadlocks waiting at an arrival no generation will ever admit.
+   *
+   * Sound: a device appearing at most G times is exactly the necessary
+   * condition for a feasible one-arrival-per-generation assignment to exist
+   * (e.g. A,A,B,B with deviceCount=2 has G=2 and each device appears
+   * exactly 2 times — feasible, and correctly accepted).
+   */
+  private static validateBarrierExcessDeviceArrivals(plan: Plan): void {
+    const usageByLock = this.collectBarrierLockUsage(plan);
+    const errors: string[] = [];
+
+    for (const [lock, usage] of usageByLock.entries()) {
+      if (usage.deviceCounts.size !== 1) {
+        continue;
+      }
+      const deviceCount = usage.deviceCounts.values().next().value as number;
+      if (deviceCount < 1 || usage.arrivals % deviceCount !== 0) {
+        // Inconsistent-count and incomplete-generation cases are already
+        // reported by the other checks; skip here to avoid a meaningless G.
+        continue;
+      }
+      const generations = usage.arrivals / deviceCount;
+
+      for (const [device, occurrences] of usage.deviceOccurrences.entries()) {
+        if (occurrences <= generations) {
+          continue;
+        }
+        errors.push(
+          `barrier lock "${lock}" has ${generations} generation${generations === 1 ? "" : "s"} available (deviceCount=${deviceCount}, ${usage.arrivals} total arrivals), but device "${device}" arrives ${occurrences} times. A device can participate in a lock at most once per generation, since each device's track executes sequentially, so this device would deadlock waiting for a generation that never admits it again.`,
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
+  private static collectBarrierLockUsage(plan: Plan): Map<string, BarrierLockUsage> {
+    const usageByLock = new Map<string, BarrierLockUsage>();
 
     for (const step of plan.steps) {
       if (step.tool === "barrier") {
@@ -515,7 +573,7 @@ export class PlanValidator {
   }
 
   private static recordBarrierLockUsage(
-    usageByLock: Map<string, { devices: Set<string>; deviceCounts: Set<number>; arrivals: number }>,
+    usageByLock: Map<string, BarrierLockUsage>,
     step: PlanStep,
   ): void {
     const lock = this.effectiveField(step, "lock");
@@ -527,12 +585,14 @@ export class PlanValidator {
       devices: new Set<string>(),
       deviceCounts: new Set<number>(),
       arrivals: 0,
+      deviceOccurrences: new Map<string, number>(),
     };
     usage.arrivals += 1;
 
     const device = this.effectiveField(step, "device");
     if (typeof device === "string" && device.length > 0) {
       usage.devices.add(device);
+      usage.deviceOccurrences.set(device, (usage.deviceOccurrences.get(device) ?? 0) + 1);
     }
 
     const deviceCount = this.effectiveField(step, "deviceCount");

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -149,12 +149,16 @@ export class PlanValidator {
         continue;
       }
 
-      // Every step must declare a device, including criticalSection.
-      const device = step.params?.device;
+      // Every step must declare a device, including criticalSection. Uses
+      // effectiveField (not a raw params read) so an inline-form barrier
+      // step -- lock/deviceCount/device sitting directly on the step rather
+      // than nested under params -- is resolved correctly instead of
+      // reporting a spurious missing-device error (#6215 review).
+      const device = this.effectiveField(step, "device");
       if (device === undefined || device === null || device === "") {
         missingLabels.push({ index: i, tool: step.tool });
-      } else if (!deviceSet.has(device)) {
-        invalidLabels.push({ index: i, tool: step.tool, device });
+      } else if (typeof device !== "string" || !deviceSet.has(device)) {
+        invalidLabels.push({ index: i, tool: step.tool, device: String(device) });
       }
 
       // Additionally, criticalSection sub-steps must each declare a device.
@@ -363,6 +367,28 @@ export class PlanValidator {
       throw new ActionableError(errors.join("\n"));
     }
   }
+
+  // ---------------------------------------------------------------------
+  // Barrier coordination checks below enforce NECESSARY conditions for a
+  // barrier plan to be executable — they do not prove full deadlock-freedom.
+  // Specifically NOT checked (tracked in issue #6231):
+  //   - Generation-boundary stranding within one lock: e.g. deviceCount=3
+  //     with arrivals A,A/B,B/C/D passes every check below (4 distinct
+  //     devices, 6 arrivals divisible by 3, no device exceeds its 2-generation
+  //     budget), but if A/C/D happen to complete generation 1 first, B's two
+  //     arrivals can never both be scheduled into the same generation and it
+  //     deadlocks. Proving this requires reasoning about which subsets of
+  //     arrivals can complete each generation — a scheduling-feasibility
+  //     problem, not a simple count check.
+  //   - Cross-lock ordering cycles: device A doing barrier(X) then
+  //     barrier(Y), and device B doing barrier(Y) then barrier(X), with both
+  //     locks needing exactly {A, B} — A blocks at X waiting for B, B blocks
+  //     at Y waiting for A. Every per-lock check below passes because each
+  //     lock individually has enough distinct arrivals and no device exceeds
+  //     its generation budget. A sound version of this check is possible but
+  //     only for locks with zero population slack (evaluated and deferred
+  //     during the #6215 review — see issue #6231 for why).
+  // ---------------------------------------------------------------------
 
   /**
    * Validates each barrier step's own params (required `lock`, required

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -2,11 +2,6 @@ import { Plan } from "../../models/Plan";
 import { ActionableError } from "../../models";
 import { normalizePlanDevices } from "./PlanDevices";
 
-interface BarrierOccurrence {
-  stepIndex: number;
-  deviceCount: unknown;
-}
-
 /**
  * Validates a plan structure and enforces multi-device rules.
  */
@@ -224,13 +219,13 @@ export class PlanValidator {
   }
 
   /**
-   * Validates cross-step consistency for both coordination tools:
-   * criticalSection locks (a lock is entered at most once per plan) and
-   * barrier locks (a lock may recur across multiple synchronization rounds).
+   * Validates coordination-tool params: criticalSection's cross-step lock
+   * consistency (a lock is entered at most once per plan), and barrier's
+   * own per-step params.
    */
   private static validateCoordinationLocks(plan: Plan): void {
     this.validateCriticalSectionLocks(plan);
-    this.validateBarrierRounds(plan);
+    this.validateBarrierParams(plan);
   }
 
   /**
@@ -329,40 +324,23 @@ export class PlanValidator {
   }
 
   /**
-   * Validates that every barrier lock has a consistent contract *per round*.
+   * Validates each barrier step's own params (required `lock`, required
+   * positive-integer `deviceCount`) — the same per-step param parity
+   * criticalSection gets.
    *
-   * Unlike criticalSection, the same barrier lock name is meant to be reused
-   * across multiple synchronization phases within a plan: the runtime
-   * coordinator (CriticalSectionCoordinator.waitAtBarrier) clears its arrival
-   * set once a round's deviceCount is reached, so each device can arrive at
-   * the same lock again for a later round. Collapsing every occurrence of a
-   * lock name into one bucket (as criticalSection does) would false-reject a
-   * plan that legitimately reuses a barrier across phases, since the total
-   * occurrence count would outnumber deviceCount.
-   *
-   * Rounds are inferred positionally: for a given lock, a device's Nth
-   * barrier step (in plan step order) belongs to round N, and round N across
-   * devices is validated as one group — same deviceCount declared, and
-   * exactly deviceCount devices participate in that round.
+   * Unlike criticalSection, a barrier lock name is meant to be reused across
+   * multiple synchronization rounds within a plan (the runtime coordinator,
+   * CriticalSectionCoordinator.waitAtBarrier, clears its arrival set once a
+   * round's deviceCount is reached). Rounds aren't explicitly delineated in
+   * plan YAML, so this deliberately does NOT try to statically reconstruct
+   * them or validate arrival counts across steps — that would require
+   * inferring round boundaries from step order, which is unsound when
+   * successive rounds use different device sets. Cross-round arrival-count
+   * consistency is left to the runtime coordinator, which already matches
+   * arrivals per round at execution time.
    */
-  private static validateBarrierRounds(plan: Plan): void {
-    const perLockPerDevice = this.collectBarrierOccurrencesByLockAndDevice(plan);
-
+  private static validateBarrierParams(plan: Plan): void {
     const errors: string[] = [];
-    for (const [lock, byDevice] of perLockPerDevice.entries()) {
-      errors.push(...this.validateBarrierLockRounds(lock, byDevice));
-    }
-
-    if (errors.length > 0) {
-      throw new ActionableError(errors.join("\n"));
-    }
-  }
-
-  private static collectBarrierOccurrencesByLockAndDevice(
-    plan: Plan,
-  ): Map<string, Map<string, BarrierOccurrence[]>> {
-    // lock -> device -> ordered occurrences (index within the array is the round)
-    const perLockPerDevice = new Map<string, Map<string, BarrierOccurrence[]>>();
 
     for (let i = 0; i < plan.steps.length; i++) {
       const step = plan.steps[i];
@@ -371,82 +349,26 @@ export class PlanValidator {
       }
       const params = step.params;
       if (!params || typeof params !== "object") {
+        errors.push(`barrier step ${i} is missing its params object.`);
         continue;
       }
+
       const lock = (params as { lock?: unknown }).lock;
       if (typeof lock !== "string" || lock.length === 0) {
-        // Schema-level requirements are validated elsewhere; skip silently.
-        continue;
-      }
-      const device = (params as { device?: unknown }).device;
-      if (typeof device !== "string" || device.length === 0) {
-        // Missing/invalid device labels are reported by validateDeviceLabelsPresent.
-        continue;
+        errors.push(`barrier step ${i} is missing a non-empty 'lock' parameter.`);
       }
 
-      const byDevice = perLockPerDevice.get(lock) ?? new Map<string, BarrierOccurrence[]>();
-      const occurrences = byDevice.get(device) ?? [];
-      occurrences.push({
-        stepIndex: i,
-        deviceCount: (params as { deviceCount?: unknown }).deviceCount,
-      });
-      byDevice.set(device, occurrences);
-      perLockPerDevice.set(lock, byDevice);
+      const deviceCount = (params as { deviceCount?: unknown }).deviceCount;
+      if (typeof deviceCount !== "number" || !Number.isInteger(deviceCount) || deviceCount < 1) {
+        errors.push(
+          `barrier step ${i} must declare a positive integer 'deviceCount', got ${JSON.stringify(deviceCount)}.`,
+        );
+      }
     }
 
-    return perLockPerDevice;
-  }
-
-  /**
-   * Validates every round of a single barrier lock: a device's Nth barrier
-   * step (in plan step order) belongs to round N, and round N across devices
-   * is validated as one group.
-   */
-  private static validateBarrierLockRounds(
-    lock: string,
-    byDevice: Map<string, BarrierOccurrence[]>,
-  ): string[] {
-    const roundCounts = Array.from(byDevice.values()).map((o) => o.length);
-    const maxRounds = roundCounts.length > 0 ? Math.max(...roundCounts) : 0;
-    const rounds = Array.from({ length: maxRounds }, (_, round) =>
-      Array.from(byDevice.values())
-        .map((occurrences) => occurrences[round])
-        .filter((occurrence): occurrence is BarrierOccurrence => occurrence !== undefined),
-    );
-
-    return rounds.flatMap((roundOccurrences, round) =>
-      this.validateBarrierRound(lock, round, roundOccurrences),
-    );
-  }
-
-  private static validateBarrierRound(
-    lock: string,
-    round: number,
-    roundOccurrences: BarrierOccurrence[],
-  ): string[] {
-    const deviceCounts = new Set(
-      roundOccurrences.map((o) => o.deviceCount).filter((c) => typeof c === "number"),
-    );
-
-    if (deviceCounts.size > 1) {
-      const detail = roundOccurrences
-        .map((o) => `step ${o.stepIndex} deviceCount=${String(o.deviceCount)}`)
-        .join(", ");
-      return [
-        `barrier lock "${lock}" round ${round + 1} has inconsistent deviceCount values: ${detail}. All steps sharing a barrier round must declare the same deviceCount.`,
-      ];
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
     }
-
-    const declaredCount =
-      deviceCounts.size === 1 ? (deviceCounts.values().next().value as number) : undefined;
-
-    if (declaredCount !== undefined && roundOccurrences.length !== declaredCount) {
-      return [
-        `barrier lock "${lock}" round ${round + 1} declares deviceCount=${declaredCount} but ${roundOccurrences.length} step${roundOccurrences.length === 1 ? "" : "s"} reference${roundOccurrences.length === 1 ? "s" : ""} it. Every participating device needs its own barrier step for this round.`,
-      ];
-    }
-
-    return [];
   }
 
   /**

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -929,6 +929,40 @@ steps:
       expect(result.valid).toBe(true);
     });
 
+    it("should accept a barrier step with coordination fields SPLIT across inline and params", () => {
+      // PlanNormalizer merges inline fields and params together before
+      // execution, so a field counts as present wherever it appears -- lock
+      // inline + deviceCount in params must validate (#6215 review).
+      const yaml = `
+name: barrier-split-fields-test
+devices:
+  - A
+steps:
+  - tool: barrier
+    lock: sync-point
+    params:
+      device: A
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a barrier step missing deviceCount from BOTH inline and params", () => {
+      const yaml = `
+name: barrier-split-fields-missing-devicecount
+devices:
+  - A
+steps:
+  - tool: barrier
+    lock: sync-point
+    params:
+      device: A
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should accept a criticalSection step with INLINE coordination params", () => {
       const yaml = `
 name: critical-section-inline-test

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -793,11 +793,13 @@ steps:
       expect(result.valid).toBe(true);
     });
 
-    it("should reject a barrier timeout exceeding Number.MAX_SAFE_INTEGER", () => {
-      // barrierTools.ts declares timeout as z.number().int().positive() --
-      // a value beyond the IEEE-754 safe-integer range passes this
-      // schema's simple exclusiveMinimum check yet fails the runtime
-      // contract, so the plan would only fail at execution (#6215 review).
+    it("should reject a barrier timeout exceeding setTimeout's usable range", () => {
+      // barrierTools.ts declares timeout as z.number().int().positive(), and
+      // CriticalSectionCoordinator.waitAtBarrier passes it straight to
+      // production setTimeout -- Node/Bun clamp any delay >= 2^31
+      // (2147483648) to 1ms instead of honoring it, so a value at or beyond
+      // that range passes this schema's simple exclusiveMinimum check yet
+      // times out almost instantly at runtime (#6215 review).
       const yaml = `
 name: barrier-timeout-over-cap
 devices:
@@ -809,7 +811,7 @@ steps:
       device: A
       lock: sync1
       deviceCount: 2
-      timeout: 9007199254740992
+      timeout: 2147483648
   - tool: barrier
     params:
       device: B
@@ -820,7 +822,7 @@ steps:
       expect(result.valid).toBe(false);
     });
 
-    it("should accept a barrier timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+    it("should accept a barrier timeout at exactly setTimeout's usable range", () => {
       const yaml = `
 name: barrier-timeout-at-cap
 devices:
@@ -832,7 +834,7 @@ steps:
       device: A
       lock: sync1
       deviceCount: 2
-      timeout: 9007199254740991
+      timeout: 2147483647
   - tool: barrier
     params:
       device: B
@@ -843,7 +845,7 @@ steps:
       expect(result.valid).toBe(true);
     });
 
-    it("should reject a criticalSection timeout exceeding Number.MAX_SAFE_INTEGER", () => {
+    it("should reject a criticalSection timeout exceeding setTimeout's usable range", () => {
       // criticalSectionTools.ts has the identical z.number().int().positive()
       // contract as barrier, so the same cap applies.
       const yaml = `
@@ -856,7 +858,7 @@ steps:
       device: A
       lock: sync1
       deviceCount: 1
-      timeout: 9007199254740992
+      timeout: 2147483648
       steps:
         - tool: observe
           params:
@@ -866,7 +868,7 @@ steps:
       expect(result.valid).toBe(false);
     });
 
-    it("should accept a criticalSection timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+    it("should accept a criticalSection timeout at exactly setTimeout's usable range", () => {
       const yaml = `
 name: critical-section-timeout-at-cap
 devices:
@@ -877,7 +879,7 @@ steps:
       device: A
       lock: sync1
       deviceCount: 1
-      timeout: 9007199254740991
+      timeout: 2147483647
       steps:
         - tool: observe
           params:

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -793,6 +793,100 @@ steps:
       expect(result.valid).toBe(true);
     });
 
+    it("should reject a barrier timeout exceeding Number.MAX_SAFE_INTEGER", () => {
+      // barrierTools.ts declares timeout as z.number().int().positive() --
+      // a value beyond the IEEE-754 safe-integer range passes this
+      // schema's simple exclusiveMinimum check yet fails the runtime
+      // contract, so the plan would only fail at execution (#6215 review).
+      const yaml = `
+name: barrier-timeout-over-cap
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 2
+      timeout: 9007199254740992
+  - tool: barrier
+    params:
+      device: B
+      lock: sync1
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a barrier timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+      const yaml = `
+name: barrier-timeout-at-cap
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 2
+      timeout: 9007199254740991
+  - tool: barrier
+    params:
+      device: B
+      lock: sync1
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a criticalSection timeout exceeding Number.MAX_SAFE_INTEGER", () => {
+      // criticalSectionTools.ts has the identical z.number().int().positive()
+      // contract as barrier, so the same cap applies.
+      const yaml = `
+name: critical-section-timeout-over-cap
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 1
+      timeout: 9007199254740992
+      steps:
+        - tool: observe
+          params:
+            device: A
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a criticalSection timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+      const yaml = `
+name: critical-section-timeout-at-cap
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 1
+      timeout: 9007199254740991
+      steps:
+        - tool: observe
+          params:
+            device: A
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
     it("should provide line numbers for field errors when possible", () => {
       const yaml = `
 name: test-plan

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -699,6 +699,100 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should reject an authored '__lockNamespace' on a barrier step's params", () => {
+      // __lockNamespace is a reserved field injected internally by
+      // PlanExecutor at runtime to scope a plan's lock state. If two
+      // participants authored different truthy values for the same lock,
+      // every per-lock feasibility check would pass yet they'd wait in
+      // separate namespaced barriers at runtime until timeout (#6215
+      // review).
+      const yaml = `
+name: barrier-authored-lock-namespace
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 2
+      __lockNamespace: one
+  - tool: barrier
+    params:
+      device: B
+      lock: sync1
+      deviceCount: 2
+      __lockNamespace: two
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject an authored inline '__lockNamespace' on a barrier step", () => {
+      const yaml = `
+name: barrier-authored-lock-namespace-inline
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync1
+    deviceCount: 2
+    __lockNamespace: one
+  - tool: barrier
+    device: B
+    lock: sync1
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject an authored '__lockNamespace' on a criticalSection step's params", () => {
+      const yaml = `
+name: critical-section-authored-lock-namespace
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 1
+      __lockNamespace: one
+      steps:
+        - tool: observe
+          params:
+            device: A
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a normal barrier plan that does not author '__lockNamespace'", () => {
+      const yaml = `
+name: barrier-normal-no-lock-namespace
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync1
+      deviceCount: 2
+  - tool: barrier
+    params:
+      device: B
+      lock: sync1
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
     it("should provide line numbers for field errors when possible", () => {
       const yaml = `
 name: test-plan

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -1000,6 +1000,67 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should reject a barrier step with a malformed platform value", () => {
+      // addDeviceTargetingToSchema restricts platform to android/ios at
+      // execution; the authoring schema must reject an invalid value too,
+      // instead of only failing at execution (#6215 review).
+      const yaml = `
+name: barrier-malformed-platform
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 2
+      platform: windows
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a barrier step with a valid platform value", () => {
+      const yaml = `
+name: barrier-valid-platform
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 2
+      platform: android
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a criticalSection step with a malformed platform value", () => {
+      const yaml = `
+name: critical-section-malformed-platform
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 1
+      platform: windows
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: Button
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should accept a barrier step with a positive timeout", () => {
       const yaml = `
 name: barrier-positive-timeout

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -1039,6 +1039,51 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should accept a barrier whose inline deviceCount is invalid but params.deviceCount (the effective, params-wins value) is valid", () => {
+      // PlanNormalizer's { ...inlineParams, ...paramsFromStep } merge means
+      // params.deviceCount overrides the inline sibling at normalization, so
+      // the discarded inline value must NOT be schema-validated (#6215
+      // review, mirroring the #6090/#6107 networkCondition/doNotDisturb
+      // override precedence).
+      const yaml = `
+name: barrier-inline-invalid-params-valid
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: not-a-number
+    params:
+      deviceCount: 2
+  - tool: barrier
+    device: B
+    lock: sync-point
+    params:
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a barrier whose inline deviceCount is valid but params.deviceCount (the effective, params-wins value) is invalid", () => {
+      const yaml = `
+name: barrier-inline-valid-params-invalid
+devices:
+  - A
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: 2
+    params:
+      deviceCount: 0
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should validate expectations array", () => {
       const yaml = `
 name: expectations-test

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -840,8 +840,26 @@ steps:
     });
 
     it("should accept steps with tool-specific parameters", () => {
-      // Note: Tool-specific parameter validation happens at runtime by the tool handler,
-      // not by the JSON Schema. The schema only validates the basic step structure.
+      // Note: most tool-specific parameter validation happens at runtime by the
+      // tool handler, not by the JSON Schema. The schema only validates the
+      // basic step structure for the general case.
+      const yaml = `
+name: generic-tool-test
+steps:
+  - tool: tapOn
+    params:
+      text: Login
+      customField: anything
+`;
+      const result = validator.validateYaml(yaml);
+      // This is valid from a schema perspective - tapOn params are validated at runtime
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a criticalSection step missing required params (schema-level parity with barrier)", () => {
+      // Unlike most tools, criticalSection/barrier ARE validated at the schema
+      // level (parity fix #6175): missing 'deviceCount'/'steps' surfaces here
+      // instead of only at a runtime coordination timeout.
       const yaml = `
 name: critical-section-test
 steps:
@@ -850,8 +868,41 @@ steps:
       lock: sync-point
 `;
       const result = validator.validateYaml(yaml);
-      // This is valid from a schema perspective - tool params are validated at runtime
+      expect(result.valid).toBe(false);
+    });
+
+    it("should validate barrier parameters", () => {
+      const yaml = `
+name: barrier-test
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 2
+  - tool: barrier
+    params:
+      device: B
+      lock: sync-point
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(true);
+    });
+
+    it("should reject a barrier step missing required params", () => {
+      const yaml = `
+name: barrier-missing-devicecount
+steps:
+  - tool: barrier
+    params:
+      lock: sync-point
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
     });
 
     it("should validate expectations array", () => {

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -620,6 +620,85 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should reject a non-coordination step's params.device when it is not a string", () => {
+      // For a tool with no tool-specific params schema (e.g. tapOn), an
+      // invalid inline device is skipped once params declares device (params
+      // wins at normalization), but nothing previously validated params.device
+      // itself -- a plan with params.device: 456 would normalize to an
+      // invalid device and only fail at the daemon (#6215 review).
+      const yaml = `
+name: tapon-invalid-params-device-number
+devices:
+  - A
+steps:
+  - tool: tapOn
+    device: 123
+    params:
+      device: 456
+      text: hi
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject a non-coordination step's params.device when it is whitespace-only", () => {
+      const yaml = `
+name: tapon-blank-params-device
+devices:
+  - A
+steps:
+  - tool: tapOn
+    params:
+      device: " "
+      text: hi
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a valid params.device overriding an invalid inline device", () => {
+      const yaml = `
+name: tapon-valid-params-device
+devices:
+  - A
+steps:
+  - tool: tapOn
+    device: 123
+    params:
+      device: A
+      text: hi
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a barrier step's params.device when it is whitespace-only", () => {
+      // Dovetails with fp0eM: params.device: " " passed the
+      // criticalSectionParams/barrierParams schema (just type: string)
+      // before the generic non-blank constraint was added; it becomes
+      // step.device = " " after normalization, which validateDeviceLabelsPresent
+      // rejects at runtime (#6215 review).
+      const yaml = `
+name: barrier-blank-params-device
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: " "
+      lock: sync1
+      deviceCount: 2
+  - tool: barrier
+    params:
+      device: B
+      lock: sync1
+      deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should provide line numbers for field errors when possible", () => {
       const yaml = `
 name: test-plan

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -605,6 +605,21 @@ steps:
       expect(result.errors!.some((e) => e.field.includes("devices"))).toBe(true);
     });
 
+    it("should reject a whitespace-only device label", () => {
+      // A whitespace-only label like " " satisfies minLength:1 but is not a
+      // real device label -- the pattern requiring a non-whitespace
+      // character catches it at the schema level too (#6215 review).
+      const yaml = `
+name: test-plan
+devices:
+  - " "
+steps:
+  - tool: observe
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should provide line numbers for field errors when possible", () => {
       const yaml = `
 name: test-plan
@@ -1108,6 +1123,39 @@ steps:
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(false);
+    });
+
+    it("should reject an invalid inline device when params is null (not an object)", () => {
+      // JSON Schema's "required" keyword vacuously passes against a
+      // non-object value, so a naive "params has device" guard would treat
+      // params: null as if it declared 'device', wrongly skipping the
+      // inline check. The guard must require params to be an object before
+      // trusting its presence (#6215 review).
+      const yaml = `
+name: tapon-null-params-invalid-device
+devices:
+  - A
+steps:
+  - tool: tapOn
+    device: 123
+    params: null
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a valid inline device when params is null (not an object)", () => {
+      const yaml = `
+name: tapon-null-params-valid-device
+devices:
+  - A
+steps:
+  - tool: tapOn
+    device: A
+    params: null
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
     });
 
     it("should reject a barrier step with an inline malformed platform value", () => {

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -905,6 +905,106 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should accept a barrier step with INLINE coordination params (no nested params object)", () => {
+      // Plans may place lock/deviceCount/device directly on the step, the
+      // same inline-vs-params shape criticalSection (and most other tools)
+      // accept -- PlanNormalizer merges inline fields into params before
+      // execution (#6215 review).
+      const yaml = `
+name: barrier-inline-test
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: 2
+  - tool: barrier
+    device: B
+    lock: sync-point
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should accept a criticalSection step with INLINE coordination params", () => {
+      const yaml = `
+name: critical-section-inline-test
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    lock: sync-point
+    deviceCount: 1
+    steps:
+      - tool: tapOn
+        params:
+          device: A
+          text: Button
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a barrier step with a zero timeout", () => {
+      const yaml = `
+name: barrier-zero-timeout
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 2
+      timeout: 0
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a barrier step with a positive timeout", () => {
+      const yaml = `
+name: barrier-positive-timeout
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 2
+      timeout: 5000
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a criticalSection step with a zero timeout", () => {
+      const yaml = `
+name: critical-section-zero-timeout
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      lock: sync-point
+      deviceCount: 1
+      timeout: 0
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: Button
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should validate expectations array", () => {
       const yaml = `
 name: expectations-test

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -1061,6 +1061,124 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should accept a criticalSection sub-step with a discarded invalid inline device overridden by a valid params.device", () => {
+      // PlanNormalizer.normalizeSteps merges params over inline fields for
+      // EVERY step, not just the outer criticalSection/barrier step -- a
+      // nested sub-step is itself validated as a planStep (via the
+      // criticalSectionParams.steps $ref), so this precedence must be
+      // honored there too, or a discarded, invalid inline device would
+      // false-reject an otherwise-valid plan (#6215 review).
+      const yaml = `
+name: critical-section-substep-device-override
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 1
+      steps:
+        - tool: tapOn
+          device: 123
+          params:
+            device: A
+            text: Button
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject a criticalSection sub-step with an invalid inline device when params does not override it", () => {
+      const yaml = `
+name: critical-section-substep-invalid-device
+devices:
+  - A
+steps:
+  - tool: criticalSection
+    params:
+      device: A
+      lock: sync-point
+      deviceCount: 1
+      steps:
+        - tool: tapOn
+          device: 123
+          params:
+            text: Button
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject a barrier step with an inline malformed platform value", () => {
+      // The inline form must be constrained the same as the nested-params
+      // form, or PlanNormalizer moving it into params later would make the
+      // runtime addDeviceTargetingToSchema reject a plan this authoring
+      // schema accepted (#6215 review).
+      const yaml = `
+name: barrier-inline-malformed-platform
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: 2
+    platform: windows
+  - tool: barrier
+    device: B
+    lock: sync-point
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept a barrier step with an inline valid platform value", () => {
+      const yaml = `
+name: barrier-inline-valid-platform
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: 2
+    platform: android
+  - tool: barrier
+    device: B
+    lock: sync-point
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should accept a barrier step with an inline malformed platform overridden by a valid params.platform", () => {
+      const yaml = `
+name: barrier-inline-platform-override
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync-point
+    deviceCount: 2
+    platform: windows
+    params:
+      platform: android
+  - tool: barrier
+    device: B
+    lock: sync-point
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
     it("should accept a barrier step with a positive timeout", () => {
       const yaml = `
 name: barrier-positive-timeout

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -1158,6 +1158,53 @@ steps:
       expect(result.valid).toBe(true);
     });
 
+    it("should accept an inline barrier with params: null and valid inline lock/deviceCount/device", () => {
+      // PlanNormalizer.isRecord treats a non-object params (e.g. null) as
+      // absent ({}), so an inline-form barrier step with params: null is a
+      // previously-supported normalized form -- the unconditional
+      // barrierParams $ref (which requires an object) must not reject it;
+      // only the inline fields should be validated (#6215 review).
+      const yaml = `
+name: barrier-inline-null-params
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync1
+    deviceCount: 2
+    params: null
+  - tool: barrier
+    device: B
+    lock: sync1
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject an inline barrier with params: null and an invalid inline field", () => {
+      const yaml = `
+name: barrier-inline-null-params-invalid
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync1
+    deviceCount: not-a-number
+    params: null
+  - tool: barrier
+    device: B
+    lock: sync1
+    deviceCount: 2
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should reject a barrier step with an inline malformed platform value", () => {
       // The inline form must be constrained the same as the nested-params
       // form, or PlanNormalizer moving it into params later would make the

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -744,11 +744,14 @@ describe("PlanValidator", () => {
 
   describe("validateCoordinationTimeouts", () => {
     // barrierTools.ts / criticalSectionTools.ts both declare timeout as
-    // z.number().int().positive() -- a value beyond the IEEE-754
-    // safe-integer range passes the schema's exclusiveMinimum check yet
-    // fails the runtime contract, so the plan would only fail at execution
-    // (#6215 review).
-    test("throws when a barrier timeout exceeds Number.MAX_SAFE_INTEGER", () => {
+    // z.number().int().positive(), and CriticalSectionCoordinator.waitAtBarrier
+    // passes the value straight to production setTimeout -- Node/Bun clamp
+    // any delay >= 2^31 (2147483648) to 1ms instead of honoring it, so a
+    // timeout at or beyond that range passes the schema's exclusiveMinimum
+    // check yet times out almost instantly at runtime (#6215 review).
+    const MAX_SETTIMEOUT_DELAY_MS = 2147483647;
+
+    test("throws when a barrier timeout exceeds setTimeout's usable range", () => {
       const plan: Plan = {
         name: "Barrier timeout over cap",
         devices: ["A", "B"],
@@ -759,7 +762,7 @@ describe("PlanValidator", () => {
               device: "A",
               lock: "sync1",
               deviceCount: 2,
-              timeout: Number.MAX_SAFE_INTEGER + 1,
+              timeout: MAX_SETTIMEOUT_DELAY_MS + 1,
             },
           },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
@@ -767,11 +770,11 @@ describe("PlanValidator", () => {
       };
       expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
       expect(() => PlanValidator.validate(plan)).toThrow(
-        "must be a positive integer no greater than Number.MAX_SAFE_INTEGER",
+        "must be a positive integer no greater than setTimeout's usable range",
       );
     });
 
-    test("accepts a barrier timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+    test("accepts a barrier timeout at exactly setTimeout's usable range", () => {
       const plan: Plan = {
         name: "Barrier timeout at cap",
         devices: ["A", "B"],
@@ -782,7 +785,7 @@ describe("PlanValidator", () => {
               device: "A",
               lock: "sync1",
               deviceCount: 2,
-              timeout: Number.MAX_SAFE_INTEGER,
+              timeout: MAX_SETTIMEOUT_DELAY_MS,
             },
           },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
@@ -791,7 +794,7 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("throws when a criticalSection timeout exceeds Number.MAX_SAFE_INTEGER", () => {
+    test("throws when a criticalSection timeout exceeds setTimeout's usable range", () => {
       const plan: Plan = {
         name: "criticalSection timeout over cap",
         devices: ["A"],
@@ -802,7 +805,7 @@ describe("PlanValidator", () => {
               device: "A",
               lock: "sync1",
               deviceCount: 1,
-              timeout: Number.MAX_SAFE_INTEGER + 1,
+              timeout: MAX_SETTIMEOUT_DELAY_MS + 1,
               steps: [{ tool: "observe", params: { device: "A" } }],
             },
           },
@@ -810,11 +813,11 @@ describe("PlanValidator", () => {
       };
       expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
       expect(() => PlanValidator.validate(plan)).toThrow(
-        "must be a positive integer no greater than Number.MAX_SAFE_INTEGER",
+        "must be a positive integer no greater than setTimeout's usable range",
       );
     });
 
-    test("accepts a criticalSection timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+    test("accepts a criticalSection timeout at exactly setTimeout's usable range", () => {
       const plan: Plan = {
         name: "criticalSection timeout at cap",
         devices: ["A"],
@@ -825,7 +828,7 @@ describe("PlanValidator", () => {
               device: "A",
               lock: "sync1",
               deviceCount: 1,
-              timeout: Number.MAX_SAFE_INTEGER,
+              timeout: MAX_SETTIMEOUT_DELAY_MS,
               steps: [{ tool: "observe", params: { device: "A" } }],
             },
           },

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -742,6 +742,99 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateCoordinationTimeouts", () => {
+    // barrierTools.ts / criticalSectionTools.ts both declare timeout as
+    // z.number().int().positive() -- a value beyond the IEEE-754
+    // safe-integer range passes the schema's exclusiveMinimum check yet
+    // fails the runtime contract, so the plan would only fail at execution
+    // (#6215 review).
+    test("throws when a barrier timeout exceeds Number.MAX_SAFE_INTEGER", () => {
+      const plan: Plan = {
+        name: "Barrier timeout over cap",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "barrier",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 2,
+              timeout: Number.MAX_SAFE_INTEGER + 1,
+            },
+          },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "must be a positive integer no greater than Number.MAX_SAFE_INTEGER",
+      );
+    });
+
+    test("accepts a barrier timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+      const plan: Plan = {
+        name: "Barrier timeout at cap",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "barrier",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 2,
+              timeout: Number.MAX_SAFE_INTEGER,
+            },
+          },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("throws when a criticalSection timeout exceeds Number.MAX_SAFE_INTEGER", () => {
+      const plan: Plan = {
+        name: "criticalSection timeout over cap",
+        devices: ["A"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 1,
+              timeout: Number.MAX_SAFE_INTEGER + 1,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "must be a positive integer no greater than Number.MAX_SAFE_INTEGER",
+      );
+    });
+
+    test("accepts a criticalSection timeout at exactly Number.MAX_SAFE_INTEGER", () => {
+      const plan: Plan = {
+        name: "criticalSection timeout at cap",
+        devices: ["A"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 1,
+              timeout: Number.MAX_SAFE_INTEGER,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
   describe("validateNoCrossToolLockSharing", () => {
     test("throws when the same lock name is used by both a criticalSection and a barrier step", () => {
       // Both tools share the runtime coordinator's lock namespace and

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -465,6 +465,69 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("params-wins precedence for split inline/params coordination fields", () => {
+    // PlanNormalizer merges a step's inline fields and its nested `params`
+    // object as `{ ...inlineParams, ...paramsFromStep }`, so when the same
+    // field appears in both places, the params value wins and the inline
+    // value is discarded -- the same precedence #6090/#6107 established for
+    // networkCondition/doNotDisturb (#6215 review). These exercise the real
+    // YAML -> normalize -> validate pipeline so the effective (post-merge)
+    // value is what gets checked, not a hand-built already-merged Plan.
+    test("validates a barrier's effective (params) deviceCount, not its overridden inline value", async () => {
+      // Inline deviceCount=2 would pass the distinct-device-count check on
+      // its own (2 distinct devices), but params.deviceCount=3 wins at
+      // normalization -- 3 distinct devices are required and only 2 exist,
+      // so this must be REJECTED using the effective value of 3, not 2.
+      const yaml = `
+name: barrier-params-override-devicecount
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync1
+    deviceCount: 2
+    params:
+      deviceCount: 3
+  - tool: barrier
+    device: B
+    lock: sync1
+    params:
+      deviceCount: 3
+`;
+      const serializer = new YamlPlanSerializer();
+      expect(() => serializer.importPlanFromYaml(yaml)).toThrow(
+        'barrier lock "sync1" declares deviceCount=3 but only 2 distinct devices',
+      );
+    });
+
+    test("accepts a barrier whose effective (params) deviceCount matches distinct devices, ignoring a smaller inline value", async () => {
+      // Inline deviceCount=2 is irrelevant here -- params.deviceCount=2 wins
+      // and matches the 2 distinct devices, so this is valid.
+      const yaml = `
+name: barrier-params-override-devicecount-valid
+devices:
+  - A
+  - B
+steps:
+  - tool: barrier
+    device: A
+    lock: sync1
+    deviceCount: 999
+    params:
+      deviceCount: 2
+  - tool: barrier
+    device: B
+    lock: sync1
+    params:
+      deviceCount: 2
+`;
+      const serializer = new YamlPlanSerializer();
+      expect(() => serializer.importPlanFromYaml(yaml)).not.toThrow();
+    });
+  });
+
   describe("hasMultiDeviceFeatures", () => {
     test("returns false for a simple single-device plan", () => {
       const plan: Plan = {

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -373,21 +373,23 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("accepts a barrier reused across multiple rounds, even with different device sets per round", () => {
+    test("accepts a barrier reused across multiple rounds with a consistent deviceCount, even when different rounds involve different devices", () => {
       // Barrier rounds aren't statically delineated in plan YAML, and are not
       // required to share the same participants: cross-round arrival-count
       // consistency is left to the runtime coordinator
       // (CriticalSectionCoordinator), which matches arrivals per round at
-      // execution time. Static validation only checks each step's own params.
+      // execution time. Static validation only checks each step's own
+      // params, plus the plan-wide distinct-device/divisibility invariants
+      // -- deviceCount itself must stay consistent across every reuse of a
+      // given lock (see validateBarrierConsistentDeviceCount).
       const plan: Plan = {
-        name: "Multi-round barrier with varying device sets",
+        name: "Multi-round barrier with varying device sets, consistent deviceCount",
         devices: ["A", "B", "C"],
         steps: [
           { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
-          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
-          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
-          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 2 } },
         ],
       };
       expect(() => PlanValidator.validate(plan)).not.toThrow();
@@ -481,6 +483,25 @@ describe("PlanValidator", () => {
         "the following steps use invalid device labels",
       );
     });
+
+    test("throws when a barrier step omits 'device' entirely under a declared devices set", () => {
+      // devices=[A]: one deviceCount=1 barrier step for this lock omits
+      // 'device' altogether while another targets A. The device-less step
+      // is rejected by validateDeviceLabelsPresent (generic to every tool,
+      // barrier included) before the coordination checks ever run.
+      const plan: Plan = {
+        name: "Barrier step missing device",
+        devices: ["A"],
+        steps: [
+          { tool: "barrier", params: { lock: "sync1", deviceCount: 1 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 1 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "the following steps are missing 'device' parameter",
+      );
+    });
   });
 
   describe("validateBarrierGenerationCompleteness", () => {
@@ -526,17 +547,52 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("skips the generation-completeness check when a lock has no single consistent deviceCount", () => {
-      // barrier legitimately allows different deviceCount values across
-      // reuses of the same lock (different rounds, different participant
-      // counts); there's no single N to divide by, so this check must not
-      // false-reject it.
+    test("skips the generation-completeness check when a lock has no single deviceCount to divide by", () => {
+      // A lock with zero recorded (valid, positive-integer) deviceCounts has
+      // nothing to divide arrivals by; this is a defensive guard, not a
+      // reachable case in a plan that also passes validateBarrierParams
+      // (which requires every barrier step to declare one).
       const plan: Plan = {
-        name: "Inconsistent deviceCount reused lock",
+        name: "No valid deviceCount recorded",
+        devices: ["A"],
+        steps: [{ tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 1 } }],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
+  describe("validateBarrierConsistentDeviceCount", () => {
+    test("throws when a reused barrier lock declares more than one distinct deviceCount", () => {
+      // A/B at deviceCount=2, then A/B/C at deviceCount=3 for the SAME lock
+      // name: the runtime coordinator keeps one shared expected count per
+      // lock, so mixed-count reuse is racy and must be rejected regardless
+      // of whether the distinct-device/divisibility checks would otherwise
+      // pass it.
+      const plan: Plan = {
+        name: "Mixed-count barrier lock reuse",
         devices: ["A", "B", "C"],
         steps: [
           { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'barrier lock "sync1" is reused with inconsistent deviceCount values (2, 3)',
+      );
+    });
+
+    test("accepts a reused barrier lock whose deviceCount stays consistent across every use", () => {
+      const plan: Plan = {
+        name: "Consistent-count barrier lock reuse",
+        devices: ["A", "B", "C"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
           { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
           { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -151,6 +151,24 @@ describe("PlanValidator", () => {
       };
       expect(() => PlanValidator.validate(plan)).toThrow("does not declare 'devices' field");
     });
+
+    test("accepts an inline-form barrier step with a declared device (no spurious missing-device error)", () => {
+      // Before PlanNormalizer merges inline fields into params, a step's
+      // 'device' can sit directly on the step rather than nested under
+      // params. validateDeviceLabelsPresent must resolve this via
+      // effectiveField, not a raw params?.device read, or a perfectly valid
+      // inline barrier plan is rejected with a spurious missing-device
+      // error (#6215 review).
+      const plan: any = {
+        name: "Inline barrier device label",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", device: "A", lock: "sync1", deviceCount: 2 },
+          { tool: "barrier", device: "B", lock: "sync1", deviceCount: 2 },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
   });
 
   describe("validateCriticalSectionLocks", () => {

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -463,6 +463,87 @@ describe("PlanValidator", () => {
       };
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
+
+    test("throws when a barrier plan targets device labels outside the declared 'devices' set", () => {
+      // devices=[A,B] but the barrier steps target C/D: the distinct-device
+      // count (2) would otherwise satisfy deviceCount=2, but C/D are not
+      // declared devices at all, so this must be rejected regardless.
+      const plan: Plan = {
+        name: "Barrier targets undeclared devices",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "D", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "the following steps use invalid device labels",
+      );
+    });
+  });
+
+  describe("validateBarrierGenerationCompleteness", () => {
+    // Sound generation-completeness check: for a lock with a single
+    // consistent deviceCount N, the total arrival count across the plan
+    // must be an exact multiple of N, or a trailing generation is
+    // necessarily incomplete and deadlocks forever. This is checked without
+    // reconstructing rounds (deliberately not per-device-ordinal grouping,
+    // which was removed earlier as unsound).
+    test("throws when a reused barrier lock's total arrivals are not a multiple of deviceCount", () => {
+      // A, B, A with deviceCount=2: 2 distinct devices satisfies the
+      // distinct-device check, but 3 total arrivals is not a multiple of 2
+      // -- generation 1 {A,B} completes and clears, then the trailing A
+      // waits alone forever.
+      const plan: Plan = {
+        name: "Incomplete trailing barrier generation",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'barrier lock "sync1" has 3 total arrivals across the plan, which is not a multiple of its deviceCount=2',
+      );
+    });
+
+    test("accepts a reused barrier lock whose total arrivals form complete generations", () => {
+      // A, B, A, B with deviceCount=2: 4 total arrivals is a multiple of 2,
+      // so both generations complete cleanly.
+      const plan: Plan = {
+        name: "Complete barrier generations",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("skips the generation-completeness check when a lock has no single consistent deviceCount", () => {
+      // barrier legitimately allows different deviceCount values across
+      // reuses of the same lock (different rounds, different participant
+      // counts); there's no single N to divide by, so this check must not
+      // false-reject it.
+      const plan: Plan = {
+        name: "Inconsistent deviceCount reused lock",
+        devices: ["A", "B", "C"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
   });
 
   describe("params-wins precedence for split inline/params coordination fields", () => {

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -788,6 +788,24 @@ describe("PlanValidator", () => {
       };
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
+
+    test("throws when two structurally-different device definitions share a label", () => {
+      // JSON Schema's uniqueItems only compares whole entries, so an
+      // Android "A" and an iOS "A" definition pass it -- but they collapse
+      // to the same label, and the daemon's validateDevicesField rejects
+      // the duplicate regardless of the definitions' other fields (#6215
+      // review).
+      const plan: Plan = {
+        name: "Duplicate label across different definitions",
+        devices: [
+          { label: "A", platform: "android" },
+          { label: "A", platform: "ios" },
+        ],
+        steps: [{ tool: "tapOn", params: { text: "hi", device: "A" } }],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow("duplicate labels");
+    });
   });
 
   describe("params-wins precedence for split inline/params coordination fields", () => {

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -687,6 +687,61 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateNoAuthoredLockNamespace", () => {
+    // __lockNamespace is injected internally by PlanExecutor to scope a
+    // plan's lock state; an authored plan must never set it, since
+    // CriticalSectionCoordinator keys runtime state by namespace+lock while
+    // the feasibility checks above aggregate arrivals by lock name alone.
+    test("throws when a barrier step authors '__lockNamespace' under params", () => {
+      const plan: Plan = {
+        name: "Authored lock namespace on barrier",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "barrier",
+            params: { device: "A", lock: "sync1", deviceCount: 2, __lockNamespace: "one" },
+          },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow("sets '__lockNamespace'");
+    });
+
+    test("throws when a criticalSection step authors '__lockNamespace' under params", () => {
+      const plan: Plan = {
+        name: "Authored lock namespace on criticalSection",
+        devices: ["A"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 1,
+              __lockNamespace: "one",
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow("sets '__lockNamespace'");
+    });
+
+    test("accepts a normal plan that does not author '__lockNamespace'", () => {
+      const plan: Plan = {
+        name: "Normal barrier plan",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
   describe("validateNoCrossToolLockSharing", () => {
     test("throws when the same lock name is used by both a criticalSection and a barrier step", () => {
       // Both tools share the runtime coordinator's lock namespace and

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -687,6 +687,109 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateNoCrossToolLockSharing", () => {
+    test("throws when the same lock name is used by both a criticalSection and a barrier step", () => {
+      // Both tools share the runtime coordinator's lock namespace and
+      // expected-count state (keyed by lock name alone), so a
+      // criticalSection A/B pair and a barrier C/D pair both using lock
+      // "shared" with deviceCount=2 can pair mismatched participants (A
+      // with C) and overwrite each other's expected count.
+      const plan: Plan = {
+        name: "Lock shared across tool types",
+        devices: ["A", "B", "C", "D"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "B" } }],
+            },
+          },
+          { tool: "barrier", params: { device: "C", lock: "shared", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "D", lock: "shared", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'lock name "shared" is used by both a criticalSection step and a barrier step',
+      );
+    });
+
+    test("accepts a plan where criticalSection and barrier use distinct lock names", () => {
+      const plan: Plan = {
+        name: "Distinct locks per tool type",
+        devices: ["A", "B", "C", "D"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "cs-lock",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "cs-lock",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "B" } }],
+            },
+          },
+          { tool: "barrier", params: { device: "C", lock: "barrier-lock", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "D", lock: "barrier-lock", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
+  describe("mixed device declaration formats", () => {
+    test("throws when 'devices' mixes a plain-string label with a label/platform definition", () => {
+      const plan: Plan = {
+        name: "Mixed device formats",
+        devices: ["A", { label: "B", platform: "android" }],
+        steps: [{ tool: "tapOn", params: { text: "hi", device: "A" } }],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow("do not mix formats");
+    });
+
+    test("accepts a 'devices' list of all plain-string labels", () => {
+      const plan: Plan = {
+        name: "All-label devices",
+        devices: ["A", "B"],
+        steps: [{ tool: "tapOn", params: { text: "hi", device: "A" } }],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("accepts a 'devices' list of all label/platform definitions", () => {
+      const plan: Plan = {
+        name: "All-definition devices",
+        devices: [
+          { label: "A", platform: "android" },
+          { label: "B", platform: "ios" },
+        ],
+        steps: [{ tool: "tapOn", params: { text: "hi", device: "A" } }],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
   describe("params-wins precedence for split inline/params coordination fields", () => {
     // PlanNormalizer merges a step's inline fields and its nested `params`
     // object as `{ ...inlineParams, ...paramsFromStep }`, so when the same

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -561,6 +561,65 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateBarrierExcessDeviceArrivals", () => {
+    // PlanPartitioner executes each device's track sequentially, so a
+    // device can participate in a barrier lock at most once per generation.
+    // For a lock with a single consistent deviceCount N and total arrivals
+    // T (divisible by N), there are G = T/N generations; a device appearing
+    // more than G times can never be scheduled and would deadlock.
+    test("throws when a single device arrives more times than there are generations", () => {
+      // A, B, A, A with deviceCount=2: 4 arrivals is divisible by 2 (G=2),
+      // but device A appears 3 times (> G=2) -- after generation 1 {A,B}
+      // releases, A's second arrival starts generation 2, but its third
+      // arrival has no generation left to join.
+      const plan: Plan = {
+        name: "Excess single-device barrier arrivals",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'barrier lock "sync1" has 2 generations available (deviceCount=2, 4 total arrivals), but device "A" arrives 3 times',
+      );
+    });
+
+    test("accepts a barrier lock where every device arrives at most once per available generation", () => {
+      // A, A, B, B with deviceCount=2: G=2, and each device appears exactly
+      // 2 times (<= G) -- feasible, since generation 1 can be {A,B} and
+      // generation 2 can be {A,B} using the second arrival of each.
+      const plan: Plan = {
+        name: "Feasible repeated-arrival barrier lock",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("still accepts the alternating A/B/A/B case", () => {
+      const plan: Plan = {
+        name: "Alternating barrier generations",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
   describe("validateBarrierConsistentDeviceCount", () => {
     test("throws when a reused barrier lock declares more than one distinct deviceCount", () => {
       // A/B at deviceCount=2, then A/B/C at deviceCount=3 for the SAME lock

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -360,7 +360,7 @@ describe("PlanValidator", () => {
     });
   });
 
-  describe("validateCoordinationLocks (barrier)", () => {
+  describe("validateBarrierParams", () => {
     test("accepts a well-formed dual-device barrier sharing a lock", () => {
       const plan: Plan = {
         name: "Well-formed dual-device barrier",
@@ -373,69 +373,58 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("throws when barrier steps sharing a lock disagree on deviceCount", () => {
+    test("accepts a barrier reused across multiple rounds, even with different device sets per round", () => {
+      // Barrier rounds aren't statically delineated in plan YAML, and are not
+      // required to share the same participants: cross-round arrival-count
+      // consistency is left to the runtime coordinator
+      // (CriticalSectionCoordinator), which matches arrivals per round at
+      // execution time. Static validation only checks each step's own params.
       const plan: Plan = {
-        name: "Inconsistent barrier deviceCount",
-        devices: ["A", "B"],
+        name: "Multi-round barrier with varying device sets",
+        devices: ["A", "B", "C"],
         steps: [
-          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
-          { tool: "barrier", params: { device: "B", lock: "shared", deviceCount: 3 } },
-        ],
-      };
-      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
-      expect(() => PlanValidator.validate(plan)).toThrow("inconsistent deviceCount values");
-    });
-
-    test("throws when a barrier lock declares more devices than the steps that reference it", () => {
-      const plan: Plan = {
-        name: "Underpopulated barrier lock",
-        devices: ["A", "B"],
-        steps: [{ tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } }],
-      };
-      expect(() => PlanValidator.validate(plan)).toThrow(
-        "declares deviceCount=2 but 1 step references it",
-      );
-    });
-
-    test("accepts a barrier reused across two rounds with consistent per-round arrivals", () => {
-      // Unlike criticalSection, a barrier is meant to fire once per round: the
-      // same lock name recurs across phases, and each device arrives at it
-      // multiple times (the runtime coordinator clears arrival state once a
-      // round's deviceCount is reached). This must NOT be flagged as
-      // over-populating a single lock.
-      const plan: Plan = {
-        name: "Two-round barrier",
-        devices: ["A", "B"],
-        steps: [
-          { tool: "observe", params: { device: "A" } },
           { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
-          { tool: "tapOn", params: { device: "A", text: "Continue" } },
-          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
-          { tool: "observe", params: { device: "B" } },
           { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
-          { tool: "tapOn", params: { device: "B", text: "Continue" } },
-          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
         ],
       };
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("throws when a single round of a reused barrier lock has mismatched deviceCount", () => {
+    test("throws when a barrier step is missing 'lock'", () => {
       const plan: Plan = {
-        name: "Two-round barrier with one bad round",
-        devices: ["A", "B"],
-        steps: [
-          // Round 1: consistent.
-          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
-          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
-          // Round 2: device B disagrees on deviceCount.
-          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
-          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
-        ],
+        name: "Barrier missing lock",
+        devices: ["A"],
+        steps: [{ tool: "barrier", params: { device: "A", deviceCount: 2 } }],
       };
       expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
       expect(() => PlanValidator.validate(plan)).toThrow(
-        'barrier lock "sync1" round 2 has inconsistent deviceCount values',
+        "barrier step 0 is missing a non-empty 'lock' parameter",
+      );
+    });
+
+    test("throws when a barrier step is missing 'deviceCount'", () => {
+      const plan: Plan = {
+        name: "Barrier missing deviceCount",
+        devices: ["A"],
+        steps: [{ tool: "barrier", params: { device: "A", lock: "sync1" } }],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "barrier step 0 must declare a positive integer 'deviceCount'",
+      );
+    });
+
+    test("throws when a barrier step declares a non-positive-integer 'deviceCount'", () => {
+      const plan: Plan = {
+        name: "Barrier bad deviceCount",
+        devices: ["A"],
+        steps: [{ tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 0 } }],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "barrier step 0 must declare a positive integer 'deviceCount'",
       );
     });
   });

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -86,6 +86,14 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).toThrow("Device labels must be non-empty strings");
     });
 
+    test("throws with a non-empty-string message on a whitespace-only device label", () => {
+      // A whitespace-only label like " " is a non-empty string, but the
+      // daemon trims labels before checking emptiness -- a lone space
+      // must not be treated as a valid device label (#6215 review).
+      const plan: Plan = { name: "Test", devices: [" "], steps: [] };
+      expect(() => PlanValidator.validate(plan)).toThrow("Device labels must be non-empty strings");
+    });
+
     test("throws with a mixed-format message on mixed device formats", () => {
       const plan: Plan = {
         name: "Test",

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -360,6 +360,56 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateCoordinationLocks (barrier)", () => {
+    test("accepts a well-formed dual-device barrier sharing a lock", () => {
+      const plan: Plan = {
+        name: "Well-formed dual-device barrier",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("throws when barrier steps sharing a lock disagree on deviceCount", () => {
+      const plan: Plan = {
+        name: "Inconsistent barrier deviceCount",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "shared", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow("inconsistent deviceCount values");
+    });
+
+    test("throws when a barrier lock declares more devices than the steps that reference it", () => {
+      const plan: Plan = {
+        name: "Underpopulated barrier lock",
+        devices: ["A", "B"],
+        steps: [{ tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } }],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "declares deviceCount=2 but 1 step references it",
+      );
+    });
+
+    test("throws when the same device enters a barrier lock twice", () => {
+      const plan: Plan = {
+        name: "Double-entry barrier lock",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow('entered twice by device "A"');
+    });
+  });
+
   describe("hasMultiDeviceFeatures", () => {
     test("returns false for a simple single-device plan", () => {
       const plan: Plan = {
@@ -390,6 +440,14 @@ describe("PlanValidator", () => {
       const plan: Plan = {
         name: "Test",
         steps: [{ tool: "criticalSection", params: {} }],
+      };
+      expect(PlanValidator.hasMultiDeviceFeatures(plan)).toBe(true);
+    });
+
+    test("returns true when barrier is used", () => {
+      const plan: Plan = {
+        name: "Test",
+        steps: [{ tool: "barrier", params: {} }],
       };
       expect(PlanValidator.hasMultiDeviceFeatures(plan)).toBe(true);
     });

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -397,16 +397,46 @@ describe("PlanValidator", () => {
       );
     });
 
-    test("throws when the same device enters a barrier lock twice", () => {
+    test("accepts a barrier reused across two rounds with consistent per-round arrivals", () => {
+      // Unlike criticalSection, a barrier is meant to fire once per round: the
+      // same lock name recurs across phases, and each device arrives at it
+      // multiple times (the runtime coordinator clears arrival state once a
+      // round's deviceCount is reached). This must NOT be flagged as
+      // over-populating a single lock.
       const plan: Plan = {
-        name: "Double-entry barrier lock",
+        name: "Two-round barrier",
         devices: ["A", "B"],
         steps: [
-          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
-          { tool: "barrier", params: { device: "A", lock: "shared", deviceCount: 2 } },
+          { tool: "observe", params: { device: "A" } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "tapOn", params: { device: "A", text: "Continue" } },
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "observe", params: { device: "B" } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          { tool: "tapOn", params: { device: "B", text: "Continue" } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
         ],
       };
-      expect(() => PlanValidator.validate(plan)).toThrow('entered twice by device "A"');
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("throws when a single round of a reused barrier lock has mismatched deviceCount", () => {
+      const plan: Plan = {
+        name: "Two-round barrier with one bad round",
+        devices: ["A", "B"],
+        steps: [
+          // Round 1: consistent.
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 2 } },
+          // Round 2: device B disagrees on deviceCount.
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 2 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'barrier lock "sync1" round 2 has inconsistent deviceCount values',
+      );
     });
   });
 

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -429,6 +429,42 @@ describe("PlanValidator", () => {
     });
   });
 
+  describe("validateBarrierDistinctDeviceCounts", () => {
+    test("throws when fewer distinct devices target a lock than its declared deviceCount", () => {
+      // Two distinct devices (A, B) can never produce the 3 arrivals
+      // deviceCount=3 demands -- no round can ever complete.
+      const plan: Plan = {
+        name: "Underpopulated barrier lock",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'barrier lock "sync1" declares deviceCount=3 but only 2 distinct devices',
+      );
+    });
+
+    test("accepts a lock with exactly deviceCount distinct devices, even when reused across rounds", () => {
+      const plan: Plan = {
+        name: "Fully-populated barrier lock reused across rounds",
+        devices: ["A", "B", "C"],
+        steps: [
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
+          // Round 2 reuse of the same lock by the same 3 devices.
+          { tool: "barrier", params: { device: "A", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "B", lock: "sync1", deviceCount: 3 } },
+          { tool: "barrier", params: { device: "C", lock: "sync1", deviceCount: 3 } },
+        ],
+      };
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+  });
+
   describe("hasMultiDeviceFeatures", () => {
     test("returns false for a simple single-device plan", () => {
       const plan: Plan = {


### PR DESCRIPTION
## Summary

Follow-up to #6117 / #6159: `barrier` was missing the same plan-validation
treatment `criticalSection` gets, in two places outside the TS schema.

1. **`PlanValidator` was barrier-blind.** `validateCriticalSectionLocks`
   (renamed `validateCoordinationLocks`) only inspected `criticalSection`
   steps, so a `barrier` with a mismatched `deviceCount`, an underpopulated
   lock, or a device entering the same lock twice surfaced only as a 30s
   runtime barrier timeout instead of a validation error at plan-load time.
   `hasMultiDeviceFeatures` also only recognized `criticalSection` by tool
   name (barrier only counted via `params.device`).

2. **Android plan validation rejected `barrier` outright.**
   `ValidTools.TOOLS` didn't include `"barrier"`, so a YAML plan using
   `barrier` failed `TestPlanValidator` with an unknown-tool ERROR before
   ever reaching the daemon. The IDE plugin's `TestPlanToolCategories`
   "Plan execution" category was likewise missing `barrier`.

## Changes

- `src/utils/plan/PlanValidator.ts`: extend lock-consistency validation and
  `hasMultiDeviceFeatures` to treat `barrier` like `criticalSection` (minus
  the sub-step device check, which barrier has no nested steps for).
- `android/test-plan-validation/.../ValidTools.kt`: add `"barrier"` to the
  accepted tool set.
- `android/ide-plugin/.../TestPlanToolCategories.kt`: add `barrier` to the
  "Plan execution" category.
- Tests: TS cases mirroring the existing `criticalSection` lock-validation
  tests (mismatched deviceCount rejected, underpopulated lock rejected,
  double-entry device rejected, well-formed barrier plan passes) plus a
  Kotlin `TestPlanValidatorTest` case validating a barrier plan.

Closes #6175
