### PR TITLE
fix(observe): disambiguate duplicate skeleton ids and preserve identifying row labels (#6221)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4688,6 +4688,12 @@
               },
               "checked": {
                 "type": "boolean"
+              },
+              "index": {
+                "description": "Disambiguator present only when elementId repeats elsewhere in this skeleton (issue #6221). Pass verbatim as tapOn({ selector, index }) to hit this exact entry.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
               }
             },
             "required": ["bounds", "affordances"],

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -131,6 +131,8 @@ interface SkeletonAccumulator {
    * where hoisting/suppression fall back to geometric containment.
    */
   provenance?: ElementProvenance;
+  /** Disambiguator assigned by {@link assignDuplicateIndexes} (issue #6221 item 2). */
+  index?: number;
 }
 
 /** NUL-joined identity so `(elementId, label, bounds)` triples dedup without straddling. */
@@ -322,9 +324,32 @@ function distinctHoistParts(
 }
 
 /**
- * Fold `parts` onto the container: the first becomes `label` when it has none,
- * and the remainder join into `sublabel`. A container with an own label keeps it
- * and takes every part as `sublabel`.
+ * Whether `label` is an incomplete/templated own-label rather than a genuine
+ * one (issue #6221 item 3). A real Android row label built from a
+ * `"$time $name"`-style template (e.g. an alarm row) leaves its leading
+ * delimiter behind when the interpolated part comes back empty — the observed
+ * repro was a row whose own text/content-desc read literally `" Alarm"`
+ * (leading space, no time), while a sibling row of the same type read
+ * `"6:45 AM Alarm"` (own text already complete, nothing to fold in). Stray
+ * leading/trailing whitespace on the RAW (untrimmed) label is a narrow, strong
+ * signal of exactly that dropped-placeholder shape — unlike an ordinary clean
+ * single-word label ("Wi-Fi", "Alarm" with no stray space), which must NOT be
+ * clobbered by a descendant's state text (that text belongs in `sublabel`,
+ * per the AC2 #5869 behavior above).
+ */
+function isIncompleteOwnLabel(label: string): boolean {
+  return label !== label.trim();
+}
+
+/**
+ * Fold `parts` onto the container: the first becomes `label` when it has none
+ * — or when its existing own label is an incomplete template
+ * ({@link isIncompleteOwnLabel}), in which case the first part is prepended to
+ * the trimmed own label so the row keeps its generic noun ("Alarm") without
+ * losing the identifying descendant text ("8:30 AM") that made the row unique
+ * (issue #6221 item 3). The remainder always joins into `sublabel`. A
+ * container with a genuine own label keeps it verbatim and takes every part
+ * as `sublabel`.
  */
 function applyHoistedLabels(container: SkeletonAccumulator, parts: string[]): void {
   if (parts.length === 0) {
@@ -332,6 +357,11 @@ function applyHoistedLabels(container: SkeletonAccumulator, parts: string[]): vo
   }
   if (container.label === undefined) {
     container.label = parts[0];
+    if (parts.length > 1) {
+      container.sublabel = parts.slice(1).join(", ");
+    }
+  } else if (isIncompleteOwnLabel(container.label)) {
+    container.label = `${parts[0]} ${container.label.trim()}`;
     if (parts.length > 1) {
       container.sublabel = parts.slice(1).join(", ");
     }
@@ -390,10 +420,16 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
     entry.elementId = acc.elementId;
   }
   if (acc.label !== undefined) {
-    entry.label = acc.label;
+    // Never emit a leading/trailing space (issue #6221 item 3(b)) — a
+    // templated own label whose interpolated part came back empty (e.g. an
+    // alarm row's `" Alarm"`) leaves the delimiter behind even after
+    // {@link applyHoistedLabels} has folded in the identifying descendant
+    // text, and a container with no hoist candidates at all never runs that
+    // fold in the first place.
+    entry.label = acc.label.trim();
   }
   if (acc.sublabel !== undefined) {
-    entry.sublabel = acc.sublabel;
+    entry.sublabel = acc.sublabel.trim();
   }
   if (acc.testTag !== undefined) {
     entry.testTag = acc.testTag;
@@ -404,7 +440,71 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
   if (acc.checked !== undefined) {
     entry.checked = acc.checked;
   }
+  if (acc.index !== undefined) {
+    entry.index = acc.index;
+  }
   return entry;
+}
+
+/**
+ * Order two accumulators the way `tapOn`'s own explicit-`index` resolution
+ * does, so a per-entry `index` this file emits is guaranteed usable verbatim
+ * as `tapOn.index` (issue #6221 item 2).
+ *
+ * `DefaultElementSelector.pickMatch` treats an explicit `index` as "the Nth
+ * on-screen match in hierarchy order" and — critically — resolves it against
+ * the RAW DFS traversal order `ElementFinder.findElementsByResourceId` returns
+ * with `preserveTraversalOrder: true` (selecting by index skips the by-area
+ * sort `selectionStrategy: "first"` otherwise applies). That traversal order
+ * is exactly the pre-order DFS counter this file's provenance already carries:
+ * `ElementProvenance.enter`, assigned once per element by
+ * `DefaultObserveElementCollector` while walking the SAME root-group order
+ * `ElementFinder` walks (main roots, then window roots topmost-first) — so
+ * ranking duplicate entries by `enter` reproduces tapOn's index assignment
+ * exactly. Provenance-less producers (hand-built fixtures, non-provenance
+ * callers) fall back to the skeleton's own top-to-bottom/left-to-right reading
+ * order, the closest available approximation without a real traversal to rank
+ * against.
+ */
+function byHierarchyOrder(a: SkeletonAccumulator, b: SkeletonAccumulator): number {
+  if (a.provenance && b.provenance) {
+    return a.provenance.enter - b.provenance.enter;
+  }
+  return byReadingOrder(a, b);
+}
+
+/**
+ * Emit a stable per-entry `index` (issue #6221 item 2) on every entry whose
+ * `elementId` repeats within this skeleton, so a client can disambiguate with
+ * `tapOn({ selector: { elementId }, index: entry.index })` instead of
+ * guessing against the undocumented default `selectionStrategy: "first"`.
+ * Entries with a unique `elementId` (including all entries with no
+ * `elementId` at all) are left untouched — no spurious `index` on the common
+ * case. See {@link byHierarchyOrder} for why ranking by `enter` reproduces
+ * `tapOn.index` verbatim.
+ */
+function assignDuplicateIndexes(entries: SkeletonAccumulator[]): void {
+  const byElementId = new Map<string, SkeletonAccumulator[]>();
+  for (const entry of entries) {
+    if (entry.elementId === undefined) {
+      continue;
+    }
+    const group = byElementId.get(entry.elementId);
+    if (group) {
+      group.push(entry);
+    } else {
+      byElementId.set(entry.elementId, [entry]);
+    }
+  }
+  for (const group of byElementId.values()) {
+    if (group.length < 2) {
+      continue;
+    }
+    group.sort(byHierarchyOrder);
+    group.forEach((entry, position) => {
+      entry.index = position;
+    });
+  }
 }
 
 /**
@@ -419,5 +519,11 @@ export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
   // #5869) before the keep filter suppresses the now-folded text accumulators.
   hoistContainerLabels(accumulators, clickable);
 
-  return accumulators.filter((acc) => shouldKeep(acc, clickable)).map(toSkeletonEntry);
+  const kept = accumulators.filter((acc) => shouldKeep(acc, clickable));
+  // Disambiguate duplicate ids (issue #6221 item 2) against the FINAL emitted
+  // set, not the pre-filter accumulators — a duplicate suppressed by the keep
+  // rule (e.g. folded/hoisted text) must not consume an index slot a client
+  // will never see.
+  assignDuplicateIndexes(kept);
+  return kept.map(toSkeletonEntry);
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -104,6 +104,16 @@ export interface SkeletonElement {
   affordances: Affordance[];
   /** Present only for a `toggle` affordance: the current checked state. */
   checked?: boolean;
+  /**
+   * Disambiguator (issue #6221 item 2), present only when `elementId` repeats
+   * elsewhere in this same skeleton. Pass it verbatim as `tapOn({ selector,
+   * index })` to hit this exact entry instead of the `selectionStrategy:
+   * "first"` default: `index` is 0-based rank in the same "Nth on-screen match
+   * in hierarchy order" that `tapOn.index` itself resolves against (see
+   * `SkeletonProjection.assignDuplicateIndexes` for how the two are kept in
+   * sync). Unique-id entries never carry this field.
+   */
+  index?: number;
 }
 
 export type ScreenIdentitySource = "heuristic" | "sdk";

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -581,6 +581,16 @@ export const skeletonElementSchema = z
     ),
     affordances: z.array(z.enum(["tap", "long-press", "input", "scroll", "toggle"])),
     checked: z.boolean().optional(),
