### PR TITLE
fix(observe): surface state-readout context in diff-mode observations

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9815,6 +9815,92 @@
                     "additionalProperties": {}
                   }
                 },
+                "context": {
+                  "description": "Non-actionable state-readout rows from the same projection as `skeleton` (issue #6221 item 1, #6256) — a timer countdown, a toggle's current-state text — present only when at least one such row survived. Populated alongside `skeleton` so a diff-mode response never silently drops the readout a client needs to tell a failed input from a successful one.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "elementId": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "sublabel": {
+                        "type": "string"
+                      },
+                      "testTag": {
+                        "type": "string"
+                      },
+                      "semanticLinks": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "text": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "occurrence": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "start": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "end": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": ["text", "occurrence"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "bounds": {
+                        "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
+                        "type": "array",
+                        "prefixItems": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "number"
+                          }
+                        ]
+                      },
+                      "affordances": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["tap", "long-press", "input", "scroll", "toggle"]
+                        }
+                      },
+                      "checked": {
+                        "type": "boolean"
+                      },
+                      "index": {
+                        "description": "Disambiguator present only when elementId repeats elsewhere in this skeleton (issue #6221). Pass verbatim as tapOn({ selector, index }) to hit this exact entry.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": ["bounds", "affordances"],
+                    "additionalProperties": {}
+                  }
+                },
                 "added": {
                   "type": "array",
                   "items": {

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -584,11 +584,14 @@ export interface ObserveDiffNodeChange {
  * such marker). Empty `added`/`removed`/`changed` and absent `fields` means the
  * screen is unchanged.
  *
- * `skeleton` is populated by the `finalizeToolResponse` call site — never by
- * {@link diffObserveResult} itself, which only ever sees the full sanitized
- * tree — so that an agent-facing diff ALWAYS carries a usable actionable-only
- * selector surface alongside it (issue #6221 item 4.1), the same array a full
- * observation's `.skeleton` carries.
+ * `skeleton` and `context` are populated by the `finalizeToolResponse` call site
+ * — never by {@link diffObserveResult} itself, which only ever sees the full
+ * sanitized tree — so that an agent-facing diff ALWAYS carries a usable
+ * actionable-only selector surface alongside it (issue #6221 item 4.1), the same
+ * arrays a full observation's `.skeleton` / `.context` carry (issue #6256: a
+ * diff must not silently drop the non-actionable state readout `context` keeps
+ * that `skeleton` alone cannot represent, e.g. a timer countdown or a toggle's
+ * current state text).
  */
 export interface ObserveDiff {
   isDiff: true;
@@ -599,6 +602,16 @@ export interface ObserveDiff {
    * the post-action observation, not by {@link diffObserveResult}.
    */
   skeleton: SkeletonElement[];
+  /**
+   * Non-actionable state-readout rows from the same projection as `skeleton`
+   * (issue #6221 item 1, #6256), present only when at least one such row
+   * survived. Populated by the `finalizeToolResponse` call site alongside
+   * `skeleton`, not by {@link diffObserveResult} — without this a diff-mode
+   * response (`--actions-diff-observe`) carries `skeleton` but silently drops
+   * every zero-affordance readout (a timer countdown, a toggle's state text),
+   * leaving a client unable to tell a failed input from a successful one.
+   */
+  context?: SkeletonElement[];
   added: ObserveDiffNode[];
   removed: ObserveDiffNode[];
   changed: ObserveDiffNodeChange[];

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -194,6 +194,30 @@ function resolveDiffSkeleton(
 }
 
 /**
+ * The `context` to attach to a diff response (issue #6256), resolved the same
+ * way {@link resolveDiffSkeleton} resolves `skeleton` and for the same reason:
+ * `diffObserveResult` never sees `context` (it is dropped from `sanitized`
+ * before the diff runs), so without this a diff-mode response would carry the
+ * actionable `skeleton` but silently drop every non-actionable state-readout
+ * row — a timer countdown, a toggle's current-state text — leaving a client
+ * unable to tell a failed input from a successful one purely from the diff.
+ * Returns `undefined` (never an empty array) when no such row survives, so the
+ * emitted diff omits `context` entirely rather than carrying a pointless `[]`
+ * — matching how a full observation only ever carries `context` when it is
+ * non-empty (see `projectSkeletonOnto`).
+ */
+function resolveDiffContext(
+  servedObservation: ObserveResult,
+  rawObservation: ObserveResult,
+  cfg: SanitizeObserveConfig,
+): SkeletonElement[] | undefined {
+  if (servedObservation.context) {
+    return servedObservation.context;
+  }
+  return sanitizeObserveResult(rawObservation, { ...cfg, project: "skeleton" }).context;
+}
+
+/**
  * Context needed to finalize a tool response at the serialization chokepoint.
  * `name` selects where the `ObserveResult` lives (top-level for `observe`, else
  * `.observation`); `sessionUuid` keys the diff baseline. `baselineStore` enables
@@ -485,6 +509,15 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
           // cannot compute this itself — `elements` is already dropped from
           // `sanitized` by the time it runs — so it is resolved here instead.
           diff.skeleton = resolveDiffSkeleton(
+            servedObservation,
+            payload.observation as ObserveResult,
+            cfg,
+          );
+          // Issue #6256: a diff must not silently drop the state-readout
+          // `context` alongside `skeleton` — see resolveDiffContext. `undefined`
+          // (no surviving readout row) is dropped on serialization just like an
+          // absent key, so no extra branch is needed here.
+          diff.context = resolveDiffContext(
             servedObservation,
             payload.observation as ObserveResult,
             cfg,

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -686,6 +686,16 @@ export const observeDiffSchema = z
         "Always present alongside a diff (issue #6221 item 4.1): the same " +
           "actionable-only selector surface a full observation's `skeleton` carries.",
       ),
+    context: z
+      .array(skeletonElementSchema)
+      .optional()
+      .describe(
+        "Non-actionable state-readout rows from the same projection as `skeleton` " +
+          "(issue #6221 item 1, #6256) — a timer countdown, a toggle's current-state " +
+          "text — present only when at least one such row survived. Populated " +
+          "alongside `skeleton` so a diff-mode response never silently drops the " +
+          "readout a client needs to tell a failed input from a successful one.",
+      ),
     added: z.array(observeDiffNodeSchema),
     removed: z.array(observeDiffNodeSchema),
     changed: z.array(observeDiffNodeChangeSchema),

--- a/test/server/compactBoundsAdvertisement.test.ts
+++ b/test/server/compactBoundsAdvertisement.test.ts
@@ -71,8 +71,11 @@ describe("advertiseBoundsForCompact (#2990)", () => {
       return node.map(stripSkeletonNodes);
     }
     if (node && typeof node === "object") {
-      const { skeleton: _skeleton, ...rest } = node as Record<string, unknown>;
+      // `context` (issue #6256) shares `skeleton`'s always-compact-tuple bounds
+      // schema, so it must be stripped here too.
+      const { skeleton: _skeleton, context: _context, ...rest } = node as Record<string, unknown>;
       void _skeleton;
+      void _context;
       const out: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(rest)) {
         out[key] = stripSkeletonNodes(value);

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -950,6 +950,103 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.skeleton[0].elementId).toBe("com.example:id/btn");
     });
 
+    test("a diffed observation ALSO carries the state-readout `context` alongside `skeleton` (issue #6256)", () => {
+      const { store } = makeStore();
+      // A zero-affordance readout (e.g. a timer countdown) plus one actionable
+      // button — the shape `--actions-diff-observe` must not silently drop the
+      // readout from, the same way #6221 item 4.1 already guarantees `skeleton`.
+      const withReadout = (readoutText: string): ObserveResult => ({
+        ...sameScreenObserve(),
+        elements: {
+          clickable: [
+            {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "com.example:id/btn",
+              text: "Start",
+              clickable: "true",
+            } as any,
+          ],
+          scrollable: [],
+          text: [
+            {
+              bounds: { left: 0, top: 60, right: 100, bottom: 90 },
+              "resource-id": "com.example:id/countdown",
+              text: readoutText,
+            } as any,
+          ],
+          media: [],
+        },
+      });
+
+      finalizeToolResponse(createStructuredToolResponse(withReadout("00h 20m 00s")), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      // A tap changes the hierarchy (so a real diff is emitted) AND the readout's
+      // own text updates — the exact failed-vs-successful-input distinction the
+      // client needs to make.
+      const next = withReadout("00h 19m 59s");
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store },
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.changed).toHaveLength(1);
+      expect(Array.isArray(obsSc.context)).toBe(true);
+      expect(obsSc.context).toHaveLength(1);
+      expect(obsSc.context[0]).toMatchObject({
+        elementId: "com.example:id/countdown",
+        label: "00h 19m 59s",
+        affordances: [],
+      });
+
+      // Text mirror agrees.
+      const parsed = JSON.parse(finalized.content[0].text);
+      expect(parsed.observation.context).toEqual(obsSc.context);
+    });
+
+    test("a diff with no surviving readout row omits `context` entirely rather than emitting `[]`", () => {
+      const { store } = makeStore();
+      const withSkeletonElements = (): ObserveResult => ({
+        ...sameScreenObserve(),
+        elements: {
+          clickable: [
+            {
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+              "resource-id": "com.example:id/btn",
+              text: "Submit",
+              clickable: "true",
+            } as any,
+          ],
+          scrollable: [],
+          text: [],
+          media: [],
+        },
+      });
+
+      finalizeToolResponse(createStructuredToolResponse(withSkeletonElements()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const next = withSkeletonElements();
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store },
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.context).toBeUndefined();
+    });
+
     test("returns a full observation when a reported screen change would emit an empty diff", () => {
       const { store } = makeStore();
       finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), {


### PR DESCRIPTION
## What was dropped

Issue #6221 item 1 / PR #6242 correctly moved zero-affordance rows (a timer
countdown, a toggle's current-state text) out of the actionable-only
`skeleton` and into a separate, non-actionable `context` array, so the
information is preserved instead of discarded — and that plumbing (element
collection → `SkeletonProjection.projectSkeleton` → `ObserveResultOutput` →
`toolOutputSchemas`) is correct end-to-end for a **full** observation.

The gap is in **diff mode** (`--actions-diff-observe`): `diffObserveResult`
can never compute `context` itself (`elements` is already stripped from the
sanitized observation before the diff runs), and #6242 only backfilled
`diff.skeleton` at the `finalizeToolResponse` call site (per its own review
thread PRRT_kwDOP-GF5M6fq3iK, closing exactly this gap for `skeleton`).
`ObserveDiff` never carried a `context` field at all, so a diff-mode response
silently dropped every readout row — leaving a client unable to tell a failed
input from a successful one purely from the diff, which is the symptom in
#6256's dogfood repro (a 20-minute timer's `00h 20m 00s` readout, the
running-timer countdown, a Wi-Fi switch's state text).

## The fix

- Extend `ObserveDiff` (`src/features/observe/output/ObserveResultOutput.ts`)
  with an optional `context` field, documented the same way `skeleton` is.
- Add `resolveDiffContext` in `src/server/finalizeToolResponse.ts`, mirroring
  `resolveDiffSkeleton`: read `servedObservation.context` when present,
  otherwise re-project it from the raw observation. Populate `diff.context`
  from it right alongside `diff.skeleton`.
- Declare `context` on `observeDiffSchema` in `src/server/toolOutputSchemas.ts`.
- Regenerated `schemas/tool-definitions.json` via
  `scripts/update-tool-definitions.sh`.

The full-observation path (`skeleton`/`context` computation in
`SkeletonProjection.ts`, and their surfacing through `ObserveResultOutput.ts`
and the default `observe`/action-tool wiring) was already correct and is
covered by the existing test suite — no changes were needed there.

## Tests

- `test/server/finalizeToolResponse.test.ts`: a diff-mode case where a
  zero-affordance readout row changes text across two diffed observations
  (context row is present, its label reflects the new/changed state — the
  concrete failed-vs-successful-input distinction), and a case where no
  readout row survives, asserting `context` is omitted entirely (not `[]`).
- `test/server/compactBoundsAdvertisement.test.ts`: its local
  skeleton-node-stripping helper only knew about the `skeleton` key; fixed it
  to also strip `context`, since it shares the same always-compact-tuple
  bounds schema.

## Validation

- `bun test` (observe-output + finalizeToolResponse + schema/tool-registration
  paths, and the full suite) — all pass except two pre-existing worktree
  infra failures unrelated to this change (missing `oxlint` binary under this
  worktree's `node_modules`, and an unrelated webrtc device-capture gating
  test).
- `bun run lint`, `bun run typecheck`, `bun run format:check` — clean.
- `scripts/update-tool-definitions.sh` + re-checked `format:check` — clean.
- `bunx turbo run build` — succeeds.

Closes #6256