### PR TITLE
fix(daemon): --daemon restart fails loudly instead of splitting brain on port fallback

### DIFF
--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -47,6 +47,7 @@ const booleanOptions = Object.fromEntries(
     "no-report-view-ids",
     "no-retrieve-interactive-windows",
     "no-occlusion",
+    "strict-port",
   ].map((name) => [name, { type: "boolean" as const }]),
 );
 
@@ -139,6 +140,7 @@ export function parseArgs(
   const debugPerf =
     hasFlag("debug-perf") || hasFlag("ui-perf-debug") || process.env.AUTOMOBILE_DEBUG_PERF === "1";
   const debug = hasFlag("debug") || process.env.AUTOMOBILE_DEBUG === "1";
+  const strictPort = hasFlag("strict-port");
   const uiPerfMode = !hasFlag("no-ui-perf-mode");
   const memPerfAuditMode = hasFlag("mem-perf-audit");
   const a11yAuditMode = hasFlag("accessibility-audit");
@@ -354,6 +356,7 @@ export function parseArgs(
     initialSessionUuid,
     debugPerf,
     debug,
+    strictPort,
     uiPerfMode,
     memPerfAuditMode,
     a11yAuditMode,

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,4 +1,5 @@
 import { createServer as createHttpServer, Server as HttpServer } from "node:http";
+import { ActionableError } from "../models/ActionableError";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createMcpServer } from "../server";
 import { logger } from "../utils/logger";
@@ -252,6 +253,7 @@ export class Daemon {
   private acceptingHttpSessions = false;
   private port: number;
   private host: string;
+  private readonly strictPort: boolean;
   private debug: boolean;
   private healthCheckTimer: NodeJS.Timeout | null = null;
   private heartbeatMonitor: SessionHeartbeatMonitor | null = null;
@@ -306,6 +308,7 @@ export class Daemon {
     // Prefer IPv4 loopback: Bun's fetch and Node's listen can disagree on "localhost" (::1 vs 127.0.0.1),
     // which surfaces as ConnectionRefused on the Unix-socket → Streamable HTTP MCP hop (common in Linux CI).
     this.host = options.host || "127.0.0.1";
+    this.strictPort = options.strictPort ?? false;
     this.debug = options.debug || false;
     this.idGenerator = idGenerator;
     this.daemonSessionId = this.idGenerator.next();
@@ -511,8 +514,17 @@ export class Daemon {
       }),
     );
 
-    // Find an available port
-    this.port = await this.findAvailablePort(this.port);
+    // Find an available port. In strict-port mode (issue #6260, restart's
+    // atomic guard) we deliberately skip findAvailablePort()'s probe-then-
+    // release preflight and its port+1..3 fallback: that preflight releases
+    // its probe socket before this process actually binds, leaving a window
+    // for a competitor to claim the canonical port and for the fallback to
+    // paper over it with a "successful" restart on the wrong port. Leaving
+    // `this.port` as the requested port makes the real `listen()` call below
+    // (in startHttpServer) the single atomic bind-or-fail attempt.
+    if (!this.strictPort) {
+      this.port = await this.findAvailablePort(this.port);
+    }
 
     // Start HTTP MCP server
     startupBenchmark.startPhase("httpServerStart");
@@ -955,7 +967,23 @@ export class Daemon {
         resolve();
       });
 
