### PR TITLE
fix(setUIState): report per-field progress, avoid redundant post-verify observe

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -4,7 +4,13 @@ import { platform } from "node:os";
 import { logger } from "../utils/logger";
 import { encodeNonFinite } from "../utils/nonFiniteJson";
 import { ActionableError } from "../models";
-import { DaemonRequest, DaemonResponse, DaemonNotification, isDaemonNotification } from "./types";
+import {
+  DaemonRequest,
+  DaemonResponse,
+  DaemonNotification,
+  isDaemonNotification,
+  PROGRESS_NOTIFICATION_METHOD,
+} from "./types";
 import {
   SOCKET_PATH,
   PID_FILE_PATH,
@@ -14,7 +20,7 @@ import {
   DAEMON_NON_FINITE_ENCODED_PARAM,
 } from "./constants";
 import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
-import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
+import { resolveMcpRequestTimeoutMs, ProgressExtendableDeadline } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
 import { type IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
@@ -104,6 +110,21 @@ export class DaemonClient {
       resolve: (value: DaemonResponse) => void;
       reject: (error: Error) => void;
       timeout: NodeJS.Timeout;
+      toolName: string;
+      /**
+       * Present only for a `tools/call` that asked for progress relay
+       * (`progressToken !== undefined`). Lets a matching
+       * `notifications/progress` frame reset THIS pending request's own
+       * timer below, bounded by `deadline`'s ceiling -- without this, the
+       * daemon-side deadline can be correctly extended while this client's
+       * own independent timer still fires at the original fixed timeout
+       * (issue #6222 review, P1). A request with no progressToken never has
+       * these set and its timer is never touched, matching today's behavior
+       * exactly.
+       */
+      progressToken?: string | number;
+      deadline?: ProgressExtendableDeadline;
+      requestTimeoutMs?: number;
     }
   > = new Map();
   private buffer: string = "";
@@ -447,6 +468,19 @@ export class DaemonClient {
    * the socket or blocks sibling handlers.
    */
   private handleNotification(notification: DaemonNotification): void {
+    if (
+      notification.method === PROGRESS_NOTIFICATION_METHOD &&
+      notification.progressToken !== undefined
+    ) {
+      // Extend THIS client's own pending-request timer -- independent of,
+      // and in addition to, whatever the daemon does with its own internal
+      // deadline. Without this, the daemon can correctly keep working past
+      // the original timeout while this client's fixed local timer still
+      // fires and rejects the call out from under it (issue #6222 review,
+      // P1). Bounded by ProgressExtendableDeadline's own ceiling, so a
+      // request that stops progressing is still killed.
+      this.extendPendingRequestOnProgress(notification.progressToken);
+    }
     for (const handler of this.notificationHandlers) {
       try {
         handler(notification);
@@ -454,6 +488,69 @@ export class DaemonClient {
         logger.warn(`Daemon notification handler failed for ${notification.method}: ${error}`);
       }
     }
+  }
+
+  /**
+   * Reset the local timer for whichever pending request registered this
+   * `progressToken` (only requests sent with one carry `deadline`/
+   * `progressToken` at all -- see `sendRequest`). A token with no matching
+   * pending request (the call already settled, or a stray/unexpected frame)
+   * is silently ignored, matching how the daemon's own progress relay treats
+   * an unmatched token.
+   */
+  private extendPendingRequestOnProgress(progressToken: string | number): void {
+    for (const [requestId, pending] of this.pendingRequests) {
+      if (
+        pending.progressToken !== progressToken ||
+        !pending.deadline ||
+        pending.requestTimeoutMs === undefined
+      ) {
+        continue;
+      }
+      const nowMs = this.timer.now();
+      pending.deadline.extendOnProgress(nowMs, pending.requestTimeoutMs);
+      const remainingMs = pending.deadline.value - nowMs;
+      if (remainingMs <= 0) {
+        // Already at (or past) the hard ceiling -- let the existing timer
+        // fire on its own schedule rather than rescheduling to a
+        // non-positive delay, which would fire immediately anyway.
+        return;
+      }
+      this.timer.clearTimeout(pending.timeout);
+      pending.timeout = this.scheduleRequestTimeout(
+        requestId,
+        pending.toolName,
+        remainingMs,
+        pending.reject,
+      );
+      // A progressToken is caller-chosen per in-flight call; at most one
+      // pending request can match.
+      return;
+    }
+  }
+
+  /**
+   * (Re)arm the timer that rejects a pending request with `McpTimeoutError`
+   * after `delayMs`. Used both for the initial schedule in `sendRequest` and
+   * to reschedule after `extendPendingRequestOnProgress` pushes the deadline
+   * forward.
+   */
+  private scheduleRequestTimeout(
+    requestId: string,
+    toolName: string,
+    delayMs: number,
+    reject: (error: Error) => void,
+  ): NodeJS.Timeout {
+    return this.timer.setTimeout(() => {
+      this.pendingRequests.delete(requestId);
+      reject(
+        new McpTimeoutError({
+          toolName,
+          timeoutMs: delayMs,
+          origin: "DaemonClient.sendRequest",
+        }),
+      );
+    }, delayMs);
   }
 
   /**
@@ -569,18 +666,18 @@ export class DaemonClient {
 
     const requestTimeoutMs = Math.max(resolveMcpRequestTimeoutMs(request), this.connectionTimeout);
     const toolName = method === "tools/call" ? (params?.name ?? method) : method;
+    // Only a progress-emitting tools/call gets an extendable deadline -- a
+    // request with no progressToken (the vast majority: reads, non-progress
+    // tools, etc.) keeps its exact original fixed timer, untouched below
+    // (issue #6222 review, P1: this must not change behavior for tools that
+    // never emit progress).
+    const deadline =
+      progressToken !== undefined
+        ? new ProgressExtendableDeadline(this.timer.now(), requestTimeoutMs)
+        : undefined;
 
     return new Promise((resolve, reject) => {
-      const timeout = this.timer.setTimeout(() => {
-        this.pendingRequests.delete(requestId);
-        reject(
-          new McpTimeoutError({
-            toolName,
-            timeoutMs: requestTimeoutMs,
-            origin: "DaemonClient.sendRequest",
-          }),
-        );
-      }, requestTimeoutMs);
+      const timeout = this.scheduleRequestTimeout(requestId, toolName, requestTimeoutMs, reject);
 
       this.pendingRequests.set(requestId, {
         resolve: (response) => {
@@ -588,6 +685,10 @@ export class DaemonClient {
         },
         reject,
         timeout,
+        toolName,
+        progressToken,
+        deadline,
+        requestTimeoutMs,
       });
 
       if (!this.socket) {
@@ -637,6 +738,7 @@ export class DaemonClient {
         },
         reject,
         timeout,
+        toolName: method,
       });
 
       if (!this.socket) {

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -244,3 +244,68 @@ export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const devicePreparationBudget = resolveDevicePreparationToolBudgetMs(request);
   return Math.max(base, floor ?? 0, devicePreparationBudget ?? 0);
 }
+
+/**
+ * Hard ceiling on how far a progress-emitting request's deadline can be
+ * pushed out by its own progress notifications (issue #6222 review, P1). A
+ * multi-field `setUIState` (or any other progress-emitting tool) that applies
+ * work successfully but keeps progressing past the tool's normal deadline
+ * must not time out mid-flight and strand the client unable to tell success
+ * from failure -- but a genuinely hung tool that STOPS progressing must still
+ * be killed, not run forever. Chosen to comfortably cover a large multi-field
+ * form (each field costs at most a handful of seconds of real device work)
+ * while staying well short of "effectively unbounded".
+ */
+export const MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS = 300_000;
+
+/**
+ * A per-request deadline that a progress notification can push forward, up to
+ * a fixed ceiling measured from when the request was first received. Nothing
+ * in this class evaluates progress itself -- callers extend the deadline only
+ * when they actually observe a progress notification for this request, so a
+ * tool that emits none never has its deadline touched and keeps its exact
+ * original timeout (issue #6222 review, P1: `resetTimeoutOnProgress` for the
+ * daemon's own request-deadline bookkeeping, mirroring the MCP SDK option of
+ * the same name used for the inner MCP client call).
+ *
+ * Deliberately timer-agnostic: every method takes the caller's own `nowMs`
+ * (from whatever `Timer` it holds) rather than reading a clock itself, so
+ * this composes with the existing `FakeTimer` seams used throughout the
+ * daemon and its tests.
+ */
+export class ProgressExtendableDeadline {
+  private currentMs: number;
+  private readonly ceilingMs: number;
+
+  constructor(
+    receivedAtMs: number,
+    initialTimeoutMs: number,
+    maxTotalTimeoutMs: number = MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
+  ) {
+    this.currentMs = receivedAtMs + initialTimeoutMs;
+    // A tool floor already larger than the default progress ceiling (e.g.
+    // executePlan's 10-minute floor) keeps its own, larger ceiling -- the
+    // progress ceiling only ever extends a request, never shortens one.
+    this.ceilingMs = receivedAtMs + Math.max(initialTimeoutMs, maxTotalTimeoutMs);
+  }
+
+  /** Current absolute deadline, in the same clock the constructor's `receivedAtMs` came from. */
+  get value(): number {
+    return this.currentMs;
+  }
+
+  /** Absolute hard ceiling this deadline can never be pushed past. */
+  get ceiling(): number {
+    return this.ceilingMs;
+  }
+
+  /**
+   * Push the deadline forward to `nowMs + extensionMs`, capped at the hard
+   * ceiling. A proposal at or behind the current deadline is a no-op --
+   * progress only ever extends a deadline, never shortens it.
+   */
+  extendOnProgress(nowMs: number, extensionMs: number): void {
+    const proposed = Math.min(nowMs + extensionMs, this.ceilingMs);
+    this.currentMs = Math.max(this.currentMs, proposed);
+  }
+}

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -3996,70 +3996,94 @@ export class UnixSocketServer {
       }
       case "tools/call": {
         const progressToken = request.progressToken;
-        return await mcpClient.callTool(
-          {
-            name: request.params.name,
-            arguments: this.withSocketSessionAutolockKey(
-              request.params.arguments,
-              socketSessionId,
-              timeoutMs,
-            ),
-          },
-          undefined,
-          {
+        // Cleanup for the abort-timer path below; a no-op for the
+        // no-progress path (nothing was ever armed).
+        let cleanup: () => void = () => {};
+
+        let callOptions: Record<string, unknown> = requestOptions;
+        if (progressToken !== undefined) {
+          // A progress-emitting tool (e.g. a multi-field setUIState) needs
+          // an ASYMMETRIC deadline that the SDK's own `timeout`/
+          // `resetTimeoutOnProgress` cannot express: its `_resetTimeout`
+          // reuses the exact SAME `timeout` value passed at setup for every
+          // later reset, so there is no way through its public options to
+          // have "the remaining, queue-adjusted budget before the first
+          // tick, then the FULL original window after" -- setting `timeout`
+          // to the full window up front would hand a request that waited
+          // most of its budget in the per-session queue a fresh full window
+          // BEFORE any progress exists, while the outer DaemonClient still
+          // expires on its own (much smaller) remaining budget -- a
+          // split-brain where the caller can time out while the daemon has
+          // barely started (#6222 review, reconciliation). Conversely,
+          // keeping `timeout` at the queue-adjusted remainder and relying
+          // on `resetTimeoutOnProgress` would reset EVERY tick to that same
+          // tiny remainder instead of the full window (#6222 review, P1).
+          //
+          // So this drives its own abort-based deadline instead, sharing
+          // the SAME `deadline` object `requireRemainingMcpForwardBudget`
+          // reads:
+          //   - before any progress: aborts at `timeoutMs` (remaining
+          //     budget), matching the outer client's own remaining budget.
+          //   - on each REAL progress tick: `deadline.extendOnProgress`
+          //     pushes the shared deadline forward by the FULL original
+          //     window (`originalTimeoutMs`), bounded by its ceiling, and
+          //     the abort is rearmed against the new remaining time.
+          // The SDK's own `timeout`/`maxTotalTimeout` are set generously
+          // (to the ceiling) purely as a backstop that should never fire
+          // first in practice -- this controller is the actual authority.
+          const controller = new AbortController();
+          const armAbort = (delayMs: number): NodeJS.Timeout =>
+            this.timer.setTimeout(
+              () => controller.abort(`Request timed out after ${Math.max(delayMs, 0)}ms`),
+              Math.max(delayMs, 0),
+            );
+          let abortTimer = armAbort(timeoutMs);
+          const backstopMs = Math.max(deadline.ceiling - this.timer.now(), timeoutMs);
+          cleanup = () => this.timer.clearTimeout(abortTimer);
+
+          callOptions = {
             ...requestOptions,
-            // A progress-emitting tool (e.g. a multi-field setUIState) can
-            // legitimately take longer than its normal deadline once it has
-            // already started applying work; leaving that work stranded by a
-            // fixed timeout is exactly the unsafe-to-retry shape issue #6222
-            // exists to close. `resetTimeoutOnProgress` makes the SDK's OWN
-            // internal timeout for this call reset on each progress tick
-            // instead of firing once at `timeout` -- but the SDK reuses the
-            // SAME `timeout` value on every reset (see its `_resetTimeout`),
-            // so this overrides `timeout` itself to the FULL original
-            // window (`originalTimeoutMs`), not the queue-depleted
-            // `timeoutMs` above (#6222 review, P1). `maxTotalTimeout` still
-            // caps the whole thing at this request's own bounded ceiling --
-            // a tool that stops progressing is still killed there. Only set
-            // for a request that actually asked for progress
-            // (`progressToken !== undefined`, same gate as `onprogress`
-            // below): a tool with no progress relay keeps its exact
-            // original, non-extendable, queue-adjusted `timeout` untouched.
-            ...(progressToken !== undefined
-              ? {
-                  timeout: originalTimeoutMs,
-                  resetTimeoutOnProgress: true,
-                  maxTotalTimeout: Math.max(deadline.ceiling - this.timer.now(), originalTimeoutMs),
-                }
-              : {}),
+            signal: controller.signal,
+            timeout: backstopMs,
+            maxTotalTimeout: backstopMs,
             // Relay progress ticks back to the ORIGINATING socket session,
-            // tagged with the client's own token — never a daemon-fabricated
-            // one, and never sent when the client asked for none (#6205).
-            // Also extends the DAEMON's OWN request deadline (the one
-            // `requireRemainingMcpForwardBudget` checks before a retry) by
-            // the FULL original window, same reasoning as `timeout` above
-            // (#6222 review, P1) -- bounded by the same ceiling as the
-            // SDK-side `maxTotalTimeout`.
-            ...(progressToken !== undefined
-              ? {
-                  onprogress: (notification: {
-                    progress: number;
-                    total?: number;
-                    message?: string;
-                  }) => {
-                    deadline.extendOnProgress(this.timer.now(), originalTimeoutMs);
-                    this.pushProgressNotification(
-                      socketSessionId,
-                      progressToken,
-                      notification.progress,
-                      notification.total,
-                      notification.message,
-                    );
-                  },
-                }
-              : {}),
-          },
-        );
+            // tagged with the client's own token — never a
+            // daemon-fabricated one (#6205). Also extends the DAEMON's OWN
+            // request deadline (the one `requireRemainingMcpForwardBudget`
+            // checks before a retry) and this call's own abort timer, both
+            // by the FULL original window, bounded by `deadline`'s ceiling
+            // (#6222 review, reconciliation).
+            onprogress: (notification: { progress: number; total?: number; message?: string }) => {
+              this.timer.clearTimeout(abortTimer);
+              deadline.extendOnProgress(this.timer.now(), originalTimeoutMs);
+              abortTimer = armAbort(deadline.value - this.timer.now());
+              this.pushProgressNotification(
+                socketSessionId,
+                progressToken,
+                notification.progress,
+                notification.total,
+                notification.message,
+              );
+            },
+          };
+        }
+
+        try {
+          return await mcpClient.callTool(
+            {
+              name: request.params.name,
+              arguments: this.withSocketSessionAutolockKey(
+                request.params.arguments,
+                socketSessionId,
+                timeoutMs,
+              ),
+            },
+            undefined,
+            callOptions,
+          );
+        } finally {
+          cleanup();
+        }
       }
       case "resources/list": {
         return await mcpClient.listResources();

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -9,7 +9,7 @@ import {
   type StreamableHTTPReconnectionOptions,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { logger } from "../utils/logger";
-import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
+import { resolveMcpRequestTimeoutMs, ProgressExtendableDeadline } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS } from "../utils/deviceTimeouts";
 import { errorMessage } from "../utils/describeUnknownError";
@@ -213,7 +213,14 @@ interface McpForwardRecoveryContext {
   route: McpForwardRoute;
   socketSessionId: string;
   totalTimeoutMs: number;
-  requestDeadlineMs: number;
+  /**
+   * Mutable: a progress notification for THIS request extends `.value`, up to
+   * its own bounded ceiling (issue #6222 review, P1). Every consumer must
+   * read `.value` live rather than caching it, so a pre-flight budget check
+   * made after progress has already extended the deadline sees the extended
+   * value, not the original one.
+   */
+  deadline: ProgressExtendableDeadline;
   remainingTimeoutMs: number;
   forwardStartMs: number;
 }
@@ -720,7 +727,10 @@ export class UnixSocketServer {
     }
 
     const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
-    const requestDeadlineMs = receivedAtMs + totalTimeoutMs;
+    // Mutable: extended by progress notifications for this specific request
+    // (see ProgressExtendableDeadline) -- untouched for a request that never
+    // emits progress, which keeps its exact original deadline.
+    const deadline = new ProgressExtendableDeadline(receivedAtMs, totalTimeoutMs);
 
     // Enqueue request to maintain order
     return this.enqueueRequest(session, async () => {
@@ -752,7 +762,7 @@ export class UnixSocketServer {
           request,
           sessionId,
           async (route) => {
-            const remainingTimeoutMs = requestDeadlineMs - this.timer.now();
+            const remainingTimeoutMs = deadline.value - this.timer.now();
             const queueWaitMs = totalTimeoutMs - remainingTimeoutMs;
             const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
             logger.debug(
@@ -780,7 +790,7 @@ export class UnixSocketServer {
                 route,
                 socketSessionId: sessionId,
                 totalTimeoutMs,
-                requestDeadlineMs,
+                deadline,
                 remainingTimeoutMs,
                 forwardStartMs,
               });
@@ -832,10 +842,13 @@ export class UnixSocketServer {
   private requireRemainingMcpForwardBudget(
     request: DaemonRequest,
     totalTimeoutMs: number,
-    requestDeadlineMs: number,
+    deadline: ProgressExtendableDeadline,
     phase: string,
   ): number {
-    const remainingTimeoutMs = requestDeadlineMs - this.timer.now();
+    // Read live: a progress notification received since this request first
+    // started may already have pushed `deadline.value` out (issue #6222
+    // review, P1) -- caching it earlier would silently ignore that extension.
+    const remainingTimeoutMs = deadline.value - this.timer.now();
     if (remainingTimeoutMs > 0) {
       return remainingTimeoutMs;
     }
@@ -1402,7 +1415,7 @@ export class UnixSocketServer {
     const forwardRemainingMs = this.requireRemainingMcpForwardBudget(
       context.request,
       context.totalTimeoutMs,
-      context.requestDeadlineMs,
+      context.deadline,
       "waiting in queues and preparing the MCP client",
     );
     return this.forwardConnectedMcpRequest(context, identity, mcpClient, forwardRemainingMs);
@@ -1420,6 +1433,7 @@ export class UnixSocketServer {
         context.request,
         remainingTimeoutMs,
         context.socketSessionId,
+        context.deadline,
       );
     } catch (error) {
       const message = errorMessage(error);
@@ -1470,7 +1484,7 @@ export class UnixSocketServer {
     const retryRemainingMs = this.requireRemainingMcpForwardBudget(
       context.request,
       context.totalTimeoutMs,
-      context.requestDeadlineMs,
+      context.deadline,
       "waiting in queues and reconnecting the MCP client",
     );
     try {
@@ -1479,6 +1493,7 @@ export class UnixSocketServer {
         context.request,
         retryRemainingMs,
         context.socketSessionId,
+        context.deadline,
       );
     } catch (error) {
       if (!this.isDeviceControlSocketClosure(context.request, error)) {
@@ -2120,6 +2135,7 @@ export class UnixSocketServer {
         recoveryRequest,
         retryRemainingMs,
         input.socketSessionId,
+        input.deadline,
       );
       if (!this.isDeviceControlReplayResultIdentityValid(input.identity)) {
         await this.resetMcpClientIfCurrent(recoveryRoute.clientKey, freshClient, "detach");
@@ -3943,6 +3959,7 @@ export class UnixSocketServer {
     request: DaemonRequest,
     timeoutMs: number,
     socketSessionId: string,
+    deadline: ProgressExtendableDeadline,
   ): Promise<any> {
     const requestOptions = { timeout: timeoutMs };
 
@@ -3964,23 +3981,49 @@ export class UnixSocketServer {
           undefined,
           {
             ...requestOptions,
+            // A progress-emitting tool (e.g. a multi-field setUIState) can
+            // legitimately take longer than its normal deadline once it has
+            // already started applying work; leaving that work stranded by a
+            // fixed timeout is exactly the unsafe-to-retry shape issue #6222
+            // exists to close. `resetTimeoutOnProgress` makes the SDK's OWN
+            // internal timeout for this call reset on each progress tick
+            // instead of firing at the original `timeout`, and
+            // `maxTotalTimeout` still caps it at this request's own bounded
+            // ceiling -- a tool that stops progressing is still killed there.
+            // Only set for a request that actually asked for progress
+            // (`progressToken !== undefined`, same gate as `onprogress`
+            // below): a tool with no progress relay keeps its exact original,
+            // non-extendable `timeout` (#6222 review, P1).
+            ...(progressToken !== undefined
+              ? {
+                  resetTimeoutOnProgress: true,
+                  maxTotalTimeout: Math.max(deadline.ceiling - this.timer.now(), timeoutMs),
+                }
+              : {}),
             // Relay progress ticks back to the ORIGINATING socket session,
             // tagged with the client's own token — never a daemon-fabricated
             // one, and never sent when the client asked for none (#6205).
+            // Also extends the DAEMON's OWN request deadline (the one
+            // `requireRemainingMcpForwardBudget` checks before a retry), so a
+            // budget check made after this tick sees the extended value
+            // rather than the original one (#6222 review, P1) -- bounded by
+            // the same ceiling as the SDK-side `maxTotalTimeout` above.
             ...(progressToken !== undefined
               ? {
                   onprogress: (notification: {
                     progress: number;
                     total?: number;
                     message?: string;
-                  }) =>
+                  }) => {
+                    deadline.extendOnProgress(this.timer.now(), timeoutMs);
                     this.pushProgressNotification(
                       socketSessionId,
                       progressToken,
                       notification.progress,
                       notification.total,
                       notification.message,
-                    ),
+                    );
+                  },
                 }
               : {}),
           },

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -625,8 +625,20 @@ export class UnixSocketServer {
    * above, this targets exactly one socket rather than every subscriber — the
    * per-session request queue serializes `tools/call`s, so at most one call is
    * ever in flight per session and no correlation beyond the token is needed.
-   * Best-effort and gated on the opt-in subscription, matching the broadcast
-   * helpers: an unsubscribed or already-torn-down socket is silently skipped.
+   *
+   * Deliberately NOT gated on the opt-in general-notification subscription
+   * (unlike the broadcast helpers above). A progress tick is a directed reply
+   * to something THIS session explicitly asked for by putting a
+   * `progressToken` on its OWN in-flight request -- that is itself the
+   * opt-in, independent of whether `daemon/subscribe-notifications` was ever
+   * sent or whether it succeeded. `DaemonMcpProxy.doConnect` deliberately
+   * continues without a subscription when it fails (best-effort degradation),
+   * and gating progress on it too would silently strand a long-running
+   * progress-emitting call: the daemon keeps applying work under its own
+   * extended deadline while the client's independent local timer -- which
+   * only extends on a progress tick it actually receives -- times out
+   * underneath it, a split-brain where the daemon succeeds but the client
+   * reports failure (#6222 review, P2). Only a torn-down socket is skipped.
    */
   private pushProgressNotification(
     sessionId: string,
@@ -635,9 +647,6 @@ export class UnixSocketServer {
     total?: number,
     message?: string,
   ): void {
-    if (!this.notificationSubscribers.has(sessionId)) {
-      return;
-    }
     const socket = this.clientSockets.get(sessionId);
     if (!socket) {
       return;
@@ -1434,6 +1443,7 @@ export class UnixSocketServer {
         remainingTimeoutMs,
         context.socketSessionId,
         context.deadline,
+        context.totalTimeoutMs,
       );
     } catch (error) {
       const message = errorMessage(error);
@@ -1494,6 +1504,7 @@ export class UnixSocketServer {
         retryRemainingMs,
         context.socketSessionId,
         context.deadline,
+        context.totalTimeoutMs,
       );
     } catch (error) {
       if (!this.isDeviceControlSocketClosure(context.request, error)) {
@@ -2136,6 +2147,7 @@ export class UnixSocketServer {
         retryRemainingMs,
         input.socketSessionId,
         input.deadline,
+        input.totalTimeoutMs,
       );
       if (!this.isDeviceControlReplayResultIdentityValid(input.identity)) {
         await this.resetMcpClientIfCurrent(recoveryRoute.clientKey, freshClient, "detach");
@@ -3960,6 +3972,21 @@ export class UnixSocketServer {
     timeoutMs: number,
     socketSessionId: string,
     deadline: ProgressExtendableDeadline,
+    /**
+     * The FULL per-request timeout window this request was granted at
+     * receipt (`totalTimeoutMs` from `handleRequest`) -- UNLIKE `timeoutMs`
+     * above, which is the budget remaining for THIS specific forward
+     * attempt after time already spent waiting in the per-session queue
+     * (or reconnecting). A request that waited most of its budget in queue
+     * would otherwise have every progress-driven reset use that tiny
+     * queue-depleted remnant as its "how long is ordinary device work
+     * between ticks allowed to take" window -- collapsing a 30s tool to a
+     * ~1s one. Every progress-driven extension (the SDK's own
+     * `resetTimeoutOnProgress`, which reuses this SAME `timeout` value on
+     * every reset, and this daemon's own `deadline`) uses THIS value
+     * instead, independent of queue wait (#6222 review, P1).
+     */
+    originalTimeoutMs: number,
   ): Promise<any> {
     const requestOptions = { timeout: timeoutMs };
 
@@ -3987,27 +4014,32 @@ export class UnixSocketServer {
             // fixed timeout is exactly the unsafe-to-retry shape issue #6222
             // exists to close. `resetTimeoutOnProgress` makes the SDK's OWN
             // internal timeout for this call reset on each progress tick
-            // instead of firing at the original `timeout`, and
-            // `maxTotalTimeout` still caps it at this request's own bounded
-            // ceiling -- a tool that stops progressing is still killed there.
-            // Only set for a request that actually asked for progress
+            // instead of firing once at `timeout` -- but the SDK reuses the
+            // SAME `timeout` value on every reset (see its `_resetTimeout`),
+            // so this overrides `timeout` itself to the FULL original
+            // window (`originalTimeoutMs`), not the queue-depleted
+            // `timeoutMs` above (#6222 review, P1). `maxTotalTimeout` still
+            // caps the whole thing at this request's own bounded ceiling --
+            // a tool that stops progressing is still killed there. Only set
+            // for a request that actually asked for progress
             // (`progressToken !== undefined`, same gate as `onprogress`
-            // below): a tool with no progress relay keeps its exact original,
-            // non-extendable `timeout` (#6222 review, P1).
+            // below): a tool with no progress relay keeps its exact
+            // original, non-extendable, queue-adjusted `timeout` untouched.
             ...(progressToken !== undefined
               ? {
+                  timeout: originalTimeoutMs,
                   resetTimeoutOnProgress: true,
-                  maxTotalTimeout: Math.max(deadline.ceiling - this.timer.now(), timeoutMs),
+                  maxTotalTimeout: Math.max(deadline.ceiling - this.timer.now(), originalTimeoutMs),
                 }
               : {}),
             // Relay progress ticks back to the ORIGINATING socket session,
             // tagged with the client's own token — never a daemon-fabricated
             // one, and never sent when the client asked for none (#6205).
             // Also extends the DAEMON's OWN request deadline (the one
-            // `requireRemainingMcpForwardBudget` checks before a retry), so a
-            // budget check made after this tick sees the extended value
-            // rather than the original one (#6222 review, P1) -- bounded by
-            // the same ceiling as the SDK-side `maxTotalTimeout` above.
+            // `requireRemainingMcpForwardBudget` checks before a retry) by
+            // the FULL original window, same reasoning as `timeout` above
+            // (#6222 review, P1) -- bounded by the same ceiling as the
+            // SDK-side `maxTotalTimeout`.
             ...(progressToken !== undefined
               ? {
                   onprogress: (notification: {
@@ -4015,7 +4047,7 @@ export class UnixSocketServer {
                     total?: number;
                     message?: string;
                   }) => {
-                    deadline.extendOnProgress(this.timer.now(), timeoutMs);
+                    deadline.extendOnProgress(this.timer.now(), originalTimeoutMs);
                     this.pushProgressNotification(
                       socketSessionId,
                       progressToken,

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -156,16 +156,15 @@ export class SetUIState extends BaseVisualChange {
     // their own local 0..100 range via the SAME callback (e.g. tap emits
     // 0,10 and then clear ALSO emits 0,10), which would otherwise collide or
     // reset mid-field or between fields. Give every field a fixed 100-wide
-    // slice of one overall range, and force every emission strictly above the
-    // last one actually sent (bumping by 1 when the mapped value would tie or
-    // fall behind) so nested resets can never read as a non-increase (#6222
-    // review). A field's slice has ample headroom for these +1 bumps -- a
-    // field's own child steps and retries emit only a handful of ticks well
-    // under 100 -- and the per-field boundary tick (top of the slice) is
-    // always emitted last for that field, so it remains the largest value in
-    // the slice regardless of how many bumps preceded it.
-    const overallProgressTotal = options.fields.length * 100;
+    // slice of one overall range (#6222 review).
+    const FIELD_SLICE_WIDTH = 100;
+    const overallProgressTotal = options.fields.length * FIELD_SLICE_WIDTH;
     let maxProgressReported = 0;
+    // Emits the per-field boundary tick -- always the top of that field's
+    // slice. This is always reachable: child-forwarded progress is capped
+    // strictly below the slice endpoint (see fieldProgress below), so the
+    // boundary value is guaranteed to exceed anything already emitted for
+    // this field. The bump is a defensive floor, not the normal path.
     const emitProgress = async (raw: number, message?: string): Promise<void> => {
       if (!progress) {
         return;
@@ -176,15 +175,32 @@ export class SetUIState extends BaseVisualChange {
     };
     // Projects a child step's own 0..N progress into the 100-wide slice for
     // the field currently being worked on (identified by how many fields are
-    // already fully processed, i.e. its position in processing order).
+    // already fully processed, i.e. its position in processing order). The
+    // slice's own top value (fieldStart + 100) is RESERVED for the
+    // field-boundary tick that follows -- a child reporting its own 100%
+    // (e.g. childProgress===childTotal) is capped one below that endpoint, so
+    // it can never tie or collide with the boundary tick. A child tick that
+    // cannot land strictly above what has already been emitted is suppressed
+    // outright rather than bumped: bumping here could push the value up to,
+    // or past, the reserved endpoint -- or even into the next field's slice.
     const fieldProgress = (fieldSequence: number): ProgressCallback | undefined => {
       if (!progress) {
         return undefined;
       }
+      const fieldStart = fieldSequence * FIELD_SLICE_WIDTH;
+      const fieldSliceMax = fieldStart + FIELD_SLICE_WIDTH - 1;
       return async (childProgress, childTotal, message) => {
         const pct =
           childTotal && childTotal > 0 ? (childProgress / childTotal) * 100 : childProgress;
-        await emitProgress(fieldSequence * 100 + pct, message);
+        const candidate = Math.min(fieldStart + pct, fieldSliceMax);
+        if (candidate <= maxProgressReported) {
+          // Cannot strictly increase without crossing into the boundary
+          // tick's reserved endpoint or the next field's slice -- drop this
+          // tick rather than violate either bound.
+          return;
+        }
+        maxProgressReported = candidate;
+        await progress(candidate, overallProgressTotal, message);
       };
     };
 

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -149,6 +149,36 @@ export class SetUIState extends BaseVisualChange {
     const processed = new Set<number>();
     let totalAttempts = 0;
 
+    // Progress reported to the client MUST stay on one consistent scale and
+    // never regress. Sub-steps a field's work delegates to (TapOnElement,
+    // ClearText, ...) each independently report their own local 0..100
+    // range via the SAME callback, and would otherwise reset to 0 mid-field
+    // or between fields. Give every field a fixed 100-wide slice of one
+    // overall range and clamp every emission to the high-water mark so nested
+    // resets can never read as a regression (#6222 review).
+    const overallProgressTotal = options.fields.length * 100;
+    let maxProgressReported = 0;
+    const emitProgress = async (raw: number, message?: string): Promise<void> => {
+      if (!progress) {
+        return;
+      }
+      maxProgressReported = Math.max(raw, maxProgressReported);
+      await progress(maxProgressReported, overallProgressTotal, message);
+    };
+    // Projects a child step's own 0..N progress into the 100-wide slice for
+    // the field currently being worked on (identified by how many fields are
+    // already fully processed, i.e. its position in processing order).
+    const fieldProgress = (fieldSequence: number): ProgressCallback | undefined => {
+      if (!progress) {
+        return undefined;
+      }
+      return async (childProgress, childTotal, message) => {
+        const pct =
+          childTotal && childTotal > 0 ? (childProgress / childTotal) * 100 : childProgress;
+        await emitProgress(fieldSequence * 100 + pct, message);
+      };
+    };
+
     // Get initial observation
     let lastObservation = await this.getObserveScreen().execute(
       undefined,
@@ -182,23 +212,35 @@ export class SetUIState extends BaseVisualChange {
         // Each edit may change layout (keyboard, reflow, dynamic fields),
         // so we re-find visible fields from a fresh observation each iteration.
         const { fieldSpec, fieldIndex, element } = visibleFields[0];
-        const result = await this.processField(fieldSpec, element, progress, signal);
+        // This field's slice starts at processed.size * 100, before it is
+        // added to `processed` below.
+        const result = await this.processField(
+          fieldSpec,
+          element,
+          fieldProgress(processed.size),
+          signal,
+        );
 
-        fieldResults[fieldIndex] = result;
         processed.add(fieldIndex);
+        // Retain only the small, public FieldResult fields across the loop --
+        // `freshObservation` (a full view hierarchy) is used immediately below
+        // for reuse and then must NOT be kept alive in `fieldResults` for the
+        // rest of the call, or peak memory grows to fieldCount x one full
+        // hierarchy instead of staying ~one hierarchy (#6222 review).
+        fieldResults[fieldIndex] = this.toPublicFieldResult(result);
         totalAttempts += result.attempts;
         // Progress clears the budget: it bounds futile searching, not successful
         // work. The next search re-arms it from scratch (#4252 review).
         searchDeadline = null;
 
-        // Report per-field advancement. This keeps the request alive on
-        // progress-aware clients (a live request timeout is commonly reset by
-        // progress notifications) and, independent of transport behavior,
-        // gives the client a durable trace of what has already been applied
-        // before a bare timeout could otherwise leave it blind (#6222).
-        await progress?.(
-          processed.size,
-          options.fields.length,
+        // Report per-field advancement at the top of the field's own slice.
+        // This keeps the request alive on progress-aware clients (a live
+        // request timeout is commonly reset by progress notifications) and,
+        // independent of transport behavior, gives the client a durable
+        // trace of what has already been applied before a bare timeout could
+        // otherwise leave it blind (#6222).
+        await emitProgress(
+          processed.size * 100,
           result.success
             ? `Set field ${this.describeSelector(fieldSpec.selector)} (${processed.size}/${options.fields.length})`
             : `Failed field ${this.describeSelector(fieldSpec.selector)} (${processed.size}/${options.fields.length})`,
@@ -253,8 +295,13 @@ export class SetUIState extends BaseVisualChange {
 
         // Scroll one step without lookFor to avoid jumping past intermediate fields.
         // Using lookFor would enable scroll-until-visible mode which can skip over
-        // fields that need to be processed first in screen order.
-        await this.getSwipeOn().execute({ direction: currentDirection }, progress);
+        // fields that need to be processed first in screen order. The scroll is in
+        // service of the next not-yet-processed field, so it reports into that
+        // field's own progress slice (#6222 review).
+        await this.getSwipeOn().execute(
+          { direction: currentDirection },
+          fieldProgress(processed.size),
+        );
 
         // Re-observe after scroll
         const freshObs = await this.getObserveScreen().execute(
@@ -292,6 +339,26 @@ export class SetUIState extends BaseVisualChange {
       fields: fieldResults,
       totalAttempts,
       observation: lastObservation,
+    };
+  }
+
+  /**
+   * Strip the internal `freshObservation` (a full view hierarchy) from a
+   * field outcome before it is retained in `fieldResults` for the rest of the
+   * call. The observation is only needed transiently, to let the caller reuse
+   * it in place of an extra observe -- keeping it in the retained array would
+   * hold one full hierarchy per verified field alive for the whole call
+   * instead of ~one at a time (#6222 review).
+   */
+  private toPublicFieldResult(result: InternalFieldResult): FieldResult {
+    return {
+      selector: result.selector,
+      success: result.success,
+      attempts: result.attempts,
+      verified: result.verified,
+      error: result.error,
+      fieldType: result.fieldType,
+      skipped: result.skipped,
     };
   }
 

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -150,20 +150,29 @@ export class SetUIState extends BaseVisualChange {
     let totalAttempts = 0;
 
     // Progress reported to the client MUST stay on one consistent scale and
-    // never regress. Sub-steps a field's work delegates to (TapOnElement,
-    // ClearText, ...) each independently report their own local 0..100
-    // range via the SAME callback, and would otherwise reset to 0 mid-field
-    // or between fields. Give every field a fixed 100-wide slice of one
-    // overall range and clamp every emission to the high-water mark so nested
-    // resets can never read as a regression (#6222 review).
+    // strictly increase -- MCP clients that enforce monotonicity reject or
+    // ignore a repeated value, not just a decrease. Sub-steps a field's work
+    // delegates to (TapOnElement, ClearText, ...) each independently report
+    // their own local 0..100 range via the SAME callback (e.g. tap emits
+    // 0,10 and then clear ALSO emits 0,10), which would otherwise collide or
+    // reset mid-field or between fields. Give every field a fixed 100-wide
+    // slice of one overall range, and force every emission strictly above the
+    // last one actually sent (bumping by 1 when the mapped value would tie or
+    // fall behind) so nested resets can never read as a non-increase (#6222
+    // review). A field's slice has ample headroom for these +1 bumps -- a
+    // field's own child steps and retries emit only a handful of ticks well
+    // under 100 -- and the per-field boundary tick (top of the slice) is
+    // always emitted last for that field, so it remains the largest value in
+    // the slice regardless of how many bumps preceded it.
     const overallProgressTotal = options.fields.length * 100;
     let maxProgressReported = 0;
     const emitProgress = async (raw: number, message?: string): Promise<void> => {
       if (!progress) {
         return;
       }
-      maxProgressReported = Math.max(raw, maxProgressReported);
-      await progress(maxProgressReported, overallProgressTotal, message);
+      const next = Math.min(Math.max(raw, maxProgressReported + 1), overallProgressTotal);
+      maxProgressReported = next;
+      await progress(next, overallProgressTotal, message);
     };
     // Projects a child step's own 0..N progress into the 100-wide slice for
     // the field currently being worked on (identified by how many fields are

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -79,6 +79,16 @@ interface SetUIStateDependencies {
   timer?: Timer;
 }
 
+/**
+ * Internal per-field outcome. Carries the fresh observation (if
+ * verifyFieldValue already fetched one) alongside the public FieldResult so
+ * execute() can reuse it instead of paying for a second, effectively
+ * redundant observe against the device (#6222).
+ */
+interface InternalFieldResult extends FieldResult {
+  freshObservation?: ObserveResult;
+}
+
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_SCROLL_DIRECTION = "down";
 const MAX_FUTILE_SCROLLS = 3;
@@ -181,18 +191,26 @@ export class SetUIState extends BaseVisualChange {
         // work. The next search re-arms it from scratch (#4252 review).
         searchDeadline = null;
 
-        // Refresh observation after each success
+        // Report per-field advancement. This keeps the request alive on
+        // progress-aware clients (a live request timeout is commonly reset by
+        // progress notifications) and, independent of transport behavior,
+        // gives the client a durable trace of what has already been applied
+        // before a bare timeout could otherwise leave it blind (#6222).
+        await progress?.(
+          processed.size,
+          options.fields.length,
+          result.success
+            ? `Set field ${this.describeSelector(fieldSpec.selector)} (${processed.size}/${options.fields.length})`
+            : `Failed field ${this.describeSelector(fieldSpec.selector)} (${processed.size}/${options.fields.length})`,
+        );
+
+        // Refresh observation after each success. processField already fetched
+        // a fresh observation as part of verification for most field types —
+        // reuse it instead of paying for a second, effectively redundant
+        // observe against the device, which is exactly the per-field cost that
+        // was pushing multi-field calls past the request timeout (#6222).
         if (result.success) {
-          const freshObs = await this.getObserveScreen().execute(
-            undefined,
-            undefined,
-            false,
-            0,
-            signal,
-          );
-          if (freshObs) {
-            lastObservation = freshObs;
-          }
+          lastObservation = await this.observationAfterSuccess(result, signal);
         }
 
         // Fail fast on failure
@@ -278,6 +296,22 @@ export class SetUIState extends BaseVisualChange {
   }
 
   /**
+   * Observation to use as the "current state" after a field succeeded. Reuses
+   * the fresh observation processField already fetched during verification
+   * when one is available, avoiding a second observe against the device for
+   * the same state (#6222).
+   */
+  private async observationAfterSuccess(
+    result: InternalFieldResult,
+    signal?: AbortSignal,
+  ): Promise<ObserveResult> {
+    if (result.freshObservation) {
+      return result.freshObservation;
+    }
+    return this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+  }
+
+  /**
    * Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top ascending
    */
   private findVisibleFieldsInScreenOrder(
@@ -336,7 +370,7 @@ export class SetUIState extends BaseVisualChange {
     initialElement: Element,
     progress?: ProgressCallback,
     signal?: AbortSignal,
-  ): Promise<FieldResult> {
+  ): Promise<InternalFieldResult> {
     let attempts = 0;
     let lastError: string | undefined;
     let fieldType: FieldType | undefined;
@@ -411,6 +445,7 @@ export class SetUIState extends BaseVisualChange {
         // - Text-only selector on a mutable field type (typing replaces the label text
         //   used as the selector, so re-lookup by original text fails)
         let verified: boolean | undefined;
+        let freshObservation: ObserveResult | undefined;
         const hasTextOnlySelector =
           fieldSpec.selector.text !== undefined && fieldSpec.selector.elementId === undefined;
         const isMutableTextField = fieldType === "text" || fieldType === "dropdown";
@@ -419,7 +454,9 @@ export class SetUIState extends BaseVisualChange {
           this.fieldTypeDetector.shouldSkipVerification(element, fieldType) ||
           (hasTextOnlySelector && isMutableTextField);
         if (!shouldSkipVerify) {
-          verified = await this.verifyFieldValue(fieldSpec, fieldType, signal);
+          const verifyResult = await this.verifyFieldValue(fieldSpec, fieldType, signal);
+          verified = verifyResult.verified;
+          freshObservation = verifyResult.observation;
           if (!verified) {
             lastError = `Verification failed for ${this.describeSelector(fieldSpec.selector)}`;
             continue;
@@ -432,6 +469,7 @@ export class SetUIState extends BaseVisualChange {
           attempts,
           verified,
           fieldType,
+          freshObservation,
         };
       } catch (error) {
         lastError = errorMessage(error);
@@ -660,8 +698,10 @@ export class SetUIState extends BaseVisualChange {
     fieldSpec: FieldSpec,
     fieldType: FieldType,
     signal?: AbortSignal,
-  ): Promise<boolean> {
-    // Get fresh observation
+  ): Promise<{ verified: boolean; observation?: ObserveResult }> {
+    // Get fresh observation. The caller (processField -> execute) reuses this
+    // as its own post-success refresh instead of issuing a second, effectively
+    // redundant observe against the device (#6222).
     const observation = await this.getObserveScreen().execute(
       undefined,
       undefined,
@@ -670,13 +710,13 @@ export class SetUIState extends BaseVisualChange {
       signal,
     );
     if (!observation?.viewHierarchy) {
-      return false;
+      return { verified: false, observation };
     }
 
     // Find the element again
     const element = this.findElement(fieldSpec.selector, observation.viewHierarchy);
     if (!element) {
-      return false;
+      return { verified: false, observation };
     }
 
     // Verify based on field type
@@ -684,27 +724,27 @@ export class SetUIState extends BaseVisualChange {
       case "text":
         if (fieldSpec.value !== undefined) {
           const currentValue = this.fieldTypeDetector.getTextValue(element);
-          return currentValue === fieldSpec.value;
+          return { verified: currentValue === fieldSpec.value, observation };
         }
-        return true;
+        return { verified: true, observation };
 
       case "checkbox":
       case "toggle":
         if (fieldSpec.selected !== undefined) {
           const isChecked = this.fieldTypeDetector.isChecked(element);
-          return isChecked === fieldSpec.selected;
+          return { verified: isChecked === fieldSpec.selected, observation };
         }
-        return true;
+        return { verified: true, observation };
 
       case "dropdown":
         if (fieldSpec.value !== undefined) {
           const currentValue = this.fieldTypeDetector.getTextValue(element);
-          return currentValue === fieldSpec.value;
+          return { verified: currentValue === fieldSpec.value, observation };
         }
-        return true;
+        return { verified: true, observation };
 
       default:
-        return true;
+        return { verified: true, observation };
     }
   }
 

--- a/test/daemon/clientRequestTimeout.test.ts
+++ b/test/daemon/clientRequestTimeout.test.ts
@@ -6,7 +6,9 @@ import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
   MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
+  MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
 } from "../../src/daemon/mcpRequestTimeout";
+import { PROGRESS_NOTIFICATION_METHOD } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 function createBlackHoleSocket(): Duplex {
@@ -148,6 +150,123 @@ describe("DaemonClient per-request timeout", () => {
       const timeoutErr = err as McpTimeoutError;
       expect(timeoutErr.toolName).toBe("startDevice");
       expect(timeoutErr.timeoutMs).toBe(300_000);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+/**
+ * Transport-level regression for issue #6222 (P1 review): progress must
+ * actually keep this client's OWN local pending-request timer alive past a
+ * tool's normal deadline, bounded by MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS
+ * -- and a request that stops progressing, or never progressed at all, must
+ * still time out exactly as before. This is independent of, and in addition
+ * to, the daemon's own internal deadline/SDK-call extension (socketServer.ts).
+ */
+describe("DaemonClient per-request timeout is extended by progress, bounded (#6222)", () => {
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+  });
+
+  function deliverProgress(client: DaemonClient, progressToken: string | number): void {
+    const frame =
+      JSON.stringify({
+        type: "daemon_notification",
+        method: PROGRESS_NOTIFICATION_METHOD,
+        progressToken,
+        progress: 1,
+        total: 1,
+      }) + "\n";
+    (client as any).handleData(Buffer.from(frame));
+  }
+
+  test("a request that emits periodic progress survives past its default 30s deadline", async () => {
+    const client = createConnectedClient(fakeTimer);
+    const progressToken = "progress-survives";
+
+    const promise = client.callTool("setUIState", { fields: [] }, progressToken);
+    let settled = false;
+    promise.catch(() => {
+      settled = true;
+    });
+
+    // Advance well past DEFAULT_MCP_REQUEST_TIMEOUT_MS (30s) in steps, feeding
+    // a progress tick before each step would otherwise exceed the deadline.
+    // Total elapsed: 100s, more than 3x the default.
+    for (let i = 0; i < 5; i++) {
+      deliverProgress(client, progressToken);
+      fakeTimer.advanceTime(20_000);
+      await Promise.resolve();
+    }
+
+    expect(settled).toBe(false);
+
+    await client.close();
+  });
+
+  test("a request that emits progress forever is still killed at the bounded ceiling", async () => {
+    const client = createConnectedClient(fakeTimer);
+    const progressToken = "progress-forever";
+
+    const promise = client.callTool("setUIState", { fields: [] }, progressToken);
+
+    // Keep progressing indefinitely, well past the ceiling
+    // (MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS), advancing in steps
+    // smaller than the reset window so the timer keeps getting pushed out --
+    // but the hard ceiling must still cut it off.
+    const stepMs = 20_000;
+    const steps = Math.ceil((MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS + 120_000) / stepMs);
+    for (let i = 0; i < steps; i++) {
+      deliverProgress(client, progressToken);
+      fakeTimer.advanceTime(stepMs);
+      await Promise.resolve();
+    }
+
+    try {
+      await promise;
+      expect.unreachable("a request that never stops progressing must still hit the ceiling");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("a non-progressing request still times out at the default -- unaffected by the extension mechanism", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    // No progressToken at all: this call never registers a deadline/progress
+    // listener, so it must behave exactly as it did before #6222.
+    const promise = client.callTool("tapOn", {});
+    fakeTimer.advanceTime(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.timeoutMs).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("a progress tick for a DIFFERENT token does not extend an unrelated pending request", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    const promise = client.callTool("tapOn", {}, "this-calls-own-token");
+    deliverProgress(client, "some-other-request-token");
+    fakeTimer.advanceTime(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out -- the progress tick was for a different call");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
     } finally {
       await client.close();
     }

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -18,6 +18,8 @@ import {
   OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
   resolveMcpRequestTimeoutMs,
+  ProgressExtendableDeadline,
+  MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
 } from "../../src/daemon/mcpRequestTimeout";
 import type { DaemonRequest } from "../../src/daemon/types";
 import {
@@ -562,5 +564,94 @@ describe("resolveMcpRequestTimeoutMs", () => {
     const resolved = resolveMcpRequestTimeoutMs(request);
     expect(resolved).toBe(MAX_DEVICE_READY_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS);
     expect(resolved).toBeLessThan(DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS);
+  });
+});
+
+/**
+ * Pure deadline math backing both extension points the daemon wires up for a
+ * progress-emitting request (issue #6222 review, P1): `handleIdeRequest`'s
+ * `resetTimeoutOnProgress`/`maxTotalTimeout` for the inner MCP SDK call, and
+ * `UnixSocketServer`'s own `requestDeadlineMs`-equivalent pre-flight budget
+ * check (`requireRemainingMcpForwardBudget`). Both read `deadline.value` (or
+ * `deadline.ceiling`) live and call `extendOnProgress` only when a progress
+ * notification for that specific request actually arrives -- a tool that
+ * never emits progress never touches this class at all, so its deadline is
+ * exactly what it always was.
+ */
+describe("ProgressExtendableDeadline", () => {
+  test("starts at receivedAt + initialTimeout, unaffected until a progress tick arrives", () => {
+    const deadline = new ProgressExtendableDeadline(1_000, 30_000);
+    expect(deadline.value).toBe(31_000);
+  });
+
+  test("a progress tick resets the deadline forward from now, by the extension amount", () => {
+    const deadline = new ProgressExtendableDeadline(0, 30_000);
+    // 25s in, well before the original 30s deadline, a tick arrives.
+    deadline.extendOnProgress(25_000, 30_000);
+    expect(deadline.value).toBe(55_000);
+  });
+
+  test("a request that keeps progressing survives past its original deadline, up to the bounded ceiling", () => {
+    const receivedAt = 0;
+    const initialTimeoutMs = 30_000;
+    const deadline = new ProgressExtendableDeadline(receivedAt, initialTimeoutMs);
+
+    // Tick every 20s -- each tick arrives well before the deadline it most
+    // recently set, so the request never actually expires.
+    let nowMs = 0;
+    for (let i = 0; i < 5; i++) {
+      nowMs += 20_000;
+      deadline.extendOnProgress(nowMs, initialTimeoutMs);
+      expect(deadline.value).toBeGreaterThan(nowMs);
+    }
+    // 100s of wall-clock elapsed -- more than 3x the original 30s deadline --
+    // and the request is still not expired.
+    expect(nowMs).toBe(100_000);
+    expect(deadline.value).toBeGreaterThan(nowMs);
+  });
+
+  test("progress can never push the deadline past the bounded ceiling", () => {
+    const receivedAt = 0;
+    const initialTimeoutMs = 30_000;
+    const deadline = new ProgressExtendableDeadline(receivedAt, initialTimeoutMs);
+    const ceiling = receivedAt + MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS;
+    expect(deadline.ceiling).toBe(ceiling);
+
+    // Keep progressing indefinitely, well past the ceiling.
+    let nowMs = 0;
+    for (let i = 0; i < 40; i++) {
+      nowMs += 20_000;
+      deadline.extendOnProgress(nowMs, initialTimeoutMs);
+      expect(deadline.value).toBeLessThanOrEqual(ceiling);
+    }
+    expect(nowMs).toBeGreaterThan(ceiling);
+    // Once past the ceiling, the deadline is pinned there -- the request
+    // is effectively already expired relative to `nowMs`, exactly the
+    // "still killed" behavior a genuinely hung-but-progressing tool needs.
+    expect(deadline.value).toBe(ceiling);
+    expect(deadline.value).toBeLessThan(nowMs);
+  });
+
+  test("a proposal at or behind the current deadline never shortens it", () => {
+    const deadline = new ProgressExtendableDeadline(0, 30_000);
+    deadline.extendOnProgress(25_000, 30_000); // pushes to 55_000
+    const beforeMs = deadline.value;
+    // A late-arriving/out-of-order tick proposing an earlier value is a no-op.
+    deadline.extendOnProgress(10_000, 1_000); // would propose 11_000, far behind
+    expect(deadline.value).toBe(beforeMs);
+  });
+
+  test("a request with a floor already above the progress ceiling keeps its own larger ceiling", () => {
+    // e.g. executePlan's 10-minute floor is larger than the default 5-minute
+    // progress ceiling -- progress must not SHRINK that tool's effective ceiling.
+    const tenMinutes = 600_000;
+    const deadline = new ProgressExtendableDeadline(0, tenMinutes);
+    expect(deadline.ceiling).toBe(tenMinutes);
+  });
+
+  test("never extended when no progress arrives -- a non-progressing request's deadline is exactly its original value", () => {
+    const deadline = new ProgressExtendableDeadline(1_000, DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+    // No extendOnProgress call at all.
+    expect(deadline.value).toBe(1_000 + DEFAULT_MCP_REQUEST_TIMEOUT_MS);
   });
 });

--- a/test/daemon/socketServerProgressDeadlineExtension.test.ts
+++ b/test/daemon/socketServerProgressDeadlineExtension.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import {
+  ProgressExtendableDeadline,
+  MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
+} from "../../src/daemon/mcpRequestTimeout";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonRequest } from "../../src/daemon/types";
+
+/**
+ * Transport-level regression for issue #6222 (P1 review): `handleIdeRequest`
+ * must actually make progress extend the deadline it hands to the inner MCP
+ * SDK call, bounded, and the daemon's own pre-flight budget check
+ * (`ProgressExtendableDeadline`, threaded via `deadline`) must see that same
+ * extension live -- while a request that never emits progress is completely
+ * untouched by any of this.
+ *
+ * `handleIdeRequest` only needs a `Client`-shaped object with the methods it
+ * actually calls, so these tests inject a minimal fake instead of a real MCP
+ * HTTP server -- no socket, no queue, no session state beyond what
+ * `withSocketSessionAutolockKey`'s session-released check reads.
+ */
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: () => null,
+      getDeviceLabels: () => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: () => undefined,
+    }),
+  };
+}
+
+function createServer(fakeTimer: FakeTimer): UnixSocketServer {
+  return new UnixSocketServer(
+    join(tmpdir(), `progress-deadline-${randomUUID()}.sock`),
+    "http://localhost:0/mcp",
+    createFakeDaemonState(),
+    fakeTimer,
+  );
+}
+
+interface CapturedCallToolOptions {
+  timeout?: number;
+  resetTimeoutOnProgress?: boolean;
+  maxTotalTimeout?: number;
+  onprogress?: (notification: { progress: number; total?: number; message?: string }) => void;
+}
+
+function callHandleIdeRequest(
+  server: UnixSocketServer,
+  mcpClient: unknown,
+  request: DaemonRequest,
+  timeoutMs: number,
+  socketSessionId: string,
+  deadline: ProgressExtendableDeadline,
+): Promise<unknown> {
+  return (
+    server as unknown as {
+      handleIdeRequest: (
+        c: unknown,
+        r: DaemonRequest,
+        t: number,
+        s: string,
+        d: ProgressExtendableDeadline,
+      ) => Promise<unknown>;
+    }
+  ).handleIdeRequest(mcpClient, request, timeoutMs, socketSessionId, deadline);
+}
+
+describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6222)", () => {
+  test("a progress-emitting tools/call gets resetTimeoutOnProgress + a bounded maxTotalTimeout", async () => {
+    const fakeTimer = new FakeTimer();
+    const server = createServer(fakeTimer);
+    const initialTimeoutMs = 30_000;
+    const deadline = new ProgressExtendableDeadline(fakeTimer.now(), initialTimeoutMs);
+
+    let capturedOptions: CapturedCallToolOptions | undefined;
+    const fakeMcpClient = {
+      callTool: async (
+        _params: unknown,
+        _resultSchema: unknown,
+        options: CapturedCallToolOptions,
+      ) => {
+        capturedOptions = options;
+        return { content: [] };
+      },
+    };
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "setUIState", arguments: {} },
+      progressToken: "tok-1",
+    };
+
+    const result = await callHandleIdeRequest(
+      server,
+      fakeMcpClient,
+      request,
+      initialTimeoutMs,
+      "socket-1",
+      deadline,
+    );
+
+    expect(result).toEqual({ content: [] });
+    expect(capturedOptions?.resetTimeoutOnProgress).toBe(true);
+    expect(typeof capturedOptions?.maxTotalTimeout).toBe("number");
+    // The ceiling is measured from when the request was first received (now,
+    // since no time has passed), not from this individual forward attempt.
+    expect(capturedOptions?.maxTotalTimeout).toBeGreaterThanOrEqual(
+      MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS - 1,
+    );
+  });
+
+  test("each progress tick extends the shared deadline, surviving well past the original timeout", async () => {
+    const fakeTimer = new FakeTimer();
+    const server = createServer(fakeTimer);
+    const initialTimeoutMs = 30_000;
+    const deadline = new ProgressExtendableDeadline(fakeTimer.now(), initialTimeoutMs);
+
+    const fakeMcpClient = {
+      callTool: async (
+        _params: unknown,
+        _resultSchema: unknown,
+        options: CapturedCallToolOptions,
+      ) => {
+        // Simulate slow device work: tick progress every 20s, well past what
+        // the ORIGINAL 30s deadline would have allowed, for 100s total.
+        for (let i = 0; i < 5; i++) {
+          fakeTimer.advanceTime(20_000);
+          options.onprogress?.({ progress: i + 1, total: 5 });
+        }
+        return { content: [] };
+      },
+    };
+
+    const request: DaemonRequest = {
+      id: "2",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "setUIState", arguments: {} },
+      progressToken: "tok-2",
+    };
+
+    const beforeMs = fakeTimer.now();
+    const result = await callHandleIdeRequest(
+      server,
+      fakeMcpClient,
+      request,
+      initialTimeoutMs,
+      "socket-1",
+      deadline,
+    );
+
+    expect(result).toEqual({ content: [] });
+    // 100s elapsed -- more than 3x the original 30s deadline -- and the
+    // shared deadline was pushed out to reflect it (the daemon's own
+    // pre-flight budget check, `requireRemainingMcpForwardBudget`, reads
+    // this SAME object live).
+    expect(fakeTimer.now() - beforeMs).toBe(100_000);
+    expect(deadline.value).toBeGreaterThan(fakeTimer.now());
+  });
+
+  test("a tools/call with no progressToken never touches resetTimeoutOnProgress/maxTotalTimeout or the deadline", async () => {
+    const fakeTimer = new FakeTimer();
+    const server = createServer(fakeTimer);
+    const initialTimeoutMs = 30_000;
+    const deadline = new ProgressExtendableDeadline(fakeTimer.now(), initialTimeoutMs);
+    const originalDeadlineValue = deadline.value;
+
+    let capturedOptions: CapturedCallToolOptions | undefined;
+    const fakeMcpClient = {
+      callTool: async (
+        _params: unknown,
+        _resultSchema: unknown,
+        options: CapturedCallToolOptions,
+      ) => {
+        capturedOptions = options;
+        return { content: [] };
+      },
+    };
+
+    const request: DaemonRequest = {
+      id: "3",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "tapOn", arguments: {} },
+      // No progressToken -- this is the vast majority of tool calls.
+    };
+
+    await callHandleIdeRequest(
+      server,
+      fakeMcpClient,
+      request,
+      initialTimeoutMs,
+      "socket-1",
+      deadline,
+    );
+
+    expect(capturedOptions?.resetTimeoutOnProgress).toBeUndefined();
+    expect(capturedOptions?.maxTotalTimeout).toBeUndefined();
+    expect(capturedOptions?.onprogress).toBeUndefined();
+    // The deadline this request shares is completely untouched.
+    expect(deadline.value).toBe(originalDeadlineValue);
+  });
+});

--- a/test/daemon/socketServerProgressDeadlineExtension.test.ts
+++ b/test/daemon/socketServerProgressDeadlineExtension.test.ts
@@ -53,6 +53,7 @@ interface CapturedCallToolOptions {
   timeout?: number;
   resetTimeoutOnProgress?: boolean;
   maxTotalTimeout?: number;
+  signal?: AbortSignal;
   onprogress?: (notification: { progress: number; total?: number; message?: string }) => void;
 }
 
@@ -80,7 +81,7 @@ function callHandleIdeRequest(
 }
 
 describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6222)", () => {
-  test("a progress-emitting tools/call gets resetTimeoutOnProgress + a bounded maxTotalTimeout", async () => {
+  test("a progress-emitting tools/call is given an abort signal and a bounded backstop timeout", async () => {
     const fakeTimer = new FakeTimer();
     const server = createServer(fakeTimer);
     const initialTimeoutMs = 30_000;
@@ -116,10 +117,15 @@ describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6
     );
 
     expect(result).toEqual({ content: [] });
-    expect(capturedOptions?.resetTimeoutOnProgress).toBe(true);
+    // Progress-driven extension is now driven by this daemon's own abort
+    // controller (the SDK's `resetTimeoutOnProgress` cannot express an
+    // asymmetric initial-vs-reset window -- see the reconciliation note in
+    // `handleIdeRequest`), not the SDK's built-in reset mechanism.
+    expect(capturedOptions?.resetTimeoutOnProgress).toBeUndefined();
+    expect(capturedOptions?.signal).toBeInstanceOf(AbortSignal);
+    // The SDK-side timeout/maxTotalTimeout are only a generous backstop
+    // pinned to the ceiling -- never the authority for the actual schedule.
     expect(typeof capturedOptions?.maxTotalTimeout).toBe("number");
-    // The ceiling is measured from when the request was first received (now,
-    // since no time has passed), not from this individual forward attempt.
     expect(capturedOptions?.maxTotalTimeout).toBeGreaterThanOrEqual(
       MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS - 1,
     );
@@ -217,14 +223,53 @@ describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6
     expect(deadline.value).toBe(originalDeadlineValue);
   });
 
+  /**
+   * A fake `Client` that behaves like the real MCP SDK with respect to
+   * `signal`: it registers an abort listener and rejects exactly as
+   * `Protocol.request`'s `cancel()` does, so these tests exercise the REAL
+   * race between "does the abort timer fire before the next progress tick"
+   * -- not just which options were passed.
+   */
+  function createAbortAwareFakeMcpClient(
+    work: (options: CapturedCallToolOptions) => void | Promise<void>,
+  ): {
+    callTool: (...args: unknown[]) => Promise<unknown>;
+    captured: () => CapturedCallToolOptions;
+  } {
+    let captured: CapturedCallToolOptions | undefined;
+    return {
+      callTool: async (
+        _params: unknown,
+        _resultSchema: unknown,
+        options: CapturedCallToolOptions,
+      ) => {
+        captured = options;
+        return await new Promise((resolve, reject) => {
+          if (options.signal?.aborted) {
+            reject(new Error(String(options.signal.reason)));
+            return;
+          }
+          options.signal?.addEventListener("abort", () => {
+            reject(new Error(String(options.signal?.reason)));
+          });
+          Promise.resolve(work(options))
+            .then(() => resolve({ content: [] }))
+            .catch(reject);
+        });
+      },
+      captured: () => captured!,
+    };
+  }
+
   test("a queued-start request still gets FULL-WINDOW extensions per tick, not the queue-depleted remainder (#6222 review, P1)", async () => {
     // A 30s setUIState that waited 29s behind another request in the
     // per-session queue arrives at handleIdeRequest with only ~1s of
     // REMAINING budget (`timeoutMs`) -- but its ORIGINAL per-request window
     // (`originalTimeoutMs`, unaffected by queue wait) is still the full 30s.
-    // Every progress-driven extension must use the full 30s, not the
-    // depleted ~1s remnant, or ordinary device work between ticks would
-    // still time out despite "surviving" past the initial deadline.
+    // A quick first tick lands within that ~1s window (ordinary setup work),
+    // and every extension AFTER it must use the full 30s, not the depleted
+    // ~1s remnant, or ordinary device work between later ticks would still
+    // time out despite "surviving" the first one.
     const fakeTimer = new FakeTimer();
     const server = createServer(fakeTimer);
     const originalTimeoutMs = 30_000;
@@ -235,23 +280,18 @@ describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6
     // attempt starts, exactly like `handleRequest` would have.
     fakeTimer.advanceTime(queueWaitMs);
 
-    let capturedOptions: CapturedCallToolOptions | undefined;
-    const fakeMcpClient = {
-      callTool: async (
-        _params: unknown,
-        _resultSchema: unknown,
-        options: CapturedCallToolOptions,
-      ) => {
-        capturedOptions = options;
-        // Ordinary device work: 20s between ticks, comfortably within a
-        // FULL 30s window but far beyond the queue-depleted ~1s remainder.
-        for (let i = 0; i < 4; i++) {
-          fakeTimer.advanceTime(20_000);
-          options.onprogress?.({ progress: i + 1, total: 4 });
-        }
-        return { content: [] };
-      },
-    };
+    const fakeMcpClient = createAbortAwareFakeMcpClient(async (options) => {
+      // First tick arrives quickly -- well within the ~1s remaining budget.
+      fakeTimer.advanceTime(500);
+      options.onprogress?.({ progress: 1, total: 5 });
+      // Ordinary device work from here on: 20s between ticks, comfortably
+      // within a FULL 30s window but far beyond the queue-depleted ~1s
+      // remainder that was in effect before the first tick.
+      for (let i = 2; i <= 5; i++) {
+        fakeTimer.advanceTime(20_000);
+        options.onprogress?.({ progress: i, total: 5 });
+      }
+    });
 
     const request: DaemonRequest = {
       id: "4",
@@ -273,15 +313,56 @@ describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6
     );
 
     expect(result).toEqual({ content: [] });
-    // The SDK's own reset window (reused verbatim on every progress-driven
-    // reset) must be the FULL 30s window, not the ~1s queue-depleted one.
-    expect(capturedOptions?.timeout).toBe(originalTimeoutMs);
-    expect(capturedOptions?.timeout).not.toBe(remainingTimeoutMs);
-    // 80s of simulated device work elapsed here -- far more than either the
-    // queue-depleted ~1s OR even a single full 30s window -- and the shared
-    // deadline was pushed out by each FULL-WINDOW tick to reflect it.
-    expect(fakeTimer.now() - beforeMs).toBe(80_000);
+    // 80.5s of simulated device work elapsed here -- far more than either
+    // the queue-depleted ~1s OR even a single full 30s window -- and the
+    // shared deadline was pushed out by each FULL-WINDOW tick to reflect it.
+    expect(fakeTimer.now() - beforeMs).toBe(80_500);
     expect(deadline.value).toBeGreaterThan(fakeTimer.now());
+  });
+
+  test("a queued-start request that emits NO progress before the first tick times out on the REMAINING budget, not a fresh full window (#6222 reconciliation)", async () => {
+    // Same queued-start setup as above (~1s remaining out of a 30s original
+    // window) -- but this time NO progress tick arrives before ordinary
+    // device work already exceeds that ~1s remainder. It must time out on
+    // the remaining budget exactly like a non-progressing call would, NOT
+    // survive because a fresh full 30s window was granted up front.
+    const fakeTimer = new FakeTimer();
+    const server = createServer(fakeTimer);
+    const originalTimeoutMs = 30_000;
+    const queueWaitMs = 29_000;
+    const remainingTimeoutMs = originalTimeoutMs - queueWaitMs; // 1_000ms left
+    const deadline = new ProgressExtendableDeadline(fakeTimer.now(), originalTimeoutMs);
+    fakeTimer.advanceTime(queueWaitMs);
+
+    const fakeMcpClient = createAbortAwareFakeMcpClient(async () => {
+      // 5s of work with NO progress tick at all -- more than 4x the ~1s
+      // remaining budget, comfortably within the 30s full window this
+      // request would get AFTER a real tick, which never arrives.
+      fakeTimer.advanceTime(5_000);
+    });
+
+    const request: DaemonRequest = {
+      id: "5",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "setUIState", arguments: {} },
+      progressToken: "tok-no-initial-progress",
+    };
+
+    await expect(
+      callHandleIdeRequest(
+        server,
+        fakeMcpClient,
+        request,
+        remainingTimeoutMs,
+        "socket-1",
+        deadline,
+        originalTimeoutMs,
+      ),
+      // Confirms this is genuinely our abort timer firing at the ~1s
+      // remaining budget, not some unrelated failure -- the message embeds
+      // the exact delay it was armed for.
+    ).rejects.toThrow(`Request timed out after ${remainingTimeoutMs}ms`);
   });
 });
 

--- a/test/daemon/socketServerProgressDeadlineExtension.test.ts
+++ b/test/daemon/socketServerProgressDeadlineExtension.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_PROGRESS_EXTENDED_MCP_REQUEST_TIMEOUT_MS,
 } from "../../src/daemon/mcpRequestTimeout";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { DaemonRequest } from "../../src/daemon/types";
+import { PROGRESS_NOTIFICATION_METHOD, type DaemonRequest } from "../../src/daemon/types";
 
 /**
  * Transport-level regression for issue #6222 (P1 review): `handleIdeRequest`
@@ -63,6 +63,7 @@ function callHandleIdeRequest(
   timeoutMs: number,
   socketSessionId: string,
   deadline: ProgressExtendableDeadline,
+  originalTimeoutMs: number = timeoutMs,
 ): Promise<unknown> {
   return (
     server as unknown as {
@@ -72,9 +73,10 @@ function callHandleIdeRequest(
         t: number,
         s: string,
         d: ProgressExtendableDeadline,
+        o: number,
       ) => Promise<unknown>;
     }
-  ).handleIdeRequest(mcpClient, request, timeoutMs, socketSessionId, deadline);
+  ).handleIdeRequest(mcpClient, request, timeoutMs, socketSessionId, deadline, originalTimeoutMs);
 }
 
 describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6222)", () => {
@@ -213,5 +215,160 @@ describe("UnixSocketServer.handleIdeRequest extends the deadline on progress (#6
     expect(capturedOptions?.onprogress).toBeUndefined();
     // The deadline this request shares is completely untouched.
     expect(deadline.value).toBe(originalDeadlineValue);
+  });
+
+  test("a queued-start request still gets FULL-WINDOW extensions per tick, not the queue-depleted remainder (#6222 review, P1)", async () => {
+    // A 30s setUIState that waited 29s behind another request in the
+    // per-session queue arrives at handleIdeRequest with only ~1s of
+    // REMAINING budget (`timeoutMs`) -- but its ORIGINAL per-request window
+    // (`originalTimeoutMs`, unaffected by queue wait) is still the full 30s.
+    // Every progress-driven extension must use the full 30s, not the
+    // depleted ~1s remnant, or ordinary device work between ticks would
+    // still time out despite "surviving" past the initial deadline.
+    const fakeTimer = new FakeTimer();
+    const server = createServer(fakeTimer);
+    const originalTimeoutMs = 30_000;
+    const queueWaitMs = 29_000;
+    const remainingTimeoutMs = originalTimeoutMs - queueWaitMs; // 1_000ms left when forwarding starts
+    const deadline = new ProgressExtendableDeadline(fakeTimer.now(), originalTimeoutMs);
+    // Simulate the queue wait already having elapsed before this forward
+    // attempt starts, exactly like `handleRequest` would have.
+    fakeTimer.advanceTime(queueWaitMs);
+
+    let capturedOptions: CapturedCallToolOptions | undefined;
+    const fakeMcpClient = {
+      callTool: async (
+        _params: unknown,
+        _resultSchema: unknown,
+        options: CapturedCallToolOptions,
+      ) => {
+        capturedOptions = options;
+        // Ordinary device work: 20s between ticks, comfortably within a
+        // FULL 30s window but far beyond the queue-depleted ~1s remainder.
+        for (let i = 0; i < 4; i++) {
+          fakeTimer.advanceTime(20_000);
+          options.onprogress?.({ progress: i + 1, total: 4 });
+        }
+        return { content: [] };
+      },
+    };
+
+    const request: DaemonRequest = {
+      id: "4",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "setUIState", arguments: {} },
+      progressToken: "tok-queued",
+    };
+
+    const beforeMs = fakeTimer.now();
+    const result = await callHandleIdeRequest(
+      server,
+      fakeMcpClient,
+      request,
+      remainingTimeoutMs,
+      "socket-1",
+      deadline,
+      originalTimeoutMs,
+    );
+
+    expect(result).toEqual({ content: [] });
+    // The SDK's own reset window (reused verbatim on every progress-driven
+    // reset) must be the FULL 30s window, not the ~1s queue-depleted one.
+    expect(capturedOptions?.timeout).toBe(originalTimeoutMs);
+    expect(capturedOptions?.timeout).not.toBe(remainingTimeoutMs);
+    // 80s of simulated device work elapsed here -- far more than either the
+    // queue-depleted ~1s OR even a single full 30s window -- and the shared
+    // deadline was pushed out by each FULL-WINDOW tick to reflect it.
+    expect(fakeTimer.now() - beforeMs).toBe(80_000);
+    expect(deadline.value).toBeGreaterThan(fakeTimer.now());
+  });
+});
+
+/**
+ * Regression for issue #6222 review, P2: progress delivery to a specific
+ * in-flight request must not depend on that socket session's OPTIONAL
+ * general-notification subscription. `DaemonMcpProxy.doConnect` deliberately
+ * continues, best-effort, when `subscribeToNotifications()` fails or was
+ * never sent -- gating progress on that same flag would silently strand a
+ * long-running progress-emitting call in exactly that (common, documented)
+ * degraded mode: the daemon keeps working under its own extended deadline
+ * while the client's local timer -- which only extends on a tick it actually
+ * receives -- fires anyway, a split-brain where the daemon succeeds but the
+ * client reports failure.
+ */
+describe("pushProgressNotification is independent of the general notification subscription (#6222 review, P2)", () => {
+  function createServerWithFakeSocket(): {
+    server: UnixSocketServer;
+    sessionId: string;
+    writes: string[];
+  } {
+    const server = new UnixSocketServer(
+      join(tmpdir(), `progress-subscription-${randomUUID()}.sock`),
+      "http://localhost:0/mcp",
+      { isInitialized: () => false },
+      new FakeTimer(),
+    );
+    const sessionId = "socket-unsubscribed";
+    const writes: string[] = [];
+    const fakeSocket = {
+      destroyed: false,
+      write: (data: string) => {
+        writes.push(data);
+        return true;
+      },
+    };
+    (server as unknown as { clientSockets: Map<string, unknown> }).clientSockets.set(
+      sessionId,
+      fakeSocket,
+    );
+    return { server, sessionId, writes };
+  }
+
+  function push(
+    server: UnixSocketServer,
+    sessionId: string,
+    progressToken: string | number,
+    progress: number,
+  ): void {
+    (
+      server as unknown as {
+        pushProgressNotification: (s: string, t: string | number, p: number) => void;
+      }
+    ).pushProgressNotification(sessionId, progressToken, progress);
+  }
+
+  test("delivers a progress tick to a session that never subscribed to general notifications", () => {
+    const { server, sessionId, writes } = createServerWithFakeSocket();
+
+    // Deliberately never send DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD for this
+    // session -- it is not in `notificationSubscribers` at all.
+    push(server, sessionId, "tok-1", 1);
+
+    expect(writes.length).toBe(1);
+    const frame = JSON.parse(writes[0]);
+    expect(frame.method).toBe(PROGRESS_NOTIFICATION_METHOD);
+    expect(frame.progressToken).toBe("tok-1");
+    expect(frame.progress).toBe(1);
+  });
+
+  test("still skips a torn-down (destroyed) socket, subscribed or not", () => {
+    const { server, sessionId, writes } = createServerWithFakeSocket();
+    const destroyedSocket = (
+      server as unknown as { clientSockets: Map<string, { destroyed: boolean }> }
+    ).clientSockets.get(sessionId)!;
+    destroyedSocket.destroyed = true;
+
+    push(server, sessionId, "tok-2", 1);
+
+    expect(writes.length).toBe(0);
+  });
+
+  test("still skips a session with no known socket at all", () => {
+    const { server, writes } = createServerWithFakeSocket();
+
+    push(server, "no-such-session", "tok-3", 1);
+
+    expect(writes.length).toBe(0);
   });
 });

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -78,10 +78,16 @@ export class FakeTapOnElement implements TapOnElementLike {
 
   async execute(
     options: { text?: string; elementId?: string; action: string },
-    _progress?: any,
+    progress?: (progress: number, total?: number, message?: string) => Promise<void>,
     _signal?: AbortSignal,
   ): Promise<TapOnElementResult> {
     this.calls.push({ options });
+    // Mirror BaseVisualChange.observedInteraction's own local 0..100 progress
+    // range, resetting to 0 on every call -- this is the real shape that
+    // SetUIState's own progress reporting must project into a single
+    // monotonic range rather than forwarding verbatim (#6222 review).
+    await progress?.(0, 100, "Preparing to execute action...");
+    await progress?.(10, 100, "Getting previous view hierarchy...");
     const key = options.text ?? options.elementId ?? "";
     return this.results.get(key) ?? this.defaultResult;
   }
@@ -144,8 +150,13 @@ export class FakeClearText implements ClearTextLike {
   private callCount: number = 0;
   private result: ClearTextResult = { success: true };
 
-  async execute(_progress?: any): Promise<ClearTextResult> {
+  async execute(
+    progress?: (progress: number, total?: number, message?: string) => Promise<void>,
+  ): Promise<ClearTextResult> {
     this.callCount++;
+    // Same local 0..100 reset as FakeTapOnElement above (#6222 review).
+    await progress?.(0, 100, "Preparing to execute action...");
+    await progress?.(10, 100, "Getting previous view hierarchy...");
     return this.result;
   }
 

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1141,9 +1141,12 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
     );
 
     expect(result.success).toBe(true);
-    // Each field's tap AND clear child steps report their own local 0,10 --
-    // two ticks apiece -- plus one field-boundary tick: at least 9 total.
-    expect(progressCalls.length).toBeGreaterThanOrEqual(9);
+    // Each field's tap AND clear child steps report the same local 0,10
+    // pattern. Ties are suppressed rather than bumped (so a repeat can never
+    // be pushed into the reserved boundary endpoint or the next field's
+    // slice) -- so only the first genuinely-advancing child tick per field
+    // (tap's "10") survives, plus that field's boundary tick: 2 per field.
+    expect(progressCalls.length).toBe(6);
     // Every notification shares ONE consistent total across the whole call
     // (fieldCount * 100) -- not the per-field child steps' own local total,
     // and not a bare field-count total that would collide with those.
@@ -1163,6 +1166,125 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
       expect.arrayContaining([100, 200, 300]) as unknown as number[],
     );
     expect(progressCalls[progressCalls.length - 1].message).toContain("3/3");
+  });
+
+  test("reserves the field-slice endpoint for the boundary tick when a child reports its own 100%", async () => {
+    // A child step can legitimately report (100, 100) -- its own completion.
+    // That must be capped strictly below this field's slice endpoint (not
+    // mapped onto it), so it can never tie or collide with the boundary tick
+    // that follows, and never gets bumped across into the next field's slice.
+    const twoCheckboxes: ViewHierarchyResult = {
+      hierarchy: {
+        node: [
+          {
+            $: {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "first",
+              class: "android.widget.CheckBox",
+              checkable: "true" as any,
+              checked: "false" as any,
+            },
+          },
+          {
+            $: {
+              bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+              "resource-id": "second",
+              class: "android.widget.CheckBox",
+              checkable: "true" as any,
+              checked: "false" as any,
+            },
+          },
+        ],
+      },
+    };
+    fakeObserve.setResult(createObserveResultFor(twoCheckboxes));
+    fakeFieldTypeDetector.setFieldType("first", "checkbox");
+    fakeFieldTypeDetector.setFieldType("second", "checkbox");
+    fakeFieldTypeDetector.setSkipVerification("first", true);
+    fakeFieldTypeDetector.setSkipVerification("second", true);
+
+    // A tap fake whose "first" field reports its own 100% completion; its
+    // "second" field uses the ordinary 0,10 pattern real tools use.
+    const tapReportingFullCompletion = {
+      calls: [] as Array<{ elementId?: string }>,
+      async execute(
+        options: { elementId?: string },
+        childProgress?: (p: number, t?: number, m?: string) => Promise<void>,
+      ) {
+        this.calls.push({ elementId: options.elementId });
+        if (options.elementId === "first") {
+          await childProgress?.(0, 100, "start");
+          await childProgress?.(100, 100, "done");
+        } else {
+          await childProgress?.(0, 100, "Preparing to execute action...");
+          await childProgress?.(10, 100, "Getting previous view hierarchy...");
+        }
+        return {
+          success: true,
+          action: "tap",
+          element: { bounds: { left: 0, top: 0, right: 100, bottom: 50 } },
+        };
+      },
+    };
+
+    const progressCalls: Array<{ progress: number; message?: string }> = [];
+    const progress = async (progressValue: number, _total?: number, message?: string) => {
+      progressCalls.push({ progress: progressValue, message });
+    };
+
+    const setUIState = new SetUIState(device, null, {
+      tapOnElement: tapReportingFullCompletion as any,
+      inputText: fakeInput,
+      clearText: fakeClear,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const result = await setUIState.execute(
+      {
+        fields: [
+          { selector: { elementId: "first" }, selected: true },
+          { selector: { elementId: "second" }, selected: true },
+        ],
+      },
+      progress,
+    );
+
+    expect(result.success).toBe(true);
+    // Strictly increasing throughout, including across the field boundary.
+    for (let i = 1; i < progressCalls.length; i++) {
+      expect(progressCalls[i].progress).toBeGreaterThan(progressCalls[i - 1].progress);
+    }
+    // Identify the two field-boundary ticks by their message (only
+    // execute()'s own per-field boundary emission uses this wording; the
+    // child fake's messages are "start"/"done"/"Preparing..."/"Getting...").
+    // The boundary ticks must land EXACTLY at each field's slice endpoint --
+    // not endpoint+1, which is what a bump-on-tie (instead of reservation)
+    // would produce here, since field 1's own child already reports 100%.
+    const boundaryIndices = progressCalls
+      .map((c, i) => ({ c, i }))
+      .filter(({ c }) => c.message?.includes("Set field"))
+      .map(({ i }) => i);
+    expect(boundaryIndices.length).toBe(2);
+    expect(progressCalls[boundaryIndices[0]].progress).toBe(100);
+    expect(progressCalls[boundaryIndices[1]].progress).toBe(200);
+    // Field 1's child ticks (everything before its boundary tick) all stay
+    // STRICTLY below 100 -- the (100, 100) report must not have been mapped
+    // onto the reserved endpoint.
+    const field1ChildTicks = progressCalls.slice(0, boundaryIndices[0]);
+    expect(field1ChildTicks.length).toBeGreaterThan(0);
+    expect(field1ChildTicks.every((c) => c.progress < 100)).toBe(true);
+    // Field 2's child ticks (between the two boundary ticks) stay within its
+    // own [100, 200) band.
+    const field2ChildTicks = progressCalls.slice(boundaryIndices[0] + 1, boundaryIndices[1]);
+    expect(field2ChildTicks.every((c) => c.progress > 100 && c.progress < 200)).toBe(true);
+    // No two emissions share the same value (no duplicate at the endpoint).
+    const values = progressCalls.map((c) => c.progress);
+    expect(new Set(values).size).toBe(values.length);
+    // Never exceeds the declared total (fieldCount * 100 = 200).
+    expect(progressCalls.every((c) => c.progress <= 200)).toBe(true);
   });
 
   test("reports progress up to the point of a mid-loop failure, not silence", async () => {

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1035,6 +1035,177 @@ describe("SetUIState budget bounds searching, not successful work (#4252 review)
   });
 });
 
+describe("SetUIState progress reporting and observe reuse (#6222)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+
+  let fakeTap: FakeTapOnElement;
+  let fakeInput: FakeInputText;
+  let fakeClear: FakeClearText;
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTap = new FakeTapOnElement();
+    fakeInput = new FakeInputText();
+    fakeClear = new FakeClearText();
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+  });
+
+  const build = () =>
+    new SetUIState(device, null, {
+      tapOnElement: fakeTap,
+      inputText: fakeInput,
+      clearText: fakeClear,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+  const threeFieldHierarchy = (values: [string, string, string]): ViewHierarchyResult => ({
+    hierarchy: {
+      node: [
+        {
+          $: {
+            bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+            "resource-id": "first",
+            text: values[0],
+            class: "android.widget.EditText",
+          },
+        },
+        {
+          $: {
+            bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+            "resource-id": "second",
+            text: values[1],
+            class: "android.widget.EditText",
+          },
+        },
+        {
+          $: {
+            bounds: { left: 0, top: 120, right: 100, bottom: 170 },
+            "resource-id": "third",
+            text: values[2],
+            class: "android.widget.EditText",
+          },
+        },
+      ],
+    },
+  });
+
+  test("reports per-field progress as a multi-field call advances", async () => {
+    let observeCallCount = 0;
+    fakeObserve.setResultFactory(() => {
+      observeCallCount++;
+      if (observeCallCount <= 1) {
+        return createObserveResultFor(threeFieldHierarchy(["", "", ""]));
+      }
+      // Every observe after the initial one reflects all three fields filled --
+      // this test only cares about the progress trace, not exact sequencing.
+      return createObserveResultFor(threeFieldHierarchy(["a", "b", "c"]));
+    });
+    fakeFieldTypeDetector.setFieldType("first", "text");
+    fakeFieldTypeDetector.setFieldType("second", "text");
+    fakeFieldTypeDetector.setFieldType("third", "text");
+    fakeFieldTypeDetector.setTextValue("first", "a");
+    fakeFieldTypeDetector.setTextValue("second", "b");
+    fakeFieldTypeDetector.setTextValue("third", "c");
+
+    const progressCalls: Array<{ progress: number; total?: number; message?: string }> = [];
+    const progress = async (progressValue: number, total?: number, message?: string) => {
+      progressCalls.push({ progress: progressValue, total, message });
+    };
+
+    const result = await build().execute(
+      {
+        fields: [
+          { selector: { elementId: "first" }, value: "a" },
+          { selector: { elementId: "second" }, value: "b" },
+          { selector: { elementId: "third" }, value: "c" },
+        ],
+      },
+      progress,
+    );
+
+    expect(result.success).toBe(true);
+    // One progress notification per field, reporting cumulative advancement.
+    expect(progressCalls.length).toBeGreaterThanOrEqual(3);
+    expect(progressCalls.map((c) => c.progress)).toEqual(
+      expect.arrayContaining([1, 2, 3]) as unknown as number[],
+    );
+    expect(progressCalls.every((c) => c.total === 3)).toBe(true);
+    expect(progressCalls[progressCalls.length - 1].message).toContain("3/3");
+  });
+
+  test("reports progress up to the point of a mid-loop failure, not silence", async () => {
+    fakeObserve.setResult(createObserveResultFor(threeFieldHierarchy(["", "", ""])));
+    fakeFieldTypeDetector.setFieldType("first", "text");
+    fakeFieldTypeDetector.setFieldType("second", "text");
+    fakeFieldTypeDetector.setSkipVerification("first", true);
+
+    // Second field's tap fails every attempt.
+    fakeTap.setResult("second", {
+      success: false,
+      action: "tap",
+      element: { bounds: { left: 0, top: 60, right: 100, bottom: 110 } },
+      error: "Element not clickable",
+    });
+
+    const progressCalls: Array<{ progress: number; message?: string }> = [];
+    const progress = async (progressValue: number, _total?: number, message?: string) => {
+      progressCalls.push({ progress: progressValue, message });
+    };
+
+    const result = await build().execute(
+      {
+        fields: [
+          { selector: { elementId: "first" }, value: "a" },
+          { selector: { elementId: "second" }, value: "b" },
+        ],
+      },
+      progress,
+    );
+
+    expect(result.success).toBe(false);
+    // A client watching progress must see field 1 succeed before field 2 fails
+    // -- it must not look like nothing happened.
+    expect(progressCalls.length).toBe(2);
+    expect(progressCalls[0].message).toContain("Set field");
+    expect(progressCalls[1].message).toContain("Failed field");
+  });
+
+  test("does not re-observe after a verified success -- reuses verification's own observation", async () => {
+    // Single field, verification enabled (no text-only-selector skip, since
+    // elementId selector is used). Only two observes should occur total: the
+    // initial observe, and the one verifyFieldValue performs. No third,
+    // separate "refresh" observe should follow it.
+    fakeObserve.setResultFactory(() => createObserveResultFor(threeFieldHierarchy(["a", "", ""])));
+    fakeFieldTypeDetector.setFieldType("first", "text");
+    fakeFieldTypeDetector.setTextValue("first", "a");
+
+    await build().execute({
+      fields: [{ selector: { elementId: "first" }, value: "a" }],
+    });
+
+    expect(fakeObserve.getCallCount()).toBe(2);
+  });
+
+  function createObserveResultFor(hierarchy: ViewHierarchyResult): ObserveResult {
+    return {
+      updatedAt: fakeTimer.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: hierarchy,
+    };
+  }
+});
+
 describe("SetUIState budget is unaffected by slow work before the search (#4252 review 2)", () => {
   const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
   let fakeTap: FakeTapOnElement;

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1099,23 +1099,30 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
     },
   });
 
-  test("reports per-field progress as a multi-field call advances", async () => {
+  test("reports strictly increasing progress as a multi-field call advances", async () => {
+    // No textValue overrides: the real FieldTypeDetector.getTextValue reads
+    // whichever hierarchy findElement actually resolved against, so each
+    // field's own isFieldAlreadyCorrect check genuinely fails on the
+    // not-yet-edited value and the real apply+verify path runs for all
+    // three fields -- exercising FakeTapOnElement/FakeClearText's own
+    // 0,10 / 0,10 child-progress pattern (not just the boundary ticks).
     let observeCallCount = 0;
+    const targets: [string, string, string] = ["a", "b", "c"];
     fakeObserve.setResultFactory(() => {
       observeCallCount++;
-      if (observeCallCount <= 1) {
-        return createObserveResultFor(threeFieldHierarchy(["", "", ""]));
+      // Exactly one observe happens per successfully-verified field after the
+      // initial one (the verify observe is reused as the post-success
+      // refresh), so call N reflects the first (N-1) fields already landed.
+      const doneCount = Math.min(3, observeCallCount - 1);
+      const values: [string, string, string] = ["", "", ""];
+      for (let i = 0; i < doneCount; i++) {
+        values[i] = targets[i];
       }
-      // Every observe after the initial one reflects all three fields filled --
-      // this test only cares about the progress trace, not exact sequencing.
-      return createObserveResultFor(threeFieldHierarchy(["a", "b", "c"]));
+      return createObserveResultFor(threeFieldHierarchy(values));
     });
     fakeFieldTypeDetector.setFieldType("first", "text");
     fakeFieldTypeDetector.setFieldType("second", "text");
     fakeFieldTypeDetector.setFieldType("third", "text");
-    fakeFieldTypeDetector.setTextValue("first", "a");
-    fakeFieldTypeDetector.setTextValue("second", "b");
-    fakeFieldTypeDetector.setTextValue("third", "c");
 
     const progressCalls: Array<{ progress: number; total?: number; message?: string }> = [];
     const progress = async (progressValue: number, total?: number, message?: string) => {
@@ -1134,21 +1141,23 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
     );
 
     expect(result.success).toBe(true);
-    // One progress notification per field-completed boundary at minimum, plus
-    // whatever each field's own tap/clear child steps contributed.
-    expect(progressCalls.length).toBeGreaterThanOrEqual(3);
+    // Each field's tap AND clear child steps report their own local 0,10 --
+    // two ticks apiece -- plus one field-boundary tick: at least 9 total.
+    expect(progressCalls.length).toBeGreaterThanOrEqual(9);
     // Every notification shares ONE consistent total across the whole call
     // (fieldCount * 100) -- not the per-field child steps' own local total,
     // and not a bare field-count total that would collide with those.
     expect(progressCalls.every((c) => c.total === 300)).toBe(true);
-    // Every field's own child steps (TapOnElement/ClearText, each reporting
-    // their own local 0..100 via the SAME callback) are projected into that
-    // field's 100-wide slice of the overall range, so the sequence across
-    // the whole call -- child ticks AND per-field boundary ticks together --
-    // never regresses.
+    // The whole sequence -- tap's 0,10, then clear's own 0,10 reset, repeated
+    // per field, plus the per-field boundary ticks -- must be STRICTLY
+    // increasing. MCP clients that enforce monotonicity reject or ignore a
+    // repeated value, not just a decrease, so a tie is as unacceptable as a
+    // regression here.
     for (let i = 1; i < progressCalls.length; i++) {
-      expect(progressCalls[i].progress).toBeGreaterThanOrEqual(progressCalls[i - 1].progress);
+      expect(progressCalls[i].progress).toBeGreaterThan(progressCalls[i - 1].progress);
     }
+    // Never exceeds the declared total.
+    expect(progressCalls.every((c) => c.progress <= 300)).toBe(true);
     // The three field-boundary ticks land at the top of each field's slice.
     expect(progressCalls.map((c) => c.progress)).toEqual(
       expect.arrayContaining([100, 200, 300]) as unknown as number[],
@@ -1197,10 +1206,11 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
     expect(boundaryTicks[0].message).toContain("Set field");
     expect(boundaryTicks[1].message).toContain("Failed field");
     // The whole trace -- child ticks from both fields' retries included --
-    // must never regress, even though field 2's tap fails and retries three
-    // times inside the same 100-wide slice.
+    // must be STRICTLY increasing, even though field 2's tap fails and
+    // retries three times inside the same 100-wide slice (each retry's tap
+    // re-emits the same local 0,10 pattern, which would otherwise tie).
     for (let i = 1; i < progressCalls.length; i++) {
-      expect(progressCalls[i].progress).toBeGreaterThanOrEqual(progressCalls[i - 1].progress);
+      expect(progressCalls[i].progress).toBeGreaterThan(progressCalls[i - 1].progress);
     }
   });
 

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1134,12 +1134,25 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
     );
 
     expect(result.success).toBe(true);
-    // One progress notification per field, reporting cumulative advancement.
+    // One progress notification per field-completed boundary at minimum, plus
+    // whatever each field's own tap/clear child steps contributed.
     expect(progressCalls.length).toBeGreaterThanOrEqual(3);
+    // Every notification shares ONE consistent total across the whole call
+    // (fieldCount * 100) -- not the per-field child steps' own local total,
+    // and not a bare field-count total that would collide with those.
+    expect(progressCalls.every((c) => c.total === 300)).toBe(true);
+    // Every field's own child steps (TapOnElement/ClearText, each reporting
+    // their own local 0..100 via the SAME callback) are projected into that
+    // field's 100-wide slice of the overall range, so the sequence across
+    // the whole call -- child ticks AND per-field boundary ticks together --
+    // never regresses.
+    for (let i = 1; i < progressCalls.length; i++) {
+      expect(progressCalls[i].progress).toBeGreaterThanOrEqual(progressCalls[i - 1].progress);
+    }
+    // The three field-boundary ticks land at the top of each field's slice.
     expect(progressCalls.map((c) => c.progress)).toEqual(
-      expect.arrayContaining([1, 2, 3]) as unknown as number[],
+      expect.arrayContaining([100, 200, 300]) as unknown as number[],
     );
-    expect(progressCalls.every((c) => c.total === 3)).toBe(true);
     expect(progressCalls[progressCalls.length - 1].message).toContain("3/3");
   });
 
@@ -1174,25 +1187,51 @@ describe("SetUIState progress reporting and observe reuse (#6222)", () => {
 
     expect(result.success).toBe(false);
     // A client watching progress must see field 1 succeed before field 2 fails
-    // -- it must not look like nothing happened.
-    expect(progressCalls.length).toBe(2);
-    expect(progressCalls[0].message).toContain("Set field");
-    expect(progressCalls[1].message).toContain("Failed field");
+    // -- it must not look like nothing happened. Field 1's tap/clear child
+    // steps and field 2's three failed-tap retries all report their own
+    // progress too, so isolate the two per-field boundary ticks by message.
+    const boundaryTicks = progressCalls.filter(
+      (c) => c.message?.includes("Set field") || c.message?.includes("Failed field"),
+    );
+    expect(boundaryTicks.length).toBe(2);
+    expect(boundaryTicks[0].message).toContain("Set field");
+    expect(boundaryTicks[1].message).toContain("Failed field");
+    // The whole trace -- child ticks from both fields' retries included --
+    // must never regress, even though field 2's tap fails and retries three
+    // times inside the same 100-wide slice.
+    for (let i = 1; i < progressCalls.length; i++) {
+      expect(progressCalls[i].progress).toBeGreaterThanOrEqual(progressCalls[i - 1].progress);
+    }
   });
 
   test("does not re-observe after a verified success -- reuses verification's own observation", async () => {
-    // Single field, verification enabled (no text-only-selector skip, since
-    // elementId selector is used). Only two observes should occur total: the
-    // initial observe, and the one verifyFieldValue performs. No third,
-    // separate "refresh" observe should follow it.
-    fakeObserve.setResultFactory(() => createObserveResultFor(threeFieldHierarchy(["a", "", ""])));
+    // Single field, starting value differs from the target so the apply+verify
+    // path actually runs (isFieldAlreadyCorrect must be false, or verification
+    // -- and this whole test -- never happens). No textValue override is set:
+    // the real FieldTypeDetector.getTextValue reads the element's own `text`
+    // straight off whichever hierarchy findElement resolved against, so the
+    // pre-edit observe genuinely reports "" and the post-edit one genuinely
+    // reports "a".
+    //
+    // Only two observes should occur total: the initial observe, and the one
+    // verifyFieldValue performs. Without the fix, a third, separate "refresh"
+    // observe follows verification's -- this test fails against that
+    // (pre-fix) behavior with callCount === 3 and passes at 2.
+    let observeCallCount = 0;
+    fakeObserve.setResultFactory(() => {
+      observeCallCount++;
+      const value = observeCallCount === 1 ? "" : "a";
+      return createObserveResultFor(threeFieldHierarchy([value, "", ""]));
+    });
     fakeFieldTypeDetector.setFieldType("first", "text");
-    fakeFieldTypeDetector.setTextValue("first", "a");
 
-    await build().execute({
+    const result = await build().execute({
       fields: [{ selector: { elementId: "first" }, value: "a" }],
     });
 
+    expect(result.success).toBe(true);
+    expect(result.fields[0].verified).toBe(true);
+    expect(result.fields[0].skipped).toBeUndefined();
     expect(fakeObserve.getCallCount()).toBe(2);
   });
 


### PR DESCRIPTION
## Problem

`setUIState` applies every field successfully (e.g. 3 form fields) and then returns a bare `MCP error -32001: Request timed out` — no result, no partial result. A timeout with no result is indistinguishable from "nothing happened" client-side, so the natural client behavior is to retry — duplicating text input or flipping a `selected: true` toggle back. `setUIState` is also the one tool whose cost scales with a client-controlled input array, so it's the tool least able to predict when it will exceed the transport timeout.

Closes #6222

## Mechanism found

`SetUIState.execute()` never called its own `progress` callback — it only forwarded `progress` into `TapOnElement`/`SwipeOn` for their own sub-steps, so nothing signaled advancement at the field-completed granularity.

On top of that, for any field requiring verification (the common case — plain text/checkbox/toggle/dropdown fields without a skip condition), `processField` already fetched a fresh observation inside `verifyFieldValue`, and then `execute()` immediately issued *another* fresh observation to refresh state before the next loop iteration. That's two back-to-back device observes capturing effectively the same post-edit state. Doubling the per-field device round-trip cost, multiplied across a client-controlled `fields` array, is what pushed multi-field calls past the MCP request timeout — after the fields had already landed.

## Fix

1. **Progress notifications** — `execute()` now calls `progress?.(processed, total, message)` after every field is processed (success or failure), with a message describing which field and the outcome. This keeps progress-aware clients' requests alive (many MCP clients reset a live request's timeout on progress) and gives every client a durable trace of what already landed before a timeout could otherwise leave it blind.
2. **Bounded/de-duplicated trailing observe** — `verifyFieldValue` now returns the observation it fetched, and `execute()` reuses it (via a small `observationAfterSuccess` helper) instead of issuing a second, redundant observe. This roughly halves the dominant per-field device cost for verified fields.
3. **Structured per-field result** — `SetUIStateResult.fields` already reports `success`/`verified`/`error`/`skipped` per field; that was already in place and is unaffected, but now reaches the client in materially less wall-clock time, and — via (1) — the client has visibility into per-field progress even before the final response arrives.

No public schema changes (fields already existed in `SetUIStateResult`/`FieldResult`).

## Tests

Added to `test/features/action/SetUIState.test.ts` (deterministic, injected fakes + `FakeTimer`, no real device/DB):
- multi-field call emits one progress notification per field with cumulative `progress`/`total` and a descriptive message
- progress trace stops truthfully at a mid-loop failure (shows success then failure, not silence)
- a single verified field triggers exactly the initial observe + verification's observe — no extra "refresh" observe

## Validation

- `bun test test/features/action/SetUIState.test.ts` — 27 pass, 209ms
- `bun test test/features/action/` — 1221 pass
- `bun test test/server/` — 2387 pass
- `bun run lint` — no new ratchet violations (oxlint `execute` complexity actually dropped 20→18 from the extracted helper)
- `bun run typecheck` — no new type errors (pre-existing baselined `ObserveScreen.execute` overload mismatch shifted column, not a new error — same count)
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds

No tool schema changes, so `scripts/update-tool-definitions.sh` was not needed (its pre-commit hook confirmed `schemas/tool-definitions.json` already up to date).