### PR TITLE
fix(test): stop DetectIntentChooser real-ADB flake by injecting a fake executor

### DIFF
--- a/test/features/observe/DetectIntentChooser.test.ts
+++ b/test/features/observe/DetectIntentChooser.test.ts
@@ -11,6 +11,7 @@ import { FakeDeepLinkManager } from "../../fakes/FakeDeepLinkManager";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 
 describe("DetectIntentChooser", () => {
   let detectIntentChooser: DetectIntentChooser;
@@ -18,6 +19,7 @@ describe("DetectIntentChooser", () => {
   let fakeObserveScreen: FakeObserveScreen;
   let fakeWindow: FakeWindow;
   let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeAdb: FakeAdbExecutor;
 
   const mockObserveResult: ObserveResult = {
     timestamp: "2025-01-01T00:00:00.000Z",
@@ -59,6 +61,7 @@ describe("DetectIntentChooser", () => {
     fakeWindow = new FakeWindow();
     fakeAwaitIdle = new FakeAwaitIdle();
     fakeDeepLinkManager = new FakeDeepLinkManager();
+    fakeAdb = new FakeAdbExecutor();
 
     // Configure default responses
     fakeWindow.configureCachedActiveWindow(null);
@@ -69,11 +72,19 @@ describe("DetectIntentChooser", () => {
     });
     fakeObserveScreen.setObserveResult(mockObserveResult);
     fakeDeepLinkManager.setDefaultIntentChooserDetected(true);
+    fakeAdb.setDeviceTimestampMs(1735689600000);
 
     // Create DetectIntentChooser instance
     detectIntentChooser = new DetectIntentChooser(testDevice);
 
-    // Replace the internal managers with our fakes
+    // Replace the internal managers with our fakes. `observedInteraction`
+    // (BaseVisualChange) reads `this.adb.getDeviceTimestampMs()` for the
+    // action-start timestamp; left unfaked, it goes through the real
+    // AdbClient BaseVisualChange's constructor creates by default and spawns
+    // a real `adb shell date` subprocess against the non-existent
+    // "emulator-5554" device, which is slow/hangs under load and was the
+    // root cause of the intermittent timeout in #6173/#6174.
+    detectIntentChooser.adb = fakeAdb;
     (detectIntentChooser as any).observeScreen = fakeObserveScreen;
     (detectIntentChooser as any).window = fakeWindow;
     (detectIntentChooser as any).awaitIdle = fakeAwaitIdle;


### PR DESCRIPTION
## Root cause

`test/features/observe/DetectIntentChooser.test.ts` constructed `DetectIntentChooser` without overriding its ADB dependency, so `BaseVisualChange`'s constructor built a **real** `AdbClient` via `defaultAdbClientFactory`.

`DetectIntentChooser.execute()` runs through `BaseVisualChange.observedInteraction()`, which (for an Android device) calls:

```ts
if (typeof this.adb.getDeviceTimestampMs === "function") {
  return this.adb.getDeviceTimestampMs();
}
```

That resolves to `AdbClient.getDeviceTimestampMs()`, which spawns a real `adb shell date +%s%3N` subprocess against the test's device id (`emulator-5554`), which does not exist in the unit-test environment. This real IO usually returns/fails fast enough to be invisible, but under parallel load (`turbo run test`) it occasionally took long enough to trip the per-test timeout (5s isolated / 20s under turbo), always surfacing on the first `execute()` test in the `describe` block even though every non-spied `execute()` test in the file was exposed to the same real-IO path.

All of the test's other collaborators (`observeScreen`, `window`, `awaitIdle`, `deepLinkManager`) were already faked — only `adb` (a public field on `BaseVisualChange`) was left pointing at the real client.

## Fix

Inject a `FakeAdbExecutor` as `detectIntentChooser.adb` in `beforeEach`, matching the existing pattern in `test/features/observe/Idle.test.ts` and other `BaseVisualChange`-derived feature tests. `FakeAdbExecutor.getDeviceTimestampMs()` resolves synchronously (from a configured value or `Date.now()`), so `observedInteraction()` never touches a real process.

## Validation

- `bun test test/features/observe/DetectIntentChooser.test.ts` — 5x isolated runs, all 9 pass in ~170ms total, no hangs.
- 3x concurrent parallel invocations of the same file (simulating turbo load) — all pass.
- `bun test test/features/observe/` — 2381 pass, 0 fail.
- `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build` — all clean (only pre-existing baselined warnings).

Closes #6173
Closes #6174