+    index: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Disambiguator present only when elementId repeats elsewhere in this " +
+          "skeleton (issue #6221). Pass verbatim as tapOn({ selector, index }) to " +
+          "hit this exact entry.",
+      ),
   })
   .passthrough();
 

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { toSkeleton } from "../../../../src/features/observe/output/SkeletonProjection";
 import { setElementProvenance } from "../../../../src/features/observe/output/elementProvenance";
 import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
+import { DefaultElementSelector } from "../../../../src/features/utility/DefaultElementSelector";
 import { tapOnSchema } from "../../../../src/server/interactionTools";
 import type { Element } from "../../../../src/models/Element";
 import type { ObserveResult } from "../../../../src/models/ObserveResult";
 import type { SkeletonElement } from "../../../../src/models/ObserveResult";
+import type { ViewHierarchyResult } from "../../../../src/models/ViewHierarchyResult";
 import scrollBeforeFixture from "../../../fixtures/observe/diff/scroll-before.json";
 
 type ObserveElements = NonNullable<ObserveResult["elements"]>;
@@ -679,6 +681,203 @@ describe("toSkeleton — acceptance criteria", () => {
   describe("empty input", () => {
     test("no elements yields an empty skeleton", () => {
       expect(toSkeleton(makeElements({}))).toEqual([]);
+    });
+  });
+
+  describe("#6221 item 2: duplicate-id disambiguator", () => {
+    test("unique-id entries never carry an index", () => {
+      const a: Element = { bounds: bounds(0, 0, 10, 10), "resource-id": "a", clickable: "true" };
+      const b: Element = { bounds: bounds(0, 20, 10, 30), "resource-id": "b", clickable: "true" };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [a, b] }));
+
+      expect(skeleton).toHaveLength(2);
+      for (const entry of skeleton) {
+        expect("index" in entry).toBe(false);
+      }
+    });
+
+    test("a repeated id gets a per-entry index ranked by provenance hierarchy order", () => {
+      const withProvenance = (el: Element, enter: number): Element => {
+        setElementProvenance(el, { group: 0, enter, exit: enter });
+        return el;
+      };
+      // Deliberately out of array order to prove ranking follows hierarchy
+      // order (provenance.enter), not array position or geometry.
+      const third = withProvenance(
+        { bounds: bounds(0, 400, 100, 450), "resource-id": "dup", clickable: "true" },
+        5,
+      );
+      const first = withProvenance(
+        { bounds: bounds(0, 0, 100, 50), "resource-id": "dup", clickable: "true" },
+        1,
+      );
+      const second = withProvenance(
+        { bounds: bounds(0, 200, 100, 250), "resource-id": "dup", clickable: "true" },
+        3,
+      );
+      const unrelated = withProvenance(
+        { bounds: bounds(0, 600, 100, 650), "resource-id": "solo", clickable: "true" },
+        7,
+      );
+
+      const skeleton = toSkeleton(makeElements({ clickable: [third, first, second, unrelated] }));
+
+      const byBoundsTop = (a: SkeletonElement, b: SkeletonElement) => a.bounds[1] - b.bounds[1];
+      const dupEntries = skeleton.filter((e) => e.elementId === "dup").sort(byBoundsTop);
+      expect(dupEntries.map((e) => e.index)).toEqual([0, 1, 2]);
+      expect(findById(skeleton, "solo")?.index).toBeUndefined();
+    });
+
+    test("the emitted index is verbatim usable by tapOn's own index resolution (ordering contract)", () => {
+      // Three rows sharing a resource-id, built through the REAL collector so
+      // provenance.enter is the real DFS counter — the same one
+      // ElementFinder.findElementsByResourceId walks for an explicit index.
+      const viewHierarchy = {
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 1920 },
+            node: [
+              {
+                "resource-id": "com.example:id/onoff",
+                clickable: "true",
+                bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+              },
+              {
+                "resource-id": "com.example:id/onoff",
+                clickable: "true",
+                bounds: { left: 0, top: 200, right: 100, bottom: 300 },
+              },
+              {
+                "resource-id": "com.example:id/onoff",
+                clickable: "true",
+                bounds: { left: 0, top: 400, right: 100, bottom: 500 },
+              },
+            ],
+          },
+        },
+      } as unknown as NonNullable<ObserveResult["viewHierarchy"]>;
+
+      const elements = new DefaultObserveElementCollector().collect(viewHierarchy, "android");
+      const skeleton = toSkeleton(elements!);
+      const dupEntries = skeleton
+        .filter((e) => e.elementId === "com.example:id/onoff")
+        .sort((a, b) => (a.index ?? -1) - (b.index ?? -1));
+      expect(dupEntries).toHaveLength(3);
+      expect(dupEntries.map((e) => e.index)).toEqual([0, 1, 2]);
+
+      const selector = new DefaultElementSelector();
+      for (const entry of dupEntries) {
+        const result = selector.selectByResourceId(
+          viewHierarchy as unknown as ViewHierarchyResult,
+          "com.example:id/onoff",
+          { index: entry.index },
+        );
+        expect(result.element).not.toBeNull();
+        const chosenBounds = result.element?.bounds;
+        expect([
+          chosenBounds?.left,
+          chosenBounds?.top,
+          chosenBounds?.right,
+          chosenBounds?.bottom,
+        ]).toEqual(entry.bounds);
+      }
+    });
+  });
+
+  describe("#6221 item 3: identifying descendant text is not dropped from a generic own label", () => {
+    test("a leading-space generic own label folds in the identifying descendant text, trimmed", () => {
+      // Mirrors the dogfood repro: an alarm row whose own text/content-desc
+      // template dropped the time (" Alarm", leading space) while a sibling
+      // digital_clock descendant still carries the real distinguishing text,
+      // and a schedule descendant carries secondary state.
+      const row: Element = {
+        bounds: bounds(0, 0, 1080, 240),
+        "resource-id": "com.google.android.deskclock:id/alarm_item",
+        "content-desc": " Alarm",
+        clickable: "true",
+      };
+      const digitalClock: Element = {
+        bounds: bounds(72, 20, 400, 80),
+        "resource-id": "com.google.android.deskclock:id/digital_clock",
+        text: "8:30 AM",
+      };
+      const daysOfWeek: Element = {
+        bounds: bounds(72, 140, 600, 200),
+        "resource-id": "com.google.android.deskclock:id/days_of_week",
+        text: "Mon, Tue, Wed, Thu, Fri",
+      };
+
+      const skeleton = toSkeleton(
+        makeElements({ clickable: [row], text: [digitalClock, daysOfWeek] }),
+      );
+
+      const entry = findById(skeleton, "com.google.android.deskclock:id/alarm_item");
+      expect(entry?.label).toBe("8:30 AM Alarm");
+      expect(entry?.sublabel).toBe("Mon, Tue, Wed, Thu, Fri");
+      // No leading/trailing whitespace anywhere in the emitted strings.
+      expect(entry?.label).not.toMatch(/^\s|\s$/);
+      expect(entry?.sublabel).not.toMatch(/^\s|\s$/);
+    });
+
+    test("a clean (non-templated) own label is left alone; descendant text still folds into sublabel", () => {
+      // The "good" sibling row from the same repro: own text is already
+      // complete ("6:45 AM Alarm", no stray whitespace), so nothing is
+      // rewritten — this must keep working exactly as before (AC2 #5869).
+      const row: Element = {
+        bounds: bounds(0, 0, 1080, 240),
+        "resource-id": "com.google.android.deskclock:id/alarm_item",
+        text: "6:45 AM Alarm",
+        clickable: "true",
+      };
+      const notScheduled: Element = {
+        bounds: bounds(72, 140, 600, 200),
+        "resource-id": "com.google.android.deskclock:id/status",
+        text: "Not scheduled",
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [row], text: [notScheduled] }));
+
+      const entry = findById(skeleton, "com.google.android.deskclock:id/alarm_item");
+      expect(entry?.label).toBe("6:45 AM Alarm");
+      expect(entry?.sublabel).toBe("Not scheduled");
+    });
+
+    test("an ordinary single-word own label is NOT clobbered by descendant state text", () => {
+      // Regression guard: a clean, non-templated single-word label ("Wi-Fi")
+      // must still route descendant text to sublabel, not get rewritten just
+      // because it happens to be short/generic-looking.
+      const row: Element = {
+        bounds: bounds(0, 0, 1080, 240),
+        "resource-id": "wifi-row",
+        text: "Wi-Fi",
+        clickable: "true",
+      };
+      const state: Element = {
+        bounds: bounds(72, 140, 600, 200),
+        "resource-id": "wifi-state",
+        text: "Connected",
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [row], text: [state] }));
+
+      const entry = findById(skeleton, "wifi-row");
+      expect(entry?.label).toBe("Wi-Fi");
+      expect(entry?.sublabel).toBe("Connected");
+    });
+
+    test("a leading-space own label with no hoist candidates is still trimmed", () => {
+      const row: Element = {
+        bounds: bounds(0, 0, 1080, 240),
+        "resource-id": "lonely-row",
+        "content-desc": " Alarm",
+        clickable: "true",
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [row] }));
+
+      const entry = findById(skeleton, "lonely-row");
+      expect(entry?.label).toBe("Alarm");
     });
   });
 });


