### PR TITLE
fix(navigation): verify tap outcome per candidate in tapCloseButton

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -476,12 +476,9 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
   private async dismissWithCloseButton(modal: ModalState, platform: string): Promise<boolean> {
     try {
-      if (await this.tapCloseButton(platform)) {
-        await this.sleep(200);
-        if (await this.isModalDismissed(modal, platform)) {
-          logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} with close button`);
-          return true;
-        }
+      if (await this.tapCloseButton(modal, platform)) {
+        logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} with close button`);
+        return true;
       }
     } catch (error) {
       logger.debug(`[UI_STATE_SETUP] Close button tap failed: ${error}`);
@@ -516,8 +513,19 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
   /**
    * Try to tap a close/cancel button in the current view.
+   *
+   * Each candidate text is tried in turn, and a candidate only counts as
+   * success when it BOTH (a) resolved to a real element that the internal
+   * `tapOn` call actually tapped, and (b) genuinely dismissed `modal` (verified
+   * by re-observing and checking the modal is no longer present). Neither
+   * check alone is sufficient: `callInternal` resolves (does not throw) even
+   * when `tapOn` reports `{success: false}` for a missing element (#6123), and
+   * a tap that hits a real but wrong element (e.g. a non-dismissing "Close"
+   * label elsewhere on screen) would otherwise be mistaken for success. A
+   * failed or ineffective candidate falls through to the next text instead of
+   * short-circuiting the loop.
    */
-  private async tapCloseButton(platform: string): Promise<boolean> {
+  private async tapCloseButton(modal: ModalState, platform: string): Promise<boolean> {
     const tapTool = ToolRegistry.getTool("tapOn");
     if (!tapTool) {
       return false;
@@ -530,17 +538,26 @@ export class DefaultUIStateSetup implements UIStateSetup {
       try {
         // Internal close-button tap (#3087) via the callInternal seam (#3108):
         // no diff/strip, no baseline advance.
-        await ToolRegistry.callInternal(tapTool, {
+        const response = await ToolRegistry.callInternal(tapTool, {
           selector: { text },
           action: "tap",
           platform,
           deviceId: this.device.deviceId,
           ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {}),
         });
-        logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
-        return true;
+        throwIfInternalToolFailed(response, "tapOn", platform);
+
+        await this.sleep(200);
+        if (await this.isModalDismissed(modal, platform)) {
+          logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
+          return true;
+        }
+        logger.debug(
+          `[UI_STATE_SETUP] Tapped "${text}" but ${modal.type} is still present, trying next candidate`,
+        );
       } catch (error) {
-        // Button not found, try next
+        // Button not found, or the tap failed outright — try the next candidate.
+        logger.debug(`[UI_STATE_SETUP] Close button candidate "${text}" failed: ${error}`);
         continue;
       }
     }

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -372,4 +372,144 @@ describe("DefaultUIStateSetup", () => {
       expect(fakeAdb.wasCommandExecuted("shell input tap 50 50")).toBe(true);
     });
   });
+
+  // Regression for issue #6123: `tapCloseButton` returned `true` after the
+  // FIRST candidate resolved without throwing, regardless of whether the tap
+  // actually dismissed anything. `callInternal` resolves (does not throw) even
+  // when `tapOn` reports `{success: false}` for a missing element, so the
+  // remaining candidates ("Cancel"/"Dismiss"/"×"/"✕") were dead code. The fix
+  // must both surface a failed internal tap (`throwIfInternalToolFailed`, as
+  // `tapOnElement` already does) AND verify the tap genuinely closed the modal
+  // before declaring success, falling through to the next candidate otherwise.
+  describe("tapCloseButton candidate outcome verification (#6123)", () => {
+    afterEach(() => {
+      ToolRegistry.clearTools();
+    });
+
+    const dialog: ModalState = { type: "dialog", layer: 1, windowId: 7 };
+
+    function tapCloseButtonOf(setup: DefaultUIStateSetup) {
+      return (
+        setup as unknown as {
+          tapCloseButton: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).tapCloseButton;
+    }
+
+    test("first candidate succeeds (tapped and verified closed) → returns true, later candidates not tried", async () => {
+      const tappedTexts: string[] = [];
+      let dismissedAfterTap = false;
+
+      const setup = makeSetup(() => ({
+        execute: async () => ({ viewHierarchy: null }) as unknown as ObserveResult,
+      }));
+      // getCurrentUIState drives isModalDismissed: report the modal gone as
+      // soon as any candidate has been tapped.
+      (
+        setup as unknown as { getCurrentUIState: () => Promise<{ modalStack: ModalState[] }> }
+      ).getCurrentUIState = async () => ({
+        modalStack: dismissedAfterTap ? [] : [dialog],
+      });
+
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        tappedTexts.push(args.selector.text);
+        dismissedAfterTap = true;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const result = await tapCloseButtonOf(setup).call(setup, dialog, "android");
+
+      expect(result).toBe(true);
+      expect(tappedTexts).toEqual(["Close"]);
+    });
+
+    test("first candidate taps but does NOT close (no state change) → proceeds to next candidate, which closes → true", async () => {
+      const tappedTexts: string[] = [];
+      let dismissed = false;
+
+      const setup = makeSetup(() => ({
+        execute: async () => ({ viewHierarchy: null }) as unknown as ObserveResult,
+      }));
+      (
+        setup as unknown as { getCurrentUIState: () => Promise<{ modalStack: ModalState[] }> }
+      ).getCurrentUIState = async () => ({
+        modalStack: dismissed ? [] : [dialog],
+      });
+
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        const text = args.selector.text;
+        tappedTexts.push(text);
+        // "Close" taps successfully (tool-wise) but never actually dismisses
+        // the modal; "Cancel" is the one that genuinely closes it.
+        if (text === "Cancel") {
+          dismissed = true;
+        }
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const result = await tapCloseButtonOf(setup).call(setup, dialog, "android");
+
+      expect(result).toBe(true);
+      expect(tappedTexts).toEqual(["Close", "Cancel"]);
+    });
+
+    test("no candidate closes the modal → returns false after trying all candidates", async () => {
+      const tappedTexts: string[] = [];
+
+      const setup = makeSetup(() => ({
+        execute: async () => ({ viewHierarchy: null }) as unknown as ObserveResult,
+      }));
+      // Modal never leaves the stack, regardless of what was tapped.
+      (
+        setup as unknown as { getCurrentUIState: () => Promise<{ modalStack: ModalState[] }> }
+      ).getCurrentUIState = async () => ({ modalStack: [dialog] });
+
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        tappedTexts.push(args.selector.text);
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const result = await tapCloseButtonOf(setup).call(setup, dialog, "android");
+
+      expect(result).toBe(false);
+      expect(tappedTexts).toEqual(["Close", "Cancel", "Dismiss", "×", "✕"]);
+    });
+
+    test("a failed internal tap (element not found) does not short-circuit — later candidates are still attempted", async () => {
+      const tappedTexts: string[] = [];
+      let dismissed = false;
+
+      const setup = makeSetup(() => ({
+        execute: async () => ({ viewHierarchy: null }) as unknown as ObserveResult,
+      }));
+      (
+        setup as unknown as { getCurrentUIState: () => Promise<{ modalStack: ModalState[] }> }
+      ).getCurrentUIState = async () => ({
+        modalStack: dismissed ? [] : [dialog],
+      });
+
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        const text = args.selector.text;
+        tappedTexts.push(text);
+        if (text === "Close") {
+          // Element not found: tapOn's own handler reports failure without
+          // throwing (the #6123 bug — callInternal used to swallow this).
+          return createStructuredToolResponse({ success: false, error: "Element not found" });
+        }
+        if (text === "Cancel" || text === "Dismiss" || text === "×") {
+          // These candidates don't exist on screen either — same as "Close".
+          return createStructuredToolResponse({ success: false, error: "Element not found" });
+        }
+        // "✕" is the only genuine close affordance in this dialog.
+        dismissed = true;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const result = await tapCloseButtonOf(setup).call(setup, dialog, "android");
+
+      expect(result).toBe(true);
+      // All prior candidates were attempted before the one that worked.
+      expect(tappedTexts).toEqual(["Close", "Cancel", "Dismiss", "×", "✕"]);
+    });
+  });
 });


### PR DESCRIPTION
## Bug

`DefaultUIStateSetup.tapCloseButton` (`src/features/navigation/DefaultUIStateSetup.ts`) returned `true` after the FIRST close-button candidate resolved without throwing, regardless of whether the tap actually dismissed anything.

`ToolRegistry.callInternal` resolves (does not throw) even when `tapOn`'s handler reports `{success: false}` for a missing element — the sibling `tapOnElement` in the same file already guards against this with `throwIfInternalToolFailed`, but `tapCloseButton`'s loop did not. So the remaining candidates ("Cancel"/"Dismiss"/"×"/"✕") were dead code: the loop always returned `true` on the first candidate ("Close").

## Fix

`tapCloseButton` now:

1. Calls `throwIfInternalToolFailed(response, "tapOn", platform)` after each candidate's internal `tapOn` call, so a tool-level failure (missing element) falls through to the next candidate instead of being silently treated as success.
2. Re-observes and verifies the target modal is actually gone (`isModalDismissed`) before declaring a candidate successful — a tap that hits a real but non-dismissing element (e.g. a "Close" label elsewhere on screen) no longer short-circuits the loop.
3. Only returns `true` once a candidate is verified to have closed the modal; returns `false` once all candidates are exhausted.

`dismissWithCloseButton`'s duplicate post-tap dismissal check is now redundant (the verification moved inside `tapCloseButton`, which needs the modal reference to check per-candidate) and was removed.

## Tests

Added `describe("tapCloseButton candidate outcome verification (#6123)")` in `test/features/navigation/DefaultUIStateSetup.test.ts`:

- First candidate succeeds (tapped and verified closed) → returns `true`, no later candidates attempted.
- First candidate taps successfully (tool-wise) but does not close the modal → falls through to the next candidate, which does close it → `true`.
- No candidate closes the modal → all five candidates attempted, returns `false`.
- A failed internal tap (element not found) does not short-circuit the loop — later candidates, including "Cancel"/"Dismiss"/"×", are still attempted until one succeeds.

## Validation

- `bun test test/features/navigation/DefaultUIStateSetup.test.ts` — 16 pass
- `bun run lint` — no new ratchet violations
- `bun run typecheck` — no new type errors
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds

Closes #6123