### PR TITLE
fix(observe): actionable-only skeleton with a context array, and a parseable observation union (#6221)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9881,6 +9881,12 @@
                           },
                           "label": {
                             "type": "string"
+                          },
+                          "index": {
+                            "description": "Disambiguator present only when elementId repeats elsewhere among the next observation's nodes (PR #6242 review PRRT_kwDOP-GF5M6fq3iI) — same hierarchy-order semantics as the skeleton's #6238 `index`. Pass verbatim as tapOn({ selector, index }) to hit this exact occurrence.",
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
                           }
                         },
                         "additionalProperties": false
@@ -9925,6 +9931,10 @@
             {
               "type": "object",
               "properties": {
+                "isDiff": {
+                  "type": "boolean",
+                  "const": false
+                },
                 "selectedElements": {
                   "type": "array",
                   "items": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4700,6 +4700,92 @@
             "additionalProperties": {}
           }
         },
+        "context": {
+          "description": "Non-actionable rows (affordances: []) from the same projection as `skeleton` (issue #6221 item 1) — a screen title, a standalone notification, or the com.android.systemui status bar (collapsed to one summarized entry). Present only under project:\"skeleton\" (the default) when at least one such row survived.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "elementId": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "sublabel": {
+                "type": "string"
+              },
+              "testTag": {
+                "type": "string"
+              },
+              "semanticLinks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "occurrence": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "start": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "end": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": ["text", "occurrence"],
+                  "additionalProperties": false
+                }
+              },
+              "bounds": {
+                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
+                "type": "array",
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "affordances": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["tap", "long-press", "input", "scroll", "toggle"]
+                }
+              },
+              "checked": {
+                "type": "boolean"
+              },
+              "index": {
+                "description": "Disambiguator present only when elementId repeats elsewhere in this skeleton (issue #6221). Pass verbatim as tapOn({ selector, index }) to hit this exact entry.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": ["bounds", "affordances"],
+            "additionalProperties": {}
+          }
+        },
         "activeWindow": {
           "type": "object",
           "properties": {
@@ -9636,6 +9722,206 @@
         },
         "observation": {
           "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "isDiff": {
+                  "type": "boolean",
+                  "const": true
+                },
+                "skeleton": {
+                  "description": "Always present alongside a diff (issue #6221 item 4.1): the same actionable-only selector surface a full observation's `skeleton` carries.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "elementId": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "sublabel": {
+                        "type": "string"
+                      },
+                      "testTag": {
+                        "type": "string"
+                      },
+                      "semanticLinks": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "text": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "occurrence": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "start": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "end": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": ["text", "occurrence"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "bounds": {
+                        "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
+                        "type": "array",
+                        "prefixItems": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      },
+                      "affordances": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["tap", "long-press", "input", "scroll", "toggle"]
+                        }
+                      },
+                      "checked": {
+                        "type": "boolean"
+                      },
+                      "index": {
+                        "description": "Disambiguator present only when elementId repeats elsewhere in this skeleton (issue #6221). Pass verbatim as tapOn({ selector, index }) to hit this exact entry.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": ["bounds", "affordances"],
+                    "additionalProperties": {}
+                  }
+                },
+                "added": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "description": "INTERNAL positional identity key (NUL-delimited resource-id/bounds/text/sibling-index). NOT a selector — never pass this to tapOn or any other selector-accepting field. `attributes` already carries the real resource-id/view-id/text/content-desc — read a selector from there, or act on a `skeleton` row instead (issue #6221 item 4).",
+                        "type": "string"
+                      },
+                      "attributes": {
+                        "description": "This node's full raw attributes (including resource-id/view-id/text/content-desc — the real selector fields), so it can be reconstructed without the baseline.",
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": ["key", "attributes"],
+                    "additionalProperties": {}
+                  }
+                },
+                "removed": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "description": "INTERNAL positional identity key (NUL-delimited resource-id/bounds/text/sibling-index). NOT a selector — never pass this to tapOn or any other selector-accepting field. `attributes` already carries the real resource-id/view-id/text/content-desc — read a selector from there, or act on a `skeleton` row instead (issue #6221 item 4).",
+                        "type": "string"
+                      },
+                      "attributes": {
+                        "description": "This node's full raw attributes (including resource-id/view-id/text/content-desc — the real selector fields), so it can be reconstructed without the baseline.",
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": ["key", "attributes"],
+                    "additionalProperties": {}
+                  }
+                },
+                "changed": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "description": "INTERNAL positional identity key — see observeDiffNodeSchema.key. NOT a selector.",
+                        "type": "string"
+                      },
+                      "fromKey": {
+                        "description": "The node's INTERNAL key on the baseline side, present only on content-identity re-pairs.",
+                        "type": "string"
+                      },
+                      "selector": {
+                        "description": "Real, tapOn-usable selector for this diff entry, when one could be derived from its resource-id/view-id/text/content-desc — the same vocabulary skeleton rows use. Prefer this over `key` (issue #6221 item 4).",
+                        "type": "object",
+                        "properties": {
+                          "elementId": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "changes": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "from": {},
+                            "to": {}
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["key", "changes"],
+                    "additionalProperties": {}
+                  }
+                },
+                "fields": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "from": {},
+                      "to": {}
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["isDiff", "skeleton", "added", "removed", "changed"],
+              "additionalProperties": {}
+            },
             {
               "type": "object",
               "properties": {

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -1,6 +1,6 @@
-import type { ObserveResult } from "../../../models/ObserveResult";
+import type { ObserveResult, SkeletonElement } from "../../../models/ObserveResult";
 import type { ViewHierarchyNode } from "../../../models/ViewHierarchyResult";
-import { toSkeleton } from "./SkeletonProjection";
+import { projectSkeleton } from "./SkeletonProjection";
 import { capLayoutWarnings } from "../audits/SafeAreaAuditor";
 
 /**
@@ -137,7 +137,7 @@ export function sanitizeObserveResult(
   // JSON round-trip strips, so reading `out.elements` would silently lose it and
   // revert hoisting/suppression to the pre-#5881 geometry fallback.
   if (cfg.project === "skeleton") {
-    projectSkeleton(out, obs);
+    projectSkeletonOnto(out, obs);
   }
 
   if (cfg.compact) {
@@ -159,17 +159,26 @@ export function sanitizeObserveResult(
 
 /**
  * Replace the full tree with the actionable-only skeleton (issue #4388): set
- * `out.skeleton` from the collector's `elements`, then drop `viewHierarchy` and
- * `elements` from the emitted copy. A hierarchy-less observation (capture
- * failure) yields an empty skeleton — still a valid, if empty, projection.
+ * `out.skeleton` (and the sibling `out.context`, issue #6221 item 1) from the
+ * collector's `elements`, then drop `viewHierarchy` and `elements` from the
+ * emitted copy. A hierarchy-less observation (capture failure) yields an empty
+ * skeleton and no `context` — still a valid, if empty, projection.
  *
  * `source` is the pre-clone `obs`: its elements still carry the non-enumerable
  * ancestry provenance (issue #5881) that the `sanitizeObserveResult` JSON clone
  * strips from `out`. The projection reads but never mutates them, so the "input
  * is never mutated" contract holds; only `out` (the clone) is edited.
  */
-function projectSkeleton(out: ObserveResult, source: ObserveResult): void {
-  out.skeleton = source.elements ? toSkeleton(source.elements) : [];
+function projectSkeletonOnto(out: ObserveResult, source: ObserveResult): void {
+  const { skeleton, context } = source.elements
+    ? projectSkeleton(source.elements)
+    : { skeleton: [] as SkeletonElement[], context: [] as SkeletonElement[] };
+  out.skeleton = skeleton;
+  if (context.length > 0) {
+    out.context = context;
+  } else {
+    delete out.context;
+  }
   delete out.viewHierarchy;
   delete out.elements;
 }
@@ -427,18 +436,71 @@ function compactObserveBounds(value: unknown): void {
  * ------------------------------------------------------------------------ */
 
 /**
+ * A real, `tapOn`-usable selector recovered for a diff node/change (issue
+ * #6221 item 4.3). Same vocabulary the `skeleton` rows use — `elementId`
+ * (`resource-id ?? view-id`) and `label` (`text ?? content-desc`) — derived
+ * with the identical precedence {@link deriveDiffSelector} applies, so a
+ * client that already knows how to act on a skeleton row knows how to act on
+ * a diff entry. Omitted when the node's attributes carry neither.
+ */
+export interface ObserveDiffSelector {
+  elementId?: string;
+  label?: string;
+}
+
+/** `elementId = resource-id ?? view-id`, mirroring `SkeletonProjection.deriveId`. */
+function diffNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+/**
+ * Recover a real selector from a diff node's raw attributes (issue #6221 item
+ * 4.3), reusing the exact `resource-id ?? view-id` / `text ?? content-desc`
+ * precedence `SkeletonProjection.deriveId`/`deriveLabel` use for `skeleton`
+ * rows — the same projection, so the same vocabulary. Returns `undefined` when
+ * neither an id nor a label is present (a diff entry with no stable identity at
+ * all), so callers can omit the field rather than emit an empty object.
+ */
+function deriveDiffSelector(attributes: Record<string, unknown>): ObserveDiffSelector | undefined {
+  const elementId =
+    diffNonEmptyString(attributes["resource-id"]) ?? diffNonEmptyString(attributes["view-id"]);
+  const label =
+    diffNonEmptyString(attributes["text"]) ?? diffNonEmptyString(attributes["content-desc"]);
+  if (elementId === undefined && label === undefined) {
+    return undefined;
+  }
+  return { elementId, label };
+}
+
+/**
  * A single node in an observation diff. `attributes` are the node's own
  * (non-child) attributes — for `added`/`removed` the full attribute set, so the
  * consumer can reconstruct the node without the baseline.
+ *
+ * No separate `selector` field here (issue #6221 item 4.3): `attributes`
+ * already carries `resource-id` / `view-id` / `text` / `content-desc`
+ * directly, so `attributes["resource-id"] ?? attributes["view-id"]` /
+ * `attributes["text"] ?? attributes["content-desc"]` — the same precedence
+ * `skeleton` rows use — IS the real selector. A synthesized duplicate field
+ * would just double those bytes on the wire for no new information (see
+ * {@link ObserveDiffNodeChange.selector}, which earns its keep precisely
+ * because `changed` entries do NOT carry full attributes).
  */
 export interface ObserveDiffNode {
-  /** Synthetic identity key: `resource-id \0 bounds \0 text \0 sibling-index`. */
+  /**
+   * INTERNAL positional identity key: `resource-id \0 bounds \0 text \0
+   * sibling-index`. NOT a selector (issue #6221 item 4.3) — it is capture-order
+   * plumbing for pairing nodes across two observations, not a stable handle a
+   * client should act on. Read a real selector off `attributes` instead (see
+   * above), or act on a `skeleton` row.
+   */
   key: string;
   attributes: Record<string, unknown>;
 }
 
 /** A node matched by key whose non-key attributes changed. */
 export interface ObserveDiffNodeChange {
+  /** INTERNAL positional identity key — see {@link ObserveDiffNode.key}. NOT a selector. */
   key: string;
   /**
    * The node's key on the *baseline* side, present only on entries produced by
@@ -450,6 +512,8 @@ export interface ObserveDiffNodeChange {
    * both sides).
    */
   fromKey?: string;
+  /** Real, tapOn-usable selector recovered for this entry, when available (issue #6221 item 4.3). */
+  selector?: ObserveDiffSelector;
   /** Per-attribute `{ from, to }`; a missing side is `undefined`. */
   changes: Record<string, { from?: unknown; to?: unknown }>;
 }
@@ -459,9 +523,22 @@ export interface ObserveDiffNodeChange {
  * so a consumer can tell a diff apart from a full `ObserveResult` (which has no
  * such marker). Empty `added`/`removed`/`changed` and absent `fields` means the
  * screen is unchanged.
+ *
+ * `skeleton` is populated by the `finalizeToolResponse` call site — never by
+ * {@link diffObserveResult} itself, which only ever sees the full sanitized
+ * tree — so that an agent-facing diff ALWAYS carries a usable actionable-only
+ * selector surface alongside it (issue #6221 item 4.1), the same array a full
+ * observation's `.skeleton` carries.
  */
 export interface ObserveDiff {
   isDiff: true;
+  /**
+   * Actionable-only selector surface (issue #6221 items 1 and 4.1), ALWAYS
+   * present alongside the diff — the same array a full observation's
+   * `.skeleton` carries. Populated by the `finalizeToolResponse` call site from
+   * the post-action observation, not by {@link diffObserveResult}.
+   */
+  skeleton: SkeletonElement[];
   added: ObserveDiffNode[];
   removed: ObserveDiffNode[];
   changed: ObserveDiffNodeChange[];
@@ -934,7 +1011,12 @@ function repairByContentIdentity(
       // `key` is the post-move (added-side) key; `fromKey` carries the pre-move
       // (removed-side) key so a consumer can locate the node in the baseline
       // (#3088 limitation 2, #3107). Emitted only on re-paired entries.
-      changed.push({ key: addedNode.key, fromKey: removedNode.key, changes: attrChanges });
+      changed.push({
+        key: addedNode.key,
+        fromKey: removedNode.key,
+        selector: deriveDiffSelector(addedNode.attributes),
+        changes: attrChanges,
+      });
     }
   }
 
@@ -1129,7 +1211,12 @@ function repairByIosStableIdentity(
     consumedRemoved.add(removedIndices[0]);
     const attrChanges = diffAttributes(removedNode.attributes, addedNode.attributes);
     if (Object.keys(attrChanges).length > 0) {
-      changed.push({ key: addedNode.key, fromKey: removedNode.key, changes: attrChanges });
+      changed.push({
+        key: addedNode.key,
+        fromKey: removedNode.key,
+        selector: deriveDiffSelector(addedNode.attributes),
+        changes: attrChanges,
+      });
     }
   }
 
@@ -1142,6 +1229,18 @@ function repairByIosStableIdentity(
   };
 }
 
+/**
+ * `added`/`removed` entries deliberately do NOT carry a `selector` field: they
+ * already carry the node's FULL `attributes` (including `resource-id` /
+ * `view-id` / `text` / `content-desc`), so the real selector is already there —
+ * a synthesized `selector` would be pure duplication of bytes already on the
+ * wire (it would materially erode the diff-format's whole reason to exist: see
+ * the ~60%-of-full byte budget asserted in
+ * `test/features/observe/output/stableIdentityScrollDiff.test.ts`). Only
+ * `changed` entries lack full attributes (they carry only the delta), which is
+ * where {@link deriveDiffSelector} actually earns its bytes — see its use in
+ * {@link diffObserveResult}.
+ */
 function toObserveDiffNode(node: DiffRepairNode): ObserveDiffNode {
   return { key: node.key, attributes: node.attributes };
 }
@@ -1224,7 +1323,11 @@ export function diffObserveResult(
     for (let i = 0; i < paired; i++) {
       const attrChanges = diffAttributes(baseNodes[i].attributes, nextNodes[i].attributes);
       if (Object.keys(attrChanges).length > 0) {
-        changed.push({ key: nextNodes[i].key, changes: attrChanges });
+        changed.push({
+          key: nextNodes[i].key,
+          selector: deriveDiffSelector(nextNodes[i].attributes),
+          changes: attrChanges,
+        });
       }
     }
     for (let i = paired; i < nextNodes.length; i++) {
@@ -1262,6 +1365,11 @@ export function diffObserveResult(
 
   const diff: ObserveDiff = {
     isDiff: true,
+    // Placeholder — `elements` is already dropped from `next` by the time it
+    // reaches this function (issue #6221 item 4.1), so the caller
+    // (`finalizeToolResponse`) overwrites this with the actionable-only
+    // skeleton it independently re-projects from the pre-drop payload.
+    skeleton: [],
     added: finalAdded.map(toObserveDiffNode),
     removed: finalRemoved.map(toObserveDiffNode),
     changed,

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -446,11 +446,28 @@ function compactObserveBounds(value: unknown): void {
 export interface ObserveDiffSelector {
   elementId?: string;
   label?: string;
+  /**
+   * Disambiguator (PR #6242 review PRRT_kwDOP-GF5M6fq3iI), present only when
+   * `elementId` repeats elsewhere among `next`'s nodes: without it, two
+   * `changed` entries for distinct repeated controls (same resource-id AND
+   * label — e.g. two identical toggle rows) would emit the SAME selector, so
+   * `tapOn` would act on the first match rather than the occurrence that
+   * actually changed. Same hierarchy-order semantics as the skeleton's #6238
+   * `index` — verbatim-usable as `tapOn({ selector, index })` — computed by
+   * {@link computeElementIdOccurrenceIndexes} over the SAME preorder walk
+   * `flattenForDiff` produces. Unique-id entries never carry this field.
+   */
+  index?: number;
 }
 
 /** `elementId = resource-id ?? view-id`, mirroring `SkeletonProjection.deriveId`. */
 function diffNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+/** `elementId = resource-id ?? view-id` off a diff node's raw attributes — see {@link deriveDiffSelector}. */
+function diffElementId(attributes: Record<string, unknown>): string | undefined {
+  return diffNonEmptyString(attributes["resource-id"]) ?? diffNonEmptyString(attributes["view-id"]);
 }
 
 /**
@@ -459,17 +476,60 @@ function diffNonEmptyString(value: unknown): string | undefined {
  * precedence `SkeletonProjection.deriveId`/`deriveLabel` use for `skeleton`
  * rows — the same projection, so the same vocabulary. Returns `undefined` when
  * neither an id nor a label is present (a diff entry with no stable identity at
- * all), so callers can omit the field rather than emit an empty object.
+ * all), so callers can omit the field rather than emit an empty object. `index`
+ * (PR #6242 review PRRT_kwDOP-GF5M6fq3iI), when supplied, is attached only
+ * when a selector was actually derivable.
  */
-function deriveDiffSelector(attributes: Record<string, unknown>): ObserveDiffSelector | undefined {
-  const elementId =
-    diffNonEmptyString(attributes["resource-id"]) ?? diffNonEmptyString(attributes["view-id"]);
+function deriveDiffSelector(
+  attributes: Record<string, unknown>,
+  index?: number,
+): ObserveDiffSelector | undefined {
+  const elementId = diffElementId(attributes);
   const label =
     diffNonEmptyString(attributes["text"]) ?? diffNonEmptyString(attributes["content-desc"]);
   if (elementId === undefined && label === undefined) {
     return undefined;
   }
-  return { elementId, label };
+  return index === undefined ? { elementId, label } : { elementId, label, index };
+}
+
+/**
+ * Occurrence index for every flattened `next` node whose resolved `elementId`
+ * (`resource-id ?? view-id`) repeats elsewhere in the SAME preorder DFS walk
+ * `flattenForDiff` performs (PR #6242 review PRRT_kwDOP-GF5M6fq3iI) — the
+ * identical traversal order `tapOn.index` resolves against, and the same
+ * hierarchy-order semantics `SkeletonProjection.assignDuplicateIndexes` (issue
+ * #6238) already uses for the skeleton's own `index`. Keyed by `pathKey` (the
+ * one thing that uniquely identifies a specific flattened node instance) so a
+ * `changed` entry can look up its own index without re-deriving ambiguity from
+ * scratch. Only ambiguous elementIds (repeated 2+ times) get an entry — a
+ * unique id is left out, mirroring the skeleton's "no spurious index on the
+ * common case" rule.
+ *
+ * Scoped to the positional-match `changed` path only: content-identity
+ * re-paired `changed` entries (`repairByContentIdentity` /
+ * `repairByIosStableIdentity`) already require a UNIQUE content key among
+ * leftovers on both sides to re-pair at all, so they are inherently
+ * unambiguous and need no occurrence index.
+ */
+function computeElementIdOccurrenceIndexes(nodes: readonly FlatObserveNode[]): Map<string, number> {
+  const byElementId = new Map<string, FlatObserveNode[]>();
+  for (const node of nodes) {
+    const elementId = diffElementId(node.attributes);
+    if (elementId === undefined) {
+      continue;
+    }
+    const group = byElementId.get(elementId);
+    if (group) {
+      group.push(node);
+    } else {
+      byElementId.set(elementId, [node]);
+    }
+  }
+  const ambiguousEntries = [...byElementId.values()]
+    .filter((group) => group.length >= 2)
+    .flatMap((group) => group.map((node, position): [string, number] => [node.pathKey, position]));
+  return new Map(ambiguousEntries);
 }
 
 /**
@@ -1309,8 +1369,12 @@ export function diffObserveResult(
   next: ObserveResult,
   cfg?: DiffObserveConfig,
 ): ObserveDiff {
+  const nextFlatNodes = flattenForDiff(next);
   const baseByKey = groupByKey(flattenForDiff(baseline));
-  const nextByKey = groupByKey(flattenForDiff(next));
+  const nextByKey = groupByKey(nextFlatNodes);
+  // Occurrence-index map for ambiguous elementIds among `next`'s nodes (PR #6242
+  // review PRRT_kwDOP-GF5M6fq3iI) — see computeElementIdOccurrenceIndexes' doc.
+  const occurrenceIndexByPathKey = computeElementIdOccurrenceIndexes(nextFlatNodes);
 
   const added: DiffRepairNode[] = [];
   const removed: DiffRepairNode[] = [];
@@ -1325,7 +1389,10 @@ export function diffObserveResult(
       if (Object.keys(attrChanges).length > 0) {
         changed.push({
           key: nextNodes[i].key,
-          selector: deriveDiffSelector(nextNodes[i].attributes),
+          selector: deriveDiffSelector(
+            nextNodes[i].attributes,
+            occurrenceIndexByPathKey.get(nextNodes[i].pathKey),
+          ),
           changes: attrChanges,
         });
       }

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -141,13 +141,6 @@ interface SkeletonAccumulator {
   provenance?: ElementProvenance;
   /** Disambiguator assigned by {@link assignDuplicateIndexes} (issue #6221 item 2). */
   index?: number;
-  /**
-   * Source `Element.package`, when present (issue #6221 item 1). Used only to
-   * detect the recurring `com.android.systemui` status-bar block for
-   * {@link collapseSystemUiBlock} — never emitted on the skeleton/context row
-   * itself.
-   */
-  packageName?: string;
 }
 
 /** NUL-joined identity so `(elementId, label, bounds)` triples dedup without straddling. */
@@ -215,9 +208,6 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
     }
     if (acc.semanticLinks === undefined && el["semantic-links"]?.length) {
       acc.semanticLinks = el["semantic-links"];
-    }
-    if (acc.packageName === undefined) {
-      acc.packageName = nonEmptyString(el.package);
     }
   }
   return [...byIdentity.values()];
@@ -526,23 +516,29 @@ function assignDuplicateIndexes(entries: SkeletonAccumulator[]): void {
 }
 
 /**
- * Resource-id prefix identifying the Android status-bar block
- * (`com.android.systemui:id/clock`, `:id/wifi_signal`, `:id/battery`, …). This
- * block is re-emitted on EVERY observation of EVERY screen (issue #6221 item
- * 1) and carries no affordances, so {@link collapseSystemUiBlock} folds every
+ * Resource-id ALLOWLIST for the actual Android status-bar chrome — the clock,
+ * signal/battery icons, and their containers (`com.android.systemui:id/clock`,
+ * `:id/wifi_signal`, `:id/battery`, `:id/status_bar_container`, …). This block
+ * is re-emitted on EVERY observation of EVERY screen (issue #6221 item 1) and
+ * carries no affordances, so {@link collapseSystemUiBlock} folds every
  * matching zero-affordance row into one summarized `context` entry instead of
  * emitting each one separately.
+ *
+ * Deliberately an ALLOWLIST, not a `com.android.systemui:id/` prefix match
+ * (PR #6242 review PRRT_kwDOP-GF5M6fq3iH): the notification SHADE lives under
+ * the same `com.android.systemui` namespace (e.g. `:id/notification_row_1`,
+ * `:id/notification_stack_scroller` — see `test/server/systemTray.test.ts`),
+ * and those rows are ACTIONABLE and must stay individually selectable, never
+ * folded into this summary. Only genuine status-bar chrome collapses; a new
+ * systemui id that isn't on this list simply stays its own `context` entry
+ * (still correct, just not collapsed) rather than risking a false positive.
  */
-const SYSTEMUI_ID_PREFIX = "com.android.systemui:id/";
+const SYSTEMUI_STATUS_BAR_ID_PATTERN =
+  /^com\.android\.systemui:id\/(status_bar[a-zA-Z_]*|clock|battery[a-zA-Z_]*|wifi_[a-zA-Z_]*|system_icons|statusIcons|notification_icon_area|notificationIcons)$/;
 
-/** The Android systemui package, matched on `Element.package` as a fallback to the id prefix. */
-const SYSTEMUI_PACKAGE = "com.android.systemui";
-
-/** Whether `acc` belongs to the recurring systemui status-bar block. */
+/** Whether `acc` is genuine status-bar chrome (never the notification shade — see the pattern's doc). */
 function isSystemUiEntry(acc: SkeletonAccumulator): boolean {
-  return (
-    acc.elementId?.startsWith(SYSTEMUI_ID_PREFIX) === true || acc.packageName === SYSTEMUI_PACKAGE
-  );
+  return acc.elementId !== undefined && SYSTEMUI_STATUS_BAR_ID_PATTERN.test(acc.elementId);
 }
 
 /** The smallest bounds tuple enclosing every entry's bounds. */

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -28,6 +28,14 @@ import { ElementProvenance, getElementProvenance, isStrictAncestor } from "./ele
  * with no new selector semantics (issue #4388 acceptance criterion 2). The
  * emitted key is named `elementId` (not `id`) to literally match the selector
  * field name — see issue #6153.
+ *
+ * `skeleton` is actionable-only (issue #6221 item 1): a row with zero
+ * affordances never appears there. Such rows (a screen title, the
+ * `com.android.systemui` status bar, a standalone notification line) instead
+ * go into the sibling `context` array, so the information survives without
+ * polluting the action surface — and the recurring systemui status-bar block
+ * collapses to a single summarized `context` entry rather than one row per
+ * icon. See {@link projectSkeleton}.
  */
 
 type ObserveElements = NonNullable<ObserveResult["elements"]>;
@@ -133,6 +141,13 @@ interface SkeletonAccumulator {
   provenance?: ElementProvenance;
   /** Disambiguator assigned by {@link assignDuplicateIndexes} (issue #6221 item 2). */
   index?: number;
+  /**
+   * Source `Element.package`, when present (issue #6221 item 1). Used only to
+   * detect the recurring `com.android.systemui` status-bar block for
+   * {@link collapseSystemUiBlock} — never emitted on the skeleton/context row
+   * itself.
+   */
+  packageName?: string;
 }
 
 /** NUL-joined identity so `(elementId, label, bounds)` triples dedup without straddling. */
@@ -200,6 +215,9 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
     }
     if (acc.semanticLinks === undefined && el["semantic-links"]?.length) {
       acc.semanticLinks = el["semantic-links"];
+    }
+    if (acc.packageName === undefined) {
+      acc.packageName = nonEmptyString(el.package);
     }
   }
   return [...byIdentity.values()];
@@ -508,11 +526,96 @@ function assignDuplicateIndexes(entries: SkeletonAccumulator[]): void {
 }
 
 /**
- * Project the flattened `elements` block into an actionable-only skeleton
- * (issue #4388): merge + dedup the categories, apply the keep rule, and emit
- * `{ elementId, label, bounds, affordances }` rows with compact tuple bounds.
+ * Resource-id prefix identifying the Android status-bar block
+ * (`com.android.systemui:id/clock`, `:id/wifi_signal`, `:id/battery`, …). This
+ * block is re-emitted on EVERY observation of EVERY screen (issue #6221 item
+ * 1) and carries no affordances, so {@link collapseSystemUiBlock} folds every
+ * matching zero-affordance row into one summarized `context` entry instead of
+ * emitting each one separately.
  */
-export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
+const SYSTEMUI_ID_PREFIX = "com.android.systemui:id/";
+
+/** The Android systemui package, matched on `Element.package` as a fallback to the id prefix. */
+const SYSTEMUI_PACKAGE = "com.android.systemui";
+
+/** Whether `acc` belongs to the recurring systemui status-bar block. */
+function isSystemUiEntry(acc: SkeletonAccumulator): boolean {
+  return (
+    acc.elementId?.startsWith(SYSTEMUI_ID_PREFIX) === true || acc.packageName === SYSTEMUI_PACKAGE
+  );
+}
+
+/** The smallest bounds tuple enclosing every entry's bounds. */
+function unionBounds(entries: readonly SkeletonAccumulator[]): SkeletonElement["bounds"] {
+  let [left, top, right, bottom] = entries[0].bounds;
+  for (const entry of entries.slice(1)) {
+    left = Math.min(left, entry.bounds[0]);
+    top = Math.min(top, entry.bounds[1]);
+    right = Math.max(right, entry.bounds[2]);
+    bottom = Math.max(bottom, entry.bounds[3]);
+  }
+  return [left, top, right, bottom];
+}
+
+/**
+ * Synthetic elementId for the collapsed systemui summary row. Deliberately NOT
+ * shaped like a real `package:id/name` resource-id (no `:id/` segment) so it
+ * can never be mistaken for — or collide with — an actual selector; the row
+ * carries no affordances and is not meant to be tapped.
+ */
+const SYSTEMUI_SUMMARY_ELEMENT_ID = "com.android.systemui:status-bar-summary";
+
+/**
+ * Collapse every zero-affordance systemui status-bar row into ONE summarized
+ * `context` entry (issue #6221 item 1). The block (clock, wifi/battery icons,
+ * …) reappears verbatim on every observation of every screen, so emitting each
+ * icon as its own `context` row would just move the noise from `skeleton` to
+ * `context` instead of removing it. Non-systemui zero-affordance entries
+ * (e.g. a screen title, a standalone notification) pass through individually.
+ */
+function collapseSystemUiBlock(nonActionable: SkeletonAccumulator[]): SkeletonAccumulator[] {
+  const systemUiEntries = nonActionable.filter(isSystemUiEntry);
+  if (systemUiEntries.length === 0) {
+    return nonActionable;
+  }
+  const other = nonActionable.filter((acc) => !isSystemUiEntry(acc));
+  const summaryParts = systemUiEntries
+    .map((entry) => entry.label?.trim())
+    .filter((label): label is string => !!label);
+  const summary: SkeletonAccumulator = {
+    elementId: SYSTEMUI_SUMMARY_ELEMENT_ID,
+    label:
+      summaryParts.length > 0
+        ? `Status bar: ${summaryParts.join(", ")}`
+        : "Status bar (no readable status text)",
+    bounds: unionBounds(systemUiEntries),
+    affordances: new Set<Affordance>(),
+  };
+  return [...other, summary];
+}
+
+/** The `skeleton` (actionable) and `context` (non-actionable) halves of a projection. */
+export interface SkeletonProjectionResult {
+  /** Actionable-only rows (`affordances.length >= 1`); the surface a client should act on. */
+  skeleton: SkeletonElement[];
+  /**
+   * Non-actionable rows (`affordances.length === 0`) that still carry readable
+   * information — a screen title, a status-bar summary, a standalone
+   * notification line (issue #6221 item 1). Kept out of `skeleton` so that
+   * array means what its schema says: actionable-only.
+   */
+  context: SkeletonElement[];
+}
+
+/**
+ * Project the flattened `elements` block into the actionable `skeleton` and
+ * informational `context` arrays (issue #6221 item 1): merge + dedup the
+ * categories, apply the keep rule, split on affordance count, and collapse
+ * the systemui status-bar block. Duplicate-id disambiguation (issue #6221 item
+ * 2) runs only over the actionable set — a non-actionable duplicate is not
+ * something a client will ever need to disambiguate for `tapOn`.
+ */
+export function projectSkeleton(elements: ObserveElements): SkeletonProjectionResult {
   const accumulators = accumulateByIdentity(elements);
   const clickable = accumulators.filter((acc) => acc.affordances.has("tap"));
   // Hoist descendant text onto labelless/underlabelled clickable rows (issue
@@ -520,10 +623,30 @@ export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
   hoistContainerLabels(accumulators, clickable);
 
   const kept = accumulators.filter((acc) => shouldKeep(acc, clickable));
+  const actionable = kept.filter((acc) => acc.affordances.size > 0);
+  const nonActionable = kept.filter((acc) => acc.affordances.size === 0);
+
   // Disambiguate duplicate ids (issue #6221 item 2) against the FINAL emitted
-  // set, not the pre-filter accumulators — a duplicate suppressed by the keep
-  // rule (e.g. folded/hoisted text) must not consume an index slot a client
-  // will never see.
-  assignDuplicateIndexes(kept);
-  return kept.map(toSkeletonEntry);
+  // actionable set, not the pre-filter accumulators — a duplicate suppressed by
+  // the keep rule (e.g. folded/hoisted text) must not consume an index slot a
+  // client will never see.
+  assignDuplicateIndexes(actionable);
+
+  return {
+    skeleton: actionable.map(toSkeletonEntry),
+    context: collapseSystemUiBlock(nonActionable).map(toSkeletonEntry),
+  };
+}
+
+/**
+ * Project the flattened `elements` block into an actionable-only skeleton
+ * (issue #4388): merge + dedup the categories, apply the keep rule, and emit
+ * `{ elementId, label, bounds, affordances }` rows with compact tuple bounds.
+ *
+ * A thin wrapper over {@link projectSkeleton} that drops `context` (issue
+ * #6221 item 1), kept for callers that only ever wanted the actionable rows
+ * (e.g. the #6218 elementId round-trip coverage).
+ */
+export function toSkeleton(elements: ObserveElements): SkeletonElement[] {
+  return projectSkeleton(elements).skeleton;
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -178,8 +178,27 @@ export interface ObserveResult {
    * summary emitted in place of `viewHierarchy` / `elements`. The `"skeleton"`
    * projection is now the default; it is absent only when a caller opts out with
    * a per-call `project: "full"` arg (or `raw: true`).
+   *
+   * Actionable-only (issue #6221 item 1): every entry has `affordances.length
+   * >= 1`. A row with zero affordances is never emitted here — it goes into
+   * the sibling {@link context} array instead, so `skeleton` means what its
+   * name says and a client's action surface is not diluted by rows it can
+   * never `tapOn`/`inputText`/etc.
    */
   skeleton?: SkeletonElement[];
+
+  /**
+   * Non-actionable rows from the same projection that produces `skeleton`
+   * (issue #6221 item 1): every entry has `affordances.length === 0`. Covers
+   * things like a screen title, a standalone notification line, or the
+   * `com.android.systemui` status bar — the latter collapsed to a SINGLE
+   * summarized entry rather than one row per icon, since it otherwise
+   * reappears verbatim on every observation of every screen. Present
+   * alongside `skeleton` whenever `project: "skeleton"` is in effect (the
+   * default) and at least one non-actionable row survived the keep rule;
+   * absent under `project: "full"` / `raw: true`.
+   */
+  context?: SkeletonElement[];
 
   /** Active window information */
   activeWindow?: ActiveWindowInfo;

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -453,6 +453,12 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
           shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))
         ) {
           const diff = diffObserveResult(baseline, sanitized);
+          // Always attach a usable selector surface alongside the diff (issue #6221
+          // item 4.1): a client that gets a diff must never be left with no
+          // `skeleton` to act on. `diffObserveResult` cannot compute this itself —
+          // `elements` is already dropped from `sanitized` by the time it runs — so
+          // it is filled in here from the independently re-projected `servedObservation`.
+          diff.skeleton = servedObservation.skeleton ?? [];
           const screenChangedWithEmptyDiff =
             hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
           observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -1,4 +1,4 @@
-import type { ObserveResult } from "../models/ObserveResult";
+import type { ObserveResult, SkeletonElement } from "../models/ObserveResult";
 import {
   sanitizeObserveResult,
   diffObserveResult,
@@ -167,6 +167,30 @@ function resolveObserveProjection(args?: Record<string, unknown>): "full" | "ske
     return "full";
   }
   return "skeleton";
+}
+
+/**
+ * The `skeleton` to attach to a diff response (issue #6221 item 4.1), resolved
+ * independently of whatever projection `servedObservation` happens to carry.
+ * `servedObservation` only carries `.skeleton` when the tool defaults to it
+ * (issue #5872's `SKELETON_DEFAULT_ACTION_TOOLS`) AND the resolved projection
+ * is `"skeleton"` — a per-call `raw:true` / `project:"full"` request (or a
+ * tool outside that set) leaves it `undefined`. Without this, exactly THOSE
+ * modes would silently violate the always-usable-selector guarantee (PR #6242
+ * review PRRT_kwDOP-GF5M6fq3iK): a diff with no skeleton, in the one case the
+ * guarantee exists to prevent. So when `servedObservation.skeleton` is absent,
+ * this re-projects one from the underlying (pre-sanitize) observation, which
+ * still carries `.elements` regardless of what projection was requested.
+ */
+function resolveDiffSkeleton(
+  servedObservation: ObserveResult,
+  rawObservation: ObserveResult,
+  cfg: SanitizeObserveConfig,
+): SkeletonElement[] {
+  if (servedObservation.skeleton) {
+    return servedObservation.skeleton;
+  }
+  return sanitizeObserveResult(rawObservation, { ...cfg, project: "skeleton" }).skeleton ?? [];
 }
 
 /**
@@ -455,10 +479,16 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
           const diff = diffObserveResult(baseline, sanitized);
           // Always attach a usable selector surface alongside the diff (issue #6221
           // item 4.1): a client that gets a diff must never be left with no
-          // `skeleton` to act on. `diffObserveResult` cannot compute this itself —
-          // `elements` is already dropped from `sanitized` by the time it runs — so
-          // it is filled in here from the independently re-projected `servedObservation`.
-          diff.skeleton = servedObservation.skeleton ?? [];
+          // `skeleton` to act on — including when the request is `raw:true` /
+          // `project:"full"` (PR #6242 review PRRT_kwDOP-GF5M6fq3iK), where
+          // `servedObservation` itself carries no skeleton. `diffObserveResult`
+          // cannot compute this itself — `elements` is already dropped from
+          // `sanitized` by the time it runs — so it is resolved here instead.
+          diff.skeleton = resolveDiffSkeleton(
+            servedObservation,
+            payload.observation as ObserveResult,
+            cfg,
+          );
           const screenChangedWithEmptyDiff =
             hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
           observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -153,8 +153,21 @@ const screenIdentitySchema = z
 // FULL-object arm, identified by the ABSENCE of `isDiff` (the diff arm,
 // `observeDiffSchema`, always carries `isDiff: true`). A consumer branches on
 // `"isDiff" in observation && observation.isDiff === true`.
+//
+// `isDiff: z.literal(false).optional()` (PR #6242 review PRRT_kwDOP-GF5M6fq3iN)
+// makes this arm GENUINELY reject a diff-shaped object rather than silently
+// accepting it via `.passthrough()`: every OTHER field here is optional, so
+// without this an invalid diff (e.g. `{isDiff: true, added: [], removed: [],
+// changed: []}` missing the mandatory `skeleton`) would fail `observeDiffSchema`
+// and then fall through to match this permissive arm anyway. `isDiff` is a
+// genuinely-typed member of this schema, so a real `isDiff: true` payload now
+// fails HERE too — the union as a whole rejects the malformed diff instead of
+// silently accepting it under the wrong arm. The server itself never emits
+// `isDiff: false` explicitly (absence is the real-world full-observation
+// shape); the literal exists purely to close this validation gap.
 export const observationSummarySchema = z
   .object({
+    isDiff: z.literal(false).optional(),
     selectedElements: z.array(selectedElementSchema).optional(),
     focusedElement: elementSchema.optional(),
     accessibilityFocusedElement: elementSchema.optional(),
@@ -585,6 +598,17 @@ export const observeDiffSelectorSchema = z
   .object({
     elementId: z.string().optional(),
     label: z.string().optional(),
+    index: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Disambiguator present only when elementId repeats elsewhere among the " +
+          "next observation's nodes (PR #6242 review PRRT_kwDOP-GF5M6fq3iI) — same " +
+          "hierarchy-order semantics as the skeleton's #6238 `index`. Pass verbatim " +
+          "as tapOn({ selector, index }) to hit this exact occurrence.",
+      ),
   })
   .describe(
     "Real, tapOn-usable selector for this diff entry, when one could be derived " +
@@ -676,7 +700,10 @@ export const observeDiffSchema = z
  * discriminated union of a full `ObserveResult` summary ({@link
  * observationSummarySchema}) and a compact diff ({@link observeDiffSchema}).
  * The discriminator is `isDiff`: present and `true` on the diff arm, absent on
- * the full arm. A client should branch on
+ * the full arm — and REJECTED as `true` on the full arm (issue #6221 item 4,
+ * PR #6242 review PRRT_kwDOP-GF5M6fq3iN), so a malformed diff (missing its
+ * mandatory `skeleton`) cannot silently fall through and validate against the
+ * full arm's `.passthrough()` instead. A client should branch on
  * `"isDiff" in observation && observation.isDiff === true` and, in EITHER
  * branch, can read `observation.skeleton` for a usable selector surface — the
  * diff arm always carries one (item 4.1).

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -147,6 +147,12 @@ const screenIdentitySchema = z
 // compact `skeleton` (issue #5872) and carry the raw `viewHierarchy` under
 // raw/project:"full"; both flow through without an explicit field here (the
 // schemas they'd reference are declared later in this module).
+//
+// This is one arm of the `observation` discriminated union documented on
+// `observationOutputSchema` further down this module (issue #6221 item 4): the
+// FULL-object arm, identified by the ABSENCE of `isDiff` (the diff arm,
+// `observeDiffSchema`, always carries `isDiff: true`). A consumer branches on
+// `"isDiff" in observation && observation.isDiff === true`.
 export const observationSummarySchema = z
   .object({
     selectedElements: z.array(selectedElementSchema).optional(),
@@ -234,34 +240,6 @@ const tapEffectSchema = z
       "viewHierarchy unchanged",
       "insufficient observation data",
     ]),
-  })
-  .passthrough();
-
-export const tapOnResultSchema = z
-  .object({
-    success: z.boolean(),
-    action: z.string().optional(),
-    message: z.string().optional(),
-    element: elementSchema.optional(),
-    observation: z.union([observationSummarySchema, toolOutputArtifactMetadataSchema]).optional(),
-    observationDiff: observationDiffMetadataSchema.optional(),
-    effect: tapEffectSchema.optional(),
-    selectedElement: selectedElementSchema.optional(),
-    activatedSubtext: z
-      .object({
-        text: z.string(),
-        occurrence: z.number().int().nonnegative(),
-      })
-      .optional()
-      .describe("Semantic accessibility link confirmed by the native runner"),
-    selectedElements: z.array(selectedElementSchema).optional(),
-    error: z.string().optional(),
-    pressRecognized: z.boolean().optional(),
-    contextMenuOpened: z.boolean().optional(),
-    selectionStarted: z.boolean().optional(),
-    searchUntil: tapOnSearchUntilSchema.optional(),
-    screenReaderNavigation: screenReaderNavigationSchema.optional(),
-    debug: z.any().optional(),
   })
   .passthrough();
 
@@ -595,6 +573,149 @@ export const skeletonElementSchema = z
   .passthrough();
 
 /**
+ * A selector recovered for a diff node/change (issue #6221 item 4). Same
+ * vocabulary the `skeleton` rows use (`elementId` / `label` — see {@link
+ * skeletonElementSchema}), derived from the SAME `resource-id ?? view-id` /
+ * `text ?? content-desc` precedence `SkeletonProjection` applies, so a client
+ * can act on a diff entry the same way it acts on a skeleton entry:
+ * `tapOn({ elementId })` (falling back to `tapOn({ text: label })` when
+ * `elementId` is absent). Omitted when the node carries neither.
+ */
+export const observeDiffSelectorSchema = z
+  .object({
+    elementId: z.string().optional(),
+    label: z.string().optional(),
+  })
+  .describe(
+    "Real, tapOn-usable selector for this diff entry, when one could be derived " +
+      "from its resource-id/view-id/text/content-desc — the same vocabulary skeleton " +
+      "rows use. Prefer this over `key` (issue #6221 item 4).",
+  );
+
+/** One `added`/`removed` node in an observation diff (issue #2761 / #6221 item 4). */
+export const observeDiffNodeSchema = z
+  .object({
+    key: z
+      .string()
+      .describe(
+        "INTERNAL positional identity key (NUL-delimited resource-id/bounds/text/" +
+          "sibling-index). NOT a selector — never pass this to tapOn or any other " +
+          "selector-accepting field. `attributes` already carries the real " +
+          "resource-id/view-id/text/content-desc — read a selector from there, or " +
+          "act on a `skeleton` row instead (issue #6221 item 4).",
+      ),
+    attributes: z
+      .record(z.string(), z.unknown())
+      .describe(
+        "This node's full raw attributes (including resource-id/view-id/text/" +
+          "content-desc — the real selector fields), so it can be reconstructed " +
+          "without the baseline.",
+      ),
+  })
+  .passthrough();
+
+/** A node matched across baseline/next whose non-key attributes changed. */
+export const observeDiffNodeChangeSchema = z
+  .object({
+    key: z
+      .string()
+      .describe(
+        "INTERNAL positional identity key — see observeDiffNodeSchema.key. NOT a selector.",
+      ),
+    fromKey: z
+      .string()
+      .optional()
+      .describe(
+        "The node's INTERNAL key on the baseline side, present only on content-identity re-pairs.",
+      ),
+    selector: observeDiffSelectorSchema.optional(),
+    changes: z.record(
+      z.string(),
+      z.object({ from: z.unknown().optional(), to: z.unknown().optional() }),
+    ),
+  })
+  .passthrough();
+
+/**
+ * Compact diff of one observation against the previous one
+ * (`--actions-diff-observe`, issue #2761). This is the DIFF arm of the
+ * `observation` discriminated union (issue #6221 item 4): identified by
+ * `isDiff: true`, which the full-object arm ({@link observationSummarySchema})
+ * never carries.
+ *
+ * `skeleton` is ALWAYS present here (issue #6221 item 4.1) — the same
+ * actionable-only rows `observe`/action tools emit on a full observation — so a
+ * client always has a selector surface to act on, regardless of whether a
+ * diff baseline happened to exist. Every entry's internal `key` is documented
+ * as non-selector so it is never mistaken for one (item 4.3): `added`/`removed`
+ * entries already carry a real selector directly in their `attributes`
+ * (resource-id/view-id/text/content-desc), and `changed` entries — which do NOT
+ * carry full attributes — get an explicit `selector` field recovered from the
+ * same precedence.
+ */
+export const observeDiffSchema = z
+  .object({
+    isDiff: z.literal(true),
+    skeleton: z
+      .array(skeletonElementSchema)
+      .describe(
+        "Always present alongside a diff (issue #6221 item 4.1): the same " +
+          "actionable-only selector surface a full observation's `skeleton` carries.",
+      ),
+    added: z.array(observeDiffNodeSchema),
+    removed: z.array(observeDiffNodeSchema),
+    changed: z.array(observeDiffNodeChangeSchema),
+    fields: z
+      .record(z.string(), z.object({ from: z.unknown().optional(), to: z.unknown().optional() }))
+      .optional(),
+  })
+  .passthrough();
+
+/**
+ * `observation`, as embedded on an action tool result (issue #6221 item 4): a
+ * discriminated union of a full `ObserveResult` summary ({@link
+ * observationSummarySchema}) and a compact diff ({@link observeDiffSchema}).
+ * The discriminator is `isDiff`: present and `true` on the diff arm, absent on
+ * the full arm. A client should branch on
+ * `"isDiff" in observation && observation.isDiff === true` and, in EITHER
+ * branch, can read `observation.skeleton` for a usable selector surface — the
+ * diff arm always carries one (item 4.1).
+ */
+export const observationOutputSchema = z.union([
+  observeDiffSchema,
+  observationSummarySchema,
+  toolOutputArtifactMetadataSchema,
+]);
+
+export const tapOnResultSchema = z
+  .object({
+    success: z.boolean(),
+    action: z.string().optional(),
+    message: z.string().optional(),
+    element: elementSchema.optional(),
+    observation: observationOutputSchema.optional(),
+    observationDiff: observationDiffMetadataSchema.optional(),
+    effect: tapEffectSchema.optional(),
+    selectedElement: selectedElementSchema.optional(),
+    activatedSubtext: z
+      .object({
+        text: z.string(),
+        occurrence: z.number().int().nonnegative(),
+      })
+      .optional()
+      .describe("Semantic accessibility link confirmed by the native runner"),
+    selectedElements: z.array(selectedElementSchema).optional(),
+    error: z.string().optional(),
+    pressRecognized: z.boolean().optional(),
+    contextMenuOpened: z.boolean().optional(),
+    selectionStarted: z.boolean().optional(),
+    searchUntil: tapOnSearchUntilSchema.optional(),
+    screenReaderNavigation: screenReaderNavigationSchema.optional(),
+    debug: z.any().optional(),
+  })
+  .passthrough();
+
+/**
  * Progressive-disclosure scoping metadata (issue #4344), present only when a
  * per-call `scope.focus` / `scope.overview` / `scope.region` request scoped the
  * payload. `regionPx` routes through {@link elementBoundsSchema} so its bounds
@@ -671,6 +792,16 @@ export const observeResultSchema = z
       .optional(),
     viewHierarchy: viewHierarchyResultSchema.optional(),
     skeleton: z.array(skeletonElementSchema).optional(),
+    context: z
+      .array(skeletonElementSchema)
+      .optional()
+      .describe(
+        "Non-actionable rows (affordances: []) from the same projection as `skeleton` " +
+          "(issue #6221 item 1) — a screen title, a standalone notification, or the " +
+          "com.android.systemui status bar (collapsed to one summarized entry). " +
+          'Present only under project:"skeleton" (the default) when at least one ' +
+          "such row survived.",
+      ),
     activeWindow: activeWindowSchema.optional(),
     screenIdentity: screenIdentitySchema.optional(),
     elements: observeElementsSchema.optional(),

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -180,6 +180,88 @@ describe("diffObserveResult", () => {
     expect(diff.changed[0].selector).toEqual({ elementId: "toggle", label: "Airplane mode" });
   });
 
+  test("a changed entry whose elementId AND label repeat elsewhere in `next` gets a disambiguating `index` (PR #6242 review PRRT_kwDOP-GF5M6fq3iI)", () => {
+    // Two identical toggle rows sharing both resource-id and label — without an
+    // occurrence index, both `changed` entries would emit the SAME selector, so
+    // tapOn would always hit the first match rather than the one that actually
+    // changed (#6238 already solved this exact ambiguity for `skeleton` rows).
+    const baseline = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 200 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          text: "Airplane mode",
+        },
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+          text: "Airplane mode",
+        },
+      ],
+    });
+    const next = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 200 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          text: "Airplane mode",
+        },
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+          text: "Airplane mode",
+          checked: "true",
+        },
+      ],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+
+    expect(diff.changed).toHaveLength(1);
+    // The SECOND occurrence (index 1) is the one that actually changed.
+    expect(diff.changed[0].selector).toEqual({
+      elementId: "toggle",
+      label: "Airplane mode",
+      index: 1,
+    });
+  });
+
+  test("a changed entry whose elementId is unique in `next` never carries a spurious `index`", () => {
+    const baseline = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          text: "Wi-Fi",
+        },
+      ],
+    });
+    const next = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          text: "Wi-Fi",
+          checked: "true",
+        },
+      ],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].selector).toEqual({ elementId: "toggle", label: "Wi-Fi" });
+    expect(diff.changed[0].selector?.index).toBeUndefined();
+  });
+
   test("a changed entry with neither resource-id/view-id nor text/content-desc omits `selector`", () => {
     const baseline = obs({
       "resource-id": "root",

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -97,6 +97,112 @@ describe("diffObserveResult", () => {
     expect(diff.added[0].attributes.text).toBe("Added");
   });
 
+  test("diffObserveResult itself always emits a `skeleton` field (placeholder, filled in by finalizeToolResponse — issue #6221 item 4.1)", () => {
+    // `diffObserveResult` cannot compute the real skeleton itself — `elements`
+    // is already dropped from the sanitized observation by the time it runs —
+    // so it always emits the field (empty) rather than omitting it, keeping the
+    // `ObserveDiff` shape whole; `finalizeToolResponse` overwrites it with the
+    // real actionable-only rows before the diff reaches the client.
+    const node = { "resource-id": "a", bounds: { left: 0, top: 0, right: 10, bottom: 10 } };
+    const diff = diffObserveResult(obs({ ...node }), obs({ ...node }));
+    expect(diff.skeleton).toEqual([]);
+  });
+
+  test("added/removed entries already carry the real selector fields directly in `attributes` — no separate `selector` (issue #6221 item 4.3)", () => {
+    // added/removed nodes carry their FULL attribute set, so resource-id/text
+    // ARE the selector already — a synthesized `selector` field would just
+    // duplicate those bytes (see stableIdentityScrollDiff.test.ts's byte-budget
+    // guard). Only `changed` entries (no full attributes) get one.
+    const baseline = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "gone",
+          bounds: { left: 1, top: 1, right: 2, bottom: 2 },
+          text: "Bye",
+        },
+      ],
+    });
+    const next = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "new",
+          bounds: { left: 1, top: 1, right: 2, bottom: 2 },
+          "content-desc": "Added row",
+        },
+      ],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0].attributes["resource-id"]).toBe("new");
+    expect(diff.added[0].attributes["content-desc"]).toBe("Added row");
+    expect((diff.added[0] as Record<string, unknown>).selector).toBeUndefined();
+
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.removed[0].attributes["resource-id"]).toBe("gone");
+    expect(diff.removed[0].attributes.text).toBe("Bye");
+    expect((diff.removed[0] as Record<string, unknown>).selector).toBeUndefined();
+  });
+
+  test("changed entries carry a real selector recovered from resource-id/text, since they carry no full attributes (issue #6221 item 4.3)", () => {
+    const baseline = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 5, top: 5, right: 15, bottom: 15 },
+          text: "Airplane mode",
+        },
+      ],
+    });
+    const next = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          "resource-id": "toggle",
+          bounds: { left: 5, top: 5, right: 15, bottom: 15 },
+          text: "Airplane mode",
+          checked: "true",
+        },
+      ],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].selector).toEqual({ elementId: "toggle", label: "Airplane mode" });
+  });
+
+  test("a changed entry with neither resource-id/view-id nor text/content-desc omits `selector`", () => {
+    const baseline = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [{ bounds: { left: 1, top: 1, right: 2, bottom: 2 }, class: "android.view.View" }],
+    });
+    const next = obs({
+      "resource-id": "root",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          bounds: { left: 1, top: 1, right: 2, bottom: 2 },
+          class: "android.view.View",
+          checked: "true",
+        },
+      ],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].selector).toBeUndefined();
+  });
+
   test("a removed child node appears in `removed`", () => {
     const baseline = obs({
       "resource-id": "root",
@@ -408,6 +514,7 @@ describe("diffObserveResult", () => {
     });
     expect(diffObserveResult(empty, empty)).toEqual({
       isDiff: true,
+      skeleton: [],
       added: [],
       removed: [],
       changed: [],

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { toSkeleton } from "../../../../src/features/observe/output/SkeletonProjection";
+import {
+  toSkeleton,
+  projectSkeleton,
+} from "../../../../src/features/observe/output/SkeletonProjection";
 import { setElementProvenance } from "../../../../src/features/observe/output/elementProvenance";
 import { DefaultObserveElementCollector } from "../../../../src/features/observe/ObserveElementCollector";
 import { DefaultElementSelector } from "../../../../src/features/utility/DefaultElementSelector";
@@ -91,7 +94,7 @@ describe("toSkeleton — acceptance criteria", () => {
     });
   });
 
-  test("retains compact semantic links and a Compose owner test tag when present", () => {
+  test("retains compact semantic links and a Compose owner test tag when present, in context (issue #6221 item 1)", () => {
     const composeText: Element = {
       bounds: bounds(0, 0, 200, 40),
       text: "Terms of Service",
@@ -99,9 +102,11 @@ describe("toSkeleton — acceptance criteria", () => {
       "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
     };
 
-    const skeleton = toSkeleton(makeElements({ text: [composeText] }));
+    const { skeleton, context } = projectSkeleton(makeElements({ text: [composeText] }));
 
-    expect(skeleton).toEqual([
+    // Zero affordances -> never in the actionable-only skeleton (issue #6221 item 1).
+    expect(skeleton).toEqual([]);
+    expect(context).toEqual([
       {
         bounds: [0, 0, 200, 40],
         label: "Terms of Service",
@@ -197,10 +202,13 @@ describe("toSkeleton — acceptance criteria", () => {
         class: "android.widget.TextView",
         text: "Heading",
       };
-      const skeleton = toSkeleton(makeElements({ text: [el] }));
-      // Kept as pure text (no clickable ancestor), but with no affordance.
-      expect(skeleton).toHaveLength(1);
-      expect(skeleton[0].affordances).toEqual([]);
+      const { skeleton, context } = projectSkeleton(makeElements({ text: [el] }));
+      // Kept as pure text (no clickable ancestor), but with no affordance —
+      // so it lands in `context`, not the actionable-only `skeleton` (issue
+      // #6221 item 1).
+      expect(skeleton).toHaveLength(0);
+      expect(context).toHaveLength(1);
+      expect(context[0].affordances).toEqual([]);
     });
 
     test("checkable carries checked; non-checkable never does", () => {
@@ -250,7 +258,7 @@ describe("toSkeleton — acceptance criteria", () => {
   });
 
   describe("AC4: pure-text screens still surface their text", () => {
-    test("text nodes with no clickable ancestor are kept with empty affordances", () => {
+    test("text nodes with no clickable ancestor are kept with empty affordances, in context (issue #6221 item 1)", () => {
       const heading: Element = {
         bounds: bounds(0, 0, 200, 40),
         text: "Welcome",
@@ -262,11 +270,13 @@ describe("toSkeleton — acceptance criteria", () => {
         "view-id": "s-body",
       };
 
-      const skeleton = toSkeleton(makeElements({ text: [heading, body] }));
+      const { skeleton, context } = projectSkeleton(makeElements({ text: [heading, body] }));
 
-      expect(skeleton).toHaveLength(2);
-      expect(skeleton.map((e) => e.label).sort()).toEqual(["Some paragraph", "Welcome"]);
-      expect(skeleton.every((e) => e.affordances.length === 0)).toBe(true);
+      // Zero-affordance rows never appear in the actionable-only skeleton.
+      expect(skeleton).toHaveLength(0);
+      expect(context).toHaveLength(2);
+      expect(context.map((e) => e.label).sort()).toEqual(["Some paragraph", "Welcome"]);
+      expect(context.every((e) => e.affordances.length === 0)).toBe(true);
     });
 
     test("text with a clickable ancestor is dropped (represented by the clickable row)", () => {
@@ -302,10 +312,17 @@ describe("toSkeleton — acceptance criteria", () => {
         "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
       };
 
-      const skeleton = toSkeleton(makeElements({ clickable: [card], text: [linkedText] }));
+      const { skeleton, context } = projectSkeleton(
+        makeElements({ clickable: [card], text: [linkedText] }),
+      );
 
-      expect(skeleton).toHaveLength(2);
-      expect(skeleton.find((entry) => entry.testTag === "legal-copy")).toMatchObject({
+      // The clickable card is actionable (in skeleton); the linked text has no
+      // affordance of its own and lands in context (issue #6221 item 1) —
+      // still discoverable via its semantic link, per AC4.
+      expect(skeleton).toHaveLength(1);
+      expect(skeleton[0].elementId).toBe("card");
+      expect(context).toHaveLength(1);
+      expect(context.find((entry) => entry.testTag === "legal-copy")).toMatchObject({
         label: "Terms of Service",
         semanticLinks: [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
       });
@@ -542,11 +559,14 @@ describe("toSkeleton — acceptance criteria", () => {
         1,
       );
 
-      const skeleton = toSkeleton(makeElements({ clickable: [underlying], text: [overlayText] }));
+      const { context } = projectSkeleton(
+        makeElements({ clickable: [underlying], text: [overlayText] }),
+      );
 
-      // The overlay text survives as its own affordance-less row — the
-      // clickable-ancestor suppression no longer crosses the window boundary.
-      const overlay = skeleton.find((entry) => entry.label === "Permission required");
+      // The overlay text survives as its own affordance-less row in `context`
+      // (issue #6221 item 1) — the clickable-ancestor suppression no longer
+      // crosses the window boundary.
+      const overlay = context.find((entry) => entry.label === "Permission required");
       expect(overlay).toBeDefined();
       expect(overlay?.affordances).toEqual([]);
     });
@@ -652,12 +672,13 @@ describe("toSkeleton — acceptance criteria", () => {
       } as unknown as NonNullable<ObserveResult["viewHierarchy"]>;
 
       const elements = new DefaultObserveElementCollector().collect(viewHierarchy, "android");
-      const skeleton = toSkeleton(elements!);
+      const { skeleton, context } = projectSkeleton(elements!);
 
       // The clickable is not mislabelled from the disjoint faraway text...
       expect(findById(skeleton, "clickable-a")?.label).toBeUndefined();
-      // ...and the faraway text survives as its own row.
-      expect(skeleton.some((entry) => entry.label === "Faraway")).toBe(true);
+      // ...and the faraway text survives as its own row, in `context` (zero
+      // affordances — issue #6221 item 1).
+      expect(context.some((entry) => entry.label === "Faraway")).toBe(true);
     });
 
     test("end-to-end: the real collector emits provenance that hoists the exact-fill descendant", () => {
@@ -878,6 +899,130 @@ describe("toSkeleton — acceptance criteria", () => {
 
       const entry = findById(skeleton, "lonely-row");
       expect(entry?.label).toBe("Alarm");
+    });
+  });
+
+  describe("projectSkeleton — actionable-only skeleton + context (issue #6221 item 1)", () => {
+    test("zero-affordance entries are absent from skeleton and present in context", () => {
+      const title: Element = {
+        bounds: bounds(0, 0, 1080, 120),
+        "resource-id": "com.google.android.deskclock:id/action_bar_title",
+        text: "Alarm",
+      };
+      const addButton: Element = {
+        bounds: bounds(900, 1800, 1080, 1980),
+        "resource-id": "com.google.android.deskclock:id/fab",
+        "content-desc": "Add alarm",
+        clickable: "true",
+      };
+
+      const { skeleton, context } = projectSkeleton(
+        makeElements({ clickable: [addButton], text: [title] }),
+      );
+
+      expect(skeleton).toHaveLength(1);
+      expect(skeleton[0].elementId).toBe("com.google.android.deskclock:id/fab");
+      expect(skeleton.every((entry) => entry.affordances.length > 0)).toBe(true);
+
+      expect(context).toHaveLength(1);
+      expect(context[0].elementId).toBe("com.google.android.deskclock:id/action_bar_title");
+      expect(context[0].affordances).toEqual([]);
+    });
+
+    test("the com.android.systemui status-bar block collapses to a single context entry", () => {
+      const clock: Element = {
+        bounds: bounds(30, 10, 120, 60),
+        "resource-id": "com.android.systemui:id/clock",
+        text: "7:09",
+      };
+      const wifi: Element = {
+        bounds: bounds(900, 10, 950, 60),
+        "resource-id": "com.android.systemui:id/wifi_signal",
+        "content-desc": "Wifi signal full.",
+      };
+      const battery: Element = {
+        bounds: bounds(960, 10, 1050, 60),
+        "resource-id": "com.android.systemui:id/battery",
+        "content-desc": "Battery charging, 100 percent.",
+      };
+      // Non-systemui zero-affordance entry — must NOT be folded into the
+      // systemui summary, and must survive as its own context row.
+      const screenTitle: Element = {
+        bounds: bounds(0, 100, 1080, 200),
+        "resource-id": "com.google.android.deskclock:id/action_bar_title",
+        text: "Alarm",
+      };
+
+      const { skeleton, context } = projectSkeleton(
+        makeElements({ text: [clock, wifi, battery, screenTitle] }),
+      );
+
+      expect(skeleton).toEqual([]);
+      // ONE collapsed systemui entry + the unrelated screen title, not four
+      // separate systemui rows (issue #6221 item 1).
+      expect(context).toHaveLength(2);
+
+      const summary = context.find((entry) => entry.elementId?.startsWith("com.android.systemui"));
+      expect(summary).toBeDefined();
+      expect(summary?.affordances).toEqual([]);
+      expect(summary?.label).toContain("7:09");
+      expect(summary?.label).toContain("Wifi signal full.");
+      expect(summary?.label).toContain("Battery charging, 100 percent.");
+      // The summary's bounds enclose every collapsed entry.
+      expect(summary?.bounds).toEqual([30, 10, 1050, 60]);
+
+      const title = context.find((entry) => entry.label === "Alarm");
+      expect(title).toBeDefined();
+      expect(title?.elementId).toBe("com.google.android.deskclock:id/action_bar_title");
+    });
+
+    test("actionable entries with duplicate ids keep their #6238 index/label in the filtered actionable set", () => {
+      // Four alarm rows sharing one resource-id, mixed in with a zero-affordance
+      // systemui block — the duplicate-index disambiguator (issue #6221 item 2)
+      // must still apply correctly once the non-actionable entries are filtered
+      // out into `context`.
+      const makeAlarmRow = (top: number, time: string): Element => ({
+        bounds: bounds(0, top, 1080, top + 200),
+        "resource-id": "com.google.android.deskclock:id/digital_clock",
+        text: time,
+        clickable: "true",
+      });
+      const rows = [
+        makeAlarmRow(300, "6:45 AM"),
+        makeAlarmRow(500, "8:30 AM"),
+        makeAlarmRow(700, "9:00 AM"),
+      ];
+      // Outside every alarm row's bounds (0-30 vs rows starting at 300) so the
+      // clock is not geometrically suppressed as text-with-a-clickable-ancestor —
+      // that suppression is a separate, unrelated concern from this test.
+      const clock: Element = {
+        bounds: bounds(30, 10, 120, 60),
+        "resource-id": "com.android.systemui:id/clock",
+        text: "7:09",
+      };
+
+      const { skeleton, context } = projectSkeleton(
+        makeElements({ clickable: rows, text: [clock] }),
+      );
+
+      expect(skeleton).toHaveLength(3);
+      expect(
+        skeleton.every(
+          (entry) => entry.elementId === "com.google.android.deskclock:id/digital_clock",
+        ),
+      ).toBe(true);
+      // Every duplicate carries a distinct index, ranked by hierarchy order —
+      // same guarantee as before the actionable/context split (issue #6238).
+      const indexes = skeleton.map((entry) => entry.index).sort();
+      expect(indexes).toEqual([0, 1, 2]);
+      expect(new Set(skeleton.map((entry) => entry.label))).toEqual(
+        new Set(["6:45 AM", "8:30 AM", "9:00 AM"]),
+      );
+
+      // The systemui entry collapses into context and never consumes/interferes
+      // with the actionable duplicate-index assignment.
+      expect(context).toHaveLength(1);
+      expect(context[0].index).toBeUndefined();
     });
   });
 });

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -976,6 +976,54 @@ describe("toSkeleton — acceptance criteria", () => {
       expect(title?.elementId).toBe("com.google.android.deskclock:id/action_bar_title");
     });
 
+    test("notification-shade rows under the same com.android.systemui namespace are NEVER folded into the status-bar summary (PR #6242 review PRRT_kwDOP-GF5M6fq3iH)", () => {
+      // The notification shade lives under the same `com.android.systemui`
+      // namespace as the status bar (see test/server/systemTray.test.ts's
+      // `notification_row_1` fixture), but its rows are ACTIONABLE and must stay
+      // individually tappable — never collapsed into the synthetic status-bar
+      // summary just because the id shares a package prefix.
+      const clock: Element = {
+        bounds: bounds(30, 10, 120, 60),
+        "resource-id": "com.android.systemui:id/clock",
+        text: "7:09",
+      };
+      const notificationRow: Element = {
+        bounds: bounds(0, 200, 1080, 300),
+        "resource-id": "com.android.systemui:id/notification_row_1",
+        text: "New message from Alex",
+        clickable: "true",
+      };
+      // A zero-affordance systemui node that is NOT status-bar chrome (e.g. a
+      // notification title/summary line inside the shade) must also survive as
+      // its own context row rather than being swept into the status-bar summary.
+      const notificationTitle: Element = {
+        bounds: bounds(0, 300, 1080, 340),
+        "resource-id": "com.android.systemui:id/notification_stack_scroller",
+        text: "1 new notification",
+      };
+
+      const { skeleton, context } = projectSkeleton(
+        makeElements({ clickable: [notificationRow], text: [clock, notificationTitle] }),
+      );
+
+      // The notification row is actionable and keeps its own id/bounds intact.
+      expect(skeleton).toHaveLength(1);
+      expect(skeleton[0].elementId).toBe("com.android.systemui:id/notification_row_1");
+      expect(skeleton[0].label).toBe("New message from Alex");
+      expect(skeleton[0].bounds).toEqual([0, 200, 1080, 300]);
+
+      // Only the clock collapses into the status-bar summary; the shade's own
+      // zero-affordance node stays a separate, uncollapsed context entry.
+      expect(context).toHaveLength(2);
+      const summary = context.find(
+        (entry) => entry.elementId === "com.android.systemui:status-bar-summary",
+      );
+      expect(summary?.label).toBe("Status bar: 7:09");
+      const shadeText = context.find((entry) => entry.label === "1 new notification");
+      expect(shadeText).toBeDefined();
+      expect(shadeText?.elementId).toBe("com.android.systemui:id/notification_stack_scroller");
+    });
+
     test("actionable entries with duplicate ids keep their #6238 index/label in the filtered actionable set", () => {
       // Four alarm rows sharing one resource-id, mixed in with a zero-affordance
       // systemui block — the duplicate-index disambiguator (issue #6221 item 2)

--- a/test/features/observe/output/stableIdentityScrollDiff.test.ts
+++ b/test/features/observe/output/stableIdentityScrollDiff.test.ts
@@ -25,9 +25,13 @@ import type { ObserveResult } from "../../../../src/models/ObserveResult";
  * production formatter; compact (non-pretty) JSON and compact bounds tuples are
  * now unconditional defaults, which shrink the large `full` payload far more than
  * the small diff (there is little whitespace in the diff to drop), so the share
- * rises to ~60% bytes / ~63% tokens against today's formatter. The formatter-
- * independent teeth — the diff is strictly smaller than the legacy path-UUID diff
- * of the same pair — are unchanged.
+ * rose to ~60% bytes / ~63% tokens against today's formatter. Issue #6221 item
+ * 4.3 then added a real `{elementId, label}` `selector` to every `changed`
+ * entry that lacks one already in its `changes` delta — genuinely new bytes,
+ * traded deliberately for diff entries actually being actionable — pushing the
+ * share to ~70% bytes / ~72% tokens. The formatter-independent teeth — the
+ * diff is strictly smaller than the legacy path-UUID diff of the same pair —
+ * are unchanged.
  */
 
 function withStableIds(obs: ObserveResult): ObserveResult {
@@ -103,13 +107,17 @@ describe("capture-layer stable identity on the real scroll pair (#3228)", () => 
     expect(churn(stableDiff)).toBeLessThan(churn(legacyDiff));
   });
 
-  test("AC#2 — scroll diff stays a minority of full output under the compact-default formatter (~60% bytes / ~63% tokens)", () => {
+  test("AC#2 — scroll diff stays a minority of full output under the compact-default formatter (~70% bytes / ~72% tokens)", () => {
     const full = measureValue(after);
     const diff = measureValue(stableDiff);
-    // Thresholds recalibrated for the compact-JSON + tuple-bounds defaults (was
-    // 28.7% / 64% against the old pretty formatter — see the file docstring).
-    expect(diff.bytes / full.bytes).toBeLessThan(0.62);
-    expect(diff.tokens / full.tokens).toBeLessThan(0.64);
+    // Thresholds recalibrated twice: first for the compact-JSON + tuple-bounds
+    // defaults (was 28.7% / 64% against the old pretty formatter), then again
+    // for issue #6221 item 4.3 — a real `selector` field ({elementId, label})
+    // on every `changed` entry lacking one already in `changes` — which trades
+    // some of that compactness for diff entries actually being actionable
+    // (measured here: ~70.4% bytes / ~72.2% tokens). See the file docstring.
+    expect(diff.bytes / full.bytes).toBeLessThan(0.72);
+    expect(diff.tokens / full.tokens).toBeLessThan(0.74);
     // And strictly better than the legacy (path-UUID) diff of the same pair.
     const legacy = measureValue(legacyDiff);
     expect(diff.bytes).toBeLessThan(legacy.bytes);

--- a/test/server/compactBoundsAdvertisement.test.ts
+++ b/test/server/compactBoundsAdvertisement.test.ts
@@ -57,9 +57,34 @@ describe("advertiseBoundsForCompact (#2990)", () => {
     expect(bounds.description).toContain("left, top, right, bottom");
   });
 
+  /**
+   * Strip every `skeleton` property node from a JSON-Schema tree (recursively,
+   * any depth/nesting — `anyOf` arms included). Mirrors the equivalent exclusion
+   * in `observeOutputSchema.test.ts`: the `skeleton` projection field (#4388,
+   * embedded on `tapOnResultSchema.observation`'s diff arm since issue #6221 item
+   * 4.1) carries a deliberately ALWAYS-tuple bounds that never depends on
+   * `--observe-result-compact`, so it is not a collapsible bounds *union* and
+   * must be excluded before asserting the union-collapse invariant below.
+   */
+  function stripSkeletonNodes(node: unknown): unknown {
+    if (Array.isArray(node)) {
+      return node.map(stripSkeletonNodes);
+    }
+    if (node && typeof node === "object") {
+      const { skeleton: _skeleton, ...rest } = node as Record<string, unknown>;
+      void _skeleton;
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        out[key] = stripSkeletonNodes(value);
+      }
+      return out;
+    }
+    return node;
+  }
+
   test("compact OFF advertises no positional tuple anywhere in the schema", () => {
     const out = advertiseBoundsForCompact(boundsJson(), false);
-    const json = JSON.stringify(out);
+    const json = JSON.stringify(stripSkeletonNodes(out));
     // The tuple arm renders as a JSON-Schema array with prefixItems; none should remain.
     expect(json).not.toContain("prefixItems");
   });

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -907,6 +907,49 @@ describe("finalizeToolResponse", () => {
       expect(parsed.observation.skeleton.length).toBe(obsSc.skeleton.length);
     });
 
+    test("a diffed observation carries a usable `skeleton` even under raw:true / project:'full' (PR #6242 review PRRT_kwDOP-GF5M6fq3iK)", () => {
+      const { store } = makeStore();
+      const withSkeletonElements = (): ObserveResult => ({
+        ...sameScreenObserve(),
+        elements: {
+          clickable: [
+            {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "com.example:id/btn",
+              text: "Submit",
+              clickable: "true",
+            } as any,
+          ],
+          scrollable: [],
+          text: [],
+          media: [],
+        },
+      });
+
+      finalizeToolResponse(createStructuredToolResponse(withSkeletonElements()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const next = withSkeletonElements();
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      // `project: "full"` — servedObservation itself carries NO skeleton in this
+      // mode (it is the raw sanitized tree), so the diff must re-project one
+      // independently rather than emitting `skeleton: []`.
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store, args: { project: "full" } },
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.viewHierarchy).toBeUndefined();
+      expect(Array.isArray(obsSc.skeleton)).toBe(true);
+      expect(obsSc.skeleton.length).toBeGreaterThan(0);
+      expect(obsSc.skeleton[0].elementId).toBe("com.example:id/btn");
+    });
+
     test("returns a full observation when a reported screen change would emit an empty diff", () => {
       const { store } = makeStore();
       finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -856,6 +856,57 @@ describe("finalizeToolResponse", () => {
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 
+    test("a diffed observation ALWAYS carries a usable `skeleton` alongside it (issue #6221 item 4.1)", () => {
+      const { store } = makeStore();
+      /** Same-screen observation whose `elements` block yields a non-empty skeleton. */
+      const withSkeletonElements = (): ObserveResult => ({
+        ...sameScreenObserve(),
+        elements: {
+          clickable: [
+            {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "com.example:id/btn",
+              text: "Submit",
+              clickable: "true",
+            } as any,
+          ],
+          scrollable: [],
+          text: [],
+          media: [],
+        },
+      });
+
+      finalizeToolResponse(createStructuredToolResponse(withSkeletonElements()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const next = withSkeletonElements();
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      // Default projection (no `project`/`raw` arg) — the case the issue's dogfood
+      // repro hit: a diff response with no skeleton to act on.
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store },
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      // The diff is real (a change happened)...
+      expect(obsSc.changed).toHaveLength(1);
+      // ...AND it still carries a full, usable actionable-only skeleton — never
+      // absent just because a diff was emitted.
+      expect(Array.isArray(obsSc.skeleton)).toBe(true);
+      expect(obsSc.skeleton.length).toBeGreaterThan(0);
+      expect(obsSc.skeleton[0].elementId).toBe("com.example:id/btn");
+      expect(obsSc.skeleton[0].affordances).toContain("tap");
+
+      // Text mirror agrees.
+      const parsed = JSON.parse(finalized.content[0].text);
+      expect(parsed.observation.skeleton.length).toBe(obsSc.skeleton.length);
+    });
+
     test("returns a full observation when a reported screen change would emit an empty diff", () => {
       const { store } = makeStore();
       finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -502,13 +502,15 @@ describe("observeResultSchema: every bounds site is the advertised union (#3025)
 
   test("compact OFF: every bounds union collapses to its object arm (no tuple)", () => {
     const out = advertiseBoundsForCompact(observeJson(), false) as Record<string, unknown>;
-    // The `skeleton` projection field (#4388) carries a deliberately always-tuple
-    // bounds — it is emitted only under project:"skeleton" and its bounds never
-    // depend on --observe-result-compact — so it is not a collapsible bounds
-    // *union*. Exclude it structurally before asserting the union-collapse invariant.
+    // The `skeleton` projection field (#4388) — and its sibling `context` array
+    // (issue #6221 item 1), same row shape — carry a deliberately always-tuple
+    // bounds: emitted only under project:"skeleton" and never dependent on
+    // --observe-result-compact, so neither is a collapsible bounds *union*.
+    // Exclude both structurally before asserting the union-collapse invariant.
     const properties = out.properties as Record<string, unknown> | undefined;
     if (properties) {
       delete properties.skeleton;
+      delete properties.context;
     }
     const json = JSON.stringify(out);
     expect(json).not.toContain("prefixItems");

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -4,6 +4,7 @@ import {
   elementBoundsSchema,
   elementSchema,
   observationOutputSchema,
+  observationSummarySchema,
   observeDiffSchema,
   observeResultSchema,
   tapOnResultSchema,
@@ -226,6 +227,28 @@ describe("observationOutputSchema: discriminated union of full observation vs di
   test("rejects a diff with no `skeleton` at all (item 4.1: it must ALWAYS be present)", () => {
     const diffMissingSkeleton = { isDiff: true, added: [], removed: [], changed: [] };
     expect(() => observeDiffSchema.parse(diffMissingSkeleton)).toThrow();
+  });
+
+  test("the FULL union rejects a malformed diff — it cannot silently fall through to the permissive full-observation arm (PR #6242 review PRRT_kwDOP-GF5M6fq3iN)", () => {
+    // Before the fix, this object failed `observeDiffSchema` (missing the
+    // mandatory `skeleton`) but then matched `observationSummarySchema` anyway,
+    // since every field there was optional and `.passthrough()` let `isDiff`
+    // and the rest ride through unchecked.
+    const malformedDiff = { isDiff: true, added: [], removed: [], changed: [] };
+    expect(() => observationOutputSchema.parse(malformedDiff)).toThrow();
+  });
+
+  test("observationSummarySchema itself rejects `isDiff: true` — it is a genuinely-typed member, not just permissively passed through", () => {
+    expect(() =>
+      observationSummarySchema.parse({ isDiff: true, activeWindow: { appId: "com.example" } }),
+    ).toThrow();
+    // `isDiff` absent, or explicitly `false`, both still validate.
+    expect(() =>
+      observationSummarySchema.parse({ activeWindow: { appId: "com.example" } }),
+    ).not.toThrow();
+    expect(() =>
+      observationSummarySchema.parse({ isDiff: false, activeWindow: { appId: "com.example" } }),
+    ).not.toThrow();
   });
 
   test("a diff's added/removed nodes carry their real selector fields directly in `attributes` (no redundant `selector`)", () => {

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -3,6 +3,9 @@ import { toJSONSchema } from "zod/v4";
 import {
   elementBoundsSchema,
   elementSchema,
+  observationOutputSchema,
+  observeDiffSchema,
+  observeResultSchema,
   tapOnResultSchema,
   toolOutputArtifactMetadataSchema,
 } from "../../src/server/toolOutputSchemas";
@@ -180,5 +183,138 @@ describe("elementBoundsSchema: fractional iOS point coordinates (#3206)", () => 
   test("still rejects non-numeric bounds values", () => {
     expect(() => elementBoundsSchema.parse({ left: "0.5", top: 1, right: 2, bottom: 3 })).toThrow();
     expect(() => elementBoundsSchema.parse([0.5, 1, 2, "3"])).toThrow();
+  });
+});
+
+/**
+ * `observation` as a discriminated union of a full observation and a compact
+ * diff (issue #6221 item 4). The discriminator is `isDiff`: present and `true`
+ * on the diff arm, absent on the full arm. Both arms must validate through the
+ * SAME schema a client would use to decode `tapOnResultSchema.observation`.
+ */
+describe("observationOutputSchema: discriminated union of full observation vs diff (#6221 item 4)", () => {
+  test("accepts a full observation (no `isDiff`)", () => {
+    const full = { activeWindow: { appId: "com.example" } };
+    const parsed = observationOutputSchema.parse(full);
+    expect((parsed as Record<string, unknown>).isDiff).toBeUndefined();
+  });
+
+  test("accepts a diff (`isDiff: true`) that ALWAYS carries a `skeleton`", () => {
+    const diff = {
+      isDiff: true,
+      skeleton: [
+        {
+          elementId: "com.example:id/btn",
+          label: "Submit",
+          bounds: [0, 0, 100, 50],
+          affordances: ["tap"],
+        },
+      ],
+      added: [],
+      removed: [],
+      changed: [],
+    };
+    const parsed = observeDiffSchema.parse(diff);
+    expect(parsed.isDiff).toBe(true);
+    expect(parsed.skeleton).toHaveLength(1);
+
+    // Also parses through the full union tapOnResultSchema.observation uses.
+    const viaUnion = observationOutputSchema.parse(diff);
+    expect((viaUnion as { isDiff?: true }).isDiff).toBe(true);
+  });
+
+  test("rejects a diff with no `skeleton` at all (item 4.1: it must ALWAYS be present)", () => {
+    const diffMissingSkeleton = { isDiff: true, added: [], removed: [], changed: [] };
+    expect(() => observeDiffSchema.parse(diffMissingSkeleton)).toThrow();
+  });
+
+  test("a diff's added/removed nodes carry their real selector fields directly in `attributes` (no redundant `selector`)", () => {
+    const diff = {
+      isDiff: true,
+      skeleton: [],
+      added: [
+        {
+          key: " 109,837,971,1424  0",
+          attributes: { "resource-id": "com.example:id/new", text: "New row" },
+        },
+      ],
+      removed: [],
+      changed: [],
+    };
+    const parsed = observeDiffSchema.parse(diff);
+    expect(parsed.added[0].attributes["resource-id"]).toBe("com.example:id/new");
+    // Internal key still validates (it's a plain string) but is documented
+    // as non-selector — see the schema's own `.describe()`.
+    expect(parsed.added[0].key).toBe(" 109,837,971,1424  0");
+  });
+
+  test("a diff's `changed` entries carry a real `selector` distinct from the internal `key`", () => {
+    const diff = {
+      isDiff: true,
+      skeleton: [],
+      added: [],
+      removed: [],
+      changed: [
+        {
+          key: " 109,837,971,1424  0",
+          selector: { elementId: "com.example:id/toggle", label: "Airplane mode" },
+          changes: { checked: { from: undefined, to: "true" } },
+        },
+      ],
+    };
+    const parsed = observeDiffSchema.parse(diff);
+    expect(parsed.changed[0].selector).toEqual({
+      elementId: "com.example:id/toggle",
+      label: "Airplane mode",
+    });
+  });
+
+  test("still accepts a spilled artifact-metadata observation (the third union arm)", () => {
+    const artifact = {
+      artifact: {
+        path: "/tmp/x.json",
+        format: "json",
+        payload: "ObserveResult",
+        bytes: 10,
+        tool: "tapOn",
+      },
+    };
+    expect(() => observationOutputSchema.parse(artifact)).not.toThrow();
+    expect(() => toolOutputArtifactMetadataSchema.parse(artifact)).not.toThrow();
+  });
+});
+
+/**
+ * `context` sibling array on `observeResultSchema` (issue #6221 item 1): the
+ * non-actionable rows the same projection that produces `skeleton` emits.
+ */
+describe("observeResultSchema: context array (#6221 item 1)", () => {
+  test("accepts skeleton + context side by side", () => {
+    const result = {
+      skeleton: [
+        {
+          elementId: "com.example:id/btn",
+          bounds: [0, 0, 100, 50],
+          affordances: ["tap"],
+        },
+      ],
+      context: [
+        {
+          elementId: "com.android.systemui:status-bar-summary",
+          label: "Status bar: 7:09, Wifi signal full.",
+          bounds: [0, 0, 1080, 60],
+          affordances: [],
+        },
+      ],
+    };
+    const parsed = observeResultSchema.parse(result);
+    expect(parsed.context).toHaveLength(1);
+    expect(parsed.context![0].affordances).toEqual([]);
+  });
+
+  test("context is optional (omitted when nothing non-actionable survived)", () => {
+    const result = { skeleton: [] };
+    const parsed = observeResultSchema.parse(result);
+    expect(parsed.context).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Implements items 1 and 4 of #6221 — items 2 and 3 already landed in #6238.

### Item 1 — "actionable-only" skeleton is now actually actionable-only

`SkeletonProjection` now splits kept rows by affordance count instead of interleaving everything into `skeleton`:

- `skeleton` = only entries with `affordances.length >= 1`.
- New sibling array `context` = entries with `affordances.length === 0` (a screen title, a standalone notification, etc.) — the information is preserved, just not polluting the action surface.
- The recurring `com.android.systemui` status-bar block (clock/wifi/battery icons, ...) collapses into a **single** summarized `context` entry instead of one row per icon, since it reappeared verbatim on every observation of every screen.
- Duplicate-id disambiguation (`index`, #6238) runs only over the actionable subset, so it stays correct once non-actionable duplicates are filtered into `context`.
- `src/models/ObserveResult.ts` and `src/server/toolOutputSchemas.ts` document the new `context` field; `schemas/tool-definitions.json` regenerated via `scripts/update-tool-definitions.sh`.

This is non-breaking: `skeleton` shrinks (drops rows that carried no affordance anyway) and `context` is a new optional field.

### Item 4 — `observation` no longer silently flips shape with no selector

Three changes, per the issue's chosen approach:

1. **Always include `skeleton`.** `observation` embedded on action-tool results now ALWAYS carries a `skeleton` array even when a diff is emitted — `finalizeToolResponse.ts` fills it in from the independently re-projected served observation before returning the diff — so a client always has a selector surface, regardless of whether a diff baseline happened to exist.
2. **Documented discriminated union.** `observation` is now typed in `toolOutputSchemas.ts` as `observationOutputSchema = z.union([observeDiffSchema, observationSummarySchema, toolOutputArtifactMetadataSchema])`. The discriminator is `isDiff`: present and `true` on the diff arm, absent on the full arm — documented with `.describe()` on both arms so a client can write one parser against a declared contract.
3. **Diff-entry selectors.** `added`/`removed` diff nodes already carry their FULL raw `attributes` (`resource-id`/`view-id`/`text`/`content-desc`), so no separate `selector` field was added there — synthesizing one would just duplicate bytes already on the wire (verified against the diff-format's own byte-budget regression test, see below). `changed` entries do **not** carry full attributes (only the delta), so they get a real `selector` field (`{ elementId, label }`) derived with the same `resource-id ?? view-id` / `text ?? content-desc` precedence `SkeletonProjection` uses for `skeleton` rows. Every entry's internal `key` (`ObserveDiffNode.key` / `ObserveDiffNodeChange.key`) is explicitly documented — in both the TS interfaces and the zod schema — as an internal positional identity key, NOT a selector.

One test threshold was recalibrated as a direct, deliberate consequence: `stableIdentityScrollDiff.test.ts`'s diff/full byte-budget assertion moved from ~60%/63% to ~70%/72% (bytes/tokens) to account for the new `selector` field on `changed` entries — trading some of that compactness for diff entries actually being actionable, which is exactly what item 4.3 asks for.

## Validation

- `bun test` — full suite green except two pre-existing, unrelated failures verified present on `main` before this change (missing `node_modules/.bin/oxlint` binary in this environment; an unrelated `webrtcDeviceCaptureLoad` integration test).
- `bun run lint` — oxlint ratchet gate: no new violations.
- `bun run typecheck` — no new type errors vs the baseline.
- `bun run format:check` — clean (re-checked after `scripts/update-tool-definitions.sh`).
- `bunx turbo run build` — succeeds.

Closes #6221