### PR TITLE
fix: name the remediation call in session_ownership_lost and disabled-tool errors (#6259)

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -45,6 +45,7 @@ import {
 } from "../server/sessionReleaseBroadcast";
 import {
   toolSelectionProfileUuidFromResponse,
+  IDE_SET_SESSION_TOOL_ENABLED_METHOD,
   SET_TOOL_ENABLED_TOOL_NAME,
 } from "../features/toolSelection/toolSelectionControl";
 import {
@@ -2618,6 +2619,10 @@ export class UnixSocketServer {
         declaredDefault,
         [undefined],
         this.sessionToolSelectionService,
+        // No connectionProfileUuid on this channel — a caller here is on the direct IDE
+        // socket, which has no MCP connection profile and cannot invoke an MCP tool.
+        undefined,
+        IDE_SET_SESSION_TOOL_ENABLED_METHOD,
       );
       return;
     }
@@ -2633,6 +2638,12 @@ export class UnixSocketServer {
       declaredDefault,
       [baseSessionUuid, derivedSessionUuid],
       this.sessionToolSelectionService,
+      // This IDE socket-gate path never has a connection profile of its own (see
+      // formatToolEnabledRemediationSentence in toolSelectionPolicy.ts) — the remediation must
+      // name the daemon's own `ide/setSessionToolEnabled` method, not the MCP `setToolEnabled`
+      // tool, since a caller on this channel cannot invoke an MCP tool (issue #6259).
+      undefined,
+      IDE_SET_SESSION_TOOL_ENABLED_METHOD,
     );
   }
 

--- a/src/features/toolSelection/toolSelectionControl.ts
+++ b/src/features/toolSelection/toolSelectionControl.ts
@@ -1,5 +1,14 @@
 export const SET_TOOL_ENABLED_TOOL_NAME = "setToolEnabled";
 
+/**
+ * The daemon IDE-socket method (src/daemon/socketServer.ts, `ide/setSessionToolEnabled` case)
+ * that grants a tool for a session over the direct IDE socket channel. Rejections raised on that
+ * channel (`ide/setKeyValue`, `ide/removeKeyValue`, `ide/clearKeyValueFile`) must name THIS method
+ * in their remediation, not the MCP `setToolEnabled` tool — a caller on the socket channel has no
+ * way to invoke an MCP tool (issue #6259).
+ */
+export const IDE_SET_SESSION_TOOL_ENABLED_METHOD = "ide/setSessionToolEnabled";
+
 function textContent(response: unknown): string[] {
   if (!response || typeof response !== "object") {
     return [];

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -25,6 +25,42 @@ function formatSetToolEnabledRemediation(
   return `setToolEnabled { toolName: "${toolName}", enabled: true${sessionUuidArg} }`;
 }
 
+/**
+ * Builds the remediation sentence for `assertToolEnabledForAnySession`, distinguishing three
+ * cases so the advertised call is always one the retry will actually recheck:
+ *
+ * 1. One or more session candidates — name a real candidate `sessionUuid` (the sole one, or
+ *    the first/base-preferring one the caller's ordering rechecks when there is no
+ *    `connectionProfileUuid` to fall back to).
+ * 2. A `connectionProfileUuid` is part of what gets rechecked — omit `sessionUuid` entirely,
+ *    which updates the connection profile the retry rechecks.
+ * 3. Zero candidates AND no `connectionProfileUuid` (e.g. an IDE storage request against a
+ *    booted device with no owning daemon session) — there is nothing `setToolEnabled` could
+ *    enable that the retry would recheck, so do not advertise it at all. Instead, tell the
+ *    caller to acquire a device session first.
+ */
+function formatToolEnabledRemediationSentence(
+  toolName: string,
+  candidates: readonly string[],
+  connectionProfileUuid: string | undefined,
+): string {
+  if (candidates.length === 0 && connectionProfileUuid === undefined) {
+    return (
+      "No device session owns this device yet, so there is nothing setToolEnabled could enable " +
+      "that a retry would recheck. Acquire a device session with getAndroid { deviceId } " +
+      "(or getApple { deviceId }), then enable the tool with " +
+      `setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "<uuid from getAndroid/getApple>" }.`
+    );
+  }
+  const realSessionUuid =
+    candidates.length === 1
+      ? candidates[0]
+      : connectionProfileUuid === undefined
+        ? candidates[0]
+        : undefined;
+  return `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid)}.`;
+}
+
 async function explicitOverrideResult(
   service: ToolSelectionReader,
   sessionUuids: readonly string[],
@@ -174,22 +210,8 @@ export async function assertToolEnabledForAnySession(
     new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid))),
   );
   const target = candidates.join(" / ") || "(not yet bound)";
