### PR TITLE
fix(setUIState): return partial results before transport timeout on CLI path (#6222)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8645,6 +8645,9 @@
               },
               "skipped": {
                 "type": "boolean"
+              },
+              "notAttempted": {
+                "type": "boolean"
               }
             },
             "required": ["selector", "success", "attempts"],

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -8648,6 +8648,9 @@
               },
               "notAttempted": {
                 "type": "boolean"
+              },
+              "timedOut": {
+                "type": "boolean"
               }
             },
             "required": ["selector", "success", "attempts"],

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -256,7 +256,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
-# swap-fp: 7,11,13,55,56 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
+# swap-fp: 7,13,55,56,63 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -256,7 +256,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
-# swap-fp: 7,7,11,13,55 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
+# swap-fp: 7,11,13,55,56 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -27,6 +27,18 @@ export const DEFAULT_DAEMON_PORT = 3000;
 export const INTERNAL_MCP_REQUEST_TIMEOUT_PARAM = "__mcpRequestTimeoutMs";
 
 /**
+ * This execution's own start time, on the same `defaultTimer` clock used
+ * throughout `src/server/` and `src/features/`. Combined with
+ * {@link INTERNAL_MCP_REQUEST_TIMEOUT_PARAM} (`startTime + remainingMs`),
+ * gives a tool handler the ABSOLUTE wall-clock deadline of the current MCP
+ * request -- exported here (rather than kept local to `server/index.ts`,
+ * where it originates) so a tool handler outside `server/` (e.g.
+ * `setUIStateHandler` in `server/formTools.ts`) can read it back without an
+ * import cycle through `server/index.ts` (issue #6222 P1).
+ */
+export const INTERNAL_EXECUTION_START_TIME_PARAM = "__executionStartTime";
+
+/**
  * Port range to try if default port is unavailable
  */
 export const DAEMON_PORT_RANGE_START = 3000;

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -39,6 +39,28 @@ export const INTERNAL_MCP_REQUEST_TIMEOUT_PARAM = "__mcpRequestTimeoutMs";
 export const INTERNAL_EXECUTION_START_TIME_PARAM = "__executionStartTime";
 
 /**
+ * ABSOLUTE wall-clock deadline (on the same `defaultTimer` clock used
+ * throughout `src/server/` and `src/features/`), computed at the instant the
+ * daemon captured {@link INTERNAL_MCP_REQUEST_TIMEOUT_PARAM} in
+ * `UnixSocketServer.withSocketSessionAutolockKey`, immediately before the
+ * loopback `mcpClient.callTool` -- NOT re-derived from
+ * `startTime + remainingMs` on the receiving side (issue #6222 review,
+ * PRRT_kwDOP-GF5M6fuyts P1). `startTime` (see
+ * {@link INTERNAL_EXECUTION_START_TIME_PARAM}) is recorded only AFTER HTTP
+ * dispatch and this process's own admission/tool-selection repo reads
+ * complete, so `startTime + remainingMs` silently RE-GRANTS whatever time
+ * that dispatch/admission gap consumed: if it exceeds the daemon's response
+ * margin, the recomputed deadline lands LATER than the daemon's actual outer
+ * abort, and `SetUIState` can return a would-be-partial result too late for
+ * anything to still be listening. Carrying the deadline as an absolute
+ * timestamp anchored at capture time removes that gap entirely -- a handler
+ * that finds this param present should prefer it outright over recomputing
+ * from `startTime + remainingMs`, which remains only as a fallback for a
+ * caller that predates this param.
+ */
+export const INTERNAL_MCP_REQUEST_DEADLINE_PARAM = "__mcpRequestDeadlineMs";
+
+/**
  * Key into the in-process {@link module:daemon/liveDeadlineRegistry} for the
  * LIVE (possibly progress-extended) `ProgressExtendableDeadline` backing the
  * current daemon-forwarded request, when one exists (issue #6222 P1 reopen).

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -39,6 +39,26 @@ export const INTERNAL_MCP_REQUEST_TIMEOUT_PARAM = "__mcpRequestTimeoutMs";
 export const INTERNAL_EXECUTION_START_TIME_PARAM = "__executionStartTime";
 
 /**
+ * Key into the in-process {@link module:daemon/liveDeadlineRegistry} for the
+ * LIVE (possibly progress-extended) `ProgressExtendableDeadline` backing the
+ * current daemon-forwarded request, when one exists (issue #6222 P1 reopen).
+ *
+ * {@link INTERNAL_MCP_REQUEST_TIMEOUT_PARAM} is a snapshot taken once, before
+ * the request is forwarded -- it never reflects a later extension made by
+ * `UnixSocketServer.handleIdeRequest`'s `onprogress` handler as the SAME call
+ * keeps emitting progress. The daemon and the MCP HTTP server it forwards to
+ * run in one Node process (`Daemon` in `daemon.ts` owns both), so rather than
+ * try to serialize a live object over the loopback HTTP transport, the daemon
+ * registers its `ProgressExtendableDeadline` under a fresh key in that
+ * shared, in-process registry and forwards only this key. A handler that
+ * recognizes it (currently only `setUIStateHandler`) can then read the
+ * deadline's CURRENT value at each of its own admission checks instead of a
+ * frozen number. Absent when the request carries no progress token (nothing
+ * to extend) or is not daemon-forwarded at all.
+ */
+export const INTERNAL_LIVE_DEADLINE_KEY_PARAM = "__mcpLiveDeadlineKey";
+
+/**
  * Port range to try if default port is unavailable
  */
 export const DAEMON_PORT_RANGE_START = 3000;

