### PR TITLE
fix: effect.screenChanged falls through to viewHierarchy basis; diff-mode observations carry activeWindow/freshness

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9907,6 +9907,67 @@
                     "additionalProperties": {}
                   }
                 },
+                "activeWindow": {
+                  "description": "Same name/shape as a full observation's `activeWindow` (issue #6258): a diff-mode response otherwise carries no `activeWindow` at all, leaving a client no single accessor for 'what screen am I on' across full and diff modes. Populated from the post-transition observation, not by `diffObserveResult` itself.",
+                  "type": "object",
+                  "properties": {
+                    "appId": {
+                      "type": "string"
+                    },
+                    "activityName": {
+                      "type": "string"
+                    },
+                    "layoutSeqSum": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "systemOverlay": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "freshness": {
+                  "description": "Same name/shape as a full observation's `freshness` (issue #6258): a diff-mode response otherwise carries no `freshness` at all, leaving a client no single accessor for 'is this capture fresh' across full and diff modes. Populated from the post-transition observation, not by `diffObserveResult` itself.",
+                  "type": "object",
+                  "properties": {
+                    "requestedAfter": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "actualTimestamp": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "ageMs": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "verified": {
+                      "type": "boolean"
+                    },
+                    "isFresh": {
+                      "type": "boolean"
+                    },
+                    "staleDurationMs": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "warning": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["isFresh"],
+                  "additionalProperties": {}
+                },
                 "added": {
                   "type": "array",
                   "items": {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -549,6 +549,19 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
+  /**
+   * Issue #6258: a basis that resolves to "unchanged" must not stop the chain
+   * — it must fall through to the next basis rather than being taken as final
+   * proof nothing changed. A dialog open (e.g. the Material time picker) is
+   * the known dialog-window gap (#6151): `activeWindow` never reflects the new
+   * dialog window, so it resolves "unchanged" even though the hierarchy
+   * clearly changed. The old `??` chain stopped at the first *defined* result
+   * regardless of its `screenChanged` value, so `activeWindow unchanged`
+   * masked a real `viewHierarchy changed`. Priority order (screenIdentity,
+   * then activeWindow, then viewHierarchy) is preserved for a basis that DOES
+   * report a change; when none report a change, the highest-priority
+   * available basis is returned (matching prior "all unchanged" behavior).
+   */
   private deriveTapEffect(
     previousObservation: ObserveResult | null,
     currentObservation: ObserveResult | undefined,
@@ -556,14 +569,18 @@ export class TapOnElement extends BaseVisualChange {
     if (!previousObservation || !currentObservation) {
       return undefined;
     }
-    return (
-      this.compareScreenIdentity(previousObservation, currentObservation) ??
-      this.compareActiveWindow(previousObservation, currentObservation) ??
-      this.compareViewHierarchy(previousObservation, currentObservation) ?? {
-        screenChanged: false,
-        basis: "insufficient observation data",
-      }
-    );
+    const results = [
+      this.compareScreenIdentity(previousObservation, currentObservation),
+      this.compareActiveWindow(previousObservation, currentObservation),
+      this.compareViewHierarchy(previousObservation, currentObservation),
+    ].filter((result): result is NonNullable<typeof result> => result !== undefined);
+
+    const changedResult = results.find((result) => result.screenChanged);
+    if (changedResult) {
+      return changedResult;
+    }
+
+    return results[0] ?? { screenChanged: false, basis: "insufficient observation data" };
   }
 
   private async deriveTapEffectAfterPostTapObservation(

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -612,6 +612,20 @@ export interface ObserveDiff {
    * leaving a client unable to tell a failed input from a successful one.
    */
   context?: SkeletonElement[];
+  /**
+   * Same name/shape as a full observation's `activeWindow` (issue #6258).
+   * Populated by the `finalizeToolResponse` call site from the post-action
+   * observation, not by {@link diffObserveResult} — without this a client has
+   * no single accessor for "what screen am I on" across full and diff modes.
+   */
+  activeWindow?: ObserveResult["activeWindow"];
+  /**
+   * Same name/shape as a full observation's `freshness` (issue #6258).
+   * Populated by the `finalizeToolResponse` call site from the post-action
+   * observation, not by {@link diffObserveResult} — without this a client has
+   * no single accessor for "is this capture fresh" across full and diff modes.
+   */
+  freshness?: ObserveResult["freshness"];
   added: ObserveDiffNode[];
   removed: ObserveDiffNode[];
   changed: ObserveDiffNodeChange[];

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -4,6 +4,7 @@ import {
   diffObserveResult,
   isSameObservationScreen,
   type SanitizeObserveConfig,
+  type ObserveDiff,
 } from "../features/observe/output/ObserveResultOutput";
 import {
   applyObserveScopeExperiments,
@@ -215,6 +216,27 @@ function resolveDiffContext(
     return servedObservation.context;
   }
   return sanitizeObserveResult(rawObservation, { ...cfg, project: "skeleton" }).context;
+}
+
+/**
+ * The `activeWindow` and `freshness` to attach to a diff response (issue
+ * #6258), resolved the same way {@link resolveDiffSkeleton} resolves
+ * `skeleton`: `diffObserveResult` never sees either field (both are top-level
+ * on the post-transition observation, not part of the hierarchy it diffs), so
+ * without this a diff-mode `observation` would carry no `activeWindow`/no
+ * `freshness` at all — while a full-mode `observation` carries both — leaving
+ * a client unable to write one accessor for "what screen am I on / is this
+ * fresh" across modes. Sourced from `rawObservation` (the pre-sanitize
+ * observation) rather than `servedObservation` so it is populated
+ * unconditionally, regardless of projection.
+ */
+function resolveDiffScreenState(
+  rawObservation: ObserveResult,
+): Pick<ObserveDiff, "activeWindow" | "freshness"> {
+  return {
+    activeWindow: rawObservation.activeWindow,
+    freshness: rawObservation.freshness,
+  };
 }
 
 /**
@@ -522,6 +544,11 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             payload.observation as ObserveResult,
             cfg,
           );
+          // Issue #6258: a diff must not silently drop `activeWindow`/`freshness`
+          // either — see resolveDiffScreenState. Both fields come through as
+          // `undefined` when the underlying observation lacks them, which drops
+          // out of the serialized diff the same way an absent key would.
+          Object.assign(diff, resolveDiffScreenState(payload.observation as ObserveResult));
           const screenChangedWithEmptyDiff =
             hasScreenChangedEffect(payload) && isEmptyObserveDiff(diff);
           observationOut = screenChangedWithEmptyDiff ? servedObservation : diff;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -696,6 +696,24 @@ export const observeDiffSchema = z
           "alongside `skeleton` so a diff-mode response never silently drops the " +
           "readout a client needs to tell a failed input from a successful one.",
       ),
+    activeWindow: activeWindowSchema
+      .optional()
+      .describe(
+        "Same name/shape as a full observation's `activeWindow` (issue #6258): a " +
+          "diff-mode response otherwise carries no `activeWindow` at all, leaving a " +
+          "client no single accessor for 'what screen am I on' across full and diff " +
+          "modes. Populated from the post-transition observation, not by " +
+          "`diffObserveResult` itself.",
+      ),
+    freshness: freshnessSchema
+      .optional()
+      .describe(
+        "Same name/shape as a full observation's `freshness` (issue #6258): a " +
+          "diff-mode response otherwise carries no `freshness` at all, leaving a " +
+          "client no single accessor for 'is this capture fresh' across full and " +
+          "diff modes. Populated from the post-transition observation, not by " +
+          "`diffObserveResult` itself.",
+      ),
     added: z.array(observeDiffNodeSchema),
     removed: z.array(observeDiffNodeSchema),
     changed: z.array(observeDiffNodeChangeSchema),

--- a/test/features/action/TapOnElement.effectBasisFallthrough.test.ts
+++ b/test/features/action/TapOnElement.effectBasisFallthrough.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+// Issue #6258: effect.screenChanged must not be false when a tap opens a
+// dialog that the `activeWindow` basis cannot see (the known dialog-window
+// gap, #6151) but that the `viewHierarchy` basis clearly reflects. The
+// `activeWindow unchanged` basis must fall through to `viewHierarchy`
+// instead of being taken as final proof nothing changed.
+
+function makeHierarchy(marker: string): ViewHierarchyResult {
+  return { hierarchy: { node: { marker } } } as unknown as ViewHierarchyResult;
+}
+
+function makeObservation(overrides: Partial<ObserveResult>): ObserveResult {
+  return {
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    ...overrides,
+  };
+}
+
+function createTapOnElement(): TapOnElement {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  return new TapOnElement(
+    { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+    new FakeAdbClient() as any,
+    { timer },
+  );
+}
+
+describe("deriveTapEffect basis fallthrough (#6258)", () => {
+  test("falls through to viewHierarchy when activeWindow is unchanged but hierarchy changed (dialog open)", () => {
+    const tap = createTapOnElement();
+    const activeWindow = {
+      appId: "com.android.deskclock",
+      activityName: "com.android.deskclock.DeskClock",
+      layoutSeqSum: 42,
+    };
+    const previous = makeObservation({
+      activeWindow,
+      viewHierarchy: makeHierarchy("alarm-list"),
+    });
+    const current = makeObservation({
+      activeWindow, // unchanged — the dialog window isn't reflected here (#6151)
+      viewHierarchy: makeHierarchy("time-picker-dialog"),
+    });
+
+    const effect = (tap as any).deriveTapEffect(previous, current);
+
+    expect(effect.screenChanged).toBe(true);
+    expect(effect.basis).toBe("viewHierarchy changed");
+  });
+
+  test("returns false when neither activeWindow nor viewHierarchy changed", () => {
+    const tap = createTapOnElement();
+    const activeWindow = {
+      appId: "com.android.deskclock",
+      activityName: "com.android.deskclock.DeskClock",
+      layoutSeqSum: 42,
+    };
+    const hierarchy = makeHierarchy("alarm-list");
+    const previous = makeObservation({ activeWindow, viewHierarchy: hierarchy });
+    const current = makeObservation({ activeWindow, viewHierarchy: hierarchy });
+
+    const effect = (tap as any).deriveTapEffect(previous, current);
+
+    expect(effect.screenChanged).toBe(false);
+    expect(effect.basis).toBe("activeWindow unchanged");
+  });
+
+  test("still reports true immediately when activeWindow itself changed", () => {
+    const tap = createTapOnElement();
+    const previous = makeObservation({
+      activeWindow: {
+        appId: "com.android.deskclock",
+        activityName: "com.android.deskclock.DeskClock",
+        layoutSeqSum: 42,
+      },
+      viewHierarchy: makeHierarchy("alarm-list"),
+    });
+    const current = makeObservation({
+      activeWindow: {
+        appId: "com.android.deskclock",
+        activityName: "com.android.deskclock.SettingsActivity",
+        layoutSeqSum: 43,
+      },
+      viewHierarchy: makeHierarchy("settings"),
+    });
+
+    const effect = (tap as any).deriveTapEffect(previous, current);
+
+    expect(effect.screenChanged).toBe(true);
+    expect(effect.basis).toBe("activeWindow changed");
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -907,6 +907,43 @@ describe("finalizeToolResponse", () => {
       expect(parsed.observation.skeleton.length).toBe(obsSc.skeleton.length);
     });
 
+    test("a diffed observation carries `activeWindow` and `freshness` with the same shape as full mode (issue #6258)", () => {
+      const { store } = makeStore();
+      const freshness = {
+        actualTimestamp: 1000,
+        ageMs: 5,
+        isFresh: true,
+      };
+      const withFreshness = (): ObserveResult => ({
+        ...sameScreenObserve(),
+        freshness,
+      });
+
+      finalizeToolResponse(createStructuredToolResponse(withFreshness()), {
+        name: "observe",
+        sessionUuid: "s1",
+        baselineStore: store,
+      });
+
+      const next = withFreshness();
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store },
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      // Same shape/name a full-mode observation carries these fields under.
+      expect(obsSc.activeWindow).toEqual(next.activeWindow);
+      expect(obsSc.freshness).toEqual(freshness);
+
+      // Text mirror agrees.
+      const parsed = JSON.parse(finalized.content[0].text);
+      expect(parsed.observation.activeWindow).toEqual(obsSc.activeWindow);
+      expect(parsed.observation.freshness).toEqual(obsSc.freshness);
+    });
+
     test("a diffed observation carries a usable `skeleton` even under raw:true / project:'full' (PR #6242 review PRRT_kwDOP-GF5M6fq3iK)", () => {
       const { store } = makeStore();
       const withSkeletonElements = (): ObserveResult => ({


### PR DESCRIPTION
Follow-up to #6219/#6221. Fixes #6258.

## 1. effect.screenChanged is false when a tap opens a dialog

`TapOnElement.deriveTapEffect` resolved a basis via a `??` chain that stopped at the first basis with *complete data*, regardless of whether it reported a change. When a tap opens a dialog (e.g. the Material time picker), the `activeWindow` basis has complete data but never reflects the new dialog window (the known dialog-window gap, #6151), so it resolved `{screenChanged: false, basis: "activeWindow unchanged"}` and the chain stopped there — even though the same response's hierarchy diff (and `viewHierarchy` basis) shows a large change.

Fix: `deriveTapEffect` now evaluates all available bases (screenIdentity, activeWindow, viewHierarchy, in that priority order) and returns the first one that reports `screenChanged: true`. Only when none of them report a change does it fall back to the highest-priority available basis (preserving the old "all unchanged" behavior), or "insufficient observation data" when none are available.

## 2. Diff-mode observations drop activeWindow and freshness

A diff-mode `observation` (`isDiff: true`) carried `skeleton`, `added`, `removed`, `changed`, `fields` but no `activeWindow`/`freshness` — while full-mode observations carry both, and they only survived inside `observationDiff.fromScreen`/`toScreen` in a different shape. This mirrors how #6263 backfilled `context` and #6242 backfilled `skeleton` into diff-mode observations.

Fix: `finalizeToolResponse` now populates `activeWindow` and `freshness` on the diff object from the post-transition observation, with the same names/shapes as full mode. Updated `ObserveDiff` (`src/features/observe/output/ObserveResultOutput.ts`) and `observeDiffSchema` (`src/server/toolOutputSchemas.ts`), and regenerated `schemas/tool-definitions.json`.

## Tests

- `test/features/action/TapOnElement.effectBasisFallthrough.test.ts`: activeWindow-unchanged + viewHierarchy-changed → `screenChanged: true, basis: "viewHierarchy changed"`; both unchanged → `false`; activeWindow-changed → immediate `true`.
- `test/server/finalizeToolResponse.test.ts`: new case asserting a diff-mode observation carries `activeWindow`/`freshness` with the same shape as full mode.

## Validation

- `bun test` (full suite): all passing except two pre-existing, unrelated failures (missing `node_modules/.bin/oxlint` binary in this worktree; a webrtc integration test environment quirk) — neither touches files in this diff.
- `bun run lint`: no new violations (baseline ratchet unchanged).
- `bun run typecheck`: no new type errors (baseline unchanged).
- `bun run format:check`: clean.
- `scripts/update-tool-definitions.sh` + re-checked `format:check`: clean.
- `bunx turbo run build`: succeeds.