-  // Only a single resolvable candidate can be named as the real sessionUuid in the
-  // remediation call — a composite of multiple profiles is not something
-  // resolveSelectionSessionUuid would accept, so it falls back to the connection-profile form
-  // ONLY when a connection profile is actually part of what gets rechecked (`connectionProfileUuid`
-  // is defined, as on the MCP-server path). Callers with no connection profile at all — the IDE
-  // socket-gate path (`assertSocketToolEnabled`), which rechecks only its base/derived session
-  // profiles — have no connection profile for the omitted form to land on, so name the first
-  // (base-preferring, per the caller's ordering) candidate the retry will actually recheck instead.
-  const realSessionUuid =
-    candidates.length === 1
-      ? candidates[0]
-      : connectionProfileUuid === undefined
-        ? candidates[0]
-        : undefined;
   throw new ActionableError(
     `Tool ${toolName} is disabled for device session ${target}. ` +
-      `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid)}.`,
+      formatToolEnabledRemediationSentence(toolName, candidates, connectionProfileUuid),
   );
 }

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -20,9 +20,10 @@ type ToolSelectionReader = Pick<SessionToolSelectionService, "isEnabled"> &
 function formatSetToolEnabledRemediation(
   toolName: string,
   realSessionUuid: string | undefined,
+  remediationMethodName: string = SET_TOOL_ENABLED_TOOL_NAME,
 ): string {
   const sessionUuidArg = realSessionUuid ? `, sessionUuid: "${realSessionUuid}"` : "";
-  return `setToolEnabled { toolName: "${toolName}", enabled: true${sessionUuidArg} }`;
+  return `${remediationMethodName} { toolName: "${toolName}", enabled: true${sessionUuidArg} }`;
 }
 
 /**
@@ -43,13 +44,14 @@ function formatToolEnabledRemediationSentence(
   toolName: string,
   candidates: readonly string[],
   connectionProfileUuid: string | undefined,
+  remediationMethodName: string = SET_TOOL_ENABLED_TOOL_NAME,
 ): string {
   if (candidates.length === 0 && connectionProfileUuid === undefined) {
     return (
-      "No device session owns this device yet, so there is nothing setToolEnabled could enable " +
+      `No device session owns this device yet, so there is nothing ${remediationMethodName} could enable ` +
       "that a retry would recheck. Acquire a device session with getAndroid { deviceId } " +
       "(or getApple { deviceId }), then enable the tool with " +
-      `setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "<uuid from getAndroid/getApple>" }.`
+      `${formatSetToolEnabledRemediation(toolName, "<uuid from getAndroid/getApple>", remediationMethodName)}.`
     );
   }
   const realSessionUuid =
@@ -58,7 +60,7 @@ function formatToolEnabledRemediationSentence(
       : connectionProfileUuid === undefined
         ? candidates[0]
         : undefined;
-  return `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid)}.`;
+  return `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid, remediationMethodName)}.`;
 }
 
 async function explicitOverrideResult(
@@ -188,12 +190,20 @@ export async function isToolEnabledForAnyRoute(
   return false;
 }
 
+/**
+ * @param remediationMethodName The callable the remediation sentence names — the MCP
+ * `setToolEnabled` tool by default. Pass `IDE_SET_SESSION_TOOL_ENABLED_METHOD` from a rejection
+ * raised on the direct IDE socket channel (see `assertSocketToolEnabled` in
+ * src/daemon/socketServer.ts): that caller cannot invoke an MCP tool, only the socket's own
+ * `ide/setSessionToolEnabled` method (issue #6259).
+ */
 export async function assertToolEnabledForAnySession(
   toolName: string,
   declaredDefault: boolean,
   sessionUuids: ReadonlyArray<string | undefined>,
   sessionToolSelectionService?: ToolSelectionReader,
   connectionProfileUuid?: string,
+  remediationMethodName: string = SET_TOOL_ENABLED_TOOL_NAME,
 ): Promise<void> {
   if (
     await isToolEnabledForAnySession(
@@ -212,6 +222,11 @@ export async function assertToolEnabledForAnySession(
   const target = candidates.join(" / ") || "(not yet bound)";
   throw new ActionableError(
     `Tool ${toolName} is disabled for device session ${target}. ` +
-      formatToolEnabledRemediationSentence(toolName, candidates, connectionProfileUuid),
+      formatToolEnabledRemediationSentence(
+        toolName,
+        candidates,
+        connectionProfileUuid,
+        remediationMethodName,
+      ),
   );
 }

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -59,8 +59,10 @@ export async function assertToolEnabledForSession(
   ) {
     return;
   }
+  const target = sessionUuid ?? "(not yet bound)";
   throw new ActionableError(
-    `Tool ${toolName} is disabled for device session ${sessionUuid ?? "(not yet bound)"}.`,
+    `Tool ${toolName} is disabled for device session ${target}. ` +
+      `Enable it with setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "${target}" }.`,
   );
 }
 
@@ -154,5 +156,8 @@ export async function assertToolEnabledForAnySession(
   const target =
     Array.from(new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid)))).join(" / ") ||
     "(not yet bound)";
