### PR TITLE
fix(action): resolve skeleton s-<hash> elementId selectors back to their element

### DIFF
--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -55,6 +55,15 @@ export const GENERATED_VIEW_ID_PATTERN =
 export const STABLE_VIEW_ID_PREFIX = "s-";
 
 /**
+ * Fixed hex-character width of the content hash this module emits (see the
+ * `.slice(0, ...)` in `assign` below). Exported so consumers that need to
+ * recognize the producer's exact id shape - e.g. `ElementFinder`'s
+ * synthetic-vs-real-resource-id disambiguation (issue #6218 review) - read it
+ * from here rather than guessing/duplicating the width.
+ */
+export const STABLE_VIEW_ID_HASH_LENGTH = 16;
+
+/**
  * Node fields that participate in the content hash: the stable, position-free
  * description of what the node *is*. Everything else is deliberately excluded:
  * `bounds` and sibling order shift on scroll; `focused` / `checked` /
@@ -113,7 +122,10 @@ export function assignStableViewIds(root: unknown): Map<string, string> {
       ...CONTENT_FIELDS.map((field) => node[field] ?? ""),
       childHashes,
     ]);
-    const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+    const hash = createHash("sha256")
+      .update(canonical)
+      .digest("hex")
+      .slice(0, STABLE_VIEW_ID_HASH_LENGTH);
     contentHash.set(node, hash);
     return hash;
   };

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -7,6 +7,45 @@ import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { DefaultElementParser } from "./ElementParser";
 import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
 import { ANDROID_INPUT_CLASSES, isClickableElementProperties } from "../../utils/elementProperties";
+import { STABLE_VIEW_ID_PREFIX } from "../observe/android/StableNodeIdentity";
+
+/**
+ * `resourceId`/`elementId` selectors carry an `s-<hash>` content-derived
+ * stable id (`assignStableViewIds`, issue #3228) for nodes with no real
+ * `resource-id` — the skeleton projection emits exactly that value as
+ * `elementId` (`SkeletonProjection.deriveId`). Resolve it against the node's
+ * `view-id` field, not `resource-id`, so a skeleton id round-trips back to
+ * its element (issue #6218). Exact match only: the hash carries no partial-
+ * or bare-suffix semantics the way a `pkg:id/name` resource-id does.
+ */
+function isStableViewId(id: string): boolean {
+  return id.startsWith(STABLE_VIEW_ID_PREFIX);
+}
+
+function matchesResourceIdOrStableViewId(
+  nodeProperties: Record<string, unknown>,
+  resourceId: string,
+  bareResourceId: string | null,
+  partialMatch: boolean,
+): boolean {
+  const nodeResourceId = nodeProperties["resource-id"];
+  if (typeof nodeResourceId === "string") {
+    if (
+      nodeResourceId === resourceId ||
+      (bareResourceId !== null && nodeResourceId === bareResourceId) ||
+      (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
+    ) {
+      return true;
+    }
+  }
+  if (isStableViewId(resourceId)) {
+    const nodeViewId = nodeProperties["view-id"];
+    if (typeof nodeViewId === "string" && nodeViewId === resourceId) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Handles searching and selection of elements in view hierarchy
@@ -47,12 +86,14 @@ export class DefaultElementFinder implements ElementFinder {
         }
 
         const nodeProperties = this.parser.extractNodeProperties(node);
-        const nodeResourceId = nodeProperties["resource-id"];
         const nodeText = nodeProperties.text;
         const nodeContentDesc = nodeProperties["content-desc"];
         const nodeIosLabel = nodeProperties["ios-accessibility-label"];
 
-        if (container.elementId && nodeResourceId === container.elementId) {
+        if (
+          container.elementId &&
+          matchesResourceIdOrStableViewId(nodeProperties, container.elementId, null, false)
+        ) {
           containerNode = node;
           return;
         }
@@ -226,17 +267,12 @@ export class DefaultElementFinder implements ElementFinder {
     for (const searchNode of rootNodes) {
       this.parser.traverseNode(searchNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
-        if (nodeProperties["resource-id"] && typeof nodeProperties["resource-id"] === "string") {
-          const nodeResourceId = nodeProperties["resource-id"];
-          if (
-            nodeResourceId === resourceId ||
-            (bareResourceId !== null && nodeResourceId === bareResourceId) ||
-            (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
-          ) {
-            const parsedNode = this.parser.parseNodeBounds(node);
-            if (parsedNode) {
-              matches.push(parsedNode);
-            }
+        if (
+          matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch)
+        ) {
+          const parsedNode = this.parser.parseNodeBounds(node);
+          if (parsedNode) {
+            matches.push(parsedNode);
           }
         }
       });
@@ -1148,15 +1184,8 @@ export class DefaultElementFinder implements ElementFinder {
     const idSeparatorIndex = resourceId.lastIndexOf("/");
     const bareResourceId = idSeparatorIndex >= 0 ? resourceId.slice(idSeparatorIndex + 1) : null;
 
-    const matchesId = (input?: string): boolean => {
-      if (!input) {
-        return false;
-      }
-      if (partialMatch) {
-        return input.toLowerCase().includes(resourceId.toLowerCase());
-      }
-      return input === resourceId || (bareResourceId !== null && input === bareResourceId);
-    };
+    const matchesId = (nodeProperties: Record<string, unknown>): boolean =>
+      matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch);
 
     const containerNode = container
       ? this.findContainerNodeInternal(viewHierarchy, container)
@@ -1194,7 +1223,7 @@ export class DefaultElementFinder implements ElementFinder {
 
   private collectClickableSiblingsWithResourceIdInRoots(
     rootNodes: ViewHierarchyNode[],
-    matchesId: (input?: string) => boolean,
+    matchesId: (nodeProperties: Record<string, unknown>) => boolean,
   ): Element[] {
     const results: Element[] = [];
     for (const rootNode of rootNodes) {
@@ -1205,7 +1234,7 @@ export class DefaultElementFinder implements ElementFinder {
 
   private findClickableSiblingsOfResourceIdInNode(
     node: ViewHierarchyNode,
-    matchesId: (input?: string) => boolean,
+    matchesId: (nodeProperties: Record<string, unknown>) => boolean,
     results: Element[],
   ): void {
     const children = node.node;
@@ -1217,16 +1246,14 @@ export class DefaultElementFinder implements ElementFinder {
 
     const hasIdMatch = childArray.some((child) => {
       const props = this.parser.extractNodeProperties(child);
-      const rid = props["resource-id"];
-      return typeof rid === "string" && matchesId(rid);
+      return matchesId(props);
     });
 
     if (hasIdMatch) {
       for (const child of childArray) {
         const childProps = this.parser.extractNodeProperties(child);
         const isClickable = this.isClickableNode(childProps);
-        const childRid = childProps["resource-id"];
-        const isIdMatch = typeof childRid === "string" && matchesId(childRid);
+        const isIdMatch = matchesId(childProps);
 
         if (isClickable && !isIdMatch) {
           const parsedNode = this.parser.parseNodeBounds(child);

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -7,7 +7,10 @@ import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { DefaultElementParser } from "./ElementParser";
 import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
 import { ANDROID_INPUT_CLASSES, isClickableElementProperties } from "../../utils/elementProperties";
-import { STABLE_VIEW_ID_PREFIX } from "../observe/android/StableNodeIdentity";
+import {
+  STABLE_VIEW_ID_HASH_LENGTH,
+  STABLE_VIEW_ID_PREFIX,
+} from "../observe/android/StableNodeIdentity";
 import { ActionableError } from "../../models/ActionableError";
 
 /**
@@ -26,26 +29,40 @@ function isStableViewId(id: string): boolean {
 /**
  * `assignStableViewIds` disambiguates content-identical duplicate nodes with an
  * ordinal `-<k>` suffix (`s-<hash>-2`, `s-<hash>-3`, ...) assigned by document
- * order AT CAPTURE TIME (`StableNodeIdentity.ts`). That ordinal is therefore
- * capture-local: an insert or reorder between the capture an `s-<hash>-<k>` id
- * was observed from and the fresh capture a later `tapOn`/`inputText` resolves
- * it against can shift which node the k-th occurrence now lands on - silently
- * resolving to the WRONG node rather than the one the caller meant (issue
- * #6218 review thread PRRT_kwDOP-GF5M6foer0). This pattern detects that shape
- * so it can be checked against the CURRENT capture's duplicate count before
- * being trusted.
+ * order AT CAPTURE TIME (`StableNodeIdentity.ts`) - the FIRST occurrence gets
+ * the bare, un-suffixed `s-<hash>` (implicitly ordinal 1). Both forms are
+ * therefore capture-local whenever a duplicate exists: an insert or reorder
+ * between the capture an id was observed from and the fresh capture a later
+ * `tapOn`/`inputText` resolves it against can hand the bare id to a DIFFERENT
+ * node (the new first occurrence) and push the original to `-2`, or shift
+ * which node an existing `-<k>` lands on - silently resolving to the WRONG
+ * node rather than the one the caller meant (issue #6218 review thread
+ * PRRT_kwDOP-GF5M6foer0, follow-up PRRT_kwDOP-GF5M6fomf-).
+ *
+ * This pattern requires the producer's EXACT shape - the `s-` prefix plus
+ * exactly `STABLE_VIEW_ID_HASH_LENGTH` hex characters, with an optional
+ * `-<k>` ordinal - so a real, resource-id-backed `view-id` that merely starts
+ * with `s-` (e.g. a bare Compose testTag like `s-a` / `s-a-2`) is never
+ * misclassified as synthetic (review thread PRRT_kwDOP-GF5M6fomgA).
  */
-const ORDINAL_STABLE_VIEW_ID_PATTERN = /^(s-[0-9a-f]+)-\d+$/;
+const SYNTHETIC_STABLE_VIEW_ID_PATTERN = new RegExp(
+  `^(${STABLE_VIEW_ID_PREFIX}[0-9a-f]{${STABLE_VIEW_ID_HASH_LENGTH}})(?:-\\d+)?$`,
+);
 
-/** The un-suffixed base id an ordinal-suffixed stable id was derived from, or null. */
-function stableViewIdOrdinalBase(id: string): string | null {
-  const match = ORDINAL_STABLE_VIEW_ID_PATTERN.exec(id);
+/**
+ * The base id (`s-<hash>`, un-suffixed) for a synthetic stable id, whether
+ * `id` itself is the bare first-occurrence form or an ordinal-suffixed
+ * duplicate. Returns null when `id` does not match the producer's exact
+ * shape - including a real `view-id` that only superficially resembles one.
+ */
+function syntheticStableViewIdBase(id: string): string | null {
+  const match = SYNTHETIC_STABLE_VIEW_ID_PATTERN.exec(id);
   return match ? match[1] : null;
 }
 
-/** True when `viewId` is exactly `base`, or an ordinal-suffixed duplicate of it. */
+/** True when `viewId` is a synthetic id (bare or ordinal-suffixed) sharing `base`. */
 function sharesStableViewIdBase(viewId: string, base: string): boolean {
-  return viewId === base || stableViewIdOrdinalBase(viewId) === base;
+  return syntheticStableViewIdBase(viewId) === base;
 }
 
 function matchesResourceIdOrStableViewId(
@@ -434,31 +451,75 @@ export class DefaultElementFinder implements ElementFinder {
   }
 
   /**
-   * Reject an ordinal-suffixed stable-view-id selector (`s-<hash>-<k>`) when
-   * MORE THAN ONE node in the current capture shares its base content hash —
-   * i.e. the ordinal is load-bearing / capture-local rather than moot. A
-   * plain (unsuffixed) selector, or one whose base hash is unique in this
-   * capture, is left alone (issue #6218 review thread
-   * PRRT_kwDOP-GF5M6foer0). Rejecting is correct here: a wrong tap is worse
-   * than a clear failure telling the caller to use a more specific selector.
+   * True when some node anywhere in the current capture (main hierarchy plus
+   * every window) carries `id` as its REAL `resource-id` field (not merely a
+   * `view-id` that happens to look synthetic-shaped). A real resource-id is
+   * never subject to `assignStableViewIds`' ordinal semantics, so it must win
+   * over a synthetic-ordinal interpretation of the same string (review thread
+   * PRRT_kwDOP-GF5M6fomgA) even in the astronomically unlikely case a real id
+   * collides with the producer's exact `s-<16 hex>(-<k>)?` shape.
+   */
+  private hasExactResourceIdFieldMatch(viewHierarchy: ViewHierarchyResult, id: string): boolean {
+    let found = false;
+    const checkRoots = (roots: ViewHierarchyNode[]): void => {
+      for (const root of roots) {
+        if (found) {
+          return;
+        }
+        this.parser.traverseNode(root, (node: any) => {
+          if (found) {
+            return;
+          }
+          const resourceId = this.parser.extractNodeProperties(node)["resource-id"];
+          if (typeof resourceId === "string" && resourceId === id) {
+            found = true;
+          }
+        });
+      }
+    };
+
+    checkRoots(this.parser.extractRootNodes(viewHierarchy));
+    if (!found) {
+      const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+      for (const windowRoots of windowRootGroups) {
+        checkRoots(windowRoots);
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Reject a synthetic stable-view-id selector (`s-<hash>` bare OR
+   * `s-<hash>-<k>` ordinal-suffixed) when MORE THAN ONE node in the current
+   * capture shares its base content hash — i.e. it has content-identical
+   * peers, so which node holds the bare id vs. which ordinal is load-bearing
+   * / capture-local rather than moot. A selector whose base hash is unique in
+   * this capture is left alone, and so is a real `resource-id`-backed id that
+   * merely resembles the synthetic shape (issue #6218 review threads
+   * PRRT_kwDOP-GF5M6foer0, PRRT_kwDOP-GF5M6fomf-, PRRT_kwDOP-GF5M6fomgA).
+   * Rejecting is correct here: a wrong tap is worse than a clear failure
+   * telling the caller to use a more specific selector.
    */
   private assertStableViewIdSelectorNotAmbiguous(
     viewHierarchy: ViewHierarchyResult,
     id: string,
   ): void {
-    const base = stableViewIdOrdinalBase(id);
+    const base = syntheticStableViewIdBase(id);
     if (!base) {
+      return;
+    }
+    if (this.hasExactResourceIdFieldMatch(viewHierarchy, id)) {
       return;
     }
     const duplicateCount = this.countNodesSharingStableViewIdBase(viewHierarchy, base);
     if (duplicateCount > 1) {
       throw new ActionableError(
         `Skeleton element id "${id}" is ambiguous in the current capture: ${duplicateCount} ` +
-          `content-identical elements share stable id "${base}", and its "-N" ordinal suffix is ` +
-          "assigned by document order at capture time. An element insert or reorder since this id " +
-          "was observed can shift which element the ordinal now points to, so resolving it here " +
-          "could silently act on the wrong element. Use a more specific selector (text, " +
-          "content-desc, or bounds) instead.",
+          `content-identical elements share stable id "${base}", and which of them holds the ` +
+          'bare id vs. an "-N" ordinal suffix is assigned by document order at capture time. An ' +
+          "element insert or reorder since this id was observed can shift which element it now " +
+          "points to, so resolving it here could silently act on the wrong element. Use a more " +
+          "specific selector (text, content-desc, or bounds) instead.",
       );
     }
   }

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -168,7 +168,12 @@ export class DefaultElementFinder implements ElementFinder {
     }
 
     if (container.elementId) {
-      this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, container.elementId);
+      // A container selector has no enclosing scope of its own to resolve
+      // first, so it is always checked against the whole capture.
+      this.assertStableViewIdSelectorNotAmbiguous(
+        this.collectFullCaptureSearchRoots(viewHierarchy),
+        container.elementId,
+      );
     }
 
     const matchesContainerText = container.text
@@ -420,98 +425,118 @@ export class DefaultElementFinder implements ElementFinder {
   }
 
   /**
-   * Count nodes anywhere in the current capture (main hierarchy plus every
-   * window) whose `view-id` is `base` or an ordinal-suffixed duplicate of it.
-   * Used to decide whether an ordinal-suffixed `s-<hash>-<k>` selector is safe
-   * to trust in THIS capture (see `assertStableViewIdSelectorNotAmbiguous`).
+   * The full set of search roots for a capture — main hierarchy roots plus
+   * every window's roots — for callers that scope an ambiguity check to the
+   * WHOLE capture rather than one already-resolved container (see
+   * `assertStableViewIdSelectorNotAmbiguous`).
+   */
+  private collectFullCaptureSearchRoots(viewHierarchy: ViewHierarchyResult): ViewHierarchyNode[] {
+    const roots = [...this.parser.extractRootNodes(viewHierarchy)];
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      roots.push(...windowRoots);
+    }
+    return roots;
+  }
+
+  /**
+   * Count nodes within `searchRoots` whose `view-id` is `base` or an
+   * ordinal-suffixed duplicate of it. Used to decide whether a synthetic
+   * `s-<hash>(-<k>)?` selector is safe to trust WITHIN THE GIVEN SCOPE (see
+   * `assertStableViewIdSelectorNotAmbiguous`) — the scope is the whole
+   * capture when there is no container, or just the resolved container's
+   * subtree when there is one, so a duplicate OUTSIDE a selected container
+   * never blocks resolution inside it.
    */
   private countNodesSharingStableViewIdBase(
-    viewHierarchy: ViewHierarchyResult,
+    searchRoots: ViewHierarchyNode[],
     base: string,
   ): number {
     let count = 0;
-    const countInRoots = (roots: ViewHierarchyNode[]): void => {
-      for (const root of roots) {
-        this.parser.traverseNode(root, (node: any) => {
-          const nodeProperties = this.parser.extractNodeProperties(node);
-          const viewId = nodeProperties["view-id"];
-          if (typeof viewId === "string" && sharesStableViewIdBase(viewId, base)) {
-            count++;
-          }
-        });
-      }
-    };
-
-    countInRoots(this.parser.extractRootNodes(viewHierarchy));
-    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
-    for (const windowRoots of windowRootGroups) {
-      countInRoots(windowRoots);
+    for (const root of searchRoots) {
+      this.parser.traverseNode(root, (node: any) => {
+        const nodeProperties = this.parser.extractNodeProperties(node);
+        const viewId = nodeProperties["view-id"];
+        if (typeof viewId === "string" && sharesStableViewIdBase(viewId, base)) {
+          count++;
+        }
+      });
     }
     return count;
   }
 
   /**
-   * True when some node anywhere in the current capture (main hierarchy plus
-   * every window) carries `id` as its REAL `resource-id` field (not merely a
-   * `view-id` that happens to look synthetic-shaped). A real resource-id is
-   * never subject to `assignStableViewIds`' ordinal semantics, so it must win
-   * over a synthetic-ordinal interpretation of the same string (review thread
+   * True when some node within `searchRoots` carries `id` as its REAL
+   * `resource-id` field (not merely a `view-id` that happens to look
+   * synthetic-shaped). A real resource-id is never subject to
+   * `assignStableViewIds`' ordinal semantics, so it must win over a
+   * synthetic-ordinal interpretation of the same string (review thread
    * PRRT_kwDOP-GF5M6fomgA) even in the astronomically unlikely case a real id
    * collides with the producer's exact `s-<16 hex>(-<k>)?` shape.
    */
-  private hasExactResourceIdFieldMatch(viewHierarchy: ViewHierarchyResult, id: string): boolean {
+  private hasExactResourceIdFieldMatch(searchRoots: ViewHierarchyNode[], id: string): boolean {
     let found = false;
-    const checkRoots = (roots: ViewHierarchyNode[]): void => {
-      for (const root of roots) {
+    for (const root of searchRoots) {
+      if (found) {
+        break;
+      }
+      this.parser.traverseNode(root, (node: any) => {
         if (found) {
           return;
         }
-        this.parser.traverseNode(root, (node: any) => {
-          if (found) {
-            return;
-          }
-          const resourceId = this.parser.extractNodeProperties(node)["resource-id"];
-          if (typeof resourceId === "string" && resourceId === id) {
-            found = true;
-          }
-        });
-      }
-    };
-
-    checkRoots(this.parser.extractRootNodes(viewHierarchy));
-    if (!found) {
-      const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
-      for (const windowRoots of windowRootGroups) {
-        checkRoots(windowRoots);
-      }
+        const resourceId = this.parser.extractNodeProperties(node)["resource-id"];
+        if (typeof resourceId === "string" && resourceId === id) {
+          found = true;
+        }
+      });
     }
     return found;
   }
 
   /**
    * Reject a synthetic stable-view-id selector (`s-<hash>` bare OR
-   * `s-<hash>-<k>` ordinal-suffixed) when MORE THAN ONE node in the current
-   * capture shares its base content hash — i.e. it has content-identical
-   * peers, so which node holds the bare id vs. which ordinal is load-bearing
-   * / capture-local rather than moot. A selector whose base hash is unique in
-   * this capture is left alone, and so is a real `resource-id`-backed id that
-   * merely resembles the synthetic shape (issue #6218 review threads
-   * PRRT_kwDOP-GF5M6foer0, PRRT_kwDOP-GF5M6fomf-, PRRT_kwDOP-GF5M6fomgA).
+   * `s-<hash>-<k>` ordinal-suffixed) when MORE THAN ONE node within
+   * `searchRoots` shares its base content hash — i.e. it has
+   * content-identical peers IN THIS SCOPE, so which node holds the bare id
+   * vs. which ordinal is load-bearing / capture-local rather than moot. A
+   * selector whose base hash is unique within `searchRoots` is left alone,
+   * and so is a real `resource-id`-backed id that merely resembles the
+   * synthetic shape (issue #6218 review threads PRRT_kwDOP-GF5M6foer0,
+   * PRRT_kwDOP-GF5M6fomf-, PRRT_kwDOP-GF5M6fomgA, PRRT_kwDOP-GF5M6fouI_).
    * Rejecting is correct here: a wrong tap is worse than a clear failure
    * telling the caller to use a more specific selector.
+   *
+   * `searchRoots` MUST already reflect any container scoping — callers with a
+   * `container` selector resolve the container FIRST and pass only its
+   * subtree, so a content-identical duplicate OUTSIDE the named container
+   * cannot block (or wrongly influence) resolution inside it. A duplicate
+   * that exists only outside the container leaves the id's exact `view-id`
+   * string matching at most one node inside the container, which the normal
+   * exact-match lookup resolves safely (or returns no-match) on its own.
+   *
+   * KNOWN LIMITATION (issue #6229, review thread PRRT_kwDOP-GF5M6fouI8): this
+   * guard is only as good as what a single, fresh capture can reveal. If node
+   * `A` (bare `s-H`) is REMOVED before the next capture and content-identical
+   * `B` (previously `s-H-2`) is now the sole survivor, `B` is reassigned the
+   * bare `s-H` id and `duplicateCount` here is 1 — the guard cannot tell that
+   * apart from an id that was always unique, so it passes and a selector
+   * meant for `A` silently resolves to `B` instead. A correct fix needs the
+   * id to carry capture-origin provenance (which generation/session it was
+   * observed in), a design change spanning the observe layer and this finder
+   * - out of scope for the current-capture-only check implemented here.
    */
   private assertStableViewIdSelectorNotAmbiguous(
-    viewHierarchy: ViewHierarchyResult,
+    searchRoots: ViewHierarchyNode[],
     id: string,
   ): void {
     const base = syntheticStableViewIdBase(id);
     if (!base) {
       return;
     }
-    if (this.hasExactResourceIdFieldMatch(viewHierarchy, id)) {
+    if (this.hasExactResourceIdFieldMatch(searchRoots, id)) {
       return;
     }
-    const duplicateCount = this.countNodesSharingStableViewIdBase(viewHierarchy, base);
+    const duplicateCount = this.countNodesSharingStableViewIdBase(searchRoots, base);
     if (duplicateCount > 1) {
       throw new ActionableError(
         `Skeleton element id "${id}" is ambiguous in the current capture: ${duplicateCount} ` +
@@ -682,8 +707,11 @@ export class DefaultElementFinder implements ElementFinder {
       return [];
     }
 
-    this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, resourceId);
-
+    // Resolve the container FIRST when one is given, so the ambiguity check
+    // below can be scoped to just its subtree - a content-identical duplicate
+    // OUTSIDE the named container must not block (or misdirect) resolution
+    // of a uniquely-identified control inside it (review thread
+    // PRRT_kwDOP-GF5M6fouI_).
     const containerNode = container
       ? this.findContainerNodeInternal(viewHierarchy, container)
       : null;
@@ -693,6 +721,7 @@ export class DefaultElementFinder implements ElementFinder {
     }
 
     if (containerNode) {
+      this.assertStableViewIdSelectorNotAmbiguous([containerNode], resourceId);
       return this.collectResourceIdMatchesInRoots(
         [containerNode],
         resourceId,
@@ -700,6 +729,11 @@ export class DefaultElementFinder implements ElementFinder {
         !preserveTraversalOrder,
       );
     }
+
+    this.assertStableViewIdSelectorNotAmbiguous(
+      this.collectFullCaptureSearchRoots(viewHierarchy),
+      resourceId,
+    );
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
     const mainMatches = this.collectResourceIdMatchesInRoots(
@@ -1332,8 +1366,6 @@ export class DefaultElementFinder implements ElementFinder {
       return [];
     }
 
-    this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, resourceId);
-
     // See collectResourceIdMatchesInRoots: Compose testTag nodes report a bare
     // viewIdResourceName with no package qualifier, so a fully-qualified query must also
     // match against the bare suffix - not just partialMatch/exact on the full string.
@@ -1343,6 +1375,8 @@ export class DefaultElementFinder implements ElementFinder {
     const matchesId = (nodeProperties: Record<string, unknown>): boolean =>
       matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch);
 
+    // Resolve the container FIRST (same ordering fix as findElementsByResourceId)
+    // so the ambiguity check can be scoped to just its subtree.
     const containerNode = container
       ? this.findContainerNodeInternal(viewHierarchy, container)
       : null;
@@ -1354,6 +1388,11 @@ export class DefaultElementFinder implements ElementFinder {
     const searchRoots = containerNode
       ? [containerNode]
       : this.parser.extractRootNodes(viewHierarchy);
+
+    this.assertStableViewIdSelectorNotAmbiguous(
+      containerNode ? searchRoots : this.collectFullCaptureSearchRoots(viewHierarchy),
+      resourceId,
+    );
 
     const siblings = this.collectClickableSiblingsWithResourceIdInRoots(searchRoots, matchesId);
 

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -14,19 +14,6 @@ import {
 import { ActionableError } from "../../models/ActionableError";
 
 /**
- * `resourceId`/`elementId` selectors carry an `s-<hash>` content-derived
- * stable id (`assignStableViewIds`, issue #3228) for nodes with no real
- * `resource-id` — the skeleton projection emits exactly that value as
- * `elementId` (`SkeletonProjection.deriveId`). Resolve it against the node's
- * `view-id` field, not `resource-id`, so a skeleton id round-trips back to
- * its element (issue #6218). Exact match only: the hash carries no partial-
- * or bare-suffix semantics the way a `pkg:id/name` resource-id does.
- */
-function isStableViewId(id: string): boolean {
-  return id.startsWith(STABLE_VIEW_ID_PREFIX);
-}
-
-/**
  * `assignStableViewIds` disambiguates content-identical duplicate nodes with an
  * ordinal `-<k>` suffix (`s-<hash>-2`, `s-<hash>-3`, ...) assigned by document
  * order AT CAPTURE TIME (`StableNodeIdentity.ts`) - the FIRST occurrence gets
@@ -65,23 +52,59 @@ function sharesStableViewIdBase(viewId: string, base: string): boolean {
   return syntheticStableViewIdBase(viewId) === base;
 }
 
-function matchesResourceIdOrStableViewId(
+/**
+ * Match a selector against a node's REAL `resource-id` field only - never
+ * `view-id`. Callers use this alone (instead of
+ * `matchesResourceIdOrStableViewId`) once they have established that a real
+ * resource-id match exists somewhere in the active search scope, so the
+ * synthetic view-id fallback can be disabled entirely for that selector
+ * rather than unioned with it (review threads PRRT_kwDOP-GF5M6fo13g,
+ * PRRT_kwDOP-GF5M6fo2Iq).
+ */
+function matchesResourceIdFieldOnly(
   nodeProperties: Record<string, unknown>,
   resourceId: string,
   bareResourceId: string | null,
   partialMatch: boolean,
 ): boolean {
   const nodeResourceId = nodeProperties["resource-id"];
-  if (typeof nodeResourceId === "string") {
-    if (
-      nodeResourceId === resourceId ||
-      (bareResourceId !== null && nodeResourceId === bareResourceId) ||
-      (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
-    ) {
-      return true;
-    }
+  if (typeof nodeResourceId !== "string") {
+    return false;
   }
-  if (isStableViewId(resourceId)) {
+  return (
+    nodeResourceId === resourceId ||
+    (bareResourceId !== null && nodeResourceId === bareResourceId) ||
+    (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
+  );
+}
+
+/**
+ * `resourceId`/`elementId` selectors carry an `s-<hash>` content-derived
+ * stable id (`assignStableViewIds`, issue #3228) for nodes with no real
+ * `resource-id` — the skeleton projection emits exactly that value as
+ * `elementId` (`SkeletonProjection.deriveId`). Resolve it against the node's
+ * `view-id` field, not `resource-id`, so a skeleton id round-trips back to
+ * its element (issue #6218). Exact match only: the hash carries no partial-
+ * or bare-suffix semantics the way a `pkg:id/name` resource-id does. The
+ * view-id fallback is gated on the selector matching the producer's strict
+ * synthetic shape (`syntheticStableViewIdBase`), not merely the `s-` prefix,
+ * so a real id like `view-id: "s-a"` is treated as a plain resource-id, never
+ * as a synthetic ordinal (review thread PRRT_kwDOP-GF5M6fo2Ip). Callers that
+ * have already established a real resource-id match exists in scope should
+ * use `matchesResourceIdFieldOnly` instead of this function, which unions
+ * both kinds of match and is therefore only safe to use when no such
+ * precedence question is in play.
+ */
+function matchesResourceIdOrStableViewId(
+  nodeProperties: Record<string, unknown>,
+  resourceId: string,
+  bareResourceId: string | null,
+  partialMatch: boolean,
+): boolean {
+  if (matchesResourceIdFieldOnly(nodeProperties, resourceId, bareResourceId, partialMatch)) {
+    return true;
+  }
+  if (syntheticStableViewIdBase(resourceId) !== null) {
     const nodeViewId = nodeProperties["view-id"];
     if (typeof nodeViewId === "string" && nodeViewId === resourceId) {
       return true;
@@ -120,6 +143,7 @@ export class DefaultElementFinder implements ElementFinder {
     rootNodes: ViewHierarchyNode[],
     container: { elementId?: string; text?: string },
     matchesContainerText: ((input?: string) => boolean) | null,
+    preferResourceIdOnly: boolean = false,
   ): ViewHierarchyNode | null {
     for (const rootNode of rootNodes) {
       let containerNode: ViewHierarchyNode | null = null;
@@ -133,10 +157,13 @@ export class DefaultElementFinder implements ElementFinder {
         const nodeContentDesc = nodeProperties["content-desc"];
         const nodeIosLabel = nodeProperties["ios-accessibility-label"];
 
-        if (
+        const elementIdMatches =
           container.elementId &&
-          matchesResourceIdOrStableViewId(nodeProperties, container.elementId, null, false)
-        ) {
+          (preferResourceIdOnly
+            ? matchesResourceIdFieldOnly(nodeProperties, container.elementId, null, false)
+            : matchesResourceIdOrStableViewId(nodeProperties, container.elementId, null, false));
+
+        if (elementIdMatches) {
           containerNode = node;
           return;
         }
@@ -167,11 +194,18 @@ export class DefaultElementFinder implements ElementFinder {
       return null;
     }
 
+    let preferResourceIdOnly = false;
     if (container.elementId) {
       // A container selector has no enclosing scope of its own to resolve
       // first, so it is always checked against the whole capture.
-      this.assertStableViewIdSelectorNotAmbiguous(
-        this.collectFullCaptureSearchRoots(viewHierarchy),
+      const fullCaptureRoots = this.collectFullCaptureSearchRoots(viewHierarchy);
+      this.assertStableViewIdSelectorNotAmbiguous(fullCaptureRoots, container.elementId);
+      // A real resource-id match anywhere in the capture always wins over a
+      // synthetic view-id match - never unioned with one, and never shadowed
+      // by a stable-id match found in an earlier-priority scope (review
+      // threads PRRT_kwDOP-GF5M6fo13g, PRRT_kwDOP-GF5M6fo2Iq).
+      preferResourceIdOnly = this.hasExactResourceIdFieldMatch(
+        fullCaptureRoots,
         container.elementId,
       );
     }
@@ -184,6 +218,7 @@ export class DefaultElementFinder implements ElementFinder {
       rootNodes,
       container,
       matchesContainerText,
+      preferResourceIdOnly,
     );
     if (containerInMain) {
       return containerInMain;
@@ -195,6 +230,7 @@ export class DefaultElementFinder implements ElementFinder {
         windowRoots,
         container,
         matchesContainerText,
+        preferResourceIdOnly,
       );
       if (containerInWindow) {
         return containerInWindow;
@@ -305,6 +341,7 @@ export class DefaultElementFinder implements ElementFinder {
     resourceId: string,
     partialMatch: boolean,
     sortByArea: boolean = true,
+    resourceIdFieldOnly: boolean = false,
   ): Element[] {
     const matches: Element[] = [];
     // Compose semantics (Modifier.testTag) surface via AccessibilityNodeInfo.viewIdResourceName
@@ -319,9 +356,20 @@ export class DefaultElementFinder implements ElementFinder {
     for (const searchNode of rootNodes) {
       this.parser.traverseNode(searchNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
-        if (
-          matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch)
-        ) {
+        // `resourceIdFieldOnly` disables the synthetic view-id fallback
+        // entirely once a real resource-id match has been established
+        // elsewhere in the active scope (review threads
+        // PRRT_kwDOP-GF5M6fo13g, PRRT_kwDOP-GF5M6fo2Iq) - a real match must
+        // never be unioned with, or out-competed by, a synthetic one.
+        const isMatch = resourceIdFieldOnly
+          ? matchesResourceIdFieldOnly(nodeProperties, resourceId, bareResourceId, partialMatch)
+          : matchesResourceIdOrStableViewId(
+              nodeProperties,
+              resourceId,
+              bareResourceId,
+              partialMatch,
+            );
+        if (isMatch) {
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             matches.push(parsedNode);
@@ -722,18 +770,26 @@ export class DefaultElementFinder implements ElementFinder {
 
     if (containerNode) {
       this.assertStableViewIdSelectorNotAmbiguous([containerNode], resourceId);
+      // A real resource-id match anywhere in the container's subtree always
+      // wins over a synthetic view-id match, never unioned with one (review
+      // thread PRRT_kwDOP-GF5M6fo13g).
+      const preferResourceIdOnly = this.hasExactResourceIdFieldMatch([containerNode], resourceId);
       return this.collectResourceIdMatchesInRoots(
         [containerNode],
         resourceId,
         partialMatch,
         !preserveTraversalOrder,
+        preferResourceIdOnly,
       );
     }
 
-    this.assertStableViewIdSelectorNotAmbiguous(
-      this.collectFullCaptureSearchRoots(viewHierarchy),
-      resourceId,
-    );
+    const fullCaptureRoots = this.collectFullCaptureSearchRoots(viewHierarchy);
+    this.assertStableViewIdSelectorNotAmbiguous(fullCaptureRoots, resourceId);
+    // Computed against the WHOLE capture (main + every window) so a real
+    // resource-id match in one root is never shadowed by a stable-id match
+    // encountered earlier in search order (review thread
+    // PRRT_kwDOP-GF5M6fo2Iq).
+    const preferResourceIdOnly = this.hasExactResourceIdFieldMatch(fullCaptureRoots, resourceId);
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
     const mainMatches = this.collectResourceIdMatchesInRoots(
@@ -741,6 +797,7 @@ export class DefaultElementFinder implements ElementFinder {
       resourceId,
       partialMatch,
       !preserveTraversalOrder,
+      preferResourceIdOnly,
     );
     if (mainMatches.length > 0) {
       return mainMatches;
@@ -753,6 +810,7 @@ export class DefaultElementFinder implements ElementFinder {
         resourceId,
         partialMatch,
         !preserveTraversalOrder,
+        preferResourceIdOnly,
       );
       if (windowMatches.length > 0) {
         return windowMatches;
@@ -1372,9 +1430,6 @@ export class DefaultElementFinder implements ElementFinder {
     const idSeparatorIndex = resourceId.lastIndexOf("/");
     const bareResourceId = idSeparatorIndex >= 0 ? resourceId.slice(idSeparatorIndex + 1) : null;
 
-    const matchesId = (nodeProperties: Record<string, unknown>): boolean =>
-      matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch);
-
     // Resolve the container FIRST (same ordering fix as findElementsByResourceId)
     // so the ambiguity check can be scoped to just its subtree.
     const containerNode = container
@@ -1389,10 +1444,20 @@ export class DefaultElementFinder implements ElementFinder {
       ? [containerNode]
       : this.parser.extractRootNodes(viewHierarchy);
 
-    this.assertStableViewIdSelectorNotAmbiguous(
-      containerNode ? searchRoots : this.collectFullCaptureSearchRoots(viewHierarchy),
-      resourceId,
-    );
+    // Computed against the container's subtree, or the WHOLE capture when
+    // there is no container, so a real resource-id match is never unioned
+    // with, or shadowed in window-search order by, a synthetic view-id match
+    // (review threads PRRT_kwDOP-GF5M6fo13g, PRRT_kwDOP-GF5M6fo2Iq).
+    const ambiguityScopeRoots = containerNode
+      ? searchRoots
+      : this.collectFullCaptureSearchRoots(viewHierarchy);
+    this.assertStableViewIdSelectorNotAmbiguous(ambiguityScopeRoots, resourceId);
+    const preferResourceIdOnly = this.hasExactResourceIdFieldMatch(ambiguityScopeRoots, resourceId);
+
+    const matchesId = (nodeProperties: Record<string, unknown>): boolean =>
+      preferResourceIdOnly
+        ? matchesResourceIdFieldOnly(nodeProperties, resourceId, bareResourceId, partialMatch)
+        : matchesResourceIdOrStableViewId(nodeProperties, resourceId, bareResourceId, partialMatch);
 
     const siblings = this.collectClickableSiblingsWithResourceIdInRoots(searchRoots, matchesId);
 

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -572,6 +572,20 @@ export class DefaultElementFinder implements ElementFinder {
    * id to carry capture-origin provenance (which generation/session it was
    * observed in), a design change spanning the observe layer and this finder
    * - out of scope for the current-capture-only check implemented here.
+   *
+   * KNOWN LIMITATION (issue #6230, review thread PRRT_kwDOP-GF5M6fo-Pb): a
+   * synthetic id is a Merkle hash over a node's OWN content fields plus every
+   * DESCENDANT's content hash (`StableNodeIdentity.ts`), so a still-present,
+   * otherwise-unchanged ancestor's id changes whenever any descendant's
+   * `text`/`content-desc` changes between captures - e.g. a live timer child
+   * ticking "1 second" → "2 seconds" changes its row's id from one capture to
+   * the next. The exact-match lookup below then finds nothing for the id a
+   * caller observed a moment earlier, even though the intended control is
+   * still on screen (a miss, not a mis-tap). This is the counterpart of the
+   * #6229 removal case - both are inherent to a pure content hash, which is
+   * stable only while content is stable - and needs the same class of fix:
+   * structural/positional identity or capture-origin provenance, not a
+   * change to the current-capture-only matching done here.
    */
   private assertStableViewIdSelectorNotAmbiguous(
     searchRoots: ViewHierarchyNode[],

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -8,6 +8,7 @@ import { DefaultElementParser } from "./ElementParser";
 import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
 import { ANDROID_INPUT_CLASSES, isClickableElementProperties } from "../../utils/elementProperties";
 import { STABLE_VIEW_ID_PREFIX } from "../observe/android/StableNodeIdentity";
+import { ActionableError } from "../../models/ActionableError";
 
 /**
  * `resourceId`/`elementId` selectors carry an `s-<hash>` content-derived
@@ -20,6 +21,31 @@ import { STABLE_VIEW_ID_PREFIX } from "../observe/android/StableNodeIdentity";
  */
 function isStableViewId(id: string): boolean {
   return id.startsWith(STABLE_VIEW_ID_PREFIX);
+}
+
+/**
+ * `assignStableViewIds` disambiguates content-identical duplicate nodes with an
+ * ordinal `-<k>` suffix (`s-<hash>-2`, `s-<hash>-3`, ...) assigned by document
+ * order AT CAPTURE TIME (`StableNodeIdentity.ts`). That ordinal is therefore
+ * capture-local: an insert or reorder between the capture an `s-<hash>-<k>` id
+ * was observed from and the fresh capture a later `tapOn`/`inputText` resolves
+ * it against can shift which node the k-th occurrence now lands on - silently
+ * resolving to the WRONG node rather than the one the caller meant (issue
+ * #6218 review thread PRRT_kwDOP-GF5M6foer0). This pattern detects that shape
+ * so it can be checked against the CURRENT capture's duplicate count before
+ * being trusted.
+ */
+const ORDINAL_STABLE_VIEW_ID_PATTERN = /^(s-[0-9a-f]+)-\d+$/;
+
+/** The un-suffixed base id an ordinal-suffixed stable id was derived from, or null. */
+function stableViewIdOrdinalBase(id: string): string | null {
+  const match = ORDINAL_STABLE_VIEW_ID_PATTERN.exec(id);
+  return match ? match[1] : null;
+}
+
+/** True when `viewId` is exactly `base`, or an ordinal-suffixed duplicate of it. */
+function sharesStableViewIdBase(viewId: string, base: string): boolean {
+  return viewId === base || stableViewIdOrdinalBase(viewId) === base;
 }
 
 function matchesResourceIdOrStableViewId(
@@ -122,6 +148,10 @@ export class DefaultElementFinder implements ElementFinder {
   ): ViewHierarchyNode | null {
     if (!viewHierarchy || !container) {
       return null;
+    }
+
+    if (container.elementId) {
+      this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, container.elementId);
     }
 
     const matchesContainerText = container.text
@@ -372,6 +402,67 @@ export class DefaultElementFinder implements ElementFinder {
     return isClickableElementProperties(props);
   }
 
+  /**
+   * Count nodes anywhere in the current capture (main hierarchy plus every
+   * window) whose `view-id` is `base` or an ordinal-suffixed duplicate of it.
+   * Used to decide whether an ordinal-suffixed `s-<hash>-<k>` selector is safe
+   * to trust in THIS capture (see `assertStableViewIdSelectorNotAmbiguous`).
+   */
+  private countNodesSharingStableViewIdBase(
+    viewHierarchy: ViewHierarchyResult,
+    base: string,
+  ): number {
+    let count = 0;
+    const countInRoots = (roots: ViewHierarchyNode[]): void => {
+      for (const root of roots) {
+        this.parser.traverseNode(root, (node: any) => {
+          const nodeProperties = this.parser.extractNodeProperties(node);
+          const viewId = nodeProperties["view-id"];
+          if (typeof viewId === "string" && sharesStableViewIdBase(viewId, base)) {
+            count++;
+          }
+        });
+      }
+    };
+
+    countInRoots(this.parser.extractRootNodes(viewHierarchy));
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      countInRoots(windowRoots);
+    }
+    return count;
+  }
+
+  /**
+   * Reject an ordinal-suffixed stable-view-id selector (`s-<hash>-<k>`) when
+   * MORE THAN ONE node in the current capture shares its base content hash —
+   * i.e. the ordinal is load-bearing / capture-local rather than moot. A
+   * plain (unsuffixed) selector, or one whose base hash is unique in this
+   * capture, is left alone (issue #6218 review thread
+   * PRRT_kwDOP-GF5M6foer0). Rejecting is correct here: a wrong tap is worse
+   * than a clear failure telling the caller to use a more specific selector.
+   */
+  private assertStableViewIdSelectorNotAmbiguous(
+    viewHierarchy: ViewHierarchyResult,
+    id: string,
+  ): void {
+    const base = stableViewIdOrdinalBase(id);
+    if (!base) {
+      return;
+    }
+    const duplicateCount = this.countNodesSharingStableViewIdBase(viewHierarchy, base);
+    if (duplicateCount > 1) {
+      throw new ActionableError(
+        `Skeleton element id "${id}" is ambiguous in the current capture: ${duplicateCount} ` +
+          `content-identical elements share stable id "${base}", and its "-N" ordinal suffix is ` +
+          "assigned by document order at capture time. An element insert or reorder since this id " +
+          "was observed can shift which element the ordinal now points to, so resolving it here " +
+          "could silently act on the wrong element. Use a more specific selector (text, " +
+          "content-desc, or bounds) instead.",
+      );
+    }
+  }
+
   private rankTextMatches(matches: Element[]): Element[] {
     matches.sort((a, b) => Number(this.isClickableNode(b)) - Number(this.isClickableNode(a)));
     return matches;
@@ -529,6 +620,8 @@ export class DefaultElementFinder implements ElementFinder {
     if (!viewHierarchy || !resourceId) {
       return [];
     }
+
+    this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, resourceId);
 
     const containerNode = container
       ? this.findContainerNodeInternal(viewHierarchy, container)
@@ -1177,6 +1270,8 @@ export class DefaultElementFinder implements ElementFinder {
     if (!viewHierarchy || !resourceId) {
       return [];
     }
+
+    this.assertStableViewIdSelectorNotAmbiguous(viewHierarchy, resourceId);
 
     // See collectResourceIdMatchesInRoots: Compose testTag nodes report a bare
     // viewIdResourceName with no package qualifier, so a fully-qualified query must also

--- a/test/features/utility/skeletonElementIdRoundtrip.test.ts
+++ b/test/features/utility/skeletonElementIdRoundtrip.test.ts
@@ -105,16 +105,18 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     }
   });
 
-  test("content-identical duplicate nodes get distinct ordinal-suffixed ids, but the ordinal-suffixed id is rejected as capture-local rather than silently resolved", () => {
+  test("content-identical duplicate nodes get distinct ids, but BOTH the bare first-occurrence id and its ordinal-suffixed peer are rejected as capture-local", () => {
     // Two nodes with completely identical stable content (same class, no
     // text/content-desc/resource-id) — `assignStableViewIds` disambiguates them
-    // with a `-2` ordinal suffix rather than colliding on one hash. That
-    // ordinal is assigned by document order AT CAPTURE TIME (see
-    // `StableNodeIdentity.ts`), so it is capture-local: an insert or reorder
-    // before a later capture can shift which node the k-th occurrence lands
-    // on. Resolving `s-<hash>-2` here would therefore risk silently acting on
-    // the wrong element - worse than a clear failure (issue #6218 review
-    // thread PRRT_kwDOP-GF5M6foer0).
+    // with a `-2` ordinal suffix rather than colliding on one hash. The FIRST
+    // occurrence gets the bare `s-<hash>` id (implicitly ordinal 1) - that
+    // bare/ordinal split is assigned by document order AT CAPTURE TIME (see
+    // `StableNodeIdentity.ts`), so BOTH forms are capture-local whenever a
+    // duplicate exists: an insert or reorder before a later capture can hand
+    // the bare id to a different node entirely. Resolving either form here
+    // would therefore risk silently acting on the wrong element - worse than
+    // a clear failure (issue #6218 review threads PRRT_kwDOP-GF5M6foer0 and
+    // follow-up PRRT_kwDOP-GF5M6fomf-).
     const nodeA = {
       class: "android.view.View",
       bounds: { left: 0, top: 0, right: 40, bottom: 40 },
@@ -140,15 +142,70 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     expect(idA.startsWith("s-")).toBe(true);
     expect(idB).toBe(`${idA}-2`);
 
-    // The unsuffixed base id is the common case and still resolves normally -
-    // it is the only node with that EXACT (un-suffixed) view-id string.
-    const resultA = selector.selectByResourceId(viewHierarchy, idA);
-    expect(resultA.element).not.toBeNull();
-    expect(resultA.totalMatches).toBe(1);
-    expect(resultA.element!.bounds).toEqual({ left: 0, top: 0, right: 40, bottom: 40 });
-
-    // The ordinal-suffixed duplicate id is rejected outright, not resolved.
+    // Both the bare first-occurrence id and its ordinal-suffixed peer are
+    // rejected outright, not resolved - neither is safe to trust across a
+    // capture boundary while a content-identical duplicate exists.
+    expect(() => selector.selectByResourceId(viewHierarchy, idA)).toThrow(/ambiguous/i);
     expect(() => selector.selectByResourceId(viewHierarchy, idB)).toThrow(/ambiguous/i);
+  });
+
+  test("a bare s-<hash> id with no content-identical peer still resolves normally", () => {
+    // The common case (P1 follow-up): a UNIQUE base hash must keep resolving
+    // even though the bare form is now also subject to the ambiguity check.
+    const rawRoot = {
+      node: [
+        {
+          class: "android.widget.ImageButton",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "content-desc": "solo-row",
+          clickable: "true",
+          "view-id": generatedViewId("solo"),
+        },
+      ],
+    };
+    assignStableViewIds(rawRoot);
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+    const id = (rawRoot.node[0] as Record<string, unknown>)["view-id"] as string;
+    expect(id).toMatch(/^s-[0-9a-f]{16}$/);
+
+    const result = selector.selectByResourceId(viewHierarchy, id);
+    expect(result.element).not.toBeNull();
+    expect(result.totalMatches).toBe(1);
+    expect(result.element!["content-desc"]).toBe("solo-row");
+  });
+
+  test("a real bare Compose resource-id shaped like a synthetic id (s-a / s-a-2) is never misclassified as ambiguous", () => {
+    // Review thread PRRT_kwDOP-GF5M6fomgA: `SYNTHETIC_STABLE_VIEW_ID_PATTERN`
+    // must require the producer's EXACT hash width, not merely the `s-`
+    // prefix, or a real short Compose testTag colliding with that prefix
+    // would be wrongly rejected as an ambiguous synthetic ordinal.
+    const rawRoot = {
+      node: [
+        {
+          class: "androidx.compose.ui.platform.ComposeView",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "resource-id": "s-a",
+          clickable: "true",
+        },
+        {
+          class: "androidx.compose.ui.platform.ComposeView",
+          bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+          "resource-id": "s-a-2",
+          clickable: "true",
+        },
+      ],
+    };
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+    const result = selector.selectByResourceId(viewHierarchy, "s-a-2");
+    expect(result.element).not.toBeNull();
+    expect(result.totalMatches).toBe(1);
+    expect(result.element!.bounds).toEqual({ left: 0, top: 60, right: 100, bottom: 110 });
+
+    const resultBase = selector.selectByResourceId(viewHierarchy, "s-a");
+    expect(resultBase.element).not.toBeNull();
+    expect(resultBase.totalMatches).toBe(1);
+    expect(resultBase.element!.bounds).toEqual({ left: 0, top: 0, right: 100, bottom: 50 });
   });
 
   test("an ordinal id from an earlier capture does not silently resolve to the wrong node after an insert shifts the ordinals", () => {

--- a/test/features/utility/skeletonElementIdRoundtrip.test.ts
+++ b/test/features/utility/skeletonElementIdRoundtrip.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
+import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
+import { DefaultTextMatcher } from "../../../src/features/utility/TextMatcher";
+import { DefaultElementSelector } from "../../../src/features/utility/DefaultElementSelector";
+import { assignStableViewIds } from "../../../src/features/observe/android/StableNodeIdentity";
+import { toSkeleton } from "../../../src/features/observe/output/SkeletonProjection";
+import type { ViewHierarchyResult } from "../../../src/models";
+import type { Element } from "../../../src/models/Element";
+import type { ObserveResult } from "../../../src/models/ObserveResult";
+
+/**
+ * Round-trip coverage for issue #6218: the skeleton projection emits an
+ * `s-<hash>` content-derived id (`assignStableViewIds`, #3228) as the SOLE
+ * `elementId` for a node with no `resource-id`/`text`. `tapOn`/`inputText`
+ * resolve `elementId` through `DefaultElementSelector.selectByResourceId` →
+ * `DefaultElementFinder`, which previously only ever compared against
+ * `resource-id` — so a skeleton-emitted `s-<hash>` id could never match
+ * anything, despite the tool docs promising it is "directly usable as a
+ * tapOn selector". `ElementFinder` now also matches an `s-`-prefixed
+ * `elementId` against the node's `view-id` field.
+ */
+
+type ObserveElements = NonNullable<ObserveResult["elements"]>;
+
+function makeElements(partial: Partial<ObserveElements>): ObserveElements {
+  return {
+    clickable: partial.clickable ?? [],
+    scrollable: partial.scrollable ?? [],
+    text: partial.text ?? [],
+    media: partial.media ?? [],
+  };
+}
+
+/** Shape `assignStableViewIds` rewrites: the runner's generated path UUID. */
+function generatedViewId(seed: string): string {
+  // Deterministic-looking but distinct per seed; only the shape (UUID) matters.
+  const hex = Buffer.from(seed.padEnd(16, "0")).toString("hex").slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+const parser = new DefaultElementParser();
+const textMatcher = new DefaultTextMatcher();
+const finder = new DefaultElementFinder(parser, textMatcher);
+const selector = new DefaultElementSelector(finder);
+
+describe("skeleton elementId round-trips through tapOn's ElementSelector (issue #6218)", () => {
+  test("an s-<hash> elementId resolves back to the exact id-less element it was derived from", () => {
+    // Three id-less, text-less nodes distinguished only by content-desc — the
+    // "12/16 elements have no stable selector" dogfood scenario from the issue.
+    const rawRoot = {
+      node: [
+        {
+          class: "android.widget.ImageButton",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "content-desc": "row-alpha",
+          clickable: "true",
+          "view-id": generatedViewId("alpha"),
+        },
+        {
+          class: "android.widget.ImageButton",
+          bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+          "content-desc": "row-beta",
+          clickable: "true",
+          "view-id": generatedViewId("beta"),
+        },
+        {
+          class: "android.widget.ImageButton",
+          bounds: { left: 0, top: 120, right: 100, bottom: 170 },
+          "content-desc": "row-gamma",
+          clickable: "true",
+          "view-id": generatedViewId("gamma"),
+        },
+      ],
+    };
+
+    // Ingest-time rewrite: generated path UUIDs -> content-derived `s-<hash>` ids.
+    assignStableViewIds(rawRoot);
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+    const rawNodes = rawRoot.node;
+    const elements = rawNodes.map((node) => parser.parseNodeBounds(node as never) as Element);
+
+    // Every synthetic id is stable-shaped and unique.
+    const stableIds = elements.map((el) => el["view-id"]);
+    for (const id of stableIds) {
+      expect(id).toMatch(/^s-[0-9a-f]{16}(-\d+)?$/);
+    }
+    expect(new Set(stableIds).size).toBe(stableIds.length);
+
+    const skeleton = toSkeleton(makeElements({ clickable: elements }));
+    expect(skeleton).toHaveLength(3);
+
+    // Round-trip: feed each skeleton elementId back into the exact selector
+    // path tapOn uses, against the SAME hierarchy, and assert it resolves to
+    // the one element it was derived from — not any other row.
+    for (const entry of skeleton) {
+      expect(entry.elementId).toMatch(/^s-[0-9a-f]{16}(-\d+)?$/);
+      const result = selector.selectByResourceId(viewHierarchy, entry.elementId!);
+      expect(result.element).not.toBeNull();
+      expect(result.totalMatches).toBe(1);
+      const b = result.element!.bounds;
+      expect([b.left, b.top, b.right, b.bottom]).toEqual(entry.bounds);
+      expect(result.element!["content-desc"]).toBe(entry.label!);
+    }
+  });
+
+  test("content-identical duplicate nodes get distinct ordinal-suffixed ids that each resolve to their own node, not the other's", () => {
+    // Two nodes with completely identical stable content (same class, no
+    // text/content-desc/resource-id) — `assignStableViewIds` disambiguates them
+    // with a `-2` ordinal suffix rather than colliding on one hash.
+    const nodeA = {
+      class: "android.view.View",
+      bounds: { left: 0, top: 0, right: 40, bottom: 40 },
+      clickable: "true",
+      "view-id": generatedViewId("dup-a"),
+    };
+    const nodeB = {
+      class: "android.view.View",
+      bounds: { left: 0, top: 50, right: 40, bottom: 90 },
+      clickable: "true",
+      "view-id": generatedViewId("dup-b"),
+    };
+    const rawRoot = { node: [nodeA, nodeB] };
+
+    assignStableViewIds(rawRoot);
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+    const idA = (nodeA as Record<string, unknown>)["view-id"] as string;
+    const idB = (nodeB as Record<string, unknown>)["view-id"] as string;
+
+    // Deterministic, cleanly disambiguated — not the same value.
+    expect(idA).not.toBe(idB);
+    expect(idA.startsWith("s-")).toBe(true);
+    expect(idB).toBe(`${idA}-2`);
+
+    const resultA = selector.selectByResourceId(viewHierarchy, idA);
+    expect(resultA.element).not.toBeNull();
+    expect(resultA.totalMatches).toBe(1);
+    expect(resultA.element!.bounds).toEqual({ left: 0, top: 0, right: 40, bottom: 40 });
+
+    const resultB = selector.selectByResourceId(viewHierarchy, idB);
+    expect(resultB.element).not.toBeNull();
+    expect(resultB.totalMatches).toBe(1);
+    expect(resultB.element!.bounds).toEqual({ left: 0, top: 50, right: 40, bottom: 90 });
+  });
+
+  test("recomputing the synthetic id over a fresh capture of the same hierarchy is deterministic", () => {
+    const buildRoot = () => ({
+      node: [
+        {
+          class: "android.widget.TextView",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "content-desc": "fresh-capture-node",
+          clickable: "true",
+          "view-id": generatedViewId("fresh"),
+        },
+      ],
+    });
+
+    const firstCapture = buildRoot();
+    const secondCapture = buildRoot();
+    assignStableViewIds(firstCapture);
+    assignStableViewIds(secondCapture);
+
+    const firstId = (firstCapture.node[0] as Record<string, unknown>)["view-id"];
+    const secondId = (secondCapture.node[0] as Record<string, unknown>)["view-id"];
+    expect(firstId).toBe(secondId as string);
+
+    // The id emitted from capture 1's skeleton resolves against capture 2's
+    // (freshly re-observed) hierarchy — the exact cross-capture scenario
+    // between an `observe` and a subsequent `tapOn`.
+    const skeleton = toSkeleton(
+      makeElements({
+        clickable: [parser.parseNodeBounds(firstCapture.node[0] as never) as Element],
+      }),
+    );
+    const result = selector.selectByResourceId(
+      { hierarchy: secondCapture } as ViewHierarchyResult,
+      skeleton[0].elementId!,
+    );
+    expect(result.element).not.toBeNull();
+    expect(result.element!["content-desc"]).toBe("fresh-capture-node");
+  });
+
+  test("a real resource-id elementId is unaffected by the stable-view-id fallback", () => {
+    const rawRoot = {
+      node: [
+        {
+          class: "android.widget.Button",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "resource-id": "com.app:id/submit",
+          text: "Submit",
+          clickable: "true",
+        },
+      ],
+    };
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+    const result = selector.selectByResourceId(viewHierarchy, "com.app:id/submit");
+    expect(result.element).not.toBeNull();
+    expect(result.element!.text).toBe("Submit");
+  });
+});

--- a/test/features/utility/skeletonElementIdRoundtrip.test.ts
+++ b/test/features/utility/skeletonElementIdRoundtrip.test.ts
@@ -411,4 +411,172 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     expect(result.element).not.toBeNull();
     expect(result.element!.text).toBe("Submit");
   });
+
+  describe("real resource-id takes precedence over a colliding synthetic view-id (review threads PRRT_kwDOP-GF5M6fo13g, PRRT_kwDOP-GF5M6fo2Iq, PRRT_kwDOP-GF5M6fo2Ip)", () => {
+    // A resource-id shaped exactly like a synthetic hash - so it also matches
+    // `syntheticStableViewIdBase` - is the sharpest test of precedence: a real
+    // field match must win even when it superficially resembles the
+    // synthetic shape.
+    const collidingId = "s-9fb4b913ae97b1c1";
+
+    test("a real resource-id control is selected over a smaller id-less node sharing the same synthetic view-id, regardless of relative area", () => {
+      // Previously the matcher UNIONED resource-id matches and synthetic
+      // view-id matches, then area-sorted ascending - so the SMALLER
+      // synthetic node would win over the explicitly-named resource
+      // control. The real control here is deliberately much LARGER, so the
+      // old area-sort would have picked the wrong (smaller) node first.
+      const rawRoot = {
+        node: [
+          {
+            class: "android.view.View",
+            bounds: { left: 10, top: 10, right: 20, bottom: 20 }, // small
+            clickable: "true",
+            "view-id": collidingId,
+          },
+          {
+            class: "android.widget.Button",
+            bounds: { left: 0, top: 100, right: 200, bottom: 300 }, // large
+            clickable: "true",
+            "resource-id": collidingId,
+            text: "Real Control",
+          },
+        ],
+      };
+      const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+      const result = selector.selectByResourceId(viewHierarchy, collidingId);
+      expect(result.element).not.toBeNull();
+      expect(result.totalMatches).toBe(1);
+      expect(result.element!.text).toBe("Real Control");
+      expect(result.element!.bounds).toEqual({ left: 0, top: 100, right: 200, bottom: 300 });
+    });
+
+    test("cross-window: a window's real resource-id match wins over a main-root stable-id match", () => {
+      const rawRoot = {
+        node: [
+          {
+            class: "android.view.View",
+            bounds: { left: 0, top: 0, right: 50, bottom: 50 },
+            clickable: "true",
+            "view-id": collidingId,
+          },
+        ],
+      };
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: rawRoot,
+        windows: [
+          {
+            windowLayer: 1,
+            hierarchy: {
+              node: [
+                {
+                  class: "android.widget.Button",
+                  bounds: { left: 0, top: 0, right: 80, bottom: 80 },
+                  clickable: "true",
+                  "resource-id": collidingId,
+                  text: "Window Control",
+                },
+              ],
+            },
+          },
+        ],
+      } as ViewHierarchyResult;
+
+      const result = selector.selectByResourceId(viewHierarchy, collidingId);
+      expect(result.element).not.toBeNull();
+      expect(result.totalMatches).toBe(1);
+      expect(result.element!.text).toBe("Window Control");
+    });
+
+    test("findClickableSiblingsOfResourceId does not exclude a decoy synthetic-view-id sibling as if it were the real resource-id match", () => {
+      // The real anchor (non-clickable) carries the resource-id; a separate,
+      // CLICKABLE decoy node merely shares that string as its `view-id`.
+      // Precedence means the decoy is NOT the id match, so it must surface as
+      // a clickable sibling of the real anchor - previously it was unioned in
+      // as a (false) match and silently excluded from the sibling results.
+      const rawRoot = {
+        node: [
+          {
+            class: "android.view.ViewGroup",
+            bounds: { left: 0, top: 0, right: 200, bottom: 100 },
+            node: [
+              {
+                class: "android.widget.ImageButton",
+                bounds: { left: 0, top: 0, right: 50, bottom: 50 },
+                clickable: "true",
+                "view-id": collidingId, // decoy - not a real resource-id
+              },
+              {
+                class: "android.view.View",
+                bounds: { left: 60, top: 0, right: 110, bottom: 50 },
+                "resource-id": collidingId, // real match, not clickable
+              },
+            ],
+          },
+        ],
+      };
+      const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+      const siblings = finder.findClickableSiblingsOfResourceId(viewHierarchy, collidingId);
+      expect(siblings).toHaveLength(1);
+      expect(siblings[0].bounds).toEqual({ left: 0, top: 0, right: 50, bottom: 50 });
+    });
+
+    test("the container path (findContainerNode) selects the real resource-id container, not a decoy sharing its view-id", () => {
+      const rawRoot = {
+        node: [
+          {
+            class: "android.view.ViewGroup",
+            bounds: { left: 0, top: 0, right: 50, bottom: 50 },
+            "view-id": collidingId, // decoy container - not a real resource-id
+          },
+          {
+            class: "android.view.ViewGroup",
+            bounds: { left: 100, top: 100, right: 300, bottom: 300 },
+            "resource-id": collidingId, // the real, intended container
+          },
+        ],
+      };
+      const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+      const containerNode = finder.findContainerNode(viewHierarchy, { elementId: collidingId });
+      expect(containerNode).not.toBeNull();
+      const parsed = parser.parseNodeBounds(containerNode as never);
+      expect(parsed!.bounds).toEqual({ left: 100, top: 100, right: 300, bottom: 300 });
+    });
+  });
+
+  test("a real bare id (view-id: 's-a') that does not match the strict synthetic shape is treated as a plain resource-id, not a synthetic ordinal (review thread PRRT_kwDOP-GF5M6fo2Ip)", () => {
+    // Review thread PRRT_kwDOP-GF5M6fo2Ip: recognition of a synthetic id must
+    // be gated on the STRICT producer shape (`syntheticStableViewIdBase`)
+    // everywhere a selector is matched against `view-id`, not merely on an
+    // `s-` prefix. "s-a" is far short of the producer's 16-hex-character
+    // hash, so it must never trigger the synthetic view-id fallback: a
+    // separate node whose `view-id` merely happens to equal "s-a" (with no
+    // matching `resource-id` of its own) must NOT be treated as a match.
+    const rawRoot = {
+      node: [
+        {
+          class: "android.widget.Button",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          "resource-id": "s-a",
+          text: "Real Short Id",
+          clickable: "true",
+        },
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: 100, right: 300, bottom: 300 }, // much larger
+          clickable: "true",
+          "view-id": "s-a", // superficially resembles the prefix, wrong shape
+        },
+      ],
+    };
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+    const result = selector.selectByResourceId(viewHierarchy, "s-a");
+    expect(result.element).not.toBeNull();
+    expect(result.totalMatches).toBe(1);
+    expect(result.element!.text).toBe("Real Short Id");
+    expect(result.element!.bounds).toEqual({ left: 0, top: 0, right: 100, bottom: 50 });
+  });
 });

--- a/test/features/utility/skeletonElementIdRoundtrip.test.ts
+++ b/test/features/utility/skeletonElementIdRoundtrip.test.ts
@@ -105,10 +105,16 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     }
   });
 
-  test("content-identical duplicate nodes get distinct ordinal-suffixed ids that each resolve to their own node, not the other's", () => {
+  test("content-identical duplicate nodes get distinct ordinal-suffixed ids, but the ordinal-suffixed id is rejected as capture-local rather than silently resolved", () => {
     // Two nodes with completely identical stable content (same class, no
     // text/content-desc/resource-id) — `assignStableViewIds` disambiguates them
-    // with a `-2` ordinal suffix rather than colliding on one hash.
+    // with a `-2` ordinal suffix rather than colliding on one hash. That
+    // ordinal is assigned by document order AT CAPTURE TIME (see
+    // `StableNodeIdentity.ts`), so it is capture-local: an insert or reorder
+    // before a later capture can shift which node the k-th occurrence lands
+    // on. Resolving `s-<hash>-2` here would therefore risk silently acting on
+    // the wrong element - worse than a clear failure (issue #6218 review
+    // thread PRRT_kwDOP-GF5M6foer0).
     const nodeA = {
       class: "android.view.View",
       bounds: { left: 0, top: 0, right: 40, bottom: 40 },
@@ -134,15 +140,82 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     expect(idA.startsWith("s-")).toBe(true);
     expect(idB).toBe(`${idA}-2`);
 
+    // The unsuffixed base id is the common case and still resolves normally -
+    // it is the only node with that EXACT (un-suffixed) view-id string.
     const resultA = selector.selectByResourceId(viewHierarchy, idA);
     expect(resultA.element).not.toBeNull();
     expect(resultA.totalMatches).toBe(1);
     expect(resultA.element!.bounds).toEqual({ left: 0, top: 0, right: 40, bottom: 40 });
 
-    const resultB = selector.selectByResourceId(viewHierarchy, idB);
-    expect(resultB.element).not.toBeNull();
-    expect(resultB.totalMatches).toBe(1);
-    expect(resultB.element!.bounds).toEqual({ left: 0, top: 50, right: 40, bottom: 90 });
+    // The ordinal-suffixed duplicate id is rejected outright, not resolved.
+    expect(() => selector.selectByResourceId(viewHierarchy, idB)).toThrow(/ambiguous/i);
+  });
+
+  test("an ordinal id from an earlier capture does not silently resolve to the wrong node after an insert shifts the ordinals", () => {
+    // The exact P1 scenario: content-identical controls [A, B] where B was
+    // observed as `s-<hash>-2`. Inserting an identical control before them in
+    // a later capture shifts the ordinals: A becomes `s-<hash>-2` and B
+    // becomes `s-<hash>-3`. Resolving the ORIGINAL `s-<hash>-2` id (which
+    // meant B) against the reordered capture must NOT silently act on A.
+    const original = {
+      node: [
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: 0, right: 40, bottom: 40 },
+          clickable: "true",
+          "view-id": generatedViewId("orig-a"),
+        },
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: 50, right: 40, bottom: 90 },
+          clickable: "true",
+          "view-id": generatedViewId("orig-b"),
+        },
+      ],
+    };
+    assignStableViewIds(original);
+    const originalIdB = (original.node[1] as Record<string, unknown>)["view-id"] as string;
+    expect(originalIdB).toMatch(/^s-[0-9a-f]{16}-2$/);
+
+    const reordered = {
+      node: [
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: -50, right: 40, bottom: -10 },
+          clickable: "true",
+          "view-id": generatedViewId("inserted-c"),
+        },
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: 0, right: 40, bottom: 40 },
+          clickable: "true",
+          "view-id": generatedViewId("orig-a-2"),
+        },
+        {
+          class: "android.view.View",
+          bounds: { left: 0, top: 50, right: 40, bottom: 90 },
+          clickable: "true",
+          "view-id": generatedViewId("orig-b-2"),
+        },
+      ],
+    };
+    assignStableViewIds(reordered);
+    const reorderedIds = (reordered.node as Record<string, unknown>[]).map(
+      (n) => n["view-id"] as string,
+    );
+    // Same base hash for all three (content-identical) - inserted node now
+    // owns the un-suffixed base id, and A/B ordinals both shifted by one.
+    expect(reorderedIds[0]).toBe(originalIdB.replace(/-2$/, ""));
+    expect(reorderedIds[1]).toBe(originalIdB);
+    expect(reorderedIds[2]).toBe(`${originalIdB.replace(/-2$/, "")}-3`);
+
+    const reorderedViewHierarchy: ViewHierarchyResult = { hierarchy: reordered };
+
+    // The id that used to mean "B" now happens to match "A" (the inserted
+    // node's document order) - this MUST be rejected, not silently tapped.
+    expect(() => selector.selectByResourceId(reorderedViewHierarchy, originalIdB)).toThrow(
+      /ambiguous/i,
+    );
   });
 
   test("recomputing the synthetic id over a fresh capture of the same hierarchy is deterministic", () => {

--- a/test/features/utility/skeletonElementIdRoundtrip.test.ts
+++ b/test/features/utility/skeletonElementIdRoundtrip.test.ts
@@ -275,6 +275,87 @@ describe("skeleton elementId round-trips through tapOn's ElementSelector (issue 
     );
   });
 
+  test("identical controls in two distinct, uniquely-identified containers resolve via tapOn({elementId, container}) instead of being rejected as ambiguous", () => {
+    // Review thread PRRT_kwDOP-GF5M6fouI_: the ambiguity check must be scoped
+    // to the RESOLVED container, not the whole capture. Two containers each
+    // hold one content-identical target node - globally ambiguous (2 nodes
+    // share the base hash), but each container's own subtree contains only
+    // ONE of them, so a `container`-scoped selector must resolve cleanly.
+    const container1 = {
+      class: "android.view.ViewGroup",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      "resource-id": "com.app:id/container1",
+      node: [
+        {
+          class: "android.view.View",
+          bounds: { left: 10, top: 10, right: 90, bottom: 40 },
+          clickable: "true",
+          "view-id": generatedViewId("target-in-container-1"),
+        },
+      ],
+    };
+    const container2 = {
+      class: "android.view.ViewGroup",
+      bounds: { left: 0, top: 200, right: 100, bottom: 300 },
+      "resource-id": "com.app:id/container2",
+      node: [
+        {
+          class: "android.view.View",
+          bounds: { left: 10, top: 210, right: 90, bottom: 240 },
+          clickable: "true",
+          "view-id": generatedViewId("target-in-container-2"),
+        },
+      ],
+    };
+    const rawRoot = { node: [container1, container2] };
+    assignStableViewIds(rawRoot);
+    const viewHierarchy: ViewHierarchyResult = { hierarchy: rawRoot };
+
+    const idInContainer1 = (container1.node[0] as Record<string, unknown>)["view-id"] as string;
+    const idInContainer2 = (container2.node[0] as Record<string, unknown>)["view-id"] as string;
+
+    // Same base content hash, disambiguated globally by document order - the
+    // first (container1's) is bare, the second (container2's) is suffixed.
+    expect(idInContainer1).toMatch(/^s-[0-9a-f]{16}$/);
+    expect(idInContainer2).toBe(`${idInContainer1}-2`);
+
+    // Without a container, this is genuinely globally ambiguous.
+    expect(() => selector.selectByResourceId(viewHierarchy, idInContainer1)).toThrow(/ambiguous/i);
+
+    // Scoped to its OWN container, each resolves cleanly - the peer outside
+    // the container does not block or misdirect resolution inside it.
+    const resultInContainer1 = selector.selectByResourceId(viewHierarchy, idInContainer1, {
+      container: { elementId: "com.app:id/container1" },
+    });
+    expect(resultInContainer1.element).not.toBeNull();
+    expect(resultInContainer1.totalMatches).toBe(1);
+    expect(resultInContainer1.element!.bounds).toEqual({
+      left: 10,
+      top: 10,
+      right: 90,
+      bottom: 40,
+    });
+
+    const resultInContainer2 = selector.selectByResourceId(viewHierarchy, idInContainer2, {
+      container: { elementId: "com.app:id/container2" },
+    });
+    expect(resultInContainer2.element).not.toBeNull();
+    expect(resultInContainer2.totalMatches).toBe(1);
+    expect(resultInContainer2.element!.bounds).toEqual({
+      left: 10,
+      top: 210,
+      right: 90,
+      bottom: 240,
+    });
+
+    // The peer's id, scoped to the WRONG container, correctly finds nothing -
+    // not a misdirected match onto that container's own (different) node.
+    const wrongContainerResult = selector.selectByResourceId(viewHierarchy, idInContainer2, {
+      container: { elementId: "com.app:id/container1" },
+    });
+    expect(wrongContainerResult.element).toBeNull();
+  });
+
   test("recomputing the synthetic id over a fresh capture of the same hierarchy is deterministic", () => {
     const buildRoot = () => ({
       node: [


### PR DESCRIPTION
Closes #6218

## Investigation

The tapOn success-envelope half of #6218 is already fixed/merged (#6152/#6162, generalized in #6163/#6200). This PR is the remaining synthetic-id-resolution half.

- `SkeletonProjection.deriveId` (`src/features/observe/output/SkeletonProjection.ts`) emits `elementId = resource-id ?? view-id`. For a node with no `resource-id`, the `view-id` slot holds the content-derived stable id from `assignStableViewIds` (`src/features/observe/android/StableNodeIdentity.ts`, issue #3228) — an `s-<hash16>` (or `s-<hash16>-<k>` for content-identical duplicates), a SHA-256 Merkle hash over the node's own stable fields (`class`, `resource-id`, `content-desc`, `text`, `test-tag`) plus its children's hashes.
- That hash is computed **at hierarchy-ingest time** (`CtrlProxyHierarchy.ts` calls `assignStableViewIds` on every converted capture), purely from content — no bounds, no sibling position, no tree-path index. So it is deterministically reproducible: the same id-less node produces the same `s-<hash>` on a fresh `observe` and a later `tapOn`'s own hierarchy capture.
- `tapOn`/`inputText`'s `elementId` selector resolves through `DefaultElementSelector.selectByResourceId` → `DefaultElementFinder.findElementsByResourceId` → `collectResourceIdMatchesInRoots`, which only ever compared `nodeProperties["resource-id"]`. It never looked at `view-id`, so an `s-<hash>` id — which by construction only exists *because* `resource-id` is absent — could never match anything. Same gap in the container-lookup path (`findContainerNodeInRoots`) and the sibling-of-resource-id path (`findClickableSiblingsOfResourceIdInNode`).

## Fix (preferred approach — make the docs' promise true)

Made `DefaultElementFinder` resolve an `s-`-prefixed `elementId`/`resourceId`/container-`elementId` against the node's `view-id` field (exact match only — a content hash has no partial/bare-suffix semantics the way a `pkg:id/name` resource-id does), in all three resource-id-matching code paths:

- `findContainerNodeInRoots` (container selector)
- `collectResourceIdMatchesInRoots` (primary `elementId` selector — what `tapOn`/`inputText` use)
- `findClickableSiblingsOfResourceIdInNode` (the `sibling: true` variant)

`inputText` delegates its focus step to `TapOnElement` internally, so it shares this fix with no separate change needed.

I did not need the fallback approach (stop emitting a synthetic id / change the docs) — the synthetic id is already deterministically reproducible from a fresh view hierarchy, so making it resolvable is a small, contained fix that keeps `docs`/`toolSchemaHelpers.ts`'s existing "directly usable as a tapOn selector" claim true rather than walking it back.

## Test

`test/features/utility/skeletonElementIdRoundtrip.test.ts` (new, real `SkeletonProjection` + `DefaultElementFinder`/`DefaultElementSelector` + `assignStableViewIds`, no mocks, no DB):

- Three id-less/text-less elements (only `content-desc`) → skeleton emits three distinct `s-<hash>` ids → each fed back into `selector.selectByResourceId` against the *same* hierarchy resolves to exactly one match, the correct element (bounds + content-desc verified).
- Two content-identical duplicate nodes get `assignStableViewIds`'s ordinal-suffixed ids (`s-<hash>` / `s-<hash>-2`) — each resolves to its own node, never the other's (deterministic disambiguation, not silent wrong-element resolution).
- Cross-capture determinism: the id computed on one hierarchy object resolves correctly against an independently-built *second* capture of the same content — the actual `observe` → `tapOn` scenario.
- Regression check: a real `resource-id` `elementId` is unaffected by the stable-view-id fallback.

All 4 tests pass in ~1ms total (well under the 100ms budget); `bun test` shows 15725 pass / 1 pre-existing unrelated fail (`test/daemon/manager.test.ts` SIGKILL-cleanup test — reproduces identically with this diff removed, so not caused by this change).

## Validation

- `bun run lint` — oxlint ratchet gate: no new violations
- `bun run build` — clean
- `bun run format:check` — clean
- `bun run typecheck` — no new type errors (baseline unchanged)
- `bun test` — 15725 pass, 1 pre-existing unrelated fail (daemon SIGKILL test, confirmed pre-existing on this branch with the diff reverted)
- `scripts/update-tool-definitions.sh` ran via the commit hook — `schemas/tool-definitions.json` already up to date (no doc/schema text changed, since the existing "directly usable as a tapOn selector" claim is now true rather than needing revision)
