### PR TITLE
fix(mcp): implement listApps and default apps resource type to user

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -45,7 +45,7 @@ the exact arguments supported by your connection.
 
 | Tool                                                                                             | What it does                                                                                                               |
 | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| 📱 <code>listApps</code>                                                                         | Provides guidance for listing installed apps through MCP resources.                                                        |
+| 📱 <code>listApps</code>                                                                         | Lists installed apps on a device (params: `deviceId`, `type`, `search`, `profile`; default `type=user`).                   |
 | 🚀 <code>launchApp</code>                                                                        | Launches an app by package name.                                                                                           |
 | ❌ <code>terminateApp</code>                                                                     | Terminates an app by package name.                                                                                         |
 | 💥 <code>crashApp</code>                                                                         | Intentionally crashes a running app through the platform crash path.                                                       |

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -45,7 +45,7 @@ the exact arguments supported by your connection.
 
 | Tool                                                                                             | What it does                                                                                                               |
 | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| 📱 <code>listApps</code>                                                                         | Lists installed apps on a device (params: `deviceId`, `type`, `search`, `profile`; default `type=user`).                   |
+| 📱 <code>listApps</code>                                                                         | Lists installed apps on a device (params: `device`, `type`, `search`, `profile`; default `type=user`).                     |
 | 🚀 <code>launchApp</code>                                                                        | Launches an app by package name.                                                                                           |
 | ❌ <code>terminateApp</code>                                                                     | Terminates an app by package name.                                                                                         |
 | 💥 <code>crashApp</code>                                                                         | Intentionally crashes a running app through the platform crash path.                                                       |

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2882,7 +2882,7 @@
           "enum": ["user", "system", "all"]
         },
         "search": {
-          "description": "Filter by a case-insensitive substring of the package name or display name.",
+          "description": "Filter by a case-insensitive substring of the package name/bundle id. Also matches the app's display name where the platform reports one (iOS only today — Android's listing does not include app labels).",
           "type": "string"
         },
         "profile": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2871,12 +2871,43 @@
   },
   {
     "name": "listApps",
-    "description": "Guide for listing apps via MCP resources",
+    "description": "List installed apps on a device. Filters by type (default: user), search, and profile.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": {},
-      "additionalProperties": {}
+      "properties": {
+        "type": {
+          "description": "Filter by app type. Defaults to 'user'.",
+          "type": "string",
+          "enum": ["user", "system", "all"]
+        },
+        "search": {
+          "description": "Filter by a case-insensitive substring of the package name or display name.",
+          "type": "string"
+        },
+        "profile": {
+          "description": "Filter to apps visible to this user profile id.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "platform": {
+          "type": "string",
+          "enum": ["android", "ios"]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2877,7 +2877,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "Filter by app type. Defaults to 'user'.",
+          "description": "Filter by app type. Defaults to 'user', EXCEPT on a physical iOS device where user/system classification is unavailable (devicectl reports no such signal there): on such a device an omitted type returns every app (reported as 'all'), and an explicit 'user' or 'system' filter is rejected rather than silently honored.",
           "type": "string",
           "enum": ["user", "system", "all"]
         },

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -15,6 +15,7 @@ import { logger } from "../utils/logger";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { isIosPhysicalUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
 import {
   getIosInstalledAppBundleId,
   getIosInstalledAppPath,
@@ -93,7 +94,7 @@ interface AndroidInstalledAppInfo {
   recent: boolean;
 }
 
-interface IosInstalledAppInfo {
+export interface IosInstalledAppInfo {
   bundleId: string;
   type: InstalledAppType;
   displayName?: string;
@@ -238,14 +239,23 @@ function extractIosPath(app: Record<string, unknown>): string | undefined {
  * excludes them on Android.
  *
  * `simctl listapps` reports an explicit `ApplicationType` ("System"/"Hidden"
- * vs "User"); devicectl's physical-device listing carries no equivalent field,
- * so this falls back to Apple's own `com.apple.` bundle-id namespace, which
- * every first-party system app uses.
+ * vs "User") — when present it always wins. When it's absent:
+ *  - On the simulator, an unexpected/incomplete record still falls back to
+ *    Apple's `com.apple.` bundle-id namespace, which only first-party system
+ *    apps use there.
+ *  - On a PHYSICAL device, `devicectl device info apps --json-output` exposes
+ *    no equivalent field at all (only bundleIdentifier/name/version/
+ *    bundleVersion/url/appClip, per Apple's devicectl output), so the
+ *    `com.apple.` heuristic would misclassify a user's own Apple-published
+ *    apps (Pages, Numbers, Keynote, TestFlight, ...) as hidden system apps and
+ *    silently drop them from `type=user`. Without a reliable signal there,
+ *    default to "user" rather than guessing "system" (#6216 review).
  */
 // Exported for tests: pure classification, no device/cache I/O (#6155).
 export function extractIosApplicationType(
   app: Record<string, unknown>,
   bundleId: string,
+  isPhysicalDevice: boolean,
 ): InstalledAppType {
   const raw = readIosAppField(app, ["ApplicationType", "applicationType", "type", "Type"]);
   if (raw) {
@@ -257,14 +267,24 @@ export function extractIosApplicationType(
       return "user";
     }
   }
+  if (isPhysicalDevice) {
+    return "user";
+  }
   return bundleId.startsWith("com.apple.") ? "system" : "user";
 }
 
-function toQueryIosApp(app: IosInstalledAppInfo): AppsQueryAppInfo {
+// Exported for tests: pure conversion, no device/cache I/O (#6216 review).
+export function toQueryIosApp(app: IosInstalledAppInfo): AppsQueryAppInfo {
   return {
     packageName: app.bundleId,
     type: app.type,
     userId: 0,
+    // iOS has no Android-style multi-user profiles — every app belongs to the
+    // single (profile 0) user. filterAppsByQuery's profile check only reads
+    // `userIds` for non-"user" apps; without this, any profile filter (e.g.
+    // the common profile:0 case) would silently drop every iOS system app
+    // because `userIds` was left undefined (#6216 review).
+    userIds: [0],
     userProfile: "personal",
     foreground: false,
     recent: false,
@@ -439,6 +459,7 @@ async function fetchAppsForDevice(
   const result = await listInstalledApps.executeIosDetailedResult();
   const apps: IosInstalledAppInfo[] = [];
   const queryApps: AppsQueryAppInfo[] = [];
+  const isPhysicalDevice = isIosPhysicalUdid(device.deviceId);
 
   for (const app of result.apps) {
     const bundleId = getIosInstalledAppBundleId(app);
@@ -448,7 +469,11 @@ async function fetchAppsForDevice(
     const displayName = extractIosDisplayName(app as Record<string, unknown>);
     const version = extractIosVersion(app as Record<string, unknown>);
     const path = extractIosPath(app as Record<string, unknown>);
-    const type = extractIosApplicationType(app as Record<string, unknown>, bundleId);
+    const type = extractIosApplicationType(
+      app as Record<string, unknown>,
+      bundleId,
+      isPhysicalDevice,
+    );
     const info: IosInstalledAppInfo = {
       bundleId,
       type,

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -95,6 +95,7 @@ interface AndroidInstalledAppInfo {
 
 interface IosInstalledAppInfo {
   bundleId: string;
+  type: InstalledAppType;
   displayName?: string;
   version?: string;
   path?: string;
@@ -231,10 +232,38 @@ function extractIosPath(app: Record<string, unknown>): string | undefined {
   return getIosInstalledAppPath(app);
 }
 
+/**
+ * Classifies an iOS app as "user" or "system" so `type=user` (the documented
+ * default, #6155) actually excludes preinstalled apps on iOS the same way it
+ * excludes them on Android.
+ *
+ * `simctl listapps` reports an explicit `ApplicationType` ("System"/"Hidden"
+ * vs "User"); devicectl's physical-device listing carries no equivalent field,
+ * so this falls back to Apple's own `com.apple.` bundle-id namespace, which
+ * every first-party system app uses.
+ */
+// Exported for tests: pure classification, no device/cache I/O (#6155).
+export function extractIosApplicationType(
+  app: Record<string, unknown>,
+  bundleId: string,
+): InstalledAppType {
+  const raw = readIosAppField(app, ["ApplicationType", "applicationType", "type", "Type"]);
+  if (raw) {
+    const normalized = raw.toLowerCase();
+    if (normalized === "system" || normalized === "hidden") {
+      return "system";
+    }
+    if (normalized === "user") {
+      return "user";
+    }
+  }
+  return bundleId.startsWith("com.apple.") ? "system" : "user";
+}
+
 function toQueryIosApp(app: IosInstalledAppInfo): AppsQueryAppInfo {
   return {
     packageName: app.bundleId,
-    type: "user",
+    type: app.type,
     userId: 0,
     userProfile: "personal",
     foreground: false,
@@ -354,11 +383,33 @@ interface FetchedAppsCacheEntry {
   cacheable: boolean;
 }
 
+/** Narrow surface `fetchAppsForDevice` needs from `ListInstalledApps`, so tests can
+ * inject a fake without driving the real adb/simctl/devicectl command chain. */
+type InstalledAppsLister = Pick<
+  ListInstalledApps,
+  "executeDetailedResult" | "executeIosDetailedResult"
+>;
+type ListInstalledAppsFactory = (device: BootedDevice) => InstalledAppsLister;
+
+const defaultListInstalledAppsFactory: ListInstalledAppsFactory = (device) =>
+  new ListInstalledApps(device);
+
+let listInstalledAppsFactory: ListInstalledAppsFactory = defaultListInstalledAppsFactory;
+
+/** Test-only seam: inject a fake app lister so a failed listing command can be
+ * simulated without real adb/simctl/devicectl I/O (#6155). Pass null to restore
+ * the default. */
+export function setListInstalledAppsFactoryForTests(
+  factory: ListInstalledAppsFactory | null,
+): void {
+  listInstalledAppsFactory = factory ?? defaultListInstalledAppsFactory;
+}
+
 async function fetchAppsForDevice(
   device: BootedDevice,
   timer: Timer = defaultTimer,
 ): Promise<FetchedAppsCacheEntry> {
-  const listInstalledApps = new ListInstalledApps(device);
+  const listInstalledApps = listInstalledAppsFactory(device);
   const lastUpdated = new Date().toISOString();
 
   if (device.platform === "android") {
@@ -397,8 +448,10 @@ async function fetchAppsForDevice(
     const displayName = extractIosDisplayName(app as Record<string, unknown>);
     const version = extractIosVersion(app as Record<string, unknown>);
     const path = extractIosPath(app as Record<string, unknown>);
+    const type = extractIosApplicationType(app as Record<string, unknown>, bundleId);
     const info: IosInstalledAppInfo = {
       bundleId,
+      type,
       displayName,
       ...(version ? { version } : {}),
       ...(path ? { path } : {}),
@@ -606,6 +659,16 @@ export async function queryInstalledApps(
   const cacheEntry = await ensureAppsCacheEntry(device.deviceId);
   if (!cacheEntry) {
     throw new Error(`Device not found or not booted: ${device.deviceId}`);
+  }
+  // `observationComplete` is wired directly to whether the underlying adb /
+  // simctl / devicectl listing command itself succeeded (ListInstalledApps'
+  // `successful` flag) — false here means the listing FAILED, not "0 apps
+  // installed". Reporting that as a normal (possibly empty) app list would be
+  // a dishonest success; surface it as a failure instead (#6155).
+  if (!cacheEntry.content.observationComplete) {
+    throw new Error(
+      `Failed to list installed apps for device ${device.deviceId}: the app-listing command did not complete successfully`,
+    );
   }
 
   const apps = filterAppsByQuery(cacheEntry.queryApps, options);

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -34,9 +34,10 @@ export const APPS_RESOURCE_URIS = {
 const APPS_QUERY_KEYS = ["deviceId", "platform", "search", "type", "profile"] as const;
 const APPS_QUERY_TEMPLATE = `${APPS_RESOURCE_URIS.BASE}{?${APPS_QUERY_KEYS.join(",")}}`;
 const APPS_QUERY_PARAM_KEYS = new Set<string>(APPS_QUERY_KEYS);
-type AppsQueryType = "user" | "system";
+type InstalledAppType = "user" | "system";
+export type AppsQueryType = InstalledAppType | "all";
 
-interface AppsQueryOptions {
+export interface AppsQueryOptions {
   platform?: Platform;
   search?: string;
   type?: AppsQueryType;
@@ -44,9 +45,9 @@ interface AppsQueryOptions {
   deviceId?: string;
 }
 
-interface AppsQueryAppInfo {
+export interface AppsQueryAppInfo {
   packageName: string;
-  type: AppsQueryType;
+  type: InstalledAppType;
   foreground: boolean;
   recent: boolean;
   userId?: number;
@@ -63,7 +64,7 @@ interface AppsQueryDeviceContent {
   apps: AppsQueryAppInfo[];
 }
 
-interface AppsQueryResourceContent {
+export interface AppsQueryResourceContent {
   query: AppsQueryOptions;
   observationComplete: boolean;
   totalCount: number;
@@ -470,7 +471,8 @@ function parseProfileParam(value: string | undefined): number | undefined {
   return parsed;
 }
 
-function parseAppsQueryParams(params: Record<string, string>): AppsQueryOptions {
+// Exported for tests: pure query-string parsing, no device/cache I/O (#6155).
+export function parseAppsQueryParams(params: Record<string, string>): AppsQueryOptions {
   const unknownKeys = Object.keys(params).filter((key) => !APPS_QUERY_PARAM_KEYS.has(key));
   if (unknownKeys.length > 0) {
     throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
@@ -493,9 +495,11 @@ function parseAppsQueryParams(params: Record<string, string>): AppsQueryOptions 
     platform = platformRaw;
   }
 
-  let type: AppsQueryType | undefined;
+  // Documented default is "user" (see registerAppResources / listApps guidance) — an
+  // omitted type must not silently return every app, including system ones (#6155).
+  let type: AppsQueryType = "user";
   if (typeRaw) {
-    if (typeRaw !== "user" && typeRaw !== "system") {
+    if (typeRaw !== "user" && typeRaw !== "system" && typeRaw !== "all") {
       throw new Error(`Invalid type: ${typeRaw}`);
     }
     type = typeRaw;
@@ -532,14 +536,18 @@ function buildAppsUri(options: AppsQueryOptions): string {
   return queryString ? `${APPS_RESOURCE_URIS.BASE}?${queryString}` : APPS_RESOURCE_URIS.BASE;
 }
 
-function filterAppsByQuery(
+// Exported for tests: pure filtering, no device/cache I/O (#6155).
+export function filterAppsByQuery(
   apps: AppsQueryAppInfo[],
   options: AppsQueryOptions,
 ): AppsQueryAppInfo[] {
   const searchTerm = options.search?.toLowerCase();
+  // Documented default is "user" (#6155) — an omitted type must not fall through
+  // to "no filter" and return system apps too.
+  const effectiveType = options.type ?? "user";
 
   return apps.filter((app) => {
-    if (options.type && app.type !== options.type) {
+    if (effectiveType !== "all" && app.type !== effectiveType) {
       return false;
     }
 
@@ -584,41 +592,54 @@ async function getAppsQueryDevice(options: AppsQueryOptions): Promise<BootedDevi
   throw new Error(`Device not found or not booted: ${options.deviceId}`);
 }
 
+/**
+ * Resolves the target device and returns the filtered installed-apps content
+ * for it, applying the documented `type` default (see filterAppsByQuery).
+ * Shared by the `apps` resource and the `listApps` tool (#6155) so both honor
+ * the same default and filtering behavior. Throws on failure — callers that
+ * need a resource-shaped error payload should catch via getAppsQueryResource.
+ */
+export async function queryInstalledApps(
+  options: AppsQueryOptions,
+): Promise<AppsQueryResourceContent> {
+  const device = await getAppsQueryDevice(options);
+  const cacheEntry = await ensureAppsCacheEntry(device.deviceId);
+  if (!cacheEntry) {
+    throw new Error(`Device not found or not booted: ${device.deviceId}`);
+  }
+
+  const apps = filterAppsByQuery(cacheEntry.queryApps, options);
+  const deviceEntries: AppsQueryDeviceContent[] = [
+    {
+      deviceId: device.deviceId,
+      platform: device.platform,
+      totalCount: apps.length,
+      lastUpdated: cacheEntry.content.lastUpdated,
+      apps,
+    },
+  ];
+
+  const parsed = Date.parse(cacheEntry.content.lastUpdated);
+  const lastUpdated = Number.isNaN(parsed)
+    ? new Date().toISOString()
+    : new Date(parsed).toISOString();
+
+  return {
+    query: { ...options, type: options.type ?? "user" },
+    observationComplete: cacheEntry.content.observationComplete,
+    totalCount: apps.length,
+    deviceCount: 1,
+    lastUpdated,
+    devices: deviceEntries,
+  };
+}
+
 async function getAppsQueryResource(
   options: AppsQueryOptions,
   uri: string,
 ): Promise<ResourceContent> {
   try {
-    const device = await getAppsQueryDevice(options);
-    const cacheEntry = await ensureAppsCacheEntry(device.deviceId);
-    if (!cacheEntry) {
-      throw new Error(`Device not found or not booted: ${device.deviceId}`);
-    }
-
-    const apps = filterAppsByQuery(cacheEntry.queryApps, options);
-    const deviceEntries: AppsQueryDeviceContent[] = [
-      {
-        deviceId: device.deviceId,
-        platform: device.platform,
-        totalCount: apps.length,
-        lastUpdated: cacheEntry.content.lastUpdated,
-        apps,
-      },
-    ];
-
-    const parsed = Date.parse(cacheEntry.content.lastUpdated);
-    const lastUpdated = Number.isNaN(parsed)
-      ? new Date().toISOString()
-      : new Date(parsed).toISOString();
-
-    const content: AppsQueryResourceContent = {
-      query: options,
-      observationComplete: cacheEntry.content.observationComplete,
-      totalCount: apps.length,
-      deviceCount: 1,
-      lastUpdated,
-      devices: deviceEntries,
-    };
+    const content = await queryInstalledApps(options);
 
     if (options.deviceId) {
       recordAppsQueryUri(options.deviceId, uri);

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -738,9 +738,7 @@ export async function queryInstalledApps(
   // An EXPLICIT type=system/type=user filter on a physical iOS device with no
   // reliable classification signal must not silently return an empty (or
   // over-inclusive) result — that reads as "no system apps exist" rather than
-  // "we can't tell". type=all (or an omitted filter, which only ever widens
-  // to "everything" here since every unclassified app already defaults to
-  // "user") is unaffected (#6216 review, round 5).
+  // "we can't tell". type=all is unaffected (#6216 review, round 5).
   if (
     options.type !== undefined &&
     options.type !== "all" &&
@@ -752,8 +750,24 @@ export async function queryInstalledApps(
         "Use type=all (or omit type) to list every app.",
     );
   }
+  // An OMITTED type on such a device is the more common case, and must not be
+  // silently defaulted to "user" either: `--include-all-apps` is passed
+  // unconditionally when listing a physical device (DeviceAppManager), so the
+  // cached apps already include system records, and every unclassified one
+  // was defaulted to "user" (extractIosApplicationType). Applying the normal
+  // "user" default filter here would therefore let system apps straight
+  // through while the response still claimed `query.type: "user"` — exactly
+  // the over-inclusive-but-mislabeled result Codex flagged (#6216 review,
+  // round 6). Report the effective type as "all" (the truthful description
+  // of what this transport can actually filter) and skip the "user" default
+  // filter, rather than rejecting the common omitted-type call outright.
+  const effectiveType: AppsQueryType =
+    options.type === undefined && cacheEntry.iosTypeClassificationUnreliable
+      ? "all"
+      : (options.type ?? "user");
+  const effectiveOptions: AppsQueryOptions = { ...options, type: effectiveType };
 
-  const apps = filterAppsByQuery(cacheEntry.queryApps, options);
+  const apps = filterAppsByQuery(cacheEntry.queryApps, effectiveOptions);
   const deviceEntries: AppsQueryDeviceContent[] = [
     {
       deviceId: device.deviceId,
@@ -770,7 +784,7 @@ export async function queryInstalledApps(
     : new Date(parsed).toISOString();
 
   return {
-    query: { ...options, type: options.type ?? "user" },
+    query: effectiveOptions,
     observationComplete: cacheEntry.content.observationComplete,
     totalCount: apps.length,
     deviceCount: 1,

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -619,7 +619,11 @@ export function filterAppsByQuery(
   apps: AppsQueryAppInfo[],
   options: AppsQueryOptions,
 ): AppsQueryAppInfo[] {
-  const searchTerm = options.search?.toLowerCase();
+  // Trim + lowercase so callers get case-insensitive, whitespace-tolerant
+  // search (" Camera " matches "Camera") whether search arrives from the
+  // listApps tool schema (unnormalized) or the apps resource's query string
+  // (#6216 review).
+  const searchTerm = options.search?.trim().toLowerCase() || undefined;
   // Documented default is "user" (#6155) — an omitted type must not fall through
   // to "no filter" and return system apps too.
   const effectiveType = options.type ?? "user";

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -109,6 +109,13 @@ interface AppsCacheEntry {
   content: AppsResourceContent;
   appsByPackage: Map<string, InstalledAppInfo[]>;
   queryApps: AppsQueryAppInfo[];
+  /**
+   * True when at least one iOS app on this (physical) device could not be
+   * reliably classified user/system (#6216 review, round 5). Gates whether an
+   * explicit type=system/type=user filter is honored or rejected — see
+   * queryInstalledApps. Always false/undefined for Android and the simulator.
+   */
+  iosTypeClassificationUnreliable?: boolean;
 }
 
 const APPS_CACHE_TTL_MS = 60000;
@@ -251,13 +258,19 @@ function extractIosPath(app: Record<string, unknown>): string | undefined {
  *    silently drop them from `type=user`. Without a reliable signal there,
  *    default to "user" rather than guessing "system" (#6216 review).
  */
+const IOS_APPLICATION_TYPE_KEYS = ["ApplicationType", "applicationType", "type", "Type"];
+
+function readIosRawApplicationType(app: Record<string, unknown>): string | undefined {
+  return readIosAppField(app, IOS_APPLICATION_TYPE_KEYS);
+}
+
 // Exported for tests: pure classification, no device/cache I/O (#6155).
 export function extractIosApplicationType(
   app: Record<string, unknown>,
   bundleId: string,
   isPhysicalDevice: boolean,
 ): InstalledAppType {
-  const raw = readIosAppField(app, ["ApplicationType", "applicationType", "type", "Type"]);
+  const raw = readIosRawApplicationType(app);
   if (raw) {
     const normalized = raw.toLowerCase();
     if (normalized === "system" || normalized === "hidden") {
@@ -271,6 +284,23 @@ export function extractIosApplicationType(
     return "user";
   }
   return bundleId.startsWith("com.apple.") ? "system" : "user";
+}
+
+/**
+ * True when `extractIosApplicationType` had no reliable signal and had to
+ * default a physical-device app to "user" — i.e. devicectl reported no
+ * `ApplicationType`-equivalent field. An explicit `type=system`/`type=user`
+ * filter must not be silently applied against such apps: it would report an
+ * empty or over-inclusive result that looks like "no system apps exist"
+ * rather than "we can't tell" (#6216 review, round 5). Always false on the
+ * simulator and for apps that do carry a real classification.
+ */
+// Exported for tests: pure check, no device/cache I/O (#6216 review, round 5).
+export function isIosApplicationTypeUnclassified(
+  app: Record<string, unknown>,
+  isPhysicalDevice: boolean,
+): boolean {
+  return isPhysicalDevice && !readIosRawApplicationType(app);
 }
 
 // Exported for tests: pure conversion, no device/cache I/O (#6216 review).
@@ -460,20 +490,21 @@ async function fetchAppsForDevice(
   const apps: IosInstalledAppInfo[] = [];
   const queryApps: AppsQueryAppInfo[] = [];
   const isPhysicalDevice = isIosPhysicalUdid(device.deviceId);
+  let iosTypeClassificationUnreliable = false;
 
   for (const app of result.apps) {
     const bundleId = getIosInstalledAppBundleId(app);
     if (!bundleId) {
       continue;
     }
-    const displayName = extractIosDisplayName(app as Record<string, unknown>);
-    const version = extractIosVersion(app as Record<string, unknown>);
-    const path = extractIosPath(app as Record<string, unknown>);
-    const type = extractIosApplicationType(
-      app as Record<string, unknown>,
-      bundleId,
-      isPhysicalDevice,
-    );
+    const rawApp = app as Record<string, unknown>;
+    const displayName = extractIosDisplayName(rawApp);
+    const version = extractIosVersion(rawApp);
+    const path = extractIosPath(rawApp);
+    const type = extractIosApplicationType(rawApp, bundleId, isPhysicalDevice);
+    if (isIosApplicationTypeUnclassified(rawApp, isPhysicalDevice)) {
+      iosTypeClassificationUnreliable = true;
+    }
     const info: IosInstalledAppInfo = {
       bundleId,
       type,
@@ -494,6 +525,7 @@ async function fetchAppsForDevice(
       content: createAppsResourceContent(device, apps, null, lastUpdated, result.successful),
       appsByPackage: buildAppsByPackage(apps),
       queryApps,
+      iosTypeClassificationUnreliable,
     },
   };
 }
@@ -573,9 +605,13 @@ export function parseAppsQueryParams(params: Record<string, string>): AppsQueryO
     platform = platformRaw;
   }
 
-  // Documented default is "user" (see registerAppResources / listApps guidance) — an
-  // omitted type must not silently return every app, including system ones (#6155).
-  let type: AppsQueryType = "user";
+  // Left undefined (not defaulted here) when omitted so callers downstream can
+  // tell "no type filter was requested" apart from an explicit "user"/"system"
+  // request — needed to reject an explicit filter on a physical iOS device
+  // where classification is unavailable (#6216 review, round 5) without also
+  // rejecting the default, silently-lenient case. filterAppsByQuery still
+  // applies the documented "user" default (#6155) when this is undefined.
+  let type: AppsQueryType | undefined;
   if (typeRaw) {
     if (typeRaw !== "user" && typeRaw !== "system" && typeRaw !== "all") {
       throw new Error(`Invalid type: ${typeRaw}`);
@@ -697,6 +733,23 @@ export async function queryInstalledApps(
   if (!cacheEntry.content.observationComplete) {
     throw new Error(
       `Failed to list installed apps for device ${device.deviceId}: the app-listing command did not complete successfully`,
+    );
+  }
+  // An EXPLICIT type=system/type=user filter on a physical iOS device with no
+  // reliable classification signal must not silently return an empty (or
+  // over-inclusive) result — that reads as "no system apps exist" rather than
+  // "we can't tell". type=all (or an omitted filter, which only ever widens
+  // to "everything" here since every unclassified app already defaults to
+  // "user") is unaffected (#6216 review, round 5).
+  if (
+    options.type !== undefined &&
+    options.type !== "all" &&
+    cacheEntry.iosTypeClassificationUnreliable
+  ) {
+    throw new Error(
+      `Cannot filter by type=${options.type} for device ${device.deviceId}: iOS user/system ` +
+        "app classification is not available on this transport (physical device via devicectl). " +
+        "Use type=all (or omit type) to list every app.",
     );
   }
 

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -712,10 +712,18 @@ async function getAppsQueryDevice(options: AppsQueryOptions): Promise<BootedDevi
 
 /**
  * Resolves the target device and returns the filtered installed-apps content
- * for it, applying the documented `type` default (see filterAppsByQuery).
- * Shared by the `apps` resource and the `listApps` tool (#6155) so both honor
- * the same default and filtering behavior. Throws on failure — callers that
- * need a resource-shaped error payload should catch via getAppsQueryResource.
+ * for it, applying the documented `type` default (see filterAppsByQuery):
+ * an omitted `type` defaults to "user" everywhere EXCEPT a physical iOS
+ * device whose devicectl listing carries no user/system classification
+ * signal (`iosTypeClassificationUnreliable`) — there, an omitted `type`
+ * returns every app and reports `query.type: "all"` (the "user" default
+ * would otherwise silently let system apps through under a "user" label),
+ * and an explicit `type=user`/`type=system` is rejected rather than
+ * honored against data we cannot actually classify (#6216 review, rounds
+ * 5-6). Shared by the `apps` resource and the `listApps` tool (#6155) so
+ * both honor the same default and filtering behavior. Throws on failure —
+ * callers that need a resource-shaped error payload should catch via
+ * getAppsQueryResource.
  */
 export async function queryInstalledApps(
   options: AppsQueryOptions,

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -419,7 +419,12 @@ export const listAppsSchema = addDeviceTargetingToSchema(
     type: z
       .enum(["user", "system", "all"])
       .optional()
-      .describe("Filter by app type. Defaults to 'user'."),
+      .describe(
+        "Filter by app type. Defaults to 'user', EXCEPT on a physical iOS device where " +
+          "user/system classification is unavailable (devicectl reports no such signal there): " +
+          "on such a device an omitted type returns every app (reported as 'all'), and an " +
+          "explicit 'user' or 'system' filter is rejected rather than silently honored.",
+      ),
     search: z
       .string()
       .optional()

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -804,6 +804,12 @@ export function registerAppTools() {
     "List installed apps on a device. Filters by type (default: user), search, and profile.",
     listAppsSchema,
     listAppsHandler,
-    { defaultEnabled: true },
+    {
+      defaultEnabled: true,
+      // Listing installed apps only needs adb/simctl/devicectl — never CtrlProxy
+      // automation — so it should not pay for (or trigger) automation-readiness
+      // setup on the target device (#6216 review).
+      deviceReadiness: "booted",
+    },
   );
 }

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -7,6 +7,7 @@ import {
   type LaunchAppResult,
   type TerminateAppResult,
 } from "../models";
+import { toActionableError } from "../models/ActionableError";
 import { CrashApp } from "../features/action/CrashApp";
 import { LaunchApp } from "../features/action/LaunchApp";
 import { TerminateApp } from "../features/action/TerminateApp";
@@ -27,17 +28,18 @@ import {
   withJsonSchemaOverride,
 } from "./toolSchemaHelpers";
 import {
-  APPS_RESOURCE_URIS,
-  APP_RESOURCE_TEMPLATES,
   invalidateInstalledAppsCache,
   invalidateInstalledAppResourceCache,
   notifyInstalledAppResourceUpdated,
+  queryInstalledApps,
+  type AppsQueryType,
 } from "./appResources";
 import { logger } from "../utils/logger";
 import { isDeviceLostError } from "./deviceLossOutcome";
 
 export interface ListAppsToolDependencies {
   toolResponseFormatter: ToolResponseFormatter;
+  queryInstalledApps: typeof queryInstalledApps;
 }
 
 let listAppsToolDependencies: ListAppsToolDependencies | null = null;
@@ -46,6 +48,7 @@ function getListAppsToolDependencies(): ListAppsToolDependencies {
   if (!listAppsToolDependencies) {
     listAppsToolDependencies = {
       toolResponseFormatter: new DefaultToolResponseFormatter(),
+      queryInstalledApps,
     };
   }
   return listAppsToolDependencies;
@@ -55,6 +58,7 @@ export function setListAppsToolDependencies(deps: Partial<ListAppsToolDependenci
   const currentDeps = getListAppsToolDependencies();
   listAppsToolDependencies = {
     toolResponseFormatter: deps.toolResponseFormatter ?? currentDeps.toolResponseFormatter,
+    queryInstalledApps: deps.queryInstalledApps ?? currentDeps.queryInstalledApps,
   };
 }
 
@@ -410,7 +414,30 @@ export const resetKeychainSchema = withAppIdAliases(
   ),
 );
 
-export const listAppsSchema = z.object({}).passthrough();
+export const listAppsSchema = addDeviceTargetingToSchema(
+  z.object({
+    type: z
+      .enum(["user", "system", "all"])
+      .optional()
+      .describe("Filter by app type. Defaults to 'user'."),
+    search: z
+      .string()
+      .optional()
+      .describe("Filter by a case-insensitive substring of the package name or display name."),
+    profile: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Filter to apps visible to this user profile id."),
+  }),
+);
+
+export interface ListAppsArgs {
+  type?: AppsQueryType;
+  search?: string;
+  profile?: number;
+}
 
 // Export interfaces for type safety
 export interface AppActionArgs {
@@ -446,28 +473,24 @@ export type ResetKeychainArgs = z.infer<typeof resetKeychainSchema>;
 
 // Register tools
 export function registerAppTools() {
-  const listAppsHandler = async () => {
-    const { toolResponseFormatter } = getListAppsToolDependencies();
-    return toolResponseFormatter.createJSONToolResponse({
-      message:
-        "To list installed apps, follow this workflow:\n\n" +
-        "1. Get available devices:\n" +
-        "   Read resource: automobile:devices/booted\n\n" +
-        "2. List apps for a specific device (using deviceId from step 1):\n" +
-        "   Read resource: automobile:devices/{deviceId}/apps\n" +
-        "   Or query format: automobile:apps?deviceId={deviceId}\n\n" +
-        "Optional query filters:\n" +
-        "  - type=user|system (default: user)\n" +
-        "  - search=<term> (filter by package name)\n" +
-        "  - profile=<userId> (filter by user profile)\n\n" +
-        "Example: automobile:apps?deviceId=emulator-5554&type=system&search=google",
-      resources: [
-        "automobile:devices/booted",
-        APP_RESOURCE_TEMPLATES.DEVICE_APPS,
-        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}",
-      ],
-      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported.",
-    });
+  const listAppsHandler = async (device: BootedDevice, args: ListAppsArgs) => {
+    const { toolResponseFormatter, queryInstalledApps: queryApps } = getListAppsToolDependencies();
+    try {
+      const content = await queryApps({
+        deviceId: device.deviceId,
+        platform: device.platform,
+        type: args.type,
+        search: args.search,
+        profile: args.profile,
+      });
+
+      return toolResponseFormatter.createJSONToolResponse({
+        message: `Found ${content.totalCount} app(s) on ${device.deviceId}`,
+        ...content,
+      });
+    } catch (error) {
+      throw toActionableError(error, `Failed to list apps for device ${device.deviceId}`);
+    }
   };
 
   // Launch app handler
@@ -772,9 +795,9 @@ export function registerAppTools() {
     { defaultEnabled: false },
   );
 
-  ToolRegistry.register(
+  ToolRegistry.registerDeviceAware(
     "listApps",
-    "Guide for listing apps via MCP resources",
+    "List installed apps on a device. Filters by type (default: user), search, and profile.",
     listAppsSchema,
     listAppsHandler,
     { defaultEnabled: true },

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -423,7 +423,11 @@ export const listAppsSchema = addDeviceTargetingToSchema(
     search: z
       .string()
       .optional()
-      .describe("Filter by a case-insensitive substring of the package name or display name."),
+      .describe(
+        "Filter by a case-insensitive substring of the package name/bundle id. Also matches " +
+          "the app's display name where the platform reports one (iOS only today — Android's " +
+          "listing does not include app labels).",
+      ),
     profile: z
       .number()
       .int()

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -363,7 +363,7 @@ class ResourceRegistryClass {
           `  - automobile:devices/{deviceId}/apps - List apps for a device\n` +
           `  - automobile:apps?deviceId={deviceId} - Query apps with filters\n` +
           `  - automobile:observation/latest - Latest screen observation\n\n` +
-          `Use the listApps tool for detailed guidance on listing apps.`,
+          `Use the listApps tool to list apps directly (params: deviceId, type, search, profile; default type=user).`,
       );
     });
 

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -363,7 +363,7 @@ class ResourceRegistryClass {
           `  - automobile:devices/{deviceId}/apps - List apps for a device\n` +
           `  - automobile:apps?deviceId={deviceId} - Query apps with filters\n` +
           `  - automobile:observation/latest - Latest screen observation\n\n` +
-          `Use the listApps tool to list apps directly (params: deviceId, type, search, profile; default type=user).`,
+          `Use the listApps tool to list apps directly (params: device, type, search, profile; default type=user).`,
       );
     });
 

--- a/test/server/appResources.filterAppsByQuery.test.ts
+++ b/test/server/appResources.filterAppsByQuery.test.ts
@@ -45,6 +45,40 @@ describe("filterAppsByQuery type default (#6155)", () => {
   });
 });
 
+describe("filterAppsByQuery search normalization (#6216 review)", () => {
+  const cameraApp: AppsQueryAppInfo = {
+    packageName: "com.example.camera",
+    type: "user",
+    foreground: false,
+    recent: false,
+    displayName: "Camera",
+  };
+  const otherApp: AppsQueryAppInfo = {
+    packageName: "com.example.other",
+    type: "user",
+    foreground: false,
+    recent: false,
+    displayName: "Other",
+  };
+  const searchApps = [cameraApp, otherApp];
+
+  test("a search term with surrounding whitespace and different case still matches (' Camera ')", () => {
+    expect(filterAppsByQuery(searchApps, { type: "all", search: " Camera " })).toEqual([cameraApp]);
+  });
+
+  test("an all-whitespace search term is treated as no filter", () => {
+    expect(filterAppsByQuery(searchApps, { type: "all", search: "   " })).toEqual(searchApps);
+  });
+
+  test("a non-matching search term still excludes apps", () => {
+    expect(filterAppsByQuery(searchApps, { type: "all", search: " zzz " })).toEqual([]);
+  });
+
+  test("case/whitespace-insensitive matching also works against the package name", () => {
+    expect(filterAppsByQuery(searchApps, { type: "all", search: " CAMERA " })).toEqual([cameraApp]);
+  });
+});
+
 describe("parseAppsQueryParams type default (#6155)", () => {
   test("omitted type parses to the documented default of user", () => {
     const options = parseAppsQueryParams({ deviceId: "emulator-5554" });

--- a/test/server/appResources.filterAppsByQuery.test.ts
+++ b/test/server/appResources.filterAppsByQuery.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  filterAppsByQuery,
+  parseAppsQueryParams,
+  type AppsQueryAppInfo,
+} from "../../src/server/appResources";
+
+const userApp: AppsQueryAppInfo = {
+  packageName: "com.example.userapp",
+  type: "user",
+  foreground: false,
+  recent: false,
+};
+
+const systemApp: AppsQueryAppInfo = {
+  packageName: "com.android.systemui",
+  type: "system",
+  foreground: false,
+  recent: false,
+};
+
+const apps: AppsQueryAppInfo[] = [userApp, systemApp];
+
+describe("filterAppsByQuery type default (#6155)", () => {
+  test("omitted type defaults to user, not all apps", () => {
+    const result = filterAppsByQuery(apps, {});
+    expect(result).toEqual([userApp]);
+  });
+
+  test("type=system returns only system apps", () => {
+    const result = filterAppsByQuery(apps, { type: "system" });
+    expect(result).toEqual([systemApp]);
+  });
+
+  test("type=user returns only user apps", () => {
+    const result = filterAppsByQuery(apps, { type: "user" });
+    expect(result).toEqual([userApp]);
+  });
+
+  test("type=all returns every app, bypassing the default filter", () => {
+    const result = filterAppsByQuery(apps, { type: "all" });
+    expect(result).toEqual(apps);
+  });
+});
+
+describe("parseAppsQueryParams type default (#6155)", () => {
+  test("omitted type parses to the documented default of user", () => {
+    const options = parseAppsQueryParams({ deviceId: "emulator-5554" });
+    expect(options.type).toBe("user");
+  });
+
+  test("explicit type=all is accepted and preserved", () => {
+    const options = parseAppsQueryParams({ deviceId: "emulator-5554", type: "all" });
+    expect(options.type).toBe("all");
+  });
+
+  test("explicit type=system is accepted and preserved", () => {
+    const options = parseAppsQueryParams({ deviceId: "emulator-5554", type: "system" });
+    expect(options.type).toBe("system");
+  });
+
+  test("an invalid type still throws", () => {
+    expect(() => parseAppsQueryParams({ deviceId: "emulator-5554", type: "bogus" })).toThrow(
+      "Invalid type: bogus",
+    );
+  });
+});

--- a/test/server/appResources.filterAppsByQuery.test.ts
+++ b/test/server/appResources.filterAppsByQuery.test.ts
@@ -80,9 +80,12 @@ describe("filterAppsByQuery search normalization (#6216 review)", () => {
 });
 
 describe("parseAppsQueryParams type default (#6155)", () => {
-  test("omitted type parses to the documented default of user", () => {
+  test("omitted type is left undefined (filterAppsByQuery applies the 'user' default, not this parser)", () => {
+    // Left undefined so queryInstalledApps can tell "no filter requested" apart
+    // from an explicit type=user, which matters for the physical-iOS
+    // unreliable-classification rejection (#6216 review, round 5).
     const options = parseAppsQueryParams({ deviceId: "emulator-5554" });
-    expect(options.type).toBe("user");
+    expect(options.type).toBeUndefined();
   });
 
   test("explicit type=all is accepted and preserved", () => {

--- a/test/server/appResources.filterAppsByQuery.test.ts
+++ b/test/server/appResources.filterAppsByQuery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  extractIosApplicationType,
   filterAppsByQuery,
   parseAppsQueryParams,
   type AppsQueryAppInfo,
@@ -63,5 +64,61 @@ describe("parseAppsQueryParams type default (#6155)", () => {
     expect(() => parseAppsQueryParams({ deviceId: "emulator-5554", type: "bogus" })).toThrow(
       "Invalid type: bogus",
     );
+  });
+});
+
+describe("extractIosApplicationType iOS user/system classification (#6155)", () => {
+  test("simctl's explicit ApplicationType: System is classified as system", () => {
+    expect(extractIosApplicationType({ ApplicationType: "System" }, "com.apple.mobilesafari")).toBe(
+      "system",
+    );
+  });
+
+  test("simctl's ApplicationType: Hidden is classified as system", () => {
+    expect(extractIosApplicationType({ ApplicationType: "Hidden" }, "com.apple.springboard")).toBe(
+      "system",
+    );
+  });
+
+  test("simctl's ApplicationType: User is classified as user even under com.apple.", () => {
+    // A user-installed app can legitimately carry a com.apple. bundle id in
+    // fixtures/tests; an explicit ApplicationType always wins over the
+    // bundle-id fallback heuristic.
+    expect(extractIosApplicationType({ ApplicationType: "User" }, "com.apple.example")).toBe(
+      "user",
+    );
+  });
+
+  test("no ApplicationType field falls back to the com.apple. bundle-id namespace (devicectl)", () => {
+    expect(extractIosApplicationType({}, "com.apple.mobilesafari")).toBe("system");
+    expect(extractIosApplicationType({}, "com.example.myapp")).toBe("user");
+  });
+});
+
+describe("iOS apps are classified before the type=user default is applied (#6155)", () => {
+  const iosUserApp: AppsQueryAppInfo = {
+    packageName: "com.example.myapp",
+    type: "user",
+    foreground: false,
+    recent: false,
+  };
+  const iosSystemApp: AppsQueryAppInfo = {
+    packageName: "com.apple.mobilesafari",
+    type: "system",
+    foreground: false,
+    recent: false,
+  };
+  const iosApps = [iosUserApp, iosSystemApp];
+
+  test("default (omitted type) excludes iOS system apps, matching Android", () => {
+    expect(filterAppsByQuery(iosApps, {})).toEqual([iosUserApp]);
+  });
+
+  test("type=system returns only iOS system apps", () => {
+    expect(filterAppsByQuery(iosApps, { type: "system" })).toEqual([iosSystemApp]);
+  });
+
+  test("type=all returns every iOS app", () => {
+    expect(filterAppsByQuery(iosApps, { type: "all" })).toEqual(iosApps);
   });
 });

--- a/test/server/appResources.filterAppsByQuery.test.ts
+++ b/test/server/appResources.filterAppsByQuery.test.ts
@@ -3,6 +3,7 @@ import {
   extractIosApplicationType,
   filterAppsByQuery,
   parseAppsQueryParams,
+  toQueryIosApp,
   type AppsQueryAppInfo,
 } from "../../src/server/appResources";
 
@@ -68,30 +69,50 @@ describe("parseAppsQueryParams type default (#6155)", () => {
 });
 
 describe("extractIosApplicationType iOS user/system classification (#6155)", () => {
-  test("simctl's explicit ApplicationType: System is classified as system", () => {
-    expect(extractIosApplicationType({ ApplicationType: "System" }, "com.apple.mobilesafari")).toBe(
-      "system",
-    );
+  test("simctl's explicit ApplicationType: System is classified as system (simulator)", () => {
+    expect(
+      extractIosApplicationType({ ApplicationType: "System" }, "com.apple.mobilesafari", false),
+    ).toBe("system");
   });
 
-  test("simctl's ApplicationType: Hidden is classified as system", () => {
-    expect(extractIosApplicationType({ ApplicationType: "Hidden" }, "com.apple.springboard")).toBe(
-      "system",
-    );
+  test("simctl's ApplicationType: Hidden is classified as system (simulator)", () => {
+    expect(
+      extractIosApplicationType({ ApplicationType: "Hidden" }, "com.apple.springboard", false),
+    ).toBe("system");
   });
 
-  test("simctl's ApplicationType: User is classified as user even under com.apple.", () => {
+  test("simctl's ApplicationType: User is classified as user even under com.apple. (simulator)", () => {
     // A user-installed app can legitimately carry a com.apple. bundle id in
     // fixtures/tests; an explicit ApplicationType always wins over the
     // bundle-id fallback heuristic.
-    expect(extractIosApplicationType({ ApplicationType: "User" }, "com.apple.example")).toBe(
+    expect(extractIosApplicationType({ ApplicationType: "User" }, "com.apple.example", false)).toBe(
       "user",
     );
   });
 
-  test("no ApplicationType field falls back to the com.apple. bundle-id namespace (devicectl)", () => {
-    expect(extractIosApplicationType({}, "com.apple.mobilesafari")).toBe("system");
-    expect(extractIosApplicationType({}, "com.example.myapp")).toBe("user");
+  test("an explicit ApplicationType also wins on a physical device", () => {
+    expect(
+      extractIosApplicationType({ ApplicationType: "System" }, "com.apple.mobilesafari", true),
+    ).toBe("system");
+    expect(extractIosApplicationType({ ApplicationType: "User" }, "com.apple.example", true)).toBe(
+      "user",
+    );
+  });
+
+  test("no ApplicationType field falls back to the com.apple. bundle-id namespace on the simulator", () => {
+    expect(extractIosApplicationType({}, "com.apple.mobilesafari", false)).toBe("system");
+    expect(extractIosApplicationType({}, "com.example.myapp", false)).toBe("user");
+  });
+
+  test("no ApplicationType field defaults to user on a PHYSICAL device (#6216 review)", () => {
+    // devicectl's `device info apps --json-output` exposes no user/system signal
+    // at all (bundleIdentifier/name/version/bundleVersion/url/appClip only), so
+    // guessing "system" from the com.apple. bundle-id prefix would misclassify a
+    // user's own Apple-published apps (Pages, Numbers, TestFlight, ...) and hide
+    // them from the default type=user query.
+    expect(extractIosApplicationType({}, "com.apple.Pages", true)).toBe("user");
+    expect(extractIosApplicationType({}, "com.apple.mobilesafari", true)).toBe("user");
+    expect(extractIosApplicationType({}, "com.example.myapp", true)).toBe("user");
   });
 });
 
@@ -120,5 +141,51 @@ describe("iOS apps are classified before the type=user default is applied (#6155
 
   test("type=all returns every iOS app", () => {
     expect(filterAppsByQuery(iosApps, { type: "all" })).toEqual(iosApps);
+  });
+});
+
+describe("toQueryIosApp always populates userIds (#6216 review)", () => {
+  test("a system app carries userIds: [0] so a profile filter does not drop it", () => {
+    const queryApp = toQueryIosApp({ bundleId: "com.apple.mobilesafari", type: "system" });
+    expect(queryApp.userIds).toEqual([0]);
+  });
+
+  test("a user app also carries userIds: [0] (iOS has a single profile)", () => {
+    const queryApp = toQueryIosApp({ bundleId: "com.example.myapp", type: "user" });
+    expect(queryApp.userIds).toEqual([0]);
+  });
+});
+
+describe("profile filtering preserves iOS system apps (#6216 review)", () => {
+  // Matches the shape toQueryIosApp actually emits: iOS has a single (profile 0)
+  // user, so every app — user or system — carries userIds: [0].
+  const iosUserApp: AppsQueryAppInfo = {
+    packageName: "com.example.myapp",
+    type: "user",
+    userId: 0,
+    userIds: [0],
+    foreground: false,
+    recent: false,
+  };
+  const iosSystemApp: AppsQueryAppInfo = {
+    packageName: "com.apple.mobilesafari",
+    type: "system",
+    userId: 0,
+    userIds: [0],
+    foreground: false,
+    recent: false,
+  };
+  const iosApps = [iosUserApp, iosSystemApp];
+
+  test("profile:0 does not drop iOS system apps under type=system", () => {
+    expect(filterAppsByQuery(iosApps, { type: "system", profile: 0 })).toEqual([iosSystemApp]);
+  });
+
+  test("profile:0 does not drop iOS system apps under type=all", () => {
+    expect(filterAppsByQuery(iosApps, { type: "all", profile: 0 })).toEqual(iosApps);
+  });
+
+  test("a non-matching profile still excludes iOS apps (the filter itself still works)", () => {
+    expect(filterAppsByQuery(iosApps, { type: "all", profile: 1 })).toEqual([]);
   });
 });

--- a/test/server/appResources.queryInstalledApps.test.ts
+++ b/test/server/appResources.queryInstalledApps.test.ts
@@ -62,3 +62,110 @@ describe("queryInstalledApps honest-failure contract (#6155)", () => {
     expect(content.totalCount).toBe(0);
   });
 });
+
+describe("queryInstalledApps rejects an unsupported type filter on a physical iOS device (#6216 review, round 5)", () => {
+  // A physical-device UDID (8 hex + '-' + 16 hex) so isIosPhysicalUdid routes
+  // through the devicectl path, which reports no ApplicationType-equivalent
+  // field — see isIosApplicationTypeUnclassified.
+  const physicalIosDevice: BootedDevice = {
+    deviceId: "00008130-001C2D3E1234567A",
+    name: "Jason's iPhone",
+    platform: "ios",
+  };
+
+  beforeEach(() => {
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setBootedDevices("ios", [physicalIosDevice]);
+    PlatformDeviceManagerFactory.setInstance(fakeDeviceUtils);
+    setListInstalledAppsFactoryForTests(() => ({
+      executeDetailedResult: async () => {
+        throw new Error("not exercised on iOS");
+      },
+      executeIosDetailedResult: async () => ({
+        apps: [
+          { bundleIdentifier: "com.example.myapp", name: "My App" },
+          { bundleIdentifier: "com.apple.mobilesafari", name: "Safari" },
+        ],
+        successful: true,
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    setListInstalledAppsFactoryForTests(null);
+    PlatformDeviceManagerFactory.setInstance(null);
+    invalidateInstalledAppsCache(physicalIosDevice.deviceId);
+  });
+
+  test("an explicit type=system is rejected rather than silently returning an empty result", async () => {
+    await expect(
+      queryInstalledApps({ deviceId: physicalIosDevice.deviceId, type: "system" }),
+    ).rejects.toThrow(/classification is not available on this transport/);
+  });
+
+  test("an explicit type=user is also rejected (classification, not just 'system', is unreliable)", async () => {
+    await expect(
+      queryInstalledApps({ deviceId: physicalIosDevice.deviceId, type: "user" }),
+    ).rejects.toThrow(/classification is not available on this transport/);
+  });
+
+  test("type=all still returns every app (no rejection)", async () => {
+    const content = await queryInstalledApps({
+      deviceId: physicalIosDevice.deviceId,
+      type: "all",
+    });
+    expect(content.totalCount).toBe(2);
+  });
+
+  test("an omitted type filter also still returns every app (no rejection)", async () => {
+    // Every unclassified physical-device app already defaults to "user"
+    // (round 4), so the documented "user" default is a no-op filter here —
+    // over-inclusive, not misleadingly empty — and must not be rejected.
+    const content = await queryInstalledApps({ deviceId: physicalIosDevice.deviceId });
+    expect(content.totalCount).toBe(2);
+  });
+});
+
+describe("queryInstalledApps still honors type filters on the iOS simulator (#6216 review, round 5)", () => {
+  // A simulator UDID (standard 8-4-4-4-12 UUID) so isIosPhysicalUdid is false
+  // and simctl's ApplicationType classification is trusted normally.
+  const simulatorDevice: BootedDevice = {
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    name: "iPhone 15 Simulator",
+    platform: "ios",
+  };
+
+  beforeEach(() => {
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setBootedDevices("ios", [simulatorDevice]);
+    PlatformDeviceManagerFactory.setInstance(fakeDeviceUtils);
+    setListInstalledAppsFactoryForTests(() => ({
+      executeDetailedResult: async () => {
+        throw new Error("not exercised on iOS");
+      },
+      executeIosDetailedResult: async () => ({
+        apps: [
+          { bundleIdentifier: "com.example.myapp", ApplicationType: "User" },
+          { bundleIdentifier: "com.apple.mobilesafari", ApplicationType: "System" },
+        ],
+        successful: true,
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    setListInstalledAppsFactoryForTests(null);
+    PlatformDeviceManagerFactory.setInstance(null);
+    invalidateInstalledAppsCache(simulatorDevice.deviceId);
+  });
+
+  test("an explicit type=system is honored, not rejected, when classification is reliable", async () => {
+    const content = await queryInstalledApps({
+      deviceId: simulatorDevice.deviceId,
+      type: "system",
+    });
+    expect(content.totalCount).toBe(1);
+  });
+});

--- a/test/server/appResources.queryInstalledApps.test.ts
+++ b/test/server/appResources.queryInstalledApps.test.ts
@@ -125,6 +125,18 @@ describe("queryInstalledApps rejects an unsupported type filter on a physical iO
     const content = await queryInstalledApps({ deviceId: physicalIosDevice.deviceId });
     expect(content.totalCount).toBe(2);
   });
+
+  test('an omitted type filter reports query.type as "all", not the misleading "user" default (#6216 review, round 6)', async () => {
+    // devicectl's --include-all-apps listing (DeviceAppManager) already
+    // includes system records, and every unclassified app defaults to type
+    // "user" (round 4) — so applying the normal "user" default filter here
+    // would let system apps straight through while the response still
+    // claimed `query.type: "user"`. That is the over-inclusive-but-mislabeled
+    // result Codex flagged: report the effective type honestly as "all".
+    const content = await queryInstalledApps({ deviceId: physicalIosDevice.deviceId });
+    expect(content.query.type).toBe("all");
+    expect(content.totalCount).toBe(2);
+  });
 });
 
 describe("queryInstalledApps still honors type filters on the iOS simulator (#6216 review, round 5)", () => {
@@ -166,6 +178,15 @@ describe("queryInstalledApps still honors type filters on the iOS simulator (#62
       deviceId: simulatorDevice.deviceId,
       type: "system",
     });
+    expect(content.totalCount).toBe(1);
+  });
+
+  test('an omitted type filter still reports and applies the documented "user" default (#6216 review, round 6)', async () => {
+    // Control case: reliable classification (simulator ApplicationType) must
+    // keep the existing "user" default behavior — only the physical-device,
+    // unreliable-classification case reports "all".
+    const content = await queryInstalledApps({ deviceId: simulatorDevice.deviceId });
+    expect(content.query.type).toBe("user");
     expect(content.totalCount).toBe(1);
   });
 });

--- a/test/server/appResources.queryInstalledApps.test.ts
+++ b/test/server/appResources.queryInstalledApps.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  invalidateInstalledAppsCache,
+  queryInstalledApps,
+  setListInstalledAppsFactoryForTests,
+} from "../../src/server/appResources";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import type { BootedDevice } from "../../src/models";
+
+const device: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 8",
+  platform: "android",
+};
+
+describe("queryInstalledApps honest-failure contract (#6155)", () => {
+  let fakeDeviceUtils: FakeDeviceUtils;
+
+  beforeEach(() => {
+    fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [device]);
+    fakeDeviceUtils.setBootedDevices("ios", []);
+    PlatformDeviceManagerFactory.setInstance(fakeDeviceUtils);
+  });
+
+  afterEach(() => {
+    setListInstalledAppsFactoryForTests(null);
+    PlatformDeviceManagerFactory.setInstance(null);
+    invalidateInstalledAppsCache(device.deviceId);
+  });
+
+  test("a failed listing command (successful:false) rejects instead of reporting an empty success", async () => {
+    setListInstalledAppsFactoryForTests(() => ({
+      executeDetailedResult: async () => ({
+        apps: { profiles: {}, system: [] },
+        successful: false,
+      }),
+      executeIosDetailedResult: async () => {
+        throw new Error("not exercised on android");
+      },
+    }));
+
+    await expect(queryInstalledApps({ deviceId: device.deviceId })).rejects.toThrow(
+      `Failed to list installed apps for device ${device.deviceId}`,
+    );
+  });
+
+  test("a successful listing with zero apps installed is reported as success, not an error", async () => {
+    setListInstalledAppsFactoryForTests(() => ({
+      executeDetailedResult: async () => ({
+        apps: { profiles: {}, system: [] },
+        successful: true,
+      }),
+      executeIosDetailedResult: async () => {
+        throw new Error("not exercised on android");
+      },
+    }));
+
+    const content = await queryInstalledApps({ deviceId: device.deviceId });
+    expect(content.observationComplete).toBe(true);
+    expect(content.totalCount).toBe(0);
+  });
+});

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -66,6 +66,22 @@ describe("listApps tool", () => {
     expect(() => tool!.schema.parse({ type: "bogus" })).toThrow();
   });
 
+  test("the device-targeting param the docs advertise (device) is actually accepted, and actually advertised (#6216 review)", () => {
+    const tool = ToolRegistry.getTool("listApps");
+    expect(tool).toBeDefined();
+    expect(() => tool!.schema.parse({ device: "Pixel 8" })).not.toThrow();
+
+    const definition = ToolRegistry.getToolDefinitions({ includeUnavailable: true }).find(
+      (candidate) => candidate.name === "listApps",
+    );
+    const properties = definition!.inputSchema.properties as Record<string, unknown>;
+    // deviceId is deliberately stripped from the advertised schema for every
+    // device-aware tool (see isInjectedDeviceIdSchema) — docs must not promise
+    // it. `device` (the device label) is the field MCP clients actually see.
+    expect(properties.device).toBeDefined();
+    expect(properties.deviceId).toBeUndefined();
+  });
+
   test("returns structured app data (not prose) for the resolved device", async () => {
     const tool = ToolRegistry.getTool("listApps");
     expect(tool).toBeDefined();

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -11,57 +11,29 @@ import {
   setTerminateAppToolDependencies,
 } from "../../src/server/appTools";
 import {
-  APP_RESOURCE_TEMPLATES,
-  APPS_RESOURCE_URIS,
   invalidateInstalledAppResourceCache,
   invalidateInstalledAppsCache,
+  type AppsQueryOptions,
+  type AppsQueryResourceContent,
 } from "../../src/server/appResources";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeToolUtils } from "../fakes/FakeToolUtils";
-import { FakeTimer } from "../fakes/FakeTimer";
 import { getInstalledAppsCacheWriteCoordinator } from "../../src/db/installedAppsCacheWriteCoordinator";
 import type { BootedDevice } from "../../src/models";
 
-const resolveWithFakeTimer = async <T>(
-  promise: Promise<T>,
-  timer: FakeTimer,
-  stepMs: number = 1,
-): Promise<T> => {
-  let settled = false;
-  let result: T | undefined;
-  let error: unknown;
-
-  promise
-    .then((value) => {
-      settled = true;
-      result = value;
-    })
-    .catch((caught) => {
-      settled = true;
-      error = caught;
-    });
-
-  let steps = 0;
-  while (!settled) {
-    if (
-      timer.getPendingTimeoutCount() > 0 ||
-      timer.getPendingIntervalCount() > 0 ||
-      timer.getPendingSleepCount() > 0
-    ) {
-      timer.advanceTime(stepMs);
-    }
-    await new Promise((resolve) => setImmediate(resolve));
-    steps += 1;
-    if (steps > 100) {
-      throw new Error("FakeTimer pump exceeded max steps");
-    }
-  }
-
-  if (error) {
-    throw error;
-  }
-  return result as T;
-};
+function fakeAppsContent(
+  overrides: Partial<AppsQueryResourceContent> = {},
+): AppsQueryResourceContent {
+  return {
+    query: { deviceId: "emulator-5554", type: "user" },
+    observationComplete: true,
+    totalCount: 0,
+    deviceCount: 1,
+    lastUpdated: new Date(0).toISOString(),
+    devices: [],
+    ...overrides,
+  };
+}
 
 describe("listApps tool", () => {
   beforeEach(() => {
@@ -77,51 +49,102 @@ describe("listApps tool", () => {
     resetTerminateAppToolDependencies();
   });
 
-  test("registers listApps tool with a permissive schema", () => {
+  const device: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel 8",
+    platform: "android",
+  };
+
+  test("registers listApps as a device-aware tool accepting type/search/profile", () => {
     const tool = ToolRegistry.getTool("listApps");
     expect(tool).toBeDefined();
+    expect(tool?.requiresDevice).toBe(true);
+    expect(tool?.deviceAwareHandler).toBeDefined();
     expect(() => tool!.schema.parse({})).not.toThrow();
     expect(() => tool!.schema.parse({ deviceId: "device-123" })).not.toThrow();
+    expect(() => tool!.schema.parse({ type: "system", search: "clock", profile: 0 })).not.toThrow();
+    expect(() => tool!.schema.parse({ type: "bogus" })).toThrow();
   });
 
-  test("returns MCP resource guidance using a fake formatter and FakeTimer", async () => {
+  test("returns structured app data (not prose) for the resolved device", async () => {
     const tool = ToolRegistry.getTool("listApps");
     expect(tool).toBeDefined();
 
     const fakeToolUtils = new FakeToolUtils();
-    setListAppsToolDependencies({ toolResponseFormatter: fakeToolUtils });
+    let capturedOptions: AppsQueryOptions | undefined;
+    const fakeContent = fakeAppsContent({
+      totalCount: 1,
+      devices: [
+        {
+          deviceId: device.deviceId,
+          platform: device.platform,
+          totalCount: 1,
+          lastUpdated: new Date(0).toISOString(),
+          apps: [
+            { packageName: "com.example.app", type: "user", foreground: false, recent: false },
+          ],
+        },
+      ],
+    });
+    setListAppsToolDependencies({
+      toolResponseFormatter: fakeToolUtils,
+      queryInstalledApps: async (options) => {
+        capturedOptions = options;
+        return fakeContent;
+      },
+    });
 
-    const fakeTimer = new FakeTimer();
+    const result = await tool!.deviceAwareHandler!(device, {});
 
-    const result = await resolveWithFakeTimer(tool!.handler({}), fakeTimer);
+    expect(capturedOptions).toEqual({
+      deviceId: device.deviceId,
+      platform: device.platform,
+      type: undefined,
+      search: undefined,
+      profile: undefined,
+    });
 
     expect(fakeToolUtils.getJSONResponseCount()).toBe(1);
     const payload = fakeToolUtils.getLastJSONResponse();
-    expect(payload).toEqual({
-      message:
-        "To list installed apps, follow this workflow:\n\n" +
-        "1. Get available devices:\n" +
-        "   Read resource: automobile:devices/booted\n\n" +
-        "2. List apps for a specific device (using deviceId from step 1):\n" +
-        "   Read resource: automobile:devices/{deviceId}/apps\n" +
-        "   Or query format: automobile:apps?deviceId={deviceId}\n\n" +
-        "Optional query filters:\n" +
-        "  - type=user|system (default: user)\n" +
-        "  - search=<term> (filter by package name)\n" +
-        "  - profile=<userId> (filter by user profile)\n\n" +
-        "Example: automobile:apps?deviceId=emulator-5554&type=system&search=google",
-      resources: [
-        "automobile:devices/booted",
-        APP_RESOURCE_TEMPLATES.DEVICE_APPS,
-        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}",
-      ],
-      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported.",
-    });
+    expect(typeof payload.message).toBe("string");
+    expect(payload.devices).toEqual(fakeContent.devices);
+    expect(payload.totalCount).toBe(1);
 
     const content = result.content?.[0];
     expect(content?.type).toBe("text");
-    expect(content?.text).toBeDefined();
     expect(JSON.parse(content!.text)).toEqual(payload);
+  });
+
+  test("passes an explicit type filter through to the query", async () => {
+    const tool = ToolRegistry.getTool("listApps");
+    const fakeToolUtils = new FakeToolUtils();
+    let capturedOptions: AppsQueryOptions | undefined;
+    setListAppsToolDependencies({
+      toolResponseFormatter: fakeToolUtils,
+      queryInstalledApps: async (options) => {
+        capturedOptions = options;
+        return fakeAppsContent({ query: options });
+      },
+    });
+
+    await tool!.deviceAwareHandler!(device, { type: "all", search: "clock", profile: 0 });
+
+    expect(capturedOptions?.type).toBe("all");
+    expect(capturedOptions?.search).toBe("clock");
+    expect(capturedOptions?.profile).toBe(0);
+  });
+
+  test("wraps a query failure as an ActionableError", async () => {
+    const tool = ToolRegistry.getTool("listApps");
+    setListAppsToolDependencies({
+      queryInstalledApps: async () => {
+        throw new Error("device not found");
+      },
+    });
+
+    await expect(tool!.deviceAwareHandler!(device, {})).rejects.toThrow(
+      `Failed to list apps for device ${device.deviceId}`,
+    );
   });
 
   test("keeps foreground resource invalidation separate from package cache dirtying", () => {

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -174,6 +174,37 @@ describe("listApps tool", () => {
   });
 });
 
+test("listApps only requires booted-device readiness, not full CtrlProxy automation setup (#6216 review)", () => {
+  // Mirrors the interception pattern in videoRecordingReadiness.test.ts: capture
+  // the options object passed to registerDeviceAware without driving the real
+  // resolveExecutionTarget/DeviceSessionManager pipeline.
+  ToolRegistry.clearTools();
+  const registry = ToolRegistry as any;
+  const originalRegister = registry.registerDeviceAware;
+  let capturedReadiness: unknown;
+
+  registry.registerDeviceAware = (
+    name: string,
+    _description: string,
+    _schema: unknown,
+    _handler: unknown,
+    options: any,
+  ) => {
+    if (name === "listApps") {
+      capturedReadiness = options?.deviceReadiness;
+    }
+  };
+
+  try {
+    registerAppTools();
+  } finally {
+    registry.registerDeviceAware = originalRegister;
+    ToolRegistry.clearTools();
+  }
+
+  expect(capturedReadiness).toBe("booted");
+});
+
 describe("terminateApp tool", () => {
   const device: BootedDevice = {
     deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -306,7 +306,7 @@ describe("MCP Resources Read", () => {
         "  - automobile:devices/{deviceId}/apps - List apps for a device\n" +
         "  - automobile:apps?deviceId={deviceId} - Query apps with filters\n" +
         "  - automobile:observation/latest - Latest screen observation\n\n" +
-        "Use the listApps tool for detailed guidance on listing apps.",
+        "Use the listApps tool to list apps directly (params: deviceId, type, search, profile; default type=user).",
     );
   });
 

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -306,7 +306,7 @@ describe("MCP Resources Read", () => {
         "  - automobile:devices/{deviceId}/apps - List apps for a device\n" +
         "  - automobile:apps?deviceId={deviceId} - Query apps with filters\n" +
         "  - automobile:observation/latest - Latest screen observation\n\n" +
-        "Use the listApps tool to list apps directly (params: deviceId, type, search, profile; default type=user).",
+        "Use the listApps tool to list apps directly (params: device, type, search, profile; default type=user).",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes both parts of #6155:

1. **`listApps` is now a real tool, not a documentation stub.** `listAppsHandler` is device-aware (`ToolRegistry.registerDeviceAware`) and delegates to the same query logic that backs the `apps` resource (`queryInstalledApps` in `src/server/appResources.ts`), honoring `deviceId`, `type`, `search`, and `profile`, and returning structured app data instead of a prose guide.
2. **The `apps` resource now defaults `type` to `user` when omitted**, matching its documented default. Previously an omitted `type` left `filterAppsByQuery` with no filter, returning every app (user + system, e.g. 226) instead of just the user apps the docs promised. `type=all` is now a supported explicit value for callers that want everything; `type=user`/`type=system` behave as before.

## Changes

- `src/server/appResources.ts`: extracted `queryInstalledApps` (shared by the resource and the tool), defaulted `type` to `"user"` in both `parseAppsQueryParams` and `filterAppsByQuery`, and widened `AppsQueryType` to include `"all"`.
- `src/server/appTools.ts`: `listApps` is now `registerDeviceAware` with a real schema (`type`/`search`/`profile` + device targeting), and the handler calls `queryInstalledApps` and returns structured JSON, wrapping failures as `ActionableError`.
- `test/server/appTools.listApps.test.ts`: rewritten for the new device-aware handler — verifies structured (non-prose) output, that `type`/`search`/`profile` are threaded through, and that a query failure surfaces as an `ActionableError`.
- `test/server/appResources.filterAppsByQuery.test.ts` (new): unit tests for the pure `filterAppsByQuery`/`parseAppsQueryParams` helpers confirming the default is `user`, not "all apps", and that `type=all`/`type=system` still work.
- `schemas/tool-definitions.json`: regenerated via `scripts/update-tool-definitions.sh` for the new `listApps` schema/description.

## Test evidence

- `bun test test/server/appTools.listApps.test.ts` — 12 pass
- `bun test test/server/appResources.filterAppsByQuery.test.ts` — 8 pass
- `turbo run lint build test` — 862 pass, oxlint ratchet unchanged (609 baselined)
- `bun run typecheck` — no new type errors (163 baselined)
- `bun run format:check` — clean

Closes #6155
