### PR TITLE
fix(server): persist tool-selection-profile provenance across daemon restarts (fixes #6225)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -163,6 +163,10 @@ import { stopManagedAdbServer } from "../utils/android-cmdline-tools/AdbServerLi
 import { iosSimulatorCaptureHelperPool } from "../features/screen-stream";
 import { runShutdownCleanupStages } from "../shutdownCleanup";
 import { cleanupDaemonChildProcesses } from "./childProcessCleanup";
+import {
+  defaultToolSelectionProfileRegistry,
+  type ToolSelectionProfileProvenanceLoader,
+} from "../server/toolSelectionProfileRegistry";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -269,6 +273,7 @@ export class Daemon {
   private timer: Timer;
   private idGenerator: IdGenerator;
   private databaseInitializer: DatabaseInitializer;
+  private toolSelectionProfileProvenanceLoader: ToolSelectionProfileProvenanceLoader;
   private databaseHealthProbe: DatabaseHealthProbe;
   private startupFailureTracker: StartupFailureTracker;
   private recoverFromDatabaseHealthFailure: DatabaseHealthFailureRecovery;
@@ -294,6 +299,7 @@ export class Daemon {
     recoverFromDatabaseHealthFailure?: DatabaseHealthFailureRecovery,
     recoveryPolicyEnvironment: NodeJS.ProcessEnv = process.env,
     managedAdbServerShutdown: ManagedAdbServerShutdown = stopManagedAdbServer,
+    toolSelectionProfileProvenanceLoader: ToolSelectionProfileProvenanceLoader = defaultToolSelectionProfileRegistry,
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -305,6 +311,7 @@ export class Daemon {
     this.daemonSessionId = this.idGenerator.next();
     this.timer = timer;
     this.databaseInitializer = databaseInitializer;
+    this.toolSelectionProfileProvenanceLoader = toolSelectionProfileProvenanceLoader;
     this.databaseHealthProbe = databaseHealthProbe;
     this.startupFailureTracker = startupFailureTracker;
     this.stopManagedAdbServer = managedAdbServerShutdown;
@@ -2271,6 +2278,14 @@ export class Daemon {
       // getDatabase() + await ensureMigrations(): a failed startup migration
       // rejects here (rather than swallowing on a detached promise).
       await this.databaseInitializer.initialize();
+      // Reload durable tool-selection-profile provenance (issue #6225) so a
+      // profile minted before this restart/upgrade is still recognized when a
+      // client reaffirms it — without this, `setToolEnabled` would force it
+      // through a re-mint. Never fatal: the loader already logs and swallows
+      // its own failures (see PersistentToolSelectionProfileRegistry), leaving
+      // the registry empty (the pre-#6225 behavior) rather than blocking the
+      // FATAL database bring-up this method guards.
+      await this.toolSelectionProfileProvenanceLoader.load();
       // Clear installed apps cache from previous daemon sessions
       await this.installedAppsRepository.clearOldDaemonSessions(this.daemonSessionId);
       await this.deviceSessionRepository.markStaleActiveSessionsExpired(

--- a/src/db/migrations/2026_09_06_000_tool_selection_profile_provenance.ts
+++ b/src/db/migrations/2026_09_06_000_tool_selection_profile_provenance.ts
@@ -1,0 +1,36 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Durable provenance for daemon-minted tool-selection profiles (issue #6225,
+ * follow-up to #6148/#6213).
+ *
+ * `ToolSelectionProfileRegistry` (`src/server/toolSelectionProfileRegistry.ts`)
+ * is the sole signal `setToolEnabled` trusts to tell "a crypto-random profile
+ * uuid this daemon process itself minted via
+ * `createAndBindToolSelectionProfile`" apart from a fabricated or
+ * merely-echoed-header value. Before this migration that signal lived only in
+ * an in-memory `Set`, so a daemon restart/upgrade lost every minted profile: a
+ * client reaffirming its still-valid profile failed the provenance check and
+ * had to re-mint. This table lets the registry reload its membership at
+ * startup so a legitimately-minted profile survives a restart, while a value
+ * that was never minted is still rejected (it was never written here either).
+ *
+ * `profile_uuid` alone is the primary key: the table is a pure membership set,
+ * no other field is ever read back to decide provenance (parity with the
+ * in-memory `Set<string>` it backs). `created_at` is kept for observability
+ * only (e.g. a future eviction pass), matching the unpruned-growth tradeoff
+ * already accepted for `session_tool_overrides` (one entry per anonymous
+ * `setToolEnabled` call across the daemon's life).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("tool_selection_profile_provenance")
+    .ifNotExists()
+    .addColumn("profile_uuid", "text", (col) => col.primaryKey())
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("tool_selection_profile_provenance").ifExists().execute();
+}

--- a/src/db/toolSelectionProfileProvenanceRepository.ts
+++ b/src/db/toolSelectionProfileProvenanceRepository.ts
@@ -1,0 +1,65 @@
+import type { Kysely } from "kysely";
+import { ensureMigrations, getDatabase } from "./database";
+import type { Database } from "./types";
+import { logger } from "../utils/logger";
+
+/**
+ * Durable membership set for `ToolSelectionProfileRegistry` (issue #6225): one
+ * row per crypto-random tool-selection-profile uuid this daemon process has
+ * minted. Backs the in-memory registry's write-through/load so a legitimately
+ * minted profile survives a daemon restart/upgrade, while a value never
+ * inserted here is still rejected after one.
+ *
+ * Both operations are best-effort (log-and-continue on failure), matching
+ * `DeviceLockRepository`: a persistence hiccup must degrade to the pre-#6225
+ * in-memory-only behavior (re-mint on reconnect), never fail the `setToolEnabled`
+ * call that triggered it or block daemon startup.
+ */
+export class ToolSelectionProfileProvenanceRepository {
+  private db: Kysely<Database> | null;
+
+  constructor(db?: Kysely<Database>) {
+    this.db = db ?? null;
+  }
+
+  private async getDb(): Promise<Kysely<Database>> {
+    if (this.db) {
+      return this.db;
+    }
+    await ensureMigrations();
+    return getDatabase();
+  }
+
+  /** Record a minted profile uuid. Idempotent: re-inserting the same uuid is a no-op. */
+  async insert(profileUuid: string): Promise<void> {
+    try {
+      const db = await this.getDb();
+      await db
+        .insertInto("tool_selection_profile_provenance")
+        .values({ profile_uuid: profileUuid })
+        .onConflict((oc) => oc.column("profile_uuid").doNothing())
+        .execute();
+    } catch (error) {
+      logger.warn(
+        `[ToolSelectionProfileProvenanceRepository] Failed to persist minted profile ${profileUuid}: ${error}`,
+      );
+    }
+  }
+
+  /** Every previously-minted profile uuid, for reloading into the in-memory registry at startup. */
+  async loadAll(): Promise<string[]> {
+    try {
+      const db = await this.getDb();
+      const rows = await db
+        .selectFrom("tool_selection_profile_provenance")
+        .select(["profile_uuid"])
+        .execute();
+      return rows.map((row) => row.profile_uuid);
+    } catch (error) {
+      logger.warn(
+        `[ToolSelectionProfileProvenanceRepository] Failed to load persisted profiles: ${error}`,
+      );
+      return [];
+    }
+  }
+}

--- a/src/db/toolSelectionProfileProvenanceRepository.ts
+++ b/src/db/toolSelectionProfileProvenanceRepository.ts
@@ -4,6 +4,25 @@ import type { Database } from "./types";
 import { logger } from "../utils/logger";
 
 /**
+ * The narrow slice of `ToolSelectionProfileProvenanceRepository` that
+ * `ToolSelectionProfileRegistry` (`src/server/toolSelectionProfileRegistry.ts`)
+ * actually consumes (YAGNI). The concrete repository holds a private `db`
+ * field, so a structurally-compatible test fake could not satisfy the
+ * concrete class type without an `as unknown as` cast — a future change to
+ * the repository's real contract could then leave such a fake compiling but
+ * silently wrong. Consumers (and their test fakes) depend on this interface
+ * instead, so the compiler enforces the contract for real. Co-located with
+ * the concrete implementation (rather than in the registry module) so the
+ * registry can import just this type without a circular module dependency.
+ */
+export interface ToolSelectionProfileProvenanceStore {
+  /** Persist a minted profile uuid. Idempotent: re-inserting the same uuid is a no-op. */
+  insert(profileUuid: string): Promise<void>;
+  /** Every previously-minted profile uuid, for reloading into the in-memory registry at startup. */
+  loadAll(): Promise<string[]>;
+}
+
+/**
  * Durable membership set for `ToolSelectionProfileRegistry` (issue #6225): one
  * row per crypto-random tool-selection-profile uuid this daemon process has
  * minted. Backs the in-memory registry's write-through/load so a legitimately
@@ -15,7 +34,7 @@ import { logger } from "../utils/logger";
  * in-memory-only behavior (re-mint on reconnect), never fail the `setToolEnabled`
  * call that triggered it or block daemon startup.
  */
-export class ToolSelectionProfileProvenanceRepository {
+export class ToolSelectionProfileProvenanceRepository implements ToolSelectionProfileProvenanceStore {
   private db: Kysely<Database> | null;
 
   constructor(db?: Kysely<Database>) {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -563,6 +563,18 @@ export interface DeviceTeardownOperationsTable {
   updated_at: Generated<string>;
 }
 
+/**
+ * Durable membership set backing `ToolSelectionProfileRegistry` (issue #6225):
+ * one row per crypto-random tool-selection-profile uuid this daemon process
+ * has minted via `createAndBindToolSelectionProfile`. `profile_uuid` alone is
+ * ever read back to answer "was this server-issued" — see the migration
+ * (`2026_09_06_000_tool_selection_profile_provenance`) for the full rationale.
+ */
+export interface ToolSelectionProfileProvenanceTable {
+  profile_uuid: string;
+  created_at: Generated<string>;
+}
+
 // Feature flags table
 export interface FeatureFlagsTable {
   key: string;
@@ -795,6 +807,7 @@ export interface Database {
   emulator_loss_incidents: EmulatorLossIncidentsTable;
   provision_device_operations: ProvisionDeviceOperationsTable;
   device_teardown_operations: DeviceTeardownOperationsTable;
+  tool_selection_profile_provenance: ToolSelectionProfileProvenanceTable;
 }
 
 // Convenience types for each table
@@ -807,6 +820,9 @@ export type DeviceSessionUpdate = Updateable<DeviceSessionsTable>;
 
 export type DeviceLock = Selectable<DeviceLocksTable>;
 export type NewDeviceLock = Insertable<DeviceLocksTable>;
+
+export type ToolSelectionProfileProvenanceRow = Selectable<ToolSelectionProfileProvenanceTable>;
+export type NewToolSelectionProfileProvenanceRow = Insertable<ToolSelectionProfileProvenanceTable>;
 
 export type EmulatorLossIncidentRow = Selectable<EmulatorLossIncidentsTable>;
 export type NewEmulatorLossIncidentRow = Insertable<EmulatorLossIncidentsTable>;

--- a/src/server/toolSelectionProfileRegistry.ts
+++ b/src/server/toolSelectionProfileRegistry.ts
@@ -1,5 +1,10 @@
-import { ToolSelectionProfileProvenanceRepository } from "../db/toolSelectionProfileProvenanceRepository";
+import {
+  ToolSelectionProfileProvenanceRepository,
+  type ToolSelectionProfileProvenanceStore,
+} from "../db/toolSelectionProfileProvenanceRepository";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
+
+export type { ToolSelectionProfileProvenanceStore };
 
 /**
  * Tracks tool-selection-profile identifiers this daemon PROCESS itself has
@@ -105,7 +110,7 @@ export class PersistentToolSelectionProfileRegistry
 {
   private readonly memory = new InMemoryToolSelectionProfileRegistry();
 
-  constructor(private readonly repository: ToolSelectionProfileProvenanceRepository) {}
+  constructor(private readonly repository: ToolSelectionProfileProvenanceStore) {}
 
   record(profileUuid: string): void {
     this.memory.record(profileUuid);

--- a/src/server/toolSelectionProfileRegistry.ts
+++ b/src/server/toolSelectionProfileRegistry.ts
@@ -1,4 +1,5 @@
 import { ToolSelectionProfileProvenanceRepository } from "../db/toolSelectionProfileProvenanceRepository";
+import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 
 /**
  * Tracks tool-selection-profile identifiers this daemon PROCESS itself has
@@ -82,13 +83,22 @@ export class InMemoryToolSelectionProfileRegistry implements ToolSelectionProfil
  * minted profile is recognized again after a daemon restart/upgrade once
  * `load()` has repopulated the in-memory set.
  *
- * The write-through is fire-and-forget: the repository already logs and
- * swallows its own failures (matching `DeviceLockRepository`'s best-effort
- * convention), so a persistence hiccup degrades to the pre-#6225
- * in-memory-only behavior for that one entry rather than failing the
- * `setToolEnabled` call that triggered the mint. A value that is never
- * inserted — a fabricated or merely-echoed-header uuid — is never recorded
- * here either, so it is rejected identically before and after a restart.
+ * The write-through is fire-and-forget from the CALLER's perspective (`record()`
+ * stays synchronous), but it is NOT untracked: it is routed through the shared
+ * `DbWriteBarrier` (`getDbWriteBarrier().track(...)`, resolved fresh per call
+ * per the barrier's use-time-resolution contract), the same barrier
+ * `Daemon.stop()`'s graceful-shutdown drain awaits before closing the database
+ * (issue #2792's mechanism). Without this, a restart during a slow/queued
+ * SQLite write could have the drain see no outstanding work and close the DB
+ * before the insert commits — the repository would then swallow that failure,
+ * and the very next daemon would reject the profile this PR is meant to let it
+ * recognize. The repository still logs and swallows its OWN failures (matching
+ * `DeviceLockRepository`'s best-effort convention), so a genuine persistence
+ * failure (not a race with shutdown) degrades to the pre-#6225 in-memory-only
+ * behavior for that one entry rather than failing the `setToolEnabled` call
+ * that triggered the mint. A value that is never inserted — a fabricated or
+ * merely-echoed-header uuid — is never recorded here either, so it is
+ * rejected identically before and after a restart.
  */
 export class PersistentToolSelectionProfileRegistry
   implements ToolSelectionProfileRegistry, ToolSelectionProfileProvenanceLoader
@@ -100,7 +110,7 @@ export class PersistentToolSelectionProfileRegistry
   record(profileUuid: string): void {
     this.memory.record(profileUuid);
     if (profileUuid.trim().length > 0) {
-      void this.repository.insert(profileUuid);
+      void getDbWriteBarrier().track(() => this.repository.insert(profileUuid));
     }
   }
 

--- a/src/server/toolSelectionProfileRegistry.ts
+++ b/src/server/toolSelectionProfileRegistry.ts
@@ -1,3 +1,5 @@
+import { ToolSelectionProfileProvenanceRepository } from "../db/toolSelectionProfileProvenanceRepository";
+
 /**
  * Tracks tool-selection-profile identifiers this daemon PROCESS itself has
  * minted via `SessionToolBinding.createAndBindToolSelectionProfile` — the
@@ -44,6 +46,20 @@ export interface ToolSelectionProfileRegistry {
   has(profileUuid: string): boolean;
 }
 
+/**
+ * Loads previously-minted provenance into a registry (issue #6225). Narrow on
+ * purpose (YAGNI): the daemon startup path is the only consumer, and it needs
+ * nothing beyond "make persisted membership visible to `has()`".
+ */
+export interface ToolSelectionProfileProvenanceLoader {
+  /**
+   * Populate the registry's in-memory membership from durable storage. Never
+   * throws — a load failure (or a fresh/empty store) leaves the registry
+   * exactly as it was pre-#6225: empty, so an old profile must re-mint.
+   */
+  load(): Promise<void>;
+}
+
 export class InMemoryToolSelectionProfileRegistry implements ToolSelectionProfileRegistry {
   private readonly minted = new Set<string>();
 
@@ -59,12 +75,60 @@ export class InMemoryToolSelectionProfileRegistry implements ToolSelectionProfil
 }
 
 /**
+ * Durable-backed registry (issue #6225, #6148/#6213 follow-up): wraps an
+ * in-memory `InMemoryToolSelectionProfileRegistry` (so `has()`/`record()` stay
+ * synchronous and every existing call site is unchanged) and write-throughs
+ * every mint to `ToolSelectionProfileProvenanceRepository`, so a legitimately
+ * minted profile is recognized again after a daemon restart/upgrade once
+ * `load()` has repopulated the in-memory set.
+ *
+ * The write-through is fire-and-forget: the repository already logs and
+ * swallows its own failures (matching `DeviceLockRepository`'s best-effort
+ * convention), so a persistence hiccup degrades to the pre-#6225
+ * in-memory-only behavior for that one entry rather than failing the
+ * `setToolEnabled` call that triggered the mint. A value that is never
+ * inserted — a fabricated or merely-echoed-header uuid — is never recorded
+ * here either, so it is rejected identically before and after a restart.
+ */
+export class PersistentToolSelectionProfileRegistry
+  implements ToolSelectionProfileRegistry, ToolSelectionProfileProvenanceLoader
+{
+  private readonly memory = new InMemoryToolSelectionProfileRegistry();
+
+  constructor(private readonly repository: ToolSelectionProfileProvenanceRepository) {}
+
+  record(profileUuid: string): void {
+    this.memory.record(profileUuid);
+    if (profileUuid.trim().length > 0) {
+      void this.repository.insert(profileUuid);
+    }
+  }
+
+  has(profileUuid: string): boolean {
+    return this.memory.has(profileUuid);
+  }
+
+  async load(): Promise<void> {
+    const persisted = await this.repository.loadAll();
+    for (const profileUuid of persisted) {
+      this.memory.record(profileUuid);
+    }
+  }
+}
+
+/**
  * Production default: shared across every `createMcpServer()` call made
  * within this daemon process, so it survives the loopback-proxy hop. Tests
  * that construct multiple `createMcpServer()` instances to simulate that hop
  * must inject one explicit shared instance via
  * `McpServerOptions.toolSelectionProfileRegistry` instead of relying on this
  * module singleton, for isolation from other test files sharing the process.
+ *
+ * Typed as the intersection so daemon startup can call `.load()` (issue #6225)
+ * while every other consumer keeps using the narrower `ToolSelectionProfileRegistry`
+ * interface.
  */
-export const defaultToolSelectionProfileRegistry: ToolSelectionProfileRegistry =
-  new InMemoryToolSelectionProfileRegistry();
+export const defaultToolSelectionProfileRegistry: ToolSelectionProfileRegistry &
+  ToolSelectionProfileProvenanceLoader = new PersistentToolSelectionProfileRegistry(
+  new ToolSelectionProfileProvenanceRepository(),
+);

--- a/test/daemon/daemonDatabaseInitFailure.test.ts
+++ b/test/daemon/daemonDatabaseInitFailure.test.ts
@@ -8,6 +8,8 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
 import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
+import { DefaultDatabaseHealthProbe } from "../../src/db/DatabaseHealthProbe";
+import { FakeToolSelectionProfileProvenanceLoader } from "../fakes/FakeToolSelectionProfileProvenanceLoader";
 
 /**
  * Issue #2784: startup DB/migration failure must be FATAL — `initializeDatabase()`
@@ -58,6 +60,12 @@ function buildDaemon(overrides: {
     new CountingIdGenerator("daemon-session"),
     overrides.initializer,
     overrides.tracker,
+    new DefaultDatabaseHealthProbe({ timer: overrides.timer }),
+    undefined,
+    process.env,
+    undefined,
+    // Never resolve the production default (real getDatabase()) — issue #3067.
+    new FakeToolSelectionProfileProvenanceLoader(),
   );
   return { daemon, deviceSessionRepository, installedAppsRepository };
 }

--- a/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
+++ b/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
@@ -3,18 +3,22 @@ import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import * as databaseModule from "../../src/db";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
-import type { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
-import { PersistentToolSelectionProfileRegistry } from "../../src/server/toolSelectionProfileRegistry";
+import {
+  PersistentToolSelectionProfileRegistry,
+  type ToolSelectionProfileProvenanceStore,
+} from "../../src/server/toolSelectionProfileRegistry";
 import { logger } from "../../src/utils/logger";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 /**
- * A fake repository whose `insert` hangs on a manually-released gate, modeling
- * a slow/queued SQLite write mid-shutdown (issue #6225 review round 2).
+ * A fake store whose `insert` hangs on a manually-released gate, modeling a
+ * slow/queued SQLite write mid-shutdown (issue #6225 review rounds 2-3).
+ * Implements `ToolSelectionProfileProvenanceStore` directly (the narrow
+ * interface `PersistentToolSelectionProfileRegistry` actually depends on) —
+ * no `as unknown as` cast against the concrete repository type.
  */
-class DelayedToolSelectionProfileProvenanceRepository {
+class DelayedToolSelectionProfileProvenanceStore implements ToolSelectionProfileProvenanceStore {
   readonly stored = new Set<string>();
   readonly releaseInsert: () => void;
   private readonly gate: Promise<void>;
@@ -38,47 +42,9 @@ class DelayedToolSelectionProfileProvenanceRepository {
   }
 }
 
-function asRepository(
-  fake: DelayedToolSelectionProfileProvenanceRepository,
-): ToolSelectionProfileProvenanceRepository {
-  return fake as unknown as ToolSelectionProfileProvenanceRepository;
-}
-
 /**
- * Yields to the real event loop (a macrotask, not just a microtask) so timers
- * and I/O-driven promises elsewhere in `daemon.stop()`'s cleanup stages (e.g.
- * the real `stopManagedAdbServer` probe) get a chance to progress between
- * checks — a pure `await Promise.resolve()` spin could starve them and never
- * observe the state we're waiting for. Uses the injectable `Timer` (real
- * `defaultTimer`, not a raw `setTimeout`) per the repo's timer convention —
- * this genuinely needs real wall-clock scheduling to interleave with
- * `daemon.stop()`'s own real timers/I-O, so `FakeTimer` is not applicable here.
- */
-function nextMacrotask(): Promise<void> {
-  return defaultTimer.sleep(1);
-}
-
-/**
- * Polls `predicate` until it is true, bounded by `timeoutMs`. Throws (failing
- * the test with a clear message) rather than hanging or silently passing when
- * the predicate never becomes true — which is exactly what must happen here if
- * `record()`'s write-through is ever untracked again: an untracked write never
- * makes the barrier's `inFlightCount()` non-zero, so `drain()` sees no
- * outstanding work and returns immediately without this predicate ever holding.
- */
-async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadline) {
-      throw new Error(`waitUntil: condition did not become true within ${timeoutMs}ms`);
-    }
-    await nextMacrotask();
-  }
-}
-
-/**
- * Issue #6225 review round 2 (first pass): `record()`'s write-through must be
- * enlisted in the shared `DbWriteBarrier` — the exact barrier `Daemon.stop()`'s
+ * Issue #6225 review round 2: `record()`'s write-through must be enlisted in
+ * the shared `DbWriteBarrier` — the exact barrier `Daemon.stop()`'s
  * "database write drain" stage awaits before the "database" stage closes the
  * connection (issue #2792's mechanism). Without that enlistment, a graceful
  * restart mid-write could have the drain see no outstanding work and close the
@@ -88,23 +54,32 @@ async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<v
  * awaits the repository write directly, bypassing `record()`'s fire-and-forget
  * path entirely).
  *
- * Review round 2 (second pass): the first version of this test released the
- * insert gate immediately after starting `daemon.stop()` and only asserted
- * that both the insert and `closeDatabase()` EVENTUALLY happened — not their
- * relative order, and not that the insert was ever actually in-flight when the
- * drain began. `daemon.stop()` yields at its very first cleanup-stage `await`
- * (long before the write-drain stage), so that assertion passed trivially, and
- * an UNTRACKED insert (reverting the fix) would have passed it too. This
- * version fixes both problems:
- *   1. It does not release the insert gate until it has directly observed, via
- *      the SAME shared barrier `daemon.stop()` drains, that draining has begun
- *      AND the tracked write is actually counted (`isDraining() &&
- *      inFlightCount() >= 1`) — bounded so an untracked write (which can never
- *      make `inFlightCount()` non-zero) fails the test instead of hanging or
- *      passing.
- *   2. It records both events into one ordered log and asserts the insert's
- *      commit precedes the `closeDatabase()` call, not merely that both
- *      eventually occurred.
+ * Round 2 (second pass) replaced a naive "release immediately, check both
+ * eventually happened" test with a bounded wall-clock poll
+ * (`defaultTimer.sleep` in a loop) for `isDraining() && inFlightCount() >= 1`
+ * before releasing the gate.
+ *
+ * Round 3: that poll could in principle consume its whole bounded deadline
+ * before `daemon.stop()` reaches the drain stage under a stalled/loaded event
+ * loop — flaking even when barrier ordering is correct — and it depended on
+ * wall-clock despite the test already constructing a `FakeTimer`. This version
+ * removes ALL timing dependence:
+ *   1. `getDbWriteBarrier().inFlightCount()` is asserted to be exactly 1
+ *      IMMEDIATELY and SYNCHRONOUSLY after `record()` returns, with no wait at
+ *      all. `DbWriteBarrier.track()` increments the in-flight count
+ *      synchronously, before its first internal `await` — so this is a
+ *      deterministic, instant signal that the write is barrier-tracked. An
+ *      untracked write (the regression this test guards against) can never
+ *      make this non-zero, so this assertion alone fails the test immediately
+ *      if the fix regresses, before `daemon.stop()` is even called.
+ *   2. The insert gate is released from inside a `drain()` spy on the SAME
+ *      shared barrier `daemon.stop()` drains — i.e. exactly when shutdown's
+ *      "database write drain" stage invokes it. A deterministic hook, not a
+ *      polled guess. The spy delegates to the real implementation, so
+ *      `drain()`'s actual blocking-until-idle behavior is exercised for real.
+ *   3. The ordered event log still asserts the insert's commit strictly
+ *      precedes the `closeDatabase()` call, confirming the real ordering
+ *      guarantee end to end.
  */
 describe("Daemon shutdown drains an in-flight tool-selection-profile provenance write (issue #6225)", () => {
   beforeEach(() => resetDbWriteBarrier());
@@ -125,40 +100,45 @@ describe("Daemon shutdown drains an in-flight tool-selection-profile provenance 
       events.push("closeDatabase-called");
     });
 
-    const repo = new DelayedToolSelectionProfileProvenanceRepository(events);
-    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    const store = new DelayedToolSelectionProfileProvenanceStore(events);
+    const registry = new PersistentToolSelectionProfileRegistry(store);
+
+    // Grab the shared barrier before record() so both this test and record()
+    // observe/mutate the identical instance (resetDbWriteBarrier() above means
+    // none exists yet; getDbWriteBarrier() lazily creates it on first call).
+    const barrier = getDbWriteBarrier();
+    const originalDrain = barrier.drain.bind(barrier);
+    const drainSpy = spyOn(barrier, "drain").mockImplementation(async (timeoutMs: number) => {
+      // Release the gated insert at the EXACT moment shutdown's write-drain
+      // stage invokes drain() — a deterministic hook, not a wall-clock guess.
+      store.releaseInsert();
+      return originalDrain(timeoutMs);
+    });
 
     try {
       registry.record("minted-uuid");
-      // The write-through is gated open (not yet committed) — models the write
-      // still being in flight when shutdown begins.
-      expect(repo.stored.has("minted-uuid")).toBe(false);
 
-      const stop = daemon.stop();
+      // The write-through is gated open (not yet committed) — models the
+      // write still being in flight when shutdown begins.
+      expect(store.stored.has("minted-uuid")).toBe(false);
 
-      // Do NOT release the gate yet. Wait until shutdown has genuinely reached
-      // the "database write drain" stage AND the barrier counts our write as
-      // in-flight — the only state in which releasing the gate now actually
-      // exercises the drain-then-close ordering this test is for. If the fix
-      // regresses to an untracked `void this.repository.insert(...)`,
-      // `inFlightCount()` can never become non-zero and this throws instead of
-      // passing.
-      await waitUntil(
-        () => getDbWriteBarrier().isDraining() && getDbWriteBarrier().inFlightCount() >= 1,
-        2000,
-      );
-      expect(closeDatabaseSpy).not.toHaveBeenCalled();
+      // The deterministic, non-polled proof that the write is barrier-tracked.
+      // If `record()` regresses to an untracked `void store.insert(...)`, this
+      // is 0 and the test fails right here, before `daemon.stop()` even runs.
+      expect(barrier.inFlightCount()).toBe(1);
+      expect(barrier.isDraining()).toBe(false);
 
-      repo.releaseInsert();
-      await stop;
+      await daemon.stop();
 
+      expect(drainSpy).toHaveBeenCalled();
       // Both happened, AND in the required order: the write committed before
       // the database closed.
       expect(events).toEqual(["insert-committed", "closeDatabase-called"]);
-      expect(repo.stored.has("minted-uuid")).toBe(true);
+      expect(store.stored.has("minted-uuid")).toBe(true);
     } finally {
       loggerCloseSpy.mockRestore();
       closeDatabaseSpy.mockRestore();
+      drainSpy.mockRestore();
     }
-  }, 5000);
+  });
 });

--- a/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
+++ b/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import * as databaseModule from "../../src/db";
-import { resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
+import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
 import type { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
 import { PersistentToolSelectionProfileRegistry } from "../../src/server/toolSelectionProfileRegistry";
 import { logger } from "../../src/utils/logger";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -18,7 +19,7 @@ class DelayedToolSelectionProfileProvenanceRepository {
   readonly releaseInsert: () => void;
   private readonly gate: Promise<void>;
 
-  constructor() {
+  constructor(private readonly events: string[]) {
     let release!: () => void;
     this.gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -29,6 +30,7 @@ class DelayedToolSelectionProfileProvenanceRepository {
   async insert(profileUuid: string): Promise<void> {
     await this.gate;
     this.stored.add(profileUuid);
+    this.events.push("insert-committed");
   }
 
   async loadAll(): Promise<string[]> {
@@ -43,8 +45,40 @@ function asRepository(
 }
 
 /**
- * Issue #6225 review round 2: `record()`'s write-through must be enlisted in
- * the shared `DbWriteBarrier` — the exact barrier `Daemon.stop()`'s
+ * Yields to the real event loop (a macrotask, not just a microtask) so timers
+ * and I/O-driven promises elsewhere in `daemon.stop()`'s cleanup stages (e.g.
+ * the real `stopManagedAdbServer` probe) get a chance to progress between
+ * checks — a pure `await Promise.resolve()` spin could starve them and never
+ * observe the state we're waiting for. Uses the injectable `Timer` (real
+ * `defaultTimer`, not a raw `setTimeout`) per the repo's timer convention —
+ * this genuinely needs real wall-clock scheduling to interleave with
+ * `daemon.stop()`'s own real timers/I-O, so `FakeTimer` is not applicable here.
+ */
+function nextMacrotask(): Promise<void> {
+  return defaultTimer.sleep(1);
+}
+
+/**
+ * Polls `predicate` until it is true, bounded by `timeoutMs`. Throws (failing
+ * the test with a clear message) rather than hanging or silently passing when
+ * the predicate never becomes true — which is exactly what must happen here if
+ * `record()`'s write-through is ever untracked again: an untracked write never
+ * makes the barrier's `inFlightCount()` non-zero, so `drain()` sees no
+ * outstanding work and returns immediately without this predicate ever holding.
+ */
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`waitUntil: condition did not become true within ${timeoutMs}ms`);
+    }
+    await nextMacrotask();
+  }
+}
+
+/**
+ * Issue #6225 review round 2 (first pass): `record()`'s write-through must be
+ * enlisted in the shared `DbWriteBarrier` — the exact barrier `Daemon.stop()`'s
  * "database write drain" stage awaits before the "database" stage closes the
  * connection (issue #2792's mechanism). Without that enlistment, a graceful
  * restart mid-write could have the drain see no outstanding work and close the
@@ -53,6 +87,24 @@ function asRepository(
  * is the production race the restart integration test cannot exercise (it
  * awaits the repository write directly, bypassing `record()`'s fire-and-forget
  * path entirely).
+ *
+ * Review round 2 (second pass): the first version of this test released the
+ * insert gate immediately after starting `daemon.stop()` and only asserted
+ * that both the insert and `closeDatabase()` EVENTUALLY happened — not their
+ * relative order, and not that the insert was ever actually in-flight when the
+ * drain began. `daemon.stop()` yields at its very first cleanup-stage `await`
+ * (long before the write-drain stage), so that assertion passed trivially, and
+ * an UNTRACKED insert (reverting the fix) would have passed it too. This
+ * version fixes both problems:
+ *   1. It does not release the insert gate until it has directly observed, via
+ *      the SAME shared barrier `daemon.stop()` drains, that draining has begun
+ *      AND the tracked write is actually counted (`isDraining() &&
+ *      inFlightCount() >= 1`) — bounded so an untracked write (which can never
+ *      make `inFlightCount()` non-zero) fails the test instead of hanging or
+ *      passing.
+ *   2. It records both events into one ordered log and asserts the insert's
+ *      commit precedes the `closeDatabase()` call, not merely that both
+ *      eventually occurred.
  */
 describe("Daemon shutdown drains an in-flight tool-selection-profile provenance write (issue #6225)", () => {
   beforeEach(() => resetDbWriteBarrier());
@@ -64,13 +116,16 @@ describe("Daemon shutdown drains an in-flight tool-selection-profile provenance 
     resetDbWriteBarrier();
   });
 
-  test("record()'s write-through commits before the database closes", async () => {
+  test("record()'s write-through commits before the database closes, in that order", async () => {
     const timer = new FakeTimer();
     const daemon = new Daemon({}, new FakeInstalledAppsRepository(), timer);
     const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
-    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockResolvedValue(undefined);
+    const events: string[] = [];
+    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockImplementation(async () => {
+      events.push("closeDatabase-called");
+    });
 
-    const repo = new DelayedToolSelectionProfileProvenanceRepository();
+    const repo = new DelayedToolSelectionProfileProvenanceRepository(events);
     const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
 
     try {
@@ -81,21 +136,29 @@ describe("Daemon shutdown drains an in-flight tool-selection-profile provenance 
 
       const stop = daemon.stop();
 
-      // No matter how far the shutdown pipeline has progressed, it cannot reach
-      // the "database" stage's closeDatabase() until the "database write drain"
-      // stage's await on the barrier resolves — which cannot happen until the
-      // gate below is released. This assertion holds at any point before that.
+      // Do NOT release the gate yet. Wait until shutdown has genuinely reached
+      // the "database write drain" stage AND the barrier counts our write as
+      // in-flight — the only state in which releasing the gate now actually
+      // exercises the drain-then-close ordering this test is for. If the fix
+      // regresses to an untracked `void this.repository.insert(...)`,
+      // `inFlightCount()` can never become non-zero and this throws instead of
+      // passing.
+      await waitUntil(
+        () => getDbWriteBarrier().isDraining() && getDbWriteBarrier().inFlightCount() >= 1,
+        2000,
+      );
       expect(closeDatabaseSpy).not.toHaveBeenCalled();
 
       repo.releaseInsert();
       await stop;
 
-      // The write committed BEFORE the database closed: the barrier awaited it.
+      // Both happened, AND in the required order: the write committed before
+      // the database closed.
+      expect(events).toEqual(["insert-committed", "closeDatabase-called"]);
       expect(repo.stored.has("minted-uuid")).toBe(true);
-      expect(closeDatabaseSpy).toHaveBeenCalled();
     } finally {
       loggerCloseSpy.mockRestore();
       closeDatabaseSpy.mockRestore();
     }
-  });
+  }, 5000);
 });

--- a/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
+++ b/test/daemon/daemonShutdownToolSelectionProfileProvenance.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import * as databaseModule from "../../src/db";
+import { resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
+import type { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
+import { PersistentToolSelectionProfileRegistry } from "../../src/server/toolSelectionProfileRegistry";
+import { logger } from "../../src/utils/logger";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * A fake repository whose `insert` hangs on a manually-released gate, modeling
+ * a slow/queued SQLite write mid-shutdown (issue #6225 review round 2).
+ */
+class DelayedToolSelectionProfileProvenanceRepository {
+  readonly stored = new Set<string>();
+  readonly releaseInsert: () => void;
+  private readonly gate: Promise<void>;
+
+  constructor() {
+    let release!: () => void;
+    this.gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.releaseInsert = release;
+  }
+
+  async insert(profileUuid: string): Promise<void> {
+    await this.gate;
+    this.stored.add(profileUuid);
+  }
+
+  async loadAll(): Promise<string[]> {
+    return [...this.stored];
+  }
+}
+
+function asRepository(
+  fake: DelayedToolSelectionProfileProvenanceRepository,
+): ToolSelectionProfileProvenanceRepository {
+  return fake as unknown as ToolSelectionProfileProvenanceRepository;
+}
+
+/**
+ * Issue #6225 review round 2: `record()`'s write-through must be enlisted in
+ * the shared `DbWriteBarrier` — the exact barrier `Daemon.stop()`'s
+ * "database write drain" stage awaits before the "database" stage closes the
+ * connection (issue #2792's mechanism). Without that enlistment, a graceful
+ * restart mid-write could have the drain see no outstanding work and close the
+ * DB before the insert commits: the repository swallows that failure, and the
+ * next daemon rejects the profile this PR is meant to let it recognize. This
+ * is the production race the restart integration test cannot exercise (it
+ * awaits the repository write directly, bypassing `record()`'s fire-and-forget
+ * path entirely).
+ */
+describe("Daemon shutdown drains an in-flight tool-selection-profile provenance write (issue #6225)", () => {
+  beforeEach(() => resetDbWriteBarrier());
+
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+    resetDbWriteBarrier();
+  });
+
+  test("record()'s write-through commits before the database closes", async () => {
+    const timer = new FakeTimer();
+    const daemon = new Daemon({}, new FakeInstalledAppsRepository(), timer);
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockResolvedValue(undefined);
+
+    const repo = new DelayedToolSelectionProfileProvenanceRepository();
+    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+
+    try {
+      registry.record("minted-uuid");
+      // The write-through is gated open (not yet committed) — models the write
+      // still being in flight when shutdown begins.
+      expect(repo.stored.has("minted-uuid")).toBe(false);
+
+      const stop = daemon.stop();
+
+      // No matter how far the shutdown pipeline has progressed, it cannot reach
+      // the "database" stage's closeDatabase() until the "database write drain"
+      // stage's await on the barrier resolves — which cannot happen until the
+      // gate below is released. This assertion holds at any point before that.
+      expect(closeDatabaseSpy).not.toHaveBeenCalled();
+
+      repo.releaseInsert();
+      await stop;
+
+      // The write committed BEFORE the database closed: the barrier awaited it.
+      expect(repo.stored.has("minted-uuid")).toBe(true);
+      expect(closeDatabaseSpy).toHaveBeenCalled();
+    } finally {
+      loggerCloseSpy.mockRestore();
+      closeDatabaseSpy.mockRestore();
+    }
+  });
+});

--- a/test/db/toolSelectionProfileProvenanceMigration.integration.test.ts
+++ b/test/db/toolSelectionProfileProvenanceMigration.integration.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up, down } from "../../src/db/migrations/2026_09_06_000_tool_selection_profile_provenance";
+
+/**
+ * Migration coverage for #6225 (#6148/#6213 follow-up): the durable membership
+ * set backing `PersistentToolSelectionProfileRegistry`.
+ */
+describe("2026_09_06_000_tool_selection_profile_provenance migration", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(() => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function tableNames(): Promise<string[]> {
+    const rows = await sql<{ name: string }>`
+      SELECT name FROM sqlite_master WHERE type = 'table'
+    `.execute(db);
+    return rows.rows.map((r) => r.name);
+  }
+
+  test("up() creates the provenance table", async () => {
+    await up(db);
+    expect(await tableNames()).toContain("tool_selection_profile_provenance");
+  });
+
+  test("up() is idempotent (ifNotExists, re-running does not throw)", async () => {
+    await up(db);
+    await up(db);
+    expect(await tableNames()).toContain("tool_selection_profile_provenance");
+  });
+
+  test("profile_uuid is the primary key: a duplicate insert without ON CONFLICT throws", async () => {
+    await up(db);
+    await db
+      .insertInto("tool_selection_profile_provenance" as any)
+      .values({ profile_uuid: "minted-uuid" })
+      .execute();
+    await expect(
+      db
+        .insertInto("tool_selection_profile_provenance" as any)
+        .values({ profile_uuid: "minted-uuid" })
+        .execute(),
+    ).rejects.toThrow();
+  });
+
+  test("created_at defaults to the current datetime", async () => {
+    await up(db);
+    await db
+      .insertInto("tool_selection_profile_provenance" as any)
+      .values({ profile_uuid: "minted-uuid" })
+      .execute();
+    const row = await db
+      .selectFrom("tool_selection_profile_provenance" as any)
+      .select(["created_at"])
+      .executeTakeFirstOrThrow();
+    expect(typeof (row as { created_at: string }).created_at).toBe("string");
+    expect((row as { created_at: string }).created_at.length).toBeGreaterThan(0);
+  });
+
+  test("down() drops the provenance table", async () => {
+    await up(db);
+    await down(db);
+    expect(await tableNames()).not.toContain("tool_selection_profile_provenance");
+  });
+
+  test("down() is idempotent (ifExists, re-running does not throw)", async () => {
+    await up(db);
+    await down(db);
+    await down(db);
+    expect(await tableNames()).not.toContain("tool_selection_profile_provenance");
+  });
+});

--- a/test/db/toolSelectionProfileProvenanceRepository.test.ts
+++ b/test/db/toolSelectionProfileProvenanceRepository.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
+import { createTestDatabase } from "./testDbHelper";
+
+/**
+ * #6225 (#6148/#6213 follow-up): durable membership set backing
+ * `PersistentToolSelectionProfileRegistry`.
+ */
+describe("ToolSelectionProfileProvenanceRepository", () => {
+  let db: Kysely<Database>;
+  let repo: ToolSelectionProfileProvenanceRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new ToolSelectionProfileProvenanceRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("loadAll returns empty when nothing has been minted", async () => {
+    expect(await repo.loadAll()).toEqual([]);
+  });
+
+  test("insert then loadAll returns the recorded uuid", async () => {
+    await repo.insert("minted-uuid");
+    expect(await repo.loadAll()).toEqual(["minted-uuid"]);
+  });
+
+  test("insert is idempotent: inserting the same uuid twice does not duplicate or throw", async () => {
+    await repo.insert("minted-uuid");
+    await repo.insert("minted-uuid");
+    expect(await repo.loadAll()).toEqual(["minted-uuid"]);
+  });
+
+  test("loadAll returns every distinct minted uuid", async () => {
+    await repo.insert("uuid-a");
+    await repo.insert("uuid-b");
+    expect((await repo.loadAll()).sort()).toEqual(["uuid-a", "uuid-b"]);
+  });
+
+  test("a value that was never inserted never appears in loadAll (no fabricated-value leak)", async () => {
+    await repo.insert("minted-uuid");
+    expect(await repo.loadAll()).not.toContain("fabricated-uuid");
+  });
+});

--- a/test/db/toolSelectionProfileProvenanceRestart.integration.test.ts
+++ b/test/db/toolSelectionProfileProvenanceRestart.integration.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
+import { PersistentToolSelectionProfileRegistry } from "../../src/server/toolSelectionProfileRegistry";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
+import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+
+/**
+ * Issue #6225 (#6148/#6213 follow-up): the whole point of persisting
+ * tool-selection-profile provenance is that it survives an ACTUAL daemon
+ * restart — a real close of the sqlite connection followed by a fresh process
+ * reopening the same on-disk file, not just a second in-memory instance. This
+ * exercises that real close/reopen against a real file-backed DB, mirroring
+ * `navigationProvenanceLifecycle.integration.test.ts`.
+ */
+describe("tool-selection-profile provenance — real daemon-restart durability", () => {
+  let harness = createFileBackedDbHarness();
+
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  test(
+    "a minted profile is recognized after a real close+reopen; a fabricated one never is",
+    async () => {
+      // "Before restart": daemon process 1 mints and records a profile.
+      const before = await harness.openLifecycleTestDb("tool-selection-profile-provenance-");
+      const dir = before.dir;
+      try {
+        const dbBefore = before.module.getDatabase() as Kysely<Database>;
+        const repoBefore = new ToolSelectionProfileProvenanceRepository(dbBefore);
+        const registryBefore = new PersistentToolSelectionProfileRegistry(repoBefore);
+
+        // Write-through directly on the repository (not the fire-and-forget
+        // `record()` path) so the persistence write is deterministically awaited
+        // before the "restart".
+        await repoBefore.insert("minted-uuid");
+        registryBefore.record("minted-uuid");
+        expect(registryBefore.has("minted-uuid")).toBe(true);
+        expect(registryBefore.has("fabricated-uuid")).toBe(false);
+      } finally {
+        // Close the connection WITHOUT deleting the temp dir — a real daemon
+        // restart keeps the on-disk file, it just re-opens a new connection.
+        await before.module.closeDatabase();
+      }
+
+      // "After restart": daemon process 2 re-opens the SAME on-disk file (the
+      // harness leaves AUTOMOBILE_DB_DIR bound to `dir`) with a fresh module
+      // instance and a brand-new, empty in-memory registry.
+      const after = await harness.importFreshDatabaseModule();
+      try {
+        after.getDatabase();
+        await after.ensureMigrations();
+        expect(after.getDatabasePath().startsWith(dir)).toBe(true);
+
+        const dbAfter = after.getDatabase() as Kysely<Database>;
+        const repoAfter = new ToolSelectionProfileProvenanceRepository(dbAfter);
+        const registryAfter = new PersistentToolSelectionProfileRegistry(repoAfter);
+
+        // Before load(): a fresh in-memory registry recognizes nothing yet.
+        expect(registryAfter.has("minted-uuid")).toBe(false);
+
+        await registryAfter.load();
+
+        // The legitimately-minted profile survives the restart and is
+        // recognized without re-minting...
+        expect(registryAfter.has("minted-uuid")).toBe(true);
+        // ...while a value that was never minted is still rejected, because it
+        // was never persisted in the first place.
+        expect(registryAfter.has("fabricated-uuid")).toBe(false);
+      } finally {
+        await after.closeDatabase();
+      }
+    },
+    WINDOWS_FILE_DB_TEST_TIMEOUT_MS,
+  );
+});

--- a/test/fakes/FakeToolSelectionProfileProvenanceLoader.ts
+++ b/test/fakes/FakeToolSelectionProfileProvenanceLoader.ts
@@ -1,0 +1,14 @@
+import type { ToolSelectionProfileProvenanceLoader } from "../../src/server/toolSelectionProfileRegistry";
+
+/**
+ * No-op `ToolSelectionProfileProvenanceLoader` for daemon startup tests
+ * (issue #6225) that must not resolve the real `getDatabase()` singleton via
+ * the production `defaultToolSelectionProfileRegistry` default.
+ */
+export class FakeToolSelectionProfileProvenanceLoader implements ToolSelectionProfileProvenanceLoader {
+  loadCalls = 0;
+
+  async load(): Promise<void> {
+    this.loadCalls += 1;
+  }
+}

--- a/test/server/ToolSelectionProfileRegistry.test.ts
+++ b/test/server/ToolSelectionProfileRegistry.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import { InMemoryToolSelectionProfileRegistry } from "../../src/server/toolSelectionProfileRegistry";
+import {
+  InMemoryToolSelectionProfileRegistry,
+  PersistentToolSelectionProfileRegistry,
+} from "../../src/server/toolSelectionProfileRegistry";
+import type { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
+
+/**
+ * A synchronous in-memory stand-in for `ToolSelectionProfileProvenanceRepository`
+ * (issue #6225). `insert`/`loadAll` mutate `stored` before their `async` body
+ * hits its first (nonexistent) `await`, so the mutation is visible synchronously
+ * even though the method returns a `Promise` — matching how the real repository's
+ * write-through is exercised via the fire-and-forget `record()` path. Keeps this
+ * suite <100ms with no DB (per CLAUDE.md).
+ */
+class FakeToolSelectionProfileProvenanceRepository {
+  readonly stored = new Set<string>();
+  insertCalls: string[] = [];
+
+  async insert(profileUuid: string): Promise<void> {
+    this.insertCalls.push(profileUuid);
+    this.stored.add(profileUuid);
+  }
+
+  async loadAll(): Promise<string[]> {
+    return [...this.stored];
+  }
+}
+
+function asRepository(
+  fake: FakeToolSelectionProfileProvenanceRepository,
+): ToolSelectionProfileProvenanceRepository {
+  return fake as unknown as ToolSelectionProfileProvenanceRepository;
+}
 
 /**
  * #6148 round 4 — the registry is the provenance signal that must survive the
@@ -41,5 +73,105 @@ describe("InMemoryToolSelectionProfileRegistry (#6148)", () => {
 
     expect(registry.has("")).toBe(false);
     expect(registry.has("   ")).toBe(false);
+  });
+});
+
+/**
+ * Issue #6225 (#6148/#6213 follow-up): durability across a simulated daemon
+ * restart, while keeping the #6148 fabricated-value rejection intact.
+ */
+describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
+  test("recognizes a recorded uuid immediately (in-memory fast path unchanged)", () => {
+    const registry = new PersistentToolSelectionProfileRegistry(
+      asRepository(new FakeToolSelectionProfileProvenanceRepository()),
+    );
+    registry.record("minted-uuid");
+
+    expect(registry.has("minted-uuid")).toBe(true);
+  });
+
+  test("rejects a value that was never recorded", () => {
+    const registry = new PersistentToolSelectionProfileRegistry(
+      asRepository(new FakeToolSelectionProfileProvenanceRepository()),
+    );
+    registry.record("minted-uuid");
+
+    expect(registry.has("fabricated-uuid")).toBe(false);
+  });
+
+  test("ignores an empty or blank uuid, and never writes it through", () => {
+    const repo = new FakeToolSelectionProfileProvenanceRepository();
+    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    registry.record("");
+    registry.record("   ");
+
+    expect(registry.has("")).toBe(false);
+    expect(registry.has("   ")).toBe(false);
+    expect(repo.insertCalls).toEqual([]);
+  });
+
+  test("record() write-throughs the minted uuid to the durable store", () => {
+    const repo = new FakeToolSelectionProfileProvenanceRepository();
+    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    registry.record("minted-uuid");
+
+    expect(repo.insertCalls).toEqual(["minted-uuid"]);
+    expect(repo.stored.has("minted-uuid")).toBe(true);
+  });
+
+  test("a fabricated value is never persisted (has() stays false even after a would-be reload)", async () => {
+    const repo = new FakeToolSelectionProfileProvenanceRepository();
+    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    registry.record("minted-uuid");
+
+    // Never call record("fabricated-uuid") — a caller merely CLAIMING that
+    // value never puts it in the store.
+    expect(repo.stored.has("fabricated-uuid")).toBe(false);
+
+    await registry.load();
+    expect(registry.has("fabricated-uuid")).toBe(false);
+  });
+
+  test("simulated daemon restart: a fresh registry sharing the durable store recognizes a previously minted profile after load()", async () => {
+    // "Before restart": one daemon process mints a profile against the durable store.
+    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
+    const before = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    before.record("minted-uuid");
+    expect(before.has("minted-uuid")).toBe(true);
+
+    // "After restart": a BRAND NEW registry (in-memory set is empty, as it would
+    // be for a freshly-constructed process-wide singleton) backed by the SAME
+    // durable store the old process wrote to.
+    const after = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    expect(after.has("minted-uuid")).toBe(false); // not yet loaded
+
+    await after.load();
+
+    // Reaffirmation succeeds without re-minting.
+    expect(after.has("minted-uuid")).toBe(true);
+  });
+
+  test("simulated daemon restart: a fabricated/never-minted value is still rejected after load()", async () => {
+    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
+    const before = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    before.record("minted-uuid");
+
+    const after = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    await after.load();
+
+    expect(after.has("minted-uuid")).toBe(true);
+    expect(after.has("fabricated-uuid")).toBe(false);
+  });
+
+  test("load() merges persisted entries without clearing anything already recorded in this process", async () => {
+    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
+    sharedRepo.stored.add("persisted-uuid");
+    const registry = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    registry.record("locally-minted-uuid");
+
+    await registry.load();
+
+    expect(registry.has("locally-minted-uuid")).toBe(true);
+    expect(registry.has("persisted-uuid")).toBe(true);
   });
 });

--- a/test/server/ToolSelectionProfileRegistry.test.ts
+++ b/test/server/ToolSelectionProfileRegistry.test.ts
@@ -2,18 +2,21 @@ import { describe, expect, test } from "bun:test";
 import {
   InMemoryToolSelectionProfileRegistry,
   PersistentToolSelectionProfileRegistry,
+  type ToolSelectionProfileProvenanceStore,
 } from "../../src/server/toolSelectionProfileRegistry";
-import type { ToolSelectionProfileProvenanceRepository } from "../../src/db/toolSelectionProfileProvenanceRepository";
 
 /**
- * A synchronous in-memory stand-in for `ToolSelectionProfileProvenanceRepository`
- * (issue #6225). `insert`/`loadAll` mutate `stored` before their `async` body
- * hits its first (nonexistent) `await`, so the mutation is visible synchronously
- * even though the method returns a `Promise` — matching how the real repository's
- * write-through is exercised via the fire-and-forget `record()` path. Keeps this
- * suite <100ms with no DB (per CLAUDE.md).
+ * A synchronous in-memory stand-in for `ToolSelectionProfileProvenanceStore`
+ * (issue #6225 review round 3: depend on the narrow interface, not the
+ * concrete `ToolSelectionProfileProvenanceRepository`, so this fake implements
+ * the real contract directly — no `as unknown as` type-erasure). `insert`/
+ * `loadAll` mutate `stored` before their `async` body hits its first
+ * (nonexistent) `await`, so the mutation is visible synchronously even though
+ * the method returns a `Promise` — matching how the real repository's
+ * write-through is exercised via the fire-and-forget `record()` path. Keeps
+ * this suite <100ms with no DB (per CLAUDE.md).
  */
-class FakeToolSelectionProfileProvenanceRepository {
+class FakeToolSelectionProfileProvenanceStore implements ToolSelectionProfileProvenanceStore {
   readonly stored = new Set<string>();
   insertCalls: string[] = [];
 
@@ -25,12 +28,6 @@ class FakeToolSelectionProfileProvenanceRepository {
   async loadAll(): Promise<string[]> {
     return [...this.stored];
   }
-}
-
-function asRepository(
-  fake: FakeToolSelectionProfileProvenanceRepository,
-): ToolSelectionProfileProvenanceRepository {
-  return fake as unknown as ToolSelectionProfileProvenanceRepository;
 }
 
 /**
@@ -83,7 +80,7 @@ describe("InMemoryToolSelectionProfileRegistry (#6148)", () => {
 describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   test("recognizes a recorded uuid immediately (in-memory fast path unchanged)", () => {
     const registry = new PersistentToolSelectionProfileRegistry(
-      asRepository(new FakeToolSelectionProfileProvenanceRepository()),
+      new FakeToolSelectionProfileProvenanceStore(),
     );
     registry.record("minted-uuid");
 
@@ -92,7 +89,7 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
 
   test("rejects a value that was never recorded", () => {
     const registry = new PersistentToolSelectionProfileRegistry(
-      asRepository(new FakeToolSelectionProfileProvenanceRepository()),
+      new FakeToolSelectionProfileProvenanceStore(),
     );
     registry.record("minted-uuid");
 
@@ -100,8 +97,8 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   });
 
   test("ignores an empty or blank uuid, and never writes it through", () => {
-    const repo = new FakeToolSelectionProfileProvenanceRepository();
-    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    const repo = new FakeToolSelectionProfileProvenanceStore();
+    const registry = new PersistentToolSelectionProfileRegistry(repo);
     registry.record("");
     registry.record("   ");
 
@@ -111,8 +108,8 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   });
 
   test("record() write-throughs the minted uuid to the durable store", () => {
-    const repo = new FakeToolSelectionProfileProvenanceRepository();
-    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    const repo = new FakeToolSelectionProfileProvenanceStore();
+    const registry = new PersistentToolSelectionProfileRegistry(repo);
     registry.record("minted-uuid");
 
     expect(repo.insertCalls).toEqual(["minted-uuid"]);
@@ -120,8 +117,8 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   });
 
   test("a fabricated value is never persisted (has() stays false even after a would-be reload)", async () => {
-    const repo = new FakeToolSelectionProfileProvenanceRepository();
-    const registry = new PersistentToolSelectionProfileRegistry(asRepository(repo));
+    const repo = new FakeToolSelectionProfileProvenanceStore();
+    const registry = new PersistentToolSelectionProfileRegistry(repo);
     registry.record("minted-uuid");
 
     // Never call record("fabricated-uuid") — a caller merely CLAIMING that
@@ -134,15 +131,15 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
 
   test("simulated daemon restart: a fresh registry sharing the durable store recognizes a previously minted profile after load()", async () => {
     // "Before restart": one daemon process mints a profile against the durable store.
-    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
-    const before = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    const sharedRepo = new FakeToolSelectionProfileProvenanceStore();
+    const before = new PersistentToolSelectionProfileRegistry(sharedRepo);
     before.record("minted-uuid");
     expect(before.has("minted-uuid")).toBe(true);
 
     // "After restart": a BRAND NEW registry (in-memory set is empty, as it would
     // be for a freshly-constructed process-wide singleton) backed by the SAME
     // durable store the old process wrote to.
-    const after = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    const after = new PersistentToolSelectionProfileRegistry(sharedRepo);
     expect(after.has("minted-uuid")).toBe(false); // not yet loaded
 
     await after.load();
@@ -152,11 +149,11 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   });
 
   test("simulated daemon restart: a fabricated/never-minted value is still rejected after load()", async () => {
-    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
-    const before = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    const sharedRepo = new FakeToolSelectionProfileProvenanceStore();
+    const before = new PersistentToolSelectionProfileRegistry(sharedRepo);
     before.record("minted-uuid");
 
-    const after = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    const after = new PersistentToolSelectionProfileRegistry(sharedRepo);
     await after.load();
 
     expect(after.has("minted-uuid")).toBe(true);
@@ -164,9 +161,9 @@ describe("PersistentToolSelectionProfileRegistry (#6225)", () => {
   });
 
   test("load() merges persisted entries without clearing anything already recorded in this process", async () => {
-    const sharedRepo = new FakeToolSelectionProfileProvenanceRepository();
+    const sharedRepo = new FakeToolSelectionProfileProvenanceStore();
     sharedRepo.stored.add("persisted-uuid");
-    const registry = new PersistentToolSelectionProfileRegistry(asRepository(sharedRepo));
+    const registry = new PersistentToolSelectionProfileRegistry(sharedRepo);
     registry.record("locally-minted-uuid");
 
     await registry.load();


### PR DESCRIPTION
## Summary

Follow-up to #6148/#6213 (deferred as #6225). `ToolSelectionProfileRegistry` recorded server-minted tool-selection-profile provenance in-memory only, so a daemon restart/upgrade lost every minted profile: a client reaffirming its still-valid profile failed the provenance check in `setToolEnabled` and had to re-mint. This makes that provenance durable.

## Design

- **New table + migration**: `tool_selection_profile_provenance` (`src/db/migrations/2026_09_06_000_tool_selection_profile_provenance.ts`), keyed by `profile_uuid` (primary key) with a `created_at` observability column. Follows the `device_locks` migration pattern (single-key table, `ifNotExists`/`ifExists`).
- **Repository**: `ToolSelectionProfileProvenanceRepository` (`src/db/toolSelectionProfileProvenanceRepository.ts`) — `insert()` (idempotent, `ON CONFLICT DO NOTHING`) and `loadAll()`. Both are best-effort (log-and-continue on failure), matching `DeviceLockRepository`'s convention: a persistence hiccup must degrade to the pre-#6225 in-memory-only behavior, never fail the triggering `setToolEnabled` call or block daemon startup.
- **Registry**: `PersistentToolSelectionProfileRegistry` (`src/server/toolSelectionProfileRegistry.ts`) wraps the existing `InMemoryToolSelectionProfileRegistry` so `record()`/`has()` stay synchronous for every existing call site (no ripple into `src/server/index.ts`). `record()` fire-and-forget write-throughs each mint to the repository; a new `load()` repopulates the in-memory set from the store. `defaultToolSelectionProfileRegistry` is now this persistent implementation, typed as `ToolSelectionProfileRegistry & ToolSelectionProfileProvenanceLoader` so daemon startup can call `.load()` while every other consumer keeps using the narrower interface.
- **Startup wiring**: `Daemon.initializeDatabase()` awaits `toolSelectionProfileProvenanceLoader.load()` right after the database is brought up (injectable constructor param, defaulting to the production singleton), non-fatally — a load failure just leaves the registry empty, same as before this change.

Fabricated-value rejection is fully preserved: only a value actually passed to `record()` (i.e. actually minted via `createAndBindToolSelectionProfile`) is ever written to the table, so a fabricated or merely-echoed-header uuid is rejected identically before and after a restart — it was never persisted in the first place.

## Tests

- `test/db/toolSelectionProfileProvenanceMigration.integration.test.ts` — up/down, idempotency, PK uniqueness, `created_at` default.
- `test/db/toolSelectionProfileProvenanceRepository.test.ts` — insert/loadAll idempotency against an in-memory DB (`createTestDatabase()`).
- `test/db/toolSelectionProfileProvenanceRestart.integration.test.ts` — a REAL file-backed close+reopen (via the shared `withFileBackedDb` harness) proving a minted profile survives an actual daemon restart while a fabricated one never does.
- `test/server/ToolSelectionProfileRegistry.test.ts` — new `PersistentToolSelectionProfileRegistry` describe block (fake repository, <100ms): write-through, restart-simulated reaffirmation, continued fabricated-value rejection, and that `load()` merges without clobbering.
- `test/daemon/daemonDatabaseInitFailure.test.ts` updated to inject a new `FakeToolSelectionProfileProvenanceLoader` so it never resolves the real `getDatabase()` singleton via the production default (issue #3067 guard).
- Existing `#6148` semantics reverified unchanged: `test/server/setToolEnabledProxyProvenance.integration.test.ts` still passes (direct + default-proxy topologies, header-fallback never recorded).

## Validation

- `bun test` (full suite): 15976 pass, 2 fail — both pre-existing/environmental (missing `oxlint` binary in `node_modules/.bin`, and a WebRTC skip-message subprocess assertion), neither touches any file this PR changes.
- `bun run lint`: no new violations (oxlint ratchet gate, boundary checks all pass).
- `bun run typecheck`: no new type errors (163 known baseline errors, unchanged).
- `bun run format:check`: clean.
- `bunx turbo run build`: succeeds.

Closes #6225