### PR TITLE
fix(devices): resolve iOS deleteDevice by name, not just UDID

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2150,9 +2150,17 @@ function matchesTeardownStableId(
   stableId: string,
   devicePool: DevicePool | undefined,
 ): boolean {
-  return device.platform === "android" && isVirtualAndroidDevice(device)
+  // The name-or-UDID fallback is an iOS-only concern (#6250 delete-by-name).
+  // Branching explicitly on platform keeps a physical Android device whose
+  // `name` happens to collide with an unrelated target's stableId from being
+  // captured by that fallback; Android keeps matching by stable AVD name /
+  // deviceId only.
+  if (device.platform === "ios") {
+    return matchesIosTeardownIdentity(device, stableId);
+  }
+  return isVirtualAndroidDevice(device)
     ? getBootedAndroidStableName(device, devicePool) === stableId
-    : matchesIosTeardownIdentity(device, stableId);
+    : device.deviceId === stableId;
 }
 
 function teardownDeadlineDevice(args: TeardownDeviceArgs): BootedDevice {
@@ -2490,7 +2498,86 @@ async function resolveInventoryTeardownTarget(
       ),
     };
   }
+  // findInventoryTeardownTarget already deduped this match against the
+  // complete iOS inventory, so only the UDID rebind remains here.
+  await rebindIosTeardownLease(context, target);
   return { target };