-  throw new ActionableError(`Tool ${toolName} is disabled for device session ${target}.`);
+  throw new ActionableError(
+    `Tool ${toolName} is disabled for device session ${target}. ` +
+      `Enable it with setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "${target}" }.`,
+  );
 }

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -8,6 +8,23 @@ import { SET_TOOL_ENABLED_TOOL_NAME } from "./toolSelectionControl";
 type ToolSelectionReader = Pick<SessionToolSelectionService, "isEnabled"> &
   Partial<Pick<SessionToolSelectionService, "getOverride">>;
 
+/**
+ * Builds the copy-pasteable `setToolEnabled` remediation call for a disabled-tool error.
+ *
+ * `resolveSelectionSessionUuid` (src/server/toolSelectionTools.ts) only accepts a
+ * `sessionUuid` that matches the caller's current connection or routing profile — never an
+ * arbitrary display string. So this only ever names a real, resolvable session uuid when
+ * exactly one is known; otherwise it omits `sessionUuid` entirely, which updates the
+ * connection profile and is always valid.
+ */
+function formatSetToolEnabledRemediation(
+  toolName: string,
+  realSessionUuid: string | undefined,
+): string {
+  const sessionUuidArg = realSessionUuid ? `, sessionUuid: "${realSessionUuid}"` : "";
+  return `setToolEnabled { toolName: "${toolName}", enabled: true${sessionUuidArg} }`;
+}
+
 async function explicitOverrideResult(
   service: ToolSelectionReader,
   sessionUuids: readonly string[],
@@ -62,7 +79,7 @@ export async function assertToolEnabledForSession(
   const target = sessionUuid ?? "(not yet bound)";
   throw new ActionableError(
     `Tool ${toolName} is disabled for device session ${target}. ` +
-      `Enable it with setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "${target}" }.`,
+      `Enable it with ${formatSetToolEnabledRemediation(toolName, sessionUuid)}.`,
   );
 }
 
@@ -153,11 +170,16 @@ export async function assertToolEnabledForAnySession(
   ) {
     return;
   }
-  const target =
-    Array.from(new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid)))).join(" / ") ||
-    "(not yet bound)";
+  const candidates = Array.from(
+    new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid))),
+  );
+  const target = candidates.join(" / ") || "(not yet bound)";
+  // Only a single resolvable candidate can be named as the real sessionUuid in the
+  // remediation call — a composite of multiple profiles is not something
+  // resolveSelectionSessionUuid would accept, so it falls back to the connection-profile form.
+  const realSessionUuid = candidates.length === 1 ? candidates[0] : undefined;
   throw new ActionableError(
     `Tool ${toolName} is disabled for device session ${target}. ` +
-      `Enable it with setToolEnabled { toolName: "${toolName}", enabled: true, sessionUuid: "${target}" }.`,
+      `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid)}.`,
   );
 }

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -35,10 +35,16 @@ function formatSetToolEnabledRemediation(
  *    `connectionProfileUuid` to fall back to).
  * 2. A `connectionProfileUuid` is part of what gets rechecked — omit `sessionUuid` entirely,
  *    which updates the connection profile the retry rechecks.
