### PR TITLE
fix(observe): surface checkable-only switch state in skeleton toggle/checked

### DIFF
--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -1,5 +1,6 @@
 import type { ObserveResult, ViewHierarchyNode, ViewHierarchyResult } from "../../models";
 import type { Element } from "../../models/Element";
+import { isTruthy } from "../../models/Element";
 import { isClickableElementProperties } from "../../utils/elementProperties";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
@@ -101,7 +102,16 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
       ancestors.push({ depth, provenance });
 
       const nodeProperties = this.parser.extractNodeProperties(node);
-      if (isClickableElementProperties(nodeProperties)) {
+      // A `checkable` node (Android `Switch`/`SwitchCompat`/`CheckBox`) commonly
+      // sits inside a clickable preference row with `clickable="false"` on the
+      // switch itself — the parent row owns the tap, the switch only reflects
+      // state. Without this, such a node is invisible to every downstream
+      // collection and its `checked` state never reaches the skeleton
+      // projection's `toggle` affordance (issue #6257).
+      if (
+        isClickableElementProperties(nodeProperties) ||
+        isTruthy(nodeProperties.checkable as boolean | string | undefined)
+      ) {
         collections.clickable.push(parsedNode);
       }
       if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {

--- a/test/features/observe/ObserveElementsBuilder.test.ts
+++ b/test/features/observe/ObserveElementsBuilder.test.ts
@@ -214,6 +214,48 @@ describe("ObserveElementsBuilder", () => {
     ]);
   });
 
+  test("collects a checkable-but-not-clickable switch (issue #6257: Settings preference-row switch)", () => {
+    // Mirrors the AOSP `TwoStatePreference` layout: the row is clickable and
+    // toggles the switch, but the `Switch` widget itself carries
+    // `clickable="false"` — only `checkable`/`checked` reflect its state. Without
+    // this node reaching `elements.clickable`, the skeleton never sees a `toggle`
+    // affordance or `checked` value for it.
+    const preferenceRow = node({
+      bounds: { left: 0, top: 0, right: 200, bottom: 60 },
+      class: "android.widget.LinearLayout",
+      clickable: "true",
+      "resource-id": "wifi_row",
+    });
+    const switchWidget = node({
+      bounds: { left: 160, top: 10, right: 200, bottom: 50 },
+      class: "android.widget.Switch",
+      clickable: "false",
+      checkable: "true",
+      checked: "true",
+      "resource-id": "wifi_switch",
+    });
+    const viewHierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: node({ bounds: { left: 0, top: 0, right: 200, bottom: 300 }, class: "root" }, [
+          preferenceRow,
+          switchWidget,
+        ]),
+      },
+    };
+
+    const parser = new TraversalCountingParser();
+    const builder = new ObserveElementsBuilder(
+      new DefaultObserveElementCollector(parser, new IdentifyMediaViews(parser)),
+    );
+
+    const elements = builder.build(viewHierarchy, "android");
+
+    expect(elements.clickable).toEqual([
+      { ...preferenceRow.$, bounds: preferenceRow.bounds },
+      { ...switchWidget.$, bounds: switchWidget.bounds },
+    ]);
+  });
+
   test("collects iOS text and media from the shared traversal without adding accessibility-label text", () => {
     const labelOnlyImage = node({
       bounds: { left: 0, top: 0, right: 50, bottom: 50 },

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -241,6 +241,47 @@ describe("toSkeleton — acceptance criteria", () => {
       expect("checked" in (findById(skeleton, "plain") as SkeletonElement)).toBe(false);
     });
 
+    test("issue #6257: a switch's entry differs across a checked-state flip, and carries toggle", () => {
+      const wifiSwitch = (checked: boolean): Element => ({
+        bounds: bounds(0, 0, 10, 10),
+        "resource-id": "wifi_switch",
+        "content-desc": "Wi-Fi",
+        checkable: "true",
+        checked,
+      });
+
+      const before = toSkeleton(makeElements({ clickable: [wifiSwitch(true)] }));
+      const after = toSkeleton(makeElements({ clickable: [wifiSwitch(false)] }));
+
+      const beforeEntry = findById(before, "wifi_switch");
+      const afterEntry = findById(after, "wifi_switch");
+
+      expect(beforeEntry?.affordances).toContain("toggle");
+      expect(afterEntry?.affordances).toContain("toggle");
+      expect(beforeEntry?.checked).toBe(true);
+      expect(afterEntry?.checked).toBe(false);
+      // The entries must NOT be byte-identical (issue #6257) — a client can now
+      // read the state and verify a change.
+      expect(JSON.stringify(beforeEntry)).not.toEqual(JSON.stringify(afterEntry));
+    });
+
+    test("a non-checkable entry is unchanged by an unrelated checked flip elsewhere", () => {
+      const plainButton: Element = {
+        bounds: bounds(0, 40, 10, 50),
+        "resource-id": "plain",
+        clickable: "true",
+      };
+
+      const before = toSkeleton(makeElements({ clickable: [plainButton] }));
+      const after = toSkeleton(makeElements({ clickable: [{ ...plainButton } as Element] }));
+
+      expect(JSON.stringify(findById(before, "plain"))).toEqual(
+        JSON.stringify(findById(after, "plain")),
+      );
+      expect(findById(before, "plain")?.affordances).not.toContain("toggle");
+      expect("checked" in (findById(before, "plain") as SkeletonElement)).toBe(false);
+    });
+
     test("multiple affordances emit in canonical order tap,long-press,input,scroll,toggle", () => {
       const kitchenSink: Element = {
         bounds: bounds(0, 0, 10, 10),


### PR DESCRIPTION
## Problem

Settings switch rows (Wi-Fi, Airplane mode, Hotspot, Data Saver) render in the skeleton as `tap`-only with no way to read or verify state — the skeleton entry is byte-identical before and after toggling. See #6257.

## Root cause

`SkeletonProjection.ts` already had complete `toggle` affordance / `checked` field handling (from prior #4388/#6221 work) and the observe output schema/`tool-definitions.json` already declared the `checked` field and `toggle` affordance. The actual gap was one layer down: `ObserveElementCollector.collectFromRoot` only pushed a node into `elements.clickable` when it matched `isClickableElementProperties` (`clickable` or a `click` accessibility action).

AOSP `TwoStatePreference` rows put the tap handler on the outer row and set the descendant `Switch`/`SwitchCompat` to `clickable="false"` — only `checkable`/`checked` describe its state. That switch node was therefore never collected at all, so its state never reached `SkeletonProjection`, `toSkeleton`, or the client.

## Fix

`ObserveElementCollector` now also collects a node into `elements.clickable` when it is `checkable`, even if it is not itself clickable. This is the fallback the issue explicitly calls out as acceptable: the descendant switch surfaces as its own skeleton entry with `toggle` + `checked`, rather than being silently dropped.

## Tests

- `test/features/observe/ObserveElementsBuilder.test.ts`: a checkable-but-not-clickable `Switch` node (mirroring the AOSP preference-row layout) is now collected into `elements.clickable`.
- `test/features/observe/output/skeletonProjection.test.ts`: a switch's skeleton entry differs across a `checked` state flip (and carries `toggle`); a non-checkable entry is unaffected.

## Validation

- `bun test` (full suite) — 16058 pass, 2 pre-existing unrelated failures (missing `oxlint` binary in `node_modules/.bin` for `oxlintConfigScoping.integration.test.ts`; a WHIP/WHEP skip-message assertion), neither touched by this change.
- `bun run lint` — clean, ratchet unchanged.
- `bun run typecheck` — clean, baseline unchanged.
- `bun run format:check` — clean.
- `scripts/update-tool-definitions.sh` — no changes (schema already declared `toggle`/`checked` from prior work).
- `bunx turbo run build` — succeeds.

Closes #6257