### PR TITLE
fix(ios): bound imeAction to its own deadline so a stalled runner can't hang the call

### DIFF
--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -70,6 +70,15 @@ export class ImeAction extends BaseVisualChange {
     // dispatch the same action a second time (double-submit/double-nav).
     let capturedActionResult: ImeActionResult | undefined;
 
+    // Flips to true the instant the iOS wire request for `request_ime_action`
+    // is actually sent (#6249 P1 follow-up) — independent of whether a result
+    // is ever observed for it. If the outer deadline fires after dispatch but
+    // before `capturedActionResult` is known, the outcome on the device is
+    // genuinely indeterminate: it may have already mutated the UI, so it must
+    // not be reported as a plain retryable timeout (see
+    // `boundIosInteractionToDeadline`).
+    let dispatched = false;
+
     const block = async (observeResult: ObserveResult): Promise<ImeActionResult> => {
       try {
         // Platform-specific IME action execution
@@ -82,7 +91,9 @@ export class ImeAction extends BaseVisualChange {
             break;
           case "ios":
             result = await perf.track("iOSImeAction", () =>
-              this.executeiOSImeAction(action, observeResult, iosAbortController?.signal),
+              this.executeiOSImeAction(action, observeResult, iosAbortController?.signal, () => {
+                dispatched = true;
+              }),
             );
             break;
           default:
@@ -122,6 +133,7 @@ export class ImeAction extends BaseVisualChange {
       action,
       iosAbortController,
       () => capturedActionResult,
+      () => dispatched,
     );
   }
 
@@ -147,14 +159,26 @@ export class ImeAction extends BaseVisualChange {
    * action ITSELF, not whatever `observedInteraction` does once that outcome
    * is known. `getActionResult` reports whether `block` (which invokes
    * `requestImeAction`) has already resolved by the time the deadline fires.
-   * If it resolved successfully, the UI mutation already happened — throwing
-   * here would tell the caller the action never took effect, inviting a
-   * retry that dispatches it a second time (double-submit/double-nav). In
-   * that case we return the completed result with a `warning` instead of
+   * If it resolved — success OR a definitive failure (#6249 P2: e.g. "No
+   * focused element") — that outcome is real and already known; throwing
+   * here would discard it and report a misleading device-connection timeout
+   * instead, and for a success would additionally invite a retry that
+   * dispatches the action a second time (double-submit/double-nav). In that
+   * case we return the completed result (adding a `warning` only for a
+   * success, per the `warning`/`success:false` invariant) instead of
    * throwing; the abandoned post-action observation is still aborted and
-   * left to settle in the background exactly as before. Only a deadline
-   * that fires before the action result is known (pre-action observation
-   * stall, or the request itself stalling) still throws.
+   * left to settle in the background exactly as before.
+   *
+   * #6249 P1 follow-up: when the result is NOT yet known, `wasDispatched`
+   * distinguishes two remaining cases. If the wire request was never sent,
+   * nothing happened on the device — a plain retryable timeout is accurate
+   * and we still throw. But if pre-action observation/reconnect resolved
+   * just before the deadline and `sendCommand` went on to dispatch
+   * `request_ime_action`, the request is now in flight with its outcome
+   * unknown: it may complete and mutate the UI after this call has already
+   * returned. Reporting that as a plain timeout would invite a caller retry
+   * that double-applies the action, so we return a non-retryable
+   * indeterminate result instead of throwing.
    */
   private async boundIosInteractionToDeadline(
     block: (observeResult: ObserveResult) => Promise<ImeActionResult>,
@@ -162,6 +186,7 @@ export class ImeAction extends BaseVisualChange {
     action: ImeActionType,
     controller: AbortController,
     getActionResult: () => ImeActionResult | undefined,
+    wasDispatched: () => boolean,
   ): Promise<ImeActionResult> {
     const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
     let deadlineHandle: ReturnType<Timer["setTimeout"]> | undefined;
@@ -174,34 +199,13 @@ export class ImeAction extends BaseVisualChange {
     try {
       const outcome = await Promise.race([interaction, deadline]);
       if (outcome === "deadline") {
-        controller.abort();
-        void interaction.catch((error) => {
-          // The interaction's own outcome no longer matters to this call —
-          // only trace it so a slow/failing runner is still diagnosable.
-          logger.debug(
-            `[ImeAction] iOS execute() pipeline for action '${action}' settled after the local ${timeoutMs}ms deadline: ${errorMessage(error)}`,
-          );
-        });
-
-        const completedAction = getActionResult();
-        if (completedAction?.success) {
-          // The action already mutated the UI — only the post-action
-          // observation stalled. Preserve the real outcome instead of
-          // throwing a timeout that would invite a double-submit.
-          logger.warn(
-            `[ImeAction] iOS IME action '${action}' completed successfully, but the post-action observation did not settle within ${timeoutMs}ms; returning the action result without waiting further`,
-          );
-          return {
-            ...completedAction,
-            warning: `Post-action observation did not complete within ${timeoutMs}ms; the '${action}' action was already applied to the device.`,
-          };
-        }
-
-        logger.warn(
-          `[ImeAction] iOS IME action '${action}' exceeded its ${timeoutMs}ms deadline before the pre-action observation or request settled; failing without waiting further`,
-        );
-        throw new ActionableError(
-          `IME action '${action}' timed out after ${timeoutMs}ms waiting on the iOS device connection`,
+        return this.handleIosDeadline(
+          interaction,
+          timeoutMs,
+          action,
+          controller,
+          getActionResult,
+          wasDispatched,
         );
       }
       return outcome as ImeActionResult;
@@ -210,6 +214,84 @@ export class ImeAction extends BaseVisualChange {
         this.imeTimer.clearTimeout(deadlineHandle);
       }
     }
+  }
+
+  /**
+   * Resolve the outcome once the outer deadline in
+   * `boundIosInteractionToDeadline` has fired. Split out to keep that
+   * method's control flow shallow — this covers, in order: a known
+   * completed result (success or definitive failure, #6249 P1/P2), a
+   * dispatched-but-unresolved request (#6249 P1 follow-up), and finally the
+   * plain "nothing happened yet" retryable timeout.
+   */
+  private async handleIosDeadline(
+    interaction: Promise<ImeActionResult>,
+    timeoutMs: number,
+    action: ImeActionType,
+    controller: AbortController,
+    getActionResult: () => ImeActionResult | undefined,
+    wasDispatched: () => boolean,
+  ): Promise<ImeActionResult> {
+    controller.abort();
+    void interaction.catch((error) => {
+      // The interaction's own outcome no longer matters to this call — only
+      // trace it so a slow/failing runner is still diagnosable.
+      logger.debug(
+        `[ImeAction] iOS execute() pipeline for action '${action}' settled after the local ${timeoutMs}ms deadline: ${errorMessage(error)}`,
+      );
+    });
+
+    const completedAction = getActionResult();
+    if (completedAction?.success) {
+      // The action already mutated the UI — only the post-action
+      // observation stalled. Preserve the real outcome instead of throwing
+      // a timeout that would invite a double-submit.
+      logger.warn(
+        `[ImeAction] iOS IME action '${action}' completed successfully, but the post-action observation did not settle within ${timeoutMs}ms; returning the action result without waiting further`,
+      );
+      return {
+        ...completedAction,
+        warning: `Post-action observation did not complete within ${timeoutMs}ms; the '${action}' action was already applied to the device.`,
+      };
+    }
+
+    if (completedAction) {
+      // #6249 P2: a definitive failure (e.g. "No focused element") is just
+      // as real an outcome as a success — preserve it rather than
+      // discarding it for a misleading device-connection timeout. No
+      // `warning` here: that field is reserved for a known success with a
+      // stalled observation (see the `warning`/`success:false` invariant on
+      // `ImeActionResult`).
+      logger.warn(
+        `[ImeAction] iOS IME action '${action}' completed with a definitive failure ('${completedAction.error}'), but the post-action observation did not settle within ${timeoutMs}ms; returning the action's real outcome without waiting further`,
+      );
+      return completedAction;
+    }
+
+    if (wasDispatched()) {
+      // #6249 P1 follow-up: pre-action observation/reconnect resolved just
+      // before the deadline, so `sendCommand` went on to dispatch
+      // `request_ime_action` — but its result never arrived before this
+      // deadline fired. The device may still apply the action after this
+      // call returns, so this is NOT a plain "nothing happened, safe to
+      // retry" timeout.
+      logger.warn(
+        `[ImeAction] iOS IME action '${action}' was dispatched to the device but its result did not arrive within ${timeoutMs}ms; returning an indeterminate, non-retryable result instead of a timeout`,
+      );
+      return {
+        success: false,
+        action,
+        error: `IME action '${action}' outcome is indeterminate: the request was dispatched to the device but no result was received within ${timeoutMs}ms. The action may have already been applied — do not retry automatically.`,
+        retryable: false,
+      };
+    }
+
+    logger.warn(
+      `[ImeAction] iOS IME action '${action}' exceeded its ${timeoutMs}ms deadline before the pre-action observation or request settled; failing without waiting further`,
+    );
+    throw new ActionableError(
+      `IME action '${action}' timed out after ${timeoutMs}ms waiting on the iOS device connection`,
+    );
   }
 
   /**
@@ -302,6 +384,7 @@ export class ImeAction extends BaseVisualChange {
     action: ImeActionType,
     _observeResult: ObserveResult,
     outerSignal?: AbortSignal,
+    onDispatch?: () => void,
   ): Promise<ImeActionResult> {
     const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
     // Own the abort signal actually threaded into the wire request so a
@@ -318,7 +401,13 @@ export class ImeAction extends BaseVisualChange {
 
     try {
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const request = client.requestImeAction(action, timeoutMs, undefined, controller.signal);
+      const request = client.requestImeAction(
+        action,
+        timeoutMs,
+        undefined,
+        controller.signal,
+        onDispatch,
+      );
       const result = await this.raceIosImeActionDeadline(request, timeoutMs, action, controller);
 
       if (result === null) {

--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -61,22 +61,36 @@ export class ImeAction extends BaseVisualChange {
     const isIos = this.device.platform === "ios";
     const iosAbortController = isIos ? new AbortController() : undefined;
 
+    // Captures the action outcome the instant `block` resolves (#6249 P1
+    // follow-up) — independent of whatever `observedInteraction` does
+    // afterwards (post-action observation, retries). Once this is set with
+    // `success: true`, the underlying UI mutation has already happened, so a
+    // subsequently-stalled observation must never be allowed to turn the
+    // call into a thrown timeout — that would invite a caller retry to
+    // dispatch the same action a second time (double-submit/double-nav).
+    let capturedActionResult: ImeActionResult | undefined;
+
     const block = async (observeResult: ObserveResult): Promise<ImeActionResult> => {
       try {
         // Platform-specific IME action execution
+        let result: ImeActionResult;
         switch (this.device.platform) {
           case "android":
-            return await perf.track("androidImeAction", () =>
+            result = await perf.track("androidImeAction", () =>
               this.executeAndroidImeAction(action, observeResult),
             );
+            break;
           case "ios":
-            return await perf.track("iOSImeAction", () =>
+            result = await perf.track("iOSImeAction", () =>
               this.executeiOSImeAction(action, observeResult, iosAbortController?.signal),
             );
+            break;
           default:
             perf.end();
             throw new Error(`Unsupported platform: ${this.device.platform}`);
         }
+        capturedActionResult = result;
+        return result;
       } catch (error) {
         perf.end();
         const errorMsg = errorMessage(error);
@@ -102,7 +116,13 @@ export class ImeAction extends BaseVisualChange {
       return this.observedInteraction(block, options);
     }
 
-    return this.boundIosInteractionToDeadline(block, options, action, iosAbortController);
+    return this.boundIosInteractionToDeadline(
+      block,
+      options,
+      action,
+      iosAbortController,
+      () => capturedActionResult,
+    );
   }
 
   /**
@@ -122,12 +142,26 @@ export class ImeAction extends BaseVisualChange {
    * promise is left to settle in the background (logged, never thrown) so
    * the underlying client's own reconnect/health-check state can recover
    * normally for the next call instead of being torn down mid-flight.
+   *
+   * P1 fix (#6249 review): the deadline only covers the outcome of the
+   * action ITSELF, not whatever `observedInteraction` does once that outcome
+   * is known. `getActionResult` reports whether `block` (which invokes
+   * `requestImeAction`) has already resolved by the time the deadline fires.
+   * If it resolved successfully, the UI mutation already happened — throwing
+   * here would tell the caller the action never took effect, inviting a
+   * retry that dispatches it a second time (double-submit/double-nav). In
+   * that case we return the completed result with a `warning` instead of
+   * throwing; the abandoned post-action observation is still aborted and
+   * left to settle in the background exactly as before. Only a deadline
+   * that fires before the action result is known (pre-action observation
+   * stall, or the request itself stalling) still throws.
    */
   private async boundIosInteractionToDeadline(
     block: (observeResult: ObserveResult) => Promise<ImeActionResult>,
     options: Parameters<BaseVisualChange["observedInteraction"]>[1],
     action: ImeActionType,
     controller: AbortController,
+    getActionResult: () => ImeActionResult | undefined,
   ): Promise<ImeActionResult> {
     const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
     let deadlineHandle: ReturnType<Timer["setTimeout"]> | undefined;
@@ -148,6 +182,21 @@ export class ImeAction extends BaseVisualChange {
             `[ImeAction] iOS execute() pipeline for action '${action}' settled after the local ${timeoutMs}ms deadline: ${errorMessage(error)}`,
           );
         });
+
+        const completedAction = getActionResult();
+        if (completedAction?.success) {
+          // The action already mutated the UI — only the post-action
+          // observation stalled. Preserve the real outcome instead of
+          // throwing a timeout that would invite a double-submit.
+          logger.warn(
+            `[ImeAction] iOS IME action '${action}' completed successfully, but the post-action observation did not settle within ${timeoutMs}ms; returning the action result without waiting further`,
+          );
+          return {
+            ...completedAction,
+            warning: `Post-action observation did not complete within ${timeoutMs}ms; the '${action}' action was already applied to the device.`,
+          };
+        }
+
         logger.warn(
           `[ImeAction] iOS IME action '${action}' exceeded its ${timeoutMs}ms deadline before the pre-action observation or request settled; failing without waiting further`,
         );

--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -11,12 +11,21 @@ import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxy, AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import type { CtrlProxyImeActionResult } from "../observe/ios/types";
 import { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
 
 export class ImeAction extends BaseVisualChange {
   private a11yService: AndroidCtrlProxy | null = null;
   private imeTimer: Timer;
+
+  /**
+   * Local deadline for the iOS CtrlProxy IME-action request (#6249). Matches
+   * the wire-level default in `SharedTextDelegate.requestImeAction`/`sendCommand`
+   * so a healthy runner behaves identically; the difference only shows up when
+   * the connection layer is unhealthy — see `executeiOSImeAction`.
+   */
+  private static readonly IOS_IME_ACTION_TIMEOUT_MS = 5000;
 
   constructor(
     device: BootedDevice,
@@ -171,9 +180,19 @@ export class ImeAction extends BaseVisualChange {
     action: ImeActionType,
     _observeResult: ObserveResult,
   ): Promise<ImeActionResult> {
+    const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
     try {
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const result = await client.requestImeAction(action);
+      const request = client.requestImeAction(action, timeoutMs);
+      const result = await this.raceIosImeActionDeadline(request, timeoutMs, action);
+
+      if (result === null) {
+        return {
+          success: false,
+          action,
+          error: `IME action timed out after ${timeoutMs}ms`,
+        };
+      }
 
       if (result.success) {
         logger.info(`[ImeAction] IME action '${action}' completed via CtrlProxy iOS`);
@@ -185,6 +204,59 @@ export class ImeAction extends BaseVisualChange {
     } catch (error) {
       logger.error(`[ImeAction] CtrlProxy iOS exception: ${error}`);
       return { success: false, action, error: String(error) };
+    }
+  }
+
+  /**
+   * Bound an in-flight iOS CtrlProxy IME-action request with a deadline that
+   * starts immediately and runs independently of the request itself (#6249).
+   *
+   * `IOSCtrlProxyClient.requestImeAction`'s own `timeoutMs` only bounds the
+   * wait for a wire response AFTER `ensureConnected()` resolves — and
+   * `ensureConnected()` (WebSocket reconnect, iOS auto-setup, a runner mid
+   * restart) runs first and is NOT itself bounded by that timeout. A real
+   * repro of #6249 returned ~35s late against a configured 5000ms timeout,
+   * while the daemon's own reconnect-failure counter tore down the iOS
+   * CtrlProxy test-runner process in the background during that wait.
+   *
+   * Racing an independently-scheduled deadline here means this call always
+   * returns to the caller within `timeoutMs`, regardless of what the
+   * connection layer is doing. The underlying request is left to settle on
+   * its own — its eventual result is irrelevant once we've timed out, so it
+   * is only logged (never thrown) to avoid an unhandled rejection; letting it
+   * run to completion in the background is also what allows the client's own
+   * reconnect/health-check state to recover normally for the *next* call
+   * instead of being aborted mid-flight.
+   */
+  private async raceIosImeActionDeadline(
+    request: Promise<CtrlProxyImeActionResult>,
+    timeoutMs: number,
+    action: ImeActionType,
+  ): Promise<CtrlProxyImeActionResult | null> {
+    let timeoutHandle: ReturnType<Timer["setTimeout"]> | undefined;
+    const deadline = new Promise<null>((resolve) => {
+      timeoutHandle = this.imeTimer.setTimeout(() => resolve(null), timeoutMs);
+    });
+
+    try {
+      const outcome = await Promise.race([request, deadline]);
+      if (outcome === null) {
+        void request.catch((error) => {
+          // The request's own outcome no longer matters to this call — only
+          // trace it so a slow/failing runner is still diagnosable.
+          logger.debug(
+            `[ImeAction] iOS CtrlProxy request for action '${action}' settled after the local ${timeoutMs}ms deadline: ${errorMessage(error)}`,
+          );
+        });
+        logger.warn(
+          `[ImeAction] iOS IME action '${action}' exceeded its ${timeoutMs}ms local deadline before the connection/request settled; returning failure without waiting further`,
+        );
+      }
+      return outcome;
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.imeTimer.clearTimeout(timeoutHandle);
+      }
     }
   }
 }

--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -2,6 +2,7 @@ import { errorMessage } from "../../utils/describeUnknownError";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import {
+  ActionableError,
   BootedDevice,
   ImeAction as ImeActionType,
   ImeActionResult,
@@ -52,42 +53,114 @@ export class ImeAction extends BaseVisualChange {
       };
     }
 
-    return this.observedInteraction(
-      async (observeResult: ObserveResult) => {
-        try {
-          // Platform-specific IME action execution
-          switch (this.device.platform) {
-            case "android":
-              return await perf.track("androidImeAction", () =>
-                this.executeAndroidImeAction(action, observeResult),
-              );
-            case "ios":
-              return await perf.track("iOSImeAction", () =>
-                this.executeiOSImeAction(action, observeResult),
-              );
-            default:
-              perf.end();
-              throw new Error(`Unsupported platform: ${this.device.platform}`);
-          }
-        } catch (error) {
-          perf.end();
-          const errorMsg = errorMessage(error);
-          return {
-            success: false,
-            action,
-            error: `Failed to execute IME action: ${errorMsg}`,
-          };
+    // iOS gets its own abort signal + outer deadline (#6249 follow-up): the
+    // pre-action observation performed by `observedInteraction` below runs
+    // through the same unbounded `ensureConnected()` path as the IME request
+    // itself, so it must be covered by the deadline too — not just the
+    // request. See `boundIosInteractionToDeadline`.
+    const isIos = this.device.platform === "ios";
+    const iosAbortController = isIos ? new AbortController() : undefined;
+
+    const block = async (observeResult: ObserveResult): Promise<ImeActionResult> => {
+      try {
+        // Platform-specific IME action execution
+        switch (this.device.platform) {
+          case "android":
+            return await perf.track("androidImeAction", () =>
+              this.executeAndroidImeAction(action, observeResult),
+            );
+          case "ios":
+            return await perf.track("iOSImeAction", () =>
+              this.executeiOSImeAction(action, observeResult, iosAbortController?.signal),
+            );
+          default:
+            perf.end();
+            throw new Error(`Unsupported platform: ${this.device.platform}`);
         }
-      },
-      {
-        changeExpected: true,
-        tolerancePercent: 0.0,
-        timeoutMs: 3000, // IME actions should be quick
-        progress,
-        perf,
-        skipUiStability: true, // Skip UI stability wait - a11y service already waits for quiescence
-      },
-    );
+      } catch (error) {
+        perf.end();
+        const errorMsg = errorMessage(error);
+        return {
+          success: false,
+          action,
+          error: `Failed to execute IME action: ${errorMsg}`,
+        };
+      }
+    };
+
+    const options: Parameters<BaseVisualChange["observedInteraction"]>[1] = {
+      changeExpected: true,
+      tolerancePercent: 0.0,
+      timeoutMs: 3000, // IME actions should be quick
+      progress,
+      perf,
+      skipUiStability: true, // Skip UI stability wait - a11y service already waits for quiescence
+      signal: iosAbortController?.signal,
+    };
+
+    if (!iosAbortController) {
+      return this.observedInteraction(block, options);
+    }
+
+    return this.boundIosInteractionToDeadline(block, options, action, iosAbortController);
+  }
+
+  /**
+   * Bound the ENTIRE iOS `observedInteraction` call — pre-action observation
+   * AND the IME request itself — to `IOS_IME_ACTION_TIMEOUT_MS` (#6249
+   * follow-up).
+   *
+   * The pre-action observation fetched by `observedInteraction` (a cache miss
+   * falls through to `observeScreen.execute()`) goes through the same
+   * unbounded iOS `ensureConnected()` path as the IME request. Racing only
+   * the request (as `raceIosImeActionDeadline` does) leaves this earlier step
+   * free to hang indefinitely when there is no usable cached hierarchy and
+   * the runner is unhealthy. Wrapping the whole call here means `execute()`
+   * always returns within the deadline regardless of which stage stalls.
+   *
+   * As with the request-level race, the abandoned `observedInteraction`
+   * promise is left to settle in the background (logged, never thrown) so
+   * the underlying client's own reconnect/health-check state can recover
+   * normally for the next call instead of being torn down mid-flight.
+   */
+  private async boundIosInteractionToDeadline(
+    block: (observeResult: ObserveResult) => Promise<ImeActionResult>,
+    options: Parameters<BaseVisualChange["observedInteraction"]>[1],
+    action: ImeActionType,
+    controller: AbortController,
+  ): Promise<ImeActionResult> {
+    const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
+    let deadlineHandle: ReturnType<Timer["setTimeout"]> | undefined;
+    const deadline = new Promise<"deadline">((resolve) => {
+      deadlineHandle = this.imeTimer.setTimeout(() => resolve("deadline"), timeoutMs);
+    });
+
+    const interaction = this.observedInteraction(block, options);
+
+    try {
+      const outcome = await Promise.race([interaction, deadline]);
+      if (outcome === "deadline") {
+        controller.abort();
+        void interaction.catch((error) => {
+          // The interaction's own outcome no longer matters to this call —
+          // only trace it so a slow/failing runner is still diagnosable.
+          logger.debug(
+            `[ImeAction] iOS execute() pipeline for action '${action}' settled after the local ${timeoutMs}ms deadline: ${errorMessage(error)}`,
+          );
+        });
+        logger.warn(
+          `[ImeAction] iOS IME action '${action}' exceeded its ${timeoutMs}ms deadline before the pre-action observation or request settled; failing without waiting further`,
+        );
+        throw new ActionableError(
+          `IME action '${action}' timed out after ${timeoutMs}ms waiting on the iOS device connection`,
+        );
+      }
+      return outcome as ImeActionResult;
+    } finally {
+      if (deadlineHandle !== undefined) {
+        this.imeTimer.clearTimeout(deadlineHandle);
+      }
+    }
   }
 
   /**
@@ -179,12 +252,25 @@ export class ImeAction extends BaseVisualChange {
   private async executeiOSImeAction(
     action: ImeActionType,
     _observeResult: ObserveResult,
+    outerSignal?: AbortSignal,
   ): Promise<ImeActionResult> {
     const timeoutMs = ImeAction.IOS_IME_ACTION_TIMEOUT_MS;
+    // Own the abort signal actually threaded into the wire request so a
+    // request that outlives the deadline is cancelled rather than dispatched
+    // (#6249 follow-up). Also honor an outer deadline (e.g.
+    // `boundIosInteractionToDeadline`) that may fire first.
+    const controller = new AbortController();
+    const onOuterAbort = () => controller.abort();
+    if (outerSignal?.aborted) {
+      controller.abort();
+    } else {
+      outerSignal?.addEventListener("abort", onOuterAbort);
+    }
+
     try {
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const request = client.requestImeAction(action, timeoutMs);
-      const result = await this.raceIosImeActionDeadline(request, timeoutMs, action);
+      const request = client.requestImeAction(action, timeoutMs, undefined, controller.signal);
+      const result = await this.raceIosImeActionDeadline(request, timeoutMs, action, controller);
 
       if (result === null) {
         return {
@@ -204,6 +290,8 @@ export class ImeAction extends BaseVisualChange {
     } catch (error) {
       logger.error(`[ImeAction] CtrlProxy iOS exception: ${error}`);
       return { success: false, action, error: String(error) };
+    } finally {
+      outerSignal?.removeEventListener("abort", onOuterAbort);
     }
   }
 
@@ -222,16 +310,22 @@ export class ImeAction extends BaseVisualChange {
    * Racing an independently-scheduled deadline here means this call always
    * returns to the caller within `timeoutMs`, regardless of what the
    * connection layer is doing. The underlying request is left to settle on
-   * its own — its eventual result is irrelevant once we've timed out, so it
-   * is only logged (never thrown) to avoid an unhandled rejection; letting it
-   * run to completion in the background is also what allows the client's own
-   * reconnect/health-check state to recover normally for the *next* call
-   * instead of being aborted mid-flight.
+   * its own in the background — but before that, firing the deadline also
+   * aborts `controller`, which is wired all the way into `sendCommand`
+   * (`DeviceServiceUtils.ts`): if `ensureConnected()` was still resolving
+   * when the deadline hit, `sendCommand` sees the abort right after
+   * `ensureConnected()` returns and skips registering/sending
+   * `request_ime_action` entirely — no phantom dispatch after the caller has
+   * already given up (#6249 follow-up). The request's eventual settlement is
+   * only logged (never thrown) to avoid an unhandled rejection; letting the
+   * client's own connection state settle normally (rather than being torn
+   * down mid-flight) is what keeps the *next* call unaffected.
    */
   private async raceIosImeActionDeadline(
     request: Promise<CtrlProxyImeActionResult>,
     timeoutMs: number,
     action: ImeActionType,
+    controller: AbortController,
   ): Promise<CtrlProxyImeActionResult | null> {
     let timeoutHandle: ReturnType<Timer["setTimeout"]> | undefined;
     const deadline = new Promise<null>((resolve) => {
@@ -241,6 +335,7 @@ export class ImeAction extends BaseVisualChange {
     try {
       const outcome = await Promise.race([request, deadline]);
       if (outcome === null) {
+        controller.abort();
         void request.catch((error) => {
           // The request's own outcome no longer matters to this call — only
           // trace it so a slow/failing runner is still diagnosable.

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -244,6 +244,16 @@ interface SendCommandBaseOptions {
   notConnectedMessage?: string;
   /** Human-readable label used in the default timeout error. Defaults to `responseType`. */
   errorLabel?: string;
+  /**
+   * Aborted by a caller-owned deadline that started before `ensureConnected()`
+   * was awaited (#6249 follow-up). `ensureConnected()` itself is not
+   * cancellable, so this cannot interrupt an in-flight reconnect/auto-setup —
+   * but it IS checked right after that await resolves and before the request
+   * is registered/sent, so a request whose deadline already expired while
+   * `ensureConnected()` was running is never dispatched to the device (no
+   * phantom action after the caller has already given up and returned).
+   */
+  abortSignal?: AbortSignal;
 }
 
 export type SendCommandOptions<T> = SendCommandBaseOptions & CommandFallbackBuilders<T>;
@@ -282,6 +292,23 @@ export async function sendCommand<T>(
       success: false,
       totalTimeMs: 0,
       error,
+    } as T;
+  }
+
+  if (options.abortSignal?.aborted) {
+    // The caller's own deadline already fired while ensureConnected() was
+    // resolving (#6249) — do not register or dispatch a request the caller
+    // has already given up on.
+    logger.debug(
+      `[sendCommand] ${options.messageType} aborted before dispatch (deadline expired while connecting)`,
+    );
+    if (options.notConnectedError) {
+      return options.notConnectedError();
+    }
+    return {
+      success: false,
+      totalTimeMs: 0,
+      error: options.notConnectedMessage ?? "Request aborted before dispatch",
     } as T;
   }
 

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -254,6 +254,20 @@ interface SendCommandBaseOptions {
    * phantom action after the caller has already given up and returned).
    */
   abortSignal?: AbortSignal;
+  /**
+   * Invoked synchronously right after `ws.send()` succeeds — i.e. the wire
+   * request was actually dispatched to the device (#6249 P1 follow-up).
+   *
+   * A caller racing this call against its own deadline cannot tell, from the
+   * deadline firing alone, whether the request ever reached the device: if
+   * the deadline wins the race, `sendCommand`'s own response is abandoned and
+   * never observed. Without this signal a caller that sees only "timeout" has
+   * no way to distinguish "never dispatched, safe to retry" from "dispatched,
+   * outcome unknown — retrying may double-apply the action". Callers that
+   * care about that distinction (e.g. `ImeAction`) pass this to flip a local
+   * flag they can check when their own deadline fires.
+   */
+  onDispatch?: () => void;
 }
 
 export type SendCommandOptions<T> = SendCommandBaseOptions & CommandFallbackBuilders<T>;
@@ -346,6 +360,7 @@ export async function sendCommand<T>(
       throw new Error("WebSocket not connected");
     }
     ws.send(msg);
+    options.onDispatch?.();
   } catch (error) {
     context.requestManager.reject(
       requestId,

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -294,6 +294,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     timeoutMs?: number,
     perf?: PerformanceTracker,
     abortSignal?: AbortSignal,
+    onDispatch?: () => void,
   ): Promise<CtrlProxyImeActionResult>;
 
   requestSelectAll(
@@ -2254,8 +2255,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs?: number,
     perf?: PerformanceTracker,
     abortSignal?: AbortSignal,
+    onDispatch?: () => void,
   ): Promise<CtrlProxyImeActionResult> {
-    return this.text.requestImeAction(action, timeoutMs, perf, abortSignal);
+    return this.text.requestImeAction(action, timeoutMs, perf, abortSignal, onDispatch);
   }
 
   async requestSelectAll(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -293,6 +293,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     action: ImeAction,
     timeoutMs?: number,
     perf?: PerformanceTracker,
+    abortSignal?: AbortSignal,
   ): Promise<CtrlProxyImeActionResult>;
 
   requestSelectAll(
@@ -2252,8 +2253,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     action: ImeAction,
     timeoutMs?: number,
     perf?: PerformanceTracker,
+    abortSignal?: AbortSignal,
   ): Promise<CtrlProxyImeActionResult> {
-    return this.text.requestImeAction(action, timeoutMs, perf);
+    return this.text.requestImeAction(action, timeoutMs, perf, abortSignal);
   }
 
   async requestSelectAll(

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -53,6 +53,7 @@ export class SharedTextDelegate {
     action: ImeAction,
     timeoutMs: number = 5000,
     perf?: PerformanceTracker,
+    abortSignal?: AbortSignal,
   ): Promise<ActionTimingResult> {
     return sendCommand<ActionTimingResult>(this.context, {
       idPrefix: "imeAction",
@@ -61,6 +62,7 @@ export class SharedTextDelegate {
       params: { action },
       timeoutMs,
       perf,
+      abortSignal,
       notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
       unsupportedCommandError: (_messageType, error) => ({
         success: false,

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -54,6 +54,7 @@ export class SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker,
     abortSignal?: AbortSignal,
+    onDispatch?: () => void,
   ): Promise<ActionTimingResult> {
     return sendCommand<ActionTimingResult>(this.context, {
       idPrefix: "imeAction",
@@ -63,6 +64,7 @@ export class SharedTextDelegate {
       timeoutMs,
       perf,
       abortSignal,
+      onDispatch,
       notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
       unsupportedCommandError: (_messageType, error) => ({
         success: false,

--- a/src/models/ImeActionResult.ts
+++ b/src/models/ImeActionResult.ts
@@ -22,4 +22,14 @@ export interface ImeActionResult {
    * missing or stale. Never set alongside `success: false` (#6249).
    */
   warning?: string;
+  /**
+   * Set to `false` when the outcome of the action itself is indeterminate —
+   * the wire request was dispatched to the device but no result was
+   * observed before the local deadline fired (#6249 P1 follow-up). Unlike
+   * the plain retryable "timed out before dispatch" case, retrying here may
+   * double-apply an action that already reached the device (double
+   * submit/navigate). Absent (or `true`) means the caller may retry as
+   * usual; only ever `false` here, never `true`.
+   */
+  retryable?: boolean;
 }

--- a/src/models/ImeActionResult.ts
+++ b/src/models/ImeActionResult.ts
@@ -14,4 +14,12 @@ export interface ImeActionResult {
   action: string;
   error?: string;
   observation?: any;
+  /**
+   * Set when the action itself completed (mutating the UI) but a later,
+   * best-effort step — e.g. the post-action observation — did not finish
+   * within its deadline. The result is still the real outcome of the
+   * action; this only flags that the accompanying observation may be
+   * missing or stale. Never set alongside `success: false` (#6249).
+   */
+  warning?: string;
 }

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -736,5 +736,90 @@ describe("ImeAction", () => {
       expect(second.action).toBe("next");
       expect(callCount).toBe(2);
     });
+
+    test("returns an indeterminate, non-retryable result when dispatch happens but no result arrives before the deadline (#6249 P1)", async () => {
+      // The pre-action observation is served from cache (fast), so `block()`
+      // runs almost immediately and reaches `requestImeAction`. The fake
+      // mirrors `sendCommand` dispatching the wire request (invoking
+      // `onDispatch`) and then never resolving — exactly what happens when
+      // `ensureConnected()`/reconnect resolves just before the outer deadline
+      // and `sendCommand` goes on to call `ws.send` right before this call's
+      // own deadline fires. The caller must NOT see a plain retryable
+      // timeout here: the action may already be in flight on the device.
+      const stallingObserveScreen = new FakeObserveScreen();
+      (stallingObserveScreen as any).getMostRecentCachedObserveResult = async () =>
+        createObserveResult();
+
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (
+          action: string,
+          _timeoutMs?: number,
+          _perf?: unknown,
+          _signal?: AbortSignal,
+          onDispatch?: () => void,
+        ) => {
+          onDispatch?.();
+          return new Promise(() => {
+            /* dispatched, but no result is ever observed */
+          });
+        },
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      (ios as any).observeScreen = stallingObserveScreen;
+      (ios as any).window = fakeWindow;
+      (ios as any).awaitIdle = fakeAwaitIdle;
+
+      const result = await ios.execute("done");
+
+      expect(result.success).toBe(false);
+      expect(result.retryable).toBe(false);
+      expect(result.error).toContain("indeterminate");
+      expect(result.error).toContain("do not retry");
+      // Not the plain "safe to retry" device-connection timeout message.
+      expect(result.error).not.toContain("timed out after");
+      // Bounded by the outer deadline, not a hang.
+      expect(fakeTimer.getCurrentTime()).toBe(5000);
+    });
+
+    test("preserves a definitive completed failure when the post-action observation stalls (#6249 P2)", async () => {
+      // `requestImeAction` promptly returns a definitive failure (no
+      // in-flight ambiguity — the runner already answered). Only the
+      // subsequent post-action observation stalls past the deadline. This
+      // must return the real failure, not a misleading device-connection
+      // timeout — the outcome is already known.
+      const stallingObserveScreen = new FakeObserveScreen();
+      (stallingObserveScreen as any).getMostRecentCachedObserveResult = async () =>
+        createObserveResult();
+      (stallingObserveScreen as any).execute = () =>
+        new Promise(() => {
+          /* the post-action observation never settles */
+        });
+
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({
+          success: false,
+          action,
+          totalTimeMs: 5,
+          error: "No focused element",
+        }),
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      (ios as any).observeScreen = stallingObserveScreen;
+      (ios as any).window = fakeWindow;
+      (ios as any).awaitIdle = fakeAwaitIdle;
+
+      const result = await ios.execute("done");
+
+      expect(result.success).toBe(false);
+      expect(result.action).toBe("done");
+      expect(result.error).toBe("No focused element");
+      // Not a plain device-connection timeout despite the observation stall.
+      expect(result.error).not.toContain("timed out");
+      expect(result.warning).toBeUndefined();
+      // Bounded by the deadline, not a hang.
+      expect(fakeTimer.getCurrentTime()).toBe(5000);
+    });
   });
 });

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -9,6 +9,7 @@ import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 
 describe("ImeAction", () => {
   let imeAction: ImeAction;
@@ -510,6 +511,110 @@ describe("ImeAction", () => {
       expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_TAB")).toBe(true);
       // At least 2 calls for the key combination, but BaseVisualChange might make additional calls
       expect(fakeAdb.getExecutedCommands().length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("iOS platform (#6249 stalled-runner guard)", () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "ios-device",
+      platform: "ios",
+      name: "iPhone",
+    };
+    let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+    afterEach(() => {
+      getInstanceSpy?.mockRestore();
+      getInstanceSpy = null;
+    });
+
+    test("succeeds promptly when the CtrlProxy request resolves", async () => {
+      let calledAction: string | null = null;
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => {
+          calledAction = action;
+          return { success: true, action, totalTimeMs: 5 };
+        },
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      const result = await (ios as any).executeiOSImeAction("done", createObserveResult());
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("done");
+      expect(calledAction).toBe("done");
+      // The bounded deadline never had to fire.
+      expect(fakeTimer.getCurrentTime()).toBe(0);
+    });
+
+    test("propagates a runner-reported failure without waiting for the local deadline", async () => {
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({
+          success: false,
+          action,
+          totalTimeMs: 3,
+          error: "No focused element",
+        }),
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      const result = await (ios as any).executeiOSImeAction("done", createObserveResult());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No focused element");
+      expect(fakeTimer.getCurrentTime()).toBe(0);
+    });
+
+    test("bounds a stalled CtrlProxy request to the local deadline instead of hanging (#6249)", async () => {
+      // Simulates the real repro: `ensureConnected()` (WebSocket reconnect, auto-setup,
+      // a dying runner) never settles within the request's own configured timeout
+      // because that internal timeout only starts counting AFTER a connection is
+      // established. The underlying request here simply never resolves.
+      const request = new Promise(() => {
+        /* never settles — mirrors a wedged connection/runner */
+      });
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async () => request,
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      const result = await (ios as any).executeiOSImeAction("done", createObserveResult());
+
+      expect(result.success).toBe(false);
+      expect(result.action).toBe("done");
+      expect(result.error).toBe("IME action timed out after 5000ms");
+      // Returned via the independent local deadline, not a hang.
+      expect(fakeTimer.getCurrentTime()).toBe(5000);
+    });
+
+    test("a stalled iOS imeAction request does not corrupt a subsequent call against the same client (#6249)", async () => {
+      // First call: the CtrlProxy request stalls forever (wedged runner).
+      const stalledRequest = new Promise(() => {
+        /* never settles */
+      });
+      let callCount = 0;
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => {
+          callCount++;
+          if (callCount === 1) {
+            return stalledRequest;
+          }
+          // Second call: a healthy runner (or a fresh client after recovery)
+          // answers normally — this must NOT be affected by the first call's
+          // still-pending (abandoned) promise.
+          return { success: true, action, totalTimeMs: 5 };
+        },
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+
+      const first = await (ios as any).executeiOSImeAction("done", createObserveResult());
+      expect(first.success).toBe(false);
+      expect(first.error).toBe("IME action timed out after 5000ms");
+
+      const second = await (ios as any).executeiOSImeAction("next", createObserveResult());
+      expect(second.success).toBe(true);
+      expect(second.action).toBe("next");
+      expect(callCount).toBe(2);
     });
   });
 });

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -669,6 +669,43 @@ describe("ImeAction", () => {
       expect(result.action).toBe("next");
     });
 
+    test("preserves a successful action result when the post-action observation stalls past the deadline (#6249 P1)", async () => {
+      // The action itself (`requestImeAction`) succeeds promptly — the UI
+      // mutation already happened. Only the SUBSEQUENT post-action
+      // observation (`takeObservation`'s `observeScreen.execute()`) stalls
+      // past the deadline. This must NOT throw a timeout: a caller retry on
+      // a thrown timeout would resubmit/re-navigate a second time even
+      // though the action already completed.
+      const stallingObserveScreen = new FakeObserveScreen();
+      // A valid cached hierarchy so the pre-action observation is served
+      // from cache and never calls `execute()` — isolating the stall to the
+      // post-action step.
+      (stallingObserveScreen as any).getMostRecentCachedObserveResult = async () =>
+        createObserveResult();
+      (stallingObserveScreen as any).execute = () =>
+        new Promise(() => {
+          /* the post-action observation never settles */
+        });
+
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({ success: true, action, totalTimeMs: 5 }),
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      (ios as any).observeScreen = stallingObserveScreen;
+      (ios as any).window = fakeWindow;
+      (ios as any).awaitIdle = fakeAwaitIdle;
+
+      const result = await ios.execute("done");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("done");
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toContain("done");
+      // Bounded by the deadline, not a hang.
+      expect(fakeTimer.getCurrentTime()).toBe(5000);
+    });
+
     test("a stalled iOS imeAction request does not corrupt a subsequent call against the same client (#6249)", async () => {
       // First call: the CtrlProxy request stalls forever (wedged runner).
       const stalledRequest = new Promise(() => {

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -586,6 +586,89 @@ describe("ImeAction", () => {
       expect(fakeTimer.getCurrentTime()).toBe(5000);
     });
 
+    test("full execute() succeeds promptly on the fast path (#6249 follow-up)", async () => {
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({ success: true, action, totalTimeMs: 5 }),
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      (ios as any).observeScreen = fakeObserveScreen;
+      (ios as any).window = fakeWindow;
+      (ios as any).awaitIdle = fakeAwaitIdle;
+
+      const result = await ios.execute("done");
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("done");
+      // Neither the request-level nor the outer execute()-level deadline had
+      // to fire on the fast path.
+      expect(fakeTimer.getCurrentTime()).toBe(0);
+    });
+
+    test("bounds a stalled pre-action observation to the deadline and fails with an ActionableError instead of hanging (#6249 follow-up)", async () => {
+      // Simulates entering `BaseVisualChange.observedInteraction` with no
+      // usable cached hierarchy: the pre-action observe falls through to
+      // `observeScreen.execute()`, which goes through the same unbounded iOS
+      // `ensureConnected()` path as the IME request itself. Here it simply
+      // never resolves.
+      const stallingObserveScreen = new FakeObserveScreen();
+      (stallingObserveScreen as any).getMostRecentCachedObserveResult = () =>
+        new Promise(() => {
+          /* never settles */
+        });
+      (stallingObserveScreen as any).execute = () =>
+        new Promise(() => {
+          /* never settles */
+        });
+
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({ success: true, action, totalTimeMs: 5 }),
+      } as any);
+
+      const ios = new ImeAction(iosDevice, null, null, fakeTimer);
+      (ios as any).observeScreen = stallingObserveScreen;
+      (ios as any).window = fakeWindow;
+      (ios as any).awaitIdle = fakeAwaitIdle;
+
+      await expect(ios.execute("done")).rejects.toThrow(/timed out after 5000ms/);
+      // Bounded by the deadline, not a hang.
+      expect(fakeTimer.getCurrentTime()).toBe(5000);
+    });
+
+    test("a stalled pre-action observation does not corrupt a subsequent call (#6249 follow-up)", async () => {
+      const stallingObserveScreen = new FakeObserveScreen();
+      (stallingObserveScreen as any).getMostRecentCachedObserveResult = () =>
+        new Promise(() => {
+          /* never settles */
+        });
+      (stallingObserveScreen as any).execute = () =>
+        new Promise(() => {
+          /* never settles */
+        });
+
+      getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+        requestImeAction: async (action: string) => ({ success: true, action, totalTimeMs: 5 }),
+      } as any);
+
+      const first = new ImeAction(iosDevice, null, null, fakeTimer);
+      (first as any).observeScreen = stallingObserveScreen;
+      (first as any).window = fakeWindow;
+      (first as any).awaitIdle = fakeAwaitIdle;
+
+      await expect(first.execute("done")).rejects.toThrow(/timed out after 5000ms/);
+
+      // A fresh call (e.g. after recovery) against a healthy pipeline must
+      // not be affected by the first call's still-pending (abandoned) observe.
+      const second = new ImeAction(iosDevice, null, null, fakeTimer);
+      (second as any).observeScreen = fakeObserveScreen;
+      (second as any).window = fakeWindow;
+      (second as any).awaitIdle = fakeAwaitIdle;
+
+      const result = await second.execute("next");
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("next");
+    });
+
     test("a stalled iOS imeAction request does not corrupt a subsequent call against the same client (#6249)", async () => {
       // First call: the CtrlProxy request stalls forever (wedged runner).
       const stalledRequest = new Promise(() => {

--- a/test/features/observe/shared/SharedTextDelegate.test.ts
+++ b/test/features/observe/shared/SharedTextDelegate.test.ts
@@ -186,4 +186,47 @@ describe("SharedTextDelegate", () => {
       expect(result.error).toContain("timed out");
     });
   });
+
+  describe("abort signal (#6249 follow-up)", () => {
+    it("does not dispatch request_ime_action when the caller's deadline fired before ensureConnected() resolved", async () => {
+      const controller = new AbortController();
+      let resolveConnected: (v: boolean) => void = () => {};
+      const connected = new Promise<boolean>((resolve) => {
+        resolveConnected = resolve;
+      });
+      const { context, sent } = createFakeContext({ ensureConnected: () => connected });
+      const delegate = new SharedTextDelegate(context);
+
+      const promise = delegate.requestImeAction("done", 5000, undefined, controller.signal);
+
+      // Mirrors the real #6249 repro: the caller's own deadline (Promise.race
+      // in ImeAction) already fired and gave up, but the underlying
+      // ensureConnected()/reconnect machinery only settles afterwards.
+      controller.abort();
+      resolveConnected(true);
+
+      const result = await promise;
+
+      expect(result.success).toBe(false);
+      expect(result.action).toBe("done");
+      // The key assertion: no phantom dispatch after the deadline expired.
+      expect(sent.length).toBe(0);
+    });
+
+    it("dispatches normally when the signal never aborts", async () => {
+      const controller = new AbortController();
+      const { context, sent } = createFakeContext();
+      const delegate = new SharedTextDelegate(context);
+
+      const { sentMsg } = await callAndResolve(
+        sent,
+        context.requestManager,
+        () => delegate.requestImeAction("next", 5000, undefined, controller.signal),
+        { success: true, action: "next", totalTimeMs: 1 },
+      );
+
+      expect(sentMsg.type).toBe("request_ime_action");
+      expect(sent.length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Triage

TS-side bug found and fixed, but the deeper native cause (why the iOS CtrlProxy runner's WebSocket keeps closing during an `imeAction` call in the first place) is routed to a follow-up: #6271.

## Root cause

`sendCommand` (`src/features/observe/DeviceServiceUtils.ts`) does:

```ts
const connected = await context.ensureConnected();
// ...only THEN registers the request with RequestManager, whose
// timeoutMs actually starts counting.
```

`IOSCtrlProxyClient.ensureConnected()` can itself run for a long time — WebSocket reconnect/cooldown, iOS auto-setup, waiting on a runner that is mid-restart — none of which is bounded by the caller's configured `timeoutMs`. So the 5000ms timeout `ImeAction` passes to `requestImeAction` never gets a chance to fire; the call blocks on `ensureConnected()` instead. In the reported repro that took ~35s, and during that window the daemon's own reconnect-failure counter (`IOSCtrlProxyClient.onConnectionClosed` → `triggerServiceRestart`) tore down the CtrlProxy iOS runner (`xcodebuild test` SIGTERM) — see #6271 for that half.

Android's `imeAction` doesn't hit this because its accessibility-service client doesn't exhibit the same WebSocket-close churn.

## Fix

`ImeAction.executeiOSImeAction` now races the iOS CtrlProxy IME-action request against an **independently-started** deadline (`Promise.race`, own `setTimeout` via the injected `Timer`) instead of relying on the request's own internal timeout. This bounds the call to `timeoutMs` (5000ms, matching the existing wire-level default) regardless of what `ensureConnected()`/auto-setup/restart is doing underneath. The stalled request is left to settle in the background — logged at `debug`, never thrown — so the connection layer's own recovery for the *next* call isn't disturbed by us abandoning this one.

Net effect: `imeAction` on iOS now fails within ~5s with a clear `IME action timed out after 5000ms` error (surfaced as `isError: true` same as before) instead of hanging ~35s, and a subsequent tool call against the same client is not serialized behind the abandoned request.

## Tests

Added to `test/features/action/ImeAction.test.ts` (deterministic, `FakeTimer`, no real device):
- iOS `imeAction` succeeds/fails promptly when the CtrlProxy request resolves normally.
- A CtrlProxy request that never resolves (simulating the stalled-connection repro) is bounded to the local deadline (`fakeTimer.getCurrentTime()` lands on exactly `5000`), returning a clear timeout error instead of hanging.
- A stalled first call does not corrupt a second call against the same client — the second call still succeeds.

`bun test test/features/action/`, `bun run lint`, `bun run typecheck`, `bun run format:check`, and `bunx turbo run build` all pass.

Refs #6249. Native follow-up filed as #6271.