- * 3. Zero candidates AND no `connectionProfileUuid` (e.g. an IDE storage request against a
- *    booted device with no owning daemon session) — there is nothing `setToolEnabled` could
- *    enable that the retry would recheck, so do not advertise it at all. Instead, tell the
- *    caller to acquire a device session first.
+ * 3. Zero candidates AND no `connectionProfileUuid`, on the IDE-socket channel (e.g. an IDE
+ *    storage request against a booted device with no owning daemon session) — that channel has
+ *    no MCP connection profile to create, so there is nothing `ide/setSessionToolEnabled` could
+ *    enable that the retry would recheck. Tell the caller to acquire a device session first.
+ *
+ *    On the MCP channel this same zero/zero state is a BRAND-NEW connection that has not yet
+ *    called `setToolEnabled` at all (issue #6259 follow-up) — `src/server/index.ts:512-536`
+ *    creates the connection profile lazily, the first time `setToolEnabled` is called
+ *    sessionless, so the sessionless form IS real remediation here and case 3 must not apply.
+ *    It naturally falls through to case 2's omitted-`sessionUuid` form below.
  */
 function formatToolEnabledRemediationSentence(
   toolName: string,
@@ -46,7 +52,11 @@ function formatToolEnabledRemediationSentence(
   connectionProfileUuid: string | undefined,
   remediationMethodName: string = SET_TOOL_ENABLED_TOOL_NAME,
 ): string {
-  if (candidates.length === 0 && connectionProfileUuid === undefined) {
+  if (
+    candidates.length === 0 &&
+    connectionProfileUuid === undefined &&
+    remediationMethodName !== SET_TOOL_ENABLED_TOOL_NAME
+  ) {
     return (
       `No device session owns this device yet, so there is nothing ${remediationMethodName} could enable ` +
       "that a retry would recheck. Acquire a device session with getAndroid { deviceId } " +

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -176,8 +176,18 @@ export async function assertToolEnabledForAnySession(
   const target = candidates.join(" / ") || "(not yet bound)";
   // Only a single resolvable candidate can be named as the real sessionUuid in the
   // remediation call — a composite of multiple profiles is not something
-  // resolveSelectionSessionUuid would accept, so it falls back to the connection-profile form.
-  const realSessionUuid = candidates.length === 1 ? candidates[0] : undefined;
+  // resolveSelectionSessionUuid would accept, so it falls back to the connection-profile form
+  // ONLY when a connection profile is actually part of what gets rechecked (`connectionProfileUuid`
+  // is defined, as on the MCP-server path). Callers with no connection profile at all — the IDE
+  // socket-gate path (`assertSocketToolEnabled`), which rechecks only its base/derived session
+  // profiles — have no connection profile for the omitted form to land on, so name the first
+  // (base-preferring, per the caller's ordering) candidate the retry will actually recheck instead.
+  const realSessionUuid =
+    candidates.length === 1
+      ? candidates[0]
+      : connectionProfileUuid === undefined
+        ? candidates[0]
+        : undefined;
   throw new ActionableError(
     `Tool ${toolName} is disabled for device session ${target}. ` +
       `Enable it with ${formatSetToolEnabledRemediation(toolName, realSessionUuid)}.`,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -815,7 +815,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         const sessionOwnershipLost = {
           error: {
             code: "session_ownership_lost",
-            message: `Session ownership lost for ${error.sessionUuid}: ${error.release.releaseReason}`,
+            message:
+              `Session ownership lost for ${error.sessionUuid}: ${error.release.releaseReason}. ` +
+              "Call getAndroid, getApple, or startDevice to acquire a new device session.",
             sessionUuid: error.sessionUuid,
             reason: error.release.releaseReason,
             release: error.release,

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -37,7 +37,9 @@ function sessionOwnershipLostPayload(error: DaemonBoundSessionExpiredError) {
   return {
     error: {
       code: "session_ownership_lost",
-      message: `Session ownership lost for ${error.sessionUuid}: ${error.reason}`,
+      message:
+        `Session ownership lost for ${error.sessionUuid}: ${error.reason}. ` +
+        "Call getAndroid, getApple, or startDevice to acquire a new device session.",
       sessionUuid: error.sessionUuid,
       reason: error.reason,
       ...(error.release ? { release: error.release } : {}),

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { SessionToolSelectionService } from "../../../src/features/toolSelection/SessionToolSelectionService";
 import {
   assertToolEnabledForAnySession,
+  assertToolEnabledForSession,
   isToolEnabledForAnyRoute,
   isToolEnabledForAnySession,
 } from "../../../src/features/toolSelection/toolSelectionPolicy";
@@ -167,5 +168,27 @@ describe("exact-tool selection union policy", () => {
     await expect(
       assertToolEnabledForAnySession("selectAllText", false, ["session-1"], disabled),
     ).rejects.toThrow("Tool selectAllText is disabled");
+  });
+
+  test("names the setToolEnabled call with the interpolated tool and session (issue #6259)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForAnySession("systemTray", false, ["session-abc"], disabled),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "session-abc" }.',
+    );
+  });
+
+  test("assertToolEnabledForSession also names the setToolEnabled remediation (issue #6259)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForSession("systemTray", false, "session-abc", disabled),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "session-abc" }.',
+    );
   });
 });

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -204,27 +204,61 @@ describe("exact-tool selection union policy", () => {
     );
   });
 
-  test("assertToolEnabledForAnySession instructs acquiring a session instead of advertising a sessionless setToolEnabled when unbound (PRRT_kwDOP-GF5M6fucGA)", async () => {
+  test("assertToolEnabledForAnySession instructs acquiring a session instead of advertising a sessionless remediation when unbound on the IDE-socket channel (PRRT_kwDOP-GF5M6fucGA)", async () => {
     const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
       isEnabled: async () => false,
     };
-    // Zero candidates and no connectionProfileUuid (e.g. assertSocketToolEnabled against a
-    // booted device with no owning daemon session): a sessionless setToolEnabled would mint a
-    // new MCP connection profile that the retry (ide/setKeyValue etc.) never rechecks, so the
-    // tool would stay disabled. There is nothing to advertise — tell the caller to acquire a
-    // session first.
+    // Zero candidates and no connectionProfileUuid on the IDE-socket channel (e.g.
+    // assertSocketToolEnabled against a booted device with no owning daemon session): that
+    // channel has no MCP connection profile to create, so a sessionless remediation would mint
+    // a new one the retry (ide/setKeyValue etc.) never rechecks, and the tool would stay
+    // disabled. There is nothing to advertise — tell the caller to acquire a session first.
     await expect(
-      assertToolEnabledForAnySession("systemTray", false, [undefined], disabled),
+      assertToolEnabledForAnySession(
+        "systemTray",
+        false,
+        [undefined],
+        disabled,
+        undefined,
+        IDE_SET_SESSION_TOOL_ENABLED_METHOD,
+      ),
     ).rejects.toThrow(
       "Tool systemTray is disabled for device session (not yet bound). " +
-        "No device session owns this device yet, so there is nothing setToolEnabled could enable " +
+        "No device session owns this device yet, so there is nothing ide/setSessionToolEnabled could enable " +
         "that a retry would recheck. Acquire a device session with getAndroid { deviceId } " +
         "(or getApple { deviceId }), then enable the tool with " +
-        'setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "<uuid from getAndroid/getApple>" }.',
+        'ide/setSessionToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "<uuid from getAndroid/getApple>" }.',
     );
-    await expect(assertToolEnabledForAnySession("systemTray", false, [], disabled)).rejects.toThrow(
-      /Acquire a device session with getAndroid \{ deviceId \}/,
+    await expect(
+      assertToolEnabledForAnySession(
+        "systemTray",
+        false,
+        [],
+        disabled,
+        undefined,
+        IDE_SET_SESSION_TOOL_ENABLED_METHOD,
+      ),
+    ).rejects.toThrow(/Acquire a device session with getAndroid \{ deviceId \}/);
+  });
+
+  test("assertToolEnabledForAnySession advertises sessionless setToolEnabled (not device acquisition) for a fresh MCP connection with no sessionUuid and no profile yet (issue #6259)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // Zero candidates and no connectionProfileUuid on the default (MCP) channel: this is a
+    // brand-new MCP connection that has never called setToolEnabled. src/server/index.ts:512-536
+    // creates the connection profile the FIRST time setToolEnabled is called sessionless, so —
+    // unlike the IDE-socket channel above — the sessionless form is real remediation here, even
+    // for a non-device tool. Device acquisition is not required just to enable the tool.
+    await expect(
+      assertToolEnabledForAnySession("debugSearch", false, [undefined], disabled),
+    ).rejects.toThrow(
+      "Tool debugSearch is disabled for device session (not yet bound). " +
+        'Enable it with setToolEnabled { toolName: "debugSearch", enabled: true }.',
     );
+    await expect(
+      assertToolEnabledForAnySession("debugSearch", false, [], disabled),
+    ).rejects.toThrow('Enable it with setToolEnabled { toolName: "debugSearch", enabled: true }.');
   });
 
   test("assertToolEnabledForAnySession omits sessionUuid across composite connection/base/label profiles when a connection profile is actually rechecked (PRRT_kwDOP-GF5M6fuHM5)", async () => {

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -6,6 +6,7 @@ import {
   isToolEnabledForAnyRoute,
   isToolEnabledForAnySession,
 } from "../../../src/features/toolSelection/toolSelectionPolicy";
+import { IDE_SET_SESSION_TOOL_ENABLED_METHOD } from "../../../src/features/toolSelection/toolSelectionControl";
 
 describe("exact-tool selection union policy", () => {
   const only = (enabledSession: string): Pick<SessionToolSelectionService, "isEnabled"> => ({
@@ -263,6 +264,41 @@ describe("exact-tool selection union policy", () => {
         ["base-session", "base-session:label"],
         disabled,
       ),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "base-session" }.',
+    );
+  });
+
+  test("assertSocketToolEnabled's IDE-socket rejection names ide/setSessionToolEnabled, never the MCP setToolEnabled tool (issue #6259, PRRT_kwDOP-GF5M6fumZY)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // A caller on the direct IDE socket channel (src/daemon/socketServer.ts
+    // `assertSocketToolEnabled`) cannot invoke an MCP tool — only the socket's own
+    // `ide/setSessionToolEnabled` method (src/daemon/socketServer.ts:2418-2444), which requires
+    // sessionUuid, toolName, and enabled params.
+    await expect(
+      assertToolEnabledForAnySession(
+        "setKeyValue",
+        false,
+        ["base-session", "base-session:label"],
+        disabled,
+        undefined,
+        IDE_SET_SESSION_TOOL_ENABLED_METHOD,
+      ),
+    ).rejects.toThrow(
+      'Enable it with ide/setSessionToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "base-session" }.',
+    );
+  });
+
+  test("the MCP tool-dispatch rejection still names the MCP setToolEnabled tool (issue #6259)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // src/server/index.ts calls assertToolEnabledForAnySession without a remediationMethodName,
+    // so the MCP channel keeps naming the `setToolEnabled` MCP tool.
+    await expect(
+      assertToolEnabledForAnySession("setKeyValue", false, ["base-session"], disabled),
     ).rejects.toThrow(
       'Enable it with setToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "base-session" }.',
     );

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -203,14 +203,26 @@ describe("exact-tool selection union policy", () => {
     );
   });
 
-  test("assertToolEnabledForAnySession omits sessionUuid when unbound rather than naming the display placeholder", async () => {
+  test("assertToolEnabledForAnySession instructs acquiring a session instead of advertising a sessionless setToolEnabled when unbound (PRRT_kwDOP-GF5M6fucGA)", async () => {
     const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
       isEnabled: async () => false,
     };
+    // Zero candidates and no connectionProfileUuid (e.g. assertSocketToolEnabled against a
+    // booted device with no owning daemon session): a sessionless setToolEnabled would mint a
+    // new MCP connection profile that the retry (ide/setKeyValue etc.) never rechecks, so the
+    // tool would stay disabled. There is nothing to advertise — tell the caller to acquire a
+    // session first.
     await expect(
       assertToolEnabledForAnySession("systemTray", false, [undefined], disabled),
     ).rejects.toThrow(
-      'Tool systemTray is disabled for device session (not yet bound). Enable it with setToolEnabled { toolName: "systemTray", enabled: true }.',
+      "Tool systemTray is disabled for device session (not yet bound). " +
+        "No device session owns this device yet, so there is nothing setToolEnabled could enable " +
+        "that a retry would recheck. Acquire a device session with getAndroid { deviceId } " +
+        "(or getApple { deviceId }), then enable the tool with " +
+        'setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "<uuid from getAndroid/getApple>" }.',
+    );
+    await expect(assertToolEnabledForAnySession("systemTray", false, [], disabled)).rejects.toThrow(
+      /Acquire a device session with getAndroid \{ deviceId \}/,
     );
   });
 
@@ -265,6 +277,19 @@ describe("exact-tool selection union policy", () => {
     ).rejects.toThrow(
       'Enable it with setToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "derived-only" }.',
     );
+  });
+
+  test("assertToolEnabledForAnySession omits sessionUuid (rather than instructing session acquisition) when a connectionProfileUuid is rechecked even with zero routing candidates (PRRT_kwDOP-GF5M6fucGA)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // A connectionProfileUuid means the retry DOES recheck a real profile — the connection
+    // one — even though no base/derived session candidates are known, so the omitted-sessionUuid
+    // form (which targets the connection profile) still works and must be preferred over the
+    // "acquire a session" message.
+    await expect(
+      assertToolEnabledForAnySession("observe", true, [], disabled, "connection"),
+    ).rejects.toThrow('Enable it with setToolEnabled { toolName: "observe", enabled: true }.');
   });
 
   test("assertToolEnabledForAnySession names the sole real candidate session uuid, matching resolveSelectionSessionUuid's accepted values", async () => {

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -191,4 +191,58 @@ describe("exact-tool selection union policy", () => {
       'Enable it with setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "session-abc" }.',
     );
   });
+
+  test("assertToolEnabledForSession omits sessionUuid when unbound rather than naming the display placeholder", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForSession("systemTray", false, undefined, disabled),
+    ).rejects.toThrow(
+      'Tool systemTray is disabled for device session (not yet bound). Enable it with setToolEnabled { toolName: "systemTray", enabled: true }.',
+    );
+  });
+
+  test("assertToolEnabledForAnySession omits sessionUuid when unbound rather than naming the display placeholder", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForAnySession("systemTray", false, [undefined], disabled),
+    ).rejects.toThrow(
+      'Tool systemTray is disabled for device session (not yet bound). Enable it with setToolEnabled { toolName: "systemTray", enabled: true }.',
+    );
+  });
+
+  test("assertToolEnabledForAnySession omits sessionUuid across composite connection/base/label profiles (PRRT_kwDOP-GF5M6fuHM5)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForAnySession(
+        "systemTray",
+        false,
+        ["connection", "base", "base:label"],
+        disabled,
+      ),
+    ).rejects.toThrow(
+      "Tool systemTray is disabled for device session connection / base / base:label. " +
+        'Enable it with setToolEnabled { toolName: "systemTray", enabled: true }.',
+    );
+  });
+
+  test("assertToolEnabledForAnySession names the sole real candidate session uuid, matching resolveSelectionSessionUuid's accepted values", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // A single resolvable candidate (e.g. duplicate connection/routing uuids collapsing via
+    // the Set dedupe) is the one case where the advertised sessionUuid must equal what
+    // resolveSelectionSessionUuid (src/server/toolSelectionTools.ts) would accept: the
+    // caller's own connection or routing profile uuid, never a joined display string.
+    await expect(
+      assertToolEnabledForAnySession("systemTray", false, ["session-abc", "session-abc"], disabled),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "session-abc" }.',
+    );
+  });
 });

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -214,20 +214,56 @@ describe("exact-tool selection union policy", () => {
     );
   });
 
