### PR TITLE
fix(test): bound androidNavigationWorkflow integration test against CI hangs (#6236)

### DIFF
--- a/test/server/androidNavigationWorkflow.integration.test.ts
+++ b/test/server/androidNavigationWorkflow.integration.test.ts
@@ -58,11 +58,17 @@ describe("Android navigation graph workflow (#4459)", () => {
     await client.connect(clientTransport);
 
     try {
+      // Bound this real request-response round trip explicitly (issue #6236):
+      // the MCP SDK's own request timeout defaults to 60s, which is close
+      // enough to the per-test backstop below that a genuinely stuck server
+      // response would still eat most of the CI wall-timeout budget before
+      // surfacing a diagnostic. Fail fast instead.
       const result = await client.request(
         { method: "tools/list", params: {} },
         z.object({
           tools: z.array(z.object({ name: z.string() }).passthrough()),
         }),
+        { timeout: 10_000 },
       );
       const toolNames = result.tools.map((tool) => tool.name);
 
@@ -70,9 +76,15 @@ describe("Android navigation graph workflow (#4459)", () => {
         expect.arrayContaining(["explore", "getNavigationGraph", "navigateTo"]),
       );
     } finally {
+      // Close BOTH ends of the transport. Closing only the client left the
+      // server-side transport, its request-timeout timers, and the
+      // ToolRegistry/SessionReleaseBroadcaster subscriptions registered in
+      // createMcpServer() alive for the rest of the process — a plausible
+      // contributor to the intermittent whole-lane hang (issue #6236).
       await client.close();
+      await server.close();
     }
-  });
+  }, 15_000);
 
   test("discovers, inspects, and replays a learned Android path within one session", async () => {
     const sessionUuid = "android-navigation-session";
@@ -160,11 +172,22 @@ describe("Android navigation graph workflow (#4459)", () => {
       });
       return true;
     };
-    const exploration = await explore.execute({
-      maxInteractions: 1,
-      timeoutMs: 5000,
-      packageName: appId,
-    });
+    // Bound the exploration loop with a REAL wall-clock abort signal, separate
+    // from `timeoutMs` (which is measured against the injected FakeTimer and
+    // never elapses on its own outside of `advanceTime`/auto-advance). Explore
+    // checks `signal?.aborted` once per loop iteration and stops cleanly rather
+    // than looping until `maxInteractions`/`timeoutMs` are satisfied, so a
+    // regression that stops making progress fails fast with a diagnostic
+    // instead of consuming the CI lane's wall-timeout budget (issue #6236).
+    const exploration = await explore.execute(
+      {
+        maxInteractions: 1,
+        timeoutMs: 5000,
+        packageName: appId,
+      },
+      undefined,
+      AbortSignal.timeout(10_000),
+    );
     expect(exploration).toMatchObject({
       success: true,
       interactionsPerformed: 1,
@@ -240,5 +263,5 @@ describe("Android navigation graph workflow (#4459)", () => {
       stepsExecuted: 1,
     });
     expect(replayedArgs).toMatchObject({ text: "Settings", action: "tap", platform: "android" });
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

`test/server/androidNavigationWorkflow.integration.test.ts` intermittently hangs the ubuntu `Node Host Integration Tests` lane, killing it with exit 124 at the 900s wall-timeout instead of a normal test failure (#6236).

## Root cause

The hang was not reproducible locally (5/5 runs on macOS complete in ~400ms, matching the issue's own note that it's intermittent and CI/ubuntu-specific). The test carried two real-time waits with no bound that, if ever stuck, would ride the CI wall-timeout rather than fail fast:

- **`serves the debug-gated navigation tools through MCP tools/list`**: the `client.request(...)` tools/list round trip relied on the MCP SDK's default 60s request timeout, and teardown only closed the client transport (`await client.close()`) — the server-side transport/session (and its `ToolRegistry`/`SessionReleaseBroadcaster` subscriptions wired up in `createMcpServer`) was never closed, leaking live state past the test.
- **`discovers, inspects, and replays a learned Android path within one session`**: `Explore.execute({ timeoutMs: 5000, ... })` measures `timeoutMs` against the test's injected `FakeTimer`, which only elapses via `advanceTime()`/auto-advance — it carries no *real* wall-clock bound, so a regression that stops making loop progress would spin instead of terminating.

## Fix

- Pass an explicit `{ timeout: 10_000 }` to the `tools/list` request, and close **both** ends of the transport in teardown (`client.close()` **and** `server.close()`).
- Pass a real `AbortSignal.timeout(10_000)` into `Explore.execute(...)` so a stalled exploration loop aborts cleanly (checked once per loop iteration) instead of relying solely on fake-timer-measured `timeoutMs`.
- Add a per-test bun timeout backstop (`15_000` / `20_000` ms, via bun's `test(name, fn, timeoutMs)` third argument) to both tests, per the issue's ask — a future stuck wait now fails fast with bun's own diagnostic instead of consuming the 900s CI lane budget.

## Validation

- `bun test test/server/androidNavigationWorkflow.integration.test.ts` — run 5x, all pass in ~400ms each, no hangs.
- `bun run lint` — no new violations (baseline unchanged).
- `bun run typecheck` — no new type errors (baseline unchanged).
- `bun run format:check` — clean.
- `bunx turbo run build` — clean (cache hit).

Closes #6236