### PR TITLE
fix: align postNotification/setAppPermissions/navigateTo/setUIState isError with #6200

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -74,7 +74,6 @@ src/features/action/TapOnElement.ts: error TS2416: Property 'hashViewHierarchy' 
 src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'getUiAutomatorHierarchy' does not exist on type 'ViewHierarchy'.
 src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'mergeHierarchies' does not exist on type 'ViewHierarchy'.
 src/features/action/swipeon/ScrollUntilVisible.ts: error TS2322: Type 'ViewHierarchyResult | undefined' is not assignable to type 'ViewHierarchyResult | null'.
-src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
 src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
@@ -176,12 +175,12 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 11,13,13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 # swap-fp: 12,12 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 # swap-fp: 12,12 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
-# swap-fp: 13 :: src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
 # swap-fp: 13 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type '(Element | null)[]' is not assignable to type 'Element[]'.
 # swap-fp: 14 :: src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 149 :: src/server/navigationTools.ts: error TS2339: Property 'coverage' does not exist on type 'ExploreExecutionResult'.
+# swap-fp: 15 :: src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
 # swap-fp: 15 :: src/server/networkTools.ts: error TS2459: Module '"../utils/deviceUtils"' declares 'BootedDevice' locally, but it is not exported.
 # swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 16 :: src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
@@ -213,6 +212,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableParentsContainingText' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableSiblingsOfResourceId' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableSiblingsOfText' does not exist on type 'ElementFinder'.
+# swap-fp: 33 :: src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
 # swap-fp: 34 :: src/db/migrator.ts: error TS7006: Parameter 'table' implicitly has an 'any' type.
 # swap-fp: 34 :: src/features/accessibility/ContrastChecker.ts: error TS2532: Object is possibly 'undefined'.
 # swap-fp: 36 :: src/features/action/TapAnyElement.ts: error TS2339: Property 'doubleTap' does not exist on type 'IOSCtrlProxyClient'.
@@ -235,7 +235,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 46 :: src/db/bunSqliteDialect.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 46 :: src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
 # swap-fp: 47 :: src/features/observe/HierarchyPlatformValidator.ts: error TS2339: Property 'startsWith' does not exist on type '{}'.
-# swap-fp: 49 :: src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
 # swap-fp: 5 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ type: "box"; style?: HighlightStyle | null | undefined; bounds: NormalizedHighlightBounds | undefined; } | { type: "circle"; style?: HighlightStyle | ... 1 more ... | undefined; bounds: NormalizedHighlightBounds | undefined; }' is not assignable to type 'HighlightShape'.
 # swap-fp: 5 :: src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 # swap-fp: 5,7,7 :: src/server/networkGraph.ts: error TS18048: 'group' is possibly 'undefined'.
@@ -255,7 +254,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 63 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
 # swap-fp: 64,64 :: src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 # swap-fp: 67,73 :: src/features/utility/ElementFinder.ts: error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
-# swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
 # swap-fp: 7 :: src/features/observe/Idle.ts: error TS2741: Property 'updatedPrevTotalFrames' is missing in type '{ isStable: false; shouldUpdateLastNonIdleTime: true; updatedPrevMissedVsync: null; updatedPrevSlowUiThread: null; updatedPrevFrameDeadlineMissed: null; updatedFirstGfxInfoLog: false; }' but required in type 'UiStabilityResult'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -266,7 +264,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
-# swap-fp: 7,7,11,13,13 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
+# swap-fp: 7,7,11,13,55 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -799,12 +799,19 @@ export function registerAppTools() {
       scheduleExactAlarm: args.scheduleExactAlarm,
     });
 