-  test("assertToolEnabledForAnySession omits sessionUuid across composite connection/base/label profiles (PRRT_kwDOP-GF5M6fuHM5)", async () => {
+  test("assertToolEnabledForAnySession omits sessionUuid across composite connection/base/label profiles when a connection profile is actually rechecked (PRRT_kwDOP-GF5M6fuHM5)", async () => {
     const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
       isEnabled: async () => false,
     };
+    // The MCP-server path (src/server/index.ts) always passes its `connectionProfileUuid` as
+    // the 5th arg, so the omitted-sessionUuid remediation lands on a profile the retry actually
+    // rechecks.
     await expect(
       assertToolEnabledForAnySession(
         "systemTray",
         false,
         ["connection", "base", "base:label"],
         disabled,
+        "connection",
       ),
     ).rejects.toThrow(
       "Tool systemTray is disabled for device session connection / base / base:label. " +
         'Enable it with setToolEnabled { toolName: "systemTray", enabled: true }.',
+    );
+  });
+
+  test("assertToolEnabledForAnySession names the first (base-preferring) candidate rather than the connection-profile form when no connection profile is rechecked (PRRT_kwDOP-GF5M6fuRKy — socket gate)", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    // The IDE socket-gate path (`assertSocketToolEnabled` in src/daemon/socketServer.ts) never
+    // has a connection profile — it rechecks only [baseSessionUuid, derivedSessionUuid]. Omitting
+    // sessionUuid there would create/enable an unrelated MCP connection profile that the retry
+    // never looks at, so the remediation must name a real profile the gate rechecks instead —
+    // the first (base) candidate.
+    await expect(
+      assertToolEnabledForAnySession(
+        "setKeyValue",
+        false,
+        ["base-session", "base-session:label"],
+        disabled,
+      ),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "base-session" }.',
+    );
+  });
+
+  test("assertToolEnabledForAnySession names the sole candidate even without a connection profile", async () => {
+    const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    await expect(
+      assertToolEnabledForAnySession("setKeyValue", false, ["derived-only"], disabled),
+    ).rejects.toThrow(
+      'Enable it with setToolEnabled { toolName: "setKeyValue", enabled: true, sessionUuid: "derived-only" }.',
     );
   });
 

