### PR TITLE
fix(daemon): restore readiness-probe test coverage broken by #6140's win32 always-observable path

### DIFF
--- a/test/daemon/daemonManagerReadiness.integration.test.ts
+++ b/test/daemon/daemonManagerReadiness.integration.test.ts
@@ -372,6 +372,14 @@ describe("DaemonManager readiness", () => {
     expect(existsSync(socketPath)).toBe(true);
   });
 
+  // Explicitly pinned off win32 (issue #6140): `socketPathObservable()` always
+  // reports observable on win32 (a named pipe has no filesystem entry to gate
+  // on), so this fs-gated "nothing to probe yet" scenario can only be exercised
+  // deterministically with a non-win32 platform override — mirroring the
+  // pattern already used by "waitForReady still gates on existsSync off win32"
+  // and "waitForReady probes the socket on win32" below. Without this override
+  // the test fails on the real Windows CI runner: the socket path is (falsely)
+  // observable, so a probe client is created before the abort ever lands.
   test("waitForReady cancels pending polling sleep when aborted", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
@@ -389,6 +397,14 @@ describe("DaemonManager readiness", () => {
       lockPath,
       pidPath,
       socketPath,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "linux",
     );
 
     const ready = manager.waitForReady(10_000, controller.signal);
@@ -698,6 +714,15 @@ describe("DaemonManager readiness", () => {
     expect(clients[0]?.connectionSignals[0]?.aborted).toBe(true);
   });
 
+  // Explicitly pinned off win32 (issue #6140): `socketPathObservable()` always
+  // reports observable on win32 (a named pipe has no filesystem entry to gate
+  // on), so the "socket not observed" diagnostic this test asserts can only be
+  // produced deterministically with a non-win32 platform override — mirroring
+  // "waitForReady still gates on existsSync off win32" below. Without this
+  // override the test fails on the real Windows CI runner: every poll reports
+  // "socket observed" and the whole 200ms budget is consumed by a single probe
+  // (retry/backoff against the nonexistent pipe), yielding "1 polls" instead
+  // of the two fs-gated polling iterations this test expects.
   test("reports elapsed readiness timing when no daemon socket appears", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
@@ -710,6 +735,14 @@ describe("DaemonManager readiness", () => {
       lockPath,
       pidPath,
       socketPath,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "linux",
     );
 
     try {


### PR DESCRIPTION
## Problem

Main's non-required "On Merge" host-integration lane (`node-host-integration-tests`) is red on Windows: two tests in `test/daemon/daemonManagerReadiness.integration.test.ts` fail deterministically on the `windows-latest` runner.

Confirmed against the actual failing CI job (run 34022942647, `Node Host Integration Tests (windows-latest)`):

```
- "Daemon readiness probe timed out after 200ms (2 polls; socket not observed)
+ "Daemon readiness probe timed out after 200ms (1 polls; socket observed)
```

and

```
Expected length: 0
Received length: 1
```

## Root cause

#6224 (issue #6140) reworked `DaemonManager`'s readiness path so `socketPathObservable()` always reports `true` on win32:

```ts
private socketPathObservable(): boolean {
  return this.platform === "win32" || existsSync(this.socketPath);
}
```

This is intentional and correct: a Windows named pipe has no filesystem entry, so gating on `existsSync()` before probing would mean a real Windows daemon (or a peer daemon we should rejoin) could never be observed. #6224 added dedicated coverage for this (`waitForReady probes the socket on win32 even though it has no filesystem entry (#6140)`), and correctly `test.skipIf(win32)`'d the companion fs-gate test (`waitForReady still gates on existsSync off win32`).

Two *other* tests added in the same PR were missed:

- `reports elapsed readiness timing when no daemon socket appears`
- `waitForReady cancels pending polling sleep when aborted`

Both construct `DaemonManager` with no platform override and assert the non-win32, fs-gated diagnostic path (`"socket not observed"`, 2 poll iterations; zero probe clients created before an abort lands). On a real Windows CI runner `process.platform` is genuinely `"win32"`, so `socketPathObservable()` short-circuits to `true` regardless of whether any socket file exists — the very first poll immediately creates a probe client and burns the whole timeout budget retrying a connect against a nonexistent pipe, producing `"1 polls; socket observed"` instead of the expected message, and populating `clients` before the abort can take effect.

**Verdict: test staleness, not a code regression.** The win32 always-probe behavior is deliberate, documented, and already exercised by a dedicated test in the same file — reverting it would reintroduce the exact "Windows daemon socket can never be observed" bug #6140 fixed. The fix is to pin these two tests to a non-win32 platform override, matching the pattern the same PR already used for the companion `existsSync` test.

The host-integration lane is non-required, so this slipped past #6224's own local `bun test test/daemon/` run (which only runs against the current host's real platform) and past CI gating.

Separately: an earlier ubuntu run of this lane (run 34020172307, commit 823945e91) also failed, but on an unrelated hang in `test/server/androidNavigationWorkflow.integration.test.ts` (exit 124, timeout) — not these two tests. The most recent ubuntu run (34022942647) is green; ubuntu is not part of this fix.

## Fix

Pin both tests' `DaemonManager` construction to an explicit non-win32 `platformOverride` (`"linux"`), the same trailing constructor argument already used by the neighboring win32-specific tests in this file.

## Validation

- `bun test test/daemon/daemonManagerReadiness.integration.test.ts` — 34/34 pass, run 15× locally with no flakes.
- `bun test test/daemon/` — full daemon suite green (1886 pass, 0 fail; the known pre-existing SIGKILL-cleanup flake did not surface).
- Reproduced the pre-fix Windows CI failure signature via code walkthrough of `socketPathObservable()` and cross-checked against the actual job log for run 34022942647.
- `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build` — all clean.

References #6140, #6224.