-    return createJSONToolResponse({
+    const response = createJSONToolResponse({
       message: result.success
         ? `Applied ${result.changedCount} app permission change(s) for ${args.appId}`
         : (result.error ?? `Failed to apply app permission changes for ${args.appId}`),
       ...result,
     });
+    // `result.success` requires every requested change to have applied, so a
+    // partial success (some permissions changed, others didn't) already
+    // reports per-operation status via `operations`/`changedCount` and may
+    // stay isError:false. But when NOTHING applied, the primary operation did
+    // not succeed and must be reported as such (#6200, #6251).
+    const wholeOperationFailed = !result.success && result.changedCount === 0;
+    return wholeOperationFailed ? { ...response, isError: true as const } : response;
   };
 
   const getAppPermissionsHandler = async (device: BootedDevice, args: GetAppPermissionsArgs) => {

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -577,6 +577,56 @@ export type GetAppPermissionsArgs = z.infer<typeof getAppPermissionsSchema>;
 
 export type ResetKeychainArgs = z.infer<typeof resetKeychainSchema>;
 
+// Injection seam for the setAppPermissions handler (mirrors the tapAny
+// factory seam in interactionTools.ts). Lets a unit test exercise the
+// registered handler wiring with a fake AppPermissions whose setPermissions()
+// returns a chosen success/partial/failure result, instead of spying on the
+// class prototype (#6251 review — a prototype spy is a process-global patch
+// that can leak into unrelated tests running in the same process).
+export type AppPermissionsLike = Pick<AppPermissions, "setPermissions">;
+
+let appPermissionsFactory: (device: BootedDevice) => AppPermissionsLike = (device) =>
+  new AppPermissions(device);
+
+export function setAppPermissionsFactory(
+  factory: (device: BootedDevice) => AppPermissionsLike,
+): void {
+  appPermissionsFactory = factory;
+}
+
+export function resetAppPermissionsFactory(): void {
+  appPermissionsFactory = (device) => new AppPermissions(device);
+}
+
+export const setAppPermissionsHandler = async (
+  device: BootedDevice,
+  args: SetAppPermissionsArgs,
+) => {
+  const permissions = appPermissionsFactory(device);
+  const result = await permissions.setPermissions(args.appId, {
+    action: args.action,
+    permissions: args.permissions,
+    userId: args.userId,
+    notificationsEnabled: args.notificationsEnabled,
+    notificationPolicyAccess: args.notificationPolicyAccess,
+    scheduleExactAlarm: args.scheduleExactAlarm,
+  });
+
+  const response = createJSONToolResponse({
+    message: result.success
+      ? `Applied ${result.changedCount} app permission change(s) for ${args.appId}`
+      : (result.error ?? `Failed to apply app permission changes for ${args.appId}`),
+    ...result,
+  });
+  // `result.success` requires every requested change to have applied, so a
+  // partial success (some permissions changed, others didn't) already
+  // reports per-operation status via `operations`/`changedCount` and may
+  // stay isError:false. But when NOTHING applied, the primary operation did
+  // not succeed and must be reported as such (#6200, #6251).
+  const wholeOperationFailed = !result.success && result.changedCount === 0;
+  return wholeOperationFailed ? { ...response, isError: true as const } : response;
+};
+
 // Register tools
 export function registerAppTools() {
   const listAppsHandler = async (device: BootedDevice, args: ListAppsArgs) => {
@@ -786,32 +836,6 @@ export function registerAppTools() {
         logger.warn(`[AppTools] Failed to refresh app resources after uninstall: ${error}`);
       }
     }
-  };
-
-  const setAppPermissionsHandler = async (device: BootedDevice, args: SetAppPermissionsArgs) => {
-    const permissions = new AppPermissions(device);
-    const result = await permissions.setPermissions(args.appId, {
-      action: args.action,
-      permissions: args.permissions,
-      userId: args.userId,
-      notificationsEnabled: args.notificationsEnabled,
-      notificationPolicyAccess: args.notificationPolicyAccess,
-      scheduleExactAlarm: args.scheduleExactAlarm,
-    });
-
-    const response = createJSONToolResponse({
-      message: result.success
-        ? `Applied ${result.changedCount} app permission change(s) for ${args.appId}`
-        : (result.error ?? `Failed to apply app permission changes for ${args.appId}`),
-      ...result,
-    });
-    // `result.success` requires every requested change to have applied, so a
-    // partial success (some permissions changed, others didn't) already
-    // reports per-operation status via `operations`/`changedCount` and may
-    // stay isError:false. But when NOTHING applied, the primary operation did
-    // not succeed and must be reported as such (#6200, #6251).
-    const wholeOperationFailed = !result.success && result.changedCount === 0;
-    return wholeOperationFailed ? { ...response, isError: true as const } : response;
   };
 
   const getAppPermissionsHandler = async (device: BootedDevice, args: GetAppPermissionsArgs) => {

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -65,6 +65,77 @@ const setUIStateResultSchema = z.object({
   error: z.string().optional().describe("Error message"),
 });
 
+export type SetUIStateArgs = z.infer<typeof setUIStateSchema>;
+
+// Injection seam for the setUIState handler (mirrors the tapAny factory seam
+// in interactionTools.ts). Lets a unit test exercise the registered handler
+// wiring with a fake SetUIState whose execute() returns a chosen
+// success/partial/failure result, instead of spying on the class prototype
+// (#6251 review — a prototype spy is a process-global patch that can leak
+// into unrelated tests running in the same process).
+export type SetUIStateLike = Pick<SetUIState, "execute">;
+
+function createDefaultSetUIState(device: BootedDevice): SetUIStateLike {
+  const adb = device.platform === "android" ? defaultAdbClientFactory.create(device) : null;
+  return new SetUIState(device, adb);
+}
+
+let setUIStateFactory: (device: BootedDevice) => SetUIStateLike = createDefaultSetUIState;
+
+export function setSetUIStateFactory(factory: (device: BootedDevice) => SetUIStateLike): void {
+  setUIStateFactory = factory;
+}
+
+export function resetSetUIStateFactory(): void {
+  setUIStateFactory = createDefaultSetUIState;
+}
+
+export const setUIStateHandler = async (
+  device: BootedDevice,
+  args: SetUIStateArgs,
+  progress?: ProgressCallback,
+  signal?: AbortSignal,
+) => {
+  const setUIState = setUIStateFactory(device);
+
+  const result = await setUIState.execute(
+    {
+      fields: args.fields.map((f) => ({
+        selector: {
+          text: f.selector.text,
+          elementId: f.selector.elementId,
+        },
+        value: f.value,
+        selected: f.selected,
+      })),
+      scrollDirection: args.scrollDirection,
+    },
+    progress,
+    signal,
+  );
+
+  const response = createStructuredToolResponse({
+    success: result.success,
+    fields: result.fields.map((f) => ({
+      selector: f.selector,
+      success: f.success,
+      attempts: f.attempts,
+      verified: f.verified,
+      error: f.error,
+      fieldType: f.fieldType,
+      skipped: f.skipped,
+    })),
+    totalAttempts: result.totalAttempts,
+    error: result.error,
+  });
+  // Genuine partial success (some fields set, others failed) keeps
+  // isError:false — the per-field `fields` array is the actionable status
+  // (#6237). But when EVERY field failed, the primary operation did not
+  // succeed at all and must be reported as such (#6200, #6251).
+  const allFieldsFailed = result.fields.length > 0 && result.fields.every((f) => !f.success);
+  return allFieldsFailed ? { ...response, isError: true as const } : response;
+};
+
 /**
  * Register form-related tools with the tool registry
  */
@@ -74,52 +145,7 @@ export function registerFormTools(): void {
     "setUIState",
     "Set multiple form fields by desired state.",
     addDeviceTargetingToSchema(setUIStateSchema),
-    async (
-      device: BootedDevice,
-      args: z.infer<typeof setUIStateSchema>,
-      progress?: ProgressCallback,
-      signal?: AbortSignal,
-    ) => {
-      const adb = device.platform === "android" ? defaultAdbClientFactory.create(device) : null;
-      const setUIState = new SetUIState(device, adb);
-
-      const result = await setUIState.execute(
-        {
-          fields: args.fields.map((f) => ({
-            selector: {
-              text: f.selector.text,
-              elementId: f.selector.elementId,
-            },
-            value: f.value,
-            selected: f.selected,
-          })),
-          scrollDirection: args.scrollDirection,
-        },
-        progress,
-        signal,
-      );
-
-      const response = createStructuredToolResponse({
-        success: result.success,
-        fields: result.fields.map((f) => ({
-          selector: f.selector,
-          success: f.success,
-          attempts: f.attempts,
-          verified: f.verified,
-          error: f.error,
-          fieldType: f.fieldType,
-          skipped: f.skipped,
-        })),
-        totalAttempts: result.totalAttempts,
-        error: result.error,
-      });
-      // Genuine partial success (some fields set, others failed) keeps
-      // isError:false — the per-field `fields` array is the actionable status
-      // (#6237). But when EVERY field failed, the primary operation did not
-      // succeed at all and must be reported as such (#6200, #6251).
-      const allFieldsFailed = result.fields.length > 0 && result.fields.every((f) => !f.success);
-      return allFieldsFailed ? { ...response, isError: true as const } : response;
-    },
+    setUIStateHandler,
     {
       defaultEnabled: true,
       supportsProgress: true,

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -99,7 +99,7 @@ export function registerFormTools(): void {
         signal,
       );
 
-      return createStructuredToolResponse({
+      const response = createStructuredToolResponse({
         success: result.success,
         fields: result.fields.map((f) => ({
           selector: f.selector,
@@ -113,6 +113,12 @@ export function registerFormTools(): void {
         totalAttempts: result.totalAttempts,
         error: result.error,
       });
+      // Genuine partial success (some fields set, others failed) keeps
+      // isError:false — the per-field `fields` array is the actionable status
+      // (#6237). But when EVERY field failed, the primary operation did not
+      // succeed at all and must be reported as such (#6200, #6251).
+      const allFieldsFailed = result.fields.length > 0 && result.fields.every((f) => !f.success);
+      return allFieldsFailed ? { ...response, isError: true as const } : response;
     },
     {
       defaultEnabled: true,

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -69,54 +69,78 @@ function getNavigationManager(sessionUuid?: string): NavigationGraphManager {
     : NavigationGraphManager.getInstance();
 }
 
+// Injection seam for the navigateTo handler (mirrors the tapAny factory seam
+// in interactionTools.ts). Lets a unit test exercise the registered handler
+// wiring with a fake NavigateTo whose execute() returns a chosen
+// success/failure result, instead of spying on the class prototype (#6251
+// review — a prototype spy is a process-global patch that can leak into
+// unrelated tests running in the same process).
+export type NavigateToLike = Pick<NavigateTo, "execute">;
+
+function createDefaultNavigateTo(device: BootedDevice, args: NavigateToArgs): NavigateToLike {
+  const navigationManager = getNavigationManager(args.sessionUuid);
+  return new NavigateTo(
+    device,
+    undefined,
+    null,
+    null,
+    navigationManager,
+    undefined,
+    new DefaultPathOptimizer(navigationManager),
+    args.sessionUuid,
+  );
+}
+
+let navigateToFactory: (device: BootedDevice, args: NavigateToArgs) => NavigateToLike =
+  createDefaultNavigateTo;
+
+export function setNavigateToFactory(
+  factory: (device: BootedDevice, args: NavigateToArgs) => NavigateToLike,
+): void {
+  navigateToFactory = factory;
+}
+
+export function resetNavigateToFactory(): void {
+  navigateToFactory = createDefaultNavigateTo;
+}
+
+export const navigateToHandler = async (
+  device: BootedDevice,
+  args: NavigateToArgs,
+  progress?: ProgressCallback,
+) => {
+  try {
+    const navigateTo = navigateToFactory(device, args);
+    const options: NavigateToOptions = {
+      targetScreen: args.targetScreen,
+      platform: args.platform || "android",
+      sessionUuid: args.sessionUuid,
+    };
+    const result = await navigateTo.execute(options, progress);
+
+    if (result.success) {
+      return createJSONToolResponse({
+        message: result.message || `Navigated to ${args.targetScreen}`,
+        ...result,
+      });
+    } else {
+      // A failed navigation must not read as a completed one: mark the MCP
+      // envelope `isError`, exactly as tapOn/inputText do (#6200, #6251).
+      return {
+        ...createJSONToolResponse({
+          error: result.error || "Navigation failed",
+          ...result,
+        }),
+        isError: true as const,
+      };
+    }
+  } catch (error) {
+    throw new ActionableError(`Failed to navigate: ${error}`);
+  }
+};
+
 // Register navigation tools
 export function registerNavigationTools() {
-  // NavigateTo handler
-  const navigateToHandler = async (
-    device: BootedDevice,
-    args: NavigateToArgs,
-    progress?: ProgressCallback,
-  ) => {
-    try {
-      const navigationManager = getNavigationManager(args.sessionUuid);
-      const navigateTo = new NavigateTo(
-        device,
-        undefined,
-        null,
-        null,
-        navigationManager,
-        undefined,
-        new DefaultPathOptimizer(navigationManager),
-        args.sessionUuid,
-      );
-      const options: NavigateToOptions = {
-        targetScreen: args.targetScreen,
-        platform: args.platform || "android",
-        sessionUuid: args.sessionUuid,
-      };
-      const result = await navigateTo.execute(options, progress);
-
-      if (result.success) {
-        return createJSONToolResponse({
-          message: result.message || `Navigated to ${args.targetScreen}`,
-          ...result,
-        });
-      } else {
-        // A failed navigation must not read as a completed one: mark the MCP
-        // envelope `isError`, exactly as tapOn/inputText do (#6200, #6251).
-        return {
-          ...createJSONToolResponse({
-            error: result.error || "Navigation failed",
-            ...result,
-          }),
-          isError: true as const,
-        };
-      }
-    } catch (error) {
-      throw new ActionableError(`Failed to navigate: ${error}`);
-    }
-  };
-
   // Get navigation graph handler (for debugging)
   const getNavigationGraphHandler = async (device: BootedDevice, args: GetNavigationGraphArgs) => {
     try {

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -102,10 +102,15 @@ export function registerNavigationTools() {
           ...result,
         });
       } else {
-        return createJSONToolResponse({
-          error: result.error || "Navigation failed",
-          ...result,
-        });
+        // A failed navigation must not read as a completed one: mark the MCP
+        // envelope `isError`, exactly as tapOn/inputText do (#6200, #6251).
+        return {
+          ...createJSONToolResponse({
+            error: result.error || "Navigation failed",
+            ...result,
+          }),
+          isError: true as const,
+        };
       }
     } catch (error) {
       throw new ActionableError(`Failed to navigate: ${error}`);

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -122,47 +122,68 @@ export type GetNotificationPolicyArgs = z.infer<typeof getNotificationPolicySche
 
 export type SetNotificationPolicyArgs = z.infer<typeof setNotificationPolicySchema>;
 
+// Injection seam for the postNotification handler (mirrors the tapAny factory
+// seam in interactionTools.ts). Lets a unit test exercise the registered
+// handler wiring with a fake PostNotification whose execute() returns a
+// chosen success/failure result, instead of spying on the class prototype
+// (#6251 review — a prototype spy is a process-global patch that can leak
+// into unrelated tests running in the same process).
+export type PostNotificationLike = Pick<PostNotification, "execute">;
+
+let postNotificationFactory: (device: BootedDevice) => PostNotificationLike = (device) =>
+  new PostNotification(device);
+
+export function setPostNotificationFactory(
+  factory: (device: BootedDevice) => PostNotificationLike,
+): void {
+  postNotificationFactory = factory;
+}
+
+export function resetPostNotificationFactory(): void {
+  postNotificationFactory = (device) => new PostNotification(device);
+}
+
+export const postNotificationHandler = async (device: BootedDevice, args: PostNotificationArgs) => {
+  // #6154 follow-up: `platform` is optional on the wire, so the schema's
+  // per-platform appId checks (raw request platform) are skipped entirely
+  // when the caller omitted it. Re-validate against the resolved
+  // `device.platform`, before the try/catch below so the actionable message
+  // isn't re-wrapped as a generic execution failure.
+  const violation = checkPostNotificationPlatformConstraints(device.platform, args);
+  if (violation) {
+    throw new ActionableError(violation.message);
+  }
+
+  try {
+    const postNotification = postNotificationFactory(device);
+    const result = await postNotification.execute({
+      title: args.title,
+      body: args.body,
+      imageType: args.imageType,
+      imagePath: args.imagePath,
+      actions: args.actions,
+      channelId: args.channelId,
+      appId: args.appId,
+    });
+
+    const message = result.success
+      ? `Posted notification${result.method ? ` via ${result.method}` : ""}`
+      : `Failed to post notification${result.error ? `: ${result.error}` : ""}`;
+
+    const response = createJSONToolResponse({
+      message,
+      ...result,
+    });
+    // A receiver-reported failure means the notification was never delivered
+    // — the primary operation did not succeed, so the MCP envelope must say
+    // so too, exactly as tapOn/inputText do (#6200, #6251).
+    return result.success ? response : { ...response, isError: true as const };
+  } catch (error) {
+    throw new ActionableError(`Failed to post notification: ${error}`);
+  }
+};
+
 export function registerNotificationTools() {
-  const postNotificationHandler = async (device: BootedDevice, args: PostNotificationArgs) => {
-    // #6154 follow-up: `platform` is optional on the wire, so the schema's
-    // per-platform appId checks (raw request platform) are skipped entirely
-    // when the caller omitted it. Re-validate against the resolved
-    // `device.platform`, before the try/catch below so the actionable message
-    // isn't re-wrapped as a generic execution failure.
-    const violation = checkPostNotificationPlatformConstraints(device.platform, args);
-    if (violation) {
-      throw new ActionableError(violation.message);
-    }
-
-    try {
-      const postNotification = new PostNotification(device);
-      const result = await postNotification.execute({
-        title: args.title,
-        body: args.body,
-        imageType: args.imageType,
-        imagePath: args.imagePath,
-        actions: args.actions,
-        channelId: args.channelId,
-        appId: args.appId,
-      });
-
-      const message = result.success
-        ? `Posted notification${result.method ? ` via ${result.method}` : ""}`
-        : `Failed to post notification${result.error ? `: ${result.error}` : ""}`;
-
-      const response = createJSONToolResponse({
-        message,
-        ...result,
-      });
-      // A receiver-reported failure means the notification was never delivered
-      // — the primary operation did not succeed, so the MCP envelope must say
-      // so too, exactly as tapOn/inputText do (#6200, #6251).
-      return result.success ? response : { ...response, isError: true as const };
-    } catch (error) {
-      throw new ActionableError(`Failed to post notification: ${error}`);
-    }
-  };
-
   const getNotificationPolicyHandler = async (
     device: BootedDevice,
     args: GetNotificationPolicyArgs,

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -150,10 +150,14 @@ export function registerNotificationTools() {
         ? `Posted notification${result.method ? ` via ${result.method}` : ""}`
         : `Failed to post notification${result.error ? `: ${result.error}` : ""}`;
 
-      return createJSONToolResponse({
+      const response = createJSONToolResponse({
         message,
         ...result,
       });
+      // A receiver-reported failure means the notification was never delivered
+      // — the primary operation did not succeed, so the MCP envelope must say
+      // so too, exactly as tapOn/inputText do (#6200, #6251).
+      return result.success ? response : { ...response, isError: true as const };
     } catch (error) {
       throw new ActionableError(`Failed to post notification: ${error}`);
     }

--- a/test/server/isErrorConsistency.test.ts
+++ b/test/server/isErrorConsistency.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Issue #6251: postNotification, setAppPermissions, navigateTo, and
+ * setUIState must set `isError: true` whenever their primary operation did
+ * not succeed, exactly like tapOn/inputText/sqlQuery already do (#6200).
+ * setUIState is the one partial-result exception: it may stay
+ * `isError: false` for a genuine partial success (some fields set, others
+ * not, #6237), but must flip to `isError: true` when every field fails.
+ */
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { Mock } from "bun:test";
+import { registerNotificationTools } from "../../src/server/notificationTools";
+import { PostNotification } from "../../src/features/utility/PostNotification";
+import { registerAppTools } from "../../src/server/appTools";
+import { AppPermissions } from "../../src/features/action/AppPermissions";
+import { registerNavigationTools } from "../../src/server/navigationTools";
+import { NavigateTo } from "../../src/features/navigation/NavigateTo";
+import { registerFormTools } from "../../src/server/formTools";
+import { SetUIState } from "../../src/features/action/SetUIState";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice } from "../../src/models";
+
+type DeviceAwareHandler = (device: BootedDevice, args: any) => Promise<any>;
+
+function getHandler(toolName: string): DeviceAwareHandler {
+  const tools = (
+    ToolRegistry as unknown as {
+      tools: Map<string, { deviceAwareHandler?: DeviceAwareHandler }>;
+    }
+  ).tools;
+  const handler = tools.get(toolName)?.deviceAwareHandler;
+  if (!handler) {
+    throw new Error(`${toolName} was not registered as device-aware`);
+  }
+  return handler;
+}
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 8",
+  platform: "android",
+};
+
+describe("isError consistency (#6251)", () => {
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  describe("postNotification", () => {
+    let executeSpy: Mock<typeof PostNotification.prototype.execute>;
+
+    beforeEach(() => {
+      ToolRegistry.clearTools();
+      registerNotificationTools();
+      executeSpy = spyOn(PostNotification.prototype, "execute") as unknown as Mock<
+        typeof PostNotification.prototype.execute
+      >;
+    });
+
+    afterEach(() => {
+      executeSpy.mockRestore();
+    });
+
+    test("receiver-reported failure sets isError: true", async () => {
+      executeSpy.mockResolvedValue({
+        success: false,
+        supported: true,
+        error: "SDK notification receiver reported a failure",
+      });
+
+      const response = await getHandler("postNotification")(androidDevice, {
+        title: "T",
+        body: "B",
+        platform: "android",
+      });
+
+      expect(response.isError).toBe(true);
+      const payload = JSON.parse(response.content[0].text);
+      expect(payload.success).toBe(false);
+    });
+
+    test("delivered notification stays isError: false", async () => {
+      executeSpy.mockResolvedValue({
+        success: true,
+        supported: true,
+        method: "sdk",
+      });
+
+      const response = await getHandler("postNotification")(androidDevice, {
+        title: "T",
+        body: "B",
+        platform: "android",
+      });
+
+      expect(response.isError).toBeUndefined();
+      const payload = JSON.parse(response.content[0].text);
+      expect(payload.success).toBe(true);
+    });
+  });
+
+  describe("setAppPermissions", () => {
+    let setPermissionsSpy: Mock<typeof AppPermissions.prototype.setPermissions>;
+
+    beforeEach(() => {
+      ToolRegistry.clearTools();
+      registerAppTools();
+      setPermissionsSpy = spyOn(AppPermissions.prototype, "setPermissions") as unknown as Mock<
+        typeof AppPermissions.prototype.setPermissions
+      >;
+    });
+
+    afterEach(() => {
+      setPermissionsSpy.mockRestore();
+    });
+
+    test("whole-operation failure (nothing applied) sets isError: true", async () => {
+      setPermissionsSpy.mockResolvedValue({
+        success: false,
+        appId: "com.example.app",
+        deviceId: androidDevice.deviceId,
+        platform: "android",
+        action: "grant",
+        changedCount: 0,
+        failedCount: 1,
+        operations: [
+          {
+            operationId: "android_runtime_permissions:grant",
+            success: false,
+            changedCount: 0,
+            failedCount: 1,
+            error: "Failed step(s)",
+          },
+        ],
+        error: "Failed step(s)",
+      });
+
+      const response = await getHandler("setAppPermissions")(androidDevice, {
+        appId: "com.example.app",
+        action: "grant",
+        permissions: ["android.permission.CAMERA"],
+      });
+
+      expect(response.isError).toBe(true);
+    });
+
+    test("genuine partial success (some permissions applied) stays isError: false", async () => {
+      setPermissionsSpy.mockResolvedValue({
+        success: false,
+        appId: "com.example.app",
+        deviceId: androidDevice.deviceId,
+        platform: "android",
+        action: "grant",
+        changedCount: 1,
+        failedCount: 1,
+        operations: [
+          {
+            operationId: "android_runtime_permissions:grant",
+            success: true,
+            changedCount: 1,
+            failedCount: 0,
+          },
+          {
+            operationId: "android_notifications_enabled",
+            success: false,
+            changedCount: 0,
+            failedCount: 1,
+            error: "Failed to set notifications enabled",
+          },
+        ],
+        error: "Failed to set notifications enabled",
+      });
+
+      const response = await getHandler("setAppPermissions")(androidDevice, {
+        appId: "com.example.app",
+        action: "grant",
+        permissions: ["android.permission.CAMERA"],
+        notificationsEnabled: true,
+      });
+
+      expect(response.isError).toBeUndefined();
+      const payload = JSON.parse(response.content[0].text);
+      expect(payload.changedCount).toBe(1);
+    });
+
+    test("full success stays isError: false", async () => {
+      setPermissionsSpy.mockResolvedValue({
+        success: true,
+        appId: "com.example.app",
+        deviceId: androidDevice.deviceId,
+        platform: "android",
+        action: "grant",
+        changedCount: 1,
+        failedCount: 0,
+        operations: [
+          {
+            operationId: "android_runtime_permissions:grant",
+            success: true,
+            changedCount: 1,
+            failedCount: 0,
+          },
+        ],
+      });
+
+      const response = await getHandler("setAppPermissions")(androidDevice, {
+        appId: "com.example.app",
+        action: "grant",
+        permissions: ["android.permission.CAMERA"],
+      });
+
+      expect(response.isError).toBeUndefined();
+    });
+  });
+
+  describe("navigateTo", () => {
+    let executeSpy: Mock<typeof NavigateTo.prototype.execute>;
+
+    beforeEach(() => {
+      ToolRegistry.clearTools();
+      registerNavigationTools();
+      executeSpy = spyOn(NavigateTo.prototype, "execute") as unknown as Mock<
+        typeof NavigateTo.prototype.execute
+      >;
+    });
+
+    afterEach(() => {
+      executeSpy.mockRestore();
+    });
+
+    test("failed navigation sets isError: true", async () => {
+      executeSpy.mockResolvedValue({
+        success: false,
+        error: "No path to target screen",
+        currentScreen: "Home",
+        targetScreen: "Settings",
+        stepsExecuted: 0,
+      });
+
+      const response = await getHandler("navigateTo")(androidDevice, {
+        targetScreen: "Settings",
+        platform: "android",
+      });
+
+      expect(response.isError).toBe(true);
+      const payload = JSON.parse(response.content[0].text);
+      expect(payload.success).toBe(false);
+    });
+
+    test("successful navigation stays isError: false", async () => {
+      executeSpy.mockResolvedValue({
+        success: true,
+        message: "Navigated to Settings",
+        currentScreen: "Settings",
+        targetScreen: "Settings",
+        stepsExecuted: 2,
+      });
+
+      const response = await getHandler("navigateTo")(androidDevice, {
+        targetScreen: "Settings",
+        platform: "android",
+      });
+
+      expect(response.isError).toBeUndefined();
+    });
+  });
+
+  describe("setUIState", () => {
+    let executeSpy: Mock<typeof SetUIState.prototype.execute>;
+
+    beforeEach(() => {
+      ToolRegistry.clearTools();
+      registerFormTools();
+      executeSpy = spyOn(SetUIState.prototype, "execute") as unknown as Mock<
+        typeof SetUIState.prototype.execute
+      >;
+    });
+
+    afterEach(() => {
+      executeSpy.mockRestore();
+    });
+
+    test("all fields failing sets isError: true", async () => {
+      executeSpy.mockResolvedValue({
+        success: false,
+        fields: [
+          {
+            selector: { text: "Username" },
+            success: false,
+            attempts: 3,
+            error: "Element not found",
+          },
+          {
+            selector: { text: "Password" },
+            success: false,
+            attempts: 3,
+            error: "Element not found",
+          },
+        ],
+        totalAttempts: 6,
+        error: "Some fields could not be set",
+      });
+
+      const response = await getHandler("setUIState")(androidDevice, {
+        fields: [
+          { selector: { text: "Username" }, value: "alice" },
+          { selector: { text: "Password" }, value: "secret" },
+        ],
+      });
+
+      expect(response.isError).toBe(true);
+    });
+
+    test("genuine partial success (some fields ok) stays isError: false with per-field status", async () => {
+      executeSpy.mockResolvedValue({
+        success: false,
+        fields: [
+          {
+            selector: { text: "Username" },
+            success: true,
+            attempts: 1,
+            verified: true,
+          },
+          {
+            selector: { text: "Password" },
+            success: false,
+            attempts: 3,
+            error: "Element not found",
+          },
+        ],
+        totalAttempts: 4,
+        error: "Some fields could not be set",
+      });
+
+      const response = await getHandler("setUIState")(androidDevice, {
+        fields: [
+          { selector: { text: "Username" }, value: "alice" },
+          { selector: { text: "Password" }, value: "secret" },
+        ],
+      });
+
+      expect(response.isError).toBeUndefined();
+      const payload = response.structuredContent;
+      expect(payload.success).toBe(false);
+      expect(payload.fields).toHaveLength(2);
+      expect(payload.fields[0].success).toBe(true);
+      expect(payload.fields[1].success).toBe(false);
+    });
+
+    test("full success stays isError: false", async () => {
+      executeSpy.mockResolvedValue({
+        success: true,
+        fields: [
+          {
+            selector: { text: "Username" },
+            success: true,
+            attempts: 1,
+            verified: true,
+          },
+        ],
+        totalAttempts: 1,
+      });
+
+      const response = await getHandler("setUIState")(androidDevice, {
+        fields: [{ selector: { text: "Username" }, value: "alice" }],
+      });
+
+      expect(response.isError).toBeUndefined();
+    });
+  });
+});

--- a/test/server/isErrorConsistency.test.ts
+++ b/test/server/isErrorConsistency.test.ts
@@ -5,34 +5,36 @@
  * setUIState is the one partial-result exception: it may stay
  * `isError: false` for a genuine partial success (some fields set, others
  * not, #6237), but must flip to `isError: true` when every field fails.
+ *
+ * Each suite below exercises the exported handler directly through its
+ * injected factory seam (mirrors interactionTools.ts's tapAny/dragAndDrop/etc
+ * factories) rather than spying on the underlying class's prototype — a
+ * process-global prototype spy can leak a mocked result into any other test
+ * in the same process that happens to construct the same class (#6251
+ * review).
  */
-import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import type { Mock } from "bun:test";
-import { registerNotificationTools } from "../../src/server/notificationTools";
-import { PostNotification } from "../../src/features/utility/PostNotification";
-import { registerAppTools } from "../../src/server/appTools";
-import { AppPermissions } from "../../src/features/action/AppPermissions";
-import { registerNavigationTools } from "../../src/server/navigationTools";
-import { NavigateTo } from "../../src/features/navigation/NavigateTo";
-import { registerFormTools } from "../../src/server/formTools";
-import { SetUIState } from "../../src/features/action/SetUIState";
-import { ToolRegistry } from "../../src/server/toolRegistry";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  postNotificationHandler,
+  resetPostNotificationFactory,
+  setPostNotificationFactory,
+} from "../../src/server/notificationTools";
+import {
+  resetAppPermissionsFactory,
+  setAppPermissionsFactory,
+  setAppPermissionsHandler,
+} from "../../src/server/appTools";
+import {
+  navigateToHandler,
+  resetNavigateToFactory,
+  setNavigateToFactory,
+} from "../../src/server/navigationTools";
+import {
+  resetSetUIStateFactory,
+  setSetUIStateFactory,
+  setUIStateHandler,
+} from "../../src/server/formTools";
 import type { BootedDevice } from "../../src/models";
-
-type DeviceAwareHandler = (device: BootedDevice, args: any) => Promise<any>;
-
-function getHandler(toolName: string): DeviceAwareHandler {
-  const tools = (
-    ToolRegistry as unknown as {
-      tools: Map<string, { deviceAwareHandler?: DeviceAwareHandler }>;
-    }
-  ).tools;
-  const handler = tools.get(toolName)?.deviceAwareHandler;
-  if (!handler) {
-    throw new Error(`${toolName} was not registered as device-aware`);
-  }
-  return handler;
-}
 
 const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
@@ -41,33 +43,21 @@ const androidDevice: BootedDevice = {
 };
 
 describe("isError consistency (#6251)", () => {
-  afterEach(() => {
-    ToolRegistry.clearTools();
-  });
-
   describe("postNotification", () => {
-    let executeSpy: Mock<typeof PostNotification.prototype.execute>;
-
-    beforeEach(() => {
-      ToolRegistry.clearTools();
-      registerNotificationTools();
-      executeSpy = spyOn(PostNotification.prototype, "execute") as unknown as Mock<
-        typeof PostNotification.prototype.execute
-      >;
-    });
-
     afterEach(() => {
-      executeSpy.mockRestore();
+      resetPostNotificationFactory();
     });
 
     test("receiver-reported failure sets isError: true", async () => {
-      executeSpy.mockResolvedValue({
-        success: false,
-        supported: true,
-        error: "SDK notification receiver reported a failure",
-      });
+      setPostNotificationFactory(() => ({
+        execute: async () => ({
+          success: false,
+          supported: true,
+          error: "SDK notification receiver reported a failure",
+        }),
+      }));
 
-      const response = await getHandler("postNotification")(androidDevice, {
+      const response = await postNotificationHandler(androidDevice, {
         title: "T",
         body: "B",
         platform: "android",
@@ -79,13 +69,15 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("delivered notification stays isError: false", async () => {
-      executeSpy.mockResolvedValue({
-        success: true,
-        supported: true,
-        method: "sdk",
-      });
+      setPostNotificationFactory(() => ({
+        execute: async () => ({
+          success: true,
+          supported: true,
+          method: "sdk",
+        }),
+      }));
 
-      const response = await getHandler("postNotification")(androidDevice, {
+      const response = await postNotificationHandler(androidDevice, {
         title: "T",
         body: "B",
         platform: "android",
@@ -98,42 +90,34 @@ describe("isError consistency (#6251)", () => {
   });
 
   describe("setAppPermissions", () => {
-    let setPermissionsSpy: Mock<typeof AppPermissions.prototype.setPermissions>;
-
-    beforeEach(() => {
-      ToolRegistry.clearTools();
-      registerAppTools();
-      setPermissionsSpy = spyOn(AppPermissions.prototype, "setPermissions") as unknown as Mock<
-        typeof AppPermissions.prototype.setPermissions
-      >;
-    });
-
     afterEach(() => {
-      setPermissionsSpy.mockRestore();
+      resetAppPermissionsFactory();
     });
 
     test("whole-operation failure (nothing applied) sets isError: true", async () => {
-      setPermissionsSpy.mockResolvedValue({
-        success: false,
-        appId: "com.example.app",
-        deviceId: androidDevice.deviceId,
-        platform: "android",
-        action: "grant",
-        changedCount: 0,
-        failedCount: 1,
-        operations: [
-          {
-            operationId: "android_runtime_permissions:grant",
-            success: false,
-            changedCount: 0,
-            failedCount: 1,
-            error: "Failed step(s)",
-          },
-        ],
-        error: "Failed step(s)",
-      });
+      setAppPermissionsFactory(() => ({
+        setPermissions: async () => ({
+          success: false,
+          appId: "com.example.app",
+          deviceId: androidDevice.deviceId,
+          platform: "android",
+          action: "grant",
+          changedCount: 0,
+          failedCount: 1,
+          operations: [
+            {
+              operationId: "android_runtime_permissions:grant",
+              success: false,
+              changedCount: 0,
+              failedCount: 1,
+              error: "Failed step(s)",
+            },
+          ],
+          error: "Failed step(s)",
+        }),
+      }));
 
-      const response = await getHandler("setAppPermissions")(androidDevice, {
+      const response = await setAppPermissionsHandler(androidDevice, {
         appId: "com.example.app",
         action: "grant",
         permissions: ["android.permission.CAMERA"],
@@ -143,33 +127,35 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("genuine partial success (some permissions applied) stays isError: false", async () => {
-      setPermissionsSpy.mockResolvedValue({
-        success: false,
-        appId: "com.example.app",
-        deviceId: androidDevice.deviceId,
-        platform: "android",
-        action: "grant",
-        changedCount: 1,
-        failedCount: 1,
-        operations: [
-          {
-            operationId: "android_runtime_permissions:grant",
-            success: true,
-            changedCount: 1,
-            failedCount: 0,
-          },
-          {
-            operationId: "android_notifications_enabled",
-            success: false,
-            changedCount: 0,
-            failedCount: 1,
-            error: "Failed to set notifications enabled",
-          },
-        ],
-        error: "Failed to set notifications enabled",
-      });
+      setAppPermissionsFactory(() => ({
+        setPermissions: async () => ({
+          success: false,
+          appId: "com.example.app",
+          deviceId: androidDevice.deviceId,
+          platform: "android",
+          action: "grant",
+          changedCount: 1,
+          failedCount: 1,
+          operations: [
+            {
+              operationId: "android_runtime_permissions:grant",
+              success: true,
+              changedCount: 1,
+              failedCount: 0,
+            },
+            {
+              operationId: "android_notifications_enabled",
+              success: false,
+              changedCount: 0,
+              failedCount: 1,
+              error: "Failed to set notifications enabled",
+            },
+          ],
+          error: "Failed to set notifications enabled",
+        }),
+      }));
 
-      const response = await getHandler("setAppPermissions")(androidDevice, {
+      const response = await setAppPermissionsHandler(androidDevice, {
         appId: "com.example.app",
         action: "grant",
         permissions: ["android.permission.CAMERA"],
@@ -182,25 +168,27 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("full success stays isError: false", async () => {
-      setPermissionsSpy.mockResolvedValue({
-        success: true,
-        appId: "com.example.app",
-        deviceId: androidDevice.deviceId,
-        platform: "android",
-        action: "grant",
-        changedCount: 1,
-        failedCount: 0,
-        operations: [
-          {
-            operationId: "android_runtime_permissions:grant",
-            success: true,
-            changedCount: 1,
-            failedCount: 0,
-          },
-        ],
-      });
+      setAppPermissionsFactory(() => ({
+        setPermissions: async () => ({
+          success: true,
+          appId: "com.example.app",
+          deviceId: androidDevice.deviceId,
+          platform: "android",
+          action: "grant",
+          changedCount: 1,
+          failedCount: 0,
+          operations: [
+            {
+              operationId: "android_runtime_permissions:grant",
+              success: true,
+              changedCount: 1,
+              failedCount: 0,
+            },
+          ],
+        }),
+      }));
 
-      const response = await getHandler("setAppPermissions")(androidDevice, {
+      const response = await setAppPermissionsHandler(androidDevice, {
         appId: "com.example.app",
         action: "grant",
         permissions: ["android.permission.CAMERA"],
@@ -211,30 +199,22 @@ describe("isError consistency (#6251)", () => {
   });
 
   describe("navigateTo", () => {
-    let executeSpy: Mock<typeof NavigateTo.prototype.execute>;
-
-    beforeEach(() => {
-      ToolRegistry.clearTools();
-      registerNavigationTools();
-      executeSpy = spyOn(NavigateTo.prototype, "execute") as unknown as Mock<
-        typeof NavigateTo.prototype.execute
-      >;
-    });
-
     afterEach(() => {
-      executeSpy.mockRestore();
+      resetNavigateToFactory();
     });
 
     test("failed navigation sets isError: true", async () => {
-      executeSpy.mockResolvedValue({
-        success: false,
-        error: "No path to target screen",
-        currentScreen: "Home",
-        targetScreen: "Settings",
-        stepsExecuted: 0,
-      });
+      setNavigateToFactory(() => ({
+        execute: async () => ({
+          success: false,
+          error: "No path to target screen",
+          currentScreen: "Home",
+          targetScreen: "Settings",
+          stepsExecuted: 0,
+        }),
+      }));
 
-      const response = await getHandler("navigateTo")(androidDevice, {
+      const response = await navigateToHandler(androidDevice, {
         targetScreen: "Settings",
         platform: "android",
       });
@@ -245,15 +225,17 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("successful navigation stays isError: false", async () => {
-      executeSpy.mockResolvedValue({
-        success: true,
-        message: "Navigated to Settings",
-        currentScreen: "Settings",
-        targetScreen: "Settings",
-        stepsExecuted: 2,
-      });
+      setNavigateToFactory(() => ({
+        execute: async () => ({
+          success: true,
+          message: "Navigated to Settings",
+          currentScreen: "Settings",
+          targetScreen: "Settings",
+          stepsExecuted: 2,
+        }),
+      }));
 
-      const response = await getHandler("navigateTo")(androidDevice, {
+      const response = await navigateToHandler(androidDevice, {
         targetScreen: "Settings",
         platform: "android",
       });
@@ -263,42 +245,34 @@ describe("isError consistency (#6251)", () => {
   });
 
   describe("setUIState", () => {
-    let executeSpy: Mock<typeof SetUIState.prototype.execute>;
-
-    beforeEach(() => {
-      ToolRegistry.clearTools();
-      registerFormTools();
-      executeSpy = spyOn(SetUIState.prototype, "execute") as unknown as Mock<
-        typeof SetUIState.prototype.execute
-      >;
-    });
-
     afterEach(() => {
-      executeSpy.mockRestore();
+      resetSetUIStateFactory();
     });
 
     test("all fields failing sets isError: true", async () => {
-      executeSpy.mockResolvedValue({
-        success: false,
-        fields: [
-          {
-            selector: { text: "Username" },
-            success: false,
-            attempts: 3,
-            error: "Element not found",
-          },
-          {
-            selector: { text: "Password" },
-            success: false,
-            attempts: 3,
-            error: "Element not found",
-          },
-        ],
-        totalAttempts: 6,
-        error: "Some fields could not be set",
-      });
+      setSetUIStateFactory(() => ({
+        execute: async () => ({
+          success: false,
+          fields: [
+            {
+              selector: { text: "Username" },
+              success: false,
+              attempts: 3,
+              error: "Element not found",
+            },
+            {
+              selector: { text: "Password" },
+              success: false,
+              attempts: 3,
+              error: "Element not found",
+            },
+          ],
+          totalAttempts: 6,
+          error: "Some fields could not be set",
+        }),
+      }));
 
-      const response = await getHandler("setUIState")(androidDevice, {
+      const response = await setUIStateHandler(androidDevice, {
         fields: [
           { selector: { text: "Username" }, value: "alice" },
           { selector: { text: "Password" }, value: "secret" },
@@ -309,27 +283,29 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("genuine partial success (some fields ok) stays isError: false with per-field status", async () => {
-      executeSpy.mockResolvedValue({
-        success: false,
-        fields: [
-          {
-            selector: { text: "Username" },
-            success: true,
-            attempts: 1,
-            verified: true,
-          },
-          {
-            selector: { text: "Password" },
-            success: false,
-            attempts: 3,
-            error: "Element not found",
-          },
-        ],
-        totalAttempts: 4,
-        error: "Some fields could not be set",
-      });
+      setSetUIStateFactory(() => ({
+        execute: async () => ({
+          success: false,
+          fields: [
+            {
+              selector: { text: "Username" },
+              success: true,
+              attempts: 1,
+              verified: true,
+            },
+            {
+              selector: { text: "Password" },
+              success: false,
+              attempts: 3,
+              error: "Element not found",
+            },
+          ],
+          totalAttempts: 4,
+          error: "Some fields could not be set",
+        }),
+      }));
 
-      const response = await getHandler("setUIState")(androidDevice, {
+      const response = await setUIStateHandler(androidDevice, {
         fields: [
           { selector: { text: "Username" }, value: "alice" },
           { selector: { text: "Password" }, value: "secret" },
@@ -345,20 +321,22 @@ describe("isError consistency (#6251)", () => {
     });
 
     test("full success stays isError: false", async () => {
-      executeSpy.mockResolvedValue({
-        success: true,
-        fields: [
-          {
-            selector: { text: "Username" },
-            success: true,
-            attempts: 1,
-            verified: true,
-          },
-        ],
-        totalAttempts: 1,
-      });
+      setSetUIStateFactory(() => ({
+        execute: async () => ({
+          success: true,
+          fields: [
+            {
+              selector: { text: "Username" },
+              success: true,
+              attempts: 1,
+              verified: true,
+            },
+          ],
+          totalAttempts: 1,
+        }),
+      }));
 
-      const response = await getHandler("setUIState")(androidDevice, {
+      const response = await setUIStateHandler(androidDevice, {
         fields: [{ selector: { text: "Username" }, value: "alice" }],
       });
 


### PR DESCRIPTION
## The rule (aligns with #6200)

`isError: true` whenever a tool's primary operation did not succeed. A partial-result tool may stay `isError: false` only when it returns actionable per-item status AND had at least partial success; it must set `isError: true` when the whole operation failed.

## Per-tool changes

- **postNotification** (`src/server/notificationTools.ts`) — a receiver-reported failure means the notification was never delivered. Now sets `isError: true` when `result.success` is false.
- **setAppPermissions** (`src/server/appTools.ts`) — sets `isError: true` only when nothing applied (`changedCount === 0`). A genuine partial success (some permissions changed, exposed via the per-operation `operations` array) may stay `isError: false`, matching the ruling.
- **navigateTo** (`src/server/navigationTools.ts`) — a failed navigation now sets `isError: true`.
- **setUIState** (`src/server/formTools.ts`) — keeps `isError: false` for genuine partial success (#6237, per-field status via the `fields` array), but now sets `isError: true` when every field fails.

`tapOn`/`inputText`/`sqlQuery` are unchanged — they already follow the rule per #6200.

## Tests

Added `test/server/isErrorConsistency.test.ts` with fake-injected unit tests per tool:
- whole-failure -> `isError: true`
- success -> `isError: false`
- setAppPermissions/setUIState: genuine partial success (some succeeded) -> `isError: false` with per-item status

## Validation

- `bun test test/server/ test/features/action/ test/features/navigation/ test/features/utility/` — 4658 pass, 0 fail
- `bun run lint` — no new violations (ratchet baseline unchanged)
- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds

Closes #6251