--- a/test/server/deviceLossOutcomeWire.integration.test.ts
+++ b/test/server/deviceLossOutcomeWire.integration.test.ts
@@ -345,7 +345,9 @@ describe("device loss MCP outcome", () => {
     expect(JSON.parse(result.content[0].text)).toEqual({
       error: {
         code: "session_ownership_lost",
-        message: "Session ownership lost for device-session-a: heartbeat-timeout",
+        message:
+          "Session ownership lost for device-session-a: heartbeat-timeout. " +
+          "Call getAndroid, getApple, or startDevice to acquire a new device session.",
         sessionUuid: "device-session-a",
         reason: "heartbeat-timeout",
         release,

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -72,7 +72,9 @@ describe("proxy server session ownership errors", () => {
             text: JSON.stringify({
               error: {
                 code: "session_ownership_lost",
-                message: "Session ownership lost for session-123: heartbeat-timeout",
+                message:
+                  "Session ownership lost for session-123: heartbeat-timeout. " +
+                  "Call getAndroid, getApple, or startDevice to acquire a new device session.",
                 sessionUuid: "session-123",
                 reason: "heartbeat-timeout",
                 release: {


### PR DESCRIPTION
## Summary

Two error messages stated a state without naming the call that exits it. Fixes both, message-only, matching the existing actionable-error phrasing used elsewhere (e.g. `no_active_device_session`, daemon version-mismatch).

### 1. `session_ownership_lost`

Before:
```
Session ownership lost for 02712f0f-…: heartbeat-timeout
```

After:
```
Session ownership lost for 02712f0f-…: heartbeat-timeout. Call getAndroid, getApple, or startDevice to acquire a new device session.
```

This mirrors `no_active_device_session`'s exact remediation sentence, since it's the same underlying condition reached via a `sessionUuid` argument instead of a connection.

### 2. "Tool X is disabled for device session"

Before:
```
Tool systemTray is disabled for device session b5479f33-….
```

After:
```
Tool systemTray is disabled for device session b5479f33-…. Enable it with setToolEnabled { toolName: "systemTray", enabled: true, sessionUuid: "b5479f33-…" }.
```

The tool name and session UUID are interpolated so the message is copy-pasteable.

## Scope

Message-only. No control-flow, gating logic, or timeout behavior changed (the issue's note about the 10s heartbeat leash being short is explicitly out of scope here).

## Files changed

- `src/server/proxyServer.ts`, `src/server/index.ts` — append remediation to `session_ownership_lost`
- `src/features/toolSelection/toolSelectionPolicy.ts` — append `setToolEnabled` remediation to both `assertToolEnabledForSession` and `assertToolEnabledForAnySession`
- Updated existing integration tests asserting the exact message strings
- Added unit tests in `test/features/toolSelection/toolSelectionPolicy.test.ts` asserting the interpolated `setToolEnabled` remediation

## Validation

- `bun test` (affected paths + full `test/server`, `test/features/toolSelection`, `test/cli`): all pass
- `bun run lint`: clean (no new ratchet violations)
- `bun run typecheck`: clean (no new baseline errors)
- `bun run format:check`: clean
- `bunx turbo run build`: succeeds

Closes #6259