### PR TITLE
fix(observe): stop stamping verified/isFresh on stale/incomplete hierarchies; report launch-verify failure (#6219, #6220)

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -17,6 +17,7 @@ import {
 import { ClearAppData } from "./ClearAppData";
 import { logger } from "../../utils/logger";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
+import { resolveMissingForegroundWindow } from "../observe/ObserveScreen";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppManager } from "../../utils/ios-cmdline-tools/DeviceAppManager";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
@@ -1023,15 +1024,19 @@ export class LaunchApp extends BaseVisualChange {
     // Distinguish "genuinely launched but no foreground window could be read at
     // all" from "observed a different/stale app" (issue #6220 follow-up). The
     // latter is a real mismatch — reject and strip the stale observation, as
-    // before. The former names no app whatsoever (`activeWindow.appId` AND
-    // `viewHierarchy.packageName` both empty) — most commonly the status-bar-only
-    // shape ObserveScreen's own freshness now marks `verified: false` for
-    // (#6220). That is not evidence of a wrong app; treating it identically
-    // would reject-and-delete the very observation `buildLaunchAppResponse`
-    // needs to report a structured `verified: false` + `verifyFailureReason`
-    // instead of a silent/thrown failure. Preserve it: the launch action itself
-    // already succeeded, only window verification could not be confirmed.
-    if (this.getLaunchObservationPackageNames(latestObservation).length === 0) {
+    // before. The former is checked via `isMissingForegroundWindow`, a
+    // MACHINE-READABLE verdict reused verbatim from the observe freshness gate
+    // rather than re-derived from package-name absence: a status-bar-only
+    // capture can still carry STALE `packageName`/`foregroundActivity`
+    // metadata left over from a previously-resumed app, so "has package
+    // names" alone would wrongly classify it as a wrong-app mismatch (issue
+    // #6239 review follow-up). Checking the verdict FIRST — before
+    // package-count — means a status-bar-only/no-window capture is preserved
+    // as a structured `verified: false` + `verifyFailureReason` no matter what
+    // stale attribution it still carries; only a genuinely COMPLETE capture (a
+    // real foreground window) naming a different app falls through to the
+    // wrong-app reject path below.
+    if (this.isMissingForegroundWindow(latestObservation)) {
       logger.warn(
         `[LaunchApp] Launch observation for ${expectedPackageName} reports no foreground window after ${timeoutMs}ms; preserving it for the response instead of rejecting it as a stale/wrong-app capture`,
       );
@@ -1164,6 +1169,21 @@ export class LaunchApp extends BaseVisualChange {
 
     const fallbackPackageName = this.packageFromForegroundActivity(observation);
     return fallbackPackageName ? [fallbackPackageName] : [];
+  }
+
+  /**
+   * Whether an observation reports no foreground window at all (issue #6220
+   * follow-up, #6239 review): either the same machine-readable verdict the
+   * observe freshness gate uses (`resolveMissingForegroundWindow` — catches a
+   * status-bar-only capture even when it still carries stale identity
+   * metadata), or the plain "no package names at all" case that verdict
+   * doesn't cover (e.g. no `viewHierarchy` at all).
+   */
+  private isMissingForegroundWindow(observation: ObserveResult): boolean {
+    return (
+      resolveMissingForegroundWindow(observation) !== undefined ||
+      this.getLaunchObservationPackageNames(observation).length === 0
+    );
   }
 
   /**

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1138,14 +1138,32 @@ export class LaunchApp extends BaseVisualChange {
     return foregroundActivity.split("/")[0] || undefined;
   }
 
+  /**
+   * `foregroundActivity` is a FALLBACK identity signal, not an equal-weight
+   * match requirement (issue #6220 follow-up, P1): the primary signals
+   * (`activeWindow.appId`, `viewHierarchy.packageName`) are reconciled/settled
+   * values, while `foregroundActivity` is the raw accessibility read and can
+   * lag a same-observation A->B transition — e.g. a successful launch to B
+   * where `activeWindow`/`viewHierarchy` already agree on B but the wire's
+   * `foregroundActivity` still names the PREVIOUS app A. Contributing A as a
+   * competing package alongside a settled B would fail the `every` match
+   * check on a launch that actually succeeded. So: when either primary signal
+   * is present, it ALONE decides the match/attribution and `foregroundActivity`
+   * is not even consulted; only when BOTH primary signals are absent does
+   * `foregroundActivity`'s package become the (sole) fallback.
+   */
   private getLaunchObservationPackageNames(observation: ObserveResult): string[] {
-    const packageNames = [
+    const primaryPackageNames = [
       observation.activeWindow?.appId,
       observation.viewHierarchy?.packageName,
-      this.packageFromForegroundActivity(observation),
     ].filter((packageName): packageName is string => !!packageName);
 
-    return [...new Set(packageNames)];
+    if (primaryPackageNames.length > 0) {
+      return [...new Set(primaryPackageNames)];
+    }
+
+    const fallbackPackageName = this.packageFromForegroundActivity(observation);
+    return fallbackPackageName ? [fallbackPackageName] : [];
   }
 
   /**

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1020,6 +1020,28 @@ export class LaunchApp extends BaseVisualChange {
       }
     }
 
+    // Distinguish "genuinely launched but no foreground window could be read at
+    // all" from "observed a different/stale app" (issue #6220 follow-up). The
+    // latter is a real mismatch — reject and strip the stale observation, as
+    // before. The former names no app whatsoever (`activeWindow.appId` AND
+    // `viewHierarchy.packageName` both empty) — most commonly the status-bar-only
+    // shape ObserveScreen's own freshness now marks `verified: false` for
+    // (#6220). That is not evidence of a wrong app; treating it identically
+    // would reject-and-delete the very observation `buildLaunchAppResponse`
+    // needs to report a structured `verified: false` + `verifyFailureReason`
+    // instead of a silent/thrown failure. Preserve it: the launch action itself
+    // already succeeded, only window verification could not be confirmed.
+    if (this.getLaunchObservationPackageNames(latestObservation).length === 0) {
+      logger.warn(
+        `[LaunchApp] Launch observation for ${expectedPackageName} reports no foreground window after ${timeoutMs}ms; preserving it for the response instead of rejecting it as a stale/wrong-app capture`,
+      );
+      result.observation = this.preserveLaunchObservationMetadata(
+        latestObservation,
+        result.observation,
+      );
+      return result;
+    }
+
     return this.withoutStaleLaunchObservation(
       {
         ...result,

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1119,10 +1119,30 @@ export class LaunchApp extends BaseVisualChange {
     return packageNames.length > 0 ? packageNames.join(", ") : "unknown app";
   }
 
+  /**
+   * Extract the package name from `viewHierarchy.foregroundActivity` (issue
+   * #6220 follow-up): the raw accessibility signal, in the standard
+   * `package/activity` (or `package/.RelativeActivity`) wire format. This is
+   * the ONE remaining app-identity signal on a hierarchy that carries neither
+   * `activeWindow.appId` nor `viewHierarchy.packageName` — e.g. no screen
+   * dimensions, so `ObserveScreen` never derives `activeWindow` from it — and
+   * it must feed the SAME match/mismatch decision this identity drives
+   * elsewhere, so a `foregroundActivity` naming a different app is a
+   * detected mismatch rather than an empty-package vacuous accept.
+   */
+  private packageFromForegroundActivity(observation: ObserveResult): string | undefined {
+    const foregroundActivity = observation.viewHierarchy?.foregroundActivity;
+    if (!foregroundActivity) {
+      return undefined;
+    }
+    return foregroundActivity.split("/")[0] || undefined;
+  }
+
   private getLaunchObservationPackageNames(observation: ObserveResult): string[] {
     const packageNames = [
       observation.activeWindow?.appId,
       observation.viewHierarchy?.packageName,
+      this.packageFromForegroundActivity(observation),
     ].filter((packageName): packageName is string => !!packageName);
 
     return [...new Set(packageNames)];

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -607,6 +607,46 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
+  /**
+   * Guard against a self-contradicting response (issue #6219): `effect` says the
+   * screen already changed (`screenChanged: true`), but the observation attached
+   * to the SAME payload predates that transition and still stamps
+   * `freshness.verified/isFresh: true` — a client sees a stale, pre-tap tree
+   * asserted as trustworthy in the very response that also reports the window
+   * changed. Re-derives the comparison against `result.observation` as it
+   * stands right before it is returned (after any downstream mutation, e.g.
+   * `selectionStateTracker.finalize`), rather than trusting whichever
+   * intermediate observation `effect` was originally computed from, so a later
+   * mutation cannot leave the two fields disagreeing in the response.
+   *
+   * Only ever retracts freshness — never invents a `screenChanged: true` an
+   * observation didn't earn — and only when `effect` itself claims a change.
+   */
+  private enforceFreshnessConsistencyWithEffect(
+    previousObservation: ObserveResult | null,
+    result: { effect?: TapOnElementResult["effect"]; observation?: ObserveResult },
+  ): void {
+    if (!previousObservation || !result.observation || result.effect?.screenChanged !== true) {
+      return;
+    }
+    const reDerived = this.deriveTapEffect(previousObservation, result.observation);
+    if (reDerived?.screenChanged === true) {
+      // The observation being returned is itself consistent with the detected
+      // transition — nothing to correct.
+      return;
+    }
+    const existing = result.observation.freshness;
+    result.observation.freshness = {
+      ...(existing ?? { isFresh: true }),
+      verified: false,
+      isFresh: false,
+      warning:
+        "effect.screenChanged is true, but this observation's own capture still matches the " +
+        "pre-action screen — it predates the detected transition. Call observe again for the " +
+        "current, post-action state.",
+    };
+  }
+
   private isElementTapTargetOffScreen(
     element: Element,
     screenSize?: ObserveResult["screenSize"],
@@ -1763,6 +1803,7 @@ export class TapOnElement extends BaseVisualChange {
         if (selectedElements.length > 0) {
           result.observation.selectedElements = selectedElements;
         }
+        this.enforceFreshnessConsistencyWithEffect(previousObserveResult, result);
       }
 
       if (options.action === "longPress") {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -232,7 +232,18 @@ function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
 function resolveMissingForegroundWindow(
   result: ObserveResult,
 ): { reason: "status_bar_only" | "empty_active_window" } | undefined {
-  if (result.activeWindow?.appId || !result.viewHierarchy?.hierarchy?.node) {
+  // `viewHierarchy.packageName` is checked directly (not only via
+  // `activeWindow.appId`, which the package-attribution fallback above should
+  // already have backfilled from it): later stages (e.g.
+  // `reconcileActiveWindowAttribution`, the SystemUI-overlay mirroring) can
+  // still re-derive `activeWindow` after this point, and a package-attributed
+  // capture must never be reported as having no foreground window regardless
+  // of what runs afterward (issue #6220 false-positive).
+  if (
+    result.activeWindow?.appId ||
+    result.viewHierarchy?.packageName ||
+    !result.viewHierarchy?.hierarchy?.node
+  ) {
     return undefined;
   }
   return { reason: isStatusBarOnlyHierarchy(result) ? "status_bar_only" : "empty_active_window" };
@@ -968,7 +979,12 @@ export class RealObserveScreen implements ObserveScreen {
 
         // Preserve package attribution when the accessibility service did not
         // provide a usable activity and the legacy window query also failed.
-        if (result.viewHierarchy?.packageName && !result.activeWindow) {
+        // `!result.activeWindow?.appId` (not `!result.activeWindow`): the legacy
+        // query's own failure sentinel is a TRUTHY object with an empty appId
+        // (`Window.getActive`'s catch branch), which would otherwise short-circuit
+        // this fallback and leave a readable, package-attributed capture wrongly
+        // reporting no foreground window (issue #6220 false-positive).
+        if (result.viewHierarchy?.packageName && !result.activeWindow?.appId) {
           result.activeWindow = {
             appId: result.viewHierarchy.packageName,
             activityName: "",

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -229,21 +229,39 @@ function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
  * `unavailable` freshness path instead — this is only about a hierarchy that
  * WAS captured but carries no window identity.
  */
+/**
+ * Whether the observation carries ANY signal identifying a real foreground
+ * application: a usable `activeWindow.appId`, `viewHierarchy.packageName`, or
+ * a valid `foregroundActivity` (the raw accessibility signal, checked
+ * directly rather than only through `activeWindow`). The third signal matters
+ * on its own: deriving `activeWindow` from `foregroundActivity` in
+ * `collectAllData` is gated on screen dimensions being present, so a
+ * hierarchy that lacks `packageName`/dimensions but DOES carry a valid
+ * `foregroundActivity` never gets an `activeWindow` at all — it must still
+ * not be treated as identity-less (issue #6220 follow-up false-positive).
+ * Single source of truth for "does this capture name an app", so a future
+ * signal is added once here rather than risking one call site missing it.
+ */
+function hasForegroundAppIdentity(result: ObserveResult): boolean {
+  return Boolean(
+    result.activeWindow?.appId ||
+    result.viewHierarchy?.packageName ||
+    hierarchyCarriesActivitySignal(result.viewHierarchy),
+  );
+}
+
 function resolveMissingForegroundWindow(
   result: ObserveResult,
 ): { reason: "status_bar_only" | "empty_active_window" } | undefined {
-  // `viewHierarchy.packageName` is checked directly (not only via
+  // `hasForegroundAppIdentity` is checked directly (not only via
   // `activeWindow.appId`, which the package-attribution fallback above should
-  // already have backfilled from it): later stages (e.g.
-  // `reconcileActiveWindowAttribution`, the SystemUI-overlay mirroring) can
-  // still re-derive `activeWindow` after this point, and a package-attributed
-  // capture must never be reported as having no foreground window regardless
-  // of what runs afterward (issue #6220 false-positive).
-  if (
-    result.activeWindow?.appId ||
-    result.viewHierarchy?.packageName ||
-    !result.viewHierarchy?.hierarchy?.node
-  ) {
+  // already have backfilled from `viewHierarchy.packageName`): later stages
+  // (e.g. `reconcileActiveWindowAttribution`, the SystemUI-overlay mirroring)
+  // can still re-derive `activeWindow` after this point, and a
+  // package/activity-attributed capture must never be reported as having no
+  // foreground window regardless of what runs afterward (issue #6220
+  // false-positive).
+  if (hasForegroundAppIdentity(result) || !result.viewHierarchy?.hierarchy?.node) {
     return undefined;
   }
   return { reason: isStatusBarOnlyHierarchy(result) ? "status_bar_only" : "empty_active_window" };

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -253,6 +253,23 @@ function hasForegroundAppIdentity(result: ObserveResult): boolean {
 function resolveMissingForegroundWindow(
   result: ObserveResult,
 ): { reason: "status_bar_only" | "empty_active_window" } | undefined {
+  if (!result.viewHierarchy?.hierarchy?.node) {
+    return undefined;
+  }
+  // Status-bar-ONLY geometry is checked FIRST and dominates any lingering
+  // identity metadata. `packageName`/`foregroundActivity` can survive on the
+  // wire from a PRIOR resumed app even once the tree itself has collapsed to
+  // chrome-only content (both ADB foreground reads coming back empty means
+  // there is no ground truth to confirm or refute that staleness against) —
+  // the geometry is the one signal that cannot lie about what actually came
+  // back. `isStatusBarOnlyHierarchy` already distinguishes this incomplete,
+  // chrome-only strip from a legitimate FULL-height SystemUI shade capture
+  // (it returns `false` the moment any node extends below the status-bar
+  // height), so a genuine expanded shade is never caught here — only the
+  // provably-incomplete case is (issue #6239 review follow-up).
+  if (isStatusBarOnlyHierarchy(result)) {
+    return { reason: "status_bar_only" };
+  }
   // `hasForegroundAppIdentity` is checked directly (not only via
   // `activeWindow.appId`, which the package-attribution fallback above should
   // already have backfilled from `viewHierarchy.packageName`): later stages
@@ -260,11 +277,11 @@ function resolveMissingForegroundWindow(
   // can still re-derive `activeWindow` after this point, and a
   // package/activity-attributed capture must never be reported as having no
   // foreground window regardless of what runs afterward (issue #6220
-  // false-positive).
-  if (hasForegroundAppIdentity(result) || !result.viewHierarchy?.hierarchy?.node) {
+  // false-positive) — UNLESS the geometry above already proved it incomplete.
+  if (hasForegroundAppIdentity(result)) {
     return undefined;
   }
-  return { reason: isStatusBarOnlyHierarchy(result) ? "status_bar_only" : "empty_active_window" };
+  return { reason: "empty_active_window" };
 }
 
 /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -218,6 +218,27 @@ function isStatusBarOnlyHierarchy(result: ObserveResult): boolean {
 }
 
 /**
+ * Synchronous counterpart to the async, device-confirmed status-bar-only gate
+ * below (issue #6220): `activeWindow.appId` is empty even after every
+ * fallback (viewHierarchy packageName, bootstrap attribution, etc.) has
+ * already run against this result, so nothing identifies which app — if any —
+ * the captured hierarchy belongs to. The async gate needs an independent
+ * dumpsys read of the foreground app to name the mismatch; when that
+ * confirming read itself comes back empty (or races), this still catches the
+ * case without a device round-trip. A missing `viewHierarchy` is left to the
+ * `unavailable` freshness path instead — this is only about a hierarchy that
+ * WAS captured but carries no window identity.
+ */
+function resolveMissingForegroundWindow(
+  result: ObserveResult,
+): { reason: "status_bar_only" | "empty_active_window" } | undefined {
+  if (result.activeWindow?.appId || !result.viewHierarchy?.hierarchy?.node) {
+    return undefined;
+  }
+  return { reason: isStatusBarOnlyHierarchy(result) ? "status_bar_only" : "empty_active_window" };
+}
+
+/**
  * The status-bar-only verdict inputs (issue #6151): whether the service itself
  * reported the focused window as unreadable, and the device API level that
  * decides whether that can be Android 14+ data-sensitive withholding.
@@ -675,6 +696,7 @@ export class RealObserveScreen implements ObserveScreen {
           !hierarchyPlatformValid ||
           result.viewHierarchy?.hierarchy === undefined ||
           result.viewHierarchy?.hierarchy?.error !== undefined,
+        missingForegroundWindow: resolveMissingForegroundWindow(result),
         statusBarOnlyHierarchy: await this.resolveStatusBarOnlyHierarchy(
           result,
           foregroundIdentity,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -250,7 +250,15 @@ function hasForegroundAppIdentity(result: ObserveResult): boolean {
   );
 }
 
-function resolveMissingForegroundWindow(
+/**
+ * Exported so other consumers can reuse the SAME machine-readable verdict
+ * this freshness gate uses, instead of re-deriving "does this capture have a
+ * foreground window" from a weaker proxy (e.g. package-name presence, which a
+ * status-bar-only capture can still carry as stale metadata). `LaunchApp`
+ * uses this to distinguish a status-bar-only/no-window post-launch capture
+ * from a genuine wrong-app landing (issue #6239 review follow-up).
+ */
+export function resolveMissingForegroundWindow(
   result: ObserveResult,
 ): { reason: "status_bar_only" | "empty_active_window" } | undefined {
   if (!result.viewHierarchy?.hierarchy?.node) {

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -297,7 +297,7 @@ function resolveIdentityMismatch(
       isFresh: false,
       warning:
         reason === "status_bar_only"
-          ? "Observed hierarchy contains only Android status-bar content and reports no foreground application window (activeWindow.appId is empty). This capture cannot be trusted to reflect any app's screen; call observe again."
+          ? "Observed hierarchy contains only Android status-bar content — every extracted node lies within the status-bar strip, not a full foreground application window. Any package/activity attribution on this capture may be stale from a previous app; this capture cannot be trusted to reflect any app's screen. Call observe again."
           : "Observed hierarchy reports no foreground application window (activeWindow.appId is empty), so this capture cannot be trusted to reflect the current screen; call observe again.",
     };
   }

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -103,6 +103,19 @@ export interface FreshnessInputs {
    * application, and a forced recapture could not safely reconcile them.
    */
   activityAttributionMismatch?: boolean;
+  /**
+   * The observation carries no foreground application window at all:
+   * `activeWindow.appId` is empty even after every fallback (viewHierarchy
+   * packageName, etc.) has run, so nothing identifies which app — if any —
+   * the captured hierarchy belongs to (issue #6220). This is the synchronous
+   * counterpart to {@link statusBarOnlyHierarchy}: that gate needs an
+   * independent, device-confirmed read of the foreground app to name the
+   * mismatch, so when that confirming read itself comes back empty (or
+   * races), a hierarchy that is honest about carrying no window identity must
+   * still not be stamped `verified/isFresh: true`. Needs no device
+   * round-trip — derived entirely from the observation already in hand.
+   */
+  missingForegroundWindow?: { reason: "status_bar_only" | "empty_active_window" };
   /** Age budget; defaults to {@link maxObservationAgeMs}. */
   maxAgeMs?: number;
 }
@@ -266,6 +279,26 @@ function resolveIdentityMismatch(
       verified: false,
       isFresh: false,
       warning: `The accessibility service reported the capture as incomplete: it could not read the focused application's root window, even though another window's content was readable. ${incompleteCaptureGuidance(inputs.incompleteCapture.sdkInt)}`,
+    };
+  }
+  // Lowest-priority fallback (issue #6220): none of the device-confirmed gates
+  // above fired — most commonly because there was no ground-truth foreground
+  // read to confirm against — yet the observation itself names no foreground
+  // window at all. Every other branch above names the actual foreground app or
+  // a more specific cause; this one only fires when nothing more specific could
+  // be established.
+  if (inputs.missingForegroundWindow) {
+    const { reason } = inputs.missingForegroundWindow;
+    return {
+      requestedAfter,
+      actualTimestamp,
+      ageMs,
+      verified: false,
+      isFresh: false,
+      warning:
+        reason === "status_bar_only"
+          ? "Observed hierarchy contains only Android status-bar content and reports no foreground application window (activeWindow.appId is empty). This capture cannot be trusted to reflect any app's screen; call observe again."
+          : "Observed hierarchy reports no foreground application window (activeWindow.appId is empty), so this capture cannot be trusted to reflect the current screen; call observe again.",
     };
   }
   return undefined;

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -151,6 +151,45 @@ function isVerifiedLaunchObservation(
 }
 
 /**
+ * Reason a launch could not be verified (issue #6220), for the case where no
+ * foreground application window was observed at all — as opposed to an
+ * observed-but-different foreground (an accepted surface, e.g. a permission
+ * dialog, which `LaunchApp.execute` already treats as success and this
+ * response layer must not second-guess with a misleading `verified: false`).
+ */
+type LaunchVerificationFailureReason = "no_observation" | "no_foreground_window";
+
+function launchVerificationFailureReason(
+  observedAppId: string | undefined,
+  observation: LaunchAppResult["observation"],
+): LaunchVerificationFailureReason | undefined {
+  if (observedAppId) {
+    return undefined;
+  }
+  return observation === undefined ? "no_observation" : "no_foreground_window";
+}
+
+function launchVerificationFailureMessage(reason: LaunchVerificationFailureReason): string {
+  return reason === "no_observation"
+    ? "no observation was captured after launch"
+    : "no foreground application window could be observed after launch";
+}
+
+function buildLaunchMessage(
+  appId: string,
+  verified: boolean | undefined,
+  verifyFailureReason: LaunchVerificationFailureReason | undefined,
+): string {
+  if (verified === true) {
+    return `Launched app ${appId} (foreground verified)`;
+  }
+  if (verifyFailureReason) {
+    return `Launched app ${appId} (verification failed: ${launchVerificationFailureMessage(verifyFailureReason)})`;
+  }
+  return `Launched app ${appId}`;
+}
+
+/**
  * Build the launchApp tool response from a {@link LaunchAppResult}, enforcing the
  * launch postcondition instead of reporting a flat "Launched app X" success
  * regardless of what actually happened (#5868).
@@ -163,6 +202,15 @@ function isVerifiedLaunchObservation(
  * them behind a success message. On success it additionally reports the observed
  * foreground appId and whether it matched, so a client can skip a confirming
  * `observe` round-trip.
+ *
+ * `verified` is a three-way signal, never a silent `undefined` when the launch
+ * genuinely could not be confirmed (issue #6220): `true` on an exact foreground
+ * match against a fresh, verified observation; `false` (with `verifyFailureReason`
+ * naming why) when no foreground window could be observed for the launched app at
+ * all; and `undefined` only for the deliberately-ambiguous case of an observed,
+ * DIFFERENT real foreground (an accepted surface such as a permission dialog,
+ * which `LaunchApp.execute` already accepted as success) or a matching-but-stale
+ * observation, where asserting `false` would contradict the tool's own success.
  */
 export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
   if (!result.success) {
@@ -173,20 +221,26 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
 
   // Mirror `LaunchApp`'s own reconciliation, which accepts either the active
   // window's appId or the view hierarchy's packageName — so a launch verified via
-  // the hierarchy (active window absent) still reports the observed app.
+  // the hierarchy (active window absent) still reports the observed app. `||`
+  // (not `??`) so an empty-string appId (no foreground window identified, issue
+  // #6220) also falls back to the hierarchy's package rather than being treated
+  // as a real observed app.
   const observedAppId =
-    result.observation?.activeWindow?.appId ?? result.observation?.viewHierarchy?.packageName;
+    result.observation?.activeWindow?.appId || result.observation?.viewHierarchy?.packageName;
   // Only assert verification on an exact foreground match with a fresh, verified
   // observation. `LaunchApp.execute` retries an unverified observation, but this
   // response-level guard preserves the true-or-undefined contract for any direct
   // caller that supplies one.
-  const verified = isVerifiedLaunchObservation(appId, observedAppId, result.observation)
-    ? true
-    : undefined;
+  const isVerified = isVerifiedLaunchObservation(appId, observedAppId, result.observation);
+  const verifyFailureReason = isVerified
+    ? undefined
+    : launchVerificationFailureReason(observedAppId, result.observation);
+  const verified = isVerified ? true : verifyFailureReason ? false : undefined;
 
   return {
-    message: verified ? `Launched app ${appId} (foreground verified)` : `Launched app ${appId}`,
+    message: buildLaunchMessage(appId, verified, verifyFailureReason),
     verified,
+    ...(verifyFailureReason ? { verifyFailureReason } : {}),
     observedAppId,
     observation: result.observation,
     ...result,

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -15,6 +15,7 @@ import { InstallApp } from "../features/action/InstallApp";
 import { UninstallApp } from "../features/action/UninstallApp";
 import { AppPermissions } from "../features/action/AppPermissions";
 import { ResetKeychain } from "../features/action/ResetKeychain";
+import { resolveMissingForegroundWindow } from "../features/observe/ObserveScreen";
 import {
   createJSONToolResponse,
   createStructuredToolResponse,
@@ -183,10 +184,19 @@ function launchVerificationFailureReason(
   observedAppId: string | undefined,
   observation: LaunchAppResult["observation"],
 ): LaunchVerificationFailureReason | undefined {
-  if (observedAppId) {
-    return undefined;
+  if (observation === undefined) {
+    return "no_observation";
   }
-  return observation === undefined ? "no_observation" : "no_foreground_window";
+  // `resolveMissingForegroundWindow` (the SAME machine-readable verdict the
+  // observe freshness gate uses) is consulted here too, not just an empty
+  // `observedAppId` (issue #6239 review follow-up): a status-bar-only capture
+  // can still carry STALE `activeWindow.appId`/`packageName` metadata from a
+  // previously-resumed app, which would otherwise make `observedAppId` look
+  // like a real (if wrong) observed app and suppress this structured failure.
+  if (!observedAppId || resolveMissingForegroundWindow(observation) !== undefined) {
+    return "no_foreground_window";
+  }
+  return undefined;
 }
 
 function launchVerificationFailureMessage(reason: LaunchVerificationFailureReason): string {

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -138,6 +138,26 @@ export function resetCrashAppToolDependencies(): void {
   crashAppToolDependencies = null;
 }
 
+/**
+ * Extract the package name from `viewHierarchy.foregroundActivity` (issue
+ * #6220 follow-up): the raw accessibility signal, in the standard
+ * `package/activity` (or `package/.RelativeActivity`) wire format. Mirrors
+ * `LaunchApp.packageFromForegroundActivity` — kept as a matching one-liner
+ * here (not a shared import) the same way `ObserveScreen.ts` already inlines
+ * this exact parse at each of its own call sites — so the attribution driving
+ * `observedAppId` here and the match/mismatch decision in `LaunchApp.execute`
+ * can never disagree about which app a `foregroundActivity` names.
+ */
+function packageFromForegroundActivity(
+  observation: LaunchAppResult["observation"],
+): string | undefined {
+  const foregroundActivity = observation?.viewHierarchy?.foregroundActivity;
+  if (!foregroundActivity) {
+    return undefined;
+  }
+  return foregroundActivity.split("/")[0] || undefined;
+}
+
 function isVerifiedLaunchObservation(
   appId: string,
   observedAppId: string | undefined,
@@ -212,6 +232,26 @@ function buildLaunchMessage(
  * which `LaunchApp.execute` already accepted as success) or a matching-but-stale
  * observation, where asserting `false` would contradict the tool's own success.
  */
+/**
+ * Mirror `LaunchApp`'s own reconciliation, which accepts the active window's
+ * appId, the view hierarchy's packageName, OR the package parsed out of
+ * `viewHierarchy.foregroundActivity` — the one remaining app-identity signal
+ * on a hierarchy with no screen dimensions (so `ObserveScreen` never derives
+ * `activeWindow`) and no `packageName` (issue #6220 follow-up). `||` (not
+ * `??`) throughout so an empty-string appId (no foreground window
+ * identified, issue #6220) falls through each fallback rather than being
+ * treated as a real observed app.
+ */
+function resolveLaunchObservedAppId(
+  observation: LaunchAppResult["observation"],
+): string | undefined {
+  return (
+    observation?.activeWindow?.appId ||
+    observation?.viewHierarchy?.packageName ||
+    packageFromForegroundActivity(observation)
+  );
+}
+
 export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
   if (!result.success) {
     // `||` not `??`: an empty-string error must still yield the non-empty
@@ -219,14 +259,7 @@ export function buildLaunchAppResponse(appId: string, result: LaunchAppResult) {
     throw new ActionableError(result.error || `Failed to launch app ${appId}`);
   }
 
-  // Mirror `LaunchApp`'s own reconciliation, which accepts either the active
-  // window's appId or the view hierarchy's packageName — so a launch verified via
-  // the hierarchy (active window absent) still reports the observed app. `||`
-  // (not `??`) so an empty-string appId (no foreground window identified, issue
-  // #6220) also falls back to the hierarchy's package rather than being treated
-  // as a real observed app.
-  const observedAppId =
-    result.observation?.activeWindow?.appId || result.observation?.viewHierarchy?.packageName;
+  const observedAppId = resolveLaunchObservedAppId(result.observation);
   // Only assert verification on an exact foreground match with a fresh, verified
   // observation. `LaunchApp.execute` retries an unverified observation, but this
   // response-level guard preserves the true-or-undefined contract for any direct

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -3,6 +3,7 @@ import { promises as fsp } from "fs";
 import * as os from "os";
 import * as nodePath from "path";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
+import { buildLaunchAppResponse } from "../../../src/server/appTools";
 import { BootedDevice, ObserveResult } from "../../../src/models";
 import { DefaultPerformanceTracker } from "../../../src/utils/PerformanceTracker";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
@@ -630,6 +631,55 @@ describe("LaunchApp", () => {
     expect(result.observation?.freshness?.verified).toBe(false);
     expect(result.observation?.activeWindow?.appId).toBeFalsy();
     expect(result.observationOmitted).toBeUndefined();
+  });
+
+  // P1 review finding on #6239: a status-bar-ONLY final capture must be
+  // classified as "no foreground window" even when it still carries STALE
+  // `packageName`/`foregroundActivity`/`activeWindow.appId` metadata left over
+  // from a previously-resumed app. The package-count check alone would see
+  // those stale package names and misroute this to the wrong-app reject path
+  // (success:false, observation stripped, buildLaunchAppResponse throws)
+  // instead of the intended structured `verified:false` +
+  // `verifyFailureReason: "no_foreground_window"`. Reusing
+  // `resolveMissingForegroundWindow` (the SAME machine-readable verdict the
+  // observe freshness gate uses) catches this via geometry, independent of
+  // whatever stale identity survives on the wire.
+  test("preserves a status-bar-only launch observation with stale identity metadata as no-window, not wrong-app", async () => {
+    fakeTimer.enableAutoAdvance();
+    const staleAppPackageName = "com.example.previous";
+    const statusBarOnlyObservation: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 63, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: {
+        packageName: staleAppPackageName,
+        foregroundActivity: `${staleAppPackageName}/.MainActivity`,
+        hierarchy: {
+          node: {
+            bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+            node: [{ text: "12:34", bounds: { left: 21, top: 0, right: 107, bottom: 63 } }],
+          },
+        },
+      } as any,
+      // Stale identity that survived on the wire even though the tree itself
+      // has collapsed to status-bar-only content.
+      activeWindow: { appId: staleAppPackageName, activityName: "MainActivity", layoutSeqSum: 1 },
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(statusBarOnlyObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    // Preserved as a no-window outcome, NOT flipped to a wrong-app rejection.
+    expect(result.success).toBe(true);
+    expect(result.observation).toBeDefined();
+    expect(result.observationOmitted).toBeUndefined();
+
+    const payload = buildLaunchAppResponse(packageName, result);
+    expect(payload.verified).toBe(false);
+    expect(payload.verifyFailureReason).toBe("no_foreground_window");
   });
 
   // P2 review finding on #6239: a hierarchy naming a DIFFERENT app only via

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -632,6 +632,37 @@ describe("LaunchApp", () => {
     expect(result.observationOmitted).toBeUndefined();
   });
 
+  // P2 review finding on #6239: a hierarchy naming a DIFFERENT app only via
+  // `viewHierarchy.foregroundActivity` (no `activeWindow.appId`, no
+  // `viewHierarchy.packageName`) must be a detected wrong-app mismatch, not
+  // an empty-package vacuous accept — the omission previously let a genuine
+  // wrong-app landing through as if no app were observed at all.
+  test("detects a wrong-app landing named only by foregroundActivity, instead of an empty-package accept", async () => {
+    fakeTimer.enableAutoAdvance();
+    const wrongAppPackageName = "com.example.other";
+    const wrongAppObservation: ObserveResult = {
+      ...createObserveResult(undefined),
+      viewHierarchy: {
+        node: {},
+        foregroundActivity: `${wrongAppPackageName}/.MainActivity`,
+      } as any,
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(wrongAppObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(
+      `Timed out waiting for launch observation to show ${packageName}`,
+    );
+    expect(result.error).toContain(wrongAppPackageName);
+    expect(result.observation).toBeUndefined();
+    expect(result.observationOmitted).toBeDefined();
+  });
+
   test("treats Android notification permission dialogs as valid launch observations", async () => {
     fakeTimer.enableAutoAdvance();
     const permissionControllerPackageName = "com.google.android.permissioncontroller";

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -663,6 +663,63 @@ describe("LaunchApp", () => {
     expect(result.observationOmitted).toBeDefined();
   });
 
+  // P1 review finding on #6239: `foregroundActivity` must be a FALLBACK
+  // identity signal, never a competing one. The reconciled/settled primary
+  // signals (`activeWindow.appId`, `viewHierarchy.packageName`) already agree
+  // on the just-launched app B, but the raw `foregroundActivity` wire field
+  // can lag a same-observation A->B transition and still name the PREVIOUS
+  // app A. Contributing A alongside a settled B must not fail the match and
+  // turn a successful launch into a failure.
+  test("succeeds when primary signals agree on the launched app despite a lagging foregroundActivity", async () => {
+    fakeTimer.enableAutoAdvance();
+    const previousPackageName = "com.example.previous";
+    const laggedObservation: ObserveResult = {
+      ...createObserveResult(packageName),
+      viewHierarchy: {
+        ...createObserveResult(packageName).viewHierarchy,
+        // Raw accessibility signal still names the PREVIOUS app A, even
+        // though activeWindow/viewHierarchy.packageName already settled on B.
+        foregroundActivity: `${previousPackageName}/.MainActivity`,
+      } as any,
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(laggedObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observation?.activeWindow?.appId).toBe(packageName);
+    expect(result.observationOmitted).toBeUndefined();
+    // No retry needed: the primary signals alone decided the match.
+    expect(fakeObserveScreen.getExecuteCallCount()).toBe(1);
+  });
+
+  // Counterpart to the wrong-app case above: when only `foregroundActivity`
+  // names an app (no primary signals at all) and it names the RIGHT app, the
+  // launch must succeed via that fallback rather than being rejected.
+  test("succeeds via foregroundActivity fallback when it names the launched app and no primary signal is present", async () => {
+    fakeTimer.enableAutoAdvance();
+    const rightAppObservation: ObserveResult = {
+      ...createObserveResult(undefined),
+      viewHierarchy: {
+        node: {},
+        foregroundActivity: `${packageName}/.MainActivity`,
+      } as any,
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(rightAppObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observationOmitted).toBeUndefined();
+    expect(fakeObserveScreen.getExecuteCallCount()).toBe(1);
+  });
+
   test("treats Android notification permission dialogs as valid launch observations", async () => {
     fakeTimer.enableAutoAdvance();
     const permissionControllerPackageName = "com.google.android.permissioncontroller";

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -600,6 +600,38 @@ describe("LaunchApp", () => {
     expect(fakeObserveScreen.getExecuteCallCount()).toBeGreaterThan(1);
   });
 
+  // Issue #6220 follow-up (P1 review finding on #6239): a launch observation
+  // that reports NO foreground window at all (neither `activeWindow.appId` nor
+  // `viewHierarchy.packageName` name an app — the shape ObserveScreen's own
+  // freshness now marks `verified: false` for) must NOT be treated the same as
+  // "observed a different/stale app": that path rejects and deletes the
+  // observation, but the launch genuinely happened and the response builder
+  // needs the observation preserved to report a structured `verified: false` +
+  // `verifyFailureReason` instead of a thrown/silent failure.
+  test("preserves a no-foreground-window launch observation instead of rejecting it as stale", async () => {
+    fakeTimer.enableAutoAdvance();
+    const noWindowObservation = {
+      ...createObserveResult(undefined),
+      freshness: {
+        isFresh: false,
+        verified: false,
+        warning: "Observed hierarchy reports no foreground application window",
+      },
+    };
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse("shell dumpsys activity processes", { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(noWindowObservation);
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observation).toBeDefined();
+    expect(result.observation?.freshness?.verified).toBe(false);
+    expect(result.observation?.activeWindow?.appId).toBeFalsy();
+    expect(result.observationOmitted).toBeUndefined();
+  });
+
   test("treats Android notification permission dialogs as valid launch observations", async () => {
     fakeTimer.enableAutoAdvance();
     const permissionControllerPackageName = "com.google.android.permissioncontroller";

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -452,3 +452,79 @@ describe("ensureTap flag expansion", () => {
     expect(capturedOptions!.retryIfNoChange).toBe(true);
   });
 });
+
+// Issue #6219: the response must never assert `freshness.verified/isFresh: true`
+// on an inline observation while `effect.screenChanged: true` is reported in the
+// SAME payload, when that observation's own content still matches the pre-tap
+// baseline (i.e. it predates the transition `effect` is describing).
+describe("enforceFreshnessConsistencyWithEffect", () => {
+  test("retracts verified/isFresh when the returned observation still matches the pre-tap baseline", () => {
+    const { tap } = createTapOnElement();
+    const activeWindow = {
+      appId: "com.android.deskclock",
+      activityName: "com.android.deskclock.DeskClock",
+      layoutSeqSum: 1,
+    };
+    const previous = makeObservation({ activeWindow });
+    // The exact #6219 shape: effect claims the screen changed, but the
+    // observation attached to the SAME response still shows the pre-tap window.
+    const result: { effect?: any; observation?: ObserveResult } = {
+      effect: { screenChanged: true, basis: "activeWindow changed" },
+      observation: makeObservation({
+        activeWindow: { ...activeWindow },
+        freshness: { isFresh: true, verified: true },
+      }),
+    };
+
+    (tap as any).enforceFreshnessConsistencyWithEffect(previous, result);
+
+    expect(result.observation?.freshness?.verified).toBe(false);
+    expect(result.observation?.freshness?.isFresh).toBe(false);
+    expect(result.observation?.freshness?.warning).toContain("predates the detected transition");
+  });
+
+  test("leaves freshness untouched when the observation is itself consistent with the detected change", () => {
+    const { tap } = createTapOnElement();
+    const previous = makeObservation({
+      activeWindow: {
+        appId: "com.android.deskclock",
+        activityName: "com.android.deskclock.DeskClock",
+        layoutSeqSum: 1,
+      },
+    });
+    const result: { effect?: any; observation?: ObserveResult } = {
+      effect: { screenChanged: true, basis: "activeWindow changed" },
+      observation: makeObservation({
+        activeWindow: {
+          appId: "com.android.deskclock",
+          activityName: "android.app.Dialog",
+          layoutSeqSum: 2,
+        },
+        freshness: { isFresh: true, verified: true },
+      }),
+    };
+
+    (tap as any).enforceFreshnessConsistencyWithEffect(previous, result);
+
+    expect(result.observation?.freshness?.verified).toBe(true);
+    expect(result.observation?.freshness?.isFresh).toBe(true);
+  });
+
+  test("does not touch freshness when effect reports no screen change", () => {
+    const { tap } = createTapOnElement();
+    const activeWindow = { appId: "com.example.app", activityName: "Main", layoutSeqSum: 1 };
+    const previous = makeObservation({ activeWindow });
+    const result: { effect?: any; observation?: ObserveResult } = {
+      effect: { screenChanged: false, basis: "activeWindow unchanged" },
+      observation: makeObservation({
+        activeWindow: { ...activeWindow },
+        freshness: { isFresh: true, verified: true },
+      }),
+    };
+
+    (tap as any).enforceFreshnessConsistencyWithEffect(previous, result);
+
+    expect(result.observation?.freshness?.verified).toBe(true);
+    expect(result.observation?.freshness?.isFresh).toBe(true);
+  });
+});

--- a/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
+++ b/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
@@ -137,4 +137,62 @@ describe("ObserveScreen missing-foreground-window freshness (issue #6220)", () =
     expect(result.freshness?.verified).toBe(true);
     expect(result.freshness?.isFresh).toBe(true);
   });
+
+  // Regression (P1 review finding on #6239): a READABLE hierarchy carrying a
+  // real `viewHierarchy.packageName` but no usable `foregroundActivity` used to
+  // be reported as having no foreground window at all. The accessibility path
+  // never sets `activeWindow` in this shape, so the legacy `Window.getActive()`
+  // fallback runs and, on failure, returns its normal TRUTHY sentinel
+  // (`{appId:"", ...}`) — which must not (a) block the package-name fallback
+  // from running, nor (b) itself be read as "no foreground window" by the new
+  // #6220 predicate. A package-attributed capture must stay verified/fresh.
+  test("a package-attributed hierarchy with no usable foregroundActivity stays verified/isFresh:true", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      // Real package attribution, but no usable foregroundActivity: the
+      // accessibility path leaves `activeWindow` unset, so the legacy Window
+      // query (mocked below to fail) and then the package-name fallback run.
+      packageName: "com.google.android.deskclock",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Add alarm", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.deskclock", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        // The legacy Window query's normal failure sentinel: a TRUTHY object
+        // with an empty appId, not `undefined`/`null`.
+        window: noOpWindow(""),
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.google.android.deskclock");
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+  });
 });

--- a/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
+++ b/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #6220: `observe` could stamp `freshness.verified/isFresh: true` on a
+ * hierarchy that carries NO foreground application window at all —
+ * `activeWindow.appId` empty, content confined to `com.android.systemui`
+ * status-bar nodes — even when the async, device-confirmed window-identity
+ * gate (issue #5867/#6151) cannot fire because the ground-truth foreground
+ * read itself came back empty. This is the synchronous backstop: derived
+ * entirely from the observation already in hand, no device round-trip needed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeViewHierarchy } from "../../fakes/FakeViewHierarchy";
+import { FakeObserveCacheStore } from "../../fakes/FakeObserveCacheStore";
+import { resetObserveCacheStore } from "../../../src/features/observe/cache/ObserveCacheRegistry";
+import type { BootedDevice } from "../../../src/models";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 7",
+  platform: "android",
+};
+
+const noOpWindow = (appId: string) => ({
+  getActive: async () => ({ appId, activityName: "", layoutSeqSum: 0 }),
+  getActiveHash: async () => "hash",
+  getCachedActiveWindow: async () => null,
+  setCachedActiveWindow: async () => undefined,
+  clearCache: async () => undefined,
+});
+
+describe("ObserveScreen missing-foreground-window freshness (issue #6220)", () => {
+  afterEach(() => {
+    resetObserveCacheStore();
+  });
+
+  test("retracts freshness for a status-bar-only hierarchy with no foreground window, even without a ground-truth foreground read", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    // The exact #6220 repro shape: only com.android.systemui status-bar nodes,
+    // no packageName/foregroundActivity the accessibility path can attribute.
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          node: [
+            {
+              "resource-id": "com.android.systemui:id/clock",
+              text: "8:33",
+              bounds: { left: 21, top: 0, right: 107, bottom: 63 },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    // getForegroundApp returns null (default): the async, device-confirmed
+    // gate cannot fire without ground truth. The synchronous check must still
+    // catch this from the observation alone.
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: noOpWindow(""),
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("");
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("no foreground application window");
+  });
+
+  test("does not retract freshness for a normal capture with a real foreground app", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      packageName: "com.google.android.deskclock",
+      foregroundActivity: "com.google.android.deskclock/.DeskClock",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Add alarm", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.deskclock", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBe("com.google.android.deskclock");
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+  });
+});

--- a/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
+++ b/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
@@ -195,4 +195,114 @@ describe("ObserveScreen missing-foreground-window freshness (issue #6220)", () =
     expect(result.freshness?.verified).toBe(true);
     expect(result.freshness?.isFresh).toBe(true);
   });
+
+  // Regression (P2 review finding on #6239): a hierarchy that carries a valid
+  // `foregroundActivity` but lacks `packageName` AND screen dimensions used to
+  // be reported as having no foreground window at all. `collectAllData` only
+  // derives `activeWindow` from `foregroundActivity` inside the
+  // dimensions-present branch, so without dimensions `activeWindow` is never
+  // set; the legacy Window fallback then returns its empty-appId sentinel, and
+  // (before this fix) the missing-foreground predicate ignored the remaining
+  // `foregroundActivity` signal entirely. A capture that names a real activity
+  // must stay verified/fresh regardless of whether `activeWindow` got derived.
+  test("a hierarchy with a valid foregroundActivity but no packageName/dimensions stays verified/isFresh:true", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      // No screenWidth/screenHeight: the dimensions-present branch that would
+      // derive `activeWindow` from `foregroundActivity` is skipped entirely.
+      // No packageName either, so the package-attribution fallback cannot fire.
+      foregroundActivity: "com.google.android.deskclock/.DeskClock",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+          node: [{ text: "Add alarm", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp({ packageName: "com.google.android.deskclock", userId: 0 });
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        // The legacy Window query's normal failure sentinel: a TRUTHY object
+        // with an empty appId, not `undefined`/`null`.
+        window: noOpWindow(""),
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.activeWindow?.appId).toBeFalsy();
+    expect(result.viewHierarchy?.packageName).toBeFalsy();
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
+  });
+
+  // The genuine no-identity case (#6220 itself) must remain caught: no
+  // packageName, no usable foregroundActivity, no activeWindow appId at all.
+  test("keeps the genuine no-identity systemui-only case unverified", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          node: [
+            {
+              "resource-id": "com.android.systemui:id/clock",
+              text: "8:33",
+              bounds: { left: 21, top: 0, right: 107, bottom: 63 },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        window: noOpWindow(""),
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("no foreground application window");
+  });
 });

--- a/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
+++ b/test/features/observe/ObserveScreenMissingForegroundWindow.test.ts
@@ -90,7 +90,7 @@ describe("ObserveScreen missing-foreground-window freshness (issue #6220)", () =
     expect(result.activeWindow?.appId).toBe("");
     expect(result.freshness?.verified).toBe(false);
     expect(result.freshness?.isFresh).toBe(false);
-    expect(result.freshness?.warning).toContain("no foreground application window");
+    expect(result.freshness?.warning).toContain("foreground application window");
   });
 
   test("does not retract freshness for a normal capture with a real foreground app", async () => {
@@ -303,6 +303,119 @@ describe("ObserveScreen missing-foreground-window freshness (issue #6220)", () =
 
     expect(result.freshness?.verified).toBe(false);
     expect(result.freshness?.isFresh).toBe(false);
-    expect(result.freshness?.warning).toContain("no foreground application window");
+    expect(result.freshness?.warning).toContain("foreground application window");
+  });
+
+  // Regression (P1 review finding on #6239): status-bar-ONLY geometry must
+  // dominate any lingering `packageName`/`foregroundActivity` metadata. A
+  // hierarchy confined to the status-bar strip can still carry attribution
+  // stamped from a PRIOR resumed app even once the tree itself has collapsed
+  // to chrome-only content — that identity must not rescue the verdict when
+  // both ADB foreground reads (the async, device-confirmed gate) come back
+  // empty and there is no ground truth to confirm or refute the staleness.
+  test("status-bar-only geometry with stale packageName/foregroundActivity is still UNVERIFIED", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      // Stale identity metadata from a previously-resumed app, left over even
+      // though the tree itself is now confined to the status-bar strip.
+      packageName: "com.android.settings",
+      foregroundActivity: "com.android.settings/.SubSettings",
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 63 },
+          node: [
+            {
+              "resource-id": "com.android.systemui:id/clock",
+              text: "8:33",
+              bounds: { left: 21, top: 0, right: 107, bottom: 63 },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    // Both ADB foreground reads come back empty: no ground truth to confirm
+    // or refute the stale attribution, so the async gate cannot fire either.
+    fakeAdb.setForegroundApp(null);
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(false);
+    expect(result.freshness?.isFresh).toBe(false);
+    expect(result.freshness?.warning).toContain("status-bar content");
+  });
+
+  // The counterpart: a legitimate FULL-height SystemUI shade capture (the
+  // notification shade IS a valid full SystemUI window) must stay verified —
+  // `isStatusBarOnlyHierarchy` only fires when EVERY node is confined to the
+  // status-bar strip, so a full-height shade never trips the geometry check.
+  test("a full-height SystemUI shade capture stays verified/isFresh:true", async () => {
+    const now = 1_700_000_000_000;
+    const timer = new FakeTimer();
+    timer.setCurrentTime(now);
+
+    const viewHierarchy = new FakeViewHierarchy();
+    viewHierarchy.configureHierarchy({
+      updatedAt: now,
+      receivedAt: now,
+      fresh: true,
+      screenWidth: 1080,
+      screenHeight: 2400,
+      systemInsets: { top: 63, right: 0, bottom: 0, left: 0 },
+      packageName: "com.android.systemui",
+      foregroundActivity: "com.android.systemui/.shade.NotificationPanelView",
+      hierarchy: {
+        node: {
+          // The expanded shade extends well past the status-bar strip.
+          bounds: { left: 0, top: 0, right: 1080, bottom: 1400 },
+          node: [{ text: "Silent", bounds: { left: 0, top: 100, right: 200, bottom: 160 } }],
+        },
+      },
+    } as any);
+
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setForegroundApp(null);
+
+    const screen = new RealObserveScreen(
+      androidDevice,
+      new FakeAdbClientFactory(fakeAdb),
+      {
+        viewHierarchy,
+        cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+        performanceAuditor: { run: async () => undefined } as any,
+        accessibilityAuditor: { run: async () => undefined } as any,
+        accessibilityStateDetector: { run: async () => undefined } as any,
+      },
+      timer,
+    );
+
+    const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+    expect(result.freshness?.verified).toBe(true);
+    expect(result.freshness?.isFresh).toBe(true);
   });
 });

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -280,6 +280,56 @@ describe("computeFreshness", () => {
     });
   });
 
+  // --- issue #6220: no foreground window at all (status-bar-only / empty appId) ---
+  describe("missing foreground window (issue #6220)", () => {
+    test("a status-bar-only hierarchy with no foreground window is NOT verified or fresh", () => {
+      const v = computeFreshness({
+        actualTimestamp: NOW - 50,
+        now: NOW,
+        verified: true,
+        missingForegroundWindow: { reason: "status_bar_only" },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("status-bar content");
+      expect(v.warning).toContain("no foreground application window");
+    });
+
+    test("an empty activeWindow.appId with a non-status-bar hierarchy is still NOT verified or fresh", () => {
+      const v = computeFreshness({
+        actualTimestamp: NOW - 50,
+        now: NOW,
+        verified: true,
+        missingForegroundWindow: { reason: "empty_active_window" },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+      expect(v.warning).toContain("no foreground application window");
+    });
+
+    test("dominates a requested-minimum poll too", () => {
+      const v = computeFreshness({
+        requestedAfter: NOW - 1_000,
+        actualTimestamp: NOW,
+        now: NOW,
+        missingForegroundWindow: { reason: "status_bar_only" },
+      });
+      expect(v.verified).toBe(false);
+      expect(v.isFresh).toBe(false);
+    });
+
+    test("a normal successful capture with a real foreground window is unaffected", () => {
+      const v = computeFreshness({
+        actualTimestamp: NOW - 50,
+        now: NOW,
+        verified: true,
+        missingForegroundWindow: undefined,
+      });
+      expect(v.verified).toBe(true);
+      expect(v.isFresh).toBe(true);
+    });
+  });
+
   test("every `isFresh: false` names its cause", () => {
     const falseCases = [
       computeFreshness({ actualTimestamp: NOW - 999_999, now: NOW }),

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -292,7 +292,7 @@ describe("computeFreshness", () => {
       expect(v.verified).toBe(false);
       expect(v.isFresh).toBe(false);
       expect(v.warning).toContain("status-bar content");
-      expect(v.warning).toContain("no foreground application window");
+      expect(v.warning).toContain("foreground application window");
     });
 
     test("an empty activeWindow.appId with a non-status-bar hierarchy is still NOT verified or fresh", () => {

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -164,4 +164,46 @@ describe("buildLaunchAppResponse", () => {
       "Launched app com.android.settings (verification failed: no foreground application window could be observed after launch)",
     );
   });
+
+  // P2 review finding on #6239: when neither `activeWindow.appId` nor
+  // `viewHierarchy.packageName` name an app, `viewHierarchy.foregroundActivity`
+  // is the one remaining identity signal — it must drive `observedAppId` (and
+  // `verified`) the same way it drives `LaunchApp`'s own match decision.
+  test("reports the foregroundActivity-derived package as observedAppId when nothing else names an app", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        viewHierarchy: {
+          node: {},
+          foregroundActivity: "com.android.settings/.SubSettings",
+        },
+      } as ObserveResult,
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.observedAppId).toBe("com.android.settings");
+    expect(payload.verified).toBe(true);
+    expect(payload.message).toBe("Launched app com.android.settings (foreground verified)");
+  });
+
+  test("reports the foregroundActivity-derived package even when it names a different app", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        viewHierarchy: {
+          node: {},
+          foregroundActivity: "com.google.android.permissioncontroller/.GrantPermissionsActivity",
+        },
+      } as ObserveResult,
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.observedAppId).toBe("com.google.android.permissioncontroller");
+    expect(payload.verified).toBeUndefined();
+    expect(payload.message).toBe("Launched app com.android.settings");
+  });
 });

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -206,4 +206,33 @@ describe("buildLaunchAppResponse", () => {
     expect(payload.verified).toBeUndefined();
     expect(payload.message).toBe("Launched app com.android.settings");
   });
+
+  // P1 review finding on #6239: a settled `activeWindow.appId` (a primary
+  // signal) must win over a lagging `foregroundActivity` naming the previous
+  // app — the fallback is only consulted when BOTH primary signals are absent.
+  test("a settled activeWindow.appId wins over a lagging foregroundActivity naming the previous app", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        activeWindow: {
+          appId: "com.android.settings",
+          activityName: "SubSettings",
+          layoutSeqSum: 1,
+        },
+        viewHierarchy: {
+          node: {},
+          packageName: "com.android.settings",
+          // Stale/lagging raw signal still naming the PREVIOUS app.
+          foregroundActivity: "com.example.previous/.MainActivity",
+        },
+      } as ObserveResult,
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.observedAppId).toBe("com.android.settings");
+    expect(payload.verified).toBe(true);
+    expect(payload.message).toBe("Launched app com.android.settings (foreground verified)");
+  });
 });

--- a/test/server/appTools.launchAppResponse.test.ts
+++ b/test/server/appTools.launchAppResponse.test.ts
@@ -123,7 +123,10 @@ describe("buildLaunchAppResponse", () => {
     expect(payload.message).toBe("Launched app com.android.settings (foreground verified)");
   });
 
-  test("omits verification when no observation is available", () => {
+  // #6220: no observation at all is squarely "could not observe the launched
+  // app's window" — the response must say so explicitly (verified:false with a
+  // reason) instead of a silent, success-shaped `verified: undefined`.
+  test("reports an explicit verification failure when no observation is available", () => {
     const result: LaunchAppResult = {
       success: true,
       packageName: "com.android.settings",
@@ -131,8 +134,34 @@ describe("buildLaunchAppResponse", () => {
 
     const payload = buildLaunchAppResponse("com.android.settings", result);
 
-    expect(payload.verified).toBeUndefined();
+    expect(payload.verified).toBe(false);
+    expect(payload.verifyFailureReason).toBe("no_observation");
     expect(payload.observedAppId).toBeUndefined();
-    expect(payload.message).toBe("Launched app com.android.settings");
+    expect(payload.message).toBe(
+      "Launched app com.android.settings (verification failed: no observation was captured after launch)",
+    );
+  });
+
+  // #6220 repro: the observation is present but reports no foreground window at
+  // all (activeWindow.appId is empty, e.g. a status-bar-only hierarchy) — the
+  // launch must not silently drop `verified`.
+  test("reports an explicit verification failure when the observation shows no foreground window", () => {
+    const result: LaunchAppResult = {
+      success: true,
+      packageName: "com.android.settings",
+      observation: {
+        activeWindow: { appId: "", activityName: "", layoutSeqSum: 0 },
+        freshness: { isFresh: false, verified: false, warning: "no foreground window" },
+      } as ObserveResult,
+    };
+
+    const payload = buildLaunchAppResponse("com.android.settings", result);
+
+    expect(payload.verified).toBe(false);
+    expect(payload.verifyFailureReason).toBe("no_foreground_window");
+    expect(payload.observedAppId).toBeUndefined();
+    expect(payload.message).toBe(
+      "Launched app com.android.settings (verification failed: no foreground application window could be observed after launch)",
+    );
   });
 });


### PR DESCRIPTION
## Shared root

`freshness.verified`/`isFresh` were stamped from age/timestamp alone, without checking that the captured hierarchy actually reflects the intended post-action, foreground-app window.

## #6219 — action tools returning a PRE-transition observation marked verified/isFresh:true

`TapOnElement` computes `effect.screenChanged` and the inline `observation` from intermediate captures that can, in some code paths, end up out of sync by the time the response is assembled — so a client could see `effect.screenChanged:true` alongside an `observation` that still reflects the pre-tap screen, stamped `verified:true, isFresh:true`.

Fix: `TapOnElement` now re-derives the tap effect against the **final** observation right before returning (`enforceFreshnessConsistencyWithEffect`), after any downstream mutation (selection-state finalize, etc.). When `effect.screenChanged` is `true` but re-deriving the comparison against the observation actually being returned disagrees (i.e. that observation still matches the pre-tap baseline), freshness is retracted: `verified:false, isFresh:false`, with a warning naming the inconsistency. A consistent case (the returned observation genuinely reflects the detected change) is left untouched.

## #6220 — observe reports verified/isFresh:true on a status-bar-only hierarchy when the foreground window is missing; launchApp drops `verified`

Two parts:

1. **`ObserveScreen`**: added a synchronous `missingForegroundWindow` freshness input (`observationFreshness.ts`) — a backstop to the existing async, device-confirmed status-bar-only gate (#6151/#5867). It fires when `activeWindow.appId` is still empty after every fallback (viewHierarchy packageName, bootstrap attribution, etc.) has run, i.e. the observation itself carries no foreground-window identity — even when there was no ground-truth foreground read available to confirm the mismatch through the existing async gate. It's the lowest-priority branch, so all of the existing, more specific #5867/#6151 messages still win when they can fire.

2. **`launchApp`** (`appTools.ts`, `buildLaunchAppResponse`): now reports an explicit `verified:false` with a `verifyFailureReason` (`no_observation` | `no_foreground_window`) when no foreground window could be observed for the launched app at all, instead of a silent `verified:undefined`. The existing, deliberately-ambiguous case — an observed but *different* real foreground app (an accepted surface such as a permission dialog, which `LaunchApp.execute` already treats as success) — still reports `verified:undefined`, unchanged.

## Tests

- `test/features/observe/observationFreshness.test.ts` — unit tests for the new `missingForegroundWindow` input (status-bar-only, empty-active-window, requested-minimum interaction, normal case unaffected).
- `test/features/observe/ObserveScreenMissingForegroundWindow.test.ts` — new integration-style test driving `RealObserveScreen` through fakes: a #6220-shaped status-bar-only capture with no ground-truth foreground read retracts freshness; a normal capture is unaffected.
- `test/features/action/TapOnElement.retryIfNoChange.test.ts` — new tests for `enforceFreshnessConsistencyWithEffect`: retracts freshness on the #6219 contradiction shape, leaves it alone when consistent, and no-ops when `effect.screenChanged` is false.
- `test/server/appTools.launchAppResponse.test.ts` — updated/added tests: explicit `verified:false` + `verifyFailureReason` for "no observation" and "no foreground window" cases; existing accepted-surface and matched-verified cases unchanged.

## Validation

- `bun test` (targeted + full suite): all pass except two pre-existing, unrelated failures (missing `node_modules/.bin/oxlint` in this worktree, and a flaky webrtc integration test) — neither touched by this change.
- `bun run lint`: clean (no new ratchet violations).
- `bun run typecheck`: clean (no new baseline errors).
- `bun run format:check`: clean.
- `bunx turbo run build`: clean.

Closes #6219
Closes #6220