### PR DESCRIPTION
Part of #6221 — implements items 2 and 3 only. Items 1 and 4 from that issue are separate follow-up PRs.

## Item 2 — duplicate ids inside one skeleton need a disambiguator

A skeleton can contain the same resource-id many times (e.g. `:id/digital_clock` ×4), each documented as "directly usable as a tapOn selector", but each resolves to N elements and `selectionStrategy` defaults to `first`. The only escape was `tapOn.index`, whose doc ("the Nth on-screen match in hierarchy order") never said whether that matched skeleton array order.

`toSkeleton` now emits a stable per-entry `index` on every entry whose `elementId` repeats within that skeleton, so a client can disambiguate with `tapOn({ selector, index: entry.index })`. Unique-id entries never carry the field.

The value is ranked by `ElementProvenance.enter` — the same pre-order DFS traversal counter `ElementFinder` walks when `tapOn` resolves an explicit index (an explicit index skips the by-area sort `selectionStrategy: "first"` otherwise applies, so it resolves against raw traversal order). This is verified in a test that drives the real `ObserveElementCollector` + `DefaultElementSelector` against the same view hierarchy and confirms `selectByResourceId(..., { index })` lands on the exact bounds the skeleton entry names — so the ordering contract is checked in code, not just asserted in a comment.

## Item 3 — parent-row labels drop the child text that identifies the row + leading space

Row labels could aggregate to things like `" Alarm"` (leading space, time dropped) while a sibling row kept its time (`"6:45 AM Alarm"`). The row is the tappable/unique-id element; its child (e.g. `digital_clock`) held the distinguishing time but was one of the duplicate ids from item 2.

`hoistContainerLabels` now detects a narrow, specific shape: a container's own label with stray leading/trailing whitespace (a strong signal of a templated string whose interpolated part came back empty, e.g. `" Alarm"`). When that shape is detected, the identifying descendant text is folded into the label instead of being silently routed to `sublabel` only. Every emitted `label`/`sublabel` is also trimmed unconditionally, so no leading/trailing space ever reaches the client regardless of whether hoisting ran.

An ordinary clean single-word own label (e.g. `"Wi-Fi"`) is left untouched — descendant state text still routes to `sublabel` exactly as before (regression-guarded by a new test).

## Other changes

- Added `index` to `SkeletonElement` (`src/models/ObserveResult.ts`) and `skeletonElementSchema` (`src/server/toolOutputSchemas.ts`), and regenerated `schemas/tool-definitions.json`.

## Validation

- `bun test test/features/observe/output/skeletonProjection.test.ts` — 44 pass, 0 fail (~230ms)
- `bun run lint` — no new violations (ratchet gate green)
- `bun run typecheck` — no new type errors (baseline gate green)
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds