### PR TITLE
fix(performance): flag animating apps and move synthetic tap into app window

### DIFF
--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -240,13 +240,14 @@ export interface TouchLatencyPointDecision {
   /** A verified-inert coordinate to tap, present only when one was found. */
   touchPoint?: { x: number; y: number };
   /**
-   * True when there is no verified-inert point to tap - either `windowBounds`
-   * was undefined (no app window found), or every scanned candidate
+   * True when there is no verified-inert point to tap - `windowBounds` was
+   * undefined (no app window found), the view hierarchy was truncated (so
+   * the obstacle map may be incomplete), or every scanned candidate
    * overlapped an interactive element or a content-hidden region. The caller
    * must skip the touch-latency measurement entirely in this case rather
    * than fall through to `TouchLatencyTracker`'s own unverified default
    * point, which risks activating a full-screen button, WebView, map, or a
-   * hidden control (issue #6167).
+   * hidden or unemitted control (issue #6167).
    */
   skipTouchLatency: boolean;
 }
@@ -270,6 +271,21 @@ export function deriveTouchLatencyPoint(
     logger.warn(
       "[PerformanceAudit] Skipping touch-latency measurement: window bounds are malformed " +
         `(zero-area, inverted, or non-finite): ${JSON.stringify(windowBounds)}`,
+    );
+    return { skipTouchLatency: true };
+  }
+
+  // CtrlProxy stops emitting descendants once it hits a hard limit
+  // (`max_nodes`, `max_depth`) or is cancelled mid-walk - the resulting
+  // hierarchy is silently PARTIAL, not "no obstacles here". Certifying a
+  // point inert against an incomplete obstacle map risks tapping a real
+  // control whose node was simply never emitted (issue #6167 follow-up), so
+  // a truncated hierarchy can never produce a verified-inert point.
+  const truncationReasons = result.viewHierarchy?.truncationReasons;
+  if (truncationReasons && truncationReasons.length > 0) {
+    logger.warn(
+      "[PerformanceAudit] Skipping touch-latency measurement: view hierarchy is truncated " +
+        `(${truncationReasons.join(", ")}) - the obstacle map may be incomplete`,
     );
     return { skipTouchLatency: true };
   }

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -18,6 +18,7 @@ import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { hasAccessibilityAction, isTruthyFlag } from "../../../utils/elementProperties";
 import type { ElementParser } from "../../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../../utility/ElementParser";
+import { SYSTEM_TRAY_PACKAGE } from "../../../server/system-tray/notificationHints";
 
 /**
  * `AccessibilityWindowInfo.TYPE_APPLICATION` (Android SDK constant = 1): the
@@ -293,6 +294,18 @@ function unreliableHierarchyReason(
   if (truncationReasons && truncationReasons.length > 0) {
     return `view hierarchy is truncated (${truncationReasons.join(", ")}) - the obstacle map may be incomplete`;
   }
+  // When a SystemUI surface (status bar, notification shade, keyguard) owns
+  // focus, `ObserveScreen.reconcileActiveWindowAttribution` rewrites
+  // `activeWindow.appId` to `com.android.systemui` - but the real
+  // accessibility window entries never carry a `packageName`
+  // (`isCandidateAppWindow` above), so `findAppWindowBounds` still happily
+  // accepts the underlying type-1 APPLICATION window as "SystemUI's" window.
+  // A point certified inert there would tap the occluded app underneath
+  // while `gfxinfo` samples `com.android.systemui`, measuring the wrong
+  // surface's response entirely (issue #6167 follow-up).
+  if (result.activeWindow?.appId === SYSTEM_TRAY_PACKAGE) {
+    return `a SystemUI overlay owns focus (activeWindow.appId === "${SYSTEM_TRAY_PACKAGE}") - the app window beneath it cannot be safely probed`;
+  }
   return null;
 }
 
@@ -300,10 +313,13 @@ function unreliableHierarchyReason(
  * Single gate for every known way a capture can be too unreliable to trust
  * for a synthetic touch-latency tap: absent/malformed app window bounds, a
  * stale cached tree (`fresh: false`), an incomplete CtrlProxy capture
- * (`ctrlProxyIncomplete`), or a truncated hierarchy (`truncationReasons`).
- * Consolidated into one predicate (issue #6167 follow-up) so a future
- * reliability signal has exactly one place to live and can't be missed by
- * only patching one of several scattered checks.
+ * (`ctrlProxyIncomplete`), a truncated hierarchy (`truncationReasons`), or a
+ * SystemUI overlay owning focus (`activeWindow.appId ===
+ * "com.android.systemui"`, which can pass through a real but occluded app
+ * window as if it belonged to the overlay). Consolidated into one predicate
+ * (issue #6167 follow-up) so a future reliability signal has exactly one
+ * place to live and can't be missed by only patching one of several
+ * scattered checks.
  *
  * Content-hidden regions (`contentHiddenRegions`) are deliberately NOT a
  * blanket-reject signal here: unlike the checks above, the reliable part of

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -6,6 +6,7 @@ import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
 import type {
   BootedDevice,
   ElementBounds,
+  Element,
   ObserveResult,
   ViewHierarchyWindowInfo,
 } from "../../../models";
@@ -14,6 +15,7 @@ import {
   type AdbClientFactory,
 } from "../../../utils/android-cmdline-tools/AdbClientFactory";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import { hasAccessibilityAction, isTruthyFlag } from "../../../utils/elementProperties";
 
 /**
  * `AccessibilityWindowInfo.TYPE_APPLICATION` (Android SDK constant = 1): the
@@ -68,6 +70,98 @@ export function findAppWindowBounds(
   const candidates = windows.filter((w) => isCandidateAppWindow(w, appId));
   const focused = candidates.find((w) => w.isFocused);
   return (focused ?? candidates[0])?.bounds;
+}
+
+/**
+ * Candidate tap points as fractions of the app window's width/height,
+ * ordered by preference: window center first (most representative of "the
+ * app"), then the four quadrant centers, then a point near each edge.
+ * Deliberately avoids corners closest to a typical top app bar's
+ * overflow-menu icon.
+ */
+const INERT_POINT_CANDIDATE_FRACTIONS: ReadonlyArray<{ x: number; y: number }> = [
+  { x: 0.5, y: 0.5 }, // center
+  { x: 0.25, y: 0.25 },
+  { x: 0.75, y: 0.25 },
+  { x: 0.25, y: 0.75 },
+  { x: 0.75, y: 0.75 },
+  { x: 0.5, y: 0.08 }, // near top edge
+  { x: 0.5, y: 0.92 }, // near bottom edge
+  { x: 0.08, y: 0.5 }, // near left edge
+  { x: 0.92, y: 0.5 }, // near right edge
+];
+
+/**
+ * Least-interactive default when every scanned candidate overlapped an
+ * interactive element: near the bottom edge, away from a typical top app
+ * bar. Not guaranteed inert (a hierarchy that is a control everywhere has no
+ * inert point to offer) - callers must check `inert` on the result rather
+ * than treat this point as safe by construction.
+ */
+const FALLBACK_TOUCH_POINT_FRACTION = { x: 0.5, y: 0.95 };
+
+function isInteractiveElement(element: Element): boolean {
+  return (
+    isTruthyFlag(element.clickable) ||
+    isTruthyFlag(element.focusable) ||
+    isTruthyFlag(element["long-clickable"]) ||
+    hasAccessibilityAction(element.actions, "click") ||
+    hasAccessibilityAction(element.actions, "long_click")
+  );
+}
+
+function isPointInsideBounds(x: number, y: number, bounds: ElementBounds): boolean {
+  return x >= bounds.left && x < bounds.right && y >= bounds.top && y < bounds.bottom;
+}
+
+export interface InertTouchPointResult {
+  point: { x: number; y: number };
+  /**
+   * False when no scanned candidate avoided every interactive element - the
+   * returned point is the documented fallback default, not a verified-inert
+   * one (issue #6167).
+   */
+  inert: boolean;
+}
+
+/**
+ * Find a synthetic-touch point inside `windowBounds` that does not overlap
+ * any clickable/focusable/long-clickable element, so a touch-latency probe
+ * cannot activate a real control (tap a button, open a list item, follow a
+ * link) during what is meant to be a read-only performance audit
+ * (issue #6167). Scans a small set of candidate points (window center, then
+ * quadrant centers, then edge midpoints) and returns the first that hits no
+ * interactive element's bounds. Falls back to a documented default point
+ * when every candidate is obstructed, with `inert: false` so the caller
+ * knows the tap may still land on a control.
+ */
+export function findInertTouchPoint(
+  windowBounds: ElementBounds,
+  interactiveElements: readonly Element[],
+): InertTouchPointResult {
+  const obstacles = interactiveElements.filter((el) => el.bounds && isInteractiveElement(el));
+  const width = windowBounds.right - windowBounds.left;
+  const height = windowBounds.bottom - windowBounds.top;
+
+  const pointFor = (fraction: { x: number; y: number }): { x: number; y: number } => ({
+    x: Math.floor(windowBounds.left + width * fraction.x),
+    y: Math.floor(windowBounds.top + height * fraction.y),
+  });
+
+  for (const fraction of INERT_POINT_CANDIDATE_FRACTIONS) {
+    const point = pointFor(fraction);
+    const obstructed = obstacles.some((el) => isPointInsideBounds(point.x, point.y, el.bounds));
+    if (!obstructed) {
+      return { point, inert: true };
+    }
+  }
+
+  logger.warn(
+    "[PerformanceAudit] Could not find a fully inert touch point inside the app window " +
+      "(every scanned candidate overlapped an interactive element) - falling back to a " +
+      "default point that may still activate a control",
+  );
+  return { point: pointFor(FALLBACK_TOUCH_POINT_FRACTION), inert: false };
 }
 
 export interface PerformanceAuditorOptions {
@@ -137,13 +231,22 @@ export class PerformanceAuditor {
           capabilities,
         );
 
+        // Derive a touch point inside the app's own window that avoids
+        // activating a real control - a read-only performance audit must
+        // not tap a button, list item, or link as a side effect (#6167).
+        const windowBounds = findAppWindowBounds(result, result.activeWindow!.appId);
+        const touchPoint = windowBounds
+          ? findInertTouchPoint(windowBounds, result.elements?.clickable ?? []).point
+          : undefined;
+
         // Run the audit
         const auditResult = await performanceAudit.runAudit(
           result.activeWindow!.appId,
           thresholds,
           result.screenSize,
           perf,
-          findAppWindowBounds(result, result.activeWindow!.appId),
+          windowBounds,
+          touchPoint,
         );
 
         // Attach audit result to observe result

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -40,6 +40,15 @@ import { SYSTEM_TRAY_PACKAGE } from "../../../server/system-tray/notificationHin
  */
 const ACCESSIBILITY_WINDOW_TYPE_APPLICATION = 1;
 
+/**
+ * `ActiveWindowInfo.type` value `ObserveScreen` stamps when a
+ * notification-permission prompt owns the window (see
+ * `ObserveScreen.reconcileActiveWindowAttribution` and the other call sites
+ * of this literal in `ObserveScreen.ts` / `LaunchApp.ts`; not otherwise
+ * exported as a shared constant there, so this mirrors the literal).
+ */
+const NOTIFICATION_PERMISSION_DIALOG_WINDOW_TYPE = "notification_permission_dialog";
+
 function isCandidateAppWindow(window: ViewHierarchyWindowInfo, appId: string): boolean {
   if (!window.bounds || window.type !== ACCESSIBILITY_WINDOW_TYPE_APPLICATION) {
     return false;
@@ -259,41 +268,56 @@ export interface TouchLatencyPointDecision {
  * `deriveTouchLatencyPoint` log line can say *why* - useful when triaging a
  * report of touch-latency going unexpectedly missing.
  */
-function unreliableHierarchyReason(
+/**
+ * One reliability check, run in order by `unreliableHierarchyReason`.
+ * Returns the rejection reason, or `null` when this particular check passes.
+ * Modeled as a list (rather than a chain of `if`s in one function) so adding
+ * a future signal is a one-line addition here instead of growing a single
+ * function's complexity indefinitely (issue #6167 follow-up).
+ */
+type ReliabilityCheck = (
   windowBounds: ElementBounds | undefined,
   result: ObserveResult,
-): string | null {
-  if (!windowBounds) {
-    return "no app window bounds were found";
-  }
-  if (!isValidWindowBounds(windowBounds)) {
-    return (
-      "window bounds are malformed (zero-area, inverted, or non-finite): " +
-      JSON.stringify(windowBounds)
-    );
-  }
+) => string | null;
+
+const RELIABILITY_CHECKS: readonly ReliabilityCheck[] = [
+  (windowBounds) => (windowBounds ? null : "no app window bounds were found"),
+
+  (windowBounds) =>
+    windowBounds && !isValidWindowBounds(windowBounds)
+      ? "window bounds are malformed (zero-area, inverted, or non-finite): " +
+        JSON.stringify(windowBounds)
+      : null,
+
   // A stale cached tree was never verified against the device on this call -
   // an element it reports as absent (or present) may no longer reflect
   // what's actually on screen (issue #6167 follow-up).
-  if (result.viewHierarchy?.fresh === false) {
-    return "the view hierarchy is a stale cached snapshot (fresh: false), not verified against the device on this call";
-  }
+  (_windowBounds, result) =>
+    result.viewHierarchy?.fresh === false
+      ? "the view hierarchy is a stale cached snapshot (fresh: false), not verified against the device on this call"
+      : null,
+
   // CtrlProxy can withhold the focused app's own root entirely (observed in
   // split-screen) while still returning windows/elements from a DIFFERENT
   // app - certifying a point here can tap the wrong app, not just an
   // unemitted node of the right one (issue #6167 follow-up).
-  if (result.viewHierarchy?.ctrlProxyIncomplete) {
-    return "CtrlProxy reported an incomplete capture (ctrlProxyIncomplete) - the focused app's own root may have been withheld";
-  }
+  (_windowBounds, result) =>
+    result.viewHierarchy?.ctrlProxyIncomplete
+      ? "CtrlProxy reported an incomplete capture (ctrlProxyIncomplete) - the focused app's own root may have been withheld"
+      : null,
+
   // CtrlProxy stops emitting descendants once it hits a hard limit
   // (`max_nodes`, `max_depth`) or is cancelled mid-walk - the resulting
   // hierarchy is silently PARTIAL, not "no obstacles here". Certifying a
   // point inert against an incomplete obstacle map risks tapping a real
   // control whose node was simply never emitted (issue #6167 follow-up).
-  const truncationReasons = result.viewHierarchy?.truncationReasons;
-  if (truncationReasons && truncationReasons.length > 0) {
-    return `view hierarchy is truncated (${truncationReasons.join(", ")}) - the obstacle map may be incomplete`;
-  }
+  (_windowBounds, result) => {
+    const truncationReasons = result.viewHierarchy?.truncationReasons;
+    return truncationReasons && truncationReasons.length > 0
+      ? `view hierarchy is truncated (${truncationReasons.join(", ")}) - the obstacle map may be incomplete`
+      : null;
+  },
+
   // When a SystemUI surface (status bar, notification shade, keyguard) owns
   // focus, `ObserveScreen.reconcileActiveWindowAttribution` rewrites
   // `activeWindow.appId` to `com.android.systemui` - but the real
@@ -303,8 +327,39 @@ function unreliableHierarchyReason(
   // A point certified inert there would tap the occluded app underneath
   // while `gfxinfo` samples `com.android.systemui`, measuring the wrong
   // surface's response entirely (issue #6167 follow-up).
-  if (result.activeWindow?.appId === SYSTEM_TRAY_PACKAGE) {
-    return `a SystemUI overlay owns focus (activeWindow.appId === "${SYSTEM_TRAY_PACKAGE}") - the app window beneath it cannot be safely probed`;
+  (_windowBounds, result) =>
+    result.activeWindow?.appId === SYSTEM_TRAY_PACKAGE
+      ? `a SystemUI overlay owns focus (activeWindow.appId === "${SYSTEM_TRAY_PACKAGE}") - the app window beneath it cannot be safely probed`
+      : null,
+
+  // A notification-permission prompt is a special case: unlike the SystemUI
+  // overlay above, `ObserveScreen` deliberately keeps `activeWindow.appId` on
+  // the underlying app (only tagging `activeWindow.type`), while CtrlProxy
+  // reports the permission-controller prompt itself as a package-less type-1
+  // APPLICATION window - so `findAppWindowBounds` derives the PROMPT's
+  // bounds while `gfxinfo` samples the underlying app's package, producing
+  // garbage latency, AND a synthetic tap can land on the live prompt and
+  // grant/deny it (issue #6167 follow-up). `result.notificationPermissionDetected`
+  // is the primary source `ObserveScreen.reconcileActiveWindowAttribution`
+  // reads to set `activeWindow.type`; checking both covers a capture where
+  // the flag was set but the reconciliation step that stamps `type` didn't
+  // run on this particular result.
+  (_windowBounds, result) =>
+    result.notificationPermissionDetected ||
+    result.activeWindow?.type === NOTIFICATION_PERMISSION_DIALOG_WINDOW_TYPE
+      ? "a notification-permission dialog owns the window - the underlying app's bounds/gfxinfo don't correspond to the same surface"
+      : null,
+];
+
+function unreliableHierarchyReason(
+  windowBounds: ElementBounds | undefined,
+  result: ObserveResult,
+): string | null {
+  for (const check of RELIABILITY_CHECKS) {
+    const reason = check(windowBounds, result);
+    if (reason !== null) {
+      return reason;
+    }
   }
   return null;
 }
@@ -313,13 +368,24 @@ function unreliableHierarchyReason(
  * Single gate for every known way a capture can be too unreliable to trust
  * for a synthetic touch-latency tap: absent/malformed app window bounds, a
  * stale cached tree (`fresh: false`), an incomplete CtrlProxy capture
- * (`ctrlProxyIncomplete`), a truncated hierarchy (`truncationReasons`), or a
+ * (`ctrlProxyIncomplete`), a truncated hierarchy (`truncationReasons`), a
  * SystemUI overlay owning focus (`activeWindow.appId ===
  * "com.android.systemui"`, which can pass through a real but occluded app
- * window as if it belonged to the overlay). Consolidated into one predicate
- * (issue #6167 follow-up) so a future reliability signal has exactly one
- * place to live and can't be missed by only patching one of several
- * scattered checks.
+ * window as if it belonged to the overlay), or a notification-permission
+ * dialog owning the window (`notificationPermissionDetected` /
+ * `activeWindow.type === "notification_permission_dialog"` - here
+ * `activeWindow.appId` stays on the underlying app while the derived window
+ * bounds are actually the live permission prompt's). Consolidated into one
+ * predicate (issue #6167 follow-up) so a future reliability signal has
+ * exactly one place to live and can't be missed by only patching one of
+ * several scattered checks.
+ *
+ * An inverted "positive confirmation" design (require a matching window
+ * entry with a real `packageName`, a plain application type, and no dialog
+ * flag) was considered instead of enumerating bad cases, but rejected: the
+ * real accessibility window wire format never populates `packageName` at all
+ * (see `isCandidateAppWindow` above) - requiring it would reject every
+ * normal capture, not just the unreliable ones.
  *
  * Content-hidden regions (`contentHiddenRegions`) are deliberately NOT a
  * blanket-reject signal here: unlike the checks above, the reliable part of

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -240,16 +240,83 @@ export interface TouchLatencyPointDecision {
   /** A verified-inert coordinate to tap, present only when one was found. */
   touchPoint?: { x: number; y: number };
   /**
-   * True when there is no verified-inert point to tap - `windowBounds` was
-   * undefined (no app window found), the view hierarchy was truncated (so
-   * the obstacle map may be incomplete), or every scanned candidate
-   * overlapped an interactive element or a content-hidden region. The caller
-   * must skip the touch-latency measurement entirely in this case rather
-   * than fall through to `TouchLatencyTracker`'s own unverified default
-   * point, which risks activating a full-screen button, WebView, map, or a
-   * hidden or unemitted control (issue #6167).
+   * True when there is no verified-inert point to tap - the capture wasn't
+   * reliable enough to trust (see `isHierarchyReliableForTapProbe`), or
+   * every scanned candidate overlapped an interactive element or a
+   * content-hidden region. The caller must skip the touch-latency
+   * measurement entirely in this case rather than fall through to
+   * `TouchLatencyTracker`'s own unverified default point, which risks
+   * activating a full-screen button, WebView, map, or a hidden or unemitted
+   * control (issue #6167).
    */
   skipTouchLatency: boolean;
+}
+
+/**
+ * Reasons `isHierarchyReliableForTapProbe` can reject a capture, in check
+ * order. Kept as an explicit reason (rather than a bare boolean) so the one
+ * `deriveTouchLatencyPoint` log line can say *why* - useful when triaging a
+ * report of touch-latency going unexpectedly missing.
+ */
+function unreliableHierarchyReason(
+  windowBounds: ElementBounds | undefined,
+  result: ObserveResult,
+): string | null {
+  if (!windowBounds) {
+    return "no app window bounds were found";
+  }
+  if (!isValidWindowBounds(windowBounds)) {
+    return (
+      "window bounds are malformed (zero-area, inverted, or non-finite): " +
+      JSON.stringify(windowBounds)
+    );
+  }
+  // A stale cached tree was never verified against the device on this call -
+  // an element it reports as absent (or present) may no longer reflect
+  // what's actually on screen (issue #6167 follow-up).
+  if (result.viewHierarchy?.fresh === false) {
+    return "the view hierarchy is a stale cached snapshot (fresh: false), not verified against the device on this call";
+  }
+  // CtrlProxy can withhold the focused app's own root entirely (observed in
+  // split-screen) while still returning windows/elements from a DIFFERENT
+  // app - certifying a point here can tap the wrong app, not just an
+  // unemitted node of the right one (issue #6167 follow-up).
+  if (result.viewHierarchy?.ctrlProxyIncomplete) {
+    return "CtrlProxy reported an incomplete capture (ctrlProxyIncomplete) - the focused app's own root may have been withheld";
+  }
+  // CtrlProxy stops emitting descendants once it hits a hard limit
+  // (`max_nodes`, `max_depth`) or is cancelled mid-walk - the resulting
+  // hierarchy is silently PARTIAL, not "no obstacles here". Certifying a
+  // point inert against an incomplete obstacle map risks tapping a real
+  // control whose node was simply never emitted (issue #6167 follow-up).
+  const truncationReasons = result.viewHierarchy?.truncationReasons;
+  if (truncationReasons && truncationReasons.length > 0) {
+    return `view hierarchy is truncated (${truncationReasons.join(", ")}) - the obstacle map may be incomplete`;
+  }
+  return null;
+}
+
+/**
+ * Single gate for every known way a capture can be too unreliable to trust
+ * for a synthetic touch-latency tap: absent/malformed app window bounds, a
+ * stale cached tree (`fresh: false`), an incomplete CtrlProxy capture
+ * (`ctrlProxyIncomplete`), or a truncated hierarchy (`truncationReasons`).
+ * Consolidated into one predicate (issue #6167 follow-up) so a future
+ * reliability signal has exactly one place to live and can't be missed by
+ * only patching one of several scattered checks.
+ *
+ * Content-hidden regions (`contentHiddenRegions`) are deliberately NOT a
+ * blanket-reject signal here: unlike the checks above, the reliable part of
+ * the hierarchy elsewhere in the window is still trustworthy, so
+ * `findInertTouchPoint` continues to exclude those regions per-candidate
+ * (via `collectHiddenRegionBounds`) rather than discarding a window that
+ * still has a genuinely safe spot to tap.
+ */
+export function isHierarchyReliableForTapProbe(
+  windowBounds: ElementBounds | undefined,
+  result: ObserveResult,
+): boolean {
+  return unreliableHierarchyReason(windowBounds, result) === null;
 }
 
 /**
@@ -263,30 +330,11 @@ export function deriveTouchLatencyPoint(
   result: ObserveResult,
   elementParser: ElementParser = new DefaultElementParser(),
 ): TouchLatencyPointDecision {
-  if (!windowBounds) {
-    return { skipTouchLatency: true };
-  }
-
-  if (!isValidWindowBounds(windowBounds)) {
-    logger.warn(
-      "[PerformanceAudit] Skipping touch-latency measurement: window bounds are malformed " +
-        `(zero-area, inverted, or non-finite): ${JSON.stringify(windowBounds)}`,
-    );
-    return { skipTouchLatency: true };
-  }
-
-  // CtrlProxy stops emitting descendants once it hits a hard limit
-  // (`max_nodes`, `max_depth`) or is cancelled mid-walk - the resulting
-  // hierarchy is silently PARTIAL, not "no obstacles here". Certifying a
-  // point inert against an incomplete obstacle map risks tapping a real
-  // control whose node was simply never emitted (issue #6167 follow-up), so
-  // a truncated hierarchy can never produce a verified-inert point.
-  const truncationReasons = result.viewHierarchy?.truncationReasons;
-  if (truncationReasons && truncationReasons.length > 0) {
-    logger.warn(
-      "[PerformanceAudit] Skipping touch-latency measurement: view hierarchy is truncated " +
-        `(${truncationReasons.join(", ")}) - the obstacle map may be incomplete`,
-    );
+  const unreliableReason = unreliableHierarchyReason(windowBounds, result);
+  if (unreliableReason !== null || !windowBounds) {
+    if (unreliableReason !== null) {
+      logger.warn(`[PerformanceAudit] Skipping touch-latency measurement: ${unreliableReason}`);
+    }
     return { skipTouchLatency: true };
   }
 

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -140,27 +140,29 @@ function isValidWindowBounds(bounds: ElementBounds): boolean {
 export interface InertTouchPointResult {
   point: { x: number; y: number };
   /**
-   * False when no scanned candidate avoided every interactive element - the
-   * returned point is the documented fallback default, not a verified-inert
-   * one (issue #6167).
+   * False when no scanned candidate avoided every interactive element AND
+   * every content-hidden region - the returned point is the documented
+   * fallback default, not a verified-inert one (issue #6167).
    */
   inert: boolean;
 }
 
 /**
  * Find a synthetic-touch point inside `windowBounds` that does not overlap
- * any clickable/focusable/long-clickable element, so a touch-latency probe
- * cannot activate a real control (tap a button, open a list item, follow a
- * link) during what is meant to be a read-only performance audit
- * (issue #6167). Scans a small set of candidate points (window center, then
- * quadrant centers, then edge midpoints) and returns the first that hits no
- * interactive element's bounds. Falls back to a documented default point
- * when every candidate is obstructed, with `inert: false` so the caller
- * knows the tap may still land on a control.
+ * any clickable/focusable/long-clickable element, and does not fall inside
+ * any content-hidden region, so a touch-latency probe cannot activate a real
+ * control (tap a button, open a list item, follow a link) during what is
+ * meant to be a read-only performance audit (issue #6167). Scans a small set
+ * of candidate points (window center, then quadrant centers, then edge
+ * midpoints) and returns the first that hits no interactive element's bounds
+ * and no hidden region. Falls back to a documented default point when every
+ * candidate is obstructed, with `inert: false` so the caller knows the tap
+ * may still land on a control or hidden content.
  */
 export function findInertTouchPoint(
   windowBounds: ElementBounds,
   interactiveElements: readonly Element[],
+  hiddenRegions: readonly ElementBounds[] = [],
 ): InertTouchPointResult {
   const obstacles = interactiveElements.filter((el) => el.bounds && isInteractiveElement(el));
   const width = windowBounds.right - windowBounds.left;
@@ -173,16 +175,21 @@ export function findInertTouchPoint(
 
   for (const fraction of INERT_POINT_CANDIDATE_FRACTIONS) {
     const point = pointFor(fraction);
-    const obstructed = obstacles.some((el) => isPointInsideBounds(point.x, point.y, el.bounds));
-    if (!obstructed) {
+    const obstructedByElement = obstacles.some((el) =>
+      isPointInsideBounds(point.x, point.y, el.bounds),
+    );
+    const obstructedByHiddenRegion = hiddenRegions.some((region) =>
+      isPointInsideBounds(point.x, point.y, region),
+    );
+    if (!obstructedByElement && !obstructedByHiddenRegion) {
       return { point, inert: true };
     }
   }
 
   logger.warn(
     "[PerformanceAudit] Could not find a fully inert touch point inside the app window " +
-      "(every scanned candidate overlapped an interactive element) - falling back to a " +
-      "default point that may still activate a control",
+      "(every scanned candidate overlapped an interactive element or content-hidden region) - " +
+      "falling back to a default point that may still activate a control",
   );
   return { point: pointFor(FALLBACK_TOUCH_POINT_FRACTION), inert: false };
 }
@@ -214,16 +221,32 @@ export function collectInteractiveObstacles(
     .map((entry) => entry.element);
 }
 
+/**
+ * Bounds of every content-hidden region on this observation - large
+ * Compose-interop (or similar) areas where platform accessibility APIs
+ * cannot expose the rendered content's real elements
+ * (`ViewHierarchyResult.contentHiddenRegions`). A candidate touch point can
+ * fall inside such a region while showing no obstacle in
+ * `collectInteractiveObstacles`, because the region's interactive
+ * descendants are never surfaced in the accessibility hierarchy at all - so
+ * these bounds must be checked as their own exclusion, not folded into the
+ * element-obstacle list (issue #6167 follow-up).
+ */
+export function collectHiddenRegionBounds(result: ObserveResult): ElementBounds[] {
+  return (result.viewHierarchy?.contentHiddenRegions ?? []).map((region) => region.bounds);
+}
+
 export interface TouchLatencyPointDecision {
   /** A verified-inert coordinate to tap, present only when one was found. */
   touchPoint?: { x: number; y: number };
   /**
    * True when there is no verified-inert point to tap - either `windowBounds`
    * was undefined (no app window found), or every scanned candidate
-   * overlapped an interactive element. The caller must skip the
-   * touch-latency measurement entirely in this case rather than fall
-   * through to `TouchLatencyTracker`'s own unverified default point, which
-   * risks activating a full-screen button, WebView, or map (issue #6167).
+   * overlapped an interactive element or a content-hidden region. The caller
+   * must skip the touch-latency measurement entirely in this case rather
+   * than fall through to `TouchLatencyTracker`'s own unverified default
+   * point, which risks activating a full-screen button, WebView, map, or a
+   * hidden control (issue #6167).
    */
   skipTouchLatency: boolean;
 }
@@ -252,7 +275,8 @@ export function deriveTouchLatencyPoint(
   }
 
   const obstacles = collectInteractiveObstacles(result, elementParser);
-  const { point, inert } = findInertTouchPoint(windowBounds, obstacles);
+  const hiddenRegions = collectHiddenRegionBounds(result);
+  const { point, inert } = findInertTouchPoint(windowBounds, obstacles, hiddenRegions);
   if (!inert) {
     return { skipTouchLatency: true };
   }

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -16,20 +16,27 @@ import {
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 
 /**
- * Android's `AccessibilityWindowInfo.TYPE_SYSTEM` constant (status bar,
- * navigation bar, and other SystemUI chrome). The wire `WindowInfo` CtrlProxy
- * actually emits (`android/control-proxy/.../models/WindowInfo.kt`) carries
- * only `id`/`type`/`isActive`/`isFocused`/`bounds` - critically, no
+ * `AccessibilityWindowInfo.TYPE_APPLICATION` (Android SDK constant = 1): the
+ * only window type that represents genuine app content. The wire `WindowInfo`
+ * CtrlProxy actually emits (`android/control-proxy/.../models/WindowInfo.kt`,
+ * mapped from `AccessibilityWindowInfo.type` in `ViewHierarchyExtractor.kt`)
+ * carries only `id`/`type`/`isActive`/`isFocused`/`bounds` - critically, no
  * per-window `packageName` (see the real fixture,
  * `test/fixtures/observe/android-home.json`, whose `viewHierarchy.windows`
- * has this exact shape). A `type === 3` window is the SystemUI surface;
- * anything else (application, IME, overlay, ...) is a candidate for "the
- * audited app's own window".
+ * has this exact shape).
+ *
+ * Every other type is chrome, not app content, and must be excluded even
+ * when it is the focused window - most importantly `TYPE_INPUT_METHOD` (2):
+ * the soft keyboard can hold focus while it's open, and its bounds are not
+ * inside the audited app's window. Also excluded by not being
+ * TYPE_APPLICATION: `TYPE_SYSTEM` (3, status/nav bar and other SystemUI),
+ * `TYPE_ACCESSIBILITY_OVERLAY` (4), `TYPE_SPLIT_SCREEN_DIVIDER` (5), and
+ * `TYPE_MAGNIFICATION_OVERLAY` (6).
  */
-const ACCESSIBILITY_WINDOW_TYPE_SYSTEM = 3;
+const ACCESSIBILITY_WINDOW_TYPE_APPLICATION = 1;
 
 function isCandidateAppWindow(window: ViewHierarchyWindowInfo, appId: string): boolean {
-  if (!window.bounds || window.type === ACCESSIBILITY_WINDOW_TYPE_SYSTEM) {
+  if (!window.bounds || window.type !== ACCESSIBILITY_WINDOW_TYPE_APPLICATION) {
     return false;
   }
   // packageName is never populated by the real Android accessibility window
@@ -43,9 +50,11 @@ function isCandidateAppWindow(window: ViewHierarchyWindowInfo, appId: string): b
  * window list, so the touch-latency synthetic tap can be placed inside the
  * app's actual window rather than a fixed screen fraction - correct under
  * split-screen/freeform where the app doesn't occupy the full screen
- * (issue #6167). Prefers the window marked focused; falls back to any
- * non-SystemUI window if none is marked focused. Returns undefined when no
- * matching window bounds are available.
+ * (issue #6167). Prefers the focused APPLICATION-type window; if no
+ * APPLICATION window is focused (e.g. the soft keyboard holds focus instead)
+ * falls back to any other APPLICATION window. Returns undefined when no
+ * APPLICATION window bounds are available at all - the caller then falls
+ * back to a fixed-fraction default point.
  */
 export function findAppWindowBounds(
   result: ObserveResult,

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -116,6 +116,27 @@ function isPointInsideBounds(x: number, y: number, bounds: ElementBounds): boole
   return x >= bounds.left && x < bounds.right && y >= bounds.top && y < bounds.bottom;
 }
 
+/**
+ * True only for finite bounds with strictly positive width and height.
+ * Android can transiently report zero-area or inverted window bounds (e.g.
+ * mid-transition, or a window in the process of being torn down) - a naive
+ * center calculation on those still produces a defined-looking point (e.g.
+ * `{left:100, top:100, right:100, bottom:100}` -> `(100, 100)`), which is
+ * not actually inside any real content. Rejecting malformed bounds here,
+ * before a point is derived, keeps a transient bad reading from producing a
+ * touch point that gets reported inert and tapped (issue #6167 follow-up).
+ */
+function isValidWindowBounds(bounds: ElementBounds): boolean {
+  return (
+    Number.isFinite(bounds.left) &&
+    Number.isFinite(bounds.top) &&
+    Number.isFinite(bounds.right) &&
+    Number.isFinite(bounds.bottom) &&
+    bounds.right - bounds.left > 0 &&
+    bounds.bottom - bounds.top > 0
+  );
+}
+
 export interface InertTouchPointResult {
   point: { x: number; y: number };
   /**
@@ -219,6 +240,14 @@ export function deriveTouchLatencyPoint(
   elementParser: ElementParser = new DefaultElementParser(),
 ): TouchLatencyPointDecision {
   if (!windowBounds) {
+    return { skipTouchLatency: true };
+  }
+
+  if (!isValidWindowBounds(windowBounds)) {
+    logger.warn(
+      "[PerformanceAudit] Skipping touch-latency measurement: window bounds are malformed " +
+        `(zero-area, inverted, or non-finite): ${JSON.stringify(windowBounds)}`,
+    );
     return { skipTouchLatency: true };
   }
 

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -16,6 +16,8 @@ import {
 } from "../../../utils/android-cmdline-tools/AdbClientFactory";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { hasAccessibilityAction, isTruthyFlag } from "../../../utils/elementProperties";
+import type { ElementParser } from "../../../utils/interfaces/ElementParser";
+import { DefaultElementParser } from "../../utility/ElementParser";
 
 /**
  * `AccessibilityWindowInfo.TYPE_APPLICATION` (Android SDK constant = 1): the
@@ -164,6 +166,70 @@ export function findInertTouchPoint(
   return { point: pointFor(FALLBACK_TOUCH_POINT_FRACTION), inert: false };
 }
 
+/**
+ * Collect every hierarchy element that could be an obstacle for
+ * `findInertTouchPoint` - i.e. everything `isInteractiveElement` would flag,
+ * across the main hierarchy and any secondary windows (dialogs, sheets).
+ *
+ * Deliberately NOT `result.elements.clickable`: `DefaultObserveElementCollector`
+ * populates that list only for `clickable`/`click`-action nodes, but
+ * `isInteractiveElement` (and therefore the inert-point scan) also treats
+ * `focusable`, `long-clickable`, and `long_click` nodes as obstacles. A
+ * focusable-only or long-clickable-only control covering a candidate point
+ * would otherwise never be supplied as an obstacle, and the scan could land
+ * on (and activate/focus) it (issue #6167 follow-up). Walking the raw
+ * hierarchy with the same `isInteractiveElement` predicate the scan itself
+ * applies keeps the two from drifting apart.
+ */
+export function collectInteractiveObstacles(
+  result: ObserveResult,
+  elementParser: ElementParser = new DefaultElementParser(),
+): Element[] {
+  if (!result.viewHierarchy) {
+    return result.elements?.clickable ?? [];
+  }
+  return elementParser
+    .flattenViewHierarchy(result.viewHierarchy, { includeWindows: true })
+    .map((entry) => entry.element);
+}
+
+export interface TouchLatencyPointDecision {
+  /** A verified-inert coordinate to tap, present only when one was found. */
+  touchPoint?: { x: number; y: number };
+  /**
+   * True when there is no verified-inert point to tap - either `windowBounds`
+   * was undefined (no app window found), or every scanned candidate
+   * overlapped an interactive element. The caller must skip the
+   * touch-latency measurement entirely in this case rather than fall
+   * through to `TouchLatencyTracker`'s own unverified default point, which
+   * risks activating a full-screen button, WebView, or map (issue #6167).
+   */
+  skipTouchLatency: boolean;
+}
+
+/**
+ * Derive the synthetic touch-latency tap point exactly as
+ * `PerformanceAuditor.run` does, so tests can exercise this decision through
+ * the real production obstacle-collection path rather than hand-building an
+ * obstacle list for `findInertTouchPoint` directly.
+ */
+export function deriveTouchLatencyPoint(
+  windowBounds: ElementBounds | undefined,
+  result: ObserveResult,
+  elementParser: ElementParser = new DefaultElementParser(),
+): TouchLatencyPointDecision {
+  if (!windowBounds) {
+    return { skipTouchLatency: true };
+  }
+
+  const obstacles = collectInteractiveObstacles(result, elementParser);
+  const { point, inert } = findInertTouchPoint(windowBounds, obstacles);
+  if (!inert) {
+    return { skipTouchLatency: true };
+  }
+  return { touchPoint: point, skipTouchLatency: false };
+}
+
 export interface PerformanceAuditorOptions {
   device: BootedDevice;
   /**
@@ -235,9 +301,7 @@ export class PerformanceAuditor {
         // activating a real control - a read-only performance audit must
         // not tap a button, list item, or link as a side effect (#6167).
         const windowBounds = findAppWindowBounds(result, result.activeWindow!.appId);
-        const touchPoint = windowBounds
-          ? findInertTouchPoint(windowBounds, result.elements?.clickable ?? []).point
-          : undefined;
+        const { touchPoint, skipTouchLatency } = deriveTouchLatencyPoint(windowBounds, result);
 
         // Run the audit
         const auditResult = await performanceAudit.runAudit(
@@ -247,6 +311,7 @@ export class PerformanceAuditor {
           perf,
           windowBounds,
           touchPoint,
+          skipTouchLatency,
         );
 
         // Attach audit result to observe result

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -3,7 +3,12 @@ import { PerformanceAudit } from "../../performance/PerformanceAudit";
 import { ThresholdManager } from "../../performance/ThresholdManager";
 import { isPerformanceAuditEnabled } from "../../performance/performanceAuditConfig";
 import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
-import type { BootedDevice, ElementBounds, ObserveResult } from "../../../models";
+import type {
+  BootedDevice,
+  ElementBounds,
+  ObserveResult,
+  ViewHierarchyWindowInfo,
+} from "../../../models";
 import {
   defaultAdbClientFactory,
   type AdbClientFactory,
@@ -11,12 +16,35 @@ import {
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 
 /**
+ * Android's `AccessibilityWindowInfo.TYPE_SYSTEM` constant (status bar,
+ * navigation bar, and other SystemUI chrome). The wire `WindowInfo` CtrlProxy
+ * actually emits (`android/control-proxy/.../models/WindowInfo.kt`) carries
+ * only `id`/`type`/`isActive`/`isFocused`/`bounds` - critically, no
+ * per-window `packageName` (see the real fixture,
+ * `test/fixtures/observe/android-home.json`, whose `viewHierarchy.windows`
+ * has this exact shape). A `type === 3` window is the SystemUI surface;
+ * anything else (application, IME, overlay, ...) is a candidate for "the
+ * audited app's own window".
+ */
+const ACCESSIBILITY_WINDOW_TYPE_SYSTEM = 3;
+
+function isCandidateAppWindow(window: ViewHierarchyWindowInfo, appId: string): boolean {
+  if (!window.bounds || window.type === ACCESSIBILITY_WINDOW_TYPE_SYSTEM) {
+    return false;
+  }
+  // packageName is never populated by the real Android accessibility window
+  // list, but keep the check for forward-compat with a future/other source
+  // that does populate it (e.g. a merged uiautomator window list).
+  return window.packageName === undefined || window.packageName === appId;
+}
+
+/**
  * Find the audited app's own window bounds from the accessibility service's
  * window list, so the touch-latency synthetic tap can be placed inside the
  * app's actual window rather than a fixed screen fraction - correct under
  * split-screen/freeform where the app doesn't occupy the full screen
- * (issue #6167). Prefers the window marked focused; falls back to any window
- * for the package if none is marked focused. Returns undefined when no
+ * (issue #6167). Prefers the window marked focused; falls back to any
+ * non-SystemUI window if none is marked focused. Returns undefined when no
  * matching window bounds are available.
  */
 export function findAppWindowBounds(
@@ -28,9 +56,9 @@ export function findAppWindowBounds(
     return undefined;
   }
 
-  const forApp = windows.filter((w) => w.packageName === appId && w.bounds);
-  const focused = forApp.find((w) => w.isFocused);
-  return (focused ?? forApp[0])?.bounds;
+  const candidates = windows.filter((w) => isCandidateAppWindow(w, appId));
+  const focused = candidates.find((w) => w.isFocused);
+  return (focused ?? candidates[0])?.bounds;
 }
 
 export interface PerformanceAuditorOptions {

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -3,12 +3,35 @@ import { PerformanceAudit } from "../../performance/PerformanceAudit";
 import { ThresholdManager } from "../../performance/ThresholdManager";
 import { isPerformanceAuditEnabled } from "../../performance/performanceAuditConfig";
 import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
-import type { BootedDevice, ObserveResult } from "../../../models";
+import type { BootedDevice, ElementBounds, ObserveResult } from "../../../models";
 import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../../utils/android-cmdline-tools/AdbClientFactory";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Find the audited app's own window bounds from the accessibility service's
+ * window list, so the touch-latency synthetic tap can be placed inside the
+ * app's actual window rather than a fixed screen fraction - correct under
+ * split-screen/freeform where the app doesn't occupy the full screen
+ * (issue #6167). Prefers the window marked focused; falls back to any window
+ * for the package if none is marked focused. Returns undefined when no
+ * matching window bounds are available.
+ */
+export function findAppWindowBounds(
+  result: ObserveResult,
+  appId: string,
+): ElementBounds | undefined {
+  const windows = result.viewHierarchy?.windows;
+  if (!windows || windows.length === 0) {
+    return undefined;
+  }
+
+  const forApp = windows.filter((w) => w.packageName === appId && w.bounds);
+  const focused = forApp.find((w) => w.isFocused);
+  return (focused ?? forApp[0])?.bounds;
+}
 
 export interface PerformanceAuditorOptions {
   device: BootedDevice;
@@ -83,6 +106,7 @@ export class PerformanceAuditor {
           thresholds,
           result.screenSize,
           perf,
+          findAppWindowBounds(result, result.activeWindow!.appId),
         );
 
         // Attach audit result to observe result

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -342,6 +342,14 @@ export class PerformanceAudit {
         ),
       );
 
+      if (result.animating) {
+        logger.warn(
+          "[PerformanceAudit] Touch latency measurement discarded: app is rendering frames " +
+            "on its own (animating) - latency cannot be attributed to the synthetic touch",
+        );
+        return null;
+      }
+
       if (result.success) {
         logger.info(`[PerformanceAudit] Touch latency measured: ${result.latencyMs}ms`);
         return result.latencyMs;

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -96,6 +96,16 @@ interface CollectMetricsOptions {
    * (issue #6167).
    */
   touchPoint?: { x: number; y: number };
+  /**
+   * Skip the touch-latency measurement entirely rather than fall through to
+   * `TouchLatencyTracker`'s own unverified default point. Set by the caller
+   * when it could not find a point known not to overlap an interactive
+   * element (e.g. `PerformanceAuditor`'s hierarchy scan found no app window,
+   * or every scanned candidate was obstructed) - injecting real taps in that
+   * case risks activating a full-screen button, WebView, or map during what
+   * is meant to be a read-only audit (issue #6167).
+   */
+  skipTouchLatency?: boolean;
 }
 
 /**
@@ -144,6 +154,7 @@ export class PerformanceAudit {
       perf,
       opts.windowBounds,
       opts.touchPoint,
+      opts.skipTouchLatency,
     );
 
     // Optional TTFF/TTI measurement (these are heavier operations)
@@ -336,7 +347,19 @@ export class PerformanceAudit {
     perf: PerformanceTracker,
     windowBounds?: ElementBounds,
     touchPoint?: { x: number; y: number },
+    skipTouchLatency?: boolean,
   ): Promise<number | null> {
+    // The caller found no point known not to overlap an interactive element
+    // (no app window bounds, or every scanned candidate was obstructed) -
+    // skip the measurement entirely rather than let a synthetic tap land on
+    // an unverified default point and activate a real control (#6167).
+    if (skipTouchLatency) {
+      logger.info(
+        "[PerformanceAudit] Touch latency measurement skipped (no verified-inert touch point available)",
+      );
+      return null;
+    }
+
     // Only measure touch latency when UI performance mode is enabled
     if (!serverConfig.isUiPerfModeEnabled()) {
       logger.debug(
@@ -770,6 +793,7 @@ export class PerformanceAudit {
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     windowBounds?: ElementBounds,
     touchPoint?: { x: number; y: number },
+    skipTouchLatency?: boolean,
   ): Promise<PerformanceAuditResult> {
     logger.info(`[PerformanceAudit] Running audit for ${packageName}`);
 
@@ -780,6 +804,7 @@ export class PerformanceAudit {
     const metrics = await this.collectMetrics(packageName, screenSize, perf, {
       windowBounds,
       touchPoint,
+      skipTouchLatency,
     });
 
     // Validate against thresholds

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -87,6 +87,15 @@ interface CollectMetricsOptions {
    * (issue #6167).
    */
   windowBounds?: ElementBounds;
+  /**
+   * A specific in-window coordinate known not to overlap an interactive
+   * element (e.g. from `PerformanceAuditor`'s hierarchy scan), used in place
+   * of `windowBounds`' plain center. Takes precedence over `windowBounds`
+   * when both are given - moving the tap into the app window must not let it
+   * land on a real control and activate it during a read-only audit
+   * (issue #6167).
+   */
+  touchPoint?: { x: number; y: number };
 }
 
 /**
@@ -134,6 +143,7 @@ export class PerformanceAudit {
       screenSize,
       perf,
       opts.windowBounds,
+      opts.touchPoint,
     );
 
     // Optional TTFF/TTI measurement (these are heavier operations)
@@ -325,6 +335,7 @@ export class PerformanceAudit {
     screenSize: ScreenSize | undefined,
     perf: PerformanceTracker,
     windowBounds?: ElementBounds,
+    touchPoint?: { x: number; y: number },
   ): Promise<number | null> {
     // Only measure touch latency when UI performance mode is enabled
     if (!serverConfig.isUiPerfModeEnabled()) {
@@ -352,6 +363,7 @@ export class PerformanceAudit {
             sampleCount: 3,
             maxWaitMs: 200,
             windowBounds,
+            touchPoint,
           },
           perf,
         ),
@@ -757,6 +769,7 @@ export class PerformanceAudit {
     screenSize?: ScreenSize,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     windowBounds?: ElementBounds,
+    touchPoint?: { x: number; y: number },
   ): Promise<PerformanceAuditResult> {
     logger.info(`[PerformanceAudit] Running audit for ${packageName}`);
 
@@ -764,7 +777,10 @@ export class PerformanceAudit {
     const deviceCapabilities = await this.capabilitiesDetector.getCapabilities();
 
     // Collect metrics
-    const metrics = await this.collectMetrics(packageName, screenSize, perf, { windowBounds });
+    const metrics = await this.collectMetrics(packageName, screenSize, perf, {
+      windowBounds,
+      touchPoint,
+    });
 
     // Validate against thresholds
     const violations = this.validateMetrics(metrics, thresholds);

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -4,7 +4,7 @@ import {
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
-import { BootedDevice, ScreenSize } from "../../models";
+import { BootedDevice, ElementBounds, ScreenSize } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Idle } from "../observe/Idle";
 import { DeviceCapabilitiesDetector, DeviceCapabilities } from "../../utils/DeviceCapabilities";
@@ -79,6 +79,14 @@ interface PerformanceViolation {
 interface CollectMetricsOptions {
   measureTtff?: boolean;
   measureTti?: boolean;
+  /**
+   * The audited app's actual focused-window rect (e.g. from the accessibility
+   * service's window list), used to place the synthetic touch inside the
+   * real app window rather than a fixed screen fraction - correct under
+   * split-screen/freeform where the app doesn't occupy the full screen
+   * (issue #6167).
+   */
+  windowBounds?: ElementBounds;
 }
 
 /**
@@ -121,7 +129,12 @@ export class PerformanceAudit {
     ]);
 
     // Touch latency requires sequential execution after other metrics
-    const touchLatency = await this.measureTouchLatency(packageName, screenSize, perf);
+    const touchLatency = await this.measureTouchLatency(
+      packageName,
+      screenSize,
+      perf,
+      opts.windowBounds,
+    );
 
     // Optional TTFF/TTI measurement (these are heavier operations)
     let ttffMs: number | null = null;
@@ -311,6 +324,7 @@ export class PerformanceAudit {
     packageName: string,
     screenSize: ScreenSize | undefined,
     perf: PerformanceTracker,
+    windowBounds?: ElementBounds,
   ): Promise<number | null> {
     // Only measure touch latency when UI performance mode is enabled
     if (!serverConfig.isUiPerfModeEnabled()) {
@@ -337,30 +351,58 @@ export class PerformanceAudit {
           {
             sampleCount: 3,
             maxWaitMs: 200,
+            windowBounds,
           },
           perf,
         ),
       );
 
-      if (result.animating) {
-        logger.warn(
-          "[PerformanceAudit] Touch latency measurement discarded: app is rendering frames " +
-            "on its own (animating) - latency cannot be attributed to the synthetic touch",
-        );
-        return null;
-      }
-
-      if (result.success) {
-        logger.info(`[PerformanceAudit] Touch latency measured: ${result.latencyMs}ms`);
-        return result.latencyMs;
-      } else {
-        logger.warn(`[PerformanceAudit] Touch latency measurement failed: ${result.error}`);
-        return null;
-      }
+      return this.resolveTouchLatency(result);
     } catch (error) {
       logger.warn(`[PerformanceAudit] Failed to measure touch latency: ${error}`);
       return null;
     }
+  }
+
+  /**
+   * Decide what latency (if any) to report from a `TouchLatencyTracker`
+   * result. A run can be a *mix* of animating and valid samples - a single
+   * animating sample must not null out a run that also produced a real
+   * measurement (issue #6167). Only report `null` when there is no valid
+   * measurement at all.
+   */
+  private resolveTouchLatency(result: {
+    success: boolean;
+    latencyMs: number;
+    animating?: boolean;
+    error?: string;
+  }): number | null {
+    if (result.success) {
+      if (result.animating) {
+        // A mixed run: at least one sample was discounted as animating, but
+        // others still produced a real latency - report it rather than
+        // throwing away a valid measurement.
+        logger.warn(
+          `[PerformanceAudit] Touch latency measured: ${result.latencyMs}ms ` +
+            "(some samples were discounted as animating)",
+        );
+      } else {
+        logger.info(`[PerformanceAudit] Touch latency measured: ${result.latencyMs}ms`);
+      }
+      return result.latencyMs;
+    }
+
+    if (result.animating) {
+      // Every sample was discounted for animating - no valid measurement to
+      // fall back on.
+      logger.warn(
+        "[PerformanceAudit] Touch latency measurement discarded: app is rendering frames " +
+          "on its own (animating) - latency cannot be attributed to the synthetic touch",
+      );
+    } else {
+      logger.warn(`[PerformanceAudit] Touch latency measurement failed: ${result.error}`);
+    }
+    return null;
   }
 
   /**
@@ -714,6 +756,7 @@ export class PerformanceAudit {
     },
     screenSize?: ScreenSize,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    windowBounds?: ElementBounds,
   ): Promise<PerformanceAuditResult> {
     logger.info(`[PerformanceAudit] Running audit for ${packageName}`);
 
@@ -721,7 +764,7 @@ export class PerformanceAudit {
     const deviceCapabilities = await this.capabilitiesDetector.getCapabilities();
 
     // Collect metrics
-    const metrics = await this.collectMetrics(packageName, screenSize, perf);
+    const metrics = await this.collectMetrics(packageName, screenSize, perf, { windowBounds });
 
     // Validate against thresholds
     const violations = this.validateMetrics(metrics, thresholds);

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -252,23 +252,30 @@ export class TouchLatencyTracker {
   /**
    * Reduce the per-sample results of a `measureLatency` run into the final
    * result: a median latency on success, or a failure carrying the
-   * animating disposition when every sample was discounted for it.
+   * animating disposition only when animating explains *every* discounted
+   * sample. A run that mixes an animating sample with a sample that failed
+   * for some other reason (a genuine timeout, an adb error) is not safe to
+   * blanket-label "animating" - that would mask the other failure (#6167).
    */
   private buildResult(
     touchLocation: { x: number; y: number },
     measurements: number[],
-    animatingDetected: boolean,
+    animatingCount: number,
+    otherFailureCount: number,
   ): TouchLatencyResult {
+    const anySampleAnimating = animatingCount > 0;
+
     if (measurements.length === 0) {
+      const allFailuresAnimating = anySampleAnimating && otherFailureCount === 0;
       return {
         latencyMs: 0,
         touchCoordinates: touchLocation,
         success: false,
-        error: animatingDetected
+        error: allFailuresAnimating
           ? "App renders continuously (animating); touch latency cannot be isolated"
           : "No successful measurements - UI may be frozen or gfxinfo unavailable",
         sampleCount: 0,
-        animating: animatingDetected,
+        animating: allFailuresAnimating,
       };
     }
 
@@ -284,7 +291,7 @@ export class TouchLatencyTracker {
       touchCoordinates: touchLocation,
       success: true,
       sampleCount: measurements.length,
-      ...(animatingDetected ? { animating: true } : {}),
+      ...(anySampleAnimating ? { animating: true } : {}),
     };
   }
 
@@ -322,7 +329,8 @@ export class TouchLatencyTracker {
       options.windowBounds,
     );
     const measurements: number[] = [];
-    let animatingDetected = false;
+    let animatingCount = 0;
+    let otherFailureCount = 0;
 
     try {
       for (let i = 0; i < sampleCount; i++) {
@@ -331,11 +339,12 @@ export class TouchLatencyTracker {
         const sampleResult = await this.takeSample(packageName, touchLocation, maxWaitMs, perf, i);
 
         if (sampleResult.animating) {
-          animatingDetected = true;
+          animatingCount++;
         } else if (sampleResult.latencyMs !== null) {
           measurements.push(sampleResult.latencyMs);
           logger.debug(`[TouchLatency] Sample ${i + 1}: ${sampleResult.latencyMs}ms`);
         } else {
+          otherFailureCount++;
           logger.warn(`[TouchLatency] Sample ${i + 1} timeout - no response within ${maxWaitMs}ms`);
         }
 
@@ -345,7 +354,7 @@ export class TouchLatencyTracker {
         }
       }
 
-      return this.buildResult(touchLocation, measurements, animatingDetected);
+      return this.buildResult(touchLocation, measurements, animatingCount, otherFailureCount);
     } catch (error) {
       logger.error(`[TouchLatency] Failed to measure touch latency: ${error}`);
       return {

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -5,7 +5,7 @@ import {
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
-import { BootedDevice, ScreenSize } from "../../models";
+import { BootedDevice, ElementBounds, ScreenSize } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Idle } from "../observe/Idle";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
@@ -35,10 +35,13 @@ interface TouchLatencyResult {
 
 /**
  * A baseline `Total frames rendered` above this during the pre-tap idle
- * window is treated as the app animating on its own rather than a single
- * post-reset redraw settling.
+ * window is treated as the app animating on its own. Any frame rendered
+ * with zero input is evidence of animation, including a slow/low-frame-rate
+ * one that only manages a frame or two in the 50ms window — so this is 0,
+ * not a tolerance band. A genuinely static app reports 0 frames in the
+ * window and is unaffected.
  */
-const ANIMATING_BASELINE_FRAME_THRESHOLD = 2;
+const ANIMATING_BASELINE_FRAME_THRESHOLD = 0;
 
 /**
  * True when a gfxinfo counter was parsed on both sides and grew. A `null` on
@@ -71,14 +74,20 @@ export class TouchLatencyTracker {
   }
 
   /**
-   * Select a safe touch location that's unlikely to trigger UI interactions
-   * Uses screen edges or status bar area
+   * Select a safe touch location that's unlikely to trigger UI interactions.
+   * Prefers the center of the audited app's actual window bounds (correct
+   * under split-screen/freeform, where the app doesn't occupy the full
+   * screen) and falls back to a fixed-fraction default only when window
+   * geometry isn't available (issue #6167).
    * @param screenSize - Device screen dimensions
+   * @param touchPoint - Caller-provided override, takes precedence over everything
+   * @param windowBounds - The audited app's actual window rect, if known
    * @returns Touch coordinates (x, y)
    */
   private selectSafeTouchLocation(
     screenSize: ScreenSize,
     touchPoint?: { x: number; y: number },
+    windowBounds?: ElementBounds,
   ): { x: number; y: number } {
     if (touchPoint) {
       logger.debug(
@@ -87,17 +96,31 @@ export class TouchLatencyTracker {
       return touchPoint;
     }
 
-    // A point at y = 2% of screen height lands inside the SystemUI status bar
-    // on most devices, not the audited app's own window (issue #6167) — a tap
-    // there never reaches the app, so a static-but-responsive app would
-    // falsely read as frozen. Target a point horizontally centered (avoiding
-    // corner overflow-menu / navigation icons) and vertically just below the
-    // status bar and a typical top app bar, which is still content that is
-    // unlikely to be interactive.
+    if (
+      windowBounds &&
+      windowBounds.right > windowBounds.left &&
+      windowBounds.bottom > windowBounds.top
+    ) {
+      const x = Math.floor((windowBounds.left + windowBounds.right) / 2);
+      const y = Math.floor((windowBounds.top + windowBounds.bottom) / 2);
+      logger.debug(
+        `[TouchLatency] Selected touch location from app window bounds ` +
+          `${JSON.stringify(windowBounds)}: (${x}, ${y})`,
+      );
+      return { x, y };
+    }
+
+    // No window geometry available. A point at y = 2% of screen height lands
+    // inside the SystemUI status bar on most devices, not the audited app's
+    // own window — a tap there never reaches the app, so a static-but-
+    // responsive app would falsely read as frozen. Target a point
+    // horizontally centered (avoiding corner overflow-menu / navigation
+    // icons) and vertically just below the status bar and a typical top app
+    // bar, which is still content that is unlikely to be interactive.
     const x = Math.floor(screenSize.width * 0.5); // horizontally centered
     const y = Math.floor(screenSize.height * 0.12); // below status bar + app bar
 
-    logger.debug(`[TouchLatency] Selected safe touch location: (${x}, ${y})`);
+    logger.debug(`[TouchLatency] Selected safe touch location (no window bounds): (${x}, ${y})`);
     return { x, y };
   }
 
@@ -272,6 +295,8 @@ export class TouchLatencyTracker {
       maxWaitMs?: number;
       /** Override the synthetic-tap coordinate (e.g. a known-inert point inside the app window). */
       touchPoint?: { x: number; y: number };
+      /** The audited app's actual window rect, used to derive a safe in-window tap when touchPoint isn't given. */
+      windowBounds?: ElementBounds;
     } = {},
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<TouchLatencyResult> {
@@ -282,7 +307,11 @@ export class TouchLatencyTracker {
       `[TouchLatency] Measuring touch latency for ${packageName} (${sampleCount} samples)`,
     );
 
-    const touchLocation = this.selectSafeTouchLocation(screenSize, options.touchPoint);
+    const touchLocation = this.selectSafeTouchLocation(
+      screenSize,
+      options.touchPoint,
+      options.windowBounds,
+    );
     const measurements: number[] = [];
     let animatingDetected = false;
 

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -33,15 +33,21 @@ interface TouchLatencyResult {
   animating?: boolean;
 }
 
-/**
- * A baseline `Total frames rendered` above this during the pre-tap idle
- * window is treated as the app animating on its own. Any frame rendered
- * with zero input is evidence of animation, including a slow/low-frame-rate
- * one that only manages a frame or two in the 50ms window — so this is 0,
- * not a tolerance band. A genuinely static app reports 0 frames in the
- * window and is unaffected.
- */
-const ANIMATING_BASELINE_FRAME_THRESHOLD = 0;
+/** The subset of `Idle.parseMetrics` used to detect frame activity. */
+interface FrameStats {
+  totalFrames: number | null;
+  missedVsync: number | null;
+  slowUiThread: number | null;
+  frameDeadlineMissed: number | null;
+}
+
+/** A `FrameStats` reading representing "nothing has rendered yet". */
+const ZERO_FRAME_STATS: FrameStats = {
+  totalFrames: 0,
+  missedVsync: 0,
+  slowUiThread: 0,
+  frameDeadlineMissed: 0,
+};
 
 /**
  * True when a gfxinfo counter was parsed on both sides and grew. A `null` on
@@ -50,6 +56,22 @@ const ANIMATING_BASELINE_FRAME_THRESHOLD = 0;
  */
 function counterIncreased(before: number | null, current: number | null): boolean {
   return before !== null && current !== null && current > before;
+}
+
+/**
+ * True when any gfxinfo counter grew between two readings. `Total frames
+ * rendered` is the primary signal (#6124: any rendered frame is a UI
+ * response, not just a janky one); the jank counters (missed vsync, slow UI
+ * thread, frame deadline missed) are a fallback for gfxinfo variants that
+ * omit `Total frames rendered` entirely (#6167).
+ */
+function hasFrameActivity(before: FrameStats, current: FrameStats): boolean {
+  return (
+    counterIncreased(before.totalFrames, current.totalFrames) ||
+    counterIncreased(before.missedVsync, current.missedVsync) ||
+    counterIncreased(before.slowUiThread, current.slowUiThread) ||
+    counterIncreased(before.frameDeadlineMissed, current.frameDeadlineMissed)
+  );
 }
 
 /**
@@ -145,12 +167,7 @@ export class TouchLatencyTracker {
    */
   private async measureFrameResponse(
     packageName: string,
-    beforeStats: {
-      totalFrames: number | null;
-      missedVsync: number | null;
-      slowUiThread: number | null;
-      frameDeadlineMissed: number | null;
-    },
+    beforeStats: FrameStats,
     maxWaitMs: number,
     perf: PerformanceTracker,
   ): Promise<number | null> {
@@ -167,16 +184,7 @@ export class TouchLatencyTracker {
 
         const currentStats = this.idle.parseMetrics(stdout);
 
-        // Any rendered frame is a response (#6124). A smooth app never trips a
-        // jank counter, so `Total frames rendered` is the primary signal; the
-        // jank counters remain as a fallback for gfxinfo variants without it.
-        const hasFrameActivity =
-          counterIncreased(beforeStats.totalFrames, currentStats.totalFrames) ||
-          counterIncreased(beforeStats.missedVsync, currentStats.missedVsync) ||
-          counterIncreased(beforeStats.slowUiThread, currentStats.slowUiThread) ||
-          counterIncreased(beforeStats.frameDeadlineMissed, currentStats.frameDeadlineMissed);
-
-        if (hasFrameActivity) {
+        if (hasFrameActivity(beforeStats, currentStats)) {
           const latency = this.timer.now() - startTime;
           logger.debug(`[TouchLatency] Frame activity detected after ${latency}ms`);
           return latency;
@@ -219,16 +227,17 @@ export class TouchLatencyTracker {
     );
     const baselineStats = this.idle.parseMetrics(baselineStdout);
 
-    // If frames already accumulated during the idle window above, the app is
-    // rendering on its own (spinner/video/ongoing transition) — any frame
-    // delta seen after the tap can't be attributed to it.
-    if (
-      baselineStats.totalFrames !== null &&
-      baselineStats.totalFrames > ANIMATING_BASELINE_FRAME_THRESHOLD
-    ) {
+    // `dumpsys gfxinfo <pkg> reset` above zeroes these counters, so any
+    // activity in this baseline reading is activity that happened during the
+    // no-input idle window itself — the app is rendering on its own
+    // (spinner/video/ongoing transition) and any frame delta seen after the
+    // tap can't be attributed to it. Mirrors the post-tap detection
+    // (`hasFrameActivity`) so a gfxinfo variant that omits `Total frames
+    // rendered` still gets caught via the jank counters (#6167).
+    if (hasFrameActivity(ZERO_FRAME_STATS, baselineStats)) {
       logger.warn(
-        `[TouchLatency] Sample ${sampleIndex + 1}: ${baselineStats.totalFrames} frame(s) ` +
-          "rendered during the pre-tap idle window - app is animating, skipping this sample",
+        `[TouchLatency] Sample ${sampleIndex + 1}: frame activity detected during the ` +
+          "pre-tap idle window - app is animating, skipping this sample",
       );
       return { latencyMs: null, animating: true };
     }

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -41,13 +41,15 @@ interface FrameStats {
   frameDeadlineMissed: number | null;
 }
 
-/** A `FrameStats` reading representing "nothing has rendered yet". */
-const ZERO_FRAME_STATS: FrameStats = {
-  totalFrames: 0,
-  missedVsync: 0,
-  slowUiThread: 0,
-  frameDeadlineMissed: 0,
-};
+/**
+ * Length of each no-input observation window used to detect autonomous
+ * rendering before the synthetic tap. Two of these are taken back to back
+ * (issue #6167 follow-up) so a one-off settling/layout frame right after
+ * `gfxinfo reset` - which lands inside the first window and is therefore
+ * already baked into the first snapshot - doesn't by itself look like
+ * ongoing animation.
+ */
+const PRE_TAP_SETTLE_WINDOW_MS = 50;
 
 /**
  * True when a gfxinfo counter was parsed on both sides and grew. A `null` on
@@ -200,10 +202,21 @@ export class TouchLatencyTracker {
   }
 
   /**
-   * Take a single touch-latency sample: reset gfxinfo, wait out a no-input
-   * idle window to read the baseline, then either flag the app as animating
-   * (baseline already accumulated frames on its own, #6167) or inject the
-   * synthetic touch and measure the frame response.
+   * Take a single touch-latency sample: reset gfxinfo, then read two
+   * consecutive no-input frame-counter snapshots to confirm the app is
+   * actually quiescent before tapping, then either flag it as animating or
+   * inject the synthetic touch and measure the frame response.
+   *
+   * Comparing the first snapshot against zero (the original #6167 fix) let a
+   * single delayed settling/layout frame - which lands inside that first
+   * no-input window on an otherwise-static app - misclassify the whole
+   * sample as "animating" (a false positive in the opposite direction).
+   * Requiring growth BETWEEN two consecutive snapshots instead confirms
+   * *continuous* autonomous rendering: a one-off settling frame is already
+   * folded into the first snapshot and produces no further growth in the
+   * second, so it no longer discards the sample, while an app genuinely
+   * still rendering with no input keeps growing across both reads
+   * (issue #6167 follow-up).
    */
   private async takeSample(
     packageName: string,
@@ -212,32 +225,32 @@ export class TouchLatencyTracker {
     perf: PerformanceTracker,
     sampleIndex: number,
   ): Promise<{ latencyMs: number | null; animating: boolean }> {
-    // Reset gfxinfo to get clean baseline
+    // Reset gfxinfo to get a clean counter baseline.
     await perf.track("adbGfxinfoReset", () =>
       this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName} reset`),
     );
 
-    // Small delay to ensure reset is processed - this is also the no-input
-    // idle window the animating check reads the baseline over.
-    await this.timer.sleep(50);
+    // First no-input snapshot. Any one-off settling/layout frame that occurs
+    // right after reset is absorbed here rather than compared to zero.
+    await this.timer.sleep(PRE_TAP_SETTLE_WINDOW_MS);
+    const { stdout: firstStdout } = await perf.track("adbGfxinfoBaselineFirst", () =>
+      this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`),
+    );
+    const firstStats = this.idle.parseMetrics(firstStdout);
 
-    // Get baseline frame stats
-    const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaseline", () =>
+    // Second no-input snapshot, one settle window later. Real autonomous
+    // rendering shows up as continued growth here; a one-off settling frame
+    // already counted in `firstStats` does not grow further.
+    await this.timer.sleep(PRE_TAP_SETTLE_WINDOW_MS);
+    const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaselineSecond", () =>
       this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`),
     );
     const baselineStats = this.idle.parseMetrics(baselineStdout);
 
-    // `dumpsys gfxinfo <pkg> reset` above zeroes these counters, so any
-    // activity in this baseline reading is activity that happened during the
-    // no-input idle window itself — the app is rendering on its own
-    // (spinner/video/ongoing transition) and any frame delta seen after the
-    // tap can't be attributed to it. Mirrors the post-tap detection
-    // (`hasFrameActivity`) so a gfxinfo variant that omits `Total frames
-    // rendered` still gets caught via the jank counters (#6167).
-    if (hasFrameActivity(ZERO_FRAME_STATS, baselineStats)) {
+    if (hasFrameActivity(firstStats, baselineStats)) {
       logger.warn(
-        `[TouchLatency] Sample ${sampleIndex + 1}: frame activity detected during the ` +
-          "pre-tap idle window - app is animating, skipping this sample",
+        `[TouchLatency] Sample ${sampleIndex + 1}: frame activity detected across two ` +
+          "consecutive no-input snapshots - app is animating, skipping this sample",
       );
       return { latencyMs: null, animating: true };
     }

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -48,8 +48,22 @@ interface FrameStats {
  * `gfxinfo reset` - which lands inside the first window and is therefore
  * already baked into the first snapshot - doesn't by itself look like
  * ongoing animation.
+ *
+ * The gap BETWEEN the two snapshots (this constant) is what has to catch a
+ * still-animating app: growth is only visible if at least one frame of the
+ * animation renders somewhere in that gap, regardless of where the gap's
+ * phase falls relative to the animation's own period. To guarantee that for
+ * an unknown phase, the gap must be at least one full period long. 125ms
+ * covers down to ~10fps (a 100ms period) with margin, matching the slowest
+ * rendering rate worth flagging as "still animating" rather than "settled" -
+ * a further follow-up (#6167) can widen this again if a slower floor turns
+ * out to matter, at the cost of a longer pre-tap delay on every sample. An
+ * animation slower than that floor (a period at or beyond this window) is
+ * genuinely indistinguishable from a one-off settling frame within a bounded
+ * pre-tap observation - only a longer window (traded against audit latency)
+ * can pull that floor down further.
  */
-const PRE_TAP_SETTLE_WINDOW_MS = 50;
+const PRE_TAP_SETTLE_WINDOW_MS = 125;
 
 /**
  * True when a gfxinfo counter was parsed on both sides and grew. A `null` on

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -25,7 +25,20 @@ interface TouchLatencyResult {
   error?: string;
   /** Number of samples taken */
   sampleCount: number;
+  /**
+   * True when the app was rendering frames on its own (spinner, video,
+   * ongoing transition) during the pre-tap idle window, so any measured
+   * latency cannot be attributed to the synthetic touch (issue #6167).
+   */
+  animating?: boolean;
 }
+
+/**
+ * A baseline `Total frames rendered` above this during the pre-tap idle
+ * window is treated as the app animating on its own rather than a single
+ * post-reset redraw settling.
+ */
+const ANIMATING_BASELINE_FRAME_THRESHOLD = 2;
 
 /**
  * True when a gfxinfo counter was parsed on both sides and grew. A `null` on
@@ -63,11 +76,26 @@ export class TouchLatencyTracker {
    * @param screenSize - Device screen dimensions
    * @returns Touch coordinates (x, y)
    */
-  private selectSafeTouchLocation(screenSize: ScreenSize): { x: number; y: number } {
-    // Use top-right corner of status bar area (typically safe and non-interactive)
-    // Status bar is usually ~50-75px tall
-    const x = Math.floor(screenSize.width * 0.95); // 95% to right
-    const y = Math.floor(screenSize.height * 0.02); // 2% from top (status bar)
+  private selectSafeTouchLocation(
+    screenSize: ScreenSize,
+    touchPoint?: { x: number; y: number },
+  ): { x: number; y: number } {
+    if (touchPoint) {
+      logger.debug(
+        `[TouchLatency] Using caller-provided touch location: (${touchPoint.x}, ${touchPoint.y})`,
+      );
+      return touchPoint;
+    }
+
+    // A point at y = 2% of screen height lands inside the SystemUI status bar
+    // on most devices, not the audited app's own window (issue #6167) — a tap
+    // there never reaches the app, so a static-but-responsive app would
+    // falsely read as frozen. Target a point horizontally centered (avoiding
+    // corner overflow-menu / navigation icons) and vertically just below the
+    // status bar and a typical top app bar, which is still content that is
+    // unlikely to be interactive.
+    const x = Math.floor(screenSize.width * 0.5); // horizontally centered
+    const y = Math.floor(screenSize.height * 0.12); // below status bar + app bar
 
     logger.debug(`[TouchLatency] Selected safe touch location: (${x}, ${y})`);
     return { x, y };
@@ -141,6 +169,94 @@ export class TouchLatencyTracker {
   }
 
   /**
+   * Take a single touch-latency sample: reset gfxinfo, wait out a no-input
+   * idle window to read the baseline, then either flag the app as animating
+   * (baseline already accumulated frames on its own, #6167) or inject the
+   * synthetic touch and measure the frame response.
+   */
+  private async takeSample(
+    packageName: string,
+    touchLocation: { x: number; y: number },
+    maxWaitMs: number,
+    perf: PerformanceTracker,
+    sampleIndex: number,
+  ): Promise<{ latencyMs: number | null; animating: boolean }> {
+    // Reset gfxinfo to get clean baseline
+    await perf.track("adbGfxinfoReset", () =>
+      this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName} reset`),
+    );
+
+    // Small delay to ensure reset is processed - this is also the no-input
+    // idle window the animating check reads the baseline over.
+    await this.timer.sleep(50);
+
+    // Get baseline frame stats
+    const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaseline", () =>
+      this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`),
+    );
+    const baselineStats = this.idle.parseMetrics(baselineStdout);
+
+    // If frames already accumulated during the idle window above, the app is
+    // rendering on its own (spinner/video/ongoing transition) — any frame
+    // delta seen after the tap can't be attributed to it.
+    if (
+      baselineStats.totalFrames !== null &&
+      baselineStats.totalFrames > ANIMATING_BASELINE_FRAME_THRESHOLD
+    ) {
+      logger.warn(
+        `[TouchLatency] Sample ${sampleIndex + 1}: ${baselineStats.totalFrames} frame(s) ` +
+          "rendered during the pre-tap idle window - app is animating, skipping this sample",
+      );
+      return { latencyMs: null, animating: true };
+    }
+
+    // Inject touch and immediately start measuring
+    await this.injectTouch(touchLocation.x, touchLocation.y, perf);
+
+    const latencyMs = await this.measureFrameResponse(packageName, baselineStats, maxWaitMs, perf);
+    return { latencyMs, animating: false };
+  }
+
+  /**
+   * Reduce the per-sample results of a `measureLatency` run into the final
+   * result: a median latency on success, or a failure carrying the
+   * animating disposition when every sample was discounted for it.
+   */
+  private buildResult(
+    touchLocation: { x: number; y: number },
+    measurements: number[],
+    animatingDetected: boolean,
+  ): TouchLatencyResult {
+    if (measurements.length === 0) {
+      return {
+        latencyMs: 0,
+        touchCoordinates: touchLocation,
+        success: false,
+        error: animatingDetected
+          ? "App renders continuously (animating); touch latency cannot be isolated"
+          : "No successful measurements - UI may be frozen or gfxinfo unavailable",
+        sampleCount: 0,
+        animating: animatingDetected,
+      };
+    }
+
+    // Median latency (more robust than average). The empty case is handled above.
+    const medianLatency = calculateMedian(measurements) ?? 0;
+
+    logger.info(
+      `[TouchLatency] Measured latency: ${medianLatency}ms (from ${measurements.length} samples)`,
+    );
+
+    return {
+      latencyMs: medianLatency,
+      touchCoordinates: touchLocation,
+      success: true,
+      sampleCount: measurements.length,
+      ...(animatingDetected ? { animating: true } : {}),
+    };
+  }
+
+  /**
    * Measure touch latency for a given package
    * @param packageName - Package name to monitor
    * @param screenSize - Device screen dimensions
@@ -154,6 +270,8 @@ export class TouchLatencyTracker {
     options: {
       sampleCount?: number;
       maxWaitMs?: number;
+      /** Override the synthetic-tap coordinate (e.g. a known-inert point inside the app window). */
+      touchPoint?: { x: number; y: number };
     } = {},
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<TouchLatencyResult> {
@@ -164,41 +282,21 @@ export class TouchLatencyTracker {
       `[TouchLatency] Measuring touch latency for ${packageName} (${sampleCount} samples)`,
     );
 
-    const touchLocation = this.selectSafeTouchLocation(screenSize);
+    const touchLocation = this.selectSafeTouchLocation(screenSize, options.touchPoint);
     const measurements: number[] = [];
+    let animatingDetected = false;
 
     try {
       for (let i = 0; i < sampleCount; i++) {
         logger.debug(`[TouchLatency] Taking sample ${i + 1}/${sampleCount}`);
 
-        // Reset gfxinfo to get clean baseline
-        await perf.track("adbGfxinfoReset", () =>
-          this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName} reset`),
-        );
+        const sampleResult = await this.takeSample(packageName, touchLocation, maxWaitMs, perf, i);
 
-        // Small delay to ensure reset is processed
-        await this.timer.sleep(50);
-
-        // Get baseline frame stats
-        const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaseline", () =>
-          this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`),
-        );
-        const baselineStats = this.idle.parseMetrics(baselineStdout);
-
-        // Inject touch and immediately start measuring
-        await this.injectTouch(touchLocation.x, touchLocation.y, perf);
-
-        // Measure time until frame response
-        const latency = await this.measureFrameResponse(
-          packageName,
-          baselineStats,
-          maxWaitMs,
-          perf,
-        );
-
-        if (latency !== null) {
-          measurements.push(latency);
-          logger.debug(`[TouchLatency] Sample ${i + 1}: ${latency}ms`);
+        if (sampleResult.animating) {
+          animatingDetected = true;
+        } else if (sampleResult.latencyMs !== null) {
+          measurements.push(sampleResult.latencyMs);
+          logger.debug(`[TouchLatency] Sample ${i + 1}: ${sampleResult.latencyMs}ms`);
         } else {
           logger.warn(`[TouchLatency] Sample ${i + 1} timeout - no response within ${maxWaitMs}ms`);
         }
@@ -209,29 +307,7 @@ export class TouchLatencyTracker {
         }
       }
 
-      if (measurements.length === 0) {
-        return {
-          latencyMs: 0,
-          touchCoordinates: touchLocation,
-          success: false,
-          error: "No successful measurements - UI may be frozen or gfxinfo unavailable",
-          sampleCount: 0,
-        };
-      }
-
-      // Median latency (more robust than average). The empty case is handled above.
-      const medianLatency = calculateMedian(measurements) ?? 0;
-
-      logger.info(
-        `[TouchLatency] Measured latency: ${medianLatency}ms (from ${measurements.length} samples)`,
-      );
-
-      return {
-        latencyMs: medianLatency,
-        touchCoordinates: touchLocation,
-        success: true,
-        sampleCount: measurements.length,
-      };
+      return this.buildResult(touchLocation, measurements, animatingDetected);
     } catch (error) {
       logger.error(`[TouchLatency] Failed to measure touch latency: ${error}`);
       return {

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -792,4 +792,56 @@ describe("isHierarchyReliableForTapProbe / deriveTouchLatencyPoint unverified ca
     expect(decision.touchPoint).toBeDefined();
     expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
   });
+
+  // P2: ObserveScreen deliberately keeps activeWindow.appId on the
+  // underlying app while a notification-permission prompt is open (only
+  // stamping activeWindow.type), but CtrlProxy reports the prompt itself as
+  // a package-less type-1 APPLICATION window - so findAppWindowBounds
+  // derives the PROMPT's bounds while gfxinfo would sample the underlying
+  // app's package, and a synthetic tap can grant/deny a live permission
+  // prompt.
+  test("skips touch-latency when activeWindow.type is notification_permission_dialog", () => {
+    const result = makeResult({
+      activeWindow: {
+        appId: "com.example.app",
+        activityName: "MainActivity",
+        type: "notification_permission_dialog",
+      } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
+  });
+
+  test("skips touch-latency when notificationPermissionDetected is set, even without activeWindow.type stamped", () => {
+    const result = makeResult({
+      activeWindow: { appId: "com.example.app", activityName: "MainActivity" } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+      notificationPermissionDetected: true,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
+  });
+
+  test("is unaffected by a normal app window with no dialog type and no permission flag", () => {
+    const result = makeResult({
+      activeWindow: { appId: "com.example.app", activityName: "MainActivity" } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+      notificationPermissionDetected: false,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
+  });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { PerformanceAuditor } from "../../../../src/features/observe/audits/PerformanceAuditor";
+import {
+  findAppWindowBounds,
+  PerformanceAuditor,
+} from "../../../../src/features/observe/audits/PerformanceAuditor";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
 import {
   NoOpPerformanceTracker,
@@ -147,5 +150,61 @@ describe("PerformanceAuditor", () => {
     });
     await auditor.run(result, new NoOpPerformanceTracker());
     expect(factory.wasCalledForDevice(androidDevice.deviceId)).toBe(true);
+  });
+});
+
+describe("findAppWindowBounds (#6167)", () => {
+  test("returns undefined when the result has no window list", () => {
+    const result = makeResult();
+    expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
+  });
+
+  test("prefers the focused window for the app over an unfocused one", () => {
+    const focusedBounds = { left: 0, top: 960, right: 1080, bottom: 1920 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [
+          {
+            packageName: "com.example",
+            isFocused: false,
+            bounds: { left: 0, top: 0, right: 1080, bottom: 960 },
+          },
+          { packageName: "com.example", isFocused: true, bounds: focusedBounds },
+          {
+            packageName: "com.other",
+            isFocused: true,
+            bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+          },
+        ],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toEqual(focusedBounds);
+  });
+
+  test("falls back to any matching window when none is marked focused", () => {
+    // Split-screen: the audited app occupies the lower half, no window
+    // explicitly marked focused in this hierarchy snapshot.
+    const lowerHalf = { left: 0, top: 960, right: 1080, bottom: 1920 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [{ packageName: "com.example", bounds: lowerHalf }],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toEqual(lowerHalf);
+  });
+
+  test("returns undefined when no window matches the app id", () => {
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [{ packageName: "com.other", bounds: { left: 0, top: 0, right: 10, bottom: 10 } }],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
   });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  collectHiddenRegionBounds,
   collectInteractiveObstacles,
   deriveTouchLatencyPoint,
   findAppWindowBounds,
@@ -382,6 +383,35 @@ describe("findInertTouchPoint (#6167)", () => {
       y < focusableField.bounds.bottom;
     expect(insideField).toBe(false);
   });
+
+  // Regression: a content-hidden region (e.g. a large Compose-interop area)
+  // exposes no interactive descendants in the accessibility hierarchy at
+  // all, so it can never appear in the obstacle list - but a candidate point
+  // landing inside it can still tap a real (hidden) control.
+  test("treats a content-hidden region as unsafe even with no accessibility obstacles", () => {
+    const hiddenRegion = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+    const result = findInertTouchPoint(appWindow, [], [hiddenRegion]);
+
+    // Every candidate falls inside the full-window hidden region - no
+    // verified-inert point exists.
+    expect(result.inert).toBe(false);
+  });
+
+  test("avoids a small content-hidden region while still picking an inert point", () => {
+    const hiddenRegion = { left: 440, top: 900, right: 640, bottom: 1020 };
+
+    const result = findInertTouchPoint(appWindow, [], [hiddenRegion]);
+
+    expect(result.inert).toBe(true);
+    const { x, y } = result.point;
+    const insideHiddenRegion =
+      x >= hiddenRegion.left &&
+      x < hiddenRegion.right &&
+      y >= hiddenRegion.top &&
+      y < hiddenRegion.bottom;
+    expect(insideHiddenRegion).toBe(false);
+  });
 });
 
 describe("collectInteractiveObstacles / deriveTouchLatencyPoint (#6167 follow-up)", () => {
@@ -506,5 +536,83 @@ describe("collectInteractiveObstacles / deriveTouchLatencyPoint (#6167 follow-up
       y >= focusableBounds.top &&
       y < focusableBounds.bottom;
     expect(insideField).toBe(false);
+  });
+});
+
+describe("collectHiddenRegionBounds / deriveTouchLatencyPoint content-hidden regions (#6167 follow-up)", () => {
+  const appWindow = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+  test("collectHiddenRegionBounds returns the bounds of every content-hidden region", () => {
+    const region = {
+      bounds: { left: 100, top: 200, right: 900, bottom: 1800 },
+      reason: "compose-interop-no-hide-descendants" as const,
+      areaPercent: 60,
+    };
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, contentHiddenRegions: [region] } as any,
+    });
+
+    expect(collectHiddenRegionBounds(result)).toEqual([region.bounds]);
+  });
+
+  test("collectHiddenRegionBounds returns an empty array when there are none", () => {
+    const result = makeResult();
+    expect(collectHiddenRegionBounds(result)).toEqual([]);
+  });
+
+  // P1: a large Compose-interop content-hidden region exposes no
+  // interactive descendants in the accessibility hierarchy at all, so
+  // `collectInteractiveObstacles` sees nothing there - a candidate point
+  // inside it must still be rejected via the hidden-region check, and with
+  // no other candidate available the caller must skip touch-latency
+  // entirely rather than tap into the hidden content.
+  test("deriveTouchLatencyPoint skips when a full-window content-hidden region leaves no safe candidate", () => {
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        contentHiddenRegions: [
+          {
+            bounds: appWindow,
+            reason: "compose-interop-no-hide-descendants",
+            areaPercent: 100,
+          },
+        ],
+      } as any,
+      // The accessibility hierarchy is empty - no obstacle would be found
+      // without the hidden-region check.
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
+  test("deriveTouchLatencyPoint avoids a small content-hidden region via the production path", () => {
+    const hiddenBounds = { left: 440, top: 900, right: 640, bottom: 1020 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        contentHiddenRegions: [
+          {
+            bounds: hiddenBounds,
+            reason: "compose-interop-no-hide-descendants",
+            areaPercent: 10,
+          },
+        ],
+      } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    const { x, y } = decision.touchPoint!;
+    const insideHiddenRegion =
+      x >= hiddenBounds.left &&
+      x < hiddenBounds.right &&
+      y >= hiddenBounds.top &&
+      y < hiddenBounds.bottom;
+    expect(insideHiddenRegion).toBe(false);
   });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   findAppWindowBounds,
   PerformanceAuditor,
@@ -9,7 +11,7 @@ import {
   setDebugPerfEnabled,
 } from "../../../../src/utils/PerformanceTracker";
 import { serverConfig } from "../../../../src/utils/ServerConfig";
-import type { BootedDevice, ObserveResult } from "../../../../src/models";
+import type { BootedDevice, ObserveResult, ViewHierarchyWindowInfo } from "../../../../src/models";
 
 function makeResult(overrides: Partial<ObserveResult> = {}): ObserveResult {
   return {
@@ -154,54 +156,102 @@ describe("PerformanceAuditor", () => {
 });
 
 describe("findAppWindowBounds (#6167)", () => {
+  // Real production shape from CtrlProxy's `WindowInfo` wire type
+  // (android/control-proxy/.../models/WindowInfo.kt): id/type/isActive/
+  // isFocused/bounds only - notably NO per-window packageName. Loaded
+  // straight from the actual fixture rather than hand-made, per the #6167
+  // follow-up review (the earlier version of this test invented a
+  // `packageName` field the real device never emits).
+  const androidHomeFixture = JSON.parse(
+    readFileSync(resolve(__dirname, "../../../fixtures/observe/android-home.json"), "utf-8"),
+  ) as { viewHierarchy: { windows: ViewHierarchyWindowInfo[] } };
+  const realWindows = androidHomeFixture.viewHierarchy.windows;
+
   test("returns undefined when the result has no window list", () => {
     const result = makeResult();
     expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
   });
 
-  test("prefers the focused window for the app over an unfocused one", () => {
-    const focusedBounds = { left: 0, top: 960, right: 1080, bottom: 1920 };
+  test("against the real fixture: picks the focused application window, not the status bar", () => {
+    // Fixture has a type=3 (SYSTEM/status bar) window and a focused type=1
+    // (APPLICATION) window - neither carries packageName.
+    expect(realWindows.some((w) => w.packageName !== undefined)).toBe(false);
+
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, windows: realWindows } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toEqual({
+      left: 0,
+      top: 0,
+      right: 1080,
+      bottom: 2400,
+    });
+  });
+
+  test("excludes the SystemUI (type=3) window even when it is focused", () => {
+    const statusBarBounds = { left: 0, top: 0, right: 1080, bottom: 63 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [
+          { id: 67, type: 3, isActive: false, isFocused: true, bounds: statusBarBounds },
+          {
+            id: 63,
+            type: 1,
+            isActive: true,
+            isFocused: false,
+            bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          },
+        ] as ViewHierarchyWindowInfo[],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toEqual({
+      left: 0,
+      top: 0,
+      right: 1080,
+      bottom: 2400,
+    });
+  });
+
+  test("split-screen lower half: falls back to the non-SystemUI window when none is focused", () => {
+    // Split-screen, no window explicitly marked focused in this snapshot -
+    // the audited app occupies only the lower half. Real wire shape: no
+    // packageName on either window.
+    const lowerHalf = { left: 0, top: 960, right: 1080, bottom: 1920 };
     const result = makeResult({
       viewHierarchy: {
         hierarchy: {} as any,
         windows: [
           {
-            packageName: "com.example",
+            id: 1,
+            type: 3,
+            isActive: false,
             isFocused: false,
-            bounds: { left: 0, top: 0, right: 1080, bottom: 960 },
+            bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
           },
-          { packageName: "com.example", isFocused: true, bounds: focusedBounds },
-          {
-            packageName: "com.other",
-            isFocused: true,
-            bounds: { left: 0, top: 0, right: 10, bottom: 10 },
-          },
-        ],
-      } as any,
-    });
-
-    expect(findAppWindowBounds(result, "com.example")).toEqual(focusedBounds);
-  });
-
-  test("falls back to any matching window when none is marked focused", () => {
-    // Split-screen: the audited app occupies the lower half, no window
-    // explicitly marked focused in this hierarchy snapshot.
-    const lowerHalf = { left: 0, top: 960, right: 1080, bottom: 1920 };
-    const result = makeResult({
-      viewHierarchy: {
-        hierarchy: {} as any,
-        windows: [{ packageName: "com.example", bounds: lowerHalf }],
+          { id: 2, type: 1, isActive: true, isFocused: false, bounds: lowerHalf },
+        ] as ViewHierarchyWindowInfo[],
       } as any,
     });
 
     expect(findAppWindowBounds(result, "com.example")).toEqual(lowerHalf);
   });
 
-  test("returns undefined when no window matches the app id", () => {
+  test("returns undefined when only a SystemUI window is present", () => {
     const result = makeResult({
       viewHierarchy: {
         hierarchy: {} as any,
-        windows: [{ packageName: "com.other", bounds: { left: 0, top: 0, right: 10, bottom: 10 } }],
+        windows: [
+          {
+            id: 1,
+            type: 3,
+            isActive: true,
+            isFocused: true,
+            bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          },
+        ] as ViewHierarchyWindowInfo[],
       } as any,
     });
 

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -425,6 +425,40 @@ describe("collectInteractiveObstacles / deriveTouchLatencyPoint (#6167 follow-up
     expect(deriveTouchLatencyPoint(undefined, result)).toEqual({ skipTouchLatency: true });
   });
 
+  // Regression: Android can transiently report zero-area window bounds
+  // (e.g. a window mid-transition). A naive center calculation on
+  // {left:100,top:100,right:100,bottom:100} still produces a defined-looking
+  // point (100, 100) that isn't actually inside any real content - it must
+  // not be reported inert and tapped.
+  test("deriveTouchLatencyPoint skips on zero-area window bounds", () => {
+    const zeroArea = { left: 100, top: 100, right: 100, bottom: 100 };
+    const result = makeResult();
+
+    const decision = deriveTouchLatencyPoint(zeroArea, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
+  // Regression: inverted bounds (right < left, or bottom < top) must also be
+  // rejected rather than producing a negative-width/height "center".
+  test("deriveTouchLatencyPoint skips on inverted window bounds", () => {
+    const inverted = { left: 500, top: 900, right: 100, bottom: 200 };
+    const result = makeResult();
+
+    const decision = deriveTouchLatencyPoint(inverted, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
+  test("deriveTouchLatencyPoint skips on non-finite window bounds", () => {
+    const nonFinite = { left: 0, top: 0, right: Number.NaN, bottom: 1920 };
+    const result = makeResult();
+
+    const decision = deriveTouchLatencyPoint(nonFinite, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
   // P1: when every scanned candidate overlaps a control (a full-screen
   // button, WebView, or map), the caller must skip the touch-latency
   // measurement entirely rather than tap the known-unsafe fallback point.

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -257,4 +257,42 @@ describe("findAppWindowBounds (#6167)", () => {
 
     expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
   });
+
+  test("excludes the focused IME (soft keyboard, type=2) window and returns the app window instead", () => {
+    // AccessibilityWindowInfo.TYPE_INPUT_METHOD = 2. The keyboard can hold
+    // input focus while open, but its bounds are the keyboard's, not the
+    // audited app's.
+    const appBounds = { left: 0, top: 0, right: 1080, bottom: 1200 };
+    const imeBounds = { left: 0, top: 1200, right: 1080, bottom: 2400 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [
+          { id: 1, type: 1, isActive: true, isFocused: false, bounds: appBounds },
+          { id: 2, type: 2, isActive: true, isFocused: true, bounds: imeBounds },
+        ] as ViewHierarchyWindowInfo[],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toEqual(appBounds);
+  });
+
+  test("returns undefined when the only window is a focused IME (no app window to fall back to)", () => {
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        windows: [
+          {
+            id: 1,
+            type: 2,
+            isActive: true,
+            isFocused: true,
+            bounds: { left: 0, top: 1200, right: 1080, bottom: 2400 },
+          },
+        ] as ViewHierarchyWindowInfo[],
+      } as any,
+    });
+
+    expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
+  });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -759,4 +759,37 @@ describe("isHierarchyReliableForTapProbe / deriveTouchLatencyPoint unverified ca
     });
     expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
   });
+
+  // P2: when a status bar / notification shade / keyguard owns focus,
+  // ObserveScreen.reconcileActiveWindowAttribution rewrites
+  // activeWindow.appId to com.android.systemui, but the real window entries
+  // never carry packageName - so the app-window predicate still accepts the
+  // occluded app's own type-1 window as "SystemUI's" window. Certifying a
+  // point there would tap the occluded app while gfxinfo samples
+  // com.android.systemui.
+  test("skips touch-latency when activeWindow.appId is com.android.systemui, even with a normal hierarchy", () => {
+    const result = makeResult({
+      activeWindow: { appId: "com.android.systemui", activityName: "StatusBar" } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
+  });
+
+  test("is unaffected when activeWindow.appId is a normal app package", () => {
+    const result = makeResult({
+      activeWindow: { appId: "com.example.app", activityName: "MainActivity" } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
+  });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   findAppWindowBounds,
+  findInertTouchPoint,
   PerformanceAuditor,
 } from "../../../../src/features/observe/audits/PerformanceAuditor";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
@@ -11,7 +12,12 @@ import {
   setDebugPerfEnabled,
 } from "../../../../src/utils/PerformanceTracker";
 import { serverConfig } from "../../../../src/utils/ServerConfig";
-import type { BootedDevice, ObserveResult, ViewHierarchyWindowInfo } from "../../../../src/models";
+import type {
+  BootedDevice,
+  Element,
+  ObserveResult,
+  ViewHierarchyWindowInfo,
+} from "../../../../src/models";
 
 function makeResult(overrides: Partial<ObserveResult> = {}): ObserveResult {
   return {
@@ -294,5 +300,84 @@ describe("findAppWindowBounds (#6167)", () => {
     });
 
     expect(findAppWindowBounds(result, "com.example")).toBeUndefined();
+  });
+});
+
+describe("findInertTouchPoint (#6167)", () => {
+  const appWindow = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+  function button(bounds: { left: number; top: number; right: number; bottom: number }): Element {
+    return { bounds, clickable: true } as Element;
+  }
+
+  test("avoids a button at the window center, landing on inert space instead", () => {
+    // A button covering the exact center point the naive fixed-fraction
+    // default used to tap.
+    const centerButton = button({ left: 440, top: 900, right: 640, bottom: 1020 });
+
+    const result = findInertTouchPoint(appWindow, [centerButton]);
+
+    expect(result.inert).toBe(true);
+    const { x, y } = result.point;
+    const insideButton =
+      x >= centerButton.bounds.left &&
+      x < centerButton.bounds.right &&
+      y >= centerButton.bounds.top &&
+      y < centerButton.bounds.bottom;
+    expect(insideButton).toBe(false);
+    // Still inside the app window.
+    expect(x).toBeGreaterThanOrEqual(appWindow.left);
+    expect(x).toBeLessThan(appWindow.right);
+    expect(y).toBeGreaterThanOrEqual(appWindow.top);
+    expect(y).toBeLessThan(appWindow.bottom);
+  });
+
+  test("picks the plain window center when nothing overlaps it", () => {
+    const result = findInertTouchPoint(appWindow, []);
+    expect(result.inert).toBe(true);
+    expect(result.point).toEqual({ x: 540, y: 960 });
+  });
+
+  test("ignores non-interactive elements (plain text) when scanning for obstacles", () => {
+    const label: Element = { bounds: appWindow, clickable: false } as Element;
+    const result = findInertTouchPoint(appWindow, [label]);
+    expect(result.inert).toBe(true);
+    expect(result.point).toEqual({ x: 540, y: 960 });
+  });
+
+  test("falls back to a defined safe point and reports inert:false when every candidate is a control", () => {
+    // A hierarchy that is a control everywhere: one giant clickable element
+    // covering the entire app window, so no scanned candidate can avoid it.
+    const fullScreenButton = button(appWindow);
+
+    const result = findInertTouchPoint(appWindow, [fullScreenButton]);
+
+    // Does not silently report a clean, verified-inert point.
+    expect(result.inert).toBe(false);
+    // Still returns a defined, in-window point rather than throwing or
+    // omitting a coordinate.
+    expect(result.point.x).toBeGreaterThanOrEqual(appWindow.left);
+    expect(result.point.x).toBeLessThan(appWindow.right);
+    expect(result.point.y).toBeGreaterThanOrEqual(appWindow.top);
+    expect(result.point.y).toBeLessThan(appWindow.bottom);
+  });
+
+  test("treats a focusable (non-clickable) element as an obstacle too", () => {
+    const focusableField = {
+      bounds: { left: 440, top: 900, right: 640, bottom: 1020 },
+      clickable: false,
+      focusable: true,
+    } as Element;
+
+    const result = findInertTouchPoint(appWindow, [focusableField]);
+
+    expect(result.inert).toBe(true);
+    const { x, y } = result.point;
+    const insideField =
+      x >= focusableField.bounds.left &&
+      x < focusableField.bounds.right &&
+      y >= focusableField.bounds.top &&
+      y < focusableField.bounds.bottom;
+    expect(insideField).toBe(false);
   });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  collectInteractiveObstacles,
+  deriveTouchLatencyPoint,
   findAppWindowBounds,
   findInertTouchPoint,
   PerformanceAuditor,
@@ -378,6 +380,97 @@ describe("findInertTouchPoint (#6167)", () => {
       x < focusableField.bounds.right &&
       y >= focusableField.bounds.top &&
       y < focusableField.bounds.bottom;
+    expect(insideField).toBe(false);
+  });
+});
+
+describe("collectInteractiveObstacles / deriveTouchLatencyPoint (#6167 follow-up)", () => {
+  const appWindow = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+  test("falls back to elements.clickable when there is no raw view hierarchy to walk", () => {
+    const clickableEl: Element = {
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      clickable: true,
+    } as Element;
+    const result = makeResult({
+      elements: { clickable: [clickableEl], scrollable: [], text: [], media: [] },
+    });
+
+    expect(collectInteractiveObstacles(result)).toEqual([clickableEl]);
+  });
+
+  // Regression: `DefaultObserveElementCollector` only populates
+  // `elements.clickable` for clickable/click-action nodes, but a
+  // focusable-only or long-clickable-only control is also an obstacle for
+  // the inert-point scan. `elements.clickable` being empty here mirrors what
+  // the real collector produces for such a node - the obstacle must still
+  // come from walking the raw hierarchy.
+  test("includes a focusable-only node from the raw hierarchy even when elements.clickable omits it", () => {
+    const focusableBounds = { left: 440, top: 900, right: 640, bottom: 1020 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {
+          node: { $: { focusable: "true", clickable: "false", bounds: focusableBounds } },
+        },
+      } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const obstacles = collectInteractiveObstacles(result);
+    expect(obstacles.some((el) => el.bounds?.left === focusableBounds.left)).toBe(true);
+  });
+
+  test("deriveTouchLatencyPoint reports skipTouchLatency when windowBounds is undefined", () => {
+    const result = makeResult();
+    expect(deriveTouchLatencyPoint(undefined, result)).toEqual({ skipTouchLatency: true });
+  });
+
+  // P1: when every scanned candidate overlaps a control (a full-screen
+  // button, WebView, or map), the caller must skip the touch-latency
+  // measurement entirely rather than tap the known-unsafe fallback point.
+  test("deriveTouchLatencyPoint skips when every candidate overlaps a control, via the production hierarchy-walk path", () => {
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {
+          node: { $: { clickable: "true", bounds: appWindow } },
+        },
+      } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
+  // P2: a focusable-only control covering a candidate point must be avoided
+  // through the real production obstacle-collection path (raw hierarchy
+  // walk), not just via a hand-built obstacle list passed directly to
+  // findInertTouchPoint.
+  test("deriveTouchLatencyPoint avoids a focusable-only control found via the production hierarchy-walk path", () => {
+    const focusableBounds = { left: 440, top: 900, right: 640, bottom: 1020 };
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            $: { focusable: "true", clickable: "false", bounds: focusableBounds },
+          },
+        },
+      } as any,
+      // Mirrors the real DefaultObserveElementCollector output: a
+      // focusable-only node is never added to `clickable`.
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    const { x, y } = decision.touchPoint!;
+    const insideField =
+      x >= focusableBounds.left &&
+      x < focusableBounds.right &&
+      y >= focusableBounds.top &&
+      y < focusableBounds.bottom;
     expect(insideField).toBe(false);
   });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -616,3 +616,69 @@ describe("collectHiddenRegionBounds / deriveTouchLatencyPoint content-hidden reg
     expect(insideHiddenRegion).toBe(false);
   });
 });
+
+describe("deriveTouchLatencyPoint truncated hierarchy (#6167 follow-up)", () => {
+  const appWindow = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+  // P1: CtrlProxy stops emitting descendants once it hits max_nodes/max_depth
+  // or is cancelled mid-walk, so an empty accessibility hierarchy here does
+  // NOT mean "no obstacles" - it may mean "the obstacle wasn't emitted".
+  // Certifying any point as inert from a truncated hierarchy is unsafe.
+  test("skips touch-latency when truncationReasons is non-empty, even with an empty hierarchy", () => {
+    const result = makeResult({
+      viewHierarchy: {
+        hierarchy: {} as any,
+        truncationReasons: ["max_nodes"],
+      } as any,
+      // No obstacles are visible at all - without the truncation check this
+      // would wrongly certify the window center as inert.
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+  });
+
+  test("skips touch-latency for a max_depth truncation reason", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, truncationReasons: ["max_depth"] } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+  });
+
+  test("skips touch-latency for a cancelled truncation reason", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, truncationReasons: ["cancelled"] } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+  });
+
+  test("is unaffected by an empty truncationReasons array", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, truncationReasons: [] } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+  });
+
+  test("is unaffected when truncationReasons is absent entirely", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+  });
+});

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -7,6 +7,7 @@ import {
   deriveTouchLatencyPoint,
   findAppWindowBounds,
   findInertTouchPoint,
+  isHierarchyReliableForTapProbe,
   PerformanceAuditor,
 } from "../../../../src/features/observe/audits/PerformanceAuditor";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
@@ -680,5 +681,82 @@ describe("deriveTouchLatencyPoint truncated hierarchy (#6167 follow-up)", () => 
     const decision = deriveTouchLatencyPoint(appWindow, result);
     expect(decision.skipTouchLatency).toBe(false);
     expect(decision.touchPoint).toBeDefined();
+  });
+});
+
+describe("isHierarchyReliableForTapProbe / deriveTouchLatencyPoint unverified capture (#6167 follow-up)", () => {
+  const appWindow = { left: 0, top: 0, right: 1080, bottom: 1920 };
+
+  // P1: a stale cached tree was never verified against the device on this
+  // call - certifying a point from it can tap a control that has since
+  // moved, appeared, or disappeared.
+  test("skips touch-latency when fresh is false, even with an empty hierarchy", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, fresh: false } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
+  });
+
+  // P1: in the incomplete split-screen case CtrlProxy can withhold the
+  // focused app's own rootless window entirely while still returning
+  // ANOTHER app's package-less type-1 window - certifying a point here can
+  // tap the wrong app.
+  test("skips touch-latency when ctrlProxyIncomplete is true, even with an empty hierarchy", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, ctrlProxyIncomplete: true } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(true);
+    expect(decision.touchPoint).toBeUndefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
+  });
+
+  test("is unaffected when fresh is true and ctrlProxyIncomplete is absent", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, fresh: true } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
+  });
+
+  test("is unaffected when fresh and ctrlProxyIncomplete are both absent (a fully-reliable capture)", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+
+    const decision = deriveTouchLatencyPoint(appWindow, result);
+    expect(decision.skipTouchLatency).toBe(false);
+    expect(decision.touchPoint).toBeDefined();
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
+  });
+
+  test("isHierarchyReliableForTapProbe is false with no windowBounds", () => {
+    const result = makeResult();
+    expect(isHierarchyReliableForTapProbe(undefined, result)).toBe(false);
+  });
+
+  test("isHierarchyReliableForTapProbe is false with malformed windowBounds", () => {
+    const result = makeResult();
+    const zeroArea = { left: 100, top: 100, right: 100, bottom: 100 };
+    expect(isHierarchyReliableForTapProbe(zeroArea, result)).toBe(false);
+  });
+
+  test("isHierarchyReliableForTapProbe is false with non-empty truncationReasons", () => {
+    const result = makeResult({
+      viewHierarchy: { hierarchy: {} as any, truncationReasons: ["max_nodes"] } as any,
+    });
+    expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(false);
   });
 });

--- a/test/features/performance/PerformanceAudit.test.ts
+++ b/test/features/performance/PerformanceAudit.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { PerformanceAudit } from "../../../src/features/performance/PerformanceAudit";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { NoOpPerformanceTracker } from "../../../src/utils/PerformanceTracker";
 
 interface TestViolation {
   metric: string;
@@ -220,5 +221,41 @@ describe("PerformanceAudit.resolveTouchLatency (#6167)", function () {
 
   test("returns null on an ordinary measurement failure", function () {
     expect(resolve({ success: false, latencyMs: 0, error: "timeout" })).toBe(null);
+  });
+});
+
+describe("PerformanceAudit.measureTouchLatency skip (#6167 P1)", function () {
+  let audit: PerformanceAudit;
+  let factory: FakeAdbClientFactory;
+
+  beforeEach(function () {
+    factory = new FakeAdbClientFactory();
+    audit = new PerformanceAudit(
+      { deviceId: "test-device", name: "test", platform: "android" },
+      factory,
+    );
+  });
+
+  const measure = (skipTouchLatency?: boolean) =>
+    (audit as any).measureTouchLatency(
+      "com.example",
+      { width: 1080, height: 1920 },
+      new NoOpPerformanceTracker(),
+      undefined,
+      // A caller that still supplied a touch point despite asking to skip
+      // must not have it used - `skipTouchLatency` takes precedence.
+      { x: 540, y: 960 },
+      skipTouchLatency,
+    );
+
+  // Regression: when the caller (PerformanceAuditor) found no point known
+  // not to overlap an interactive element - e.g. every scanned candidate
+  // overlapped a full-screen button, WebView, or map - the touch-latency
+  // measurement must be skipped entirely rather than injecting a real tap
+  // at an unverified fallback point.
+  test("skips the measurement and injects no synthetic tap when skipTouchLatency is set", async () => {
+    const result = await measure(true);
+    expect(result).toBeNull();
+    expect(factory.getFakeClient().wasCommandExecuted("input tap")).toBe(false);
   });
 });

--- a/test/features/performance/PerformanceAudit.test.ts
+++ b/test/features/performance/PerformanceAudit.test.ts
@@ -184,3 +184,41 @@ describe("PerformanceAudit.generateDiagnostics - top contributors", function () 
     expect(generate(baseMetrics(), [])).toBe("No performance issues detected");
   });
 });
+
+describe("PerformanceAudit.resolveTouchLatency (#6167)", function () {
+  let audit: PerformanceAudit;
+
+  beforeEach(function () {
+    audit = new PerformanceAudit(
+      { deviceId: "test-device", name: "test", platform: "android" },
+      new FakeAdbClientFactory(),
+    );
+  });
+
+  const resolve = (result: {
+    success: boolean;
+    latencyMs: number;
+    animating?: boolean;
+    error?: string;
+  }) => (audit as any).resolveTouchLatency(result);
+
+  test("reports the latency from a clean (non-animating) successful run", function () {
+    expect(resolve({ success: true, latencyMs: 42 })).toBe(42);
+  });
+
+  test("preserves a valid latency from a mixed run instead of discarding it", function () {
+    // At least one sample was discounted as animating, but the run still
+    // produced a real latency from a clean sample - it must not be nulled out.
+    expect(resolve({ success: true, latencyMs: 37, animating: true })).toBe(37);
+  });
+
+  test("returns null only when every sample was animating (no valid measurement)", function () {
+    expect(resolve({ success: false, latencyMs: 0, animating: true, error: "animating" })).toBe(
+      null,
+    );
+  });
+
+  test("returns null on an ordinary measurement failure", function () {
+    expect(resolve({ success: false, latencyMs: 0, error: "timeout" })).toBe(null);
+  });
+});

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -719,6 +719,90 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.success).toBe(false);
     });
 
+    test("flags animating via the jank-counter fallback when Total frames rendered is absent (#6167)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        // Some gfxinfo variants omit "Total frames rendered" entirely, but
+        // still report jank counters. A nonzero jank counter right after a
+        // reset is still evidence the app rendered with no input.
+        return {
+          stdout: `
+            Number Missed Vsync: 2
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.animating).toBe(true);
+      expect(result.success).toBe(false);
+    });
+
+    test("does not flag animating when every fallback counter reads zero and Total frames rendered is absent", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let pollCount = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          pollCount = 0;
+          return { stdout: "", stderr: "" };
+        }
+        pollCount++;
+        // No "Total frames rendered" line at all in this gfxinfo variant.
+        // Baseline (first read) is a true zero on every counter; only after
+        // the tap does a jank counter move.
+        const missedVsync = pollCount === 1 ? 0 : 1;
+        return {
+          stdout: `
+            Number Missed Vsync: ${missedVsync}
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.animating).toBeFalsy();
+      expect(result.success).toBe(true);
+      expect(result.latencyMs).toBeGreaterThan(0);
+    });
+
     test("should not flag a genuinely static app (0 frames in the idle window)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
       let pollCount = 0;

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -165,6 +165,37 @@ describe("TouchLatencyTracker - Unit Tests", function () {
 
       expect(location).toEqual({ x: 42, y: 84 });
     });
+
+    test("should derive the location from the app window bounds when given (split-screen)", function () {
+      const fakeAdb = new FakeAdbExecutor();
+      const factory: AdbClientFactory = { create: () => fakeAdb };
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      // App occupies only the lower half of the screen.
+      const windowBounds = { left: 0, top: 960, right: 1080, bottom: 1920 };
+      const location = (tracker as any).selectSafeTouchLocation(
+        screenSize,
+        undefined,
+        windowBounds,
+      );
+
+      expect(location).toEqual({ x: 540, y: 1440 });
+    });
+
+    test("should ignore malformed window bounds and fall back to the default", function () {
+      const fakeAdb = new FakeAdbExecutor();
+      const factory: AdbClientFactory = { create: () => fakeAdb };
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const invalidBounds = { left: 100, top: 100, right: 100, bottom: 100 };
+      const location = (tracker as any).selectSafeTouchLocation(
+        screenSize,
+        undefined,
+        invalidBounds,
+      );
+
+      expect(location).toEqual({ x: Math.floor(1080 * 0.5), y: Math.floor(1920 * 0.12) });
+    });
   });
 
   describe("measureLatency", function () {
@@ -482,12 +513,13 @@ describe("TouchLatencyTracker - Unit Tests", function () {
           return { stdout: "", stderr: "" };
         }
 
-        // Frame counter present but flat, jank flat: no frame was rendered.
-        // Stays below the animating-detection threshold so this exercises
-        // the "no increase" timeout path, not the animating path (#6167).
+        // Frame counter present but flat at zero: no frame was rendered
+        // during the pre-tap idle window (not animating) and none after the
+        // tap either (frozen), so this exercises the "no increase" timeout
+        // path rather than the animating path (#6167).
         return {
           stdout: `
-            Total frames rendered: 1
+            Total frames rendered: 0
             Number Missed Vsync: 0
             Number Slow UI thread: 0
             Number Frame deadline missed: 0
@@ -645,6 +677,162 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.touchCoordinates.y).toBeLessThan(screenSize.height);
       expect(result.touchCoordinates.x).toBeGreaterThan(0);
       expect(result.touchCoordinates.x).toBeLessThan(screenSize.width);
+    });
+
+    test("should flag even a low-frame-rate (slow) animation, not just a fast one (#6167)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        // A slow animation only manages a single frame in the 50ms pre-tap
+        // idle window - still evidence the app is rendering with no input.
+        return {
+          stdout: `
+            Total frames rendered: 1
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.animating).toBe(true);
+      expect(result.success).toBe(false);
+    });
+
+    test("should not flag a genuinely static app (0 frames in the idle window)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let pollCount = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          pollCount = 0;
+          return { stdout: "", stderr: "" };
+        }
+        pollCount++;
+        const totalFrames = pollCount === 1 ? 0 : 5;
+        return {
+          stdout: `Total frames rendered: ${totalFrames}`,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.animating).toBeFalsy();
+      expect(result.success).toBe(true);
+    });
+
+    test("preserves a valid measurement from a mixed run (one animating sample, one clean)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let sampleIndex = 0;
+      let pollInSample = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          sampleIndex++;
+          pollInSample = 0;
+          return { stdout: "", stderr: "" };
+        }
+
+        pollInSample++;
+        if (sampleIndex === 1) {
+          // Sample 1: animating - frames already present at the baseline read.
+          return { stdout: `Total frames rendered: 4`, stderr: "" };
+        }
+        // Sample 2: static baseline, then a real post-tap frame.
+        const totalFrames = pollInSample === 1 ? 0 : 3;
+        return { stdout: `Total frames rendered: ${totalFrames}`, stderr: "" };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 2, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // The animating sample must not null out the run: the clean sample's
+      // latency is still reported, annotated with the animating flag.
+      expect(result.success).toBe(true);
+      expect(result.sampleCount).toBe(1);
+      expect(result.latencyMs).toBeGreaterThan(0);
+      expect(result.animating).toBe(true);
+    });
+
+    test("derives the synthetic tap from the app's actual window bounds (split-screen lower half, #6167)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+        return { stdout: `Total frames rendered: 0`, stderr: "" };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      // App occupies only the lower half of a 1920-tall screen in split-screen.
+      const lowerHalfWindow = { left: 0, top: 960, right: 1080, bottom: 1920 };
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 50, windowBounds: lowerHalfWindow },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // Not the full-screen 12% default (y=230) - inside the lower-half window.
+      expect(result.touchCoordinates.y).toBeGreaterThanOrEqual(lowerHalfWindow.top);
+      expect(result.touchCoordinates.y).toBeLessThanOrEqual(lowerHalfWindow.bottom);
+      expect(result.touchCoordinates.x).toBeGreaterThanOrEqual(lowerHalfWindow.left);
+      expect(result.touchCoordinates.x).toBeLessThanOrEqual(lowerHalfWindow.right);
     });
 
     test("should handle errors gracefully and return error result", async function () {

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -125,7 +125,11 @@ describe("TouchLatencyTracker - Unit Tests", function () {
   });
 
   describe("selectSafeTouchLocation", function () {
-    test("should select a location in the top-right corner", function () {
+    // A tap at 2% of screen height lands in the SystemUI status bar, not the
+    // audited app's window (#6167) - the default location must clear it.
+    const STATUS_BAR_BAND_RATIO = 0.02;
+
+    test("should select a location inside the app window, below the status bar", function () {
       const fakeAdb = new FakeAdbExecutor();
       const factory: AdbClientFactory = { create: () => fakeAdb };
       tracker = new TouchLatencyTracker(device, factory, fakeTimer);
@@ -133,9 +137,10 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       // Access private method via type assertion for testing
       const location = (tracker as any).selectSafeTouchLocation(screenSize);
 
-      // Should be at 95% width and 2% height (status bar area)
-      expect(location.x).toBe(Math.floor(1080 * 0.95)); // 1026
-      expect(location.y).toBe(Math.floor(1920 * 0.02)); // 38
+      expect(location.x).toBe(Math.floor(1080 * 0.5));
+      expect(location.y).toBe(Math.floor(1920 * 0.12));
+      // The old status-bar band is no longer the target.
+      expect(location.y).toBeGreaterThan(screenSize.height * STATUS_BAR_BAND_RATIO);
     });
 
     test("should handle different screen sizes", function () {
@@ -146,8 +151,19 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       const smallScreen: ScreenSize = { width: 720, height: 1280 };
       const location = (tracker as any).selectSafeTouchLocation(smallScreen);
 
-      expect(location.x).toBe(Math.floor(720 * 0.95)); // 684
-      expect(location.y).toBe(Math.floor(1280 * 0.02)); // 25
+      expect(location.x).toBe(Math.floor(720 * 0.5));
+      expect(location.y).toBe(Math.floor(1280 * 0.12));
+      expect(location.y).toBeGreaterThan(smallScreen.height * STATUS_BAR_BAND_RATIO);
+    });
+
+    test("should honor a caller-provided touchPoint override", function () {
+      const fakeAdb = new FakeAdbExecutor();
+      const factory: AdbClientFactory = { create: () => fakeAdb };
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const location = (tracker as any).selectSafeTouchLocation(screenSize, { x: 42, y: 84 });
+
+      expect(location).toEqual({ x: 42, y: 84 });
     });
   });
 
@@ -467,9 +483,11 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         // Frame counter present but flat, jank flat: no frame was rendered.
+        // Stays below the animating-detection threshold so this exercises
+        // the "no increase" timeout path, not the animating path (#6167).
         return {
           stdout: `
-            Total frames rendered: 42
+            Total frames rendered: 1
             Number Missed Vsync: 0
             Number Slow UI thread: 0
             Number Frame deadline missed: 0
@@ -496,6 +514,137 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.success).toBe(false);
       expect(result.sampleCount).toBe(0);
       expect(result.error).toContain("No successful measurements");
+      expect(result.animating).toBeFalsy();
+    });
+
+    test("should flag an app as animating when frames render during the pre-tap idle window (#6167)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        // The app keeps rendering (spinner/video) with no input at all -
+        // every read, including the pre-tap baseline, sees frame growth.
+        return {
+          stdout: `
+            Total frames rendered: 12
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // No misleading pollIntervalMs-ish latency: the sample is discounted
+      // and the result carries the animating disposition instead.
+      expect(result.animating).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.sampleCount).toBe(0);
+      expect(result.error).toContain("animating");
+    });
+
+    test("should not flag a static app as animating and should measure a real post-tap latency", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let pollCount = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          pollCount = 0;
+          return { stdout: "", stderr: "" };
+        }
+
+        pollCount++;
+        // Baseline (first read after reset) is idle: no frames. Only after
+        // the synthetic tap does the frame counter move.
+        const totalFrames = pollCount === 1 ? 0 : 5;
+        return {
+          stdout: `
+            Total frames rendered: ${totalFrames}
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.animating).toBeFalsy();
+      expect(result.success).toBe(true);
+      expect(result.sampleCount).toBe(1);
+      expect(result.latencyMs).toBeGreaterThan(0);
+    });
+
+    test("synthetic tap coordinate lands inside the app window, not the status-bar band", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+        return {
+          stdout: `
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 50 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // The old default (y = 2% of height) is the SystemUI status-bar band.
+      const statusBarBandY = Math.floor(screenSize.height * 0.02);
+      expect(result.touchCoordinates.y).toBeGreaterThan(statusBarBandY);
+      expect(result.touchCoordinates.y).toBeLessThan(screenSize.height);
+      expect(result.touchCoordinates.x).toBeGreaterThan(0);
+      expect(result.touchCoordinates.x).toBeLessThan(screenSize.width);
     });
 
     test("should handle errors gracefully and return error result", async function () {

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -209,10 +209,11 @@ describe("TouchLatencyTracker - Unit Tests", function () {
           return { stdout: "", stderr: "" };
         }
 
-        // Return baseline stats first, then show increased jank on subsequent calls
+        // Two identical no-input snapshots first (no growth between them),
+        // then show increased jank once the touch is injected.
         gfxinfoCallCount++;
-        if (gfxinfoCallCount === 1) {
-          // Baseline
+        if (gfxinfoCallCount <= 2) {
+          // Pre-tap snapshots
           return {
             stdout: `
               50th percentile: 8.5ms
@@ -275,8 +276,9 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         callCount++;
-        // Return baseline first, then activity on second call for each sample
-        if (callCount % 2 === 1) {
+        // Two identical pre-tap snapshots (no growth), then activity once
+        // polling for the post-tap response begins.
+        if (callCount <= 2) {
           return {
             stdout: `
               Number Missed Vsync: 0
@@ -366,7 +368,7 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         callCount++;
-        if (callCount === 1) {
+        if (callCount <= 2) {
           return {
             stdout: `
               Number Missed Vsync: 0
@@ -416,7 +418,7 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         callCount++;
-        if (callCount === 1) {
+        if (callCount <= 2) {
           return {
             stdout: `
               Number Missed Vsync: 0
@@ -468,8 +470,9 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         callCount++;
-        // Baseline on the first call, then +3 frames per poll, jank flat.
-        const totalFrames = callCount === 1 ? 0 : (callCount - 1) * 3;
+        // Two identical pre-tap snapshots at zero, then +3 frames per poll
+        // once the touch is injected, jank flat throughout.
+        const totalFrames = callCount <= 2 ? 0 : (callCount - 2) * 3;
         return {
           stdout: `
             Total frames rendered: ${totalFrames}
@@ -551,17 +554,20 @@ describe("TouchLatencyTracker - Unit Tests", function () {
 
     test("should flag an app as animating when frames render during the pre-tap idle window (#6167)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
+      let callCount = 0;
 
       dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
         if (command.includes("reset")) {
           return { stdout: "", stderr: "" };
         }
 
-        // The app keeps rendering (spinner/video) with no input at all -
-        // every read, including the pre-tap baseline, sees frame growth.
+        // The app keeps rendering (spinner/video) with no input at all - the
+        // counter keeps growing across the two consecutive no-input
+        // snapshots, not just showing a single one-off frame.
+        callCount++;
         return {
           stdout: `
-            Total frames rendered: 12
+            Total frames rendered: ${12 + callCount * 3}
             Number Missed Vsync: 0
             Number Slow UI thread: 0
             Number Frame deadline missed: 0
@@ -604,9 +610,10 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         pollCount++;
-        // Baseline (first read after reset) is idle: no frames. Only after
-        // the synthetic tap does the frame counter move.
-        const totalFrames = pollCount === 1 ? 0 : 5;
+        // Both pre-tap snapshots (reads 1 and 2, after reset) are idle: no
+        // frames, no growth between them. Only after the synthetic tap does
+        // the frame counter move.
+        const totalFrames = pollCount <= 2 ? 0 : 5;
         return {
           stdout: `
             Total frames rendered: ${totalFrames}
@@ -633,6 +640,60 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         fakeTimer,
       );
 
+      expect(result.animating).toBeFalsy();
+      expect(result.success).toBe(true);
+      expect(result.sampleCount).toBe(1);
+      expect(result.latencyMs).toBeGreaterThan(0);
+    });
+
+    // Regression: a naive baseline-vs-zero comparison classified a static
+    // app that emits one delayed settling/layout frame right after
+    // `gfxinfo reset` as "animating", discounting every sample even though
+    // the app never renders again with no input. Confirming growth BETWEEN
+    // two consecutive no-input snapshots (rather than comparing the first
+    // one to zero) absorbs that lone frame into the first snapshot instead.
+    test("a single settling frame right after reset is not treated as animating (#6167 follow-up)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let callCount = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        callCount++;
+        // One settling frame lands before the FIRST post-reset read (both
+        // pre-tap snapshots see the same non-zero count - no growth between
+        // them), then a real frame only after the synthetic tap.
+        const totalFrames = callCount <= 2 ? 1 : 4;
+        return {
+          stdout: `
+            Total frames rendered: ${totalFrames}
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // The sample proceeds - the tap is injected and a real latency is
+      // measured - rather than being discounted as animating.
       expect(result.animating).toBeFalsy();
       expect(result.success).toBe(true);
       expect(result.sampleCount).toBe(1);
@@ -681,17 +742,22 @@ describe("TouchLatencyTracker - Unit Tests", function () {
 
     test("should flag even a low-frame-rate (slow) animation, not just a fast one (#6167)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
+      let callCount = 0;
 
       dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
         if (command.includes("reset")) {
           return { stdout: "", stderr: "" };
         }
 
-        // A slow animation only manages a single frame in the 50ms pre-tap
-        // idle window - still evidence the app is rendering with no input.
+        // A slow animation manages only a single extra frame between the two
+        // consecutive no-input snapshots (growth, unlike a one-off settling
+        // frame baked into the first snapshot alone) - still evidence the
+        // app is rendering with no input.
+        callCount++;
+        const totalFrames = callCount === 1 ? 0 : 1;
         return {
           stdout: `
-            Total frames rendered: 1
+            Total frames rendered: ${totalFrames}
             Number Missed Vsync: 0
             Number Slow UI thread: 0
             Number Frame deadline missed: 0
@@ -721,6 +787,7 @@ describe("TouchLatencyTracker - Unit Tests", function () {
 
     test("flags animating via the jank-counter fallback when Total frames rendered is absent (#6167)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
+      let callCount = 0;
 
       dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
         if (command.includes("reset")) {
@@ -728,11 +795,14 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
 
         // Some gfxinfo variants omit "Total frames rendered" entirely, but
-        // still report jank counters. A nonzero jank counter right after a
-        // reset is still evidence the app rendered with no input.
+        // still report jank counters. A jank counter that keeps growing
+        // between the two consecutive no-input snapshots is still evidence
+        // the app rendered with no input.
+        callCount++;
+        const missedVsync = 2 * callCount;
         return {
           stdout: `
-            Number Missed Vsync: 2
+            Number Missed Vsync: ${missedVsync}
             Number Slow UI thread: 0
             Number Frame deadline missed: 0
           `,
@@ -770,9 +840,9 @@ describe("TouchLatencyTracker - Unit Tests", function () {
         }
         pollCount++;
         // No "Total frames rendered" line at all in this gfxinfo variant.
-        // Baseline (first read) is a true zero on every counter; only after
-        // the tap does a jank counter move.
-        const missedVsync = pollCount === 1 ? 0 : 1;
+        // Both pre-tap snapshots are a true zero on every counter (no
+        // growth); only after the tap does a jank counter move.
+        const missedVsync = pollCount <= 2 ? 0 : 1;
         return {
           stdout: `
             Number Missed Vsync: ${missedVsync}
@@ -813,7 +883,7 @@ describe("TouchLatencyTracker - Unit Tests", function () {
           return { stdout: "", stderr: "" };
         }
         pollCount++;
-        const totalFrames = pollCount === 1 ? 0 : 5;
+        const totalFrames = pollCount <= 2 ? 0 : 5;
         return {
           stdout: `Total frames rendered: ${totalFrames}`,
           stderr: "",
@@ -853,11 +923,13 @@ describe("TouchLatencyTracker - Unit Tests", function () {
 
         pollInSample++;
         if (sampleIndex === 1) {
-          // Sample 1: animating - frames already present at the baseline read.
-          return { stdout: `Total frames rendered: 4`, stderr: "" };
+          // Sample 1: animating - the counter keeps growing across the two
+          // consecutive pre-tap snapshots.
+          return { stdout: `Total frames rendered: ${4 * pollInSample}`, stderr: "" };
         }
-        // Sample 2: static baseline, then a real post-tap frame.
-        const totalFrames = pollInSample === 1 ? 0 : 3;
+        // Sample 2: static across both pre-tap snapshots, then a real
+        // post-tap frame.
+        const totalFrames = pollInSample <= 2 ? 0 : 3;
         return { stdout: `Total frames rendered: ${totalFrames}`, stderr: "" };
       });
 
@@ -887,19 +959,24 @@ describe("TouchLatencyTracker - Unit Tests", function () {
     test("does not report animating when a run fails for mixed reasons (one animating, one genuine timeout)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
       let sampleIndex = 0;
+      let pollInSample = 0;
 
       dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
         if (command.includes("reset")) {
           sampleIndex++;
+          pollInSample = 0;
           return { stdout: "", stderr: "" };
         }
 
+        pollInSample++;
         if (sampleIndex === 1) {
-          // Sample 1: animating - frames already present at the baseline read.
-          return { stdout: `Total frames rendered: 4`, stderr: "" };
+          // Sample 1: animating - the counter keeps growing across the two
+          // consecutive pre-tap snapshots.
+          return { stdout: `Total frames rendered: ${4 * pollInSample}`, stderr: "" };
         }
-        // Sample 2: a genuinely frozen app - flat at zero baseline and
-        // after the tap, no frame activity ever, times out.
+        // Sample 2: a genuinely frozen app - flat at zero across both
+        // pre-tap snapshots and after the tap, no frame activity ever, times
+        // out.
         return { stdout: `Total frames rendered: 0`, stderr: "" };
       });
 

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -884,6 +884,49 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.animating).toBe(true);
     });
 
+    test("does not report animating when a run fails for mixed reasons (one animating, one genuine timeout)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let sampleIndex = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          sampleIndex++;
+          return { stdout: "", stderr: "" };
+        }
+
+        if (sampleIndex === 1) {
+          // Sample 1: animating - frames already present at the baseline read.
+          return { stdout: `Total frames rendered: 4`, stderr: "" };
+        }
+        // Sample 2: a genuinely frozen app - flat at zero baseline and
+        // after the tap, no frame activity ever, times out.
+        return { stdout: `Total frames rendered: 0`, stderr: "" };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 2, maxWaitMs: 50 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // Zero valid measurements, and not every failure was animating - must
+      // not blanket-label the run "animating" and mask the genuine timeout.
+      expect(result.success).toBe(false);
+      expect(result.sampleCount).toBe(0);
+      expect(result.animating).toBeFalsy();
+      expect(result.error).toContain("No successful measurements");
+      expect(result.error).not.toContain("animating");
+    });
+
     test("derives the synthetic tap from the app's actual window bounds (split-screen lower half, #6167)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
 

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -700,6 +700,63 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.latencyMs).toBeGreaterThan(0);
     });
 
+    // Regression: with only ~50ms between the two pre-tap snapshots, a slow
+    // continuous animation (e.g. 10fps, frames ~100ms apart) could read flat
+    // across both snapshots and then increment right after the tap - its
+    // next autonomous frame misreported as touch latency. The widened
+    // observation window (issue #6167 follow-up) must span at least one full
+    // period of a 10fps animation so growth is guaranteed to show up between
+    // the two snapshots regardless of phase. This fake ties frame counts to
+    // the FakeTimer's own elapsed time (frames at t=25ms, 125ms, 225ms, ...)
+    // rather than call count, so it genuinely exercises the widened window's
+    // real duration.
+    test("detects a slow (10fps-style) autonomous animation across the widened pre-tap window (#6167 follow-up)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      const FRAME_PERIOD_MS = 100;
+      const FIRST_FRAME_AT_MS = 25;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        const elapsed = fakeTimer.now();
+        const totalFrames =
+          elapsed < FIRST_FRAME_AT_MS
+            ? 0
+            : Math.floor((elapsed - FIRST_FRAME_AT_MS) / FRAME_PERIOD_MS) + 1;
+        return {
+          stdout: `
+            Total frames rendered: ${totalFrames}
+            Number Missed Vsync: 0
+            Number Slow UI thread: 0
+            Number Frame deadline missed: 0
+          `,
+          stderr: "",
+        };
+      });
+
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // Discounted as animating - not misreported as a real touch latency.
+      expect(result.animating).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.sampleCount).toBe(0);
+    });
+
     test("synthetic tap coordinate lands inside the app window, not the status-bar band", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
 


### PR DESCRIPTION
Follow-up to #6124 / PR #6157, which made `Total frames rendered` the primary "UI responded" signal in `TouchLatencyTracker.measureFrameResponse`. Fixes both limitations deliberately left out of that PR.

## 1. Flag animating apps

`measureLatency` already resets `gfxinfo`, sleeps 50ms, then reads a baseline *before* injecting the synthetic tap. That baseline read is a no-input idle window: if `Total frames rendered` already grew during it, the app is rendering on its own (spinner, video, in-progress transition) and any post-tap frame delta cannot be attributed to the touch.

`TouchLatencyTracker.takeSample` (extracted from `measureLatency`) now checks `baselineStats.totalFrames` against a small threshold (`ANIMATING_BASELINE_FRAME_THRESHOLD = 2`, to tolerate a single post-reset settle frame) and, when exceeded, skips injecting the tap for that sample and marks it `animating`. `measureLatency` discounts animating samples from the latency median; if every sample was animating, the result is `success: false, animating: true` with an explicit error instead of a misleading `latencyMs`. `TouchLatencyResult` gains an optional `animating?: boolean` field (backward compatible). `PerformanceAudit.measureTouchLatency` now logs and returns `null` (instead of surfacing a number) when the tracker reports `animating`.

## 2. Move the synthetic tap inside the app window

`selectSafeTouchLocation` used `y = 2%` of screen height, which lands inside the SystemUI status bar on most devices, not the audited app's own window — a static-but-responsive app could legitimately render no frame there and be misreported as frozen.

The default tap point moved to a horizontally centered coordinate at `y = 12%` of screen height, clearing both the status bar and a typical top app bar while avoiding corner overflow-menu icons. `measureLatency` also accepts an optional `touchPoint` override (per the issue's suggestion) so a caller with real window geometry (e.g. `observe`'s `activeWindow`) can pick a known-inert point instead.

Per the issue, moving off the status bar ideally wants hardware verification of where a tap actually lands relative to the app window; that verification is fixture-based here (`DynamicFakeAdbExecutor` + `FakeTimer`), not from a live device in this change.

## Testing

- `test/features/performance/TouchLatencyTracker.test.ts`:
  - New: an app rendering frames during the pre-tap idle window is flagged `animating` with no misleading latency.
  - New: a static app with a real post-tap frame still reports a normal, non-animating latency.
  - New: the synthetic tap coordinate is asserted to land outside the old 2% status-bar band.
  - Updated `selectSafeTouchLocation` tests for the new default location and the `touchPoint` override.
  - Adjusted one pre-existing "frozen" fixture's flat `Total frames rendered` value (42 → 1) so it stays below the new animating threshold and continues to exercise the "no increase" timeout path rather than the new animating path.
- `turbo run lint build test`, `bun run format:check`, `bun run typecheck` all pass.

Closes #6167