-      this.httpServer!.on("error", (error) => {
+      this.httpServer!.on("error", (error: NodeJS.ErrnoException) => {
+        if (this.strictPort && error.code === "EADDRINUSE") {
+          // The authoritative guard (issue #6260): this listen() call is the
+          // one atomic bind attempt in strict-port mode, so a genuine
+          // EADDRINUSE here means another process holds the canonical port
+          // RIGHT NOW — not a stale probe result. Fail loudly instead of the
+          // caller (start()) ever falling back to a different port.
+          reject(
+            new ActionableError(
+              `Port ${this.port} on ${this.host} is required for this daemon start but is ` +
+                `already in use by another process. Refusing to fall back to a different port ` +
+                `and risk a split-brain daemon (issue #6260) — find and stop whatever holds ` +
+                `port ${this.port} and retry.`,
+            ),
+          );
+          return;
+        }
         logger.error(`HTTP server error: ${error}`);
         reject(error);
       });

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -302,6 +302,7 @@ export class Daemon {
     recoveryPolicyEnvironment: NodeJS.ProcessEnv = process.env,
     managedAdbServerShutdown: ManagedAdbServerShutdown = stopManagedAdbServer,
     toolSelectionProfileProvenanceLoader: ToolSelectionProfileProvenanceLoader = defaultToolSelectionProfileRegistry,
+    private readonly httpServerFactory: () => HttpServer = () => createHttpServer(),
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -686,7 +687,7 @@ export class Daemon {
    * Start the HTTP MCP server (internal daemon transport, not exposed publicly)
    */
   private async startHttpServer(): Promise<void> {
-    this.httpServer = createHttpServer();
+    this.httpServer = this.httpServerFactory();
     this.httpServerClosePromise = null;
     this.acceptingHttpSessions = true;
 

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -183,6 +183,15 @@ export function readPidFileDataSync(pidFilePath: string = PID_FILE_PATH): PidFil
 }
 
 export function isProcessRunning(pid: number): boolean {
+  // `process.kill(pid, 0)` treats non-positive PIDs specially rather than
+  // naming a single process: pid 0 signals the CURRENT process group and
+  // pid -1 signals EVERY process this user can signal — both "succeed" even
+  // though no single real process named `0`/`-1` exists. A corrupt or stale
+  // lock containing such a PID must never be reported as a live owner (issue
+  // #6260) — that footgun would surface a `kill 0` / `kill -1` suggestion.
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
   try {
     process.kill(pid, 0);
     return true;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1800,9 +1800,13 @@ export class DaemonManager implements DaemonManagerLike {
     if (survivors.length > 0) {
       throw new ActionableError(
         `Restart could not confirm the previous AutoMobile daemon process(es) stopped: ` +
-          `PID(s) ${survivors.join(", ")} still running. Refusing to start a second daemon on a ` +
-          `fallback port and split ownership of the device pool. Stop the orphan(s) yourself ` +
-          `(e.g. \`kill ${survivors.join(" ")}\`) and run \`--daemon restart\` again.`,
+          `PID(s) ${survivors.join(", ")} still running an AutoMobile daemon (matched by ` +
+          `\`--daemon-mode\` on its command line). Refusing to start a second daemon on a ` +
+          `fallback port and split ownership of the device pool. A PID can be recycled to an ` +
+          `unrelated process between this scan and when you act on it, so re-verify identity ` +
+          `before stopping anything — e.g. \`ps -p ${survivors.join(",")} -o pid=,command= | ` +
+          `grep -- --daemon-mode\` — and kill only the PID(s) that still match, then run ` +
+          `\`--daemon restart\` again.`,
       );
     }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,5 +1,6 @@
 import { errorMessage } from "../utils/describeUnknownError";
 import { execSync, type ChildProcess } from "node:child_process";
+import { createServer as createNetServer } from "node:net";
 import { open, readFile, rm } from "node:fs/promises";
 import { existsSync, openSync, closeSync, readFileSync } from "node:fs";
 import { basename, isAbsolute, join, resolve, sep } from "node:path";
@@ -30,6 +31,7 @@ import {
   DAEMON_SHUTDOWN_TIMEOUT_MS,
   READINESS_PROBE_MAX_ATTEMPTS,
   READINESS_PROBE_BACKOFF_MS,
+  DEFAULT_DAEMON_PORT,
 } from "./constants";
 import { DaemonStatus, PidFileData, DaemonOptions } from "./types";
 import {
@@ -363,6 +365,44 @@ export interface ExtractionCleaner {
   removeExtractionForEntryScript(entryScript: string): Promise<boolean>;
 }
 
+/**
+ * Confirms whether a TCP port is free to bind, from the MANAGER side (issue
+ * #6260) — independent of process-table detection. `restart()` uses this as a
+ * last line of defense right before `start()`: even when process discovery
+ * believes every prior AutoMobile daemon was stopped, a still-bound canonical
+ * port is definitive proof one was not, and `start()`'s own `findAvailablePort`
+ * would otherwise silently fall back to the next port in range and report
+ * unqualified success — precisely the split-brain #6260 describes.
+ */
+export interface DaemonPortAvailabilityChecker {
+  isPortFree(port: number, host: string): Promise<boolean>;
+}
+
+const PORT_AVAILABILITY_PROBE_TIMEOUT_MS = 1000;
+
+class NetDaemonPortAvailabilityChecker implements DaemonPortAvailabilityChecker {
+  isPortFree(port: number, host: string): Promise<boolean> {
+    return new Promise((resolvePromise) => {
+      const probeServer = createNetServer();
+      let settled = false;
+      const finish = (result: boolean): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        defaultTimer.clearTimeout(timeoutHandle);
+        probeServer.close(() => resolvePromise(result));
+      };
+      const timeoutHandle = defaultTimer.setTimeout(
+        () => finish(false),
+        PORT_AVAILABILITY_PROBE_TIMEOUT_MS,
+      );
+      probeServer.once("error", () => finish(false));
+      probeServer.listen(port, host, () => finish(true));
+    });
+  }
+}
+
 function resolveExtractionRootForEntryScript(entryScript: string): string | null {
   const resolved = resolve(entryScript);
   const parts = resolved.split(sep);
@@ -563,6 +603,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly processFinder: DaemonProcessFinder;
   private readonly processLivenessChecker: DaemonProcessLivenessChecker;
   private readonly processSignaler: DaemonProcessSignaler;
+  private readonly portAvailabilityChecker: DaemonPortAvailabilityChecker;
   private readonly extractionCleaner: ExtractionCleaner;
   private readonly launcher: DaemonLauncher;
   private readonly fallbackLauncher: DaemonLauncher;
@@ -612,8 +653,10 @@ export class DaemonManager implements DaemonManagerLike {
     idGenerator: IdGenerator = defaultIdGenerator,
     peerSocketReachability: DaemonSocketReachabilityLike | undefined = undefined,
     platformOverride: NodeJS.Platform = process.platform,
+    portAvailabilityChecker: DaemonPortAvailabilityChecker = new NetDaemonPortAvailabilityChecker(),
   ) {
     this.platform = platformOverride;
+    this.portAvailabilityChecker = portAvailabilityChecker;
     this.startupLockOwnerToken = idGenerator.next();
     // Construct the reachability probe here (not in a field initializer) so its connect
     // timeout is bound to the injected timer — a field initializer would capture the
@@ -1711,9 +1754,56 @@ export class DaemonManager implements DaemonManagerLike {
       () => (status.running ? this.stop() : undefined),
       () => this.stopUnrecordedDaemonsForExplicitRestart(status.pid),
     ]);
+    // Confirm the previous daemon(s) are actually gone before starting a
+    // replacement (issue #6260). `awaitRestartCleanup` above only rejects when a
+    // DISCOVERED candidate refused to stop; it cannot catch a candidate that
+    // process-table discovery never found in the first place — the exact split-
+    // brain #6260 reports, where `--daemon restart` printed no stop line at all,
+    // then silently started a second daemon on a fallback port and reported
+    // unqualified success while the old one kept CtrlProxy forwarding ownership.
+    // Failing loudly here, naming the orphan, is strictly better than that.
+    await this.assertNoSurvivingDaemonBeforeRestart(restartOptions);
     // Wait a bit before starting
     await this.timer.sleep(1000);
     await this.start(restartOptions);
+  }
+
+  /**
+   * Last line of defense before an explicit restart starts a replacement daemon
+   * (issue #6260). Two independent confirmations, either of which fails loudly
+   * rather than letting `start()` silently fall back to a different port:
+   *
+   * 1. Re-scan the process table: if any AutoMobile daemon process is still
+   *    alive, name it rather than starting a second one beside it.
+   * 2. Probe the canonical port directly: process-table detection can miss a
+   *    live daemon (a stale/mismatched PID record, a process-table scan that
+   *    raced the kill) even when the port it holds is unmistakably still bound.
+   *    A definitive "the port is still taken" is worth failing on even without a
+   *    named PID.
+   */
+  private async assertNoSurvivingDaemonBeforeRestart(options: DaemonOptions): Promise<void> {
+    const survivors = this.findLiveDaemonProcesses();
+    if (survivors.length > 0) {
+      throw new ActionableError(
+        `Restart could not confirm the previous AutoMobile daemon process(es) stopped: ` +
+          `PID(s) ${survivors.join(", ")} still running. Refusing to start a second daemon on a ` +
+          `fallback port and split ownership of the device pool. Stop the orphan(s) yourself ` +
+          `(e.g. \`kill ${survivors.join(" ")}\`) and run \`--daemon restart\` again.`,
+      );
+    }
+
+    const port = options.port ?? DEFAULT_DAEMON_PORT;
+    const host = options.host ?? "127.0.0.1";
+    if (await this.portAvailabilityChecker.isPortFree(port, host)) {
+      return;
+    }
+    throw new ActionableError(
+      `Restart stopped every AutoMobile daemon process it could find, but port ${port} on ${host} ` +
+        `is still in use. Refusing to silently start the replacement daemon on a fallback port — ` +
+        `that is how an orphaned process ends up owning device forwarding while a second daemon ` +
+        `reports success. Find and stop whatever still holds port ${port} (it may not be an ` +
+        `AutoMobile process this scan could name) and run \`--daemon restart\` again.`,
+    );
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1117,6 +1117,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.host) {
       args.push("--host", options.host);
     }
+    if (options.strictPort) {
+      args.push("--strict-port");
+    }
     if (options.debug) {
       args.push("--debug");
     }
@@ -1746,7 +1749,18 @@ export class DaemonManager implements DaemonManagerLike {
     const requestedOptions = Object.fromEntries(
       Object.entries(options).filter(([, value]) => value !== undefined),
     ) as DaemonOptions;
-    const restartOptions: DaemonOptions = { ...runningOptions, ...requestedOptions };
+    // Force the authoritative bind-or-fail guard (issue #6260, PRRT ft82d):
+    // the preflight check in assertNoSurvivingDaemonBeforeRestart below is
+    // fast feedback only — it releases its probe socket before this sleep and
+    // before the child actually binds, so a competitor can still win the
+    // canonical port in that window. strictPort makes the child's own
+    // listen() call the atomic guard, failing loudly instead of silently
+    // falling back to port + 1..3 and recreating the split-brain.
+    const restartOptions: DaemonOptions = {
+      ...runningOptions,
+      ...requestedOptions,
+      strictPort: true,
+    };
     // All restart cleanup follows the same 10s graceful + 1s forced-stop
     // budget. Run the PID-recorded daemon and every cross-namespace candidate
     // concurrently so the launcher timeout remains bounded by one cleanup window.
@@ -2490,6 +2504,8 @@ export function parseDaemonArgs(
         options.host = host;
         i++;
       }
+    } else if (args[i] === "--strict-port") {
+      options.strictPort = true;
     } else if (args[i] === "--debug") {
       options.debug = true;
     } else if (args[i] === "--debug-perf" || args[i] === "--ui-perf-debug") {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -217,6 +217,15 @@ export interface DaemonOptions {
   port?: number;
   /** Host for internal MCP server */
   host?: string;
+  /**
+   * Require the daemon's HTTP bind to succeed on exactly `port` (or the
+   * default port) and fail loudly instead of silently falling back to
+   * `port + 1..3` via `findAvailablePort()`. Set by `DaemonManager.restart()`
+   * so the child's own atomic `listen()` call — not a preflight probe that
+   * releases its socket before the child actually binds — is the
+   * authoritative guard against the #6260 TOCTOU split-brain.
+   */
+  strictPort?: boolean;
   /** Enable debug mode */
   debug?: boolean;
   /** Enable debug performance tracking */

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -15,6 +15,7 @@
  */
 
 import WebSocket from "ws";
+import { errorMessage } from "../../utils/describeUnknownError";
 import { logger } from "../../utils/logger";
 import type { PerformanceTracker } from "../../utils/PerformanceTracker";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -76,6 +77,13 @@ export abstract class DeviceServiceClient {
   protected isConnecting: boolean = false;
   protected connectionAttempts: number = 0;
   protected lastConnectionAttempt: number = 0;
+  // The most recent connect-attempt failure message (issue #6260), e.g. a
+  // platform-setup error such as "Another AutoMobile process owns CtrlProxy
+  // forwarding...". `waitForConnection` only reports a boolean, so a caller
+  // that needs the actual cause of a connect failure (RunnerReadinessService,
+  // to surface it instead of a generic "runner did not become responsive")
+  // reads this instead of re-deriving it. Cleared on a successful connect.
+  private lastConnectionFailureMessage: string | undefined;
   // Bumped by close() so a connection that opens after close() is discarded
   // instead of installing its socket and restarting the health check.
   protected connectionGeneration: number = 0;
@@ -516,6 +524,7 @@ export abstract class DeviceServiceClient {
               this.protectRegisteredRequestSends(ws);
               this.isConnecting = false;
               this.connectionAttempts = 0; // Reset on successful connection
+              this.lastConnectionFailureMessage = undefined;
 
               // Start health check monitoring
               this.startHealthCheck();
@@ -568,9 +577,19 @@ export abstract class DeviceServiceClient {
     } catch (error) {
       this.isConnecting = false;
       this.lastConnectionAttempt = this.timer.now();
+      this.lastConnectionFailureMessage = errorMessage(error);
       logger.warn(`[${this.logTag}] Failed to connect to WebSocket: ${error}`);
       return false;
     }
+  }
+
+  /**
+   * The most recent connect-attempt failure message, or `undefined` when the
+   * client has never failed to connect (or has connected successfully since).
+   * See {@link lastConnectionFailureMessage}.
+   */
+  public getLastConnectionFailureMessage(): string | undefined {
+    return this.lastConnectionFailureMessage;
   }
 
   private async runPlatformSetup(perf: PerformanceTracker): Promise<void> {

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -24,6 +24,7 @@ import { defaultTimer } from "../../utils/SystemTimer";
 import { RequestManager } from "../../utils/RequestManager";
 import { RetryExecutor, defaultRetryExecutor } from "../../utils/retry/RetryExecutor";
 import type { CtrlProxyReconnectStatus } from "../../models/CtrlProxyReconnectStatus";
+import { CtrlProxyForwardingLeaseConflictError } from "./shared/CtrlProxyForwardingLeaseConflictError";
 import type { DelegateContext } from "./shared/types";
 
 /**
@@ -84,6 +85,13 @@ export abstract class DeviceServiceClient {
   // to surface it instead of a generic "runner did not become responsive")
   // reads this instead of re-deriving it. Cleared on a successful connect.
   private lastConnectionFailureMessage: string | undefined;
+  // Whether lastConnectionFailureMessage is specifically the CtrlProxy
+  // forwarding-lease conflict (issue #6260 PRRT ft82e), rather than an
+  // ordinary connect failure (ECONNREFUSED, a timeout, ...). Detected via
+  // `instanceof` on the caught error so RunnerReadinessService can scope its
+  // orphan-naming diagnostic to this exact condition instead of any stored
+  // error.
+  private lastConnectionFailureIsForwardingLeaseConflict: boolean = false;
   // Bumped by close() so a connection that opens after close() is discarded
   // instead of installing its socket and restarting the health check.
   protected connectionGeneration: number = 0;
@@ -525,6 +533,7 @@ export abstract class DeviceServiceClient {
               this.isConnecting = false;
               this.connectionAttempts = 0; // Reset on successful connection
               this.lastConnectionFailureMessage = undefined;
+              this.lastConnectionFailureIsForwardingLeaseConflict = false;
 
               // Start health check monitoring
               this.startHealthCheck();
@@ -578,6 +587,8 @@ export abstract class DeviceServiceClient {
       this.isConnecting = false;
       this.lastConnectionAttempt = this.timer.now();
       this.lastConnectionFailureMessage = errorMessage(error);
+      this.lastConnectionFailureIsForwardingLeaseConflict =
+        error instanceof CtrlProxyForwardingLeaseConflictError;
       logger.warn(`[${this.logTag}] Failed to connect to WebSocket: ${error}`);
       return false;
     }
@@ -590,6 +601,16 @@ export abstract class DeviceServiceClient {
    */
   public getLastConnectionFailureMessage(): string | undefined {
     return this.lastConnectionFailureMessage;
+  }
+
+  /**
+   * Whether {@link getLastConnectionFailureMessage} describes the CtrlProxy
+   * forwarding-lease conflict specifically (issue #6260 PRRT ft82e), as
+   * opposed to an ordinary connect failure. See
+   * {@link lastConnectionFailureIsForwardingLeaseConflict}.
+   */
+  public isLastConnectionFailureForwardingLeaseConflict(): boolean {
+    return this.lastConnectionFailureIsForwardingLeaseConflict;
   }
 
   private async runPlatformSetup(perf: PerformanceTracker): Promise<void> {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -23,6 +23,7 @@ import {
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger, type Logger } from "../../../utils/logger";
 import { rewriteUnknownCommandError } from "../shared/rewriteUnknownCommandError";
+import { CtrlProxyForwardingLeaseConflictError } from "../shared/CtrlProxyForwardingLeaseConflictError";
 import {
   BootedDevice,
   ImeAction,
@@ -3268,11 +3269,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       // cause — a stale/orphaned AutoMobile process still holding forwarding
       // for this device, most commonly left behind by a `--daemon restart`
       // that could not confirm the previous daemon stopped.
-      throw new Error(
-        describeCtrlProxyForwardingLeaseConflict(
-          this.device.deviceId,
-          this.ctrlProxyForwardLease.getLastOwnerPid(),
-        ),
+      const ownerPid = this.ctrlProxyForwardLease.getLastOwnerPid();
+      throw new CtrlProxyForwardingLeaseConflictError(
+        describeCtrlProxyForwardingLeaseConflict(this.device.deviceId, ownerPid),
+        ownerPid,
       );
     }
     // Verify port forwarding is still active even if we think it's set up

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1136,6 +1136,40 @@ function describeCtrlProxyForwardingLeaseConflict(
   );
 }
 
+/**
+ * Raise the appropriate error for a failed {@link CtrlProxyForwardLease.tryAcquire}
+ * (issue #6260 / PRRT_kwDOP-GF5M6fuKn9). Split out of `setupPortForwarding` to keep
+ * that method's branching complexity down; always throws.
+ */
+function throwCtrlProxyForwardingLeaseConflict(
+  deviceId: string,
+  ownerPid: number | undefined,
+): never {
+  if (ownerPid === process.pid) {
+    // Same-process transient, NOT an orphan: shutdown recovery can evict a
+    // singleton while its in-flight setup still holds the lease, so a
+    // REPLACEMENT client constructed in THIS SAME process can observe its own
+    // PID as the current owner. Naming and suggesting `kill` on that PID would
+    // tell the caller to kill itself. This case must keep waiting for the live
+    // in-process lease to release rather than reclaim it (see
+    // `FileCtrlProxyForwardLease.tryAcquire` — reclaiming mid-setup would let
+    // two instances race the same port forward), so throw the same plain,
+    // non-actionable-kill error this path threw before this diagnostic existed
+    // and let the caller's existing retry path recover once the lease frees.
+    throw new Error(describeCtrlProxyForwardingLeaseConflict(deviceId, undefined));
+  }
+  // Named explicitly (issue #6260): this exact string is matched by
+  // RunnerReadinessService to replace a generic, device-blaming
+  // "runner did not become responsive" failure with the real, actionable
+  // cause — a stale/orphaned AutoMobile process still holding forwarding
+  // for this device, most commonly left behind by a `--daemon restart`
+  // that could not confirm the previous daemon stopped.
+  throw new CtrlProxyForwardingLeaseConflictError(
+    describeCtrlProxyForwardingLeaseConflict(deviceId, ownerPid),
+    ownerPid,
+  );
+}
+
 class NoOpCtrlProxyForwardLease implements CtrlProxyForwardLease {
   public tryAcquire(): boolean {
     return true;
@@ -3263,16 +3297,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       return;
     }
     if (!this.ctrlProxyForwardLease.tryAcquire()) {
-      // Named explicitly (issue #6260): this exact string is matched by
-      // RunnerReadinessService to replace a generic, device-blaming
-      // "runner did not become responsive" failure with the real, actionable
-      // cause — a stale/orphaned AutoMobile process still holding forwarding
-      // for this device, most commonly left behind by a `--daemon restart`
-      // that could not confirm the previous daemon stopped.
-      const ownerPid = this.ctrlProxyForwardLease.getLastOwnerPid();
-      throw new CtrlProxyForwardingLeaseConflictError(
-        describeCtrlProxyForwardingLeaseConflict(this.device.deviceId, ownerPid),
-        ownerPid,
+      throwCtrlProxyForwardingLeaseConflict(
+        this.device.deviceId,
+        this.ctrlProxyForwardLease.getLastOwnerPid(),
       );
     }
     // Verify port forwarding is still active even if we think it's set up

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -119,7 +119,11 @@ import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 import { defaultIdGenerator } from "../../../utils/IdGenerator";
-import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../../utils/fileLock";
+import {
+  readLockOwnerPid,
+  releaseExclusiveLock,
+  tryAcquireExclusiveLock,
+} from "../../../utils/fileLock";
 import { ensureSecureSharedAutoMobileDirSync } from "../../../utils/tempDir";
 
 // Import delegates
@@ -1053,12 +1057,20 @@ const VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT = 2;
 interface CtrlProxyForwardLease {
   tryAcquire(): boolean;
   release(): void;
+  /**
+   * PID of the process currently holding the lease, when a preceding
+   * {@link tryAcquire} call returned `false` (issue #6260). Lets the caller
+   * name the orphan in its actionable error instead of a bare "another
+   * process owns this" message the client cannot act on.
+   */
+  getLastOwnerPid(): number | undefined;
 }
 
 class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
   private lockPath: string | null = null;
   private readonly ownerToken = defaultIdGenerator.next();
   private acquired = false;
+  private lastOwnerPid: number | undefined;
 
   public constructor(private readonly deviceId: string) {}
 
@@ -1084,6 +1096,7 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     this.acquired = tryAcquireExclusiveLock(this.resolveLockPath(), {
       ownerToken: this.ownerToken,
     });
+    this.lastOwnerPid = this.acquired ? undefined : readLockOwnerPid(this.resolveLockPath());
     return this.acquired;
   }
 
@@ -1094,6 +1107,32 @@ class FileCtrlProxyForwardLease implements CtrlProxyForwardLease {
     releaseExclusiveLock(this.resolveLockPath(), process.pid, this.ownerToken);
     this.acquired = false;
   }
+
+  public getLastOwnerPid(): number | undefined {
+    return this.lastOwnerPid;
+  }
+}
+
+/**
+ * Actionable message for a CtrlProxy forwarding-lease conflict (issue #6260).
+ * Named the owning PID when known, so a client is pointed at the orphan
+ * process rather than left to guess or, worse, blame the device.
+ */
+function describeCtrlProxyForwardingLeaseConflict(
+  deviceId: string,
+  ownerPid: number | undefined,
+): string {
+  if (ownerPid !== undefined) {
+    return (
+      `Another AutoMobile process (PID ${ownerPid}) owns CtrlProxy forwarding for ${deviceId}. ` +
+      `This is usually a stale/orphaned AutoMobile daemon left behind by an incomplete ` +
+      `\`--daemon restart\` — stop it (\`kill ${ownerPid}\`) and retry.`
+    );
+  }
+  return (
+    `Another AutoMobile process owns CtrlProxy forwarding for ${deviceId}. This is usually a ` +
+    `stale/orphaned AutoMobile daemon — run \`--daemon restart\` or find and stop it directly.`
+  );
 }
 
 class NoOpCtrlProxyForwardLease implements CtrlProxyForwardLease {
@@ -1102,6 +1141,10 @@ class NoOpCtrlProxyForwardLease implements CtrlProxyForwardLease {
   }
 
   public release(): void {}
+
+  public getLastOwnerPid(): undefined {
+    return undefined;
+  }
 }
 
 /**
@@ -3219,8 +3262,17 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       return;
     }
     if (!this.ctrlProxyForwardLease.tryAcquire()) {
+      // Named explicitly (issue #6260): this exact string is matched by
+      // RunnerReadinessService to replace a generic, device-blaming
+      // "runner did not become responsive" failure with the real, actionable
+      // cause — a stale/orphaned AutoMobile process still holding forwarding
+      // for this device, most commonly left behind by a `--daemon restart`
+      // that could not confirm the previous daemon stopped.
       throw new Error(
-        `Another AutoMobile process owns CtrlProxy forwarding for ${this.device.deviceId}`,
+        describeCtrlProxyForwardingLeaseConflict(
+          this.device.deviceId,
+          this.ctrlProxyForwardLease.getLastOwnerPid(),
+        ),
       );
     }
     // Verify port forwarding is still active even if we think it's set up

--- a/src/features/observe/shared/CtrlProxyForwardingLeaseConflictError.ts
+++ b/src/features/observe/shared/CtrlProxyForwardingLeaseConflictError.ts
@@ -1,0 +1,24 @@
+/**
+ * Typed error for the CtrlProxy forwarding-lease conflict (issue #6260): this
+ * device's forwarding lease is already held by another AutoMobile process,
+ * most commonly a stale/orphaned daemon left behind by an incomplete
+ * `--daemon restart`.
+ *
+ * Thrown by the platform-specific client (e.g. AndroidCtrlProxyClient) and
+ * detected via `instanceof` by `DeviceServiceClient`/`RunnerReadinessService`
+ * (PRRT ft82e) so the orphan-naming diagnostic is surfaced ONLY for this
+ * specific condition — never for an ordinary `ECONNREFUSED`, timeout, or
+ * other connect failure, which must keep the existing device diagnostics
+ * (e.g. Android's `primaryUserStartState`/`deviceLock`). A tagged class is
+ * used instead of matching the message substring so detection can't drift
+ * from the thrown text.
+ */
+export class CtrlProxyForwardingLeaseConflictError extends Error {
+  constructor(
+    message: string,
+    readonly ownerPid: number | undefined,
+  ) {
+    super(message);
+    this.name = "CtrlProxyForwardingLeaseConflictError";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ async function main() {
       initialSessionUuid,
       debugPerf,
       debug,
+      strictPort,
       uiPerfMode,
       memPerfAuditMode,
       a11yAuditMode,
@@ -458,6 +459,7 @@ async function main() {
       await startDaemon({
         port: daemonPort,
         ...(daemonHost !== undefined ? { host: daemonHost } : {}),
+        strictPort,
         debug,
         debugPerf,
         planExecutionLockScope,

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -104,6 +104,17 @@ export interface ReadinessClient {
    * caller never sees it.
    */
   getLastConnectionFailureMessage?(): string | undefined;
+  /**
+   * Whether {@link getLastConnectionFailureMessage}'s message describes the
+   * CtrlProxy forwarding-lease conflict specifically (issue #6260 PRRT
+   * ft82e) — another AutoMobile process (typically a stale/orphaned daemon)
+   * already owns forwarding for this device. Every OTHER connect failure
+   * (ECONNREFUSED, a timeout, ...) must fall through to the existing
+   * device diagnostics below instead of this generic transport text, so a
+   * runner unavailable because its user is locked or still booting keeps
+   * surfacing `primaryUserStartState`/`deviceLock`, not raw transport text.
+   */
+  isLastConnectionFailureForwardingLeaseConflict?(): boolean;
   getAccessibilityHierarchy?(
     queryOptions?: undefined,
     perf?: undefined,
@@ -775,15 +786,35 @@ export class RunnerReadinessService {
         await this.dependencies.timer.sleep(Math.min(READINESS_RETRY_DELAY_MS, remaining));
       }
     }
-    // A known connect-attempt failure (e.g. a stale/orphaned AutoMobile process
-    // still owning CtrlProxy forwarding for this device) is the actual, actionable
-    // cause of a runner-connect failure — surface IT instead of the generic
-    // device-blaming message below, which points a caller at rebooting a device
-    // that was never the problem (issue #6260).
-    const lastConnectionFailure =
-      phase === "runner-connect" ? client.getLastConnectionFailureMessage?.() : undefined;
-    if (lastConnectionFailure) {
-      this.fail(context, phase, attempts, lastConnectionFailure);
+    await this.failUnresponsiveClient(context, client, phase, attempts);
+  }
+
+  /**
+   * Report why `waitForResponsiveClient` gave up. A known connect-attempt
+   * failure that is SPECIFICALLY the CtrlProxy forwarding-lease conflict (a
+   * stale/orphaned AutoMobile process still owning forwarding for this
+   * device) is the actual, actionable cause — surface IT instead of the
+   * generic device-blaming message below, which points a caller at rebooting
+   * a device that was never the problem (issue #6260). Every OTHER stored
+   * connect failure (ECONNREFUSED, a timeout, ...) must NOT take this
+   * branch: it would replace the existing Android diagnostics
+   * (primaryUserStartState, deviceLock) with raw transport text for a runner
+   * that is merely locked or still booting (PRRT ft82e).
+   */
+  private async failUnresponsiveClient(
+    context: ReadinessAttemptContext,
+    client: ReadinessClient,
+    phase: RunnerReadinessPhase,
+    attempts: number,
+  ): Promise<never> {
+    const isForwardingLeaseConflict =
+      phase === "runner-connect" &&
+      (client.isLastConnectionFailureForwardingLeaseConflict?.() ?? false);
+    if (isForwardingLeaseConflict) {
+      const lastConnectionFailure = client.getLastConnectionFailureMessage?.();
+      if (lastConnectionFailure) {
+        this.fail(context, phase, attempts, lastConnectionFailure);
+      }
     }
     const diagnostic = await this.runnerConnectFailureDiagnostic(context, phase);
     this.fail(

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -95,6 +95,15 @@ export interface ReadinessClient {
   isConnected(): boolean;
   waitForConnection(maxAttempts?: number, delayMs?: number): Promise<boolean>;
   verifyServiceReady(maxAttempts?: number, delayMs?: number, timeoutMs?: number): Promise<boolean>;
+  /**
+   * The most recent connect-attempt failure message, when the client tracks
+   * one (issue #6260) — e.g. "Another AutoMobile process (PID N) owns
+   * CtrlProxy forwarding...". Used to replace a generic "runner did not
+   * become responsive" failure with the real, actionable cause when one is
+   * known, instead of leaving it stuck at WARN in the daemon log where the
+   * caller never sees it.
+   */
+  getLastConnectionFailureMessage?(): string | undefined;
   getAccessibilityHierarchy?(
     queryOptions?: undefined,
     perf?: undefined,
@@ -765,6 +774,16 @@ export class RunnerReadinessService {
       if (remaining > 0) {
         await this.dependencies.timer.sleep(Math.min(READINESS_RETRY_DELAY_MS, remaining));
       }
+    }
+    // A known connect-attempt failure (e.g. a stale/orphaned AutoMobile process
+    // still owning CtrlProxy forwarding for this device) is the actual, actionable
+    // cause of a runner-connect failure — surface IT instead of the generic
+    // device-blaming message below, which points a caller at rebooting a device
+    // that was never the problem (issue #6260).
+    const lastConnectionFailure =
+      phase === "runner-connect" ? client.getLastConnectionFailureMessage?.() : undefined;
+    if (lastConnectionFailure) {
+      this.fail(context, phase, attempts, lastConnectionFailure);
     }
     const diagnostic = await this.runnerConnectFailureDiagnostic(context, phase);
     this.fail(

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -124,8 +124,17 @@ export function formatLockContent(pid: number, ownerToken?: string, metadata?: s
  */
 export function parseLockContent(content: string): LockContent {
   const [pidLine, tokenLine, metadataLine] = content.split("\n", 3);
+  const rawPid = Number.parseInt(pidLine, 10);
+  // A PID <= 0 is never a real single-process owner: `process.kill(0, 0)`
+  // signals the current process group and `process.kill(-1, 0)` signals
+  // every process this user can signal, so both "succeed" as a liveness
+  // check without naming a real process. Treat a corrupt/stale lock
+  // containing one the same as an unreadable PID (NaN) rather than ever
+  // reporting it as a live owner or surfacing it in a `kill` suggestion
+  // (issue #6260).
+  const pid = Number.isInteger(rawPid) && rawPid > 0 ? rawPid : NaN;
   const parsed: LockContent = {
-    pid: Number.parseInt(pidLine, 10),
+    pid,
     token: tokenLine || undefined,
   };
   if (metadataLine) {

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -225,6 +225,32 @@ export function tryAcquireExclusiveLock(
 }
 
 /**
+ * Read the PID recorded in an exclusive lock file without attempting to
+ * acquire or reclaim it (issue #6260). Used by callers that need to name the
+ * process currently holding a lease in an actionable error — e.g. "another
+ * AutoMobile process (PID N) owns this resource" — rather than a bare
+ * boolean. Returns `undefined` when the file is missing, unreadable, or
+ * names a process that is not (or no longer) running.
+ */
+export function readLockOwnerPid(
+  lockFilePath: string,
+  isProcessRunning: (pid: number) => boolean = defaultIsProcessRunning,
+): number | undefined {
+  let content: string;
+  try {
+    content = readFileSync(lockFilePath, "utf-8").trim();
+  } catch (error) {
+    logger.debug(`src/utils/fileLock.ts readLockOwnerPid: lock unreadable: ${error}`, error);
+    return undefined;
+  }
+  const { pid } = parseLockContent(content);
+  if (Number.isNaN(pid) || !isProcessRunning(pid)) {
+    return undefined;
+  }
+  return pid;
+}
+
+/**
  * Release a lock owned by `pid`. Compare-and-delete: the file is removed only if
  * it still holds `pid`, so a reclaim race can't delete a lock that a *different*
  * opener now owns (mirrors `shouldCleanupForExpectedPid` in `daemonFiles.ts`).

--- a/test/daemon/daemonFiles.test.ts
+++ b/test/daemon/daemonFiles.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { cleanupDaemonFiles, cleanupDaemonFilesSync } from "../../src/daemon/daemonFiles";
+import {
+  cleanupDaemonFiles,
+  cleanupDaemonFilesSync,
+  isProcessRunning,
+} from "../../src/daemon/daemonFiles";
 import type { PidFileData } from "../../src/daemon/types";
 
 describe("daemon file cleanup", () => {
@@ -59,6 +63,24 @@ describe("daemon file cleanup", () => {
 
     expect(existsSync(socketPath)).toBe(true);
     expect(existsSync(pidFilePath)).toBe(true);
+  });
+});
+
+describe("isProcessRunning", () => {
+  // Issue #6260 (PRRT ft82g): `process.kill(pid, 0)` treats non-positive PIDs
+  // specially — 0 signals the current process GROUP, -1 signals EVERY process
+  // this user can signal — so both "succeed" without naming a real process. A
+  // corrupt/stale lock recording one of these must never be reported as a
+  // live owner (which would surface a `kill 0` / `kill -1` suggestion).
+  test.each([0, -1, -100, 1.5, NaN])(
+    "reports a non-positive/non-integer PID (%p) as not running without signaling it",
+    (pid) => {
+      expect(isProcessRunning(pid)).toBe(false);
+    },
+  );
+
+  test("reports the current process as running (sanity check for a real positive PID)", () => {
+    expect(isProcessRunning(process.pid)).toBe(true);
   });
 });
 

--- a/test/daemon/daemonStrictPortBind.test.ts
+++ b/test/daemon/daemonStrictPortBind.test.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from "node:events";
+import type { Server as HttpServer } from "node:http";
 import { afterEach, describe, expect, test } from "bun:test";
-import { createServer, type Server } from "node:http";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { ActionableError } from "../../src/models/ActionableError";
@@ -13,28 +14,81 @@ import { ActionableError } from "../../src/models/ActionableError";
  * findAvailablePort() fallback to `port + 1..3`, and a genuine EADDRINUSE at
  * bind time must throw an actionable error instead of ever reporting success
  * on a different port.
+ *
+ * These tests fake the bind/port-availability seam (an injected
+ * `httpServerFactory`) instead of racing a real OS port: reclaiming an
+ * ephemeral port after releasing it is inherently non-deterministic under
+ * concurrent test runs (PRRT fuUIK), so the fake server's `listen()` decides
+ * synchronously-via-microtask whether the bind succeeds or reports
+ * EADDRINUSE, with no real socket involved.
  */
 
 interface DaemonHttpBindInternals {
   startHttpServer(): Promise<void>;
+  closeHttpListener(): Promise<void>;
 }
 
 function bindInternals(daemon: Daemon): DaemonHttpBindInternals {
   return daemon as unknown as DaemonHttpBindInternals;
 }
 
-async function listenOnEphemeralPort(): Promise<{ server: Server; port: number }> {
-  const server = createServer();
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const address = server.address();
-  if (address === null || typeof address === "string") {
-    throw new Error("Expected an AddressInfo from an ephemeral port bind");
+/**
+ * Minimal fake standing in for `node:http`'s `Server` at the one seam
+ * `startHttpServer()` actually exercises: `listen()`, the `"error"` event,
+ * and `close()`. `outcome` decides deterministically whether the fake bind
+ * succeeds or reports the requested port as already in use — no real socket
+ * is ever opened, so there is nothing for a competing process to race.
+ */
+class FakeBindServer extends EventEmitter {
+  listening = false;
+  requestTimeout = 0;
+  headersTimeout = 0;
+  timeout = 0;
+
+  constructor(private readonly outcome: "bind-ok" | "bind-refused") {
+    super();
   }
-  return { server, port: address.port };
+
+  listen(_port: number, _host: string, callback: () => void): this {
+    queueMicrotask(() => {
+      if (this.outcome === "bind-ok") {
+        this.listening = true;
+        callback();
+      } else {
+        const error = new Error("bind EADDRINUSE") as NodeJS.ErrnoException;
+        error.code = "EADDRINUSE";
+        this.emit("error", error);
+      }
+    });
+    return this;
+  }
+
+  close(callback?: (error?: Error) => void): this {
+    this.listening = false;
+    callback?.();
+    return this;
+  }
 }
 
-function closeServer(server: Server): Promise<void> {
-  return new Promise((resolve) => server.close(() => resolve()));
+function daemonWithFakeHttpServer(
+  options: ConstructorParameters<typeof Daemon>[0],
+  outcome: "bind-ok" | "bind-refused",
+): Daemon {
+  return new Daemon(
+    options,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    () => new FakeBindServer(outcome) as unknown as HttpServer,
+  );
 }
 
 describe("Daemon strict-port bind (issue #6260)", () => {
@@ -44,46 +98,51 @@ describe("Daemon strict-port bind (issue #6260)", () => {
     }
   });
 
-  test("strictPort fails loudly with an actionable error when the requested port is taken at bind time", async () => {
-    const { server: competitor, port } = await listenOnEphemeralPort();
-    const daemon = new Daemon({ port, host: "127.0.0.1", strictPort: true });
+  test("strictPort fails loudly with an actionable error when the fake bind reports the port is taken", async () => {
+    const port = 54321;
+    const daemon = daemonWithFakeHttpServer(
+      { port, host: "127.0.0.1", strictPort: true },
+      "bind-refused",
+    );
 
-    try {
-      await expect(bindInternals(daemon).startHttpServer()).rejects.toThrow(ActionableError);
-      await expect(bindInternals(daemon).startHttpServer()).rejects.toThrow(
-        new RegExp(`Port ${port}.*already in use`),
-      );
-    } finally {
-      await closeServer(competitor);
-    }
+    await expect(bindInternals(daemon).startHttpServer()).rejects.toThrow(ActionableError);
+
+    const daemonAgain = daemonWithFakeHttpServer(
+      { port, host: "127.0.0.1", strictPort: true },
+      "bind-refused",
+    );
+    await expect(bindInternals(daemonAgain).startHttpServer()).rejects.toThrow(
+      new RegExp(`Port ${port}.*already in use`),
+    );
   });
 
-  test("without strictPort, the same EADDRINUSE surfaces the raw (non-actionable) HTTP server error", async () => {
-    const { server: competitor, port } = await listenOnEphemeralPort();
-    const daemon = new Daemon({ port, host: "127.0.0.1" });
+  test("without strictPort, the same fake EADDRINUSE surfaces the raw (non-actionable) HTTP server error", async () => {
+    const port = 54322;
+    const daemon = daemonWithFakeHttpServer({ port, host: "127.0.0.1" }, "bind-refused");
 
+    let caught: unknown;
     try {
-      let caught: unknown;
-      try {
-        await bindInternals(daemon).startHttpServer();
-      } catch (error) {
-        caught = error;
-      }
-      expect(caught).toBeDefined();
-      expect(caught).not.toBeInstanceOf(ActionableError);
-    } finally {
-      await closeServer(competitor);
+      await bindInternals(daemon).startHttpServer();
+    } catch (error) {
+      caught = error;
     }
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(ActionableError);
   });
 
-  test("strictPort binds successfully when the requested port is actually free", async () => {
-    const { server: probe, port } = await listenOnEphemeralPort();
-    await closeServer(probe);
-    const daemon = new Daemon({ port, host: "127.0.0.1", strictPort: true });
+  test("strictPort binds using exactly the requested port when the fake bind succeeds", async () => {
+    const port = 54323;
+    const daemon = daemonWithFakeHttpServer(
+      { port, host: "127.0.0.1", strictPort: true },
+      "bind-ok",
+    );
 
     await bindInternals(daemon).startHttpServer();
 
-    // Clean up the real listener this test bound.
-    await (daemon as unknown as { closeHttpListener(): Promise<void> }).closeHttpListener();
+    // No port+1..3 fallback: the daemon must still be configured for the
+    // exact requested port, not a substitute one.
+    expect((daemon as unknown as { port: number }).port).toBe(port);
+
+    await bindInternals(daemon).closeHttpListener();
   });
 });

--- a/test/daemon/daemonStrictPortBind.test.ts
+++ b/test/daemon/daemonStrictPortBind.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { ActionableError } from "../../src/models/ActionableError";
+
+/**
+ * Issue #6260 (PRRT ft82d): `restart()`'s port-availability preflight is a
+ * non-atomic probe-then-release check with a window between releasing the
+ * probe socket and the child actually binding. `strictPort` closes that
+ * TOCTOU by making the child's own `listen()` call — inside
+ * `startHttpServer()` — the single, atomic bind-or-fail attempt: no
+ * findAvailablePort() fallback to `port + 1..3`, and a genuine EADDRINUSE at
+ * bind time must throw an actionable error instead of ever reporting success
+ * on a different port.
+ */
+
+interface DaemonHttpBindInternals {
+  startHttpServer(): Promise<void>;
+}
+
+function bindInternals(daemon: Daemon): DaemonHttpBindInternals {
+  return daemon as unknown as DaemonHttpBindInternals;
+}
+
+async function listenOnEphemeralPort(): Promise<{ server: Server; port: number }> {
+  const server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected an AddressInfo from an ephemeral port bind");
+  }
+  return { server, port: address.port };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("Daemon strict-port bind (issue #6260)", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("strictPort fails loudly with an actionable error when the requested port is taken at bind time", async () => {
+    const { server: competitor, port } = await listenOnEphemeralPort();
+    const daemon = new Daemon({ port, host: "127.0.0.1", strictPort: true });
+
+    try {
+      await expect(bindInternals(daemon).startHttpServer()).rejects.toThrow(ActionableError);
+      await expect(bindInternals(daemon).startHttpServer()).rejects.toThrow(
+        new RegExp(`Port ${port}.*already in use`),
+      );
+    } finally {
+      await closeServer(competitor);
+    }
+  });
+
+  test("without strictPort, the same EADDRINUSE surfaces the raw (non-actionable) HTTP server error", async () => {
+    const { server: competitor, port } = await listenOnEphemeralPort();
+    const daemon = new Daemon({ port, host: "127.0.0.1" });
+
+    try {
+      let caught: unknown;
+      try {
+        await bindInternals(daemon).startHttpServer();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeDefined();
+      expect(caught).not.toBeInstanceOf(ActionableError);
+    } finally {
+      await closeServer(competitor);
+    }
+  });
+
+  test("strictPort binds successfully when the requested port is actually free", async () => {
+    const { server: probe, port } = await listenOnEphemeralPort();
+    await closeServer(probe);
+    const daemon = new Daemon({ port, host: "127.0.0.1", strictPort: true });
+
+    await bindInternals(daemon).startHttpServer();
+
+    // Clean up the real listener this test bound.
+    await (daemon as unknown as { closeHttpListener(): Promise<void> }).closeHttpListener();
+  });
+});

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -128,7 +128,11 @@ describe("DaemonManager restart", () => {
 
     expect(statusSpy).toHaveBeenCalledTimes(1);
     expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith(recordedOptions);
+    // strictPort:true is always forced onto a restart (issue #6260 PRRT
+    // ft82d) so the child's own listen() call — not a preflight probe that
+    // releases its socket before the child binds — is the authoritative
+    // bind-or-fail guard against the port-fallback split-brain.
+    expect(startSpy).toHaveBeenCalledWith({ ...recordedOptions, strictPort: true });
   });
 });
 
@@ -2019,7 +2023,7 @@ describe("Daemon manager process detection", () => {
       await manager.restart();
 
       expect(signaler.signals).toEqual([{ pid: candidatePid, signal: "SIGTERM" }]);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       startSpy.mockRestore();
       statusSpy.mockRestore();
@@ -2075,7 +2079,7 @@ describe("Daemon manager process detection", () => {
         { pid: 452, signal: "SIGTERM" },
         { pid: 453, signal: "SIGTERM" },
       ]);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       startSpy.mockRestore();
       statusSpy.mockRestore();
@@ -2134,7 +2138,7 @@ describe("Daemon manager process detection", () => {
 
       expect(stopSpy).toHaveBeenCalledTimes(1);
       expect(signaler.signals).toEqual([{ pid: crossNamespacePid, signal: "SIGTERM" }]);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       startSpy.mockRestore();
       stopSpy.mockRestore();
@@ -2207,7 +2211,7 @@ describe("Daemon manager process detection", () => {
         { pid: crossNamespacePid, signal: "SIGKILL" },
       ]);
       expect(fakeTimer.now()).toBe(12_000);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       killSpy.mockRestore();
       startSpy.mockRestore();
@@ -2404,7 +2408,7 @@ describe("Daemon manager process detection", () => {
       await manager.restart();
 
       expect(signaler.signals).toEqual([]);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       startSpy.mockRestore();
       statusSpy.mockRestore();
@@ -2557,7 +2561,7 @@ describe("Daemon manager process detection", () => {
 
       expect(stopSpy).toHaveBeenCalledTimes(1);
       expect(portChecker.checkedPorts).toEqual([3000]);
-      expect(startSpy).toHaveBeenCalledWith({});
+      expect(startSpy).toHaveBeenCalledWith({ strictPort: true });
     } finally {
       startSpy.mockRestore();
       stopSpy.mockRestore();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -24,6 +24,7 @@ import type {
   DaemonProcessSignaler,
   DaemonProcessSpawner,
   DaemonProcessRecord,
+  DaemonPortAvailabilityChecker,
   ExtractionCleaner,
 } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
@@ -101,6 +102,14 @@ describe("DaemonManager restart", () => {
         findDaemonProcesses: () => [],
         isProcessRunning: () => false,
       },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const recordedOptions: DaemonOptions = {
       debug: true,
@@ -630,6 +639,23 @@ class FakeDaemonProcessSignaler implements DaemonProcessSignaler {
   signal(pid: number, signal: NodeJS.Signals): void {
     this.signals.push({ pid, signal });
     this.onSignal?.(pid, signal);
+  }
+}
+
+/**
+ * Deterministic stand-in for the real net-based port probe (issue #6260) so
+ * restart tests never touch a real socket. Defaults to reporting every port
+ * free, matching a healthy stop; pass `free: false` to simulate a canonical
+ * port that stayed bound after cleanup.
+ */
+class FakeDaemonPortAvailabilityChecker implements DaemonPortAvailabilityChecker {
+  public readonly checkedPorts: number[] = [];
+
+  constructor(private readonly free: boolean = true) {}
+
+  isPortFree(port: number): Promise<boolean> {
+    this.checkedPorts.push(port);
+    return Promise.resolve(this.free);
   }
 }
 
@@ -1981,6 +2007,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
@@ -2030,6 +2060,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
@@ -2081,6 +2115,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({
       running: true,
@@ -2138,6 +2176,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({
       running: true,
@@ -2201,6 +2243,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({
       running: true,
@@ -2274,6 +2320,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
@@ -2342,6 +2392,10 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       signaler,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonPortAvailabilityChecker(),
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
@@ -2353,6 +2407,160 @@ describe("Daemon manager process detection", () => {
       expect(startSpy).toHaveBeenCalledWith({});
     } finally {
       startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("explicit restart refuses to start a second daemon when a survivor is still on the process table (issue #6260)", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    // Simulates the exact #6260 split-brain: the recorded/status() read finds
+    // nothing to stop, and the cross-namespace sweep's own candidate list is
+    // ALSO empty at that instant (a process-table scan miss) even though the
+    // old daemon (PID 71579-alike) is still alive — cleanup reports success
+    // without ever having found it. The post-cleanup survivor re-check must
+    // still catch it before start() is ever called.
+    const orphanPid = 71579;
+    let scanCount = 0;
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => {
+        scanCount++;
+        // The cleanup-phase scan (call 1) misses the orphan; the post-cleanup
+        // confirmation (call 2) finds it, exactly like the real ps scan would
+        // once its transient miss condition (whatever caused it) clears.
+        return scanCount === 1
+          ? []
+          : [{ pid: orphanPid, ppid: 1, command: "bun /checkout/dist/src/index.js --daemon-mode" }];
+      },
+      isProcessRunning: (pid) => pid === orphanPid,
+    };
+    const signaler = new FakeDaemonProcessSignaler();
+    const portChecker = new FakeDaemonPortAvailabilityChecker();
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
+      undefined,
+      undefined,
+      undefined,
+      portChecker,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+
+    try {
+      await expect(manager.restart()).rejects.toThrow(`PID(s) ${orphanPid} still running`);
+      expect(startSpy).not.toHaveBeenCalled();
+      // The port must never even be consulted once a live survivor is found —
+      // failing on the named PID is strictly more actionable.
+      expect(portChecker.checkedPorts).toEqual([]);
+    } finally {
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("explicit restart refuses to start a second daemon on a fallback port when the canonical port stays bound (issue #6260)", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: () => false,
+    };
+    // Cleanup found nothing to stop, and no live daemon process remains on the
+    // table — but the canonical port is still held by something (a process
+    // this scan could not identify as an AutoMobile daemon, or one it missed
+    // entirely). Restart must fail rather than let start() silently take the
+    // next port in range.
+    const portChecker = new FakeDaemonPortAvailabilityChecker(false);
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      portChecker,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+
+    try {
+      await expect(manager.restart()).rejects.toThrow("port 3000");
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(portChecker.checkedPorts).toEqual([3000]);
+    } finally {
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("explicit restart starts a single daemon on the canonical port once the previous daemon is confirmed stopped (issue #6260)", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const recordedPid = 71579;
+    const livePids = new Set([recordedPid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () =>
+        [...livePids].map((pid) => ({
+          pid,
+          ppid: 1,
+          command: "bun /checkout/dist/src/index.js --daemon-mode",
+        })),
+      isProcessRunning: (pid) => livePids.has(pid),
+    };
+    const portChecker = new FakeDaemonPortAvailabilityChecker();
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      portChecker,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({
+      running: true,
+      pid: recordedPid,
+    });
+    const stopSpy = spyOn(manager, "stop").mockImplementation(async () => {
+      livePids.delete(recordedPid);
+    });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+
+    try {
+      await manager.restart();
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(portChecker.checkedPorts).toEqual([3000]);
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      startSpy.mockRestore();
+      stopSpy.mockRestore();
       statusSpy.mockRestore();
     }
   });

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -2461,7 +2461,23 @@ describe("Daemon manager process detection", () => {
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
 
     try {
-      await expect(manager.restart()).rejects.toThrow(`PID(s) ${orphanPid} still running`);
+      let caught: unknown;
+      try {
+        await manager.restart();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toContain(`PID(s) ${orphanPid} still running`);
+      // PRRT fuUIM (issue #6260): the remediation must not hand out a bare
+      // `kill <pid>` from this stale process-table snapshot — that PID can be
+      // recycled to an unrelated process by the time anyone acts on it. It
+      // must instead point at an identity re-check using the same
+      // `--daemon-mode` command-line pattern findLiveDaemonProcesses() itself
+      // matches on, so only a still-matching PID gets killed.
+      expect(message).toContain("--daemon-mode");
+      expect(message).not.toContain(`kill ${orphanPid}\``);
       expect(startSpy).not.toHaveBeenCalled();
       // The port must never even be consulted once a live survivor is found —
       // failing on the named PID is strictly more actionable.

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -57,7 +57,10 @@ describe("AndroidCtrlProxyClient", function () {
     public acquireAttempts = 0;
     public releases = 0;
 
-    public constructor(private readonly canAcquire: boolean = true) {}
+    public constructor(
+      private readonly canAcquire: boolean = true,
+      private readonly ownerPid?: number,
+    ) {}
 
     public tryAcquire(): boolean {
       this.acquireAttempts++;
@@ -66,6 +69,10 @@ describe("AndroidCtrlProxyClient", function () {
 
     public release(): void {
       this.releases++;
+    }
+
+    public getLastOwnerPid(): number | undefined {
+      return this.canAcquire ? undefined : this.ownerPid;
     }
   }
 
@@ -1246,6 +1253,36 @@ describe("AndroidCtrlProxyClient", function () {
     }
   });
 
+  test("names the orphan PID when another process owns the device lease (issue #6260)", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52004 tcp:8765\n`);
+    const lease = new FakeCtrlProxyForwardLease(false, 71579);
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      lease,
+    );
+    try {
+      await expect((client as any).setupPortForwarding()).rejects.toThrow(
+        /Another AutoMobile process \(PID 71579\) owns CtrlProxy forwarding.*stale\/orphaned AutoMobile daemon.*--daemon restart.*kill 71579/s,
+      );
+    } finally {
+      await client.close();
+    }
+  });
+
   test("does not reclaim a live file lease from a synchronously evicted same-process client", async function () {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();
@@ -1275,6 +1312,9 @@ describe("AndroidCtrlProxyClient", function () {
         fakeTimer,
       );
       expect((replacement as any).ctrlProxyForwardLease.tryAcquire()).toBe(false);
+      // The real file lease (issue #6260) must resolve the owner PID from the
+      // lock file it just lost the race for, not merely report the boolean.
+      expect((replacement as any).ctrlProxyForwardLease.getLastOwnerPid()).toBe(process.pid);
     } finally {
       await replacement?.close();
       await original.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../../src/db/dbWriteBarrier";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { CtrlProxyFocus } from "../../../src/features/observe/android/CtrlProxyFocus";
+import { CtrlProxyForwardingLeaseConflictError } from "../../../src/features/observe/shared/CtrlProxyForwardingLeaseConflictError";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
@@ -1278,6 +1279,48 @@ describe("AndroidCtrlProxyClient", function () {
       await expect((client as any).setupPortForwarding()).rejects.toThrow(
         /Another AutoMobile process \(PID 71579\) owns CtrlProxy forwarding.*stale\/orphaned AutoMobile daemon.*--daemon restart.*kill 71579/s,
       );
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("does not suggest killing self when the lease owner is this same process (PRRT_kwDOP-GF5M6fuKn9)", async function () {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeAdb.clearHistory();
+    stubForwardLifecycleCommands(() => `${testDevice.deviceId} tcp:52004 tcp:8765\n`);
+    // Shutdown recovery can evict a singleton while its in-flight setup still
+    // holds the lease, so a replacement client in THIS SAME process can observe
+    // its own PID as the current owner. That must never surface the orphan-kill
+    // diagnostic, since the PID it would name is the caller's own.
+    const lease = new FakeCtrlProxyForwardLease(false, process.pid);
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      lease,
+    );
+    try {
+      let caught: unknown;
+      try {
+        await (client as any).setupPortForwarding();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(CtrlProxyForwardingLeaseConflictError);
+      const message = (caught as Error).message;
+      expect(message).toContain("Another AutoMobile process owns CtrlProxy forwarding");
+      expect(message).not.toMatch(/kill/i);
     } finally {
       await client.close();
     }

--- a/test/features/observe/DeviceServiceClientForwardingLeaseConflict.test.ts
+++ b/test/features/observe/DeviceServiceClientForwardingLeaseConflict.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { DeviceServiceClient } from "../../../src/features/observe/DeviceServiceClient";
+import { CtrlProxyForwardingLeaseConflictError } from "../../../src/features/observe/shared/CtrlProxyForwardingLeaseConflictError";
+import { createSuccessWebSocketFactory } from "../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { PerformanceTracker } from "../../../src/utils/PerformanceTracker";
+import { NoOpPerformanceTracker } from "../../../src/utils/PerformanceTracker";
+import type WebSocket from "ws";
+
+/**
+ * Concrete subclass of DeviceServiceClient whose platform-setup failure is
+ * controlled per-test (issue #6260 PRRT ft82e): RunnerReadinessService must
+ * detect a CtrlProxyForwardingLeaseConflictError specifically, not any
+ * connect-attempt failure.
+ */
+class TestDeviceServiceClient extends DeviceServiceClient {
+  protected readonly logTag = "TestClient";
+  setupError: Error | null = null;
+
+  constructor(timer: FakeTimer, wsFactory: (url: string) => WebSocket) {
+    super(timer, wsFactory);
+  }
+
+  protected getWebSocketUrl(): string {
+    return "ws://localhost:9999/ws";
+  }
+
+  protected handleMessage(_data: WebSocket.Data): void {}
+
+  protected onConnectionEstablished(): void {}
+
+  protected onConnectionClosed(): void {}
+
+  protected async setupBeforeConnect(
+    _perf: PerformanceTracker,
+    _signal: AbortSignal,
+  ): Promise<void> {
+    if (this.setupError) {
+      throw this.setupError;
+    }
+  }
+
+  disableAutoReconnect(): void {
+    this.autoReconnectEnabled = false;
+  }
+}
+
+describe("DeviceServiceClient forwarding-lease conflict detection (issue #6260 PRRT ft82e)", () => {
+  let client: TestDeviceServiceClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      client.disableAutoReconnect();
+      await client.close();
+      client = null;
+    }
+  });
+
+  test("tags a CtrlProxyForwardingLeaseConflictError as the forwarding-lease conflict", async () => {
+    const timer = new FakeTimer();
+    client = new TestDeviceServiceClient(timer, createSuccessWebSocketFactory());
+    client.disableAutoReconnect();
+    client.setupError = new CtrlProxyForwardingLeaseConflictError(
+      "Another AutoMobile process (PID 71579) owns CtrlProxy forwarding for emulator-5554.",
+      71579,
+    );
+
+    const connected = await client.ensureConnected(new NoOpPerformanceTracker());
+
+    expect(connected).toBe(false);
+    expect(client.getLastConnectionFailureMessage()).toContain("owns CtrlProxy forwarding");
+    expect(client.isLastConnectionFailureForwardingLeaseConflict()).toBe(true);
+  });
+
+  test("does NOT tag an ordinary connect failure as the forwarding-lease conflict", async () => {
+    const timer = new FakeTimer();
+    client = new TestDeviceServiceClient(timer, createSuccessWebSocketFactory());
+    client.disableAutoReconnect();
+    client.setupError = new Error("connect ECONNREFUSED 127.0.0.1:5037");
+
+    const connected = await client.ensureConnected(new NoOpPerformanceTracker());
+
+    expect(connected).toBe(false);
+    expect(client.getLastConnectionFailureMessage()).toContain("ECONNREFUSED");
+    expect(client.isLastConnectionFailureForwardingLeaseConflict()).toBe(false);
+  });
+
+  test("clears the forwarding-lease-conflict tag once a later connect succeeds", async () => {
+    const timer = new FakeTimer();
+    client = new TestDeviceServiceClient(timer, createSuccessWebSocketFactory());
+    client.disableAutoReconnect();
+    client.setupError = new CtrlProxyForwardingLeaseConflictError(
+      "Another AutoMobile process owns CtrlProxy forwarding for emulator-5554.",
+      undefined,
+    );
+    expect(await client.ensureConnected(new NoOpPerformanceTracker())).toBe(false);
+    expect(client.isLastConnectionFailureForwardingLeaseConflict()).toBe(true);
+
+    client.setupError = null;
+    expect(await client.ensureConnected(new NoOpPerformanceTracker())).toBe(true);
+
+    expect(client.getLastConnectionFailureMessage()).toBeUndefined();
+    expect(client.isLastConnectionFailureForwardingLeaseConflict()).toBe(false);
+  });
+});

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -32,6 +32,7 @@ class FakeReadinessClient implements ReadinessClient {
   tapCoordinates: Array<{ x: number; y: number }> = [];
   onTap?: () => Promise<void> | void;
   getLastConnectionFailureMessage?: () => string | undefined;
+  isLastConnectionFailureForwardingLeaseConflict?: () => boolean;
 
   isConnected(): boolean {
     return this.connected;
@@ -1058,6 +1059,7 @@ describe("RunnerReadinessService", () => {
       "Another AutoMobile process (PID 71579) owns CtrlProxy forwarding for emulator-5554. " +
       "This is usually a stale/orphaned AutoMobile daemon left behind by an incomplete " +
       "`--daemon restart` — stop it (`kill 71579`) and retry.";
+    client.isLastConnectionFailureForwardingLeaseConflict = () => true;
     const { service } = createService({
       androidClient: client,
       // A diagnostic is available, but the known connect-failure cause must win —
@@ -1085,6 +1087,43 @@ describe("RunnerReadinessService", () => {
         readinessTimeoutMs: 1_000,
       }),
     ).rejects.not.toThrow(/runner did not become responsive/);
+  });
+
+  test("preserves the Android diagnostic for an ordinary connect failure that is not a forwarding-lease conflict (issue #6260 PRRT ft82e)", async () => {
+    const client = new FakeReadinessClient();
+    client.connected = false;
+    client.connectionResults = [];
+    // A stored connect failure exists (e.g. ECONNREFUSED), but it is NOT the
+    // CtrlProxy forwarding-lease conflict — the existing Android diagnostics
+    // (primaryUserStartState/deviceLock) must be preserved, not replaced by
+    // this raw transport text.
+    client.getLastConnectionFailureMessage = () => "connect ECONNREFUSED 127.0.0.1:5037";
+    client.isLastConnectionFailureForwardingLeaseConflict = () => false;
+    const { service } = createService({
+      androidClient: client,
+      getAndroidRunnerConnectDiagnostic: async () => ({
+        deviceLock: { locked: true, keyguardShowing: true, secure: true },
+        primaryUserStartState: "RUNNING_LOCKED",
+      }),
+    });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(/phase=runner-connect.*RUNNING_LOCKED/);
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.not.toThrow(/ECONNREFUSED/);
   });
 
   test("diagnoses a locked primary user when runner connection times out", async () => {

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -31,6 +31,7 @@ class FakeReadinessClient implements ReadinessClient {
   tapResult = { success: true };
   tapCoordinates: Array<{ x: number; y: number }> = [];
   onTap?: () => Promise<void> | void;
+  getLastConnectionFailureMessage?: () => string | undefined;
 
   isConnected(): boolean {
     return this.connected;
@@ -1047,6 +1048,43 @@ describe("RunnerReadinessService", () => {
     ).rejects.toThrow(
       /platform=android.*requested=\[platform=android name=Pixel_9_Pro\].*resolved=\[Pixel_9_Pro \(emulator-5554\)\].*phase=runner-connect.*attempts=[1-9].*remainingBudgetMs=0/,
     );
+  });
+
+  test("surfaces a known connect-attempt failure instead of the generic unresponsive message (issue #6260)", async () => {
+    const client = new FakeReadinessClient();
+    client.connected = false;
+    client.connectionResults = [];
+    client.getLastConnectionFailureMessage = () =>
+      "Another AutoMobile process (PID 71579) owns CtrlProxy forwarding for emulator-5554. " +
+      "This is usually a stale/orphaned AutoMobile daemon left behind by an incomplete " +
+      "`--daemon restart` — stop it (`kill 71579`) and retry.";
+    const { service } = createService({
+      androidClient: client,
+      // A diagnostic is available, but the known connect-failure cause must win —
+      // a client should be pointed at the orphan process, not the device.
+      getAndroidRunnerConnectDiagnostic: async () => ({
+        deviceLock: { locked: false, keyguardShowing: false, secure: false },
+        primaryUserStartState: "RUNNING_UNLOCKED",
+      }),
+    });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(/Another AutoMobile process \(PID 71579\) owns CtrlProxy forwarding/);
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+        totalDeadlineMs: 1_000,
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.not.toThrow(/runner did not become responsive/);
   });
 
   test("diagnoses a locked primary user when runner connection times out", async () => {

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -268,6 +268,15 @@ describe("fileLock primitive", () => {
     test("parseLockContent reports NaN for an unreadable PID line", () => {
       expect(parseLockContent("not-a-pid").pid).toBeNaN();
     });
+
+    // Issue #6260 (PRRT ft82g): PID 0 signals the current process GROUP and
+    // PID -1 signals EVERY process a user can signal to `process.kill`, so
+    // both "succeed" as a liveness probe without naming a real process. A
+    // corrupt/stale lock containing one must never be treated as a live
+    // owner, or a caller could surface a `kill 0` / `kill -1` suggestion.
+    test.each([0, -1, -100])("parseLockContent reports NaN for a non-positive PID (%d)", (pid) => {
+      expect(parseLockContent(formatLockContent(pid)).pid).toBeNaN();
+    });
   });
 
   describe("releaseExclusiveLock (compare-and-delete)", () => {


### PR DESCRIPTION
## Root cause

`DaemonManager.restart()` stops the PID-recorded daemon and, in
parallel, force-stops every OTHER live AutoMobile process it can find
on the process table (`stopUnrecordedDaemonsForExplicitRestart`). Both
operations reported success via `Promise.allSettled` — but that only
guards against a *discovered* candidate refusing to stop. It cannot
catch a live daemon that was never discovered as a candidate in the
first place (a process-table scan miss, a stale/mismatched PID record,
etc.). `restart()` then called `start()` unconditionally.

`start()`'s own port selection (`findAvailablePort` in `daemon.ts`)
silently falls back to the next port in `DAEMON_PORT_RANGE_START..END`
when the canonical port (3000) is still bound, and reports unqualified
success either way. So a restart that failed to actually stop the old
daemon produced exactly the symptom in #6260: no "Stopping daemon..."
line, a second daemon on port 3001, and "Daemon started successfully"
— while the orphaned old daemon kept holding CtrlProxy port-forwarding
ownership for the device, via `AndroidCtrlProxyClient`'s
`FileCtrlProxyForwardLease`.

Every subsequent device acquisition through the new daemon then failed
with a generic, device-blaming `runner did not become responsive`
error, because `DeviceServiceClient.connectWebSocket()` swallows the
real cause (`Another AutoMobile process owns CtrlProxy forwarding for
<device>`) down to a `logger.warn` and a bare `false`.

## Fix

1. **`DaemonManager.restart()` now confirms the old daemon is actually
   gone before starting a replacement.** Right before `start()`, it:
   - Re-scans the process table (`findLiveDaemonProcesses()`) and, if
     any AutoMobile daemon process remains, throws an `ActionableError`
     naming the orphan PID(s) and how to kill them, rather than
     starting a second daemon beside it.
   - Probes the canonical port directly via a new
     `DaemonPortAvailabilityChecker` (injectable; production default is
     a real `net` listen/close probe). If the port is still bound —
     even when process-table detection found nothing to blame — it
     fails loudly instead of letting `start()` silently take a
     fallback port.

2. **The CtrlProxy forwarding-lease conflict now names the owning
   PID.** `fileLock.ts` gains `readLockOwnerPid()`; `FileCtrlProxyForwardLease`
   uses it so the "Another AutoMobile process owns CtrlProxy forwarding
   for `<device>`" error becomes actionable (`PID <n>`, `kill <n>`,
   points at a stale `--daemon restart`).

3. **`RunnerReadinessService` surfaces that real cause instead of the
   generic message.** `DeviceServiceClient` now remembers the last
   connect-attempt failure message (`getLastConnectionFailureMessage`);
   when the exhausted phase is `runner-connect` and one is present,
   `RunnerReadinessService.waitForResponsiveClient` throws it directly
   instead of the generic "runner did not become responsive... " text
   — so a client is pointed at the orphan AutoMobile process, not sent
   to reboot a healthy device.

The existing #6140 invariants (O_EXCL startup lock, never unlinking a
socket outside a confirmed-dead/locked path) are untouched — all new
checks are additive guards *before* `start()` is called.

## Tests

`test/daemon/manager.test.ts`:
- restart refuses to start a second daemon when a survivor is found by
  the post-cleanup process-table re-check, even though the recorded
  status and the cross-namespace sweep both reported nothing to stop
  (the exact #6260 split-brain).
- restart refuses to start a second daemon when the canonical port
  stays bound despite a clean process-table sweep.
- restart proceeds to a single daemon on the canonical port once the
  previous daemon is confirmed stopped.

`test/features/observe/CtrlProxyClient.test.ts`:
- the forwarding-lease conflict error names the orphan PID.
- the real `FileCtrlProxyForwardLease` resolves the owner PID from the
  lock file it lost the race for (not just the boolean).

`test/utils/RunnerReadinessService.test.ts`:
- a known connect-attempt failure (forwarding-ownership conflict) is
  surfaced verbatim instead of the generic "runner did not become
  responsive" message, even when an Android diagnostic is also
  available.

## Validation

- `bun test test/daemon/ test/utils/RunnerReadinessService.test.ts test/features/observe/CtrlProxyClient.test.ts` — all pass (the pre-existing "remains live after SIGKILL" flake in `manager.test.ts` is unrelated, per project notes).
- `bun run lint` — clean, no new ratchet violations.
- `bun run typecheck` — clean, no new baseline errors.
- `bun run format:check` — clean.
- `bunx turbo run build` — succeeds.

Closes #6260