--- a/src/daemon/liveDeadlineRegistry.ts
+++ b/src/daemon/liveDeadlineRegistry.ts
@@ -1,0 +1,45 @@
+import type { ProgressExtendableDeadline } from "./mcpRequestTimeout";
+
+/**
+ * In-process side channel that lets a long-running tool call read back the
+ * LIVE value of the daemon's own `ProgressExtendableDeadline` for the
+ * request it is currently executing (issue #6222 P1 reopen).
+ *
+ * `UnixSocketServer.handleIdeRequest` extends that deadline as the SAME call
+ * emits progress notifications (see `onprogress` there), but that extension
+ * is otherwise invisible to the tool handler on the other side of the
+ * loopback HTTP call -- it only ever sees the frozen remaining-budget number
+ * captured before the request was forwarded
+ * (`INTERNAL_MCP_REQUEST_TIMEOUT_PARAM`). The daemon and the MCP HTTP server
+ * it forwards to run in the SAME Node process (`Daemon` in `daemon.ts` owns
+ * both the Unix socket server and the `createMcpServer`-backed HTTP
+ * listener), so this registry shares the actual `ProgressExtendableDeadline`
+ * object by reference instead of trying to serialize live updates over HTTP.
+ *
+ * Lifecycle: the daemon registers its deadline under a fresh key before
+ * forwarding a progress-capable `tools/call`, forwards only the key as an
+ * internal argument (`INTERNAL_LIVE_DEADLINE_KEY_PARAM`), and unregisters it
+ * once the call settles (success, failure, or abandonment). A handler that
+ * recognizes the key can read `.value` live at any point during execution.
+ */
+const registry = new Map<string, ProgressExtendableDeadline>();
+
+/** Register a live deadline under `key`. Overwrites any existing entry for that key. */
+export function registerLiveDeadline(key: string, deadline: ProgressExtendableDeadline): void {
+  registry.set(key, deadline);
+}
+
+/** Remove the entry for `key`, if any. Safe to call more than once (e.g. from a `finally`). */
+export function unregisterLiveDeadline(key: string): void {
+  registry.delete(key);
+}
+
+/**
+ * Read the CURRENT absolute deadline (same clock as the registering caller's
+ * `Timer`) registered under `key`, or `undefined` when no such entry exists
+ * -- either the key is unknown, or the call has already settled and been
+ * unregistered.
+ */
+export function getLiveDeadlineMs(key: string): number | undefined {
+  return registry.get(key)?.value;
+}

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -88,6 +88,23 @@ export const MIN_UNINSTALL_APP_MCP_TIMEOUT_MS = 60_000;
 export const MIN_PREFERENCE_MCP_TIMEOUT_MS = 60_000;
 
 /**
+ * Floor for `setUIState` -- a multi-field call chains several fields' apply
+ * + verify device round trips sequentially, and on the direct CLI->daemon
+ * transport it never carries the MCP `_meta.progressToken` needed for
+ * `ProgressExtendableDeadline` to extend this budget (issue #6222 reopen):
+ * `runToolViaDaemon` in `src/cli/index.ts` calls `DaemonMcpProxy.callTool`
+ * with no progressToken, so `notifications/progress` -- and the deadline
+ * extension it drives -- never fires on that path, unlike the MCP-server
+ * proxy path (`src/server/proxyServer.ts`) which always forwards the
+ * caller's own token. `SetUIState` itself now self-limits to a smaller
+ * internal result deadline and returns a structured partial result before
+ * this transport-level timeout could fire -- that is the real safety net.
+ * This floor is a second line of defense, giving a legitimate multi-field
+ * form extra transport headroom even when progress relay never engages.
+ */
+export const MIN_SET_UI_STATE_MCP_TIMEOUT_MS = 60_000;
+
+/**
  * Headroom added to a `tapAny` longPress duration when sizing the OUTER MCP
  * request deadline. `TapAnyElement` raises the CtrlProxy-level request
  * timeout for a long press to `duration + LONG_PRESS_TIMEOUT_HEADROOM_MS`
@@ -129,6 +146,7 @@ const TOOL_TIMEOUT_FLOORS: Readonly<Record<string, number>> = {
   crashApp: MIN_CRASH_APP_MCP_TIMEOUT_MS,
   getPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
   setPreference: MIN_PREFERENCE_MCP_TIMEOUT_MS,
+  setUIState: MIN_SET_UI_STATE_MCP_TIMEOUT_MS,
 };
 
 /**

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -33,6 +33,7 @@ import {
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_VERSION,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
   INTERNAL_LIVE_DEADLINE_KEY_PARAM,
 } from "./constants";
 import { registerLiveDeadline, unregisterLiveDeadline } from "./liveDeadlineRegistry";
@@ -4149,10 +4150,18 @@ export class UnixSocketServer {
     socketSessionId: string,
     timeoutMs: number,
   ): unknown {
+    // Anchor the absolute deadline to THIS instant -- immediately before the
+    // loopback `mcpClient.callTool` -- rather than letting the receiving
+    // process re-derive it from `startTime + remainingMs` after its own HTTP
+    // dispatch and admission/tool-selection repo reads have already consumed
+    // part of `timeoutMs` (issue #6222 review, PRRT_kwDOP-GF5M6fuyts P1). See
+    // `INTERNAL_MCP_REQUEST_DEADLINE_PARAM` for the full rationale.
+    const deadlineMs = this.timer.now() + timeoutMs;
     if (args === null || args === undefined) {
       return {
         __mcpSessionId: socketSessionId,
         [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: timeoutMs,
+        [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: deadlineMs,
       };
     }
 
@@ -4177,6 +4186,7 @@ export class UnixSocketServer {
       ...forwardedArgs,
       __mcpSessionId: socketSessionId,
       [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: timeoutMs,
+      [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: deadlineMs,
     };
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -33,7 +33,9 @@ import {
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_VERSION,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
 } from "./constants";
+import { registerLiveDeadline, unregisterLiveDeadline } from "./liveDeadlineRegistry";
 import {
   ListChangedBroadcaster,
   LIST_CHANGED_NOTIFICATION_METHODS,
@@ -3999,6 +4001,12 @@ export class UnixSocketServer {
         // Cleanup for the abort-timer path below; a no-op for the
         // no-progress path (nothing was ever armed).
         let cleanup: () => void = () => {};
+        // Set only on the progress-capable path below. Lets a handler on the
+        // OTHER side of this same call (e.g. `setUIStateHandler`) read this
+        // exact `deadline`'s CURRENT (possibly progress-extended) value via
+        // `liveDeadlineRegistry` instead of only the frozen snapshot forwarded
+        // through `INTERNAL_MCP_REQUEST_TIMEOUT_PARAM` (issue #6222 P1 reopen).
+        let liveDeadlineKey: string | undefined;
 
         let callOptions: Record<string, unknown> = requestOptions;
         if (progressToken !== undefined) {
@@ -4039,7 +4047,13 @@ export class UnixSocketServer {
             );
           let abortTimer = armAbort(timeoutMs);
           const backstopMs = Math.max(deadline.ceiling - this.timer.now(), timeoutMs);
-          cleanup = () => this.timer.clearTimeout(abortTimer);
+          liveDeadlineKey = this.idGenerator.next();
+          registerLiveDeadline(liveDeadlineKey, deadline);
+          const registeredLiveDeadlineKey = liveDeadlineKey;
+          cleanup = () => {
+            this.timer.clearTimeout(abortTimer);
+            unregisterLiveDeadline(registeredLiveDeadlineKey);
+          };
 
           callOptions = {
             ...requestOptions,
@@ -4069,14 +4083,15 @@ export class UnixSocketServer {
         }
 
         try {
+          const forwardedArguments = this.withSocketSessionAutolockKey(
+            request.params.arguments,
+            socketSessionId,
+            timeoutMs,
+          );
           return await mcpClient.callTool(
             {
               name: request.params.name,
-              arguments: this.withSocketSessionAutolockKey(
-                request.params.arguments,
-                socketSessionId,
-                timeoutMs,
-              ),
+              arguments: this.withLiveDeadlineKey(forwardedArguments, liveDeadlineKey),
             },
             undefined,
             callOptions,
@@ -4111,6 +4126,22 @@ export class UnixSocketServer {
       default:
         throw new Error(`Unsupported daemon method: ${request.method}`);
     }
+  }
+
+  /**
+   * Merge {@link INTERNAL_LIVE_DEADLINE_KEY_PARAM} onto `args` when a live
+   * deadline was registered for this call (issue #6222 P1 reopen) -- a no-op
+   * when there is none, or `args` is not a plain forwardable object (e.g.
+   * `null`/an array), in which case it is returned unchanged.
+   */
+  private withLiveDeadlineKey(args: unknown, liveDeadlineKey: string | undefined): unknown {
+    if (liveDeadlineKey === undefined || !args || typeof args !== "object" || Array.isArray(args)) {
+      return args;
+    }
+    return {
+      ...(args as Record<string, unknown>),
+      [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: liveDeadlineKey,
+    };
   }
 
   private withSocketSessionAutolockKey(

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -556,21 +556,37 @@ export class SetUIState extends BaseVisualChange {
         // fields that need to be processed first in screen order. The scroll is in
         // service of the next not-yet-processed field, so it reports into that
         // field's own progress slice (#6222 review).
-        await this.getSwipeOn().execute(
-          { direction: currentDirection },
-          fieldProgress(processed.size),
+        //
+        // Both the swipe and the follow-up re-observe are UNBOUNDED device
+        // I/O -- if either stalls, the daemon's outer abort fires first and
+        // discards the accumulated structured result built up so far,
+        // exactly the failure mode this whole feature exists to prevent.
+        // Race the whole iteration against the same live cutoff every other
+        // device call in this method already respects (issue #6222 review,
+        // PRRT_kwDOP-GF5M6fuyts): a stall here stops the search and returns
+        // what has already been applied instead of letting the outer abort
+        // discard it.
+        const searchRaced = await this.raceAgainstDeadline<ObserveResult | undefined>(
+          async (onTick) => {
+            await this.getSwipeOn().execute(
+              { direction: currentDirection },
+              this.withRearmOnTick(fieldProgress(processed.size), onTick),
+            );
+
+            // Re-observe after scroll
+            return this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+          },
+          () => cutoffMs(),
+          "off-screen search (swipe + re-observe)",
         );
 
-        // Re-observe after scroll
-        const freshObs = await this.getObserveScreen().execute(
-          undefined,
-          undefined,
-          false,
-          0,
-          signal,
-        );
-        if (freshObs) {
-          lastObservation = freshObs;
+        if (searchRaced === "timed-out") {
+          resultBudgetSpent = true;
+          break;
+        }
+
+        if (searchRaced) {
+          lastObservation = searchRaced;
         }
       }
     }

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -105,6 +105,29 @@ const MAX_FUTILE_SCROLLS = 3;
 const SEARCH_BUDGET_MS = 20_000;
 
 /**
+ * Wall-clock ceiling for the WHOLE `execute()` call, measured from when it is
+ * invoked. This is the safety net for issue #6222's reopen: PR #6237 made
+ * per-field progress notifications extend the *transport's* request
+ * deadline, but that extension only fires for a caller who set MCP's
+ * `_meta.progressToken` -- the direct CLI->daemon path never does
+ * (`runToolViaDaemon` in `src/cli/index.ts` calls `DaemonMcpProxy.callTool`
+ * with no progressToken), so on that path the per-field progress plumbing is
+ * entirely inert and a multi-field call that keeps applying fields
+ * successfully still hits the transport's fixed deadline and gets its
+ * accumulated `fields` results discarded by a bare `-32001` timeout.
+ *
+ * `SetUIState` cannot see or rely on the transport's actual deadline (it is
+ * never threaded down through the tool handler), so it self-limits instead:
+ * once this internal budget is spent, it stops starting new fields and
+ * returns the accumulated per-field results as a normal (if
+ * `success: false`) result -- never a silent discard -- while there is still
+ * headroom before `DEFAULT_MCP_REQUEST_TIMEOUT_MS` (and the larger
+ * `MIN_SET_UI_STATE_MCP_TIMEOUT_MS` floor added alongside this) can fire.
+ * Deliberately smaller than both so this always wins the race.
+ */
+const RESULT_DEADLINE_BUDGET_MS = 45_000;
+
+/**
  * SetUIState - Declarative form field population tool
  *
  * Populates form fields by specifying desired end-state rather than procedural steps.
@@ -148,6 +171,10 @@ export class SetUIState extends BaseVisualChange {
     const fieldResults: FieldResult[] = new Array(options.fields.length);
     const processed = new Set<number>();
     let totalAttempts = 0;
+    // See RESULT_DEADLINE_BUDGET_MS -- this is the whole-call safety net,
+    // independent of (and in addition to) the search budget below.
+    const resultDeadlineMs = this.timer.now() + RESULT_DEADLINE_BUDGET_MS;
+    let resultBudgetSpent = false;
 
     // Progress reported to the client MUST stay on one consistent scale and
     // strictly increase -- MCP clients that enforce monotonicity reject or
@@ -223,6 +250,16 @@ export class SetUIState extends BaseVisualChange {
     let budgetSpent = false;
 
     while (processed.size < options.fields.length) {
+      // Check the whole-call budget BEFORE starting another field's work --
+      // give each field the same bounded budget it gets when it is the only
+      // field in the call, then stop and return what has already been
+      // applied rather than let the transport's own deadline discard it
+      // (issue #6222 reopen).
+      if (this.timer.now() >= resultDeadlineMs) {
+        resultBudgetSpent = true;
+        break;
+      }
+
       // Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top
       const visibleFields = this.findVisibleFieldsInScreenOrder(
         options.fields,
@@ -348,14 +385,24 @@ export class SetUIState extends BaseVisualChange {
         .filter((_, i) => !processed.has(i))
         .map((f) => this.describeSelector(f.selector));
 
+      // The result-deadline case is NOT "not found" -- these fields may well
+      // be on screen, they were simply never reached. Say so distinctly and
+      // mark them `notAttempted` so a client can tell "safe to retry just
+      // these" apart from "attempted and failed" (issue #6222 reopen).
+      const notAttemptedReason = resultBudgetSpent
+        ? `Not attempted: setUIState's internal result deadline (${Math.round(RESULT_DEADLINE_BUDGET_MS / 1000)}s) was reached after applying ${processed.size}/${options.fields.length} field(s)`
+        : undefined;
+
       return {
         success: false,
-        fields: this.collectResults(fieldResults, options.fields, processed),
+        fields: this.collectResults(fieldResults, options.fields, processed, notAttemptedReason),
         totalAttempts,
         observation: lastObservation,
-        error: budgetSpent
-          ? `Fields not found within the ${Math.round(SEARCH_BUDGET_MS / 1000)}s search budget: ${missing.join(", ")}`
-          : `Fields not found after scrolling: ${missing.join(", ")}`,
+        error: resultBudgetSpent
+          ? `setUIState result deadline (${Math.round(RESULT_DEADLINE_BUDGET_MS / 1000)}s) reached after applying ${processed.size}/${options.fields.length} field(s); not attempted: ${missing.join(", ")}`
+          : budgetSpent
+            ? `Fields not found within the ${Math.round(SEARCH_BUDGET_MS / 1000)}s search budget: ${missing.join(", ")}`
+            : `Fields not found after scrolling: ${missing.join(", ")}`,
       };
     }
 
@@ -437,11 +484,20 @@ export class SetUIState extends BaseVisualChange {
     results: FieldResult[],
     fields: FieldSpec[],
     processed: Set<number>,
+    notAttemptedReason?: string,
   ): FieldResult[] {
     const out: FieldResult[] = [];
     for (let i = 0; i < fields.length; i++) {
       if (processed.has(i) && results[i]) {
         out.push(results[i]);
+      } else if (notAttemptedReason !== undefined) {
+        out.push({
+          selector: fields[i].selector,
+          success: false,
+          attempts: 0,
+          notAttempted: true,
+          error: notAttemptedReason,
+        });
       } else {
         out.push({
           selector: fields[i].selector,

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -215,10 +215,17 @@ export class SetUIState extends BaseVisualChange {
       transportDeadlineMs !== undefined
         ? transportDeadlineMs - PER_FIELD_ADMISSION_HEADROOM_MS
         : undefined;
-    const resultDeadlineMs =
-      transportBoundDeadlineMs !== undefined
-        ? Math.min(internalResultDeadlineMs, transportBoundDeadlineMs)
-        : internalResultDeadlineMs;
+    // When the caller knows the ACTUAL transport deadline, that is always the
+    // bound that matters -- respect it even when it is LARGER than the fixed
+    // internal budget (e.g. a progress-aware caller whose
+    // `ProgressExtendableDeadline` has extended the transport deadline toward
+    // its ceiling). Clamping to the fixed 45s here would silently undo that
+    // extension and under-cut a legitimately larger budget, which also
+    // truncates `executePlan` steps that route through this same `execute()`
+    // (issue #6222 P1). The fixed `RESULT_DEADLINE_BUDGET_MS` is a FALLBACK
+    // for when no transport deadline is known at all (a direct, non-daemon
+    // call) -- never a ceiling imposed on top of a known one.
+    const resultDeadlineMs = transportBoundDeadlineMs ?? internalResultDeadlineMs;
     // Only used to phrase the "why we stopped" message below -- the actual
     // bound applied is whichever of the internal/transport-derived deadlines
     // is tighter, which may be smaller OR larger than RESULT_DEADLINE_BUDGET_MS.
@@ -279,6 +286,25 @@ export class SetUIState extends BaseVisualChange {
         await progress(candidate, overallProgressTotal, message);
       };
     };
+
+    // Check the budget BEFORE paying for the initial observation, not just at
+    // the top of the field loop below. Queueing on the daemon path can by
+    // itself consume most of a 60s transport budget before `execute()` is
+    // even invoked; if the admission deadline is already gone (or too tight
+    // to admit even one field's headroom), a cold/stalled initial observe can
+    // still blow the transport deadline before any field is attempted,
+    // discarding the whole call. Fail fast into the same structured
+    // all-`notAttempted` shape used below instead (issue #6222 P1).
+    if (this.timer.now() >= resultDeadlineMs) {
+      const missing = options.fields.map((f) => this.describeSelector(f.selector));
+      const notAttemptedReason = `Not attempted: setUIState's result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was already reached before the initial observation`;
+      return {
+        success: false,
+        fields: this.collectResults(fieldResults, options.fields, processed, notAttemptedReason),
+        totalAttempts: 0,
+        error: `setUIState result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was already reached before the initial observation; not attempted: ${missing.join(", ")}`,
+      };
+    }
 
     // Get initial observation
     let lastObservation = await this.getObserveScreen().execute(

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -116,16 +116,35 @@ const SEARCH_BUDGET_MS = 20_000;
  * successfully still hits the transport's fixed deadline and gets its
  * accumulated `fields` results discarded by a bare `-32001` timeout.
  *
- * `SetUIState` cannot see or rely on the transport's actual deadline (it is
- * never threaded down through the tool handler), so it self-limits instead:
- * once this internal budget is spent, it stops starting new fields and
- * returns the accumulated per-field results as a normal (if
+ * `setUIStateHandler` (`src/server/formTools.ts`) now recovers the ACTUAL
+ * transport deadline when the call was daemon-forwarded (issue #6222 P1) and
+ * passes it into `execute()` as `transportDeadlineMs`, in which case it --
+ * minus `PER_FIELD_ADMISSION_HEADROOM_MS` -- takes over as the bound (see
+ * `resultDeadlineMs` in `execute()`) instead of this fixed clock. This budget
+ * remains the FALLBACK for a path with no known transport deadline (a direct,
+ * non-daemon call): once it is spent, `execute()` stops starting new fields
+ * and returns the accumulated per-field results as a normal (if
  * `success: false`) result -- never a silent discard -- while there is still
  * headroom before `DEFAULT_MCP_REQUEST_TIMEOUT_MS` (and the larger
- * `MIN_SET_UI_STATE_MCP_TIMEOUT_MS` floor added alongside this) can fire.
- * Deliberately smaller than both so this always wins the race.
+ * `MIN_SET_UI_STATE_MCP_TIMEOUT_MS` floor added alongside the original fix)
+ * can fire. Deliberately smaller than both so this always wins the race.
  */
 const RESULT_DEADLINE_BUDGET_MS = 45_000;
+
+/**
+ * Headroom reserved before admitting the NEXT field once the caller's
+ * `transportDeadlineMs` is known (issue #6222 P1). A field admitted with
+ * almost no budget left can still run for a while after admission --
+ * `applyFieldValue` (tap + clear + type, or open+select for a dropdown) plus
+ * `verifyFieldValue`'s post-success observe -- and the dogfood report that
+ * reopened #6222 showed a field admitted at 44s of a 60s transport deadline
+ * running roughly 20s more, overrunning the transport and losing the whole
+ * accumulated result to a bare `-32001`. Only admit another field while at
+ * least this much of the transport budget remains; otherwise stop and return
+ * the accumulated per-field results while there is still time for the
+ * transport to deliver them.
+ */
+const PER_FIELD_ADMISSION_HEADROOM_MS = 20_000;
 
 /**
  * SetUIState - Declarative form field population tool
@@ -159,12 +178,24 @@ export class SetUIState extends BaseVisualChange {
    * @param options - Configuration options
    * @param progress - Optional progress callback
    * @param signal - Optional abort signal
+   * @param transportDeadlineMs - Absolute wall-clock deadline (same clock as
+   *   `this.timer.now()`) of the CURRENT MCP request, when known. This is the
+   *   real transport deadline the caller (`setUIStateHandler`) recovered from
+   *   the daemon-forwarded request's own budget -- accounting for time
+   *   already spent queued -- NOT a fresh clock started here. When provided,
+   *   field admission is bounded by this deadline (minus
+   *   `PER_FIELD_ADMISSION_HEADROOM_MS`) instead of only the internal
+   *   `RESULT_DEADLINE_BUDGET_MS` clock, so a call never keeps admitting
+   *   fields past the point the transport itself would discard the result
+   *   (issue #6222 P1). Undefined on a direct/non-daemon call, where the
+   *   internal budget alone is the only bound available.
    * @returns Result of the operation
    */
   async execute(
     options: SetUIStateOptions,
     progress?: ProgressCallback,
     signal?: AbortSignal,
+    transportDeadlineMs?: number,
   ): Promise<SetUIStateResult> {
     const scrollDirection = options.scrollDirection ?? DEFAULT_SCROLL_DIRECTION;
 
@@ -172,8 +203,26 @@ export class SetUIState extends BaseVisualChange {
     const processed = new Set<number>();
     let totalAttempts = 0;
     // See RESULT_DEADLINE_BUDGET_MS -- this is the whole-call safety net,
-    // independent of (and in addition to) the search budget below.
-    const resultDeadlineMs = this.timer.now() + RESULT_DEADLINE_BUDGET_MS;
+    // independent of (and in addition to) the search budget below. When the
+    // caller knows the ACTUAL transport deadline, bound admission by that
+    // instead (minus per-field headroom) -- it can be tighter OR looser than
+    // the fixed internal budget, but it is always the one that actually
+    // matters (issue #6222 P1). Falls back to the internal-only budget when
+    // no transport deadline is known.
+    const callStartMs = this.timer.now();
+    const internalResultDeadlineMs = callStartMs + RESULT_DEADLINE_BUDGET_MS;
+    const transportBoundDeadlineMs =
+      transportDeadlineMs !== undefined
+        ? transportDeadlineMs - PER_FIELD_ADMISSION_HEADROOM_MS
+        : undefined;
+    const resultDeadlineMs =
+      transportBoundDeadlineMs !== undefined
+        ? Math.min(internalResultDeadlineMs, transportBoundDeadlineMs)
+        : internalResultDeadlineMs;
+    // Only used to phrase the "why we stopped" message below -- the actual
+    // bound applied is whichever of the internal/transport-derived deadlines
+    // is tighter, which may be smaller OR larger than RESULT_DEADLINE_BUDGET_MS.
+    const resultDeadlineBudgetMsForMessage = resultDeadlineMs - callStartMs;
     let resultBudgetSpent = false;
 
     // Progress reported to the client MUST stay on one consistent scale and
@@ -390,7 +439,7 @@ export class SetUIState extends BaseVisualChange {
       // mark them `notAttempted` so a client can tell "safe to retry just
       // these" apart from "attempted and failed" (issue #6222 reopen).
       const notAttemptedReason = resultBudgetSpent
-        ? `Not attempted: setUIState's internal result deadline (${Math.round(RESULT_DEADLINE_BUDGET_MS / 1000)}s) was reached after applying ${processed.size}/${options.fields.length} field(s)`
+        ? `Not attempted: setUIState's result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was reached after applying ${processed.size}/${options.fields.length} field(s)`
         : undefined;
 
       return {
@@ -399,7 +448,7 @@ export class SetUIState extends BaseVisualChange {
         totalAttempts,
         observation: lastObservation,
         error: resultBudgetSpent
-          ? `setUIState result deadline (${Math.round(RESULT_DEADLINE_BUDGET_MS / 1000)}s) reached after applying ${processed.size}/${options.fields.length} field(s); not attempted: ${missing.join(", ")}`
+          ? `setUIState result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) reached after applying ${processed.size}/${options.fields.length} field(s); not attempted: ${missing.join(", ")}`
           : budgetSpent
             ? `Fields not found within the ${Math.round(SEARCH_BUDGET_MS / 1000)}s search budget: ${missing.join(", ")}`
             : `Fields not found after scrolling: ${missing.join(", ")}`,

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -510,7 +510,49 @@ export class SetUIState extends BaseVisualChange {
         // observe against the device, which is exactly the per-field cost that
         // was pushing multi-field calls past the request timeout (#6222).
         if (result.success) {
-          lastObservation = await this.observationAfterSuccess(result, signal);
+          // The field itself already succeeded and is recorded in
+          // `fieldResults` above -- only the follow-up observation used to
+          // locate the NEXT field is at risk here. Without a
+          // `freshObservation`, `observationAfterSuccess`'s fallback issues
+          // an UNBOUNDED `ObserveScreen.execute()`; if that stalls, awaiting
+          // it directly would let the daemon's outer transport deadline win
+          // and discard everything already applied -- exactly the failure
+          // mode this whole feature exists to prevent. Race it against the
+          // SAME live cutoff every other device call in this method already
+          // respects (issue #6222 review, PRRT_kwDOP-GF5M6fu4ev).
+          const observationRaced = await this.raceAgainstDeadline<ObserveResult>(
+            () => this.observationAfterSuccess(result, signal),
+            () => cutoffMs(),
+            "post-success observation refresh",
+          );
+
+          if (observationRaced === "timed-out") {
+            logger.warn(
+              `[SetUIState] Post-success observation refresh stalled after field ${this.describeSelector(fieldSpec.selector)}; returning ${processed.size}/${options.fields.length} accumulated field result(s) without a fresh observation`,
+            );
+            const notAttemptedReason =
+              processed.size < options.fields.length
+                ? `Not attempted: setUIState's post-success observation refresh stalled after applying ${processed.size}/${options.fields.length} field(s)`
+                : undefined;
+            return {
+              success: false,
+              fields: this.collectResults(
+                fieldResults,
+                options.fields,
+                processed,
+                notAttemptedReason,
+              ),
+              totalAttempts,
+              // Keep whatever observation is already on hand (from the
+              // PREVIOUS successful field, or the initial observation)
+              // rather than blocking on the unbounded refresh -- omitted
+              // only when no observation was ever captured.
+              observation: lastObservation,
+              error: `setUIState's post-success observation refresh did not settle within the result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) after applying ${processed.size}/${options.fields.length} field(s); the applied field(s) succeeded but the refreshed observation is unavailable`,
+            };
+          }
+
+          lastObservation = observationRaced;
         }
 
         // Fail fast on failure

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -147,6 +147,25 @@ const RESULT_DEADLINE_BUDGET_MS = 45_000;
 const PER_FIELD_ADMISSION_HEADROOM_MS = 20_000;
 
 /**
+ * Single source of truth for "how much headroom must remain before the live
+ * deadline for a device-I/O await to be raced against it" (issue #6222 P1,
+ * unifying the fujug/fujuk/fujun review round). The daemon's own outer abort
+ * (the `controller` armed in `handleIdeRequest`, `src/daemon/socketServer.ts`
+ * -- see `armAbort(timeoutMs)` / `armAbort(deadline.value - now)`) fires
+ * EXACTLY at the live `ProgressExtendableDeadline`'s current value, with no
+ * headroom of its own. A field or observe race that only stops "at" that
+ * same instant is a coin flip against response serialization, not a
+ * guarantee -- if the outer abort wins, the transport discards the whole
+ * call before this file's structured (partial or complete) result can ever
+ * be returned (fujug). Every cutoff this file races an await against is
+ * therefore `liveDeadlineMs() - RESPONSE_HEADROOM_MS`, strictly BEFORE the
+ * outer abort, so building and returning the result always has time to
+ * finish first. Kept well above zero (the outer abort's own margin) so this
+ * headroom is the thing that actually buys the safety margin.
+ */
+const RESPONSE_HEADROOM_MS = 3_000;
+
+/**
  * SetUIState - Declarative form field population tool
  *
  * Populates form fields by specifying desired end-state rather than procedural steps.
@@ -250,18 +269,25 @@ export class SetUIState extends BaseVisualChange {
         ? liveTransportDeadlineMs - PER_FIELD_ADMISSION_HEADROOM_MS
         : internalResultDeadlineMs;
     };
-    // The bound that governs how long an ALREADY-ADMITTED field is allowed to
-    // keep running before `execute()` gives up on it and returns the
-    // accumulated partial result (issue #6222 review, coderabbit fuTtO). This
-    // is deliberately the FULL transport deadline (no headroom subtracted):
-    // headroom exists to protect the NEXT field's admission, not to shrink
-    // the CURRENT field's own budget -- an admitted field that finishes
-    // within the real transport deadline must not be treated as a stall just
-    // because it ran past the smaller admission-only bound above. Falls back
-    // to the same fixed internal budget as `admissionDeadlineMs` when no
-    // transport deadline is known at all.
-    const fieldHardDeadlineMs = (): number =>
-      currentTransportDeadlineMs() ?? internalResultDeadlineMs;
+    // Single source of truth for the live deadline: the CURRENT (possibly
+    // progress-extended) transport deadline when known, else the fixed
+    // internal fallback. Read fresh on every call -- never cached -- so a
+    // `ProgressExtendableDeadline` extension that lands between two checks is
+    // always visible (issue #6222 P1, fujuk).
+    const liveDeadlineMs = (): number => currentTransportDeadlineMs() ?? internalResultDeadlineMs;
+    // The cutoff EVERY device-I/O await in this file (the initial
+    // observation and each admitted field) is raced against -- deliberately
+    // `RESPONSE_HEADROOM_MS` BEFORE the live deadline, not AT it, so the
+    // structured result this file builds always has time to be returned
+    // ahead of the daemon's own outer abort, which fires exactly at the live
+    // deadline with no headroom of its own (issue #6222 P1, fujug). This is
+    // intentionally a SEPARATE, much smaller margin than
+    // `PER_FIELD_ADMISSION_HEADROOM_MS` above: that headroom decides whether
+    // it is worth STARTING another field at all; this one decides when an
+    // ALREADY-STARTED await must be treated as stalled. An admitted field
+    // that finishes within this cutoff must not be treated as a stall just
+    // because it ran past the smaller admission-only bound above.
+    const cutoffMs = (): number => liveDeadlineMs() - RESPONSE_HEADROOM_MS;
     // Only used to phrase "why we stopped" messages below -- the actual bound
     // applied is whichever of the internal/transport-derived deadlines is
     // tighter at the moment of the check, which may be smaller OR larger than
@@ -344,14 +370,31 @@ export class SetUIState extends BaseVisualChange {
       };
     }
 
-    // Get initial observation
-    let lastObservation = await this.getObserveScreen().execute(
-      undefined,
-      undefined,
-      false,
-      0,
-      signal,
+    // Get initial observation -- RACED against `cutoffMs()`, not merely
+    // preceded by the admission check above (issue #6222 P1, fujun). Queueing
+    // can leave slightly more than `PER_FIELD_ADMISSION_HEADROOM_MS` of
+    // budget, passing the check above, and a cold or stalled observation can
+    // still overrun the transport deadline if simply awaited unbounded. This
+    // is a safety net, not real cancellation: `ObserveScreen` cannot
+    // currently be cancelled, so a timed-out observe is left running in the
+    // background (see `raceAgainstDeadline`) and this call returns the same
+    // structured all-`notAttempted` shape used by the admission check above.
+    const initialObservationRaced = await this.raceAgainstDeadline(
+      () => this.getObserveScreen().execute(undefined, undefined, false, 0, signal),
+      () => cutoffMs(),
+      "initial observation",
     );
+    if (initialObservationRaced === "timed-out") {
+      const missing = options.fields.map((f) => this.describeSelector(f.selector));
+      const notAttemptedReason = `Not attempted: setUIState's initial observation did not settle within setUIState's result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s)`;
+      return {
+        success: false,
+        fields: this.collectResults(fieldResults, options.fields, processed, notAttemptedReason),
+        totalAttempts: 0,
+        error: `setUIState's initial observation did not settle within the result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s); not attempted: ${missing.join(", ")}`,
+      };
+    }
+    let lastObservation = initialObservationRaced;
 
     let scrollsWithoutProgress = 0;
     let currentDirection: "up" | "down" = scrollDirection;
@@ -388,13 +431,30 @@ export class SetUIState extends BaseVisualChange {
         // so we re-find visible fields from a fresh observation each iteration.
         const { fieldSpec, fieldIndex, element } = visibleFields[0];
         // This field's slice starts at processed.size * 100, before it is
-        // added to `processed` below.
-        const fieldBudgetMs = fieldHardDeadlineMs() - this.timer.now();
-        const raced = await this.raceFieldAgainstDeadline(
-          () => this.processField(fieldSpec, element, fieldProgress(processed.size), signal),
-          fieldSpec,
-          fieldBudgetMs,
-        );
+        // added to `processed` below. `fieldBudgetMs` here is only a snapshot
+        // for the timeout message below -- the race itself re-reads
+        // `cutoffMs()` live, both at admission and again on every progress
+        // tick via `onTick` (issue #6222 P1, fujuk): a mid-field progress
+        // notification that extends the live transport deadline re-arms this
+        // SAME field's own timeout against the new, larger budget instead of
+        // timing out against the stale value captured here.
+        const fieldBudgetMs = cutoffMs() - this.timer.now();
+        const raced = await this.raceAgainstDeadline<InternalFieldResult>(
+          (onTick) =>
+            this.processField(
+              fieldSpec,
+              element,
+              this.withRearmOnTick(fieldProgress(processed.size), onTick),
+              signal,
+            ),
+          () => cutoffMs(),
+          this.describeSelector(fieldSpec.selector),
+        ).catch((error: unknown): InternalFieldResult => ({
+          selector: fieldSpec.selector,
+          success: false,
+          attempts: 0,
+          error: errorMessage(error),
+        }));
 
         processed.add(fieldIndex);
 
@@ -653,113 +713,173 @@ export class SetUIState extends BaseVisualChange {
   }
 
   /**
-   * Race an already-admitted field's `processField()` call against its own
-   * remaining share of the transport deadline (issue #6222 review, coderabbit
-   * fuTtO). `processField` delegates into `ClearTextLike.execute` and
-   * `InputTextLike.execute`, neither of which can currently be cancelled --
-   * without this, a field that stalls (e.g. after a UI mutation) can run past
-   * the transport deadline and reproduce the exact silent-discard this whole
-   * feature exists to prevent, even though it was correctly admitted under
-   * budget at the time.
+   * Wraps a field's progress callback so every tick that reaches it also
+   * calls `onTick` -- the hook `raceAgainstDeadline` uses to re-arm an
+   * in-flight race's timeout against the LIVE cutoff (issue #6222 P1,
+   * fujuk). A progress notification is the only thing that can move a
+   * `ProgressExtendableDeadline` forward (`extendOnProgress`,
+   * `src/daemon/socketServer.ts`), so re-checking exactly when one is
+   * forwarded -- rather than only once at field admission -- is what lets a
+   * mid-field extension apply to THIS SAME field's own remaining budget
+   * instead of only to fields admitted afterward. A no-op (returns
+   * `undefined`) when there is no inner callback to wrap, matching
+   * `fieldProgress`'s own contract.
+   */
+  private withRearmOnTick(
+    inner: ProgressCallback | undefined,
+    onTick: () => void,
+  ): ProgressCallback | undefined {
+    if (!inner) {
+      return undefined;
+    }
+    return async (childProgress, childTotal, message) => {
+      await inner(childProgress, childTotal, message);
+      onTick();
+    };
+  }
+
+  /**
+   * Race a unit of device I/O against a live-read cutoff (issue #6222 P1,
+   * unifying fujug/fujuk/fujun). Used for both the initial observation and
+   * each admitted field's `processField()` call. Neither can currently be
+   * cancelled -- without this, either can run past the transport deadline
+   * and reproduce the exact silent-discard this whole feature exists to
+   * prevent, even though it was correctly started under budget at the time.
    *
    * This is a SAFETY NET, not real cancellation: the started call is left
    * running in the background when the timeout wins the race -- its eventual
-   * settlement is swallowed (any rejection is only logged) rather than
-   * aborted. Real per-field cancellation into `ClearText`/`InputText` via an
-   * `AbortSignal` is a larger, separate change; tracked as a follow-up rather
-   * than attempted here.
+   * settlement is swallowed (only logged) rather than aborted. Real
+   * cancellation via an `AbortSignal` into `ClearText`/`InputText`/
+   * `ObserveScreen` is a larger, separate change; tracked as a follow-up
+   * rather than attempted here.
    *
-   * Takes a THUNK, not an already-started promise: `startField()` must not be
-   * called until AFTER the timeout is armed. `processField()`'s own
-   * dependencies can run synchronously far enough to matter (fakes in tests
-   * advance a shared clock synchronously; real device I/O at least burns real
-   * wall-clock time before its first genuine suspension) -- starting it as
-   * part of evaluating this method's arguments, before its body runs, would
-   * arm the timeout against a clock that already moved, silently shrinking
-   * the field's actual budget.
+   * Takes a THUNK, not an already-started promise: `startWork()` must not be
+   * called until AFTER the timeout is armed. Its own dependencies can run
+   * synchronously far enough to matter (fakes in tests advance a shared
+   * clock synchronously; real device I/O at least burns real wall-clock time
+   * before its first genuine suspension) -- starting it as part of
+   * evaluating this method's arguments, before its body runs, would arm the
+   * timeout against a clock that already moved, silently shrinking the
+   * work's actual budget.
    *
-   * @param startField - Starts the field's `processField()` call. Invoked
-   *   exactly once, after the timeout below is armed.
-   * @param fieldSpec - Only used to describe the field in a debug log if the
-   *   background promise eventually settles after the race already timed out.
-   * @param budgetMs - This field's remaining share of the hard deadline, in
-   *   milliseconds. A non-positive value still starts the field (so its
-   *   background settlement can be traced) but times out immediately without
-   *   arming a timer.
-   * @returns The field's real result if it settles in time, or the literal
+   * `getCutoffMs` is read fresh both when the timeout is (re-)armed here and
+   * again every time `startWork`'s own `onTick` hook fires (see
+   * `withRearmOnTick`) -- so a live-extended deadline applies to an
+   * ALREADY-RUNNING race, not just to work started afterward (fujuk). A
+   * cutoff at or before now re-arms as an IMMEDIATE timeout rather than a
+   * no-op, so an extension that shrinks the effective remaining time (e.g.
+   * the live deadline did not move) still resolves promptly.
+   *
+   * @param startWork - Starts the work. Invoked exactly once, after the
+   *   timeout below is first armed. Receives `onTick`, to be invoked
+   *   whenever the caller learns the live cutoff may have moved.
+   * @param getCutoffMs - Returns the CURRENT absolute cutoff (already
+   *   headroom-adjusted, e.g. `cutoffMs()`) this race must finish before.
+   *   Read fresh on every (re-)arm, never cached.
+   * @param describeWork - Only used to identify the work in a debug log if
+   *   its promise eventually settles after the race already timed out.
+   * @returns The work's real result if it settles in time, or the literal
    *   string `"timed-out"` if the timeout wins the race.
    */
-  private async raceFieldAgainstDeadline(
-    startField: () => Promise<InternalFieldResult>,
-    fieldSpec: FieldSpec,
-    budgetMs: number,
-  ): Promise<InternalFieldResult | "timed-out"> {
+  private async raceAgainstDeadline<T>(
+    startWork: (onTick: () => void) => Promise<T>,
+    getCutoffMs: () => number,
+    describeWork: string,
+  ): Promise<T | "timed-out"> {
     // A background settlement after abandonment has no observer left to
-    // report to beyond this debug trace -- expected once the field's own
+    // report to beyond this debug trace -- expected once the work's own
     // budget has already been spent.
-    const logBackgroundSettlement = (fieldPromise: Promise<InternalFieldResult>): void => {
-      fieldPromise
+    const logBackgroundSettlement = (workPromise: Promise<T>): void => {
+      workPromise
         .then(() => {
-          logger.debug(
-            `[SetUIState] Background field settled after timeout for ${this.describeSelector(fieldSpec.selector)}`,
-          );
+          logger.debug(`[SetUIState] Background work settled after timeout for ${describeWork}`);
         })
-        .catch((error) => {
+        .catch((error: unknown) => {
           logger.debug(
-            `[SetUIState] Background field rejected after timeout for ${this.describeSelector(fieldSpec.selector)}: ${errorMessage(error)}`,
+            `[SetUIState] Background work rejected after timeout for ${describeWork}: ${errorMessage(error)}`,
           );
         });
     };
 
-    if (budgetMs <= 0) {
-      logBackgroundSettlement(startField());
-      return "timed-out";
-    }
-
-    return new Promise<InternalFieldResult | "timed-out">((resolve) => {
+    return new Promise<T | "timed-out">((resolve, reject) => {
       let settled = false;
-      // Declared (not yet assigned) BEFORE arming the timeout: on a
-      // FakeTimer-driven test, `startField()`'s own synchronous prefix can
-      // advance the clock far enough to fire this SAME timeout re-entrantly,
-      // synchronously, before `startField()` even returns -- at which point
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      // Declared (not yet assigned) BEFORE the first arm: on a
+      // FakeTimer-driven test, `startWork()`'s own synchronous prefix can
+      // advance the clock far enough to fire the timeout re-entrantly,
+      // synchronously, before `startWork()` even returns -- at which point
       // this closure has not yet been assigned. `let` (rather than `const`)
       // avoids a TDZ crash in that case: a bare `let x;` initializes its
       // binding to `undefined` immediately at THIS line, so the timeout
       // closure below can safely read it even if it fires before the
-      // assignment further down ever runs; a `const` declared only at the
-      // assignment site would still be in its TDZ at that point instead. The
-      // guard below skips tracing when it is still `undefined`, and the
-      // post-`startField()` check a few lines down handles that case instead.
+      // assignment further down ever runs. The guard below skips tracing
+      // when it is still `undefined`, and the post-`startWork()` check a few
+      // lines down handles that case instead.
       // oxlint-disable-next-line prefer-const -- see comment above: `let` is required for TDZ safety, not a style preference.
-      let fieldPromise: Promise<InternalFieldResult> | undefined;
-      const timeoutHandle = this.timer.setTimeout(() => {
+      let workPromise: Promise<T> | undefined;
+
+      const finishTimedOut = (): void => {
         if (settled) {
           return;
         }
         settled = true;
-        if (fieldPromise) {
-          logBackgroundSettlement(fieldPromise);
+        if (timeoutHandle !== undefined) {
+          this.timer.clearTimeout(timeoutHandle);
+          timeoutHandle = undefined;
+        }
+        if (workPromise) {
+          logBackgroundSettlement(workPromise);
         }
         resolve("timed-out");
-      }, budgetMs);
+      };
 
-      // Armed above; only now does the field's real work actually start.
-      fieldPromise = startField();
-      const startedFieldPromise = fieldPromise;
+      // (Re-)arms the timeout against a FRESHLY read cutoff. A non-positive
+      // remaining budget still resolves "timed-out" immediately rather than
+      // arming a timer for it.
+      const armTimeout = (): void => {
+        if (settled) {
+          return;
+        }
+        if (timeoutHandle !== undefined) {
+          this.timer.clearTimeout(timeoutHandle);
+          timeoutHandle = undefined;
+        }
+        const budgetMs = getCutoffMs() - this.timer.now();
+        if (budgetMs <= 0) {
+          finishTimedOut();
+          return;
+        }
+        timeoutHandle = this.timer.setTimeout(finishTimedOut, budgetMs);
+      };
+
+      // Passed to `startWork` as `onTick`: re-arms against the live cutoff
+      // whenever the caller learns it may have moved (issue #6222 P1,
+      // fujuk). A no-op once already settled.
+      const onTick = (): void => {
+        armTimeout();
+      };
+
+      armTimeout();
+      // Armed above; only now does the work actually start.
+      workPromise = startWork(onTick);
+      const startedWorkPromise = workPromise;
       if (settled) {
-        // The timeout above already fired re-entrantly while `startField()`
-        // was still running synchronously -- it could not see `fieldPromise`
-        // yet, so trace its eventual settlement here instead.
-        logBackgroundSettlement(startedFieldPromise);
+        // The timeout above already fired (synchronously, budget<=0, or
+        // re-entrantly while `startWork()` was still running synchronously)
+        // before this closure could observe it via `workPromise` -- trace
+        // its eventual settlement here instead.
+        logBackgroundSettlement(startedWorkPromise);
         return;
       }
-      startedFieldPromise.then(
+      startedWorkPromise.then(
         (result) => {
           if (settled) {
             return;
           }
           settled = true;
-          this.timer.clearTimeout(timeoutHandle);
+          if (timeoutHandle !== undefined) {
+            this.timer.clearTimeout(timeoutHandle);
+          }
           resolve(result);
         },
         (error: unknown) => {
@@ -767,17 +887,15 @@ export class SetUIState extends BaseVisualChange {
             return;
           }
           settled = true;
-          this.timer.clearTimeout(timeoutHandle);
-          // processField() catches its own internal errors per-attempt and
-          // only resolves (never rejects) in practice -- this branch is a
-          // defensive fallback for something truly unexpected, surfaced as a
-          // failed field rather than rejecting the whole call.
-          resolve({
-            selector: fieldSpec.selector,
-            success: false,
-            attempts: 0,
-            error: errorMessage(error),
-          });
+          if (timeoutHandle !== undefined) {
+            this.timer.clearTimeout(timeoutHandle);
+          }
+          // The known callers (`processField`, `ObserveScreen.execute`)
+          // resolve rather than reject in practice -- this is a defensive
+          // fallback for something truly unexpected. Propagated to the
+          // caller rather than swallowed here, since only the caller knows
+          // how to shape a failure specific to what it was racing.
+          reject(error);
         },
       );
     });

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -188,7 +188,19 @@ export class SetUIState extends BaseVisualChange {
    *   `RESULT_DEADLINE_BUDGET_MS` clock, so a call never keeps admitting
    *   fields past the point the transport itself would discard the result
    *   (issue #6222 P1). Undefined on a direct/non-daemon call, where the
-   *   internal budget alone is the only bound available.
+   *   internal budget alone is the only bound available. Superseded, on every
+   *   check, by `getLiveTransportDeadlineMs()` when that is provided.
+   * @param getLiveTransportDeadlineMs - Optional getter for the CURRENT value
+   *   of the transport deadline, read fresh at every admission check instead
+   *   of relying on the `transportDeadlineMs` snapshot above. A
+   *   daemon-forwarded, progress-capable call's real deadline can be pushed
+   *   FORWARD after `execute()` started (`ProgressExtendableDeadline`,
+   *   extended as THIS call's own progress notifications reach the daemon) --
+   *   `transportDeadlineMs` alone can never reflect that, since it is
+   *   captured once before `execute()` is even invoked. When this getter
+   *   returns `undefined` (e.g. the daemon-side entry was never registered,
+   *   or the call is not daemon-forwarded), `transportDeadlineMs` is used
+   *   as-is (issue #6222 P1 reopen, fuQ88 review).
    * @returns Result of the operation
    */
   async execute(
@@ -196,6 +208,7 @@ export class SetUIState extends BaseVisualChange {
     progress?: ProgressCallback,
     signal?: AbortSignal,
     transportDeadlineMs?: number,
+    getLiveTransportDeadlineMs?: () => number | undefined,
   ): Promise<SetUIStateResult> {
     const scrollDirection = options.scrollDirection ?? DEFAULT_SCROLL_DIRECTION;
 
@@ -203,19 +216,22 @@ export class SetUIState extends BaseVisualChange {
     const processed = new Set<number>();
     let totalAttempts = 0;
     // See RESULT_DEADLINE_BUDGET_MS -- this is the whole-call safety net,
-    // independent of (and in addition to) the search budget below. When the
-    // caller knows the ACTUAL transport deadline, bound admission by that
-    // instead (minus per-field headroom) -- it can be tighter OR looser than
-    // the fixed internal budget, but it is always the one that actually
-    // matters (issue #6222 P1). Falls back to the internal-only budget when
-    // no transport deadline is known.
+    // independent of (and in addition to) the search budget below.
     const callStartMs = this.timer.now();
     const internalResultDeadlineMs = callStartMs + RESULT_DEADLINE_BUDGET_MS;
-    const transportBoundDeadlineMs =
-      transportDeadlineMs !== undefined
-        ? transportDeadlineMs - PER_FIELD_ADMISSION_HEADROOM_MS
-        : undefined;
-    // When the caller knows the ACTUAL transport deadline, that is always the
+
+    // Read fresh on every call, never cached: `getLiveTransportDeadlineMs`
+    // (when provided) always wins over the frozen `transportDeadlineMs`
+    // snapshot, since it is the CURRENT value of the same live object the
+    // daemon itself extends on progress (issue #6222 P1 reopen, fuQ88
+    // review). Falls back to the frozen snapshot when no live getter is
+    // available, or it has nothing registered (e.g. the daemon-side entry
+    // already expired).
+    const currentTransportDeadlineMs = (): number | undefined =>
+      getLiveTransportDeadlineMs?.() ?? transportDeadlineMs;
+
+    // The bound that governs whether it is safe to ADMIT another field: when
+    // the caller knows the ACTUAL transport deadline, that is always the
     // bound that matters -- respect it even when it is LARGER than the fixed
     // internal budget (e.g. a progress-aware caller whose
     // `ProgressExtendableDeadline` has extended the transport deadline toward
@@ -224,12 +240,34 @@ export class SetUIState extends BaseVisualChange {
     // truncates `executePlan` steps that route through this same `execute()`
     // (issue #6222 P1). The fixed `RESULT_DEADLINE_BUDGET_MS` is a FALLBACK
     // for when no transport deadline is known at all (a direct, non-daemon
-    // call) -- never a ceiling imposed on top of a known one.
-    const resultDeadlineMs = transportBoundDeadlineMs ?? internalResultDeadlineMs;
-    // Only used to phrase the "why we stopped" message below -- the actual
-    // bound applied is whichever of the internal/transport-derived deadlines
-    // is tighter, which may be smaller OR larger than RESULT_DEADLINE_BUDGET_MS.
-    const resultDeadlineBudgetMsForMessage = resultDeadlineMs - callStartMs;
+    // call) -- never a ceiling imposed on top of a known one. Reserving
+    // `PER_FIELD_ADMISSION_HEADROOM_MS` here (only when a transport deadline
+    // is actually known) accounts for the worst-case runtime of whatever
+    // field is admitted next.
+    const admissionDeadlineMs = (): number => {
+      const liveTransportDeadlineMs = currentTransportDeadlineMs();
+      return liveTransportDeadlineMs !== undefined
+        ? liveTransportDeadlineMs - PER_FIELD_ADMISSION_HEADROOM_MS
+        : internalResultDeadlineMs;
+    };
+    // The bound that governs how long an ALREADY-ADMITTED field is allowed to
+    // keep running before `execute()` gives up on it and returns the
+    // accumulated partial result (issue #6222 review, coderabbit fuTtO). This
+    // is deliberately the FULL transport deadline (no headroom subtracted):
+    // headroom exists to protect the NEXT field's admission, not to shrink
+    // the CURRENT field's own budget -- an admitted field that finishes
+    // within the real transport deadline must not be treated as a stall just
+    // because it ran past the smaller admission-only bound above. Falls back
+    // to the same fixed internal budget as `admissionDeadlineMs` when no
+    // transport deadline is known at all.
+    const fieldHardDeadlineMs = (): number =>
+      currentTransportDeadlineMs() ?? internalResultDeadlineMs;
+    // Only used to phrase "why we stopped" messages below -- the actual bound
+    // applied is whichever of the internal/transport-derived deadlines is
+    // tighter at the moment of the check, which may be smaller OR larger than
+    // RESULT_DEADLINE_BUDGET_MS and can change between checks when a live
+    // getter is in play.
+    const admissionDeadlineBudgetMsForMessage = (): number => admissionDeadlineMs() - callStartMs;
     let resultBudgetSpent = false;
 
     // Progress reported to the client MUST stay on one consistent scale and
@@ -295,14 +333,14 @@ export class SetUIState extends BaseVisualChange {
     // still blow the transport deadline before any field is attempted,
     // discarding the whole call. Fail fast into the same structured
     // all-`notAttempted` shape used below instead (issue #6222 P1).
-    if (this.timer.now() >= resultDeadlineMs) {
+    if (this.timer.now() >= admissionDeadlineMs()) {
       const missing = options.fields.map((f) => this.describeSelector(f.selector));
-      const notAttemptedReason = `Not attempted: setUIState's result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was already reached before the initial observation`;
+      const notAttemptedReason = `Not attempted: setUIState's result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) was already reached before the initial observation`;
       return {
         success: false,
         fields: this.collectResults(fieldResults, options.fields, processed, notAttemptedReason),
         totalAttempts: 0,
-        error: `setUIState result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was already reached before the initial observation; not attempted: ${missing.join(", ")}`,
+        error: `setUIState result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) was already reached before the initial observation; not attempted: ${missing.join(", ")}`,
       };
     }
 
@@ -330,7 +368,7 @@ export class SetUIState extends BaseVisualChange {
       // field in the call, then stop and return what has already been
       // applied rather than let the transport's own deadline discard it
       // (issue #6222 reopen).
-      if (this.timer.now() >= resultDeadlineMs) {
+      if (this.timer.now() >= admissionDeadlineMs()) {
         resultBudgetSpent = true;
         break;
       }
@@ -351,14 +389,37 @@ export class SetUIState extends BaseVisualChange {
         const { fieldSpec, fieldIndex, element } = visibleFields[0];
         // This field's slice starts at processed.size * 100, before it is
         // added to `processed` below.
-        const result = await this.processField(
+        const fieldBudgetMs = fieldHardDeadlineMs() - this.timer.now();
+        const raced = await this.raceFieldAgainstDeadline(
+          () => this.processField(fieldSpec, element, fieldProgress(processed.size), signal),
           fieldSpec,
-          element,
-          fieldProgress(processed.size),
-          signal,
+          fieldBudgetMs,
         );
 
         processed.add(fieldIndex);
+
+        if (raced === "timed-out") {
+          // The field WAS admitted and started but did not settle within its
+          // remaining share of the real transport deadline -- `processField`
+          // (and the `ClearTextLike`/`InputTextLike` it delegates into)
+          // cannot currently be cancelled, so this is a safety net rather
+          // than real cancellation: the underlying call may still be running
+          // against the device, its eventual outcome no longer awaited or
+          // reported. Stop immediately and return the accumulated partial
+          // result instead of risking the SAME overrun this whole feature
+          // exists to prevent (issue #6222 review, coderabbit fuTtO).
+          fieldResults[fieldIndex] = {
+            selector: fieldSpec.selector,
+            success: false,
+            attempts: 0,
+            timedOut: true,
+            error: `Field ${this.describeSelector(fieldSpec.selector)} did not settle within its ${Math.round(Math.max(fieldBudgetMs, 0) / 1000)}s share of setUIState's result deadline; it may still be applying in the background`,
+          };
+          resultBudgetSpent = true;
+          break;
+        }
+
+        const result = raced;
         // Retain only the small, public FieldResult fields across the loop --
         // `freshObservation` (a full view hierarchy) is used immediately below
         // for reuse and then must NOT be kept alive in `fieldResults` for the
@@ -454,8 +515,12 @@ export class SetUIState extends BaseVisualChange {
       }
     }
 
-    // Check for any unprocessed fields
-    if (processed.size < options.fields.length) {
+    // Check for any unprocessed fields -- or a per-field timeout on the LAST
+    // admitted field (issue #6222 review, coderabbit fuTtO): that field IS in
+    // `processed` (it was admitted and started) but did not succeed, so
+    // `processed.size === options.fields.length` alone would otherwise fall
+    // through to the unconditional success return below despite the timeout.
+    if (processed.size < options.fields.length || resultBudgetSpent) {
       const missing = options.fields
         .filter((_, i) => !processed.has(i))
         .map((f) => this.describeSelector(f.selector));
@@ -465,7 +530,7 @@ export class SetUIState extends BaseVisualChange {
       // mark them `notAttempted` so a client can tell "safe to retry just
       // these" apart from "attempted and failed" (issue #6222 reopen).
       const notAttemptedReason = resultBudgetSpent
-        ? `Not attempted: setUIState's result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) was reached after applying ${processed.size}/${options.fields.length} field(s)`
+        ? `Not attempted: setUIState's result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) was reached after applying ${processed.size}/${options.fields.length} field(s)`
         : undefined;
 
       return {
@@ -474,7 +539,9 @@ export class SetUIState extends BaseVisualChange {
         totalAttempts,
         observation: lastObservation,
         error: resultBudgetSpent
-          ? `setUIState result deadline (${Math.round(resultDeadlineBudgetMsForMessage / 1000)}s) reached after applying ${processed.size}/${options.fields.length} field(s); not attempted: ${missing.join(", ")}`
+          ? missing.length > 0
+            ? `setUIState result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) reached after applying ${processed.size}/${options.fields.length} field(s); not attempted: ${missing.join(", ")}`
+            : `setUIState result deadline (${Math.round(admissionDeadlineBudgetMsForMessage() / 1000)}s) reached while applying field(s); the last-admitted field did not settle in time`
           : budgetSpent
             ? `Fields not found within the ${Math.round(SEARCH_BUDGET_MS / 1000)}s search budget: ${missing.join(", ")}`
             : `Fields not found after scrolling: ${missing.join(", ")}`,
@@ -583,6 +650,137 @@ export class SetUIState extends BaseVisualChange {
       }
     }
     return out;
+  }
+
+  /**
+   * Race an already-admitted field's `processField()` call against its own
+   * remaining share of the transport deadline (issue #6222 review, coderabbit
+   * fuTtO). `processField` delegates into `ClearTextLike.execute` and
+   * `InputTextLike.execute`, neither of which can currently be cancelled --
+   * without this, a field that stalls (e.g. after a UI mutation) can run past
+   * the transport deadline and reproduce the exact silent-discard this whole
+   * feature exists to prevent, even though it was correctly admitted under
+   * budget at the time.
+   *
+   * This is a SAFETY NET, not real cancellation: the started call is left
+   * running in the background when the timeout wins the race -- its eventual
+   * settlement is swallowed (any rejection is only logged) rather than
+   * aborted. Real per-field cancellation into `ClearText`/`InputText` via an
+   * `AbortSignal` is a larger, separate change; tracked as a follow-up rather
+   * than attempted here.
+   *
+   * Takes a THUNK, not an already-started promise: `startField()` must not be
+   * called until AFTER the timeout is armed. `processField()`'s own
+   * dependencies can run synchronously far enough to matter (fakes in tests
+   * advance a shared clock synchronously; real device I/O at least burns real
+   * wall-clock time before its first genuine suspension) -- starting it as
+   * part of evaluating this method's arguments, before its body runs, would
+   * arm the timeout against a clock that already moved, silently shrinking
+   * the field's actual budget.
+   *
+   * @param startField - Starts the field's `processField()` call. Invoked
+   *   exactly once, after the timeout below is armed.
+   * @param fieldSpec - Only used to describe the field in a debug log if the
+   *   background promise eventually settles after the race already timed out.
+   * @param budgetMs - This field's remaining share of the hard deadline, in
+   *   milliseconds. A non-positive value still starts the field (so its
+   *   background settlement can be traced) but times out immediately without
+   *   arming a timer.
+   * @returns The field's real result if it settles in time, or the literal
+   *   string `"timed-out"` if the timeout wins the race.
+   */
+  private async raceFieldAgainstDeadline(
+    startField: () => Promise<InternalFieldResult>,
+    fieldSpec: FieldSpec,
+    budgetMs: number,
+  ): Promise<InternalFieldResult | "timed-out"> {
+    // A background settlement after abandonment has no observer left to
+    // report to beyond this debug trace -- expected once the field's own
+    // budget has already been spent.
+    const logBackgroundSettlement = (fieldPromise: Promise<InternalFieldResult>): void => {
+      fieldPromise
+        .then(() => {
+          logger.debug(
+            `[SetUIState] Background field settled after timeout for ${this.describeSelector(fieldSpec.selector)}`,
+          );
+        })
+        .catch((error) => {
+          logger.debug(
+            `[SetUIState] Background field rejected after timeout for ${this.describeSelector(fieldSpec.selector)}: ${errorMessage(error)}`,
+          );
+        });
+    };
+
+    if (budgetMs <= 0) {
+      logBackgroundSettlement(startField());
+      return "timed-out";
+    }
+
+    return new Promise<InternalFieldResult | "timed-out">((resolve) => {
+      let settled = false;
+      // Declared (not yet assigned) BEFORE arming the timeout: on a
+      // FakeTimer-driven test, `startField()`'s own synchronous prefix can
+      // advance the clock far enough to fire this SAME timeout re-entrantly,
+      // synchronously, before `startField()` even returns -- at which point
+      // this closure has not yet been assigned. `let` (rather than `const`)
+      // avoids a TDZ crash in that case: a bare `let x;` initializes its
+      // binding to `undefined` immediately at THIS line, so the timeout
+      // closure below can safely read it even if it fires before the
+      // assignment further down ever runs; a `const` declared only at the
+      // assignment site would still be in its TDZ at that point instead. The
+      // guard below skips tracing when it is still `undefined`, and the
+      // post-`startField()` check a few lines down handles that case instead.
+      // oxlint-disable-next-line prefer-const -- see comment above: `let` is required for TDZ safety, not a style preference.
+      let fieldPromise: Promise<InternalFieldResult> | undefined;
+      const timeoutHandle = this.timer.setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (fieldPromise) {
+          logBackgroundSettlement(fieldPromise);
+        }
+        resolve("timed-out");
+      }, budgetMs);
+
+      // Armed above; only now does the field's real work actually start.
+      fieldPromise = startField();
+      const startedFieldPromise = fieldPromise;
+      if (settled) {
+        // The timeout above already fired re-entrantly while `startField()`
+        // was still running synchronously -- it could not see `fieldPromise`
+        // yet, so trace its eventual settlement here instead.
+        logBackgroundSettlement(startedFieldPromise);
+        return;
+      }
+      startedFieldPromise.then(
+        (result) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.timer.clearTimeout(timeoutHandle);
+          resolve(result);
+        },
+        (error: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.timer.clearTimeout(timeoutHandle);
+          // processField() catches its own internal errors per-attempt and
+          // only resolves (never rejects) in practice -- this branch is a
+          // defensive fallback for something truly unexpected, surfaced as a
+          // failed field rather than rejecting the whole call.
+          resolve({
+            selector: fieldSpec.selector,
+            success: false,
+            attempts: 0,
+            error: errorMessage(error),
+          });
+        },
+      );
+    });
   }
 
   /**

--- a/src/models/SetUIStateResult.ts
+++ b/src/models/SetUIStateResult.ts
@@ -32,6 +32,15 @@ export interface FieldResult {
    * "attempted and failed" without parsing `error` text.
    */
   notAttempted?: boolean;
+  /**
+   * True when this field WAS admitted and started, but did not settle within
+   * its share of the remaining result-deadline budget before `execute()` had
+   * to return the accumulated partial result (issue #6222 review, coderabbit
+   * fuTtO). Distinct from `notAttempted` (never started at all): the
+   * underlying operation may still be running in the background against the
+   * device -- its eventual outcome is no longer awaited or reported.
+   */
+  timedOut?: boolean;
 }
 
 /**

--- a/src/models/SetUIStateResult.ts
+++ b/src/models/SetUIStateResult.ts
@@ -24,6 +24,14 @@ export interface FieldResult {
   fieldType?: FieldType;
   /** Whether the field was skipped because it already had the correct value */
   skipped?: boolean;
+  /**
+   * True when this field was never reached because the overall call's
+   * internal result deadline (issue #6222 reopen) was hit before processing
+   * got to it -- distinct from `error` describing an attempted-and-failed
+   * field. Lets a client tell "not attempted, safe to retry" apart from
+   * "attempted and failed" without parsing `error` text.
+   */
+  notAttempted?: boolean;
 }
 
 /**

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -53,6 +53,7 @@ const fieldResultSchema = z.object({
   error: z.string().optional(),
   fieldType: z.enum(["text", "checkbox", "toggle", "dropdown", "unknown"]).optional(),
   skipped: z.boolean().optional(),
+  notAttempted: z.boolean().optional(),
 });
 
 /**
@@ -124,6 +125,7 @@ export const setUIStateHandler = async (
       error: f.error,
       fieldType: f.fieldType,
       skipped: f.skipped,
+      notAttempted: f.notAttempted,
     })),
     totalAttempts: result.totalAttempts,
     error: result.error,

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -6,6 +6,10 @@ import { createStructuredToolResponse } from "../utils/toolUtils";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { elementIdTextFieldsSchema, validateElementIdTextSelector } from "./elementSelectorSchemas";
+import {
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
+} from "../daemon/constants";
 
 /**
  * Schema for a single field specification
@@ -91,6 +95,39 @@ export function resetSetUIStateFactory(): void {
   setUIStateFactory = createDefaultSetUIState;
 }
 
+/**
+ * Recover the ABSOLUTE deadline of the current MCP request from the internal
+ * params the server attaches to every daemon-forwarded call (issue #6222
+ * P1). `__mcpRequestTimeoutMs` is the transport budget still remaining when
+ * the request reached this process -- time already spent in the daemon's
+ * per-session queue is already deducted (see `resolveMcpRequestTimeoutMs`
+ * and `ProgressExtendableDeadline` in `src/daemon/mcpRequestTimeout.ts`).
+ * `__executionStartTime` is this execution's own start time on the SAME
+ * `defaultTimer` clock `SetUIState` uses. Their sum is the absolute
+ * wall-clock deadline `SetUIState.execute()` must return before. Neither
+ * field is present on a direct, non-daemon call, in which case there is no
+ * transport deadline to bound against and `SetUIState` falls back to its own
+ * conservative internal budget.
+ */
+function resolveTransportDeadlineMs(args: unknown): number | undefined {
+  if (!args || typeof args !== "object") {
+    return undefined;
+  }
+  const record = args as Record<string, unknown>;
+  const remainingMs = record[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+  const startTimeMs = record[INTERNAL_EXECUTION_START_TIME_PARAM];
+  if (
+    typeof remainingMs !== "number" ||
+    !Number.isFinite(remainingMs) ||
+    remainingMs <= 0 ||
+    typeof startTimeMs !== "number" ||
+    !Number.isFinite(startTimeMs)
+  ) {
+    return undefined;
+  }
+  return startTimeMs + remainingMs;
+}
+
 export const setUIStateHandler = async (
   device: BootedDevice,
   args: SetUIStateArgs,
@@ -98,6 +135,7 @@ export const setUIStateHandler = async (
   signal?: AbortSignal,
 ) => {
   const setUIState = setUIStateFactory(device);
+  const transportDeadlineMs = resolveTransportDeadlineMs(args);
 
   const result = await setUIState.execute(
     {
@@ -113,6 +151,7 @@ export const setUIStateHandler = async (
     },
     progress,
     signal,
+    transportDeadlineMs,
   );
 
   const response = createStructuredToolResponse({

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -9,7 +9,9 @@ import { elementIdTextFieldsSchema, validateElementIdTextSelector } from "./elem
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
   INTERNAL_EXECUTION_START_TIME_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
 } from "../daemon/constants";
+import { getLiveDeadlineMs } from "../daemon/liveDeadlineRegistry";
 
 /**
  * Schema for a single field specification
@@ -58,6 +60,7 @@ const fieldResultSchema = z.object({
   fieldType: z.enum(["text", "checkbox", "toggle", "dropdown", "unknown"]).optional(),
   skipped: z.boolean().optional(),
   notAttempted: z.boolean().optional(),
+  timedOut: z.boolean().optional(),
 });
 
 /**
@@ -128,6 +131,26 @@ function resolveTransportDeadlineMs(args: unknown): number | undefined {
   return startTimeMs + remainingMs;
 }
 
+/**
+ * Resolve a getter for the LIVE (possibly progress-extended) transport
+ * deadline, when the daemon registered one for this exact request (issue
+ * #6222 P1 reopen). `__mcpLiveDeadlineKey` is only ever present on a
+ * daemon-forwarded, progress-capable call (see `INTERNAL_LIVE_DEADLINE_KEY_PARAM`
+ * and `liveDeadlineRegistry`) -- absent, this returns `undefined` and
+ * `SetUIState.execute()` falls back to the frozen `transportDeadlineMs`
+ * snapshot from {@link resolveTransportDeadlineMs}.
+ */
+function resolveLiveTransportDeadlineGetter(args: unknown): (() => number | undefined) | undefined {
+  if (!args || typeof args !== "object") {
+    return undefined;
+  }
+  const key = (args as Record<string, unknown>)[INTERNAL_LIVE_DEADLINE_KEY_PARAM];
+  if (typeof key !== "string" || key.length === 0) {
+    return undefined;
+  }
+  return () => getLiveDeadlineMs(key);
+}
+
 export const setUIStateHandler = async (
   device: BootedDevice,
   args: SetUIStateArgs,
@@ -136,6 +159,7 @@ export const setUIStateHandler = async (
 ) => {
   const setUIState = setUIStateFactory(device);
   const transportDeadlineMs = resolveTransportDeadlineMs(args);
+  const getLiveTransportDeadlineMs = resolveLiveTransportDeadlineGetter(args);
 
   const result = await setUIState.execute(
     {
@@ -152,6 +176,7 @@ export const setUIStateHandler = async (
     progress,
     signal,
     transportDeadlineMs,
+    getLiveTransportDeadlineMs,
   );
 
   const response = createStructuredToolResponse({
@@ -165,6 +190,7 @@ export const setUIStateHandler = async (
       fieldType: f.fieldType,
       skipped: f.skipped,
       notAttempted: f.notAttempted,
+      timedOut: f.timedOut,
     })),
     totalAttempts: result.totalAttempts,
     error: result.error,

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -8,6 +8,7 @@ import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { elementIdTextFieldsSchema, validateElementIdTextSelector } from "./elementSelectorSchemas";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
   INTERNAL_EXECUTION_START_TIME_PARAM,
   INTERNAL_LIVE_DEADLINE_KEY_PARAM,
 } from "../daemon/constants";
@@ -101,22 +102,35 @@ export function resetSetUIStateFactory(): void {
 /**
  * Recover the ABSOLUTE deadline of the current MCP request from the internal
  * params the server attaches to every daemon-forwarded call (issue #6222
- * P1). `__mcpRequestTimeoutMs` is the transport budget still remaining when
- * the request reached this process -- time already spent in the daemon's
- * per-session queue is already deducted (see `resolveMcpRequestTimeoutMs`
- * and `ProgressExtendableDeadline` in `src/daemon/mcpRequestTimeout.ts`).
- * `__executionStartTime` is this execution's own start time on the SAME
- * `defaultTimer` clock `SetUIState` uses. Their sum is the absolute
- * wall-clock deadline `SetUIState.execute()` must return before. Neither
- * field is present on a direct, non-daemon call, in which case there is no
- * transport deadline to bound against and `SetUIState` falls back to its own
- * conservative internal budget.
+ * P1).
+ *
+ * Prefers `__mcpRequestDeadlineMs` ({@link INTERNAL_MCP_REQUEST_DEADLINE_PARAM}),
+ * an absolute deadline the DAEMON anchored at the instant it captured the
+ * remaining transport budget, immediately before the loopback
+ * `mcpClient.callTool` (`UnixSocketServer.withSocketSessionAutolockKey`).
+ * Falls back to recomputing `__executionStartTime + __mcpRequestTimeoutMs`
+ * only when the newer param is absent (an older daemon build): `startTime`
+ * is this execution's own start time on the SAME `defaultTimer` clock
+ * `SetUIState` uses, but it is recorded only AFTER this process's HTTP
+ * dispatch and admission/tool-selection repo reads -- re-deriving the
+ * deadline from it RE-GRANTS whatever time that gap consumed, which can push
+ * the computed deadline later than the daemon's actual outer abort (issue
+ * #6222 review, PRRT_kwDOP-GF5M6fuyts P1). The anchored param removes that
+ * gap entirely, so it is the preferred source whenever present.
+ *
+ * Neither field is present on a direct, non-daemon call, in which case there
+ * is no transport deadline to bound against and `SetUIState` falls back to
+ * its own conservative internal budget.
  */
 function resolveTransportDeadlineMs(args: unknown): number | undefined {
   if (!args || typeof args !== "object") {
     return undefined;
   }
   const record = args as Record<string, unknown>;
+  const anchoredDeadlineMs = record[INTERNAL_MCP_REQUEST_DEADLINE_PARAM];
+  if (typeof anchoredDeadlineMs === "number" && Number.isFinite(anchoredDeadlineMs)) {
+    return anchoredDeadlineMs;
+  }
   const remainingMs = record[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
   const startTimeMs = record[INTERNAL_EXECUTION_START_TIME_PARAM];
   if (

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,7 @@ import { TerminalSessionError } from "../daemon/sessionManager";
 import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
   DAEMON_NON_FINITE_ENCODED_PARAM,
 } from "../daemon/constants";
 import {
@@ -143,7 +144,6 @@ export interface McpServerOptions {
 
 const INTERNAL_MCP_SESSION_PARAM = "__mcpSessionId";
 const INTERNAL_EXECUTION_ID_PARAM = "__executionId";
-const INTERNAL_EXECUTION_START_TIME_PARAM = "__executionStartTime";
 
 async function resolveDeviceLossOutcome(
   deviceLoss: DeviceLossOutcome,
@@ -646,6 +646,18 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
               : {}),
             [INTERNAL_EXECUTION_ID_PARAM]: execution.id,
             [INTERNAL_EXECUTION_START_TIME_PARAM]: execution.startTime,
+            // Forwarded back onto handlerParams (rather than only used locally
+            // above) so a handler that needs the ACTUAL transport deadline --
+            // not a fresh internal budget -- can recover it: this value plus
+            // `execution.startTime` is the absolute wall-clock deadline of the
+            // current request. Only present on a daemon-forwarded call (see
+            // `withSocketSessionAutolockKey` in `src/daemon/socketServer.ts`);
+            // absent on a direct/non-daemon call, which a handler must treat as
+            // "no transport deadline known" (issue #6222 P1, `setUIStateHandler`
+            // is the first consumer).
+            ...(requestTimeoutMs !== undefined
+              ? { [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: requestTimeoutMs }
+              : {}),
           }
         : parsedParams;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,7 @@ import { TerminalSessionError } from "../daemon/sessionManager";
 import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
   INTERNAL_EXECUTION_START_TIME_PARAM,
   INTERNAL_LIVE_DEADLINE_KEY_PARAM,
   DAEMON_NON_FINITE_ENCODED_PARAM,
@@ -185,6 +186,22 @@ function extractInternalMcpRequestTimeoutMs(params: unknown): number | undefined
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+/**
+ * Extract {@link INTERNAL_MCP_REQUEST_DEADLINE_PARAM} -- the ABSOLUTE
+ * deadline the daemon anchored at capture time, before this process's own
+ * HTTP dispatch and admission/tool-selection repo reads could consume any of
+ * `requestTimeoutMs`'s budget (issue #6222 review, PRRT_kwDOP-GF5M6fuyts P1).
+ * A handler that receives this should prefer it outright over recomputing
+ * `execution.startTime + requestTimeoutMs`, which re-grants that gap.
+ */
+function extractInternalMcpRequestDeadlineMs(params: unknown): number | undefined {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  const value = (params as Record<string, unknown>)[INTERNAL_MCP_REQUEST_DEADLINE_PARAM];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 function extractInternalLiveDeadlineKey(params: unknown): string | undefined {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return undefined;
@@ -212,6 +229,7 @@ function stripInternalToolParams(params: unknown): unknown {
   delete rest[INTERNAL_EXECUTION_ID_PARAM];
   delete rest[INTERNAL_EXECUTION_START_TIME_PARAM];
   delete rest[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+  delete rest[INTERNAL_MCP_REQUEST_DEADLINE_PARAM];
   delete rest[INTERNAL_LIVE_DEADLINE_KEY_PARAM];
   // Safety net: revival already strips this transport-provenance flag (#5863), but
   // guard the tool boundary against any future path that sets it without reviving.
@@ -612,6 +630,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const requestTimeoutMs = daemonMode
       ? extractInternalMcpRequestTimeoutMs(toolParams)
       : undefined;
+    const requestDeadlineMs = daemonMode
+      ? extractInternalMcpRequestDeadlineMs(toolParams)
+      : undefined;
     const requestLiveDeadlineKey = daemonMode
       ? extractInternalLiveDeadlineKey(toolParams)
       : undefined;
@@ -684,6 +705,15 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
             // is the first consumer).
             ...(requestTimeoutMs !== undefined
               ? { [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: requestTimeoutMs }
+              : {}),
+            // The daemon's own capture-time-anchored absolute deadline, when
+            // present -- see `INTERNAL_MCP_REQUEST_DEADLINE_PARAM`. Forwarded
+            // through unchanged so a handler can prefer it over recomputing
+            // `execution.startTime + requestTimeoutMs`, which would re-grant
+            // whatever time this dispatch/admission step itself consumed
+            // (issue #6222 review, PRRT_kwDOP-GF5M6fuyts P1).
+            ...(requestDeadlineMs !== undefined
+              ? { [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: requestDeadlineMs }
               : {}),
             // Same daemon-only provenance as `requestTimeoutMs` above -- lets
             // `setUIStateHandler` resolve the LIVE (possibly progress-extended)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
   INTERNAL_EXECUTION_START_TIME_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
   DAEMON_NON_FINITE_ENCODED_PARAM,
 } from "../daemon/constants";
 import {
@@ -184,6 +185,14 @@ function extractInternalMcpRequestTimeoutMs(params: unknown): number | undefined
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function extractInternalLiveDeadlineKey(params: unknown): string | undefined {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  const value = (params as Record<string, unknown>)[INTERNAL_LIVE_DEADLINE_KEY_PARAM];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function stripInternalToolParams(params: unknown): unknown {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return params;
@@ -203,6 +212,7 @@ function stripInternalToolParams(params: unknown): unknown {
   delete rest[INTERNAL_EXECUTION_ID_PARAM];
   delete rest[INTERNAL_EXECUTION_START_TIME_PARAM];
   delete rest[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+  delete rest[INTERNAL_LIVE_DEADLINE_KEY_PARAM];
   // Safety net: revival already strips this transport-provenance flag (#5863), but
   // guard the tool boundary against any future path that sets it without reviving.
   delete rest[DAEMON_NON_FINITE_ENCODED_PARAM];
@@ -587,7 +597,24 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     );
 
     const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
-    const requestTimeoutMs = extractInternalMcpRequestTimeoutMs(toolParams);
+    // Only ever honor these two when the call is DAEMON-forwarded. Extraction
+    // happens on the RAW `toolParams` before schema validation, and a direct
+    // (non-daemon, e.g. stdio) caller controls those raw arguments outright --
+    // `daemonMode` is a server-CONSTRUCTION boundary such a caller cannot
+    // influence (see the `reviveNonFiniteArguments` gate above for the same
+    // reasoning), so gating on it is the only thing that stops a direct
+    // caller from forging its own transport deadline: a huge value would
+    // silently disable `setUIState`'s internal fallback budget, and a tiny
+    // one would make it discard already-completed work immediately (issue
+    // #6222 P1 review, fuQ8_ / fuTtS). Only a daemon-forwarded request ever
+    // legitimately sets either of these (`withSocketSessionAutolockKey` in
+    // `src/daemon/socketServer.ts`).
+    const requestTimeoutMs = daemonMode
+      ? extractInternalMcpRequestTimeoutMs(toolParams)
+      : undefined;
+    const requestLiveDeadlineKey = daemonMode
+      ? extractInternalLiveDeadlineKey(toolParams)
+      : undefined;
     const implicitAutolockMcpSessionId =
       requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
     const rawSessionUuid =
@@ -657,6 +684,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
             // is the first consumer).
             ...(requestTimeoutMs !== undefined
               ? { [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: requestTimeoutMs }
+              : {}),
+            // Same daemon-only provenance as `requestTimeoutMs` above -- lets
+            // `setUIStateHandler` resolve the LIVE (possibly progress-extended)
+            // deadline via `liveDeadlineRegistry` instead of only this frozen
+            // snapshot (issue #6222 P1 reopen).
+            ...(requestLiveDeadlineKey !== undefined
+              ? { [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: requestLiveDeadlineKey }
               : {}),
           }
         : parsedParams;

--- a/test/cli/setUIStateProgressToken.test.ts
+++ b/test/cli/setUIStateProgressToken.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  runCliCommand,
+  setDaemonProxyFactoryForTesting,
+  resetDaemonProxyFactoryForTesting,
+} from "../../src/cli";
+
+/**
+ * Root-cause regression for issue #6222's reopen. PR #6237 made a
+ * progress-emitting `tools/call` extend the daemon's request deadline via
+ * `notifications/progress`, keyed by MCP's `_meta.progressToken`. That
+ * plumbing depends entirely on the caller asking for progress relay --
+ * `DaemonMcpProxy.callTool(name, args, progressToken, onProgress)` only
+ * forwards a token, and `UnixSocketServer`/`DaemonClient` only arm
+ * `ProgressExtendableDeadline` extension, when one is present (see
+ * `test/daemon/socketServerProgressDeadlineExtension.test.ts`,
+ * "a tools/call with no progressToken never touches ... the deadline").
+ *
+ * `runToolViaDaemon` (the direct CLI->daemon path exercised by
+ * `runCliCommand`, as opposed to the MCP-server proxy in
+ * `src/server/proxyServer.ts` which always echoes the calling MCP client's
+ * own token) calls `proxy.callTool(toolName, params)` with NEITHER argument.
+ * So on this transport #6237's fix is entirely inert: a multi-field
+ * `setUIState` that keeps applying fields successfully still hits the
+ * daemon's un-extended, fixed timeout and has its accumulated per-field
+ * results discarded by a bare `-32001` timeout -- exactly what was
+ * reproduced against a real emulator in the reopen comment on #6222.
+ *
+ * This test pins the CLI-side half of that gap: it never even attempts to
+ * request progress relay, regardless of tool or field count.
+ */
+describe("runCliCommand never requests progress relay (issue #6222 reopen)", () => {
+  afterEach(() => {
+    resetDaemonProxyFactoryForTesting();
+  });
+
+  test("setUIState is forwarded with no progressToken and no onProgress callback", async () => {
+    const calls: unknown[][] = [];
+    setDaemonProxyFactoryForTesting((): any => ({
+      callTool: async (...args: unknown[]): Promise<any> => {
+        calls.push(args);
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+      close: async (): Promise<void> => {
+        // no-op fake
+      },
+    }));
+
+    await runCliCommand([
+      "setUIState",
+      "--fields",
+      JSON.stringify([
+        { selector: { text: "First name" }, value: "Grace" },
+        { selector: { text: "Last name" }, value: "Hopper" },
+        { selector: { text: "Phone" }, value: "5125550199" },
+      ]),
+    ]);
+
+    expect(calls).toHaveLength(1);
+    const [toolName, , progressToken, onProgress] = calls[0];
+    expect(toolName).toBe("setUIState");
+    // The bug: neither of these is ever populated on this transport, so the
+    // daemon has nothing to extend its deadline on no matter how long the
+    // fields take or how many of them there are.
+    expect(progressToken).toBeUndefined();
+    expect(onProgress).toBeUndefined();
+  });
+});

--- a/test/daemon/liveDeadlineRegistry.test.ts
+++ b/test/daemon/liveDeadlineRegistry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  registerLiveDeadline,
+  unregisterLiveDeadline,
+  getLiveDeadlineMs,
+} from "../../src/daemon/liveDeadlineRegistry";
+import { ProgressExtendableDeadline } from "../../src/daemon/mcpRequestTimeout";
+
+/**
+ * Issue #6222 P1 reopen (fuQ88 review): the in-process side channel that lets
+ * a tool handler on the OTHER side of the daemon's loopback HTTP call read
+ * back the LIVE value of a `ProgressExtendableDeadline` the daemon keeps
+ * extending as that SAME call emits progress -- instead of only a frozen
+ * snapshot forwarded once at call start.
+ */
+describe("liveDeadlineRegistry", () => {
+  test("returns undefined for a key that was never registered", () => {
+    expect(getLiveDeadlineMs("never-registered")).toBeUndefined();
+  });
+
+  test("returns the CURRENT value of a registered deadline, reflecting a later extension", () => {
+    const receivedAtMs = 1_000;
+    const deadline = new ProgressExtendableDeadline(receivedAtMs, 10_000);
+    const key = "req-1";
+    registerLiveDeadline(key, deadline);
+
+    expect(getLiveDeadlineMs(key)).toBe(receivedAtMs + 10_000);
+
+    // A progress tick extends the SAME object -- the registry must reflect
+    // that live, not the value captured at registration time.
+    deadline.extendOnProgress(receivedAtMs + 5_000, 50_000);
+    expect(getLiveDeadlineMs(key)).toBe(deadline.value);
+    expect(getLiveDeadlineMs(key)).toBeGreaterThan(receivedAtMs + 10_000);
+
+    unregisterLiveDeadline(key);
+  });
+
+  test("unregistering removes the entry so later reads see undefined again", () => {
+    const key = "req-2";
+    registerLiveDeadline(key, new ProgressExtendableDeadline(0, 1_000));
+    expect(getLiveDeadlineMs(key)).toBeDefined();
+
+    unregisterLiveDeadline(key);
+    expect(getLiveDeadlineMs(key)).toBeUndefined();
+  });
+
+  test("unregistering an unknown key is a safe no-op", () => {
+    expect(() => unregisterLiveDeadline("unknown-key")).not.toThrow();
+  });
+
+  test("registering under an existing key overwrites the previous entry", () => {
+    const key = "req-3";
+    const first = new ProgressExtendableDeadline(0, 1_000);
+    const second = new ProgressExtendableDeadline(0, 99_000);
+    registerLiveDeadline(key, first);
+    registerLiveDeadline(key, second);
+
+    expect(getLiveDeadlineMs(key)).toBe(second.value);
+
+    unregisterLiveDeadline(key);
+  });
+});

--- a/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.integration.test.ts
@@ -13,6 +13,7 @@ import {
   DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
 } from "../../src/daemon/constants";
 import { DEFAULT_OBSERVE_MCP_TIMEOUT_MS } from "../../src/daemon/mcpRequestTimeout";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -1930,8 +1931,45 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(args).toEqual({
       __mcpSessionId: expect.any(String),
       [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: DEFAULT_OBSERVE_MCP_TIMEOUT_MS,
+      [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: expect.any(Number),
     });
     expect(typeof args.__mcpSessionId).toBe("string");
+  });
+
+  test("anchors __mcpRequestDeadlineMs to the capture instant, not a later re-derived time (issue #6222 review, PRRT_kwDOP-GF5M6fuyts)", async () => {
+    let forwardedCall: unknown;
+    const beforeNowMs = fakeTimer.now();
+
+    server.mcpClientFactory = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async (request) => {
+          forwardedCall = request;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const response = await sendToolsCallWithoutArgs(socketPath, "observe");
+    const afterNowMs = fakeTimer.now();
+
+    expect(response.success).toBe(true);
+    const args = (forwardedCall as { arguments: Record<string, unknown> }).arguments;
+    const anchoredDeadlineMs = args[INTERNAL_MCP_REQUEST_DEADLINE_PARAM] as number;
+    const timeoutMs = args[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM] as number;
+
+    // The anchored deadline must equal "now (at capture) + the remaining
+    // budget forwarded alongside it" -- anchored to the SAME instant the
+    // remaining budget itself was computed, bounded by whatever the fake
+    // clock did across the whole round trip, with no additional unaccounted
+    // gap on top of `timeoutMs`.
+    expect(anchoredDeadlineMs).toBeGreaterThanOrEqual(beforeNowMs + timeoutMs);
+    expect(anchoredDeadlineMs).toBeLessThanOrEqual(afterNowMs + timeoutMs);
   });
 
   test("queued request fails fast when queue wait exceeds its timeout", async () => {

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1556,13 +1556,20 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     });
   };
 
-  test("reproduces the reopen: realistic per-field cost applies two fields then must return a structured partial result, never nothing", async () => {
+  test("reproduces the reopen: realistic per-field cost applies one field then must return a structured partial result, never nothing", async () => {
     // ~23s per field: two fields (46s) alone exceeds the whole-call budget,
     // reproducing "applies fields, then the transport would time out and
     // discard everything" from the dogfood report on a real CtrlProxy/adb
     // round trip -- except here execute() must stop itself and hand back
     // what it already did, instead of relying on the caller's transport to
     // ever return anything at all.
+    //
+    // The second field is admitted (field 1 finished well inside the 45s
+    // budget), but its own cost (23s) does not fit in what remains of that
+    // budget (22s) -- the per-field safety net (issue #6222 review,
+    // coderabbit fuTtO) now cuts it off mid-flight at the 45s deadline
+    // instead of letting it run to completion 1s past that deadline, which is
+    // exactly the overrun this whole feature exists to prevent.
     const result = await build(23_000).execute({
       fields: [
         { selector: { elementId: "firstName" }, value: "Grace" },
@@ -1579,12 +1586,16 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     const [first, last, phone] = result.fields;
     expect(first.success).toBe(true);
     expect(first.notAttempted).toBeFalsy();
-    expect(last.success).toBe(true);
+    // Admitted, started, but cut off by the per-field safety net before it
+    // could settle -- distinct from both "not attempted" and "attempted and
+    // failed".
+    expect(last.success).toBe(false);
     expect(last.notAttempted).toBeFalsy();
+    expect(last.timedOut).toBe(true);
 
     // The third field was never reached -- marked distinctly from "attempted
     // and failed" so a client knows it is safe to retry just this one field
-    // without re-sending (and duplicating) the two that already landed.
+    // without re-sending (and duplicating) the one that already landed.
     expect(phone.success).toBe(false);
     expect(phone.notAttempted).toBe(true);
     expect(result.error).toContain("result deadline");
@@ -1792,5 +1803,120 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     // and the fake was never invoked.
     expect(fakeObserve.getCallCount()).toBe(0);
     expect(fakeTimer.now()).toBe(callStartMs);
+  });
+
+  test("reads the LIVE (progress-extended) transport deadline via getLiveTransportDeadlineMs, not the frozen snapshot (issue #6222 P1 reopen, fuQ88 review)", async () => {
+    // A daemon call with a progress token keeps pushing its REAL transport
+    // deadline forward via `ProgressExtendableDeadline` as THIS call emits
+    // its own per-field progress notifications -- but the frozen
+    // `transportDeadlineMs` snapshot captured before `execute()` even started
+    // can never reflect that extension. `getLiveTransportDeadlineMs` models
+    // the caller (`setUIStateHandler`) reading that live object's CURRENT
+    // value at every check instead.
+    const callStartMs = fakeTimer.now();
+    const frozenTransportDeadlineMs = callStartMs + 50_000;
+    const liveTransportDeadlineMs = callStartMs + 300_000;
+
+    const result = await build(44_000).execute(
+      {
+        fields: [
+          { selector: { elementId: "firstName" }, value: "Grace" },
+          { selector: { elementId: "lastName" }, value: "Hopper" },
+          { selector: { elementId: "phone" }, value: "5125550199" },
+        ],
+      },
+      undefined,
+      undefined,
+      frozenTransportDeadlineMs,
+      () => liveTransportDeadlineMs,
+    );
+
+    // All three fields admitted and completed -- the frozen 50s snapshot
+    // alone would only have admitted the first (as the dedicated "ACTUAL
+    // transport deadline" test above proves).
+    expect(result.success).toBe(true);
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields.every((f) => f.success)).toBe(true);
+    expect(result.fields.every((f) => !f.notAttempted)).toBe(true);
+    expect(result.fields.every((f) => !f.timedOut)).toBe(true);
+
+    // Proof the LIVE value won, not the smaller frozen snapshot.
+    expect(fakeTimer.now() - callStartMs).toBeGreaterThan(50_000);
+    expect(fakeTimer.now()).toBeLessThan(liveTransportDeadlineMs);
+  });
+
+  test("a single admitted field that stalls past its budget returns a structured partial result before the transport deadline, never a bare discard (issue #6222 review, coderabbit fuTtO)", async () => {
+    // Models a field that is correctly ADMITTED (plenty of budget at the
+    // time) but then stalls indefinitely mid-flight -- e.g. a UI mutation
+    // that never settles. `ClearTextLike`/`InputTextLike` cannot currently be
+    // cancelled, so without the per-field safety net this would block
+    // `execute()` past the transport deadline and rediscover the exact
+    // silent-discard this whole feature exists to prevent.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 60_000;
+
+    let tapCalls = 0;
+    const stallingDependencies = {
+      tapOnElement: {
+        execute: async () => {
+          tapCalls++;
+          // Never resolves -- the only way this field's own promise can ever
+          // settle from here is if the abandoned call happens to finish in
+          // the background sometime after the race has already timed out.
+          return new Promise<{ success: boolean }>(() => {});
+        },
+      },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+    };
+
+    fakeFieldTypeDetector.setSkipVerification("firstName", true);
+    fakeObserve.setResult({
+      updatedAt: 0,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: threeFieldHierarchy,
+    });
+
+    const setUIState = new SetUIState(device, null, {
+      ...stallingDependencies,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    // Flush microtasks until the field's own admission/tap path has run and
+    // the race's timeout is armed against `fakeTimer` -- `advanceTime()`
+    // before that point would have nothing due to fire.
+    for (let i = 0; i < 10 && fakeTimer.getPendingTimeoutCount() === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
+    expect(tapCalls).toBe(1);
+
+    // Advance past the field's entire budget (the full transport deadline,
+    // per issue #6222 review -- headroom only bounds admission of the NEXT
+    // field, not this one's own hard deadline).
+    fakeTimer.advanceTime(60_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].success).toBe(false);
+    expect(result.fields[0].timedOut).toBe(true);
+    expect(result.fields[0].notAttempted).toBeFalsy();
+
+    // The structured result comes back with time to spare before the
+    // transport's own deadline -- never at or past it -- even though the
+    // stalled tap call is still pending in the background.
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
   });
 });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1894,17 +1894,23 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     );
 
     // Flush microtasks until the field's own admission/tap path has run and
-    // the race's timeout is armed against `fakeTimer` -- `advanceTime()`
-    // before that point would have nothing due to fire.
-    for (let i = 0; i < 10 && fakeTimer.getPendingTimeoutCount() === 0; i++) {
+    // its race's timeout is armed against `fakeTimer` -- `advanceTime()`
+    // before that point would have nothing due to fire. Waiting on `tapCalls`
+    // rather than merely "a pending timeout exists" matters now that the
+    // initial observation is ALSO raced (issue #6222 P1, fujun): that race
+    // arms (and quickly clears) its own timeout first, so a bare
+    // `pendingTimeoutCount() > 0` check could observe that earlier timer
+    // instead of the field's.
+    for (let i = 0; i < 50 && tapCalls === 0; i++) {
       await Promise.resolve();
     }
-    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
     expect(tapCalls).toBe(1);
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
 
-    // Advance past the field's entire budget (the full transport deadline,
-    // per issue #6222 review -- headroom only bounds admission of the NEXT
-    // field, not this one's own hard deadline).
+    // Advance past the field's entire budget (the full transport deadline
+    // minus RESPONSE_HEADROOM_MS, per issue #6222 P1 -- headroom only bounds
+    // admission of the NEXT field, not this one's own hard deadline, but the
+    // race must still finish strictly before the outer transport abort).
     fakeTimer.advanceTime(60_000);
     const result = await resultPromise;
 
@@ -1917,6 +1923,203 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     // The structured result comes back with time to spare before the
     // transport's own deadline -- never at or past it -- even though the
     // stalled tap call is still pending in the background.
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
+  });
+
+  test("a stalled field's race is armed to end at liveDeadline - RESPONSE_HEADROOM_MS, strictly before the daemon's outer abort (issue #6222 P1, fujug)", async () => {
+    // The daemon's own outer abort (`controller.abort()` in
+    // `handleIdeRequest`, `src/daemon/socketServer.ts`) fires EXACTLY at the
+    // live deadline, with no headroom of its own. If this field's race were
+    // armed for the SAME instant, the two timers would be a coin flip
+    // against response serialization instead of a guarantee that the
+    // structured partial result wins. Assert the armed duration directly,
+    // rather than only the final (forced-to-target) fake-clock reading a
+    // single big `advanceTime()` call would otherwise leave observable.
+    const RESPONSE_HEADROOM_MS = 3_000; // mirrors SetUIState's internal constant
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 60_000;
+
+    let tapCalls = 0;
+    const stallingDependencies = {
+      tapOnElement: {
+        execute: async () => {
+          tapCalls++;
+          // Never resolves.
+          return new Promise<{ success: boolean }>(() => {});
+        },
+      },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+    };
+
+    fakeFieldTypeDetector.setSkipVerification("firstName", true);
+    fakeObserve.setResult({
+      updatedAt: 0,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: threeFieldHierarchy,
+    });
+
+    const setUIState = new SetUIState(device, null, {
+      ...stallingDependencies,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    for (let i = 0; i < 50 && tapCalls === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(tapCalls).toBe(1);
+
+    // Exactly one pending timeout at this point -- the initial observation's
+    // own race already resolved and cleared its timer. Its duration must be
+    // the deadline minus the response headroom, not the full transport
+    // deadline.
+    const pending = fakeTimer.getPendingTimeouts();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toBe(transportDeadlineMs - RESPONSE_HEADROOM_MS - fakeTimer.now());
+
+    fakeTimer.advanceTime(60_000);
+    const result = await resultPromise;
+
+    expect(result.fields[0].timedOut).toBe(true);
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
+  });
+
+  test("a mid-field progress notification that extends the live deadline re-arms THAT field's own race, not just fields admitted afterward (issue #6222 P1, fujuk)", async () => {
+    // Models a field whose total device cost (50s) exceeds the ORIGINAL 30s
+    // transport deadline's own cutoff (27s, after RESPONSE_HEADROOM_MS), but
+    // whose own tap step reports progress partway through -- the trigger
+    // that extends a real `ProgressExtendableDeadline` on the daemon side.
+    // Without re-arming against the LIVE deadline on that tick, this field
+    // would incorrectly time out at the stale 27s snapshot despite the
+    // transport itself remaining valid far longer.
+    const callStartMs = fakeTimer.now();
+    const frozenTransportDeadlineMs = callStartMs + 30_000;
+    let liveDeadlineMs = frozenTransportDeadlineMs;
+
+    const stallingDependencies = {
+      tapOnElement: {
+        execute: async (
+          _opts: unknown,
+          progress?: (p: number, t?: number, m?: string) => Promise<void>,
+        ) => {
+          fakeTimer.advanceTime(10_000);
+          await progress?.(1, 2, "tap done");
+          return { success: true };
+        },
+      },
+      clearText: {
+        execute: async () => {
+          fakeTimer.advanceTime(20_000);
+          return { success: true };
+        },
+      },
+      inputText: {
+        execute: async (text: string) => {
+          fakeTimer.advanceTime(20_000);
+          return { success: true, text };
+        },
+      },
+    };
+
+    fakeFieldTypeDetector.setSkipVerification("firstName", true);
+    fakeObserve.setResult({
+      updatedAt: 0,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: threeFieldHierarchy,
+    });
+
+    const setUIState = new SetUIState(device, null, {
+      ...stallingDependencies,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const result = await setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      // Stands in for the daemon's onprogress handler: extends the shared
+      // `ProgressExtendableDeadline` SYNCHRONOUSLY as part of handling this
+      // call's own progress notification, exactly as `extendOnProgress`
+      // (`src/daemon/socketServer.ts`) does before the notification's own
+      // round trip completes -- not merely sometime after.
+      async () => {
+        liveDeadlineMs = callStartMs + 120_000;
+      },
+      undefined,
+      frozenTransportDeadlineMs,
+      () => liveDeadlineMs,
+    );
+
+    // The field ran for 50s total -- well past the ORIGINAL 30s deadline's
+    // own cutoff -- and still succeeded, because the mid-field progress
+    // extension re-armed its race against the NEW, larger live deadline
+    // instead of leaving it bound by the stale snapshot captured at
+    // admission.
+    expect(result.success).toBe(true);
+    expect(result.fields[0].success).toBe(true);
+    expect(result.fields[0].timedOut).toBeFalsy();
+    expect(fakeTimer.now() - callStartMs).toBeGreaterThan(30_000);
+    expect(fakeTimer.now()).toBeLessThan(liveDeadlineMs);
+  });
+
+  test("a stalled initial observation with a tight post-queue budget returns bounded all-notAttempted results, never awaited unbounded (issue #6222 P1, fujun)", async () => {
+    // Queueing leaves just over the 20s admission headroom (21s), so the
+    // coarse pre-check passes -- but the initial observation itself then
+    // stalls indefinitely. Only racing the observation itself (not merely
+    // preceding it with the pre-check) keeps this bounded.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 21_000;
+
+    const stallingObserve = {
+      execute: () => new Promise<never>(() => {}),
+    };
+
+    const setUIState = new SetUIState(device, null, {
+      tapOnElement: { execute: async () => ({ success: true }) },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+      swipeOn: fakeSwipe,
+      observeScreen: stallingObserve as unknown as FakeObserveScreenForSetUIState,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    for (let i = 0; i < 50 && fakeTimer.getPendingTimeoutCount() === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
+
+    fakeTimer.advanceTime(21_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.totalAttempts).toBe(0);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].notAttempted).toBe(true);
+    expect(result.error).toContain("initial observation");
+
+    // Returned strictly before the outer transport deadline, never at or
+    // past it.
     expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
   });
 });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { SetUIState } from "../../../src/features/action/SetUIState";
 import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { MIN_SET_UI_STATE_MCP_TIMEOUT_MS } from "../../../src/daemon/mcpRequestTimeout";
 import {
   FakeTapOnElement,
   FakeInputText,
@@ -1428,11 +1429,19 @@ describe("SetUIState budget is unaffected by slow work before the search (#4252 
 
     fakeFieldTypeDetector.setSkipVerification("first", true);
 
+    let observeCalls = 0;
     fakeObserve.setResultFactory(() => {
-      // Must EXCEED the 20s budget. At 19s the old rolling deadline — re-armed
-      // to now+20s just before this observe — still had a second left, so a
-      // scroll attempt happened either way and the test could not fail.
-      fakeTimer.advanceTime(25_000);
+      observeCalls++;
+      // Only the post-success refresh observe (the 2nd call) needs to EXCEED
+      // the 20s search budget to regression-proof #4252 — at 19s the old
+      // rolling deadline, re-armed to now+20s just before this observe,
+      // still had a second left, so a scroll attempt happened either way and
+      // the test could not fail. The initial pre-loop observe stays cheap so
+      // the total stays comfortably under the whole-call
+      // RESULT_DEADLINE_BUDGET_MS safety net added for issue #6222's
+      // reopen — that budget is a different, larger concern this test does
+      // not exercise.
+      fakeTimer.advanceTime(observeCalls === 1 ? 1_000 : 25_000);
       return {
         updatedAt: fakeTimer.now(),
         screenSize: { width: 1080, height: 1920 },
@@ -1451,5 +1460,205 @@ describe("SetUIState budget is unaffected by slow work before the search (#4252 
     // The off-screen field must have been searched for, not skipped because
     // earlier work had already aged the deadline.
     expect(fakeSwipe.getCallCount()).toBeGreaterThan(0);
+  });
+});
+
+describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  /** All three fields are visible on screen from the very first observation. */
+  const threeFieldHierarchy: ViewHierarchyResult = {
+    hierarchy: {
+      node: [
+        {
+          $: {
+            bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+            "resource-id": "firstName",
+            class: "android.widget.EditText",
+          },
+        },
+        {
+          $: {
+            bounds: { left: 0, top: 60, right: 100, bottom: 110 },
+            "resource-id": "lastName",
+            class: "android.widget.EditText",
+          },
+        },
+        {
+          $: {
+            bounds: { left: 0, top: 120, right: 100, bottom: 170 },
+            "resource-id": "phone",
+            class: "android.widget.EditText",
+          },
+        },
+      ],
+    },
+  } as unknown as ViewHierarchyResult;
+
+  /**
+   * A tap/clear/input trio that costs `perFieldMs` of simulated device time
+   * per field, modeling the real per-field apply work (tap + clear + type)
+   * that on real hardware takes several seconds each -- the same layers
+   * (SetUIState's field loop) the CLI->daemon path drives in production.
+   */
+  function buildSlowFieldDependencies(perFieldMs: number) {
+    const tapOnElement = {
+      execute: async () => {
+        fakeTimer.advanceTime(Math.round(perFieldMs * 0.6));
+        return { success: true };
+      },
+    };
+    const clearText = {
+      execute: async () => {
+        fakeTimer.advanceTime(Math.round(perFieldMs * 0.2));
+        return { success: true };
+      },
+    };
+    const inputText = {
+      execute: async (text: string) => {
+        fakeTimer.advanceTime(Math.round(perFieldMs * 0.2));
+        return { success: true, text };
+      },
+    };
+    return { tapOnElement, clearText, inputText };
+  }
+
+  const build = (perFieldMs: number) => {
+    const { tapOnElement, clearText, inputText } = buildSlowFieldDependencies(perFieldMs);
+    fakeFieldTypeDetector.setSkipVerification("firstName", true);
+    fakeFieldTypeDetector.setSkipVerification("lastName", true);
+    fakeFieldTypeDetector.setSkipVerification("phone", true);
+    fakeObserve.setResult({
+      updatedAt: 0,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: threeFieldHierarchy,
+    });
+    return new SetUIState(device, null, {
+      tapOnElement,
+      clearText,
+      inputText,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+  };
+
+  test("reproduces the reopen: realistic per-field cost applies two fields then must return a structured partial result, never nothing", async () => {
+    // ~23s per field: two fields (46s) alone exceeds the whole-call budget,
+    // reproducing "applies fields, then the transport would time out and
+    // discard everything" from the dogfood report on a real CtrlProxy/adb
+    // round trip -- except here execute() must stop itself and hand back
+    // what it already did, instead of relying on the caller's transport to
+    // ever return anything at all.
+    const result = await build(23_000).execute({
+      fields: [
+        { selector: { elementId: "firstName" }, value: "Grace" },
+        { selector: { elementId: "lastName" }, value: "Hopper" },
+        { selector: { elementId: "phone" }, value: "5125550199" },
+      ],
+    });
+
+    // A real result -- never a thrown timeout -- and it must not lie about
+    // overall success once a field was left unattempted.
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(3);
+
+    const [first, last, phone] = result.fields;
+    expect(first.success).toBe(true);
+    expect(first.notAttempted).toBeFalsy();
+    expect(last.success).toBe(true);
+    expect(last.notAttempted).toBeFalsy();
+
+    // The third field was never reached -- marked distinctly from "attempted
+    // and failed" so a client knows it is safe to retry just this one field
+    // without re-sending (and duplicating) the two that already landed.
+    expect(phone.success).toBe(false);
+    expect(phone.notAttempted).toBe(true);
+    expect(result.error).toContain("result deadline");
+  });
+
+  test("stays within the setUIState transport floor even in the worst case", async () => {
+    const result = await build(23_000).execute({
+      fields: [
+        { selector: { elementId: "firstName" }, value: "Grace" },
+        { selector: { elementId: "lastName" }, value: "Hopper" },
+        { selector: { elementId: "phone" }, value: "5125550199" },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    // The whole call must return well inside MIN_SET_UI_STATE_MCP_TIMEOUT_MS
+    // (the transport floor added alongside this fix) -- this is the property
+    // that keeps a real client from ever seeing a bare -32001 after work was
+    // applied, on the direct CLI->daemon path where progress relay never
+    // extends anything.
+    expect(fakeTimer.now()).toBeLessThan(MIN_SET_UI_STATE_MCP_TIMEOUT_MS);
+  });
+
+  test("a fast multi-field call still returns full, unmarked results (no false positives from the new budget)", async () => {
+    const result = await build(500).execute({
+      fields: [
+        { selector: { elementId: "firstName" }, value: "Grace" },
+        { selector: { elementId: "lastName" }, value: "Hopper" },
+        { selector: { elementId: "phone" }, value: "5125550199" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields.every((f) => f.success)).toBe(true);
+    expect(result.fields.every((f) => !f.notAttempted)).toBe(true);
+  });
+
+  test("single-field fast-fail is unaffected by the new budget", async () => {
+    // Matches the issue's "Phone" case: an unclassifiable single field fails
+    // instantly with its own diagnosis, well under any budget.
+    const hierarchyWithLabel: ViewHierarchyResult = {
+      hierarchy: {
+        node: [
+          {
+            $: { bounds: { left: 0, top: 0, right: 100, bottom: 50 }, text: "Phone" },
+          },
+        ],
+      },
+    } as unknown as ViewHierarchyResult;
+    fakeObserve.setResult({
+      updatedAt: 0,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: hierarchyWithLabel,
+    });
+    fakeFieldTypeDetector.setFieldType("Phone", "unknown" as any);
+
+    const result = await new SetUIState(device, null, {
+      tapOnElement: { execute: async () => ({ success: true }) },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    }).execute({
+      fields: [{ selector: { text: "Phone" }, value: "5125550199" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].notAttempted).toBeFalsy();
+    expect(result.error).toContain("Phone");
+    expect(fakeTimer.now()).toBeLessThan(1_000);
   });
 });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -2123,3 +2123,141 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
   });
 });
+
+describe("SetUIState off-screen search device I/O is bounded by the result deadline (issue #6222 review, PRRT_kwDOP-GF5M6fuyts)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  /** The requested field is absent from every observation -- the search loop runs. */
+  const emptyHierarchy: ViewHierarchyResult = {
+    hierarchy: { node: [] },
+  } as unknown as ViewHierarchyResult;
+
+  beforeEach(() => {
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  test("a stalled SwipeOn.execute during off-screen search returns the accumulated result instead of letting the outer abort discard it", async () => {
+    // When a requested field is absent from the current hierarchy, the last
+    // deadline check runs BEFORE the unbounded swipe + re-observe pair. If
+    // the swipe stalls, that award must still be bounded by the same live
+    // cutoff every other device call in this method already respects.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 30_000;
+
+    let swipeCalls = 0;
+    const stallingSwipe = {
+      execute: async () => {
+        swipeCalls++;
+        // Never resolves.
+        return new Promise<{ success: boolean }>(() => {});
+      },
+    };
+
+    const observeScreen = {
+      execute: async () => ({
+        updatedAt: fakeTimer.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        viewHierarchy: emptyHierarchy,
+      }),
+    };
+
+    const setUIState = new SetUIState(device, null, {
+      tapOnElement: { execute: async () => ({ success: true }) },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+      swipeOn: stallingSwipe as unknown as FakeSwipeOn,
+      observeScreen: observeScreen as unknown as FakeObserveScreenForSetUIState,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    for (let i = 0; i < 50 && swipeCalls === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(swipeCalls).toBe(1);
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
+
+    fakeTimer.advanceTime(30_000);
+    const result = await resultPromise;
+
+    // A real, structured result -- never a hang past the deadline -- with the
+    // never-found field marked not-attempted rather than silently discarded.
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].notAttempted).toBe(true);
+    expect(result.error).toContain("result deadline");
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
+  });
+
+  test("a stalled follow-up ObserveScreen.execute during off-screen search returns the accumulated result instead of letting the outer abort discard it", async () => {
+    // Same hazard as above, but the swipe itself completes and it is the
+    // follow-up re-observe (the second call into ObserveScreen -- the first
+    // is the initial observation) that stalls.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 30_000;
+
+    const swipeOn = {
+      execute: async () => ({ success: true }),
+    };
+
+    let observeCalls = 0;
+    const observeScreen = {
+      execute: async () => {
+        observeCalls++;
+        if (observeCalls === 1) {
+          return {
+            updatedAt: fakeTimer.now(),
+            screenSize: { width: 1080, height: 1920 },
+            systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+            viewHierarchy: emptyHierarchy,
+          };
+        }
+        // The follow-up re-observe after the swipe -- never resolves.
+        return new Promise<never>(() => {});
+      },
+    };
+
+    const setUIState = new SetUIState(device, null, {
+      tapOnElement: { execute: async () => ({ success: true }) },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+      swipeOn: swipeOn as unknown as FakeSwipeOn,
+      observeScreen: observeScreen as unknown as FakeObserveScreenForSetUIState,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "firstName" }, value: "Grace" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    for (let i = 0; i < 50 && observeCalls < 2; i++) {
+      await Promise.resolve();
+    }
+    expect(observeCalls).toBe(2);
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
+
+    fakeTimer.advanceTime(30_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].notAttempted).toBe(true);
+    expect(result.error).toContain("result deadline");
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
+  });
+});

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1705,4 +1705,92 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     expect(result.error).toContain("Phone");
     expect(fakeTimer.now()).toBeLessThan(1_000);
   });
+
+  test("a progress-extended transport deadline (200s) is respected, NOT capped at the internal 45s budget (issue #6222 P1)", async () => {
+    // Models a progress-aware caller (executePlan, or a daemon call with a
+    // progressToken) whose ProgressExtendableDeadline has extended the
+    // transport deadline well past the fixed internal RESULT_DEADLINE_BUDGET_MS
+    // fallback -- e.g. toward the 300s ceiling. Three fields at 50s each (150s
+    // total) would have been truncated at ~45s by the old `Math.min` against
+    // the fixed internal budget; with a known, larger transport deadline all
+    // three must be admitted and none marked `notAttempted`.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 200_000;
+
+    const result = await build(50_000).execute(
+      {
+        fields: [
+          { selector: { elementId: "firstName" }, value: "Grace" },
+          { selector: { elementId: "lastName" }, value: "Hopper" },
+          { selector: { elementId: "phone" }, value: "5125550199" },
+        ],
+      },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields.every((f) => f.success)).toBe(true);
+    expect(result.fields.every((f) => !f.notAttempted)).toBe(true);
+
+    // The whole call ran well past the fixed 45s internal budget (the
+    // fallback used only when no transport deadline is known) -- proof the
+    // extended transport deadline was actually honored rather than clamped.
+    const INTERNAL_RESULT_DEADLINE_BUDGET_MS = 45_000;
+    expect(fakeTimer.now() - callStartMs).toBeGreaterThan(INTERNAL_RESULT_DEADLINE_BUDGET_MS);
+    // And it still lands safely under the ACTUAL (extended) transport deadline.
+    expect(fakeTimer.now()).toBeLessThan(transportDeadlineMs);
+  });
+
+  test("checks the budget BEFORE the initial observation: an already-expired admission deadline returns all-notAttempted without observing (issue #6222 P1)", async () => {
+    // Models queueing having already consumed more than 40s of a 60s socket
+    // budget before execute() is even invoked: the transport deadline handed
+    // in has only 20s left, which is entirely eaten by
+    // PER_FIELD_ADMISSION_HEADROOM_MS, so there is no budget left for even one
+    // field. The initial observation must never be awaited in this case -- a
+    // cold/stalled observe could otherwise blow the transport deadline before
+    // any field is attempted, discarding everything.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 20_000;
+
+    // If the initial observe were ever called, this would burn 30s of
+    // simulated time -- proving (via the call count and elapsed time
+    // assertions below) that execute() never reached it.
+    fakeObserve.setResultFactory(() => {
+      fakeTimer.advanceTime(30_000);
+      return {
+        updatedAt: fakeTimer.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        viewHierarchy: threeFieldHierarchy,
+      };
+    });
+
+    const result = await build(500).execute(
+      {
+        fields: [
+          { selector: { elementId: "firstName" }, value: "Grace" },
+          { selector: { elementId: "lastName" }, value: "Hopper" },
+          { selector: { elementId: "phone" }, value: "5125550199" },
+        ],
+      },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.totalAttempts).toBe(0);
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields.every((f) => f.notAttempted)).toBe(true);
+    expect(result.fields.every((f) => !f.success)).toBe(true);
+    expect(result.error).toContain("before the initial observation");
+
+    // The initial observe was never awaited -- no simulated time was burned
+    // and the fake was never invoked.
+    expect(fakeObserve.getCallCount()).toBe(0);
+    expect(fakeTimer.now()).toBe(callStartMs);
+  });
 });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -2261,3 +2261,94 @@ describe("SetUIState off-screen search device I/O is bounded by the result deadl
     expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
   });
 });
+
+describe("SetUIState post-success observation refresh is bounded by the result deadline (issue #6222 review, PRRT_kwDOP-GF5M6fu4ev)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  test("a stalled post-success observation refresh after a verification-skipped field returns the accumulated result instead of letting the outer abort discard it", async () => {
+    // Password fields skip verification, so `processField()` returns without
+    // a `freshObservation` -- `observationAfterSuccess()`'s fallback then
+    // issues an unbounded `ObserveScreen.execute()`. If THAT stalls, it must
+    // still be bounded by the same live cutoff every other device call in
+    // this method already respects.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 30_000;
+
+    const passwordHierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: [
+          {
+            $: {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "password",
+              text: "",
+              class: "android.widget.EditText",
+              password: "true",
+            },
+          },
+        ],
+      },
+    };
+
+    fakeFieldTypeDetector.setFieldType("password", "text");
+    fakeFieldTypeDetector.setIsPasswordField("password", true);
+
+    let observeCalls = 0;
+    const observeScreen = {
+      execute: async () => {
+        observeCalls++;
+        if (observeCalls === 1) {
+          return {
+            updatedAt: fakeTimer.now(),
+            screenSize: { width: 1080, height: 1920 },
+            systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+            viewHierarchy: passwordHierarchy,
+          };
+        }
+        // The post-success observation refresh -- never resolves.
+        return new Promise<never>(() => {});
+      },
+    };
+
+    const setUIState = new SetUIState(device, null, {
+      tapOnElement: { execute: async () => ({ success: true }) },
+      clearText: { execute: async () => ({ success: true }) },
+      inputText: { execute: async (text: string) => ({ success: true, text }) },
+      swipeOn: { execute: async () => ({ success: true }) } as unknown as FakeSwipeOn,
+      observeScreen: observeScreen as unknown as FakeObserveScreenForSetUIState,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer,
+    });
+
+    const resultPromise = setUIState.execute(
+      { fields: [{ selector: { elementId: "password" }, value: "secret123" }] },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    for (let i = 0; i < 50 && observeCalls < 2; i++) {
+      await Promise.resolve();
+    }
+    expect(observeCalls).toBe(2);
+    expect(fakeTimer.getPendingTimeoutCount()).toBeGreaterThan(0);
+
+    fakeTimer.advanceTime(30_000);
+    const result = await resultPromise;
+
+    // The field itself succeeded and must be reported as such -- only the
+    // follow-up observation stalled -- and the call must return a real,
+    // structured result rather than hang past the deadline.
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].success).toBe(true);
+    expect(result.error).toContain("post-success observation refresh");
+    expect(fakeTimer.now()).toBeLessThanOrEqual(transportDeadlineMs);
+  });
+});

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1608,6 +1608,50 @@ describe("SetUIState whole-call result deadline (issue #6222 reopen)", () => {
     expect(fakeTimer.now()).toBeLessThan(MIN_SET_UI_STATE_MCP_TIMEOUT_MS);
   });
 
+  test("bounds field admission by the ACTUAL transport deadline, not just the internal 45s budget (issue #6222 P1)", async () => {
+    // Models the exact overshoot the P1 review flagged: a daemon-forwarded
+    // call whose 60s transport budget already had queue time deducted by the
+    // time it reached execute() -- represented here directly as the absolute
+    // deadline `transportDeadlineMs`, since that is all `execute()` ever
+    // sees. Field 1 costs 44s, landing close to that deadline with only 6s
+    // of transport budget left -- far short of the reserved per-field
+    // headroom -- so field 2 must NOT be admitted.
+    const callStartMs = fakeTimer.now();
+    const transportDeadlineMs = callStartMs + 50_000;
+
+    const result = await build(44_000).execute(
+      {
+        fields: [
+          { selector: { elementId: "firstName" }, value: "Grace" },
+          { selector: { elementId: "lastName" }, value: "Hopper" },
+          { selector: { elementId: "phone" }, value: "5125550199" },
+        ],
+      },
+      undefined,
+      undefined,
+      transportDeadlineMs,
+    );
+
+    // A real, structured result -- never a bare discard.
+    expect(result.success).toBe(false);
+    expect(result.fields).toHaveLength(3);
+
+    const [first, last, phone] = result.fields;
+    expect(first.success).toBe(true);
+    expect(first.notAttempted).toBeFalsy();
+    // Neither remaining field was admitted -- there wasn't enough of the
+    // ACTUAL transport budget left to safely start another.
+    expect(last.notAttempted).toBe(true);
+    expect(phone.notAttempted).toBe(true);
+
+    // The structured result comes back with real time to spare before the
+    // transport's own deadline -- never at or past it.
+    expect(fakeTimer.now()).toBeLessThan(transportDeadlineMs);
+    // And it also stays comfortably inside the setUIState transport floor,
+    // measured from when this call actually started.
+    expect(fakeTimer.now() - callStartMs).toBeLessThan(MIN_SET_UI_STATE_MCP_TIMEOUT_MS);
+  });
+
   test("a fast multi-field call still returns full, unmarked results (no false positives from the new budget)", async () => {
     const result = await build(500).execute({
       fields: [

--- a/test/server/formTools.setUIStateDeadline.test.ts
+++ b/test/server/formTools.setUIStateDeadline.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/server/formTools";
 import {
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
   INTERNAL_EXECUTION_START_TIME_PARAM,
   INTERNAL_LIVE_DEADLINE_KEY_PARAM,
 } from "../../src/daemon/constants";
@@ -131,5 +132,61 @@ describe("setUIStateHandler transport-deadline wiring (issue #6222 P1 reopen)", 
 
     expect(capturedGetLiveTransportDeadlineMs).toBeDefined();
     expect(capturedGetLiveTransportDeadlineMs?.()).toBeUndefined();
+  });
+
+  test("prefers the anchored __mcpRequestDeadlineMs over recomputing startTime + remainingMs (issue #6222 review, PRRT_kwDOP-GF5M6fuyts)", async () => {
+    // Simulate dispatch/admission delay between when the daemon captured the
+    // remaining budget (executionStartTime here is the LATER, post-dispatch
+    // timestamp `INTERNAL_EXECUTION_START_TIME_PARAM` carries) and when it
+    // actually captured `remainingMs` moments earlier -- the anchored
+    // deadline must win regardless of that gap.
+    const anchoredDeadlineMs = 5_000;
+    const executionStartTime = 4_000; // recorded AFTER a dispatch delay
+    const remainingMs = 10_000; // captured BEFORE that delay
+
+    let capturedTransportDeadlineMs: number | undefined;
+    setSetUIStateFactory(() => ({
+      execute: async (_options, _progress, _signal, transportDeadlineMs) => {
+        capturedTransportDeadlineMs = transportDeadlineMs;
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+
+    const argsWithBothParams = {
+      ...baseArgs,
+      [INTERNAL_EXECUTION_START_TIME_PARAM]: executionStartTime,
+      [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: remainingMs,
+      [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: anchoredDeadlineMs,
+    } as unknown as SetUIStateArgs;
+
+    await setUIStateHandler(androidDevice, argsWithBothParams);
+
+    // Naively recomputing from startTime + remainingMs would yield 14_000 --
+    // LATER than the daemon's real outer abort. The anchored value must win.
+    expect(capturedTransportDeadlineMs).toBe(anchoredDeadlineMs);
+    expect(capturedTransportDeadlineMs).not.toBe(executionStartTime + remainingMs);
+  });
+
+  test("falls back to startTime + remainingMs when no anchored deadline is present (older daemon build)", async () => {
+    const executionStartTime = 1_000;
+    const remainingMs = 10_000;
+
+    let capturedTransportDeadlineMs: number | undefined;
+    setSetUIStateFactory(() => ({
+      execute: async (_options, _progress, _signal, transportDeadlineMs) => {
+        capturedTransportDeadlineMs = transportDeadlineMs;
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+
+    const argsWithLegacyParamsOnly = {
+      ...baseArgs,
+      [INTERNAL_EXECUTION_START_TIME_PARAM]: executionStartTime,
+      [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: remainingMs,
+    } as unknown as SetUIStateArgs;
+
+    await setUIStateHandler(androidDevice, argsWithLegacyParamsOnly);
+
+    expect(capturedTransportDeadlineMs).toBe(executionStartTime + remainingMs);
   });
 });

--- a/test/server/formTools.setUIStateDeadline.test.ts
+++ b/test/server/formTools.setUIStateDeadline.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Issue #6222 P1 reopen (fuQ88 review): `setUIStateHandler` must resolve both
+ * the frozen transport-deadline snapshot AND a LIVE getter backed by
+ * `liveDeadlineRegistry`, and pass both through to `SetUIState.execute()` --
+ * the live getter (when present) is what lets `execute()` see a
+ * progress-driven extension the frozen snapshot alone can never reflect.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  resetSetUIStateFactory,
+  setSetUIStateFactory,
+  setUIStateHandler,
+} from "../../src/server/formTools";
+import {
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_EXECUTION_START_TIME_PARAM,
+  INTERNAL_LIVE_DEADLINE_KEY_PARAM,
+} from "../../src/daemon/constants";
+import {
+  registerLiveDeadline,
+  unregisterLiveDeadline,
+} from "../../src/daemon/liveDeadlineRegistry";
+import { ProgressExtendableDeadline } from "../../src/daemon/mcpRequestTimeout";
+import type { BootedDevice } from "../../src/models";
+import type { SetUIStateArgs } from "../../src/server/formTools";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 8",
+  platform: "android",
+};
+
+const baseArgs = {
+  fields: [{ selector: { elementId: "firstName" }, value: "Grace" }],
+} as unknown as SetUIStateArgs;
+
+describe("setUIStateHandler transport-deadline wiring (issue #6222 P1 reopen)", () => {
+  afterEach(() => {
+    resetSetUIStateFactory();
+  });
+
+  test("passes both the frozen transportDeadlineMs snapshot and a live getter through to execute()", async () => {
+    const executionStartTime = 1_000;
+    const remainingMs = 10_000;
+    const liveKey = "test-live-key-1";
+    const deadline = new ProgressExtendableDeadline(executionStartTime, remainingMs);
+    registerLiveDeadline(liveKey, deadline);
+
+    let capturedTransportDeadlineMs: number | undefined;
+    let capturedGetLiveTransportDeadlineMs: (() => number | undefined) | undefined;
+    setSetUIStateFactory(() => ({
+      execute: async (
+        _options,
+        _progress,
+        _signal,
+        transportDeadlineMs,
+        getLiveTransportDeadlineMs,
+      ) => {
+        capturedTransportDeadlineMs = transportDeadlineMs;
+        capturedGetLiveTransportDeadlineMs = getLiveTransportDeadlineMs;
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+
+    const argsWithInternalParams = {
+      ...baseArgs,
+      [INTERNAL_EXECUTION_START_TIME_PARAM]: executionStartTime,
+      [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: remainingMs,
+      [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: liveKey,
+    } as unknown as SetUIStateArgs;
+
+    await setUIStateHandler(androidDevice, argsWithInternalParams);
+
+    expect(capturedTransportDeadlineMs).toBe(executionStartTime + remainingMs);
+    expect(capturedGetLiveTransportDeadlineMs).toBeDefined();
+    // The live getter reads the registry LIVE -- proof it is not just a
+    // second copy of the frozen snapshot.
+    expect(capturedGetLiveTransportDeadlineMs?.()).toBe(deadline.value);
+    deadline.extendOnProgress(executionStartTime + 5_000, 300_000);
+    expect(capturedGetLiveTransportDeadlineMs?.()).toBe(deadline.value);
+    expect(capturedGetLiveTransportDeadlineMs?.()).toBeGreaterThan(
+      executionStartTime + remainingMs,
+    );
+
+    unregisterLiveDeadline(liveKey);
+  });
+
+  test("resolves no live getter when no live-deadline key is present (direct/non-daemon call)", async () => {
+    let capturedGetLiveTransportDeadlineMs: (() => number | undefined) | undefined = () => 0;
+    setSetUIStateFactory(() => ({
+      execute: async (
+        _options,
+        _progress,
+        _signal,
+        _transportDeadlineMs,
+        getLiveTransportDeadlineMs,
+      ) => {
+        capturedGetLiveTransportDeadlineMs = getLiveTransportDeadlineMs;
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+
+    await setUIStateHandler(androidDevice, baseArgs);
+
+    expect(capturedGetLiveTransportDeadlineMs).toBeUndefined();
+  });
+
+  test("the live getter reads undefined once the registry entry is gone (call already settled)", async () => {
+    const liveKey = "test-live-key-2";
+    // Never registered -- models a call whose deadline already expired.
+    let capturedGetLiveTransportDeadlineMs: (() => number | undefined) | undefined;
+    setSetUIStateFactory(() => ({
+      execute: async (
+        _options,
+        _progress,
+        _signal,
+        _transportDeadlineMs,
+        getLiveTransportDeadlineMs,
+      ) => {
+        capturedGetLiveTransportDeadlineMs = getLiveTransportDeadlineMs;
+        return { success: true, fields: [], totalAttempts: 0 };
+      },
+    }));
+
+    const argsWithLiveKeyOnly = {
+      ...baseArgs,
+      [INTERNAL_LIVE_DEADLINE_KEY_PARAM]: liveKey,
+    } as unknown as SetUIStateArgs;
+
+    await setUIStateHandler(androidDevice, argsWithLiveKeyOnly);
+
+    expect(capturedGetLiveTransportDeadlineMs).toBeDefined();
+    expect(capturedGetLiveTransportDeadlineMs?.()).toBeUndefined();
+  });
+});

--- a/test/server/internalTimeoutParamProvenance.test.ts
+++ b/test/server/internalTimeoutParamProvenance.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #6222 P1 review (codex fuQ8_ / coderabbit fuTtS): a direct MCP caller
+ * on a non-daemon server (`createMcpServer({ daemonMode: false })`) must
+ * never be able to forge its own transport deadline by supplying the
+ * undocumented `__mcpRequestTimeoutMs` argument -- only a daemon-forwarded
+ * call (`daemonMode: true`, the only topology that ever legitimately sets it,
+ * see `withSocketSessionAutolockKey` in `src/daemon/socketServer.ts`) may
+ * have it honored and reattached onto the handler's arguments.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { createStructuredToolResponse, getStructuredField } from "../../src/utils/toolUtils";
+import { INTERNAL_MCP_REQUEST_TIMEOUT_PARAM } from "../../src/daemon/constants";
+
+const TOOL = "__internal_timeout_provenance_probe_6222__";
+
+describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", () => {
+  beforeAll(() => {
+    ToolRegistry.register(
+      TOOL,
+      "probe tool that reports back whatever internal timeout param it received",
+      // Deliberately NOT `.passthrough()` -- matches `setUIStateSchema`'s
+      // real shape (a plain z.object), which silently strips any unknown key
+      // (including a caller-forged `__mcpRequestTimeoutMs`) during
+      // `tool.schema.parse()`. The reattachment this test targets happens
+      // AFTER that parse, straight onto `handlerParams`, so it is exercised
+      // regardless of schema shape -- passthrough would conflate that with
+      // an unrelated pre-existing gap in `stripInternalToolParams`'s guard.
+      z.object({}),
+      async (args: unknown) => {
+        const received = (args as Record<string, unknown>)[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+        return createStructuredToolResponse({
+          success: true,
+          receivedTimeoutMs: typeof received === "number" ? received : null,
+        });
+      },
+      {
+        outputSchema: z.object({
+          success: z.boolean(),
+          receivedTimeoutMs: z.number().nullable(),
+        }),
+      },
+    );
+  });
+
+  afterAll(() => {
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(TOOL);
+  });
+
+  describe("daemonMode: false (direct, non-daemon server)", () => {
+    let fixture: McpTestFixture;
+
+    beforeAll(async () => {
+      fixture = new McpTestFixture({ daemonMode: false });
+      await fixture.setup();
+    });
+
+    afterEach(async () => {
+      await fixture.teardown();
+    });
+
+    test("a caller-supplied __mcpRequestTimeoutMs is IGNORED, never reattached", async () => {
+      const { client } = fixture.getContext();
+      const result = await client.callTool({
+        name: TOOL,
+        arguments: { [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: 1 },
+      });
+
+      expect(getStructuredField(result, "receivedTimeoutMs")).toBeNull();
+    });
+  });
+
+  describe("daemonMode: true (daemon-forwarded loopback server)", () => {
+    let fixture: McpTestFixture;
+
+    beforeAll(async () => {
+      fixture = new McpTestFixture({ daemonMode: true });
+      await fixture.setup();
+    });
+
+    afterEach(async () => {
+      await fixture.teardown();
+    });
+
+    test("a legitimate __mcpRequestTimeoutMs is honored and reattached", async () => {
+      const { client } = fixture.getContext();
+      const result = await client.callTool({
+        name: TOOL,
+        arguments: { [INTERNAL_MCP_REQUEST_TIMEOUT_PARAM]: 12_345 },
+      });
+
+      expect(getStructuredField(result, "receivedTimeoutMs")).toBe(12_345);
+    });
+  });
+});

--- a/test/server/internalTimeoutParamProvenance.test.ts
+++ b/test/server/internalTimeoutParamProvenance.test.ts
@@ -7,12 +7,15 @@
  * see `withSocketSessionAutolockKey` in `src/daemon/socketServer.ts`) may
  * have it honored and reattached onto the handler's arguments.
  */
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { createStructuredToolResponse, getStructuredField } from "../../src/utils/toolUtils";
-import { INTERNAL_MCP_REQUEST_TIMEOUT_PARAM } from "../../src/daemon/constants";
+import {
+  INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
+  INTERNAL_MCP_REQUEST_DEADLINE_PARAM,
+} from "../../src/daemon/constants";
 
 const TOOL = "__internal_timeout_provenance_probe_6222__";
 
@@ -31,15 +34,20 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
       z.object({}),
       async (args: unknown) => {
         const received = (args as Record<string, unknown>)[INTERNAL_MCP_REQUEST_TIMEOUT_PARAM];
+        const receivedDeadline = (args as Record<string, unknown>)[
+          INTERNAL_MCP_REQUEST_DEADLINE_PARAM
+        ];
         return createStructuredToolResponse({
           success: true,
           receivedTimeoutMs: typeof received === "number" ? received : null,
+          receivedDeadlineMs: typeof receivedDeadline === "number" ? receivedDeadline : null,
         });
       },
       {
         outputSchema: z.object({
           success: z.boolean(),
           receivedTimeoutMs: z.number().nullable(),
+          receivedDeadlineMs: z.number().nullable(),
         }),
       },
     );
@@ -52,7 +60,7 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
   describe("daemonMode: false (direct, non-daemon server)", () => {
     let fixture: McpTestFixture;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       fixture = new McpTestFixture({ daemonMode: false });
       await fixture.setup();
     });
@@ -70,12 +78,22 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
 
       expect(getStructuredField(result, "receivedTimeoutMs")).toBeNull();
     });
+
+    test("a caller-supplied __mcpRequestDeadlineMs is IGNORED, never reattached", async () => {
+      const { client } = fixture.getContext();
+      const result = await client.callTool({
+        name: TOOL,
+        arguments: { [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: 1 },
+      });
+
+      expect(getStructuredField(result, "receivedDeadlineMs")).toBeNull();
+    });
   });
 
   describe("daemonMode: true (daemon-forwarded loopback server)", () => {
     let fixture: McpTestFixture;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       fixture = new McpTestFixture({ daemonMode: true });
       await fixture.setup();
     });
@@ -92,6 +110,16 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
       });
 
       expect(getStructuredField(result, "receivedTimeoutMs")).toBe(12_345);
+    });
+
+    test("a legitimate __mcpRequestDeadlineMs is honored and reattached", async () => {
+      const { client } = fixture.getContext();
+      const result = await client.callTool({
+        name: TOOL,
+        arguments: { [INTERNAL_MCP_REQUEST_DEADLINE_PARAM]: 98_765 },
+      });
+
+      expect(getStructuredField(result, "receivedDeadlineMs")).toBe(98_765);
     });
   });
 });


### PR DESCRIPTION
## Diagnosis: why #6237 didn't hold

#6237 made `setUIState` emit per-field `notifications/progress` and added
`ProgressExtendableDeadline` so a progress tick can push the daemon's request
deadline out. That mechanism only activates when the inbound `tools/call`
request carries MCP's `_meta.progressToken` — the daemon and the MCP
server's tool-registration wrapper (`toolRegistry.ts`) both gate the
progress callback / deadline extension on `progressToken !== undefined`.

The real path the dogfood report hit — the local CLI binary calling the
daemon directly — **never sets a progressToken**:

- `runToolViaDaemon` in `src/cli/index.ts` calls
  `proxy.callTool(toolName, params)` — two arguments, no `progressToken`, no
  `onProgress`.
- Contrast with `src/server/proxyServer.ts` (the actual MCP-server-facing
  proxy used by Claude Desktop / `bunx`), which always forwards
  `proxy.callTool(name, args, requestProgressToken, onProgress)`, echoing the
  *external* MCP client's own token.

So on the CLI→daemon transport:

1. The daemon's socket request has no `progressToken`.
2. `ProgressExtendableDeadline` is constructed with the fixed
   `resolveMcpRequestTimeoutMs()` result and is **never extended** — nothing
   ever calls `extendOnProgress`.
3. The forwarded MCP `tools/call` to the in-process MCP server carries no
   `_meta.progressToken` either, so `toolRegistry.ts`'s `wrappedHandler`
   takes the `else` branch and invokes the tool with `progress: undefined`.
4. Every `emitProgress()` call inside `SetUIState.execute()` is a no-op
   (`if (!progress) return;`) for the entire call.
5. The daemon's fixed ~30s deadline (`setUIState` had no timeout floor)
   fires regardless of how much real work `SetUIState` has already done,
   aborting the in-flight call and returning a bare `-32001` to the CLI —
   discarding the two fields that had already been applied.

This was confirmed by exercising the real code paths (not just reasoning):
`test/daemon/socketServerProgressDeadlineExtension.test.ts` already pins "a
tools/call with no progressToken never touches ... the deadline", and the
new `test/cli/setUIStateProgressToken.test.ts` in this PR pins the missing
half — that `runCliCommand` never supplies one in the first place.

## Fix

**(a) Deadline-aware early return (the real safety net).** `SetUIState`
cannot see the transport's actual deadline (it isn't threaded down through
the tool handler at all), so it now tracks its **own** whole-call result
deadline (`RESULT_DEADLINE_BUDGET_MS`, 45s) independent of progress/transport
wiring. Before starting a new field, it checks this budget; once spent, it
stops and returns the fields it already applied as a normal `success: false`
result — never a silent discard. Unreached fields are marked
`notAttempted: true` with a distinct message, so a client can tell "never
attempted, safe to retry" apart from "attempted and failed" without parsing
error text.

**(b) Extra transport headroom, as a second line of defense.** Added
`MIN_SET_UI_STATE_MCP_TIMEOUT_MS` (60s) as a timeout floor for `setUIState`
in `mcpRequestTimeout.ts` — `setUIState` had no floor at all before this, so
it only got the bare 30s default. This gives legitimate multi-field forms
extra room even when progress relay never engages, on top of (a).

I did not touch the CLI to start requesting progress relay — (a) already
delivers the non-negotiable outcome (a structured result, never a bare
timeout after work was applied) without depending on progress plumbing that
the direct CLI transport doesn't use.

## Changes

- `src/features/action/SetUIState.ts`: whole-call `RESULT_DEADLINE_BUDGET_MS`
  safety net; `collectResults` now accepts a `notAttemptedReason` for fields
  never reached.
- `src/models/SetUIStateResult.ts`: new `FieldResult.notAttempted` flag.
- `src/server/formTools.ts`: thread `notAttempted` through the tool's output
  schema and response mapping.
- `src/daemon/mcpRequestTimeout.ts`: `MIN_SET_UI_STATE_MCP_TIMEOUT_MS` floor
  for `setUIState`.
- `schemas/tool-definitions.json`: regenerated for the schema change.

## Tests

- `test/features/action/SetUIState.test.ts`: reproduces the reopen with
  realistic per-field latency (FakeTimer) — two fields complete, the budget
  is spent, the third comes back `notAttempted` instead of being discarded;
  confirms a fast multi-field call is unaffected and the issue's
  single-field fast-fail case (`Phone`) is unaffected. Adjusted one #4252
  regression test's synthetic latency so it no longer collides with the new
  whole-call budget while keeping its original invariant intact.
- `test/cli/setUIStateProgressToken.test.ts` (new): pins the CLI-side half
  of the root cause — `runCliCommand` forwards `setUIState` with neither a
  `progressToken` nor an `onProgress` callback.

## Validation

- `bun test test/daemon/ test/features/action/SetUIState.test.ts test/cli/` — all pass
- `bun test` (full suite) — all pass except two pre-existing, unrelated
  failures documented in project memory: `test/lint/oxlintConfigScoping.integration.test.ts`
  (missing `node_modules/.bin/oxlint` in this worktree) and
  `test/integration/webrtcDeviceCaptureLoad.integration.test.ts` (known flake)
- `bun run lint` — no new violations (ratchet baseline unchanged)
- `bun run typecheck` — no new type errors (baseline unchanged)
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds

Closes #6222
