### PR TITLE
fix(ios): fail-safe VoiceOver detection on unknown/timeout state

### DIFF
--- a/src/features/action/TapAnyElement.ts
+++ b/src/features/action/TapAnyElement.ts
@@ -453,7 +453,10 @@ export class TapAnyElement extends BaseVisualChange {
     element?: Element,
   ): Promise<void> {
     const xcTestClient = IOSCtrlProxyClient.getInstance(this.device);
-    const isVoiceOverEnabled = await this.iosVoiceOverDetector.isVoiceOverEnabled(
+    // Fail-safe tap-bias variant (#6267): an indeterminate probe must route
+    // through the VoiceOver activation gesture rather than a plain
+    // coordinate touch that would get reported as a successful activation.
+    const isVoiceOverEnabled = await this.iosVoiceOverDetector.isVoiceOverActiveOrUnknown(
       this.device.deviceId,
       xcTestClient,
       this.featureFlags,

--- a/src/features/action/strategies/IosTapStrategy.ts
+++ b/src/features/action/strategies/IosTapStrategy.ts
@@ -46,7 +46,11 @@ export class IosTapStrategy implements TapStrategy {
     const ctrlProxy = IOSCtrlProxyClient.getInstance(this.device);
     // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
     // apply to tap detection uniformly with the observe path (#3925).
-    return this.iosVoiceOverDetector.isVoiceOverEnabled(
+    // Use the fail-safe tap-bias variant (#6267): an indeterminate probe must
+    // route through the VoiceOver activation gesture rather than a plain
+    // coordinate touch, unlike the honest `isVoiceOverEnabled` used by
+    // toggle-confirmation/state-query consumers.
+    return this.iosVoiceOverDetector.isVoiceOverActiveOrUnknown(
       this.device.deviceId,
       ctrlProxy,
       this.featureFlags,

--- a/src/utils/IosVoiceOverDetector.ts
+++ b/src/utils/IosVoiceOverDetector.ts
@@ -26,18 +26,21 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
   }
 
   /**
-   * Check if VoiceOver is enabled on the device
+   * Check if VoiceOver is enabled on the device.
+   *
+   * Honest result: only a confirmed-enabled probe resolves to `true`. An
+   * indeterminate probe (timeout, error, or an unsuccessful CtrlProxy
+   * response) resolves to `false` — same as confirmed-disabled — because
+   * this method's consumers (toggle confirmation, state query) must treat
+   * "unknown" as NOT-confirmed rather than assuming success. Tap consumers
+   * that need the opposite bias use {@link isVoiceOverActiveOrUnknown}
+   * (#6267 follow-up: the shared detector must not coerce indeterminate to
+   * `true` for every consumer — see that method's doc for why).
    *
    * @param deviceId - The device identifier (for caching)
    * @param client - CtrlProxy service for executing the detection command
    * @param featureFlags - Feature flag service for override support
-   * @returns Promise resolving to true if VoiceOver is enabled, or if the
-   *   probe's state is indeterminate (timeout, error, or an unsuccessful
-   *   CtrlProxy response). Fail-safe (#6267): an indeterminate result is
-   *   never coalesced to `false`, so callers never mistake a focus-only
-   *   coordinate touch for a successful VoiceOver activation. Only an
-   *   explicit `enabled: false` response, or the `accessibility-auto-detect`
-   *   feature flag being off, returns `false`.
+   * @returns Promise resolving to true only when VoiceOver is confirmed enabled
    */
   async isVoiceOverEnabled(
     deviceId: string,
@@ -45,6 +48,54 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
     featureFlags?: FeatureFlagService,
     timeoutMs?: number,
   ): Promise<boolean> {
+    const state = await this.resolveVoiceOverState(deviceId, client, featureFlags, timeoutMs);
+    return state === true;
+  }
+
+  /**
+   * Fail-safe variant for tapOn/tapAny: resolves to `true` for a
+   * confirmed-enabled probe AND for an indeterminate probe (timeout, error,
+   * or an unsuccessful CtrlProxy response). Those consumers branch on the
+   * result to choose between a plain coordinate touch and a VoiceOver
+   * activation gesture, so silently treating "unknown" as "off" would make a
+   * real VoiceOver-enabled device receive a focus-only coordinate touch that
+   * gets reported as a successful activation. Treating "unknown" as "on"
+   * instead means the worst case is an unnecessary (but harmless)
+   * accessibility-action path on a device where VoiceOver is actually off —
+   * never a false success (#6267).
+   *
+   * Do not use this for toggle-confirmation or state-query consumers — see
+   * {@link isVoiceOverEnabled}.
+   */
+  async isVoiceOverActiveOrUnknown(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+  ): Promise<boolean> {
+    const state = await this.resolveVoiceOverState(deviceId, client, featureFlags, timeoutMs);
+    if (state === null) {
+      logger.warn(
+        `[IosVoiceOverDetector] VoiceOver state for device ${deviceId} could not be determined; ` +
+          `treating as enabled (fail-safe) so the tap path takes the activation gesture instead of a plain touch`,
+      );
+      return true;
+    }
+    return state;
+  }
+
+  /**
+   * Resolves the current VoiceOver state, applying feature-flag overrides
+   * and the detection cache. Returns `null` when the underlying probe is
+   * indeterminate (timeout, error, or an unsuccessful CtrlProxy response) —
+   * callers decide how to coalesce that null themselves.
+   */
+  private async resolveVoiceOverState(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+  ): Promise<boolean | null> {
     // Check feature flag override first
     if (featureFlags?.isEnabled("force-accessibility-mode")) {
       logger.debug(`[IosVoiceOverDetector] Force-enabled via feature flag for device ${deviceId}`);
@@ -84,28 +135,13 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
       );
     }
 
-    // Only cache on successful detection — don't persist transient connection failures
+    // Only cache on successful detection — don't persist transient connection
+    // failures, so a subsequent call always retries rather than reusing a
+    // fail-safe/coalesced value.
     if (detected !== null) {
       this.cache.set(deviceId, detected);
     }
 
-    if (detected === null) {
-      // Fail-safe (#6267): an indeterminate probe (timeout, error, or an
-      // unsuccessful CtrlProxy response) must NOT be coalesced to "disabled".
-      // Callers (TapOnElement/TapAnyElement) branch on this boolean to choose
-      // between a plain coordinate touch and a VoiceOver activation gesture.
-      // Silently treating "unknown" as "off" makes a real device with
-      // VoiceOver on receive a focus-only coordinate touch that gets reported
-      // as a successful activation. Treating "unknown" as "on" instead means
-      // the worst case is an unnecessary (but harmless) accessibility-action
-      // path on a device where VoiceOver is actually off — never a false
-      // success.
-      logger.warn(
-        `[IosVoiceOverDetector] VoiceOver state for device ${deviceId} could not be determined; ` +
-          `treating as enabled (fail-safe) so callers take the activation path instead of a plain touch`,
-      );
-      return true;
-    }
     return detected;
   }
 

--- a/src/utils/IosVoiceOverDetector.ts
+++ b/src/utils/IosVoiceOverDetector.ts
@@ -31,7 +31,13 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
    * @param deviceId - The device identifier (for caching)
    * @param client - CtrlProxy service for executing the detection command
    * @param featureFlags - Feature flag service for override support
-   * @returns Promise resolving to true if VoiceOver is enabled
+   * @returns Promise resolving to true if VoiceOver is enabled, or if the
+   *   probe's state is indeterminate (timeout, error, or an unsuccessful
+   *   CtrlProxy response). Fail-safe (#6267): an indeterminate result is
+   *   never coalesced to `false`, so callers never mistake a focus-only
+   *   coordinate touch for a successful VoiceOver activation. Only an
+   *   explicit `enabled: false` response, or the `accessibility-auto-detect`
+   *   feature flag being off, returns `false`.
    */
   async isVoiceOverEnabled(
     deviceId: string,
@@ -82,7 +88,25 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
     if (detected !== null) {
       this.cache.set(deviceId, detected);
     }
-    return detected ?? false;
+
+    if (detected === null) {
+      // Fail-safe (#6267): an indeterminate probe (timeout, error, or an
+      // unsuccessful CtrlProxy response) must NOT be coalesced to "disabled".
+      // Callers (TapOnElement/TapAnyElement) branch on this boolean to choose
+      // between a plain coordinate touch and a VoiceOver activation gesture.
+      // Silently treating "unknown" as "off" makes a real device with
+      // VoiceOver on receive a focus-only coordinate touch that gets reported
+      // as a successful activation. Treating "unknown" as "on" instead means
+      // the worst case is an unnecessary (but harmless) accessibility-action
+      // path on a device where VoiceOver is actually off — never a false
+      // success.
+      logger.warn(
+        `[IosVoiceOverDetector] VoiceOver state for device ${deviceId} could not be determined; ` +
+          `treating as enabled (fail-safe) so callers take the activation path instead of a plain touch`,
+      );
+      return true;
+    }
+    return detected;
   }
 
   /**

--- a/src/utils/interfaces/IosVoiceOverDetector.ts
+++ b/src/utils/interfaces/IosVoiceOverDetector.ts
@@ -7,14 +7,49 @@ import type { IOSCtrlProxy } from "../../features/observe/ios";
  */
 export interface IosVoiceOverDetector {
   /**
-   * Check if VoiceOver is enabled on the device
+   * Check if VoiceOver is enabled on the device.
+   *
+   * Honest result: resolves to `true` only for a confirmed-enabled probe.
+   * An indeterminate probe (timeout, error, or an unsuccessful CtrlProxy
+   * response) resolves to `false`, same as a confirmed-disabled probe —
+   * callers that need to distinguish "confirmed off" from "unknown" and bias
+   * toward the VoiceOver-activation path on "unknown" must use
+   * {@link isVoiceOverActiveOrUnknown} instead (issue #6267 follow-up).
    *
    * @param deviceId - The device identifier (for caching)
    * @param client - CtrlProxy service for executing the detection command
    * @param featureFlags - Feature flag service for override support (optional)
-   * @returns Promise resolving to true if VoiceOver is enabled
+   * @returns Promise resolving to true only when VoiceOver is confirmed enabled
    */
   isVoiceOverEnabled(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+  ): Promise<boolean>;
+
+  /**
+   * Fail-safe variant for consumers that must choose between a plain
+   * coordinate touch and a VoiceOver activation gesture (tapOn/tapAny only).
+   *
+   * Resolves to `true` for a confirmed-enabled probe AND for an
+   * indeterminate probe (timeout, error, or an unsuccessful CtrlProxy
+   * response) — never coalescing "unknown" to "disabled" — so a real
+   * VoiceOver-enabled device never receives a focus-only coordinate touch
+   * that gets reported as a successful activation. Only a confirmed
+   * `enabled: false` response, or the `accessibility-auto-detect` feature
+   * flag being off, resolves to `false` (issue #6267).
+   *
+   * Do NOT use this for state-confirmation consumers (toggle/query) — they
+   * must treat "unknown" as NOT-confirmed, which is what
+   * {@link isVoiceOverEnabled} provides.
+   *
+   * @param deviceId - The device identifier (for caching)
+   * @param client - CtrlProxy service for executing the detection command
+   * @param featureFlags - Feature flag service for override support (optional)
+   * @returns Promise resolving to true when VoiceOver is confirmed enabled or the probe is indeterminate
+   */
+  isVoiceOverActiveOrUnknown(
     deviceId: string,
     client: IOSCtrlProxy,
     featureFlags?: FeatureFlagService,

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -67,6 +67,26 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
   }
 
+  /**
+   * Fake tap-bias variant. Tests configure the desired resolved boolean via
+   * `setVoiceOverEnabled`/`enqueueVoiceOverEnabledResults` the same way as
+   * `isVoiceOverEnabled` — this fake models a resolved outcome, not the
+   * indeterminate/confirmed distinction the real detector's two methods
+   * diverge on (that distinction is covered at the DefaultIosVoiceOverDetector
+   * unit-test level).
+   */
+  async isVoiceOverActiveOrUnknown(
+    _deviceId: string,
+    _client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number,
+  ): Promise<boolean> {
+    this.callCount++;
+    this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
+    this.isVoiceOverEnabledTimeoutMsArgs.push(timeoutMs);
+    return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
+  }
+
   invalidateCache(deviceId: string): void {
     this.invalidatedDevices.push(deviceId);
   }

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -4,6 +4,7 @@ import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
 import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
+import { DefaultIosVoiceOverDetector } from "../../../src/utils/IosVoiceOverDetector";
 import type { BootedDevice } from "../../../src/models";
 
 const SIMULATOR_DEVICE: BootedDevice = {
@@ -206,6 +207,33 @@ describe("VoiceOverToggle", () => {
       expect(result.supported).toBe(true);
       expect(result.applied).toBe(false);
       expect(result.reason).toContain("No process to signal.");
+    });
+
+    // P1 regression fix (#6267 follow-up, PRRT_kwDOP-GF5M6fvDz7): the shared
+    // detector must NOT coerce an indeterminate post-enable probe to
+    // confirmed-true for a toggle-confirmation consumer. Wires the real
+    // DefaultIosVoiceOverDetector (not the boolean-only Fake) against a
+    // CtrlProxy client whose requestVoiceOverState always throws, so
+    // waitForState's honest isVoiceOverEnabled never confirms the toggle
+    // despite simctl reporting success.
+    test("does not report applied:true when the post-enable confirmation probe is indeterminate", async () => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const realDetector = new DefaultIosVoiceOverDetector(timer);
+      const fakeClient = new FakeIOSCtrlProxy();
+      fakeClient.setFailureMode("voiceOverState", new Error("CtrlProxy timeout"));
+
+      const toggle = new VoiceOverToggle(
+        SIMULATOR_DEVICE,
+        realDetector,
+        fakeExec,
+        timer,
+        () => fakeClient,
+      );
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).not.toBe(true);
     });
 
     test("always applies even when detection would report already-enabled (CtrlProxy-safe)", async () => {

--- a/test/features/action/TapAnyElement.ios.test.ts
+++ b/test/features/action/TapAnyElement.ios.test.ts
@@ -9,6 +9,7 @@ import { FakeElementSelector } from "../../fakes/FakeElementSelector";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
+import { DefaultIosVoiceOverDetector } from "../../../src/utils/IosVoiceOverDetector";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeWindow } from "../../fakes/FakeWindow";
@@ -144,6 +145,33 @@ describe("TapAnyElement iOS gesture dispatch (public execute())", () => {
   // TapOnElement.executeiOSTap's VoiceOver-detection + activation path.
   test("VoiceOver enabled + tap routes through requestVoiceOverActivate, not a coordinate tap", async () => {
     fakeVoiceOverDetector.setVoiceOverEnabled(true);
+
+    const result = await tapAny.execute({ action: "tap" });
+
+    expect(result.success).toBe(true);
+    expect(fakeIosClient.getVoiceOverActivateHistory()).toEqual([
+      { label: "Target Button", action: "activate" },
+    ]);
+    expect(fakeIosClient.getTapHistory()).toHaveLength(0);
+  });
+
+  // #6267 follow-up (P1 regression fix): an indeterminate probe must still
+  // route the real DefaultIosVoiceOverDetector -> isVoiceOverActiveOrUnknown
+  // -> tap-bias path, not the honest isVoiceOverEnabled a toggle/query
+  // consumer would use. Wires the real detector (not the boolean-only Fake)
+  // against a CtrlProxy client whose requestVoiceOverState throws, so this
+  // exercises the actual fail-safe bias rather than a hand-set boolean.
+  test("VoiceOver probe indeterminate (CtrlProxy failure) + tap still routes through requestVoiceOverActivate", async () => {
+    const realDetector = new DefaultIosVoiceOverDetector(fakeTimer);
+    fakeIosClient.setFailureMode("voiceOverState", new Error("CtrlProxy timeout"));
+    tapAny = new TapAnyElement(IOS_DEVICE, new FakeAdbClient() as any, {
+      timer: fakeTimer,
+      elementSelector: fakeElementSelector,
+      iosVoiceOverDetector: realDetector,
+    });
+    (tapAny as any).observeScreen = fakeObserveScreen;
+    (tapAny as any).awaitIdle = fakeAwaitIdle;
+    (tapAny as any).window = fakeWindow;
 
     const result = await tapAny.execute({ action: "tap" });
 

--- a/test/utils/IosVoiceOverDetector.test.ts
+++ b/test/utils/IosVoiceOverDetector.test.ts
@@ -106,11 +106,12 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
       expect(fakeClient.timeoutMsArgs).toEqual([1_250]);
     });
 
-    test("fails safe to true (not false) when CtrlProxy reports failure — #6267", async () => {
-      // An unsuccessful CtrlProxy response is an UNKNOWN state, not a confirmed
-      // "disabled". Coalescing it to false would make tapOn/tapAny perform a
-      // plain coordinate touch and report it as a successful VoiceOver
-      // activation on a device where VoiceOver is actually on.
+    test("resolves honestly to false (NOT true) when CtrlProxy reports failure — #6267 follow-up", async () => {
+      // An unsuccessful CtrlProxy response is an UNKNOWN state. isVoiceOverEnabled
+      // is the honest, non-tap-biased method used by toggle-confirmation and
+      // state-query consumers: they must treat "unknown" as NOT-confirmed
+      // rather than assuming VoiceOver came on. Only isVoiceOverActiveOrUnknown
+      // (used by tapOn/tapAny) biases an indeterminate probe to true.
       fakeClient.shouldFail = true;
 
       const enabled = await detector.isVoiceOverEnabled(
@@ -118,12 +119,12 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
         fakeClient as unknown as IOSCtrlProxy,
       );
 
-      expect(enabled).toBe(true);
+      expect(enabled).toBe(false);
     });
 
-    test("fails safe to true (not false) when CtrlProxy throws — #6267", async () => {
-      // A thrown error (e.g. a probe timeout) is also an UNKNOWN state and
-      // must not be silently treated as "VoiceOver is off".
+    test("resolves honestly to false (NOT true) when CtrlProxy throws — #6267 follow-up", async () => {
+      // A thrown error (e.g. a probe timeout) is also an UNKNOWN state; the
+      // honest isVoiceOverEnabled must not report it as confirmed-enabled.
       const throwingClient = {
         async requestVoiceOverState(): Promise<CtrlProxyVoiceOverResult> {
           throw new Error("Connection refused");
@@ -135,13 +136,91 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
         throwingClient as unknown as IOSCtrlProxy,
       );
 
-      expect(enabled).toBe(true);
+      expect(enabled).toBe(false);
     });
 
-    test("does not cache the fail-safe true result on an indeterminate probe — #6267", async () => {
+    test("does not cache the indeterminate probe result", async () => {
       fakeClient.shouldFail = true;
 
       const first = await detector.isVoiceOverEnabled(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+      expect(first).toBe(false);
+      expect(fakeClient.callCount).toBe(1);
+
+      // A confirmed-enabled response on the next probe must not be masked by
+      // a cached value from the earlier indeterminate probe.
+      fakeClient.shouldFail = false;
+      fakeClient.voiceOverEnabled = true;
+      const second = await detector.isVoiceOverEnabled(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+      expect(second).toBe(true);
+      expect(fakeClient.callCount).toBe(2);
+    });
+  });
+
+  describe("isVoiceOverActiveOrUnknown (tapOn/tapAny fail-safe bias) — #6267", () => {
+    test("returns true when VoiceOver is confirmed enabled", async () => {
+      fakeClient.voiceOverEnabled = true;
+
+      const active = await detector.isVoiceOverActiveOrUnknown(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+
+      expect(active).toBe(true);
+    });
+
+    test("returns false when VoiceOver is confirmed disabled", async () => {
+      fakeClient.voiceOverEnabled = false;
+
+      const active = await detector.isVoiceOverActiveOrUnknown(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+
+      expect(active).toBe(false);
+    });
+
+    test("fails safe to true (not false) when CtrlProxy reports failure", async () => {
+      // An unsuccessful CtrlProxy response is an UNKNOWN state, not a confirmed
+      // "disabled". Coalescing it to false would make tapOn/tapAny perform a
+      // plain coordinate touch and report it as a successful VoiceOver
+      // activation on a device where VoiceOver is actually on.
+      fakeClient.shouldFail = true;
+
+      const active = await detector.isVoiceOverActiveOrUnknown(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+
+      expect(active).toBe(true);
+    });
+
+    test("fails safe to true (not false) when CtrlProxy throws", async () => {
+      // A thrown error (e.g. a probe timeout) is also an UNKNOWN state and
+      // must not be silently treated as "VoiceOver is off".
+      const throwingClient = {
+        async requestVoiceOverState(): Promise<CtrlProxyVoiceOverResult> {
+          throw new Error("Connection refused");
+        },
+      };
+
+      const active = await detector.isVoiceOverActiveOrUnknown(
+        "device123",
+        throwingClient as unknown as IOSCtrlProxy,
+      );
+
+      expect(active).toBe(true);
+    });
+
+    test("does not cache the fail-safe true result on an indeterminate probe", async () => {
+      fakeClient.shouldFail = true;
+
+      const first = await detector.isVoiceOverActiveOrUnknown(
         "device123",
         fakeClient as unknown as IOSCtrlProxy,
       );
@@ -152,12 +231,35 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
       // a cached fail-safe value from the earlier indeterminate probe.
       fakeClient.shouldFail = false;
       fakeClient.voiceOverEnabled = false;
-      const second = await detector.isVoiceOverEnabled(
+      const second = await detector.isVoiceOverActiveOrUnknown(
         "device123",
         fakeClient as unknown as IOSCtrlProxy,
       );
       expect(second).toBe(false);
       expect(fakeClient.callCount).toBe(2);
+    });
+
+    test("an indeterminate probe on isVoiceOverEnabled does not poison a later isVoiceOverActiveOrUnknown call, and vice versa", async () => {
+      // Both methods share the same cache keyed by deviceId; an indeterminate
+      // probe is never cached regardless of which method triggered it.
+      fakeClient.shouldFail = true;
+      expect(
+        await detector.isVoiceOverEnabled("device123", fakeClient as unknown as IOSCtrlProxy),
+      ).toBe(false);
+      expect(
+        await detector.isVoiceOverActiveOrUnknown(
+          "device123",
+          fakeClient as unknown as IOSCtrlProxy,
+        ),
+      ).toBe(true);
+      expect(fakeClient.callCount).toBe(2);
+
+      fakeClient.shouldFail = false;
+      fakeClient.voiceOverEnabled = true;
+      expect(
+        await detector.isVoiceOverEnabled("device123", fakeClient as unknown as IOSCtrlProxy),
+      ).toBe(true);
+      expect(fakeClient.callCount).toBe(3);
     });
   });
 

--- a/test/utils/IosVoiceOverDetector.test.ts
+++ b/test/utils/IosVoiceOverDetector.test.ts
@@ -106,7 +106,11 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
       expect(fakeClient.timeoutMsArgs).toEqual([1_250]);
     });
 
-    test("returns false when CtrlProxy reports failure", async () => {
+    test("fails safe to true (not false) when CtrlProxy reports failure — #6267", async () => {
+      // An unsuccessful CtrlProxy response is an UNKNOWN state, not a confirmed
+      // "disabled". Coalescing it to false would make tapOn/tapAny perform a
+      // plain coordinate touch and report it as a successful VoiceOver
+      // activation on a device where VoiceOver is actually on.
       fakeClient.shouldFail = true;
 
       const enabled = await detector.isVoiceOverEnabled(
@@ -114,10 +118,12 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
         fakeClient as unknown as IOSCtrlProxy,
       );
 
-      expect(enabled).toBe(false);
+      expect(enabled).toBe(true);
     });
 
-    test("returns false when CtrlProxy throws", async () => {
+    test("fails safe to true (not false) when CtrlProxy throws — #6267", async () => {
+      // A thrown error (e.g. a probe timeout) is also an UNKNOWN state and
+      // must not be silently treated as "VoiceOver is off".
       const throwingClient = {
         async requestVoiceOverState(): Promise<CtrlProxyVoiceOverResult> {
           throw new Error("Connection refused");
@@ -129,7 +135,29 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
         throwingClient as unknown as IOSCtrlProxy,
       );
 
-      expect(enabled).toBe(false);
+      expect(enabled).toBe(true);
+    });
+
+    test("does not cache the fail-safe true result on an indeterminate probe — #6267", async () => {
+      fakeClient.shouldFail = true;
+
+      const first = await detector.isVoiceOverEnabled(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+      expect(first).toBe(true);
+      expect(fakeClient.callCount).toBe(1);
+
+      // A confirmed-disabled response on the next probe must not be masked by
+      // a cached fail-safe value from the earlier indeterminate probe.
+      fakeClient.shouldFail = false;
+      fakeClient.voiceOverEnabled = false;
+      const second = await detector.isVoiceOverEnabled(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+      );
+      expect(second).toBe(false);
+      expect(fakeClient.callCount).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Bug

`DefaultIosVoiceOverDetector.isVoiceOverEnabled` (`src/utils/IosVoiceOverDetector.ts`) coalesced an indeterminate probe result — a CtrlProxy timeout, thrown error, or unsuccessful response — straight to `false`. `TapOnElement`/`TapAnyElement` branch on this boolean to choose between a plain coordinate touch and a VoiceOver accessibility-action activation. Silently treating 'unknown' as 'off' made those tools perform a focus-only coordinate touch on a real VoiceOver-enabled device and report it as a successful activation.

## Fix

Applies option 2 from the issue (fail-safe): an indeterminate detection result now resolves to `true` instead of `false`, so callers take the VoiceOver activation path rather than a plain coordinate touch. The worst case becomes an unnecessary (but harmless) accessibility-action attempt on a device where VoiceOver is actually off — never a false-positive activation report.

- Confirmed-disabled (`enabled: false`) and confirmed-enabled (`enabled: true`) behavior is unchanged.
- Indeterminate results are still never cached (as before), so the next call retries detection rather than pinning the fail-safe value.
- The `IosVoiceOverDetector` interface and `FakeIosVoiceOverDetector` seam are untouched — all consumers (TapOnElement, TapAnyElement, VoiceOverSwipeExecutor, IosTapStrategy, VoiceOverToggle, AccessibilityStateDetector) already branch on the returned boolean and need no changes.

## Tests

Added/updated in `test/utils/IosVoiceOverDetector.test.ts`:
1. Confirmed-disabled → still returns `false` (unchanged).
2. Confirmed-enabled → still returns `true` (unchanged).
3. CtrlProxy reports failure, or throws → now returns `true` (fail-safe) instead of `false`, and the fail-safe result is not cached so a later confirmed-disabled probe is not masked.

## Validation

- `bun test test/utils/IosVoiceOverDetector.test.ts` — 17 pass
- `bun test` on the VoiceOver consumer suites (TapOnElement, TapAnyElement, VoiceOverSwipeExecutor, VoiceOverToggle, TapStrategy) — 82 pass
- `bun run lint` — clean, ratchet baseline unchanged
- `bun run typecheck` — clean, baseline unchanged (158 known errors)
- `bun run format:check` — clean
- `bunx turbo run build` — success

Closes #6267