+}
+
+/**
+ * A booted-device match found via the iOS name fallback only checked the
+ * *booted* device list, so a name that also matches a distinct *stopped*
+ * simulator was never detected as ambiguous (#6250 review). Re-check the
+ * requested name against the complete iOS inventory (booted + stopped)
+ * before committing to it, and rebind the teardown lifecycle lease to the
+ * resolved UDID so it shares the same keyspace as start/provision leases.
+ */
+async function finalizeIosNameResolvedTeardownTarget(
+  context: TeardownContext,
+  target: TeardownResolvedTarget,
+): Promise<TeardownResolution> {
+  if (target.device.platform !== "ios" || context.args.target.stableId === target.device.deviceId) {
+    return { target };
+  }
+  const inventory = await readTeardownInventory(
+    context,
+    "ios",
+    "platform inventory precondition did not complete",
+  );
+  if (!completedInventoryFor(inventory, "ios")) {
+    return {
+      response: createTeardownFailureResponse(
+        context.args,
+        "precondition",
+        "inventory_incomplete",
+        "Cannot resolve the requested iOS device name against the complete inventory because platform discovery did not complete.",
+        target.device,
+      ),
+    };
+  }
+  const matches = inventory.devices.filter(
+    (device) =>
+      device.platform === "ios" && matchesIosTeardownIdentity(device, context.args.target.stableId),
+  );
+  if (matches.length > 1) {
+    return {
+      response: createTeardownFailureResponse(
+        context.args,
+        "precondition",
+        "target_identity_conflict",
+        "Multiple iOS devices matched the requested stable name; refusing to guess which one to delete.",
+        target.device,
+      ),
+    };
+  }
+  await rebindIosTeardownLease(context, target);
+  return { target };
+}
+
+/**
+ * Delete-by-name reserves the teardown lease under the supplied display
+ * name, but iOS start/provision paths reserve the same simulator by UDID
+ * (#6250 review). Rebind to the resolved UDID once the name has resolved to
+ * a real device so the lease actually shares a keyspace with — and mutually
+ * excludes — a concurrent start/provision of that simulator.
+ */
+async function rebindIosTeardownLease(
+  context: TeardownContext,
+  target: TeardownResolvedTarget,
+): Promise<void> {
+  const resolvedUdid = target.device.deviceId;
+  if (
+    target.device.platform !== "ios" ||
+    !resolvedUdid ||
+    context.args.target.stableId === resolvedUdid ||
+    !context.lifecycleLease
+  ) {
+    return;
+  }
+  await context.lifecycleLease.bindCanonicalIdentity({
+    platform: "ios",
+    stableId: resolvedUdid,
+  });
 }
 
 async function resolveTeardownTarget(context: TeardownContext): Promise<TeardownResolution> {
@@ -2526,7 +2613,7 @@ async function resolveTeardownTarget(context: TeardownContext): Promise<Teardown
     };
   }
   if (bootedTarget.target) {
-    return { target: bootedTarget.target };
+    return await finalizeIosNameResolvedTeardownTarget(context, bootedTarget.target);
   }
   const unresolvedAndroidRuntime = booted.devices.find(
     (device) =>

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2135,6 +2135,16 @@ function getBootedAndroidStableName(
   return getValidatedPooledAndroidAvdName(device, devicePool) ?? device.name;
 }
 
+// iOS `deleteDevice` targets are frequently expressed by name (the identifier
+// `provisionDevice` echoes back), not by UDID. Matching only on `deviceId`
+// leaves a name-based lookup unresolved even though the simulator is present,
+// which upstream callers treat as proof of absence (#6250). Match on either
+// the UDID or the display name so name-based delete resolves to the real
+// device, and only a lookup that matches neither is treated as "not found".
+function matchesIosTeardownIdentity(device: { deviceId?: string; name: string }, stableId: string) {
+  return device.deviceId === stableId || device.name === stableId;
+}
+
 function matchesTeardownStableId(
   device: BootedDevice,
   stableId: string,
@@ -2142,7 +2152,7 @@ function matchesTeardownStableId(
 ): boolean {
   return device.platform === "android" && isVirtualAndroidDevice(device)
     ? getBootedAndroidStableName(device, devicePool) === stableId
-    : device.deviceId === stableId;
+    : matchesIosTeardownIdentity(device, stableId);
 }
 
 function teardownDeadlineDevice(args: TeardownDeviceArgs): BootedDevice {
@@ -2286,7 +2296,7 @@ function findInventoryTeardownTarget(
     (device) =>
       device.platform === args.target.platform &&
       (device.platform === "ios"
-        ? device.deviceId === args.target.stableId
+        ? matchesIosTeardownIdentity(device, args.target.stableId)
         : device.name === args.target.stableId),
   );
   if (matches.length > 1) {

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -241,6 +241,97 @@ describe("deleteDevice handler", () => {
     ]);
   });
 
+  // #6250: delete-by-name on iOS (where the caller's identifier is the
+  // simulator's display name, not its UDID) must resolve to the real device
+  // and destroy it, never falsely report already_absent while it still lists.
+  test("resolves an iOS delete-by-name (name != UDID) to the real device and destroys it", async () => {
+    const device: BootedDevice = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "466A9467-CD90-41F3-902B-DC1625471C77",
+    };
+    manager.setBootedDevices("ios", [device]);
+    manager.setDeviceImages("ios", [{ ...device, isRunning: true }]);
+
+    // stableId is the device NAME here, exactly like the issue's repro
+    // (no stableName supplied, and no UDID supplied at all).
+    const response = await teardownTool().handler(request("ios", device.name));
+    const body = responseBody(response);
+
+    expect(body.state).toBe("destroyed");
+    expect(body.command).toEqual({ stop: "accepted", destroy: "accepted" });
+    expect(body.verification).toEqual({
+      notRunning: "confirmed",
+      inventory: "complete_absence_confirmed",
+    });
+    expect(manager.wasMethodCalled("killDevice")).toBe(true);
+    expect(manager.destroyRequests).toEqual([
+      expect.objectContaining({
+        device: expect.objectContaining({
+          platform: "ios",
+          name: device.name,
+          deviceId: device.deviceId,
+        }),
+      }),
+    ]);
+  });
+
+  test("resolves an unbooted iOS delete-by-name (name != UDID) via inventory and destroys it", async () => {
+    const device: DeviceInfo = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "466A9467-CD90-41F3-902B-DC1625471C77",
+      isRunning: false,
+    };
+    manager.setDeviceImages("ios", [device]);
+
+    const response = await teardownTool().handler(request("ios", device.name));
+    const body = responseBody(response);
+
+    expect(body.state).toBe("destroyed");
+    expect(manager.destroyRequests).toEqual([
+      expect.objectContaining({
+        device: expect.objectContaining({
+          platform: "ios",
+          name: device.name,
+          deviceId: device.deviceId,
+        }),
+      }),
+    ]);
+  });
+
+  test("does not report already_absent for an iOS delete-by-name while the device still lists", async () => {
+    const device: BootedDevice = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "466A9467-CD90-41F3-902B-DC1625471C77",
+    };
+    manager.setBootedDevices("ios", [device]);
+    manager.setDeviceImages("ios", [{ ...device, isRunning: true }]);
+
+    const response = await teardownTool().handler(request("ios", device.name));
+    const body = responseBody(response);
+
+    expect(body.state).not.toBe("already_absent");
+  });
+
+  test("still reports already_absent for a genuinely absent iOS device looked up by name", async () => {
+    // A different device exists, but nothing matches the requested name by
+    // either UDID or display name — this must remain a true absence, not a
+    // false positive from an unrelated device being present.
+    manager.setBootedDevices("ios", []);
+    manager.setDeviceImages("ios", [
+      { platform: "ios", name: "some-other-sim", deviceId: "OTHER-UDID", isRunning: false },
+    ]);
+
+    const response = await teardownTool().handler(request("ios", "totally-unknown-sim"));
+    const body = responseBody(response);
+
+    expect(body.state).toBe("already_absent");
+    expect(body.command).toEqual({ stop: "not_required", destroy: "not_required" });
+    expect(manager.destroyRequests).toEqual([]);
+  });
+
   test("finalizes a segmented recording before deleting its booted Android AVD", async () => {
     const device: BootedDevice = {
       platform: "android",

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -332,6 +332,119 @@ describe("deleteDevice handler", () => {
     expect(manager.destroyRequests).toEqual([]);
   });
 
+  // #6250 review: the iOS name-or-UDID fallback must be scoped to iOS only.
+  // A physical Android device whose `name` happens to collide with the
+  // requested AVD stableId must not be captured by it — the AVD inventory
+  // lookup must still get a chance to resolve the real target.
+  test("does not let a physical Android device's colliding name capture the iOS name fallback", async () => {
+    const avdName = "Pixel_8_API_35";
+    manager.setBootedDevices("android", [
+      {
+        platform: "android",
+        name: avdName,
+        deviceId: "R58N123ABCD", // physical serial, not "emulator-*"
+      },
+    ]);
+    manager.setDeviceImages("android", [{ platform: "android", name: avdName, isRunning: false }]);
+
+    const response = await teardownTool().handler(request("android", avdName));
+    const body = responseBody(response);
+
+    expect(body.state).toBe("destroyed");
+    expect(body.command).toEqual({ stop: "not_required", destroy: "accepted" });
+    expect(manager.destroyRequests).toEqual([
+      expect.objectContaining({
+        device: expect.objectContaining({ platform: "android", name: avdName }),
+      }),
+    ]);
+  });
+
+  // #6250 review: a name that resolves against ONLY the booted device list
+  // can miss a distinct stopped simulator sharing that same name. Ambiguity
+  // must be detected against the complete inventory, not just the booted
+  // snapshot, and must never silently pick the booted device.
+  test("returns target_identity_conflict when an iOS name matches both a booted and a stopped simulator", async () => {
+    const booted: BootedDevice = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "BOOTED-UDID",
+    };
+    const stopped: DeviceInfo = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "STOPPED-UDID",
+      isRunning: false,
+    };
+    manager.setBootedDevices("ios", [booted]);
+    manager.setDeviceImages("ios", [{ ...booted, isRunning: true }, stopped]);
+
+    const response = await teardownTool().handler(request("ios", booted.name));
+    const body = responseBody(response);
+
+    expect(body.state).toBe("failed");
+    expect(body.failure).toEqual(
+      expect.objectContaining({
+        code: "target_identity_conflict",
+        phase: "precondition",
+      }),
+    );
+    expect(manager.destroyRequests).toEqual([]);
+    expect(manager.wasMethodCalled("killDevice")).toBe(false);
+  });
+
+  // #6250 review: delete-by-name reserves the teardown lease under the
+  // supplied display NAME, but iOS start/provision reserve the same
+  // simulator by UDID. Once the name resolves to a real device, the lease
+  // must be rebound to that UDID so it actually shares start/provision's
+  // keyspace and blocks a concurrent UDID-keyed acquire.
+  test("rebinds an iOS delete-by-name teardown lease to the resolved UDID", async () => {
+    const device: DeviceInfo = {
+      platform: "ios",
+      name: "am-sweep-sim",
+      deviceId: "466A9467-CD90-41F3-902B-DC1625471C77",
+      isRunning: false,
+    };
+    let releaseDestroy!: () => void;
+    const destroyStarted = new Promise<void>((resolve) => {
+      manager.destroyStarted = resolve;
+    });
+    manager.destroyGate = new Promise<void>((resolve) => {
+      releaseDestroy = resolve;
+    });
+    manager.setDeviceImages("ios", [device]);
+
+    // stableId is the device NAME (delete-by-name), not the UDID.
+    const teardown = teardownTool().handler(request("ios", device.name));
+    await destroyStarted;
+    manager.clearHistory();
+
+    // A concurrent UDID-keyed acquire must be blocked by the rebound lease —
+    // proof the teardown lease now shares the UDID keyspace with start.
+    const start = getAppleTool().handler({
+      udid: device.deviceId,
+      bootTimeoutMs: 30_000,
+      automationReadyTimeoutMs: 30_000,
+    });
+    let startSettled = false;
+    void start.then(
+      () => {
+        startSettled = true;
+      },
+      () => {
+        startSettled = true;
+      },
+    );
+    for (let attempt = 0; attempt < 50; attempt++) {
+      await Promise.resolve();
+    }
+    expect(startSettled).toBe(false);
+    expect(manager.getExecutedOperations()).toEqual([]);
+
+    releaseDestroy();
+    await teardown;
+    await expect(start).rejects.toThrow(/not found/);
+  });
+
   test("finalizes a segmented recording before deleting its booted Android AVD", async () => {
     const device: BootedDevice = {
       platform: "android",


### PR DESCRIPTION
## Root cause

`deleteDevice` with `verifyAbsence: true` falsely reported `state: "already_absent"` / `verification.notRunning: "confirmed"` whenever `target.stableId` could not be resolved to a device — treating "couldn't find/resolve the target" as proof the device is gone.

On iOS this bites hard because delete-by-name is a real, expected shape: `provisionDevice` accepts and echoes `device.name`, but the teardown path matched targets **only** by `device.deviceId` (the UDID). So calling `deleteDevice` with the same name `provisionDevice` just used silently fell through to the absence path and reported success — while `simctl` still listed the simulator. The same call with the UDID worked correctly. Android was unaffected because the AVD name already *is* the platform's stable id.

## Fix

Added `matchesIosTeardownIdentity(device, stableId)`, which matches an iOS device by **either** its UDID or its display name, and used it in both places that resolve a teardown target:

- `matchesTeardownStableId` — the booted-device precondition check
- `findInventoryTeardownTarget` — the platform inventory lookup

This resolves delete-by-name to the real device (its actual UDID), so it is stopped/destroyed/verified through that identity — matching how `provisionDevice` already speaks in names. Ambiguity (multiple devices matching) still surfaces as the existing `target_identity_conflict` failure. A lookup that matches neither the UDID nor the name, in a *complete* platform inventory, still (and only) reports `already_absent` — so genuine absence keeps working correctly, as does the existing `inventory_incomplete` guard when the inventory can't be trusted.

## Tests

Added unit tests (fakes only, no real devices) to `test/server/deviceTools.teardownDevice.test.ts`:

- iOS delete-by-name (name != UDID) on a **booted** device resolves to the real device and destroys it
- iOS delete-by-name (name != UDID) on a **stopped** device resolves via inventory and destroys it
- iOS delete-by-name never reports `already_absent` while the device still lists
- A genuinely absent iOS device, looked up by name, still correctly reports `already_absent` (with an unrelated device present, to rule out false matches)
- Existing Android (name == stableId) and UDID-based iOS tests are unchanged and still pass

`bun test test/server/deviceTools.teardownDevice.test.ts`: 47 pass, 0 fail, ~250ms.

## Validation

- `bun test test/server/deviceTools.teardownDevice.test.ts` — 47 pass
- `bun run lint` — no new violations
- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- `bunx turbo run build` — success

Closes #6250