### PR TITLE
fix: honor tool deviceReadiness on persisted daemon-session path

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -4587,8 +4587,13 @@ export class DevicePool {
     replacement: BootedDevice,
     sourceImage: DeviceInfo,
     childProcess?: ChildProcess | null,
+    beforeReplacementPublishes?: () => void,
   ): Promise<SystemUiAnrRecoveryHandoff> {
     return await this.assignmentMutex.runExclusive(async () => {
+      // The caller's marker must cover the entire visible replacement
+      // lifecycle, including a replacement that another pool path has already
+      // discovered. It is moved before any session rebind or addDevice call.
+      beforeReplacementPublishes?.();
       const currentExpectedDevice = this.devices.get(expectedDevice.id);
       const existingReplacement = this.devices.get(replacement.deviceId);
       if (
@@ -4610,6 +4615,7 @@ export class DevicePool {
           expectedDevice,
           replacement,
           sourceImage,
+          beforeReplacementPublishes,
         );
         await this.trackStartedDeviceProcess(replacement, childProcess);
         if (this.devices.get(replacementDevice.id) !== replacementDevice) {
@@ -4727,6 +4733,7 @@ export class DevicePool {
     expectedDevice: PooledDevice,
     replacement: BootedDevice,
     sourceImage: DeviceInfo,
+    beforeReplacementPublishes?: () => void,
   ): Promise<PooledDevice> {
     const priorAssignmentCount = expectedDevice.assignmentCount;
     const priorLastUsedAt = expectedDevice.lastUsedAt;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "child_process";
 import { logger } from "../utils/logger";
 import { SessionManager, type Session, type SessionExecutionMetadata } from "./sessionManager";
+import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 import { ActionableError, BootedDevice, DeviceInfo, Platform } from "../models";
 import { Mutex } from "async-mutex";
 import {
@@ -5542,6 +5543,7 @@ export class DevicePool {
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
+    achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string | undefined> {
     if (!isDevicePoolAutolockEnabled()) {
       return undefined;
@@ -5556,6 +5558,7 @@ export class DevicePool {
         expectedIdentity,
         readinessReservationOwners,
         verifiedAndroidAvdIdentity,
+        achievedReadiness,
       ),
     );
   }
@@ -5569,6 +5572,7 @@ export class DevicePool {
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform" | "observedAt">,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
+    achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
     const sessionId = this.idGenerator.next();
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
@@ -5651,6 +5655,15 @@ export class DevicePool {
     const session = await this.createSessionOrRestore(device, assignmentSnapshot, () =>
       this.sessionManager.createSession(sessionId, deviceId, platform, timeoutMs, timeoutMs),
     );
+    // #6227 (round 9): record the achieved readiness BEFORE publishing the
+    // autolock route below. `mcpSessionAutolockMap.set` makes this session
+    // reachable to a concurrent tool call from the same MCP client (via
+    // `resolveAutolockSessionForMcpClient`); if that call resolved the session
+    // and consulted `getDeviceReadiness` before the caller recorded the level,
+    // it would see an unrecorded readiness and redundantly re-run (or wrongly
+    // skip) setup. The setter is monotonic, so recording here is safe even for
+    // a restored session that already reached a higher level.
+    this.sessionManager.setDeviceReadiness(sessionId, achievedReadiness);
     if (mcpSessionId) {
       this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
     }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -17,6 +17,7 @@ import {
   type BiometricEnrollment,
   type NetworkConditionProfile,
 } from "../features/utility/DeviceState";
+import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
 /**
  * Device-label → session-UUID map. `buildDeviceLabelMap` assigns each configured
@@ -98,6 +99,16 @@ export interface SessionCacheData {
   biometricEnrollment?: BiometricEnrollmentSessionState; // Original iOS Simulator biometric enrollment, restored on release
   networkCondition?: NetworkConditionSessionState; // Original device-wide network condition, restored on release (#6012)
   deviceLabels?: DeviceLabelMap; // Device-label → session map for multi-device (`device:`-labelled) sessions
+  /**
+   * Highest {@link DeviceReadinessLevel} actually achieved by
+   * `ToolExecutionContext`'s setup for this session (#6227). Lets a later call
+   * on the same (possibly persisted/recovered) session detect that it needs a
+   * higher readiness than a prior call achieved — e.g. a `booted`-only tool
+   * ran first and left CtrlProxy/accessibility-service setup unprepared, then
+   * an `automationReady` tool reuses the session — and upgrade in place
+   * instead of silently skipping setup on the `existingSession` fast path.
+   */
+  deviceReadiness?: DeviceReadinessLevel;
 }
 
 /**
@@ -2467,6 +2478,26 @@ export class SessionManager {
    */
   getKeepScreenAwake(sessionId: string): KeepScreenAwakeState | undefined {
     return this.getSession(sessionId)?.cacheData.keepScreenAwake;
+  }
+
+  /**
+   * Record the highest {@link DeviceReadinessLevel} actually achieved for a
+   * session (#6227). Mirrors `setKeepScreenAwake`'s typed-slot pattern so a
+   * later call reusing the same session UUID can detect an upgrade is needed
+   * (e.g. a prior `booted`-only call left CtrlProxy setup unprepared) rather
+   * than trusting `existingSession` alone.
+   */
+  setDeviceReadiness(sessionId: string, level: DeviceReadinessLevel): void {
+    this.updateSessionCache(sessionId, { deviceReadiness: level });
+  }
+
+  /**
+   * Read the achieved readiness level without recording session activity
+   * (mirrors `getKeepScreenAwake`). Returns `undefined` for an unknown/expired
+   * session or before any setup has recorded a level.
+   */
+  getDeviceReadiness(sessionId: string): DeviceReadinessLevel | undefined {
+    return this.getSession(sessionId)?.cacheData.deviceReadiness;
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -17,7 +17,7 @@ import {
   type BiometricEnrollment,
   type NetworkConditionProfile,
 } from "../features/utility/DeviceState";
-import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
+import { deviceReadinessRank, type DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
 /**
  * Device-label → session-UUID map. `buildDeviceLabelMap` assigns each configured
@@ -2486,8 +2486,28 @@ export class SessionManager {
    * later call reusing the same session UUID can detect an upgrade is needed
    * (e.g. a prior `booted`-only call left CtrlProxy setup unprepared) rather
    * than trusting `existingSession` alone.
+   *
+   * MONOTONIC by achieved level (#6227 round 7): only ever RAISES the
+   * recorded level, never lowers it. `bindOrReuseDeviceSession` can hand back
+   * a live session already bound to the exact requested device — a session
+   * that previously reached `automationReady` through one acquisition path.
+   * A later, less-demanding acquisition on that same session (e.g.
+   * `provisionDevice({ readiness: "none" })`, or the `booted`-only branch of
+   * `ensureReadinessUpgraded`) would otherwise overwrite that recorded level
+   * with `"booted"`, silently downgrading it — a later `automationReady` tool
+   * would then trust the stale `booted` record and skip CtrlProxy/
+   * accessibility-service setup the device still needs, or an unnecessary
+   * redundant setup would run. Comparing against the currently recorded level
+   * and only writing when the new one is higher (or none has been recorded
+   * yet) closes that hole. There is currently no caller that needs to lower
+   * or clear a recorded level — a genuine reset/teardown should add a
+   * distinct, explicitly-named method rather than repurposing this recorder.
    */
   setDeviceReadiness(sessionId: string, level: DeviceReadinessLevel): void {
+    const current = this.getDeviceReadiness(sessionId);
+    if (current !== undefined && deviceReadinessRank(current) >= deviceReadinessRank(level)) {
+      return;
+    }
     this.updateSessionCache(sessionId, { deviceReadiness: level });
   }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -65,6 +65,16 @@ interface ToolExecutionContext {
 export interface SessionOptions {
   keepScreenAwake?: boolean;
   platform?: Platform;
+  /**
+   * `booted` skips automation-only setup (accessibility-service / CtrlProxy
+   * preparation) for a tool that only needs the device connected and booted.
+   * `automationReady` (the default when omitted) performs full setup, matching
+   * the historical unconditional behavior. Mirrors
+   * {@link import("../utils/DeviceSessionManager").DeviceReadinessLevel} so both
+   * the fresh-session (legacy) and persisted daemon-session paths honor a
+   * tool's declared `deviceReadiness` (#6227).
+   */
+  deviceReadiness?: "booted" | "automationReady";
 }
 
 /**
@@ -138,7 +148,7 @@ async function setupSession(
   }
 
   ensureSessionIsCurrent(session, sessionManager);
-  if (session.platform === "android") {
+  if (session.platform === "android" && sessionOptions.deviceReadiness !== "booted") {
     await ensureAccessibilityServiceReady(
       session.assignedDevice,
       session.sessionId,

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -9,6 +9,7 @@ import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScree
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { createPerformanceTracker, type TimingData } from "../utils/PerformanceTracker";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
+import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
 /**
  * Storage for accessibility service setup timing.
@@ -70,11 +71,11 @@ export interface SessionOptions {
    * preparation) for a tool that only needs the device connected and booted.
    * `automationReady` (the default when omitted) performs full setup, matching
    * the historical unconditional behavior. Mirrors
-   * {@link import("../utils/DeviceSessionManager").DeviceReadinessLevel} so both
-   * the fresh-session (legacy) and persisted daemon-session paths honor a
-   * tool's declared `deviceReadiness` (#6227).
+   * {@link DeviceReadinessLevel} so both the fresh-session (legacy) and
+   * persisted daemon-session paths honor a tool's declared `deviceReadiness`
+   * (#6227).
    */
-  deviceReadiness?: "booted" | "automationReady";
+  deviceReadiness?: DeviceReadinessLevel;
 }
 
 /**
@@ -136,6 +137,23 @@ export async function createToolExecutionContext(
   };
 }
 
+function isReadinessSatisfied(
+  achieved: DeviceReadinessLevel | undefined,
+  required: DeviceReadinessLevel,
+): boolean {
+  // `undefined` means this session was never routed through this module's own
+  // setup — e.g. a test (or another internal caller) that tracks a session
+  // directly via `SessionManager.createSession`. Trust the existing-session
+  // fast path exactly as it behaved before #6227 rather than forcing setup
+  // on a session this code has no record of ever needing it.
+  if (achieved === undefined) {
+    return true;
+  }
+  // `booted` is satisfied by either recorded level; `automationReady` needs
+  // the higher level to have actually been achieved.
+  return required === "booted" || achieved === "automationReady";
+}
+
 async function setupSession(
   session: Session,
   existingSession: boolean,
@@ -143,18 +161,27 @@ async function setupSession(
   sessionOptions: SessionOptions,
 ): Promise<void> {
   await ensureKeepScreenAwake(session, sessionManager, sessionOptions);
+  const requiredReadiness: DeviceReadinessLevel =
+    sessionOptions.deviceReadiness ?? "automationReady";
+
   if (existingSession) {
+    // #6227: `existingSession` only means this call reused an already-tracked
+    // session — it says nothing about which readiness level that session's
+    // prior setup actually reached. A session first touched by a `booted`
+    // tool leaves CtrlProxy/accessibility-service setup unprepared; a later
+    // call on the same UUID that needs `automationReady` must run that setup
+    // now rather than trusting the fast path and returning early against a
+    // disconnected/unprepared device.
+    if (
+      !isReadinessSatisfied(sessionManager.getDeviceReadiness(session.sessionId), requiredReadiness)
+    ) {
+      await runDeviceReadinessSetup(session, sessionManager, requiredReadiness);
+    }
     return;
   }
 
   ensureSessionIsCurrent(session, sessionManager);
-  if (session.platform === "android" && sessionOptions.deviceReadiness !== "booted") {
-    await ensureAccessibilityServiceReady(
-      session.assignedDevice,
-      session.sessionId,
-      session.platform,
-    );
-  }
+  await runDeviceReadinessSetup(session, sessionManager, requiredReadiness);
   ensureSessionIsCurrent(session, sessionManager);
 
   // Start test coverage session for navigation graph tracking
@@ -168,6 +195,29 @@ async function setupSession(
       `[ToolExecutionContext] Started test coverage tracking for session ${session.sessionId}`,
     );
   }
+}
+
+/**
+ * Run the automation-only setup (CtrlProxy / accessibility service) needed to
+ * reach `requiredReadiness` for `session`, then record the achieved level
+ * (#6227). Only android needs the extra setup for `automationReady`; every
+ * other case is a no-op setup that still records the level so a later
+ * `existingSession` call can compare against it.
+ */
+async function runDeviceReadinessSetup(
+  session: Session,
+  sessionManager: SessionManager,
+  requiredReadiness: DeviceReadinessLevel,
+): Promise<void> {
+  if (session.platform === "android" && requiredReadiness !== "booted") {
+    await ensureAccessibilityServiceReady(
+      session.assignedDevice,
+      session.sessionId,
+      session.platform,
+    );
+  }
+  ensureSessionIsCurrent(session, sessionManager);
+  sessionManager.setDeviceReadiness(session.sessionId, requiredReadiness);
 }
 
 function ensureSessionIsCurrent(session: Session, sessionManager: SessionManager): void {

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -168,6 +168,59 @@ function isReadinessSatisfied(
   return required === "booted" || achieved === "automationReady";
 }
 
+/**
+ * Per-session in-flight readiness upgrade (#6227 P1 follow-up: single-flight).
+ *
+ * A recovered/newly-published session can be observed by two concurrent
+ * `automationReady` calls (e.g. reaching the daemon through different
+ * queues) before either has recorded a readiness level. Without
+ * serialization both calls would see the same insufficient
+ * `getDeviceReadiness` result and both invoke `runDeviceReadinessSetup`,
+ * which calls `AndroidCtrlProxyManager.resetSetupState()` on the *shared*
+ * per-device manager — the second caller's reset can land mid-setup for the
+ * first, corrupting both. Keying by session UUID and having a concurrent
+ * caller await the same in-flight promise (rather than starting its own)
+ * closes that race; each waiter re-checks the achieved readiness once the
+ * in-flight setup settles, upgrading further only if still insufficient.
+ */
+const readinessUpgradeInFlight = new Map<string, Promise<void>>();
+
+async function ensureReadinessUpgraded(
+  session: Session,
+  sessionManager: SessionManager,
+  requiredReadiness: DeviceReadinessLevel,
+): Promise<void> {
+  for (;;) {
+    if (
+      isReadinessSatisfied(sessionManager.getDeviceReadiness(session.sessionId), requiredReadiness)
+    ) {
+      return;
+    }
+
+    const inFlight = readinessUpgradeInFlight.get(session.sessionId);
+    if (inFlight) {
+      // Another caller is already upgrading this session's readiness — wait
+      // for it rather than racing a second `runDeviceReadinessSetup` call,
+      // then loop back to re-check whether it reached the level we need.
+      await inFlight;
+      continue;
+    }
+
+    const setupPromise = runDeviceReadinessSetup(
+      session,
+      sessionManager,
+      requiredReadiness,
+    ).finally(() => {
+      if (readinessUpgradeInFlight.get(session.sessionId) === setupPromise) {
+        readinessUpgradeInFlight.delete(session.sessionId);
+      }
+    });
+    readinessUpgradeInFlight.set(session.sessionId, setupPromise);
+    await setupPromise;
+    return;
+  }
+}
+
 async function setupSession(
   session: Session,
   existingSession: boolean,
@@ -185,12 +238,10 @@ async function setupSession(
     // tool leaves CtrlProxy/accessibility-service setup unprepared; a later
     // call on the same UUID that needs `automationReady` must run that setup
     // now rather than trusting the fast path and returning early against a
-    // disconnected/unprepared device.
-    if (
-      !isReadinessSatisfied(sessionManager.getDeviceReadiness(session.sessionId), requiredReadiness)
-    ) {
-      await runDeviceReadinessSetup(session, sessionManager, requiredReadiness);
-    }
+    // disconnected/unprepared device. `ensureReadinessUpgraded` serializes
+    // concurrent upgrades for the same session (single-flight, #6227 P1
+    // follow-up) so two racing callers can't both trigger setup.
+    await ensureReadinessUpgraded(session, sessionManager, requiredReadiness);
     return;
   }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -8,7 +8,11 @@ import { logger } from "../utils/logger";
 import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { createPerformanceTracker, type TimingData } from "../utils/PerformanceTracker";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
-import { deviceReadinessLockKey, withDeviceReadinessLock } from "../utils/deviceReadinessLock";
+import {
+  deviceReadinessLockKey,
+  getDeviceAcquisitionReadiness,
+  withDeviceReadinessLock,
+} from "../utils/deviceReadinessLock";
 import { serverConfig } from "../utils/ServerConfig";
 import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
@@ -251,6 +255,22 @@ async function ensureReadinessUpgraded(
       // for it rather than racing a second `runDeviceReadinessSetup` call,
       // then loop back to re-check whether it reached the level we need.
       await inFlight;
+      continue;
+    }
+
+    // #6280 P2 follow-up: a device acquisition (`startDevice`/`getAndroid`)
+    // can still be binding/recording readiness for THIS session even after it
+    // has released the per-device readiness lock — that lock only covers the
+    // CtrlProxy setup itself, not the bind/record that follows. Racing our
+    // own `runDeviceReadinessSetup` here would acquire the now-free lock and
+    // redundantly reset/rerun CtrlProxy on the device the acquisition just
+    // prepared. Await the acquisition's marker instead, then loop back to
+    // re-check — by the time it settles, readiness has been recorded.
+    const acquisitionInFlight = getDeviceAcquisitionReadiness(
+      deviceReadinessLockKey(session.platform, session.assignedDevice),
+    );
+    if (acquisitionInFlight) {
+      await acquisitionInFlight;
       continue;
     }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -267,6 +267,13 @@ async function ensureReadinessUpgraded(
 
     const inFlight = readinessUpgradeInFlight.get(session);
     if (inFlight) {
+      // A flight whose final subscriber already left is being cancelled. A
+      // later caller must not inherit that unrelated cancellation; wait for
+      // its cleanup to settle, then establish or join a fresh flight.
+      if (inFlight.controller.signal.aborted) {
+        await inFlight.work.catch(() => undefined);
+        continue;
+      }
       // Another caller is already upgrading this session's readiness — wait
       // for it rather than racing a second `runDeviceReadinessSetup` call,
       // then loop back to re-check whether it reached the level we need.

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -13,6 +13,7 @@ import {
   getDeviceAcquisitionReadiness,
   withDeviceReadinessLock,
 } from "../utils/deviceReadinessLock";
+import { runWithAbortSignal } from "../utils/AbortContext";
 import { serverConfig } from "../utils/ServerConfig";
 import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
@@ -101,6 +102,7 @@ export async function createToolExecutionContext(
   // persisted, non-terminal row (restart recovery) is admissible. Internal callers
   // that intentionally mint fresh derived sessions (device labels) leave it false.
   requireIssuedSession = false,
+  signal?: AbortSignal,
 ): Promise<ToolExecutionContext> {
   if (!sessionUuid) {
     return {};
@@ -128,8 +130,13 @@ export async function createToolExecutionContext(
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);
   }
 
-  await sessionManager.trackSessionSetup(session, () =>
-    setupSession(session, existingSession === session, sessionManager, sessionOptions),
+  await awaitReadinessWork(
+    sessionManager.trackSessionSetup(session, () =>
+      runWithAbortSignal(signal, () =>
+        setupSession(session, existingSession === session, sessionManager, sessionOptions, signal),
+      ),
+    ),
+    signal,
   );
   ensureSessionIsCurrent(session, sessionManager);
 
@@ -224,8 +231,10 @@ async function ensureReadinessUpgraded(
   session: Session,
   sessionManager: SessionManager,
   requiredReadiness: DeviceReadinessLevel,
+  signal?: AbortSignal,
 ): Promise<void> {
   for (;;) {
+    signal?.throwIfAborted();
     if (
       isReadinessSatisfied(sessionManager.getDeviceReadiness(session.sessionId), requiredReadiness)
     ) {
@@ -245,7 +254,7 @@ async function ensureReadinessUpgraded(
       // executes synchronously up to (and including) the
       // `setDeviceReadiness` write, so it can't race a concurrent
       // automationReady flight's own write.
-      await runDeviceReadinessSetup(session, sessionManager, "booted");
+      await runDeviceReadinessSetup(session, sessionManager, "booted", signal);
       return;
     }
 
@@ -254,7 +263,7 @@ async function ensureReadinessUpgraded(
       // Another caller is already upgrading this session's readiness — wait
       // for it rather than racing a second `runDeviceReadinessSetup` call,
       // then loop back to re-check whether it reached the level we need.
-      await inFlight;
+      await awaitReadinessWork(inFlight, signal);
       continue;
     }
 
@@ -270,7 +279,7 @@ async function ensureReadinessUpgraded(
       deviceReadinessLockKey(session.platform, session.assignedDevice),
     );
     if (acquisitionInFlight) {
-      await acquisitionInFlight;
+      await awaitReadinessWork(acquisitionInFlight, signal);
       continue;
     }
 
@@ -278,13 +287,14 @@ async function ensureReadinessUpgraded(
       session,
       sessionManager,
       requiredReadiness,
+      signal,
     ).finally(() => {
       if (readinessUpgradeInFlight.get(session) === setupPromise) {
         readinessUpgradeInFlight.delete(session);
       }
     });
     readinessUpgradeInFlight.set(session, setupPromise);
-    await setupPromise;
+    await awaitReadinessWork(setupPromise, signal);
     return;
   }
 }
@@ -294,6 +304,7 @@ async function setupSession(
   existingSession: boolean,
   sessionManager: SessionManager,
   sessionOptions: SessionOptions,
+  signal?: AbortSignal,
 ): Promise<void> {
   await ensureKeepScreenAwake(session, sessionManager, sessionOptions);
   const requiredReadiness: DeviceReadinessLevel =
@@ -309,7 +320,7 @@ async function setupSession(
     // disconnected/unprepared device. `ensureReadinessUpgraded` serializes
     // concurrent upgrades for the same session (single-flight, #6227 P1
     // follow-up) so two racing callers can't both trigger setup.
-    await ensureReadinessUpgraded(session, sessionManager, requiredReadiness);
+    await ensureReadinessUpgraded(session, sessionManager, requiredReadiness, signal);
     return;
   }
 
@@ -320,7 +331,7 @@ async function setupSession(
   // caller racing for the same recovered session — whether it takes the
   // fresh or existing-session path — joins the one in-flight setup instead
   // of starting a second.
-  await ensureReadinessUpgraded(session, sessionManager, requiredReadiness);
+  await ensureReadinessUpgraded(session, sessionManager, requiredReadiness, signal);
   ensureSessionIsCurrent(session, sessionManager);
 
   // Start test coverage session for navigation graph tracking
@@ -347,7 +358,9 @@ async function runDeviceReadinessSetup(
   session: Session,
   sessionManager: SessionManager,
   requiredReadiness: DeviceReadinessLevel,
+  signal?: AbortSignal,
 ): Promise<void> {
+  signal?.throwIfAborted();
   if (session.platform === "android" && requiredReadiness !== "booted") {
     // #6227 P1 follow-up: serialize this session-scoped upgrade against the
     // SAME per-device readiness lock the acquisition paths
@@ -362,15 +375,42 @@ async function runDeviceReadinessSetup(
     await withDeviceReadinessLock(
       deviceReadinessLockKey(session.platform, session.assignedDevice),
       () =>
-        ensureAccessibilityServiceReady(
-          session.assignedDevice,
-          session.sessionId,
-          session.platform,
+        runWithAbortSignal(signal, () =>
+          ensureAccessibilityServiceReady(
+            session.assignedDevice,
+            session.sessionId,
+            session.platform,
+            defaultTimer,
+            signal,
+          ),
         ),
+      { signal },
     );
   }
   ensureSessionIsCurrent(session, sessionManager);
   sessionManager.setDeviceReadiness(session.sessionId, requiredReadiness);
+}
+
+/** Await shared readiness work without making a cancelled request wait for it. */
+function awaitReadinessWork<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return work;
+  }
+  signal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener("abort", abort, { once: true });
+    void work.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
 }
 
 function ensureSessionIsCurrent(session: Session, sessionManager: SessionManager): void {
@@ -431,6 +471,7 @@ async function ensureAccessibilityServiceReady(
   sessionId: string,
   platform: Platform,
   timer: Timer = defaultTimer,
+  signal?: AbortSignal,
 ): Promise<void> {
   const device: BootedDevice = {
     name: deviceId,
@@ -447,6 +488,7 @@ async function ensureAccessibilityServiceReady(
   const RETRY_DELAY_MS = 3000;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    signal?.throwIfAborted();
     const perf = createPerformanceTracker(true);
     perf.serial("ensureAccessibilityServiceReady");
 
@@ -468,7 +510,7 @@ async function ensureAccessibilityServiceReady(
         logger.warn(
           `[A11yRetry] Transient failure on attempt ${attempt}/${MAX_ATTEMPTS}, retrying in ${RETRY_DELAY_MS}ms: ${errorMsg}`,
         );
-        await timer.sleep(RETRY_DELAY_MS);
+        await awaitReadinessWork(timer.sleep(RETRY_DELAY_MS), signal);
         continue;
       }
 
@@ -482,7 +524,7 @@ async function ensureAccessibilityServiceReady(
     }
 
     const connected = await perf.track("waitForConnection", () =>
-      readinessDriver.waitForConnection(),
+      awaitReadinessWork(readinessDriver.waitForConnection(), signal),
     );
 
     perf.end();

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -385,11 +385,23 @@ async function assertCtrlProxyInstalledWhenDownloadsDisabled(
   if (!serverConfig.isSkipCtrlProxyDownloadEnabled()) {
     return;
   }
-  const installed = await getDeviceReadinessProxyDriver(device).isInstalled();
+  const driver = getDeviceReadinessProxyDriver(device);
+  const installed = await driver.isInstalled();
   if (!installed) {
     throw new ActionableError(
       `Failed to setup accessibility service for device ${device.deviceId} (session ${sessionId}): ` +
         `CtrlProxy is not installed and runner downloads are disabled`,
+    );
+  }
+  // Downloads disabled cannot upgrade an incompatible installed proxy, so an
+  // installed-but-incompatible CtrlProxy must be rejected here rather than
+  // proceeding to `setup()` against it — matching the fresh acquisition path
+  // (`RunnerReadinessService.ensureAndroidReadyWithoutDownloads`).
+  const compatible = await driver.isVersionCompatible();
+  if (!compatible) {
+    throw new ActionableError(
+      `Failed to setup accessibility service for device ${device.deviceId} (session ${sessionId}): ` +
+        `CtrlProxy version mismatch; run without skipCtrlProxyDownload to install a compatible version`,
     );
   }
 }

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -225,7 +225,14 @@ function isReadinessSatisfied(
  * its own flights, and the predecessor's entry becomes eligible for GC once
  * nothing else references that stale `Session`.
  */
-const readinessUpgradeInFlight = new WeakMap<Session, Promise<void>>();
+interface ReadinessUpgradeFlight {
+  controller: AbortController;
+  work: Promise<void>;
+  settled: boolean;
+  waiters: number;
+}
+
+const readinessUpgradeInFlight = new WeakMap<Session, ReadinessUpgradeFlight>();
 
 async function ensureReadinessUpgraded(
   session: Session,
@@ -263,7 +270,7 @@ async function ensureReadinessUpgraded(
       // Another caller is already upgrading this session's readiness — wait
       // for it rather than racing a second `runDeviceReadinessSetup` call,
       // then loop back to re-check whether it reached the level we need.
-      await awaitReadinessWork(inFlight, signal);
+      await awaitReadinessFlight(inFlight, signal);
       continue;
     }
 
@@ -283,19 +290,43 @@ async function ensureReadinessUpgraded(
       continue;
     }
 
-    const setupPromise = runDeviceReadinessSetup(
+    const controller = new AbortController();
+    let flight!: ReadinessUpgradeFlight;
+    const work = runDeviceReadinessSetup(
       session,
       sessionManager,
       requiredReadiness,
-      signal,
+      controller.signal,
     ).finally(() => {
-      if (readinessUpgradeInFlight.get(session) === setupPromise) {
+      flight.settled = true;
+      if (readinessUpgradeInFlight.get(session) === flight) {
         readinessUpgradeInFlight.delete(session);
       }
     });
-    readinessUpgradeInFlight.set(session, setupPromise);
-    await awaitReadinessWork(setupPromise, signal);
+    flight = { controller, work, settled: false, waiters: 0 };
+    readinessUpgradeInFlight.set(session, flight);
+    await awaitReadinessFlight(flight, signal);
     return;
+  }
+}
+
+/**
+ * A request may stop waiting for shared readiness work without cancelling a
+ * still-interested joiner. If every subscriber leaves, stop the background
+ * setup instead of continuing a cancelled request's device mutation.
+ */
+async function awaitReadinessFlight(
+  flight: ReadinessUpgradeFlight,
+  signal?: AbortSignal,
+): Promise<void> {
+  flight.waiters += 1;
+  try {
+    await awaitReadinessWork(flight.work, signal);
+  } finally {
+    flight.waiters -= 1;
+    if (flight.waiters === 0 && !flight.settled && !flight.controller.signal.aborted) {
+      flight.controller.abort(signal?.reason);
+    }
   }
 }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -310,8 +310,17 @@ async function ensureReadinessUpgraded(
     }
 
     const controller = new AbortController();
-    let flight!: ReadinessUpgradeFlight;
-    const work = runDeviceReadinessSetup(
+    // `flight.work` is wired up after construction so `flight` itself can stay
+    // `const`: the `.finally()` callback below only ever runs once the setup
+    // promise settles, which is always after this synchronous block finishes
+    // assigning `flight.work`.
+    const flight: ReadinessUpgradeFlight = {
+      controller,
+      work: Promise.resolve(),
+      settled: false,
+      waiters: 0,
+    };
+    flight.work = runDeviceReadinessSetup(
       session,
       sessionManager,
       requiredReadiness,
@@ -322,7 +331,6 @@ async function ensureReadinessUpgraded(
         readinessUpgradeInFlight.delete(session);
       }
     });
-    flight = { controller, work, settled: false, waiters: 0 };
     readinessUpgradeInFlight.set(session, flight);
     await awaitReadinessFlight(flight, signal);
     return;

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -130,14 +130,28 @@ export async function createToolExecutionContext(
     throw new ActionableError(`Session ${sessionUuid} was released during setup`);
   }
 
-  await awaitReadinessWork(
-    sessionManager.trackSessionSetup(session, () =>
-      runWithAbortSignal(signal, () =>
-        setupSession(session, existingSession === session, sessionManager, sessionOptions, signal),
+  // Acquisition readiness can include an ANR recovery rebind, and that rebind
+  // drains tracked session setup before it records the replacement's achieved
+  // readiness. Waiting for its marker *inside* trackSessionSetup therefore
+  // forms a cycle. Keep marker-only waits outside the tracked mutation and
+  // retry if a new acquisition begins while setup is being admitted.
+  do {
+    await awaitPendingDeviceAcquisitionReadiness(session, signal);
+    await awaitReadinessWork(
+      sessionManager.trackSessionSetup(session, () =>
+        runWithAbortSignal(signal, () =>
+          setupSession(
+            session,
+            existingSession === session,
+            sessionManager,
+            sessionOptions,
+            signal,
+          ),
+        ),
       ),
-    ),
-    signal,
-  );
+      signal,
+    );
+  } while (await awaitPendingDeviceAcquisitionReadiness(session, signal));
   ensureSessionIsCurrent(session, sessionManager);
 
   return {
@@ -147,6 +161,20 @@ export async function createToolExecutionContext(
     sessionManager,
     devicePool,
   };
+}
+
+async function awaitPendingDeviceAcquisitionReadiness(
+  session: Session,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const acquisitionInFlight = getDeviceAcquisitionReadiness(
+    deviceReadinessLockKey(session.platform, session.assignedDevice),
+  );
+  if (!acquisitionInFlight) {
+    return false;
+  }
+  await awaitReadinessWork(acquisitionInFlight, signal);
+  return true;
 }
 
 function isReadinessSatisfied(
@@ -278,22 +306,6 @@ async function ensureReadinessUpgraded(
       // for it rather than racing a second `runDeviceReadinessSetup` call,
       // then loop back to re-check whether it reached the level we need.
       await awaitReadinessFlight(inFlight, signal);
-      continue;
-    }
-
-    // #6280 P2 follow-up: a device acquisition (`startDevice`/`getAndroid`)
-    // can still be binding/recording readiness for THIS session even after it
-    // has released the per-device readiness lock — that lock only covers the
-    // CtrlProxy setup itself, not the bind/record that follows. Racing our
-    // own `runDeviceReadinessSetup` here would acquire the now-free lock and
-    // redundantly reset/rerun CtrlProxy on the device the acquisition just
-    // prepared. Await the acquisition's marker instead, then loop back to
-    // re-check — by the time it settles, readiness has been recorded.
-    const acquisitionInFlight = getDeviceAcquisitionReadiness(
-      deviceReadinessLockKey(session.platform, session.assignedDevice),
-    );
-    if (acquisitionInFlight) {
-      await awaitReadinessWork(acquisitionInFlight, signal);
       continue;
     }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -1,12 +1,11 @@
 import { SessionManager } from "../daemon/sessionManager";
 import type { Session, SessionExecutionMetadata } from "../daemon/sessionManager";
 import { DevicePool } from "../daemon/devicePool";
-import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
+import { getDeviceReadinessProxyDriver } from "./deviceReadinessProxyProvider";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { logger } from "../utils/logger";
 import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
-import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { createPerformanceTracker, type TimingData } from "../utils/PerformanceTracker";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
 import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
@@ -376,9 +375,9 @@ async function ensureAccessibilityServiceReady(
     const perf = createPerformanceTracker(true);
     perf.serial("ensureAccessibilityServiceReady");
 
-    const serviceManager = AndroidCtrlProxyManager.getInstance(device);
-    serviceManager.resetSetupState();
-    const setupResult = await serviceManager.setup(false, perf);
+    const readinessDriver = getDeviceReadinessProxyDriver(device);
+    readinessDriver.resetSetupState();
+    const setupResult = await readinessDriver.setup(false, perf);
 
     if (!setupResult.success) {
       perf.end();
@@ -407,9 +406,8 @@ async function ensureAccessibilityServiceReady(
       logger.info(`[A11yRetry] Setup succeeded on attempt ${attempt}/${MAX_ATTEMPTS}`);
     }
 
-    const accessibilityClient = AndroidCtrlProxyClient.getInstance(device);
     const connected = await perf.track("waitForConnection", () =>
-      accessibilityClient.waitForConnection(),
+      readinessDriver.waitForConnection(),
     );
 
     perf.end();

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -169,7 +169,7 @@ function isReadinessSatisfied(
 }
 
 /**
- * Per-session in-flight readiness upgrade (#6227 P1 follow-up: single-flight).
+ * Per-session in-flight readiness setup (#6227 P1 follow-ups: single-flight).
  *
  * A recovered/newly-published session can be observed by two concurrent
  * `automationReady` calls (e.g. reaching the daemon through different
@@ -182,6 +182,19 @@ function isReadinessSatisfied(
  * caller await the same in-flight promise (rather than starting its own)
  * closes that race; each waiter re-checks the achieved readiness once the
  * in-flight setup settles, upgrading further only if still insufficient.
+ *
+ * This map is shared by BOTH the fresh-session setup path (`setupSession`'s
+ * `!existingSession` branch) and the existing-session upgrade path
+ * (`ensureReadinessUpgraded`). A second P1 follow-up closed a further race:
+ * two post-restart calls racing for the same recovered UUID can each compute
+ * `existingSession` before the session is published, then one takes the
+ * fresh path and the other the existing-session path — if only the upgrade
+ * path went through this map, the fresh-path call would run
+ * `runDeviceReadinessSetup` directly and unguarded, concurrently with a
+ * guarded upgrade for the very same session. Routing the fresh path through
+ * `ensureReadinessUpgraded` too (keyed by the same `session.sessionId`)
+ * ensures any concurrent caller — fresh or existing — for that session joins
+ * the one in-flight setup instead of starting a second.
  */
 const readinessUpgradeInFlight = new Map<string, Promise<void>>();
 
@@ -246,7 +259,12 @@ async function setupSession(
   }
 
   ensureSessionIsCurrent(session, sessionManager);
-  await runDeviceReadinessSetup(session, sessionManager, requiredReadiness);
+  // #6227 P1 follow-up: route the fresh-session setup through the same
+  // single-flight map used by the existing-session upgrade path (keyed by
+  // `session.sessionId`) so a concurrent caller racing for the same
+  // recovered session — whether it takes the fresh or existing-session path
+  // — joins the one in-flight setup instead of starting a second.
+  await ensureReadinessUpgraded(session, sessionManager, requiredReadiness);
   ensureSessionIsCurrent(session, sessionManager);
 
   // Start test coverage session for navigation graph tracking

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -141,13 +141,27 @@ function isReadinessSatisfied(
   achieved: DeviceReadinessLevel | undefined,
   required: DeviceReadinessLevel,
 ): boolean {
-  // `undefined` means this session was never routed through this module's own
-  // setup — e.g. a test (or another internal caller) that tracks a session
-  // directly via `SessionManager.createSession`. Trust the existing-session
-  // fast path exactly as it behaved before #6227 rather than forcing setup
-  // on a session this code has no record of ever needing it.
+  // #6227 P1 follow-up: `undefined` must NOT be treated as satisfied here.
+  // A recovered/newly-published session becomes visible to a concurrent
+  // `getSessionForNewExecution` lookup (`this.sessions.set(...)` in
+  // `persistAndPublishSession`) *before* this module's own setup path gets a
+  // chance to call `setDeviceReadiness` (setup runs later, inside
+  // `setupSession` -> `runDeviceReadinessSetup`, after `getOrCreateSession`
+  // has already returned). A concurrent call that lands in that window would
+  // see the session as "existing" with `achieved === undefined` and — if we
+  // treated that as satisfied — skip CtrlProxy/accessibility-service setup
+  // entirely, running automation against an unprepared device.
+  //
+  // Treating `undefined` as NOT satisfied closes that hole: the
+  // `existingSession` branch below always runs `runDeviceReadinessSetup` for
+  // a session whose readiness has never been recorded, which is safe because
+  // that setup is idempotent (redundant concurrent runs are harmless, merely
+  // wasteful). Callers that track a session directly (e.g.
+  // `SessionManager.createSession` in tests) and want to skip this module's
+  // setup must record an explicit readiness level via `setDeviceReadiness`
+  // rather than relying on `undefined` meaning "already satisfied".
   if (achieved === undefined) {
-    return true;
+    return false;
   }
   // `booted` is satisfied by either recorded level; `automationReady` needs
   // the higher level to have actually been achieved.

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -178,10 +178,10 @@ function isReadinessSatisfied(
  * `getDeviceReadiness` result and both invoke `runDeviceReadinessSetup`,
  * which calls `AndroidCtrlProxyManager.resetSetupState()` on the *shared*
  * per-device manager — the second caller's reset can land mid-setup for the
- * first, corrupting both. Keying by session UUID and having a concurrent
- * caller await the same in-flight promise (rather than starting its own)
- * closes that race; each waiter re-checks the achieved readiness once the
- * in-flight setup settles, upgrading further only if still insufficient.
+ * first, corrupting both. Having a concurrent caller await the same
+ * in-flight promise (rather than starting its own) closes that race; each
+ * waiter re-checks the achieved readiness once the in-flight setup settles,
+ * upgrading further only if still insufficient.
  *
  * This map is shared by BOTH the fresh-session setup path (`setupSession`'s
  * `!existingSession` branch) and the existing-session upgrade path
@@ -192,11 +192,28 @@ function isReadinessSatisfied(
  * path went through this map, the fresh-path call would run
  * `runDeviceReadinessSetup` directly and unguarded, concurrently with a
  * guarded upgrade for the very same session. Routing the fresh path through
- * `ensureReadinessUpgraded` too (keyed by the same `session.sessionId`)
+ * `ensureReadinessUpgraded` too (keyed by the same session incarnation)
  * ensures any concurrent caller — fresh or existing — for that session joins
  * the one in-flight setup instead of starting a second.
+ *
+ * Keyed by the `Session` object itself (its incarnation), NOT by the bare
+ * session UUID (#6227 P2 follow-up). `SessionManager` creates a brand-new
+ * `Session` object per incarnation (`createSession` / restart recovery), and
+ * a session's `cacheData` — where `getDeviceReadiness` reads from — lives on
+ * that object, so a replacement incarnation with the same UUID always starts
+ * with a clean readiness slate. Keying this map by the bare UUID string
+ * would break that isolation: if a nonterminal release reaches its ~1s
+ * setup-drain timeout while the old incarnation's setup is still pending and
+ * the same UUID is then recreated (possibly bound to a different device),
+ * the replacement would find the *predecessor's* promise still registered
+ * under that UUID and join it — waiting on, and possibly resolving to, a
+ * flight that belongs to a session that no longer exists. A `WeakMap` keyed
+ * by the `Session` object scopes each flight to its own incarnation for
+ * free: a replacement session is a distinct object, so it can only ever see
+ * its own flights, and the predecessor's entry becomes eligible for GC once
+ * nothing else references that stale `Session`.
  */
-const readinessUpgradeInFlight = new Map<string, Promise<void>>();
+const readinessUpgradeInFlight = new WeakMap<Session, Promise<void>>();
 
 async function ensureReadinessUpgraded(
   session: Session,
@@ -210,7 +227,24 @@ async function ensureReadinessUpgraded(
       return;
     }
 
-    const inFlight = readinessUpgradeInFlight.get(session.sessionId);
+    if (requiredReadiness === "booted") {
+      // #6227 P1 follow-up: by the time we get here,
+      // `devicePool.assertSessionReadyForAutomation` has already confirmed
+      // the device itself is booted — a `booted`-only caller (e.g.
+      // `listApps`) needs nothing further that a stricter, possibly
+      // in-flight `automationReady` setup provides. Joining that flight
+      // below would make the `booted` call wait on, and fail from,
+      // automation setup (CtrlProxy / accessibility-service) it was
+      // specifically routed around. Record the booted baseline directly
+      // instead of consulting/joining `readinessUpgradeInFlight` — this
+      // executes synchronously up to (and including) the
+      // `setDeviceReadiness` write, so it can't race a concurrent
+      // automationReady flight's own write.
+      await runDeviceReadinessSetup(session, sessionManager, "booted");
+      return;
+    }
+
+    const inFlight = readinessUpgradeInFlight.get(session);
     if (inFlight) {
       // Another caller is already upgrading this session's readiness — wait
       // for it rather than racing a second `runDeviceReadinessSetup` call,
@@ -224,11 +258,11 @@ async function ensureReadinessUpgraded(
       sessionManager,
       requiredReadiness,
     ).finally(() => {
-      if (readinessUpgradeInFlight.get(session.sessionId) === setupPromise) {
-        readinessUpgradeInFlight.delete(session.sessionId);
+      if (readinessUpgradeInFlight.get(session) === setupPromise) {
+        readinessUpgradeInFlight.delete(session);
       }
     });
-    readinessUpgradeInFlight.set(session.sessionId, setupPromise);
+    readinessUpgradeInFlight.set(session, setupPromise);
     await setupPromise;
     return;
   }
@@ -261,9 +295,10 @@ async function setupSession(
   ensureSessionIsCurrent(session, sessionManager);
   // #6227 P1 follow-up: route the fresh-session setup through the same
   // single-flight map used by the existing-session upgrade path (keyed by
-  // `session.sessionId`) so a concurrent caller racing for the same
-  // recovered session — whether it takes the fresh or existing-session path
-  // — joins the one in-flight setup instead of starting a second.
+  // this session's own incarnation, #6227 P2 follow-up) so a concurrent
+  // caller racing for the same recovered session — whether it takes the
+  // fresh or existing-session path — joins the one in-flight setup instead
+  // of starting a second.
   await ensureReadinessUpgraded(session, sessionManager, requiredReadiness);
   ensureSessionIsCurrent(session, sessionManager);
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -8,6 +8,8 @@ import { logger } from "../utils/logger";
 import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { createPerformanceTracker, type TimingData } from "../utils/PerformanceTracker";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
+import { deviceReadinessLockKey, withDeviceReadinessLock } from "../utils/deviceReadinessLock";
+import { serverConfig } from "../utils/ServerConfig";
 import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 
 /**
@@ -327,10 +329,24 @@ async function runDeviceReadinessSetup(
   requiredReadiness: DeviceReadinessLevel,
 ): Promise<void> {
   if (session.platform === "android" && requiredReadiness !== "booted") {
-    await ensureAccessibilityServiceReady(
-      session.assignedDevice,
-      session.sessionId,
-      session.platform,
+    // #6227 P1 follow-up: serialize this session-scoped upgrade against the
+    // SAME per-device readiness lock the acquisition paths
+    // (startDevice/getAndroid/provision, via `RunnerReadinessService`) hold
+    // while preparing a device. The per-session single-flight above
+    // (`readinessUpgradeInFlight`) only stops two upgrades for the *same
+    // session* from colliding; without this per-DEVICE lock an upgrade and a
+    // concurrent device preparation could both run `resetSetupState()` +
+    // `setup()` on the shared per-device `AndroidCtrlProxyManager` singleton.
+    // Both paths derive the key via `deviceReadinessLockKey`, so they queue on
+    // one lock and setup on a device is never run concurrently.
+    await withDeviceReadinessLock(
+      deviceReadinessLockKey(session.platform, session.assignedDevice),
+      () =>
+        ensureAccessibilityServiceReady(
+          session.assignedDevice,
+          session.sessionId,
+          session.platform,
+        ),
     );
   }
   ensureSessionIsCurrent(session, sessionManager);
@@ -353,6 +369,31 @@ function isTransientA11yError(error: string): boolean {
   return A11Y_TRANSIENT_ERROR_PATTERNS.some((p) => error.includes(p));
 }
 
+/**
+ * #6227 P1 follow-up: honor `--skip-ctrl-proxy-download` on the session-scoped
+ * readiness upgrade exactly as the fresh acquisition path does
+ * (`RunnerReadinessService.ensureAndroidReadyWithoutDownloads`). When downloads
+ * are disabled and the CtrlProxy artifact is not already installed, the fresh
+ * path refuses with an actionable error rather than downloading — an upgrade of
+ * a booted-only session must degrade the same way instead of triggering
+ * `setup()`'s download/install of a missing artifact.
+ */
+async function assertCtrlProxyInstalledWhenDownloadsDisabled(
+  device: BootedDevice,
+  sessionId: string,
+): Promise<void> {
+  if (!serverConfig.isSkipCtrlProxyDownloadEnabled()) {
+    return;
+  }
+  const installed = await getDeviceReadinessProxyDriver(device).isInstalled();
+  if (!installed) {
+    throw new ActionableError(
+      `Failed to setup accessibility service for device ${device.deviceId} (session ${sessionId}): ` +
+        `CtrlProxy is not installed and runner downloads are disabled`,
+    );
+  }
+}
+
 async function ensureAccessibilityServiceReady(
   deviceId: string,
   sessionId: string,
@@ -367,6 +408,8 @@ async function ensureAccessibilityServiceReady(
   logger.info(
     `[ToolExecutionContext] Ensuring accessibility service is ready for session ${sessionId}`,
   );
+
+  await assertCtrlProxyInstalledWhenDownloadsDisabled(device, sessionId);
 
   const MAX_ATTEMPTS = 2;
   const RETRY_DELAY_MS = 3000;

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -62,6 +62,7 @@ export const registerDeviceLabelMap = async (
   primaryLabel?: string,
   sessionOptions: SessionOptions = {},
   execution?: SessionExecutionMetadata,
+  signal?: AbortSignal,
 ): Promise<DeviceLabelMap> => {
   if (!DaemonState.getInstance().isInitialized()) {
     throw new ActionableError("Device labels require an active daemon session.");
@@ -85,6 +86,9 @@ export const registerDeviceLabelMap = async (
     devicePool,
     sessionOptions,
     execution,
+    undefined,
+    false,
+    signal,
   );
 
   const assignedSessions = new Set(Object.values(deviceLabelMap));
@@ -97,6 +101,9 @@ export const registerDeviceLabelMap = async (
       devicePool,
       sessionOptions,
       execution,
+      undefined,
+      false,
+      signal,
     );
   }
 

--- a/src/server/deviceReadinessProxyProvider.ts
+++ b/src/server/deviceReadinessProxyProvider.ts
@@ -41,6 +41,15 @@ export interface DeviceReadinessProxyDriver {
    * `ToolExecutionContext.ensureAccessibilityServiceReady`.
    */
   isInstalled(): Promise<boolean>;
+  /**
+   * Whether the installed CtrlProxy artifact is version-compatible with this
+   * server (#6227). Consulted only when `--skip-ctrl-proxy-download` is enabled:
+   * an installed-but-incompatible proxy cannot be upgraded (downloads disabled),
+   * so the session-scoped readiness upgrade must refuse rather than run
+   * `setup()` against it — matching the fresh acquisition path's
+   * `RunnerReadinessService.ensureAndroidReadyWithoutDownloads`.
+   */
+  isVersionCompatible(): Promise<boolean>;
 }
 
 export type DeviceReadinessProxyDriverProvider = (
@@ -54,6 +63,7 @@ const realProvider: DeviceReadinessProxyDriverProvider = (device) => {
     setup: (force, perf) => manager.setup(force, perf),
     waitForConnection: () => AndroidCtrlProxyClient.getInstance(device).waitForConnection(),
     isInstalled: () => manager.isInstalled(),
+    isVersionCompatible: () => manager.isVersionCompatible(),
   };
 };
 

--- a/src/server/deviceReadinessProxyProvider.ts
+++ b/src/server/deviceReadinessProxyProvider.ts
@@ -1,0 +1,66 @@
+import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../features/observe/android";
+import type { BootedDevice } from "../models";
+import type { PerformanceTracker } from "../utils/PerformanceTracker";
+import type { ProxySetupResult } from "../utils/interfaces/ProxyManager";
+
+/**
+ * Narrow driver that {@link ToolExecutionContext}'s
+ * `ensureAccessibilityServiceReady` uses to bring a per-session Android device
+ * to automation readiness: reset setup state, run accessibility-service setup,
+ * then wait for the CtrlProxy connection.
+ *
+ * It exists as an injectable seam because `createToolExecutionContext`'s
+ * device-readiness upgrade (#6227) now runs this real setup for ANY
+ * `existingSession` with no recorded readiness — including sessions minted
+ * directly via `SessionManager.createSession` / `DevicePool` in integration
+ * tests, which bypass the `deviceTools.ts` acquisition recorder. Against those
+ * tests' fake device there is no real `adb`/network, so
+ * `AndroidCtrlProxyManager.getInstance(device).setup()` and
+ * `AndroidCtrlProxyClient.getInstance(device).waitForConnection()` can block on
+ * unbounded host I/O well past bun's 5000ms test timeout; a timed-out test skips
+ * its `finally` cleanup and leaks process-wide singletons (e.g. `DaemonState`)
+ * into every later test in the same `bun test` process.
+ *
+ * The shared test preload (`test/setup/testPreload.ts`) installs a fast no-op
+ * provider here so NO test can hang on this path, regardless of which file
+ * creates the session. Scoping the neutralization to THIS readiness driver —
+ * rather than globally replacing `AndroidCtrlProxyManager.getInstance` /
+ * `AndroidCtrlProxyClient.getInstance` — leaves the dedicated CtrlProxy
+ * manager/client suites exercising real behavior.
+ */
+export interface DeviceReadinessProxyDriver {
+  resetSetupState(): void;
+  setup(force: boolean, perf: PerformanceTracker): Promise<ProxySetupResult>;
+  waitForConnection(): Promise<boolean>;
+}
+
+export type DeviceReadinessProxyDriverProvider = (
+  device: BootedDevice,
+) => DeviceReadinessProxyDriver;
+
+const realProvider: DeviceReadinessProxyDriverProvider = (device) => {
+  const manager = AndroidCtrlProxyManager.getInstance(device);
+  return {
+    resetSetupState: () => manager.resetSetupState(),
+    setup: (force, perf) => manager.setup(force, perf),
+    waitForConnection: () => AndroidCtrlProxyClient.getInstance(device).waitForConnection(),
+  };
+};
+
+let provider: DeviceReadinessProxyDriverProvider = realProvider;
+
+/** Resolve the readiness driver for a device through the (possibly overridden) provider. */
+export function getDeviceReadinessProxyDriver(device: BootedDevice): DeviceReadinessProxyDriver {
+  return provider(device);
+}
+
+/**
+ * Test seam: override the readiness driver provider process-wide. Pass `null`
+ * to restore the real provider.
+ */
+export function setDeviceReadinessProxyDriverProviderForTesting(
+  next: DeviceReadinessProxyDriverProvider | null,
+): void {
+  provider = next ?? realProvider;
+}

--- a/src/server/deviceReadinessProxyProvider.ts
+++ b/src/server/deviceReadinessProxyProvider.ts
@@ -33,6 +33,14 @@ export interface DeviceReadinessProxyDriver {
   resetSetupState(): void;
   setup(force: boolean, perf: PerformanceTracker): Promise<ProxySetupResult>;
   waitForConnection(): Promise<boolean>;
+  /**
+   * Whether the CtrlProxy artifact is already installed on the device (#6227).
+   * Consulted only when `--skip-ctrl-proxy-download` is enabled, so the
+   * session-scoped readiness upgrade can refuse to download a missing artifact
+   * exactly as the fresh acquisition path does — see
+   * `ToolExecutionContext.ensureAccessibilityServiceReady`.
+   */
+  isInstalled(): Promise<boolean>;
 }
 
 export type DeviceReadinessProxyDriverProvider = (
@@ -45,6 +53,7 @@ const realProvider: DeviceReadinessProxyDriverProvider = (device) => {
     resetSetupState: () => manager.resetSetupState(),
     setup: (force, perf) => manager.setup(force, perf),
     waitForConnection: () => AndroidCtrlProxyClient.getInstance(device).waitForConnection(),
+    isInstalled: () => manager.isInstalled(),
   };
 };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -5264,6 +5264,7 @@ export function registerDeviceTools() {
           verifiedAndroidAvdIdentity,
         );
       if (autolockSessionId) {
+        recordAcquiredSessionReadiness(daemonState, autolockSessionId);
         return autolockSessionId;
       }
     }
@@ -5273,7 +5274,7 @@ export function registerDeviceTools() {
       registerDirectSessionDevice(sessionId, device);
       return sessionId;
     }
-    return daemonState
+    const boundSessionId = await daemonState
       .getDevicePool()
       .bindOrReuseDeviceSession(
         sessionId,
@@ -5286,6 +5287,30 @@ export function registerDeviceTools() {
         readinessReservationOwners,
         verifiedAndroidAvdIdentity,
       );
+    recordAcquiredSessionReadiness(daemonState, boundSessionId);
+    return boundSessionId;
+  }
+
+  /**
+   * Record `automationReady` for a session bound by `bindBootedDeviceSession`
+   * (#6227 P1 follow-up). By the time that function runs, the caller
+   * (`bootAndPrepareDevice`) has already awaited
+   * `prepareStartDeviceRunnerReadiness` successfully for this device — CtrlProxy
+   * / accessibility-service setup for android is genuinely done, not merely
+   * assumed. Without recording it here, the session's `deviceReadiness` slot
+   * stays `undefined` and the first subsequent `automationReady` tool call
+   * (e.g. `observe`) sees that as unsatisfied and redundantly reruns setup via
+   * `ToolExecutionContext`'s `existingSession` upgrade path.
+   *
+   * This is only reached for a freshly-bound (non-recovered) session: the
+   * `readinessResult.preservedSessionId` recovery path in `bootAndPrepareDevice`
+   * skips `bindBootedDeviceSession` entirely, so a recovered session whose
+   * readiness was never actually re-verified after recovery stays unrecorded
+   * and still runs setup on next use, preserving the concurrency-hole fix in
+   * `isReadinessSatisfied`.
+   */
+  function recordAcquiredSessionReadiness(daemonState: DaemonState, sessionId: string): void {
+    daemonState.getSessionManager().setDeviceReadiness(sessionId, "automationReady");
   }
 
   async function buildBootedResponse(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -5319,9 +5319,14 @@ export function registerDeviceTools() {
           device,
           readinessReservationOwners,
           verifiedAndroidAvdIdentity,
+          achievedReadiness,
         );
       if (autolockSessionId) {
-        recordAcquiredSessionReadiness(daemonState, autolockSessionId, achievedReadiness);
+        // #6227 (round 9): readiness is recorded INSIDE `autolockDevice`, before
+        // it publishes the session to the `mcpSessionAutolockMap` route, so a
+        // concurrent tool call from the same MCP client cannot observe an
+        // unrecorded readiness. Recording here (after exposure) would reopen
+        // that race, so it must not move back out.
         return autolockSessionId;
       }
     }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -74,6 +74,10 @@ import {
   SystemUiAnrRecoveryRequiredError,
 } from "../utils/RunnerReadinessService";
 import {
+  deviceReadinessLockKey,
+  trackDeviceAcquisitionReadiness,
+} from "../utils/deviceReadinessLock";
+import {
   DEFAULT_RUNNER_READINESS_TIMEOUT_MS,
   MAX_RUNNER_READINESS_TIMEOUT_MS,
   MIN_RUNNER_READINESS_TIMEOUT_MS,
@@ -5007,70 +5011,91 @@ export function registerDeviceTools() {
     clearColdBootShutdownMarker(state.boot.source, state.boot.device.deviceId);
 
     const ctrlProxySetup = deps.ensureCtrlProxyReady ?? ensureCtrlProxyReady;
-    const readinessResult = await prepareStartDeviceRunnerReadiness({
-      boot: state.boot,
-      args,
-      bootService,
-      deviceUtils,
-      daemonState,
-      totalDeadlineMs: budgets.automationDeadlineMs,
-      readinessTimeoutMs: budgets.automationReadyTimeoutMs,
-      timer: deps.timer,
-      signal,
-      progress,
-      perf,
-      requestedIdentity,
-      ensureCtrlProxyReady: ctrlProxySetup,
-      releaseReadinessReservations,
-    });
-    state.boot = readinessResult.boot;
-    sourceImage = state.boot.sourceImage ?? sourceImage;
-    // Re-check under the later binding lock because pool identity can change
-    // while runner setup is in flight.
-    validatePooledDeviceMapping(state.boot.device, requestedIdentity);
-
-    // Publish only after runner health passes. Readiness remains per-device,
-    // so 20-40 concurrent emulators do not serialize on a host-wide gate.
-    publishWarmDeviceReady(state.boot.source, state.boot.device.deviceId);
-    await validatePreservedSystemUiAnrRecoverySession(
-      readinessResult.preservedSessionId,
-      readinessResult.validatePreservedSession,
-      readinessResult.retireReplacement,
+    // #6280 P2 follow-up: mark this device's readiness lock key as having an
+    // acquisition in flight for the ENTIRE span from runner setup through
+    // session bind/record, not just while the readiness lock itself is held.
+    // `RunnerReadinessService.ensureReady` (invoked inside
+    // `prepareStartDeviceRunnerReadiness`) releases that lock the instant
+    // CtrlProxy setup finishes — well before this function goes on to bind
+    // (or reuse) the session and record its achieved readiness below. A
+    // concurrent tool call on an already-known session UUID (a post-restart
+    // recovered session reused rather than freshly created here) can queue
+    // behind the readiness lock and acquire it in that gap; without this
+    // marker it would observe still-unrecorded readiness and redundantly
+    // reset/rerun CtrlProxy on the device just prepared.
+    // `ensureReadinessUpgraded` in `ToolExecutionContext` awaits this marker
+    // instead of racing a second setup.
+    const acquisitionReadinessKey = deviceReadinessLockKey(
+      state.boot.device.platform,
+      state.boot.device.deviceId,
     );
-    const verifiedWarmAndroidAvdIdentity = getVerifiedWarmAndroidAvdIdentity(
-      state.boot,
-      sourceImage,
-    );
-    const sessionId =
-      readinessResult.preservedSessionId ??
-      (await bindBootedDeviceSession(
-        state.boot.device,
+    const sessionId = await trackDeviceAcquisitionReadiness(acquisitionReadinessKey, async () => {
+      const readinessResult = await prepareStartDeviceRunnerReadiness({
+        boot: state.boot!,
         args,
-        state.boot.source === "cold-boot" ? sourceImage : undefined,
-        state.boot.processHandle,
-        new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
-        verifiedWarmAndroidAvdIdentity,
-      ));
-    if (readinessResult.preservedSessionId) {
-      // #6227 round 7: the System UI ANR recovery path above bypasses
-      // `bindBootedDeviceSession` (and therefore its own
-      // `recordAcquiredSessionReadiness` call) entirely when a preserved
-      // session is being reused. But by this point
-      // `prepareStartDeviceRunnerReadiness` has already run the *same*
-      // `ensureCtrlProxyReady` setup this function always awaits for a
-      // freshly-bound session — recovery re-verified runner readiness on the
-      // replacement device before handing back `preservedSessionId` (see
-      // `ensureRunnerReadyWithSystemUiAnrRecovery`) — so the achieved level
-      // here is unconditionally `automationReady`, exactly like the
-      // freshly-bound branch. Recording it here closes the gap where a
-      // recovered session's readiness cache stayed `undefined` and the first
-      // `automationReady` tool after recovery redundantly re-ran setup.
-      recordAcquiredSessionReadiness(
+        bootService,
+        deviceUtils,
         daemonState,
+        totalDeadlineMs: budgets.automationDeadlineMs,
+        readinessTimeoutMs: budgets.automationReadyTimeoutMs,
+        timer: deps.timer,
+        signal,
+        progress,
+        perf,
+        requestedIdentity,
+        ensureCtrlProxyReady: ctrlProxySetup,
+        releaseReadinessReservations,
+      });
+      state.boot = readinessResult.boot;
+      sourceImage = state.boot.sourceImage ?? sourceImage;
+      // Re-check under the later binding lock because pool identity can change
+      // while runner setup is in flight.
+      validatePooledDeviceMapping(state.boot.device, requestedIdentity);
+
+      // Publish only after runner health passes. Readiness remains per-device,
+      // so 20-40 concurrent emulators do not serialize on a host-wide gate.
+      publishWarmDeviceReady(state.boot.source, state.boot.device.deviceId);
+      await validatePreservedSystemUiAnrRecoverySession(
         readinessResult.preservedSessionId,
-        "automationReady",
+        readinessResult.validatePreservedSession,
+        readinessResult.retireReplacement,
       );
-    }
+      const verifiedWarmAndroidAvdIdentity = getVerifiedWarmAndroidAvdIdentity(
+        state.boot,
+        sourceImage,
+      );
+      const boundSessionId =
+        readinessResult.preservedSessionId ??
+        (await bindBootedDeviceSession(
+          state.boot.device,
+          args,
+          state.boot.source === "cold-boot" ? sourceImage : undefined,
+          state.boot.processHandle,
+          new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
+          verifiedWarmAndroidAvdIdentity,
+        ));
+      if (readinessResult.preservedSessionId) {
+        // #6227 round 7: the System UI ANR recovery path above bypasses
+        // `bindBootedDeviceSession` (and therefore its own
+        // `recordAcquiredSessionReadiness` call) entirely when a preserved
+        // session is being reused. But by this point
+        // `prepareStartDeviceRunnerReadiness` has already run the *same*
+        // `ensureCtrlProxyReady` setup this function always awaits for a
+        // freshly-bound session — recovery re-verified runner readiness on the
+        // replacement device before handing back `preservedSessionId` (see
+        // `ensureRunnerReadyWithSystemUiAnrRecovery`) — so the achieved level
+        // here is unconditionally `automationReady`, exactly like the
+        // freshly-bound branch. Recording it here closes the gap where a
+        // recovered session's readiness cache stayed `undefined` and the first
+        // `automationReady` tool after recovery redundantly re-ran setup.
+        recordAcquiredSessionReadiness(
+          daemonState,
+          readinessResult.preservedSessionId,
+          "automationReady",
+        );
+      }
+      return boundSessionId;
+    });
     state.ownershipTransferred = true;
 
     await notifyResourcesAfterDeviceBoot(state.boot, perf, deps.notifyResourcesChanged);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -51,6 +51,7 @@ import {
   type DeviceProvisioner,
 } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
+import type { DeviceReadinessLevel } from "../utils/DeviceSessionManager";
 import type { DevicePool, DeviceReadinessReservation, PooledDevice } from "../daemon/devicePool";
 import type { Session, SessionManager } from "../daemon/sessionManager";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
@@ -4651,6 +4652,9 @@ export function registerDeviceTools() {
         },
         provisioned.device,
         boot.processHandle,
+        undefined,
+        undefined,
+        resolveProvisionDeviceAchievedReadiness(args.readiness),
       );
       ownershipTransferred = true;
       return { device: boot.device, sessionId, source: boot.source };
@@ -4662,6 +4666,19 @@ export function registerDeviceTools() {
     } finally {
       await releaseReadinessReservation?.();
     }
+  }
+
+  /**
+   * The `DeviceReadinessLevel` actually achieved by `provisionDevice` for the
+   * requested `readiness` option. `"automation"` runs `ensureCtrlProxyReady`
+   * in `ensureProvisionDeviceReadiness` and reaches `automationReady`;
+   * `"none"` deliberately skips that setup, leaving the device merely booted
+   * (#6227 round 6).
+   */
+  function resolveProvisionDeviceAchievedReadiness(
+    readiness: ProvisionDeviceArgs["readiness"],
+  ): DeviceReadinessLevel {
+    return readiness === "automation" ? "automationReady" : "booted";
   }
 
   async function reserveProvisionDeviceReadiness(
@@ -5246,6 +5263,7 @@ export function registerDeviceTools() {
     childProcess?: ChildProcess | null,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
+    achievedReadiness: DeviceReadinessLevel = "automationReady",
   ): Promise<string> {
     // Reserve the exact ready device before resource notifications publish it
     // to concurrent allocators.
@@ -5264,7 +5282,7 @@ export function registerDeviceTools() {
           verifiedAndroidAvdIdentity,
         );
       if (autolockSessionId) {
-        recordAcquiredSessionReadiness(daemonState, autolockSessionId);
+        recordAcquiredSessionReadiness(daemonState, autolockSessionId, achievedReadiness);
         return autolockSessionId;
       }
     }
@@ -5287,20 +5305,24 @@ export function registerDeviceTools() {
         readinessReservationOwners,
         verifiedAndroidAvdIdentity,
       );
-    recordAcquiredSessionReadiness(daemonState, boundSessionId);
+    recordAcquiredSessionReadiness(daemonState, boundSessionId, achievedReadiness);
     return boundSessionId;
   }
 
   /**
-   * Record `automationReady` for a session bound by `bindBootedDeviceSession`
-   * (#6227 P1 follow-up). By the time that function runs, the caller
-   * (`bootAndPrepareDevice`) has already awaited
-   * `prepareStartDeviceRunnerReadiness` successfully for this device — CtrlProxy
-   * / accessibility-service setup for android is genuinely done, not merely
-   * assumed. Without recording it here, the session's `deviceReadiness` slot
-   * stays `undefined` and the first subsequent `automationReady` tool call
-   * (e.g. `observe`) sees that as unsatisfied and redundantly reruns setup via
-   * `ToolExecutionContext`'s `existingSession` upgrade path.
+   * Record the readiness level actually ACHIEVED by acquisition for a session
+   * bound by `bindBootedDeviceSession` (#6227 P1 follow-up, round 6 fix). By
+   * the time that function runs, the caller has already awaited whatever
+   * readiness setup it chose to run for this device: normal `getAndroid` /
+   * `startDevice` acquisition always awaits `prepareStartDeviceRunnerReadiness`
+   * successfully, so CtrlProxy / accessibility-service setup is genuinely done
+   * and `automationReady` is correct. But `provisionDevice({ readiness: "none" })`
+   * deliberately SKIPS that setup in `ensureProvisionDeviceReadiness` — for that
+   * path recording a hardcoded `automationReady` would be a lie: a later
+   * `observe` (or any other `automationReady`-requiring tool) would see the
+   * session's `deviceReadiness` slot already satisfied and skip the setup it
+   * still needs. Callers must pass the readiness level actually achieved
+   * (`achievedReadiness`), not assume the highest one.
    *
    * This is only reached for a freshly-bound (non-recovered) session: the
    * `readinessResult.preservedSessionId` recovery path in `bootAndPrepareDevice`
@@ -5309,8 +5331,12 @@ export function registerDeviceTools() {
    * and still runs setup on next use, preserving the concurrency-hole fix in
    * `isReadinessSatisfied`.
    */
-  function recordAcquiredSessionReadiness(daemonState: DaemonState, sessionId: string): void {
-    daemonState.getSessionManager().setDeviceReadiness(sessionId, "automationReady");
+  function recordAcquiredSessionReadiness(
+    daemonState: DaemonState,
+    sessionId: string,
+    achievedReadiness: DeviceReadinessLevel,
+  ): void {
+    daemonState.getSessionManager().setDeviceReadiness(sessionId, achievedReadiness);
   }
 
   async function buildBootedResponse(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -75,6 +75,7 @@ import {
 } from "../utils/RunnerReadinessService";
 import {
   deviceReadinessLockKey,
+  moveDeviceAcquisitionReadiness,
   trackDeviceAcquisitionReadiness,
 } from "../utils/deviceReadinessLock";
 import {
@@ -5049,6 +5050,10 @@ export function registerDeviceTools() {
         releaseReadinessReservations,
       });
       state.boot = readinessResult.boot;
+      moveDeviceAcquisitionReadiness(
+        acquisitionReadinessKey,
+        deviceReadinessLockKey(state.boot.device.platform, state.boot.device.deviceId),
+      );
       sourceImage = state.boot.sourceImage ?? sourceImage;
       // Re-check under the later binding lock because pool identity can change
       // while runner setup is in flight.

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -4212,7 +4212,26 @@ export function registerDeviceTools() {
     if (!revalidatedSession || !getLiveProvisionDeviceSession(result)) {
       return false;
     }
-    await DaemonState.getInstance()
+    const daemonState = DaemonState.getInstance();
+    // #6227 round 7: this point confirms the persisted session is live and
+    // bound to the requested device (`getLiveProvisionDeviceSession` re-check
+    // above), and — when `args.readiness === "automation"` — that
+    // `ensureProvisionDeviceReadiness` just re-verified (or re-established, if
+    // a prior CtrlProxy connection had dropped) automation readiness for it.
+    // Record the readiness level `args.readiness` implies the same way the
+    // initial `bootExactProvisionedDevice` acquisition does
+    // (`resolveProvisionDeviceAchievedReadiness`), so a session whose cache
+    // lost its recorded level (e.g. a fresh `Session` incarnation after daemon
+    // recovery) doesn't report unrecorded readiness to a later tool call and
+    // redundantly re-run setup. `setDeviceReadiness` is monotonic, so this is
+    // a no-op when the level is already recorded at or above what applies
+    // here.
+    recordAcquiredSessionReadiness(
+      daemonState,
+      revalidatedSession.sessionId,
+      resolveProvisionDeviceAchievedReadiness(args.readiness),
+    );
+    await daemonState
       .getDevicePool()
       .attachAutolockSessionToMcpSession(revalidatedSession.sessionId, args.__mcpSessionId);
     return true;
@@ -5032,6 +5051,26 @@ export function registerDeviceTools() {
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
         verifiedWarmAndroidAvdIdentity,
       ));
+    if (readinessResult.preservedSessionId) {
+      // #6227 round 7: the System UI ANR recovery path above bypasses
+      // `bindBootedDeviceSession` (and therefore its own
+      // `recordAcquiredSessionReadiness` call) entirely when a preserved
+      // session is being reused. But by this point
+      // `prepareStartDeviceRunnerReadiness` has already run the *same*
+      // `ensureCtrlProxyReady` setup this function always awaits for a
+      // freshly-bound session — recovery re-verified runner readiness on the
+      // replacement device before handing back `preservedSessionId` (see
+      // `ensureRunnerReadyWithSystemUiAnrRecovery`) — so the achieved level
+      // here is unconditionally `automationReady`, exactly like the
+      // freshly-bound branch. Recording it here closes the gap where a
+      // recovered session's readiness cache stayed `undefined` and the first
+      // `automationReady` tool after recovery redundantly re-ran setup.
+      recordAcquiredSessionReadiness(
+        daemonState,
+        readinessResult.preservedSessionId,
+        "automationReady",
+      );
+    }
     state.ownershipTransferred = true;
 
     await notifyResourcesAfterDeviceBoot(state.boot, perf, deps.notifyResourcesChanged);
@@ -5324,12 +5363,17 @@ export function registerDeviceTools() {
    * still needs. Callers must pass the readiness level actually achieved
    * (`achievedReadiness`), not assume the highest one.
    *
-   * This is only reached for a freshly-bound (non-recovered) session: the
-   * `readinessResult.preservedSessionId` recovery path in `bootAndPrepareDevice`
-   * skips `bindBootedDeviceSession` entirely, so a recovered session whose
-   * readiness was never actually re-verified after recovery stays unrecorded
-   * and still runs setup on next use, preserving the concurrency-hole fix in
-   * `isReadinessSatisfied`.
+   * Called directly (bypassing `bindBootedDeviceSession`) from
+   * `bootAndPrepareDevice`'s `readinessResult.preservedSessionId` branch too
+   * (#6227 round 7): recovery re-verifies runner readiness on the
+   * replacement device before handing back a preserved session id, so that
+   * path's achieved level is likewise always `automationReady`.
+   *
+   * The setter this delegates to (`SessionManager.setDeviceReadiness`) is
+   * monotonic by achieved level (#6227 round 7): a lower level passed here
+   * for a session that already recorded a higher one is a no-op rather than
+   * a downgrade, so callers do not need to compare against the existing
+   * record themselves.
    */
   function recordAcquiredSessionReadiness(
     daemonState: DaemonState,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3303,6 +3303,7 @@ async function rebootAndroidAfterSystemUiAnr(
   timer: Timer,
   signal: AbortSignal | undefined,
   progress: { report: ProgressCallback } | undefined,
+  publishReplacementReadinessMarker?: (replacement: BootedDevice) => void,
 ): Promise<{
   boot: DeviceBootResult;
   preservedSessionId?: string;
@@ -3353,6 +3354,7 @@ async function rebootAndroidAfterSystemUiAnr(
       shutdownReservation,
       adoptedReplacementBoot,
       sourceImage,
+      publishReplacementReadinessMarker,
     );
     keepReadinessReservation = true;
     return {
@@ -3462,6 +3464,7 @@ async function handoffSystemUiAnrReplacement(
   shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>,
   replacementBoot: DeviceBootResult,
   sourceImage: DeviceInfo,
+  publishReplacementReadinessMarker?: (replacement: BootedDevice) => void,
 ): Promise<Awaited<ReturnType<DevicePool["replaceDeviceForSystemUiAnrRecovery"]>> | undefined> {
   if (!devicePool || !shutdownReservation) {
     return undefined;
@@ -3471,6 +3474,7 @@ async function handoffSystemUiAnrReplacement(
     replacementBoot.device,
     sourceImage,
     replacementBoot.processHandle,
+    () => publishReplacementReadinessMarker?.(replacementBoot.device),
   );
 }
 
@@ -3542,7 +3546,6 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
   boot: DeviceBootResult,
   ensureRunnerReady: (candidate: DeviceBootResult) => Promise<void>,
   rebootAfterSystemUiAnr: (candidate: DeviceBootResult) => Promise<SystemUiAnrRecoveryResult>,
-  publishRecoveredReadinessMarker?: (candidate: DeviceBootResult) => void,
 ): Promise<SystemUiAnrRecoveryResult & { recovered: boolean }> {
   try {
     await ensureRunnerReady(boot);
@@ -3556,11 +3559,6 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
     }
     const recovery = await rebootAfterSystemUiAnr(boot);
     try {
-      // The replacement's runner readiness lock can release before this async
-      // function resumes. Publish the acquisition marker under its new device
-      // key before starting that readiness attempt so a queued session upgrade
-      // cannot observe an unrecorded replacement and start duplicate setup.
-      publishRecoveredReadinessMarker?.(recovery.boot);
       await ensureRunnerReady(recovery.boot);
     } catch (readinessError) {
       try {
@@ -3667,7 +3665,6 @@ async function prepareStartDeviceRunnerReadiness(
     input.boot,
     createRunnerReadinessAttempt(input),
     createSystemUiAnrRebooter(input, devicePool),
-    (replacement) => input.publishRecoveredReadinessMarker?.(replacement.device),
   );
   if (readinessResult.recovered) {
     try {
@@ -3769,6 +3766,7 @@ function createSystemUiAnrRebooter(
       input.timer,
       input.signal,
       input.progress ? { report: input.progress } : undefined,
+      (replacement) => input.publishRecoveredReadinessMarker?.(replacement),
     );
 }
 
@@ -5208,6 +5206,17 @@ export function registerDeviceTools() {
 
   // Compatibility implementation. New callers use getAndroid/getApple so their
   // platform identity and readiness budgets are explicit.
+  const stripInternalAcquisitionParams = (rawArgs: object) => {
+    const externalArgs = { ...rawArgs } as Record<string, unknown>;
+    delete externalArgs.__mcpSessionId;
+    delete externalArgs.__executionId;
+    delete externalArgs.__executionStartTime;
+    delete externalArgs.__mcpRequestTimeoutMs;
+    delete externalArgs.__mcpRequestDeadlineMs;
+    delete externalArgs.__mcpLiveDeadlineKey;
+    return externalArgs;
+  };
+
   const startDeviceHandler = async (
     rawArgs: StartDeviceArgs,
     progress?: ProgressCallback,
@@ -5215,7 +5224,7 @@ export function registerDeviceTools() {
   ) => {
     const internalSessionId = rawArgs.__mcpSessionId;
     const args = {
-      ...startDeviceSchema.parse(rawArgs),
+      ...startDeviceSchema.parse(stripInternalAcquisitionParams(rawArgs)),
       __mcpSessionId: internalSessionId,
     };
     const totalTimeoutMs = args.timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
@@ -5244,10 +5253,7 @@ export function registerDeviceTools() {
     signal?: AbortSignal,
   ) => {
     const { __mcpSessionId } = rawArgs;
-    const externalArgs = { ...rawArgs };
-    delete externalArgs.__mcpSessionId;
-    delete externalArgs.__executionId;
-    delete externalArgs.__executionStartTime;
+    const externalArgs = stripInternalAcquisitionParams(rawArgs);
     const args = getAndroidSchema.parse(externalArgs);
     const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
     const automationReadyTimeoutMs =
@@ -5298,10 +5304,7 @@ export function registerDeviceTools() {
     signal?: AbortSignal,
   ) => {
     const { __mcpSessionId } = rawArgs;
-    const externalArgs = { ...rawArgs };
-    delete externalArgs.__mcpSessionId;
-    delete externalArgs.__executionId;
-    delete externalArgs.__executionStartTime;
+    const externalArgs = stripInternalAcquisitionParams(rawArgs);
     const args = getAppleSchema.parse(externalArgs);
     // #5870: `deviceId` is an accepted alias for `udid` on iOS.
     const udid = args.udid ?? args.deviceId!;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3542,6 +3542,7 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
   boot: DeviceBootResult,
   ensureRunnerReady: (candidate: DeviceBootResult) => Promise<void>,
   rebootAfterSystemUiAnr: (candidate: DeviceBootResult) => Promise<SystemUiAnrRecoveryResult>,
+  publishRecoveredReadinessMarker?: (candidate: DeviceBootResult) => void,
 ): Promise<SystemUiAnrRecoveryResult & { recovered: boolean }> {
   try {
     await ensureRunnerReady(boot);
@@ -3555,6 +3556,11 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
     }
     const recovery = await rebootAfterSystemUiAnr(boot);
     try {
+      // The replacement's runner readiness lock can release before this async
+      // function resumes. Publish the acquisition marker under its new device
+      // key before starting that readiness attempt so a queued session upgrade
+      // cannot observe an unrecorded replacement and start duplicate setup.
+      publishRecoveredReadinessMarker?.(recovery.boot);
       await ensureRunnerReady(recovery.boot);
     } catch (readinessError) {
       try {
@@ -3650,6 +3656,7 @@ interface StartDeviceRunnerReadinessInput {
   requestedIdentity: string;
   ensureCtrlProxyReady: (request: RunnerReadinessRequest) => Promise<void>;
   releaseReadinessReservations: DeviceReadinessReservation[];
+  publishRecoveredReadinessMarker?: (device: BootedDevice) => void;
 }
 
 async function prepareStartDeviceRunnerReadiness(
@@ -3660,6 +3667,7 @@ async function prepareStartDeviceRunnerReadiness(
     input.boot,
     createRunnerReadinessAttempt(input),
     createSystemUiAnrRebooter(input, devicePool),
+    (replacement) => input.publishRecoveredReadinessMarker?.(replacement.device),
   );
   if (readinessResult.recovered) {
     try {
@@ -5048,6 +5056,11 @@ export function registerDeviceTools() {
         requestedIdentity,
         ensureCtrlProxyReady: ctrlProxySetup,
         releaseReadinessReservations,
+        publishRecoveredReadinessMarker: (replacement) =>
+          moveDeviceAcquisitionReadiness(
+            acquisitionReadinessKey,
+            deviceReadinessLockKey(replacement.platform, replacement.deviceId),
+          ),
       });
       state.boot = readinessResult.boot;
       moveDeviceAcquisitionReadiness(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -4193,52 +4193,49 @@ export function registerDeviceTools() {
     if (!liveSession) {
       return false;
     }
-    if (args.readiness === "automation") {
-      const perf = createPerformanceTracker(true);
-      perf.serial("provisionDeviceReplay");
-      try {
-        const totalDeadlineMs =
-          deps.timer.now() + (args.timeoutMs ?? DEFAULT_PROVISION_DEVICE_TIMEOUT_MS);
-        await ensureProvisionDeviceReadiness(
-          args,
-          deps,
-          liveSession.device,
-          `platform=${args.device.platform} name=${args.device.name}`,
-          totalDeadlineMs,
-          perf,
-          signal,
+    // A replay can re-establish readiness for a persisted session whose cache
+    // was lost during daemon recovery. Keep that setup, its live-session
+    // recheck, and the readiness record in one device transaction: a tool that
+    // resolves the session concurrently must join this marker rather than see
+    // an unrecorded level after CtrlProxy setup and start a second reset/setup.
+    return await trackDeviceAcquisitionReadiness(
+      deviceReadinessLockKey(liveSession.device.platform, liveSession.device.deviceId),
+      async () => {
+        if (args.readiness === "automation") {
+          const perf = createPerformanceTracker(true);
+          perf.serial("provisionDeviceReplay");
+          try {
+            const totalDeadlineMs =
+              deps.timer.now() + (args.timeoutMs ?? DEFAULT_PROVISION_DEVICE_TIMEOUT_MS);
+            await ensureProvisionDeviceReadiness(
+              args,
+              deps,
+              liveSession.device,
+              `platform=${args.device.platform} name=${args.device.name}`,
+              totalDeadlineMs,
+              perf,
+              signal,
+            );
+          } finally {
+            perf.end();
+          }
+        }
+        const revalidatedSession = getPersistedProvisionDeviceSession(result);
+        if (!revalidatedSession || !getLiveProvisionDeviceSession(result)) {
+          return false;
+        }
+        const daemonState = DaemonState.getInstance();
+        recordAcquiredSessionReadiness(
+          daemonState,
+          revalidatedSession.sessionId,
+          resolveProvisionDeviceAchievedReadiness(args.readiness),
         );
-      } finally {
-        perf.end();
-      }
-    }
-    const revalidatedSession = getPersistedProvisionDeviceSession(result);
-    if (!revalidatedSession || !getLiveProvisionDeviceSession(result)) {
-      return false;
-    }
-    const daemonState = DaemonState.getInstance();
-    // #6227 round 7: this point confirms the persisted session is live and
-    // bound to the requested device (`getLiveProvisionDeviceSession` re-check
-    // above), and — when `args.readiness === "automation"` — that
-    // `ensureProvisionDeviceReadiness` just re-verified (or re-established, if
-    // a prior CtrlProxy connection had dropped) automation readiness for it.
-    // Record the readiness level `args.readiness` implies the same way the
-    // initial `bootExactProvisionedDevice` acquisition does
-    // (`resolveProvisionDeviceAchievedReadiness`), so a session whose cache
-    // lost its recorded level (e.g. a fresh `Session` incarnation after daemon
-    // recovery) doesn't report unrecorded readiness to a later tool call and
-    // redundantly re-run setup. `setDeviceReadiness` is monotonic, so this is
-    // a no-op when the level is already recorded at or above what applies
-    // here.
-    recordAcquiredSessionReadiness(
-      daemonState,
-      revalidatedSession.sessionId,
-      resolveProvisionDeviceAchievedReadiness(args.readiness),
+        await daemonState
+          .getDevicePool()
+          .attachAutolockSessionToMcpSession(revalidatedSession.sessionId, args.__mcpSessionId);
+        return true;
+      },
     );
-    await daemonState
-      .getDevicePool()
-      .attachAutolockSessionToMcpSession(revalidatedSession.sessionId, args.__mcpSessionId);
-    return true;
   }
 
   async function revalidateProvisionDeviceReplay(
@@ -4654,30 +4651,35 @@ export function registerDeviceTools() {
       validatePooledDeviceMapping(boot.device, requestedIdentity);
       releaseReadinessReservation = await reserveProvisionDeviceReadiness(boot.device);
       clearColdBootShutdownMarker(boot.source, boot.device.deviceId);
-      await ensureProvisionDeviceReadiness(
-        args,
-        deps,
-        boot.device,
-        requestedIdentity,
-        totalDeadlineMs,
-        perf,
-        signal,
-      );
-      validatePooledDeviceMapping(boot.device, requestedIdentity);
-      publishWarmDeviceReady(boot.source, boot.device.deviceId);
-      const sessionId = await bindBootedDeviceSession(
-        boot.device,
-        {
-          platform: args.device.platform,
-          name: args.device.name,
-          timeoutMs: args.timeoutMs,
-          __mcpSessionId: args.__mcpSessionId,
+      const sessionId = await trackDeviceAcquisitionReadiness(
+        deviceReadinessLockKey(boot.device.platform, boot.device.deviceId),
+        async () => {
+          await ensureProvisionDeviceReadiness(
+            args,
+            deps,
+            boot!.device,
+            requestedIdentity,
+            totalDeadlineMs,
+            perf,
+            signal,
+          );
+          validatePooledDeviceMapping(boot!.device, requestedIdentity);
+          publishWarmDeviceReady(boot!.source, boot!.device.deviceId);
+          return await bindBootedDeviceSession(
+            boot!.device,
+            {
+              platform: args.device.platform,
+              name: args.device.name,
+              timeoutMs: args.timeoutMs,
+              __mcpSessionId: args.__mcpSessionId,
+            },
+            provisioned.device,
+            boot!.processHandle,
+            undefined,
+            undefined,
+            resolveProvisionDeviceAchievedReadiness(args.readiness),
+          );
         },
-        provisioned.device,
-        boot.processHandle,
-        undefined,
-        undefined,
-        resolveProvisionDeviceAchievedReadiness(args.readiness),
       );
       ownershipTransferred = true;
       return { device: boot.device, sessionId, source: boot.source };

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -523,6 +523,7 @@ export class PlanExecutionOrchestrator {
       this.request.device,
       { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform },
       getToolSelectionContext()?.execution,
+      this.signal,
     );
 
     return deviceMapping;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -530,6 +530,15 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         {
           keepScreenAwake,
           platform: platform === "android" || platform === "ios" ? platform : undefined,
+          // #6227: the persisted/daemon-session path must honor a tool's declared
+          // deviceReadiness the same way the legacy/no-session path below does
+          // (ensureDeviceReady's `readiness` option), so a `booted`-only tool
+          // (e.g. listApps, videoRecordingTools) doesn't pay for (or fail on)
+          // full CtrlProxy accessibility-service setup.
+          deviceReadiness:
+            typeof options.deviceReadiness === "function"
+              ? options.deviceReadiness(args)
+              : options.deviceReadiness,
         },
         execution,
         admittedSession,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -554,6 +554,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
         // discussion for why the reported #6069 bound-connection bypass could not
         // be reproduced through any current public route in-harness.
         true,
+        signal,
       );
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -242,6 +242,22 @@ export interface DeviceSessionManager {
 
 export type DeviceReadinessLevel = "booted" | "automationReady";
 
+/**
+ * Ordering of {@link DeviceReadinessLevel} by how much setup each represents
+ * having achieved. `SessionManager.setDeviceReadiness` (#6227 round 7) uses
+ * this to keep the recorded level monotonic — a session's readiness record
+ * may only be raised, never silently downgraded by a later, less-demanding
+ * acquisition of the same session.
+ */
+const DEVICE_READINESS_RANK: Readonly<Record<DeviceReadinessLevel, number>> = {
+  booted: 0,
+  automationReady: 1,
+};
+
+export function deviceReadinessRank(level: DeviceReadinessLevel): number {
+  return DEVICE_READINESS_RANK[level];
+}
+
 export interface DeviceReadyOptions {
   skipCtrlProxyDownload?: boolean;
   signal?: AbortSignal;

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -9,6 +9,11 @@ import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 import { redactAndroidCommandOutput } from "./android-cmdline-tools/redactAndroidCommandOutput";
 import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import { defaultTimer, type Timer } from "./SystemTimer";
+import {
+  acquireDeviceReadinessLock,
+  deviceReadinessLockKey,
+  type DeviceReadinessLockRelease,
+} from "./deviceReadinessLock";
 import type { PerformanceTracker } from "./PerformanceTracker";
 import type { ProxySetupResult } from "./interfaces/ProxyManager";
 import { runWithAbortSignal } from "./AbortContext";
@@ -181,25 +186,6 @@ interface ReadinessAttemptContext extends RunnerReadinessRequest {
   healthDeadlineMs: number | null;
 }
 
-type ReadinessRelease = () => void;
-
-interface ReadinessWaiter {
-  active: boolean;
-  resolve: (release: ReadinessRelease) => void;
-  reject: (error: unknown) => void;
-  timer: Timer;
-  timeoutHandle?: NodeJS.Timeout;
-  abortListener?: () => void;
-  signal?: AbortSignal;
-}
-
-interface ReadinessLock {
-  locked: boolean;
-  waiters: ReadinessWaiter[];
-}
-
-const readinessLocksByDevice = new Map<string, ReadinessLock>();
-
 export class RunnerReadinessService {
   constructor(private readonly dependencies: RunnerReadinessDependencies) {}
 
@@ -208,7 +194,7 @@ export class RunnerReadinessService {
     // window is opened later (see `startHealthWindow`) so a cold launch cannot
     // starve it (#5376).
     const context: ReadinessAttemptContext = { ...request, healthDeadlineMs: null };
-    const key = `${request.device.platform}:${request.device.deviceId}`;
+    const key = deviceReadinessLockKey(request.device.platform, request.device.deviceId);
     const release = await this.acquireReadinessTurn(context, key);
     try {
       await this.ensureReadyUncoordinated(context);
@@ -228,87 +214,22 @@ export class RunnerReadinessService {
   private async acquireReadinessTurn(
     context: ReadinessAttemptContext,
     key: string,
-  ): Promise<ReadinessRelease> {
+  ): Promise<DeviceReadinessLockRelease> {
     if (this.remainingForPhase(context, "runner-setup") <= 0) {
       this.fail(context, "runner-setup", 1, "readiness budget exhausted before setup lock");
     }
-    const lock = readinessLocksByDevice.get(key) ?? { locked: false, waiters: [] };
-    readinessLocksByDevice.set(key, lock);
-    if (!lock.locked) {
-      lock.locked = true;
-      return this.createReadinessRelease(key, lock);
-    }
     try {
-      return await new Promise<ReadinessRelease>((resolve, reject) => {
-        const waiter: ReadinessWaiter = {
-          active: true,
-          resolve,
-          reject,
-          timer: this.dependencies.timer,
-          signal: context.signal,
-        };
-        const abandon = (error: unknown) => {
-          if (!waiter.active) {
-            return;
-          }
-          waiter.active = false;
-          this.removeReadinessWaiter(lock, waiter);
-          this.cleanupReadinessWaiter(waiter);
-          reject(error);
-        };
-        waiter.timeoutHandle = this.dependencies.timer.setTimeout(
-          () => abandon(new Error("readiness setup lock exceeded this request's deadline")),
-          this.remainingForPhase(context, "runner-setup"),
-        );
-        waiter.abortListener = () => abandon(context.signal?.reason);
-        context.signal?.addEventListener("abort", waiter.abortListener, { once: true });
-        lock.waiters.push(waiter);
-        if (context.signal?.aborted) {
-          waiter.abortListener();
-        }
+      // Shared per-device lock (#6227): the session-scoped readiness upgrade in
+      // ToolExecutionContext participates in this SAME lock, so an acquisition
+      // and an upgrade never reset+setup the same device concurrently.
+      return await acquireDeviceReadinessLock(key, {
+        timer: this.dependencies.timer,
+        signal: context.signal,
+        timeoutMs: this.remainingForPhase(context, "runner-setup"),
+        timeoutError: () => new Error("readiness setup lock exceeded this request's deadline"),
       });
     } catch (error) {
       this.fail(context, "runner-setup", 1, normalizeDiagnostic(error));
-    }
-  }
-
-  private createReadinessRelease(key: string, lock: ReadinessLock): ReadinessRelease {
-    let released = false;
-    return () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      let waiter = lock.waiters.shift();
-      while (waiter && !waiter.active) {
-        waiter = lock.waiters.shift();
-      }
-      if (waiter) {
-        waiter.active = false;
-        this.cleanupReadinessWaiter(waiter);
-        waiter.resolve(this.createReadinessRelease(key, lock));
-        return;
-      }
-      lock.locked = false;
-      if (readinessLocksByDevice.get(key) === lock) {
-        readinessLocksByDevice.delete(key);
-      }
-    };
-  }
-
-  private removeReadinessWaiter(lock: ReadinessLock, waiter: ReadinessWaiter): void {
-    const index = lock.waiters.indexOf(waiter);
-    if (index >= 0) {
-      lock.waiters.splice(index, 1);
-    }
-  }
-
-  private cleanupReadinessWaiter(waiter: ReadinessWaiter): void {
-    if (waiter.timeoutHandle) {
-      waiter.timer.clearTimeout(waiter.timeoutHandle);
-    }
-    if (waiter.abortListener) {
-      waiter.signal?.removeEventListener("abort", waiter.abortListener);
     }
   }
 

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -214,9 +214,21 @@ export async function trackDeviceAcquisitionReadiness<T>(
     return await fn();
   } finally {
     settle();
-    if (deviceAcquisitionReadiness.get(key) === marker) {
-      deviceAcquisitionReadiness.delete(key);
+    // A recovery can replace a device serial after this acquisition begins.
+    // Clear every alias of this marker, not only its original key.
+    for (const [markerKey, current] of deviceAcquisitionReadiness) {
+      if (current === marker) {
+        deviceAcquisitionReadiness.delete(markerKey);
+      }
     }
+  }
+}
+
+/** Move an in-flight acquisition marker to a replacement device identity. */
+export function moveDeviceAcquisitionReadiness(fromKey: string, toKey: string): void {
+  const marker = deviceAcquisitionReadiness.get(fromKey);
+  if (marker && fromKey !== toKey) {
+    deviceAcquisitionReadiness.set(toKey, marker);
   }
 }
 

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -167,3 +167,59 @@ function cleanupReadinessWaiter(waiter: ReadinessWaiter): void {
     waiter.signal?.removeEventListener("abort", waiter.abortListener);
   }
 }
+
+/**
+ * Device-scoped "acquisition is recording readiness" marker (#6280 P2
+ * follow-up).
+ *
+ * The acquisition path (`startDevice`/`getAndroid`) releases the readiness
+ * lock above as soon as `RunnerReadinessService.ensureReady` finishes CtrlProxy
+ * setup — well before it goes on to bind (or reuse) the device's session and
+ * record the achieved readiness on it (`recordAcquiredSessionReadiness` in
+ * `deviceTools.ts`). For a device whose session already existed before this
+ * acquisition started (a post-restart recovered session, reused rather than
+ * freshly created), that session is addressable by UUID throughout this gap.
+ * A concurrent tool call on that UUID can queue behind the readiness lock,
+ * acquire it the instant CtrlProxy setup finishes, observe the still-`undefined`
+ * readiness (not recorded yet), and redundantly reset/rerun CtrlProxy on the
+ * device that was just prepared.
+ *
+ * This map lets that concurrent caller (`ensureReadinessUpgraded` in
+ * `ToolExecutionContext`) detect the in-flight acquisition and await its
+ * completion instead of racing a second setup: once the marker settles,
+ * readiness has been recorded and the caller's own satisfaction check
+ * (re-run in a loop) passes without redoing setup.
+ */
+const deviceAcquisitionReadiness = new Map<string, Promise<void>>();
+
+/**
+ * Run `fn` while `key` is marked as having readiness acquisition in flight.
+ * Callers awaiting {@link getDeviceAcquisitionReadiness} for the same key
+ * resolve once `fn` settles (successfully or not) and the marker is cleared.
+ */
+export async function trackDeviceAcquisitionReadiness<T>(
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let settle!: () => void;
+  const marker = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  deviceAcquisitionReadiness.set(key, marker);
+  try {
+    return await fn();
+  } finally {
+    settle();
+    if (deviceAcquisitionReadiness.get(key) === marker) {
+      deviceAcquisitionReadiness.delete(key);
+    }
+  }
+}
+
+/**
+ * The in-flight acquisition-readiness marker for `key`, if any device
+ * acquisition is currently binding/recording readiness for it.
+ */
+export function getDeviceAcquisitionReadiness(key: string): Promise<void> | undefined {
+  return deviceAcquisitionReadiness.get(key);
+}

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -68,6 +68,10 @@ export function acquireDeviceReadinessLock(
   key: string,
   options: AcquireDeviceReadinessLockOptions = {},
 ): Promise<DeviceReadinessLockRelease> {
+  // A caller that was cancelled before it reached the lock must never start
+  // setup merely because there happened to be no current holder. Queued
+  // callers already get this behavior through their abort listener below.
+  options.signal?.throwIfAborted();
   const timer = options.timer ?? defaultTimer;
   const lock = readinessLocksByDevice.get(key) ?? { locked: false, waiters: [] };
   readinessLocksByDevice.set(key, lock);

--- a/src/utils/deviceReadinessLock.ts
+++ b/src/utils/deviceReadinessLock.ts
@@ -1,0 +1,169 @@
+import { defaultTimer, type Timer } from "./SystemTimer";
+
+/**
+ * Per-device readiness serialization lock (#6227).
+ *
+ * Bringing an Android device to automation readiness resets and re-runs setup
+ * on the *shared*, process-wide per-device `AndroidCtrlProxyManager` singleton
+ * (`resetSetupState()` + `setup()`). Two readiness setups running concurrently
+ * against the same physical device — e.g. a `startDevice`/`getAndroid`/provision
+ * acquisition preparing the device through one daemon queue while a persisted
+ * session's readiness *upgrade* (`ToolExecutionContext`) prepares the same
+ * device through another — would corrupt each other's setup state.
+ *
+ * This module owns the single, process-wide map that serializes readiness setup
+ * per device so both the acquisition path (`RunnerReadinessService`) and the
+ * session-scoped upgrade path (`ToolExecutionContext`) participate in the SAME
+ * lock. The lock is a per-key FIFO mutex: the first caller acquires
+ * immediately, later callers queue and are handed the lock in arrival order as
+ * each holder releases. Waiters may optionally bound their wait with a timeout
+ * and/or an `AbortSignal` (the acquisition path uses its readiness deadline);
+ * an unbounded waiter (the upgrade path) simply waits its turn.
+ */
+
+export type DeviceReadinessLockRelease = () => void;
+
+interface ReadinessWaiter {
+  active: boolean;
+  resolve: (release: DeviceReadinessLockRelease) => void;
+  reject: (error: unknown) => void;
+  timer: Timer;
+  timeoutHandle?: NodeJS.Timeout;
+  abortListener?: () => void;
+  signal?: AbortSignal;
+}
+
+interface ReadinessLock {
+  locked: boolean;
+  waiters: ReadinessWaiter[];
+}
+
+const readinessLocksByDevice = new Map<string, ReadinessLock>();
+
+/**
+ * Canonical lock key for a device. Both the acquisition path and the upgrade
+ * path must derive the key identically so they serialize on the same entry.
+ */
+export function deviceReadinessLockKey(platform: string, deviceId: string): string {
+  return `${platform}:${deviceId}`;
+}
+
+export interface AcquireDeviceReadinessLockOptions {
+  /** Timer used for the optional wait timeout (injected for deterministic tests). */
+  timer?: Timer;
+  /** Aborts a queued wait (never interrupts a holder). */
+  signal?: AbortSignal;
+  /** Bounds how long a queued caller waits before abandoning its turn. */
+  timeoutMs?: number;
+  /** Error a timed-out wait rejects with; defaults to a generic timeout error. */
+  timeoutError?: () => unknown;
+}
+
+/**
+ * Acquire the readiness lock for `key`, resolving with a release function.
+ * Release exactly once (a `withDeviceReadinessLock` wrapper is provided for the
+ * common try/finally case).
+ */
+export function acquireDeviceReadinessLock(
+  key: string,
+  options: AcquireDeviceReadinessLockOptions = {},
+): Promise<DeviceReadinessLockRelease> {
+  const timer = options.timer ?? defaultTimer;
+  const lock = readinessLocksByDevice.get(key) ?? { locked: false, waiters: [] };
+  readinessLocksByDevice.set(key, lock);
+  if (!lock.locked) {
+    lock.locked = true;
+    return Promise.resolve(createRelease(key, lock));
+  }
+  return new Promise<DeviceReadinessLockRelease>((resolve, reject) => {
+    const waiter: ReadinessWaiter = {
+      active: true,
+      resolve,
+      reject,
+      timer,
+      signal: options.signal,
+    };
+    const abandon = (error: unknown) => {
+      if (!waiter.active) {
+        return;
+      }
+      waiter.active = false;
+      removeReadinessWaiter(lock, waiter);
+      cleanupReadinessWaiter(waiter);
+      reject(error);
+    };
+    if (options.timeoutMs !== undefined) {
+      waiter.timeoutHandle = timer.setTimeout(
+        () =>
+          abandon(
+            options.timeoutError
+              ? options.timeoutError()
+              : new Error("device readiness lock wait timed out"),
+          ),
+        options.timeoutMs,
+      );
+    }
+    if (options.signal) {
+      waiter.abortListener = () => abandon(options.signal!.reason);
+      options.signal.addEventListener("abort", waiter.abortListener, { once: true });
+    }
+    lock.waiters.push(waiter);
+    if (options.signal?.aborted) {
+      waiter.abortListener!();
+    }
+  });
+}
+
+/** Acquire the device readiness lock, run `fn`, and release the lock. */
+export async function withDeviceReadinessLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  options: AcquireDeviceReadinessLockOptions = {},
+): Promise<T> {
+  const release = await acquireDeviceReadinessLock(key, options);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+function createRelease(key: string, lock: ReadinessLock): DeviceReadinessLockRelease {
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    let waiter = lock.waiters.shift();
+    while (waiter && !waiter.active) {
+      waiter = lock.waiters.shift();
+    }
+    if (waiter) {
+      waiter.active = false;
+      cleanupReadinessWaiter(waiter);
+      waiter.resolve(createRelease(key, lock));
+      return;
+    }
+    lock.locked = false;
+    if (readinessLocksByDevice.get(key) === lock) {
+      readinessLocksByDevice.delete(key);
+    }
+  };
+}
+
+function removeReadinessWaiter(lock: ReadinessLock, waiter: ReadinessWaiter): void {
+  const index = lock.waiters.indexOf(waiter);
+  if (index >= 0) {
+    lock.waiters.splice(index, 1);
+  }
+}
+
+function cleanupReadinessWaiter(waiter: ReadinessWaiter): void {
+  if (waiter.timeoutHandle) {
+    waiter.timer.clearTimeout(waiter.timeoutHandle);
+  }
+  if (waiter.abortListener) {
+    waiter.signal?.removeEventListener("abort", waiter.abortListener);
+  }
+}

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -350,6 +350,48 @@ describe("DevicePool autolock", () => {
       ).toBeUndefined();
     });
 
+    it("records achieved readiness before publishing the MCP session route (#6227 round 9)", async () => {
+      await initializeLiveAndroidDevice();
+
+      // A concurrent tool call from the same MCP client reaches the new session
+      // through `resolveAutolockSessionForMcpSession`. Readiness must be recorded
+      // before that route is publishable, or the concurrent call could observe an
+      // unrecorded readiness and redundantly re-run (or wrongly skip) setup.
+      const originalSetter = sessionManager.setDeviceReadiness.bind(sessionManager);
+      let routeResolvableAtRecordTime: string | undefined = "setter-not-called";
+      sessionManager.setDeviceReadiness = (sessionId, level) => {
+        routeResolvableAtRecordTime = pool.resolveAutolockSessionForMcpSession(
+          "mcp-session-1",
+          "android",
+        );
+        originalSetter(sessionId, level);
+      };
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+
+      expect(routeResolvableAtRecordTime).toBeUndefined();
+      expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(sessionId);
+      expect(sessionManager.getDeviceReadiness(sessionId!)).toBe("automationReady");
+    });
+
+    it("honors the achieved readiness level passed to autolockDevice (#6227 round 9)", async () => {
+      await initializeLiveAndroidDevice();
+
+      const sessionId = await pool.autolockDevice(
+        "emulator-5554",
+        "android",
+        "mcp-session-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "booted",
+      );
+
+      expect(sessionManager.getDeviceReadiness(sessionId!)).toBe("booted");
+    });
+
     it("clears MCP session mapping when the autolock session expires", async () => {
       await initializeLiveAndroidDevice();
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6288,4 +6288,56 @@ describe("DevicePool", () => {
       expect(appsAfter.length).toBe(0);
     });
   });
+
+  // #6227 round 7: `bindOrReuseDeviceSession` can hand back a live session
+  // already bound to the exact requested device (`reuseExistingDeviceSession`)
+  // instead of the caller's own session id. A later, less-demanding
+  // acquisition of that same reused session (e.g. a `booted`-only or
+  // `provisionDevice({ readiness: "none" })` caller) must not downgrade its
+  // already-recorded `automationReady` readiness — `setDeviceReadiness` is
+  // monotonic by achieved level, so recording the lower level afterward is a
+  // no-op.
+  describe("bindOrReuseDeviceSession reuse keeps readiness monotonic (#6227 round 7)", () => {
+    test("readiness recorded for a reused live session is not downgraded", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+
+      const firstBinding = await devicePool.bindOrReuseDeviceSession(
+        "session-first",
+        "emulator-5554",
+        "android",
+        sourceImage,
+      );
+      expect(firstBinding).toBe("session-first");
+      sessionManager.setDeviceReadiness("session-first", "automationReady");
+      expect(sessionManager.getDeviceReadiness("session-first")).toBe("automationReady");
+
+      // A second, unrelated session id requests the same already-live device
+      // without a fresh source image (mirrors a warm/already-booted
+      // acquisition) — the pool hands back the existing session rather than
+      // binding the new id.
+      const secondBinding = await devicePool.bindOrReuseDeviceSession(
+        "session-second",
+        "emulator-5554",
+        "android",
+        undefined,
+      );
+      expect(secondBinding).toBe("session-first");
+
+      // The caller that requested this acquisition only needed `booted` (or
+      // ran `provisionDevice({ readiness: "none" })`), so it records that
+      // lower achieved level on the session it got back — which is the
+      // reused `session-first`, not its own requested id.
+      sessionManager.setDeviceReadiness(secondBinding, "booted");
+
+      expect(sessionManager.getDeviceReadiness("session-first")).toBe("automationReady");
+    });
+  });
 });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2317,12 +2317,21 @@ describe("DevicePool", () => {
           ...device,
           deviceId: "emulator-5556",
         };
+        let readinessMarkerPublished = false;
         const handoff = await devicePool.replaceDeviceForSystemUiAnrRecovery(
           shutdownReservation.device,
           replacement,
           sourceImage,
+          undefined,
+          () => {
+            // Session work can discover the replacement inside addDevice, so
+            // the marker must exist before that publication point.
+            expect(devicePool.getDevice(replacement.deviceId)).toBeNull();
+            readinessMarkerPublished = true;
+          },
         );
 
+        expect(readinessMarkerPublished).toBe(true);
         expect(handoff.preservedSessionId).toBe("owner-session");
         expect(devicePool.getDevice(device.deviceId)).toBeNull();
         expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -3555,4 +3555,33 @@ describe("SessionManager", () => {
       manager.stopCleanupTimer();
     }
   });
+
+  describe("setDeviceReadiness (#6227 round 7)", () => {
+    test("records a level when none is recorded yet", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      sessionManager.setDeviceReadiness("session-1", "booted");
+      expect(sessionManager.getDeviceReadiness("session-1")).toBe("booted");
+    });
+
+    test("raises the recorded level from booted to automationReady", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      sessionManager.setDeviceReadiness("session-1", "booted");
+      sessionManager.setDeviceReadiness("session-1", "automationReady");
+      expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
+    });
+
+    test("does NOT downgrade automationReady to booted (monotonic)", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      sessionManager.setDeviceReadiness("session-1", "automationReady");
+      sessionManager.setDeviceReadiness("session-1", "booted");
+      expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
+    });
+
+    test("re-recording the same level is a no-op", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      sessionManager.setDeviceReadiness("session-1", "automationReady");
+      sessionManager.setDeviceReadiness("session-1", "automationReady");
+      expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
+    });
+  });
 });

--- a/test/helpers/stubCtrlProxySetup.ts
+++ b/test/helpers/stubCtrlProxySetup.ts
@@ -38,6 +38,7 @@ export function installNoOpReadinessDriver(): void {
     resetSetupState: () => {},
     setup: async () => ({ success: true, message: "ok" }),
     waitForConnection: async () => true,
+    isInstalled: async () => true,
   }));
 }
 
@@ -51,6 +52,7 @@ export function stubCtrlProxySetup(): CtrlProxySetupStub {
       return { success: true, message: "ok" };
     },
     waitForConnection: async () => true,
+    isInstalled: async () => true,
   }));
 
   return {

--- a/test/helpers/stubCtrlProxySetup.ts
+++ b/test/helpers/stubCtrlProxySetup.ts
@@ -39,6 +39,7 @@ export function installNoOpReadinessDriver(): void {
     setup: async () => ({ success: true, message: "ok" }),
     waitForConnection: async () => true,
     isInstalled: async () => true,
+    isVersionCompatible: async () => true,
   }));
 }
 
@@ -53,6 +54,7 @@ export function stubCtrlProxySetup(): CtrlProxySetupStub {
     },
     waitForConnection: async () => true,
     isInstalled: async () => true,
+    isVersionCompatible: async () => true,
   }));
 
   return {

--- a/test/helpers/stubCtrlProxySetup.ts
+++ b/test/helpers/stubCtrlProxySetup.ts
@@ -1,59 +1,61 @@
-import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
-import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { setDeviceReadinessProxyDriverProviderForTesting } from "../../src/server/deviceReadinessProxyProvider";
+
+export { setDeviceReadinessProxyDriverProviderForTesting };
 
 /**
  * #6227: `createToolExecutionContext`'s device-readiness upgrade
  * (`ensureReadinessUpgraded` -> `runDeviceReadinessSetup` ->
- * `ensureAccessibilityServiceReady`) now runs for ANY `existingSession` with
- * no recorded readiness, including sessions minted directly via
- * `SessionManager.createSession` / `DevicePool` in integration tests — which
- * bypass the `deviceTools.ts` acquisition recorder that would otherwise have
- * recorded a readiness level.
+ * `ensureAccessibilityServiceReady`) runs a real Android accessibility-service
+ * setup for ANY `existingSession` with no recorded readiness — including
+ * sessions minted directly via `SessionManager.createSession` / `DevicePool` in
+ * integration tests, which bypass the `deviceTools.ts` acquisition recorder.
  *
- * Against these tests' fake Android device there is no real `adb` (or
- * network) backing `AndroidCtrlProxyManager.getInstance(device).setup()`, so
- * that call can block on a real, unbounded host command / download well
- * past bun's default 5000ms test timeout. A timed-out test skips its
- * `finally` cleanup, leaking process-wide singletons (e.g. `DaemonState`)
- * into every later test in the same `bun test` process — a cascade of
- * unrelated failures.
- *
- * Any integration test that drives a real `ToolRegistry`/`SessionManager`
- * path for an android device MUST call this in `beforeEach` (and
- * `.restore()` in `afterEach`) so accessibility-service setup resolves
- * immediately instead of touching real `adb`.
+ * The shared test preload (`test/setup/testPreload.ts`) already installs a fast
+ * no-op readiness driver process-wide, so no integration test needs to stub this
+ * path itself. This helper remains ONLY for the few tests that must ASSERT the
+ * readiness path ran (via {@link CtrlProxySetupStub.setupCallCount}); it swaps in
+ * a counting no-op driver and, on `restore()`, re-installs the preload's plain
+ * no-op default so later tests in the same process stay neutralized.
  */
 export interface CtrlProxySetupStub {
-  /** Restore the original `getInstance` statics. Call in `afterEach`. */
+  /** Restore the process-wide no-op readiness driver. Call in `afterEach`. */
   restore(): void;
-  /** Number of times the stubbed `setup()` was invoked. */
+  /** Number of times the stubbed readiness `setup()` was invoked. */
   setupCallCount(): number;
 }
 
+/**
+ * Re-install the plain no-op readiness driver used by the shared test preload.
+ *
+ * Test files that need the REAL readiness path (so their own
+ * `AndroidCtrlProxyManager.getInstance` / `AndroidCtrlProxyClient.getInstance`
+ * overrides take effect) call
+ * `setDeviceReadinessProxyDriverProviderForTesting(null)` in `beforeEach` and
+ * this in `afterEach`, so the rest of the `bun test` process stays neutralized.
+ */
+export function installNoOpReadinessDriver(): void {
+  setDeviceReadinessProxyDriverProviderForTesting(() => ({
+    resetSetupState: () => {},
+    setup: async () => ({ success: true, message: "ok" }),
+    waitForConnection: async () => true,
+  }));
+}
+
 export function stubCtrlProxySetup(): CtrlProxySetupStub {
-  const originalGetInstance = AndroidCtrlProxyManager.getInstance;
-  const originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
   let calls = 0;
 
-  AndroidCtrlProxyManager.getInstance = () =>
-    ({
-      resetSetupState: () => {},
-      setup: async () => {
-        calls += 1;
-        return { success: true, message: "ok" };
-      },
-    }) as any;
-  AndroidCtrlProxyClient.getInstance = (() => ({
+  setDeviceReadinessProxyDriverProviderForTesting(() => ({
+    resetSetupState: () => {},
+    setup: async () => {
+      calls += 1;
+      return { success: true, message: "ok" };
+    },
     waitForConnection: async () => true,
-    close: async () => {},
-  })) as any;
-  AndroidCtrlProxyClient.resetInstances();
+  }));
 
   return {
     restore(): void {
-      AndroidCtrlProxyManager.getInstance = originalGetInstance;
-      AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
-      AndroidCtrlProxyClient.resetInstances();
+      installNoOpReadinessDriver();
     },
     setupCallCount: () => calls,
   };

--- a/test/helpers/stubCtrlProxySetup.ts
+++ b/test/helpers/stubCtrlProxySetup.ts
@@ -1,0 +1,60 @@
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+
+/**
+ * #6227: `createToolExecutionContext`'s device-readiness upgrade
+ * (`ensureReadinessUpgraded` -> `runDeviceReadinessSetup` ->
+ * `ensureAccessibilityServiceReady`) now runs for ANY `existingSession` with
+ * no recorded readiness, including sessions minted directly via
+ * `SessionManager.createSession` / `DevicePool` in integration tests — which
+ * bypass the `deviceTools.ts` acquisition recorder that would otherwise have
+ * recorded a readiness level.
+ *
+ * Against these tests' fake Android device there is no real `adb` (or
+ * network) backing `AndroidCtrlProxyManager.getInstance(device).setup()`, so
+ * that call can block on a real, unbounded host command / download well
+ * past bun's default 5000ms test timeout. A timed-out test skips its
+ * `finally` cleanup, leaking process-wide singletons (e.g. `DaemonState`)
+ * into every later test in the same `bun test` process — a cascade of
+ * unrelated failures.
+ *
+ * Any integration test that drives a real `ToolRegistry`/`SessionManager`
+ * path for an android device MUST call this in `beforeEach` (and
+ * `.restore()` in `afterEach`) so accessibility-service setup resolves
+ * immediately instead of touching real `adb`.
+ */
+export interface CtrlProxySetupStub {
+  /** Restore the original `getInstance` statics. Call in `afterEach`. */
+  restore(): void;
+  /** Number of times the stubbed `setup()` was invoked. */
+  setupCallCount(): number;
+}
+
+export function stubCtrlProxySetup(): CtrlProxySetupStub {
+  const originalGetInstance = AndroidCtrlProxyManager.getInstance;
+  const originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
+  let calls = 0;
+
+  AndroidCtrlProxyManager.getInstance = () =>
+    ({
+      resetSetupState: () => {},
+      setup: async () => {
+        calls += 1;
+        return { success: true, message: "ok" };
+      },
+    }) as any;
+  AndroidCtrlProxyClient.getInstance = (() => ({
+    waitForConnection: async () => true,
+    close: async () => {},
+  })) as any;
+  AndroidCtrlProxyClient.resetInstances();
+
+  return {
+    restore(): void {
+      AndroidCtrlProxyManager.getInstance = originalGetInstance;
+      AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
+      AndroidCtrlProxyClient.resetInstances();
+    },
+    setupCallCount: () => calls,
+  };
+}

--- a/test/plan/planExecutorInternalNoDiffE2E.test.ts
+++ b/test/plan/planExecutorInternalNoDiffE2E.test.ts
@@ -15,6 +15,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
+import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * End-to-end guard for issue #3053 part 2: run a real `DefaultPlanExecutor` step
@@ -36,6 +37,7 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
   let originalDiff: boolean;
+  let ctrlProxyStub: CtrlProxySetupStub;
 
   function sameScreenObserve(): ObserveResult {
     return {
@@ -85,6 +87,12 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
     originalDiff = serverConfig.isActionsDiffObserveEnabled();
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    // #6227: `setupAutolockedSession` creates its session directly via
+    // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
+    // recorder), so it drives real per-session accessibility-service setup
+    // against a fake device with no real `adb`/network backing it — see
+    // test/helpers/stubCtrlProxySetup.ts.
+    ctrlProxyStub = stubCtrlProxySetup();
   });
 
   afterEach(() => {
@@ -96,6 +104,7 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
     registerInteractionTools();
+    ctrlProxyStub.restore();
   });
 
   test("a plan tapOn step neither diffs its observation nor advances the agent baseline", async () => {

--- a/test/plan/planExecutorInternalNoDiffE2E.test.ts
+++ b/test/plan/planExecutorInternalNoDiffE2E.test.ts
@@ -15,7 +15,6 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
-import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * End-to-end guard for issue #3053 part 2: run a real `DefaultPlanExecutor` step
@@ -37,7 +36,6 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
   let originalDiff: boolean;
-  let ctrlProxyStub: CtrlProxySetupStub;
 
   function sameScreenObserve(): ObserveResult {
     return {
@@ -90,9 +88,9 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
     // #6227: `setupAutolockedSession` creates its session directly via
     // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
     // recorder), so it drives real per-session accessibility-service setup
-    // against a fake device with no real `adb`/network backing it — see
-    // test/helpers/stubCtrlProxySetup.ts.
-    ctrlProxyStub = stubCtrlProxySetup();
+    // against a fake device. The shared test preload
+    // (test/setup/testPreload.ts) installs a no-op readiness driver so that
+    // setup cannot block on real `adb`/network.
   });
 
   afterEach(() => {
@@ -104,7 +102,6 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
     registerInteractionTools();
-    ctrlProxyStub.restore();
   });
 
   test("a plan tapOn step neither diffs its observation nor advances the agent baseline", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -143,6 +143,92 @@ describe("ToolExecutionContext", () => {
     ).toBeUndefined();
   });
 
+  // #6227: the persisted daemon-session path (ToolRegistry passing sessionUuid
+  // into createToolExecutionContext) must honor a tool's declared
+  // deviceReadiness the same way the legacy/no-session path already does via
+  // DeviceSessionManager.ensureDeviceReady's `readiness` option.
+  test("skips accessibility setup for a new session when deviceReadiness is booted (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+
+    const context = await createToolExecutionContext("session-1", sessionManager, devicePool, {
+      ...sessionOptions,
+      deviceReadiness: "booted",
+    });
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(0);
+  });
+
+  test("still runs accessibility setup for a new session when deviceReadiness is automationReady (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const context = await createToolExecutionContext("session-1", sessionManager, devicePool, {
+      ...sessionOptions,
+      deviceReadiness: "automationReady",
+    });
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+  });
+
+  test("a tool not requiring readiness (deviceReadiness omitted) is unaffected on the persisted path (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // No deviceReadiness set — behaves exactly as before this fix (default
+    // automationReady semantics), for both a new session...
+    const freshContext = await createToolExecutionContext(
+      "session-1",
+      sessionManager,
+      devicePool,
+      sessionOptions,
+    );
+    expect(freshContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+
+    // ...and an already-established session (existingSession short-circuit,
+    // unrelated to deviceReadiness).
+    const existingContext = await createToolExecutionContext(
+      "session-1",
+      sessionManager,
+      devicePool,
+      sessionOptions,
+    );
+    expect(existingContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -229,6 +229,93 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(1);
   });
 
+  // #6227 P1 follow-up: a session first reached via a `booted` tool must be
+  // *upgraded* — not left disconnected — when a later call on the same
+  // sessionUuid needs `automationReady`. The `existingSession` fast path must
+  // not silently satisfy a stricter readiness requirement than the session
+  // actually achieved.
+  test("upgrades a booted-only session to automationReady when a later call needs it (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const bootedContext = await createToolExecutionContext(
+      "session-1",
+      sessionManager,
+      devicePool,
+      {
+        ...sessionOptions,
+        deviceReadiness: "booted",
+      },
+    );
+    expect(bootedContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(0);
+    expect(sessionManager.getDeviceReadiness("session-1")).toBe("booted");
+
+    // Same sessionUuid, now via an automationReady tool — must run setup
+    // (upgrade), not take the existingSession skip path.
+    const upgradedContext = await createToolExecutionContext(
+      "session-1",
+      sessionManager,
+      devicePool,
+      {
+        ...sessionOptions,
+        deviceReadiness: "automationReady",
+      },
+    );
+    expect(upgradedContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
+  });
+
+  test("does not redundantly re-run setup for a booted tool after an automationReady session (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const readyContext = await createToolExecutionContext("session-1", sessionManager, devicePool, {
+      ...sessionOptions,
+      deviceReadiness: "automationReady",
+    });
+    expect(readyContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+
+    // Same sessionUuid, now via a booted-only tool — must NOT downgrade or
+    // redundantly redo setup.
+    const bootedContext = await createToolExecutionContext(
+      "session-1",
+      sessionManager,
+      devicePool,
+      {
+        ...sessionOptions,
+        deviceReadiness: "booted",
+      },
+    );
+    expect(bootedContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -783,10 +783,12 @@ describe("ToolExecutionContext", () => {
   test("does not download CtrlProxy when upgrading a booted-only session while --skip-ctrl-proxy-download is set (#6227)", async () => {
     let setupCalls = 0;
     let installed = false;
+    let versionCompatible = true;
     AndroidCtrlProxyManager.getInstance = () =>
       ({
         resetSetupState: () => {},
         isInstalled: async () => installed,
+        isVersionCompatible: async () => versionCompatible,
         setup: async () => {
           setupCalls += 1;
           return { success: true, message: "ok" };
@@ -822,9 +824,24 @@ describe("ToolExecutionContext", () => {
       expect(setupCalls).toBe(0);
       expect(sessionManager.getDeviceReadiness("session-skip-dl")).toBe("booted");
 
-      // With the artifact already present, the upgrade proceeds without a
-      // download (setup runs against an installed package).
+      // Installed but INCOMPATIBLE version: downloads are disabled, so the
+      // incompatible proxy cannot be upgraded. The upgrade must refuse with the
+      // version-mismatch actionable error rather than run `setup()` against the
+      // incompatible installed proxy.
       installed = true;
+      versionCompatible = false;
+      await expect(
+        createToolExecutionContext("session-skip-dl", sessionManager, devicePool, {
+          ...sessionOptions,
+          deviceReadiness: "automationReady",
+        }),
+      ).rejects.toThrow(/CtrlProxy version mismatch/);
+      expect(setupCalls).toBe(0);
+      expect(sessionManager.getDeviceReadiness("session-skip-dl")).toBe("booted");
+
+      // With the artifact already present AND compatible, the upgrade proceeds
+      // without a download (setup runs against an installed package).
+      versionCompatible = true;
       const upgraded = await createToolExecutionContext(
         "session-skip-dl",
         sessionManager,

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -19,6 +19,7 @@ import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepositor
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { getAbortSignal } from "../../src/utils/AbortContext";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
 import type { DeviceSession } from "../../src/db/types";
 
@@ -966,6 +967,70 @@ describe("ToolExecutionContext", () => {
     expect(context.deviceId).toBe("device-1");
     expect(setupCalls).toBe(0);
     expect(sessionManager.getDeviceReadiness("session-acquisition-race")).toBe("automationReady");
+  });
+
+  test("cancels while queued for a device readiness transaction without starting setup (#6280)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+    await sessionManager.createSession("session-cancelled-readiness", "device-1", "android");
+
+    const release = await acquireDeviceReadinessLock(deviceReadinessLockKey("android", "device-1"));
+    const controller = new AbortController();
+    const context = createToolExecutionContext(
+      "session-cancelled-readiness",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      undefined,
+      false,
+      controller.signal,
+    );
+
+    controller.abort(new Error("request cancelled"));
+    await expect(context).rejects.toThrow("request cancelled");
+    release();
+    expect(setupCalls).toBe(0);
+  });
+
+  test("runs session readiness setup with the request abort signal in its ambient context (#6280)", async () => {
+    let setupSignal: AbortSignal | undefined;
+    setDeviceReadinessProxyDriverProviderForTesting(() => ({
+      resetSetupState: () => {},
+      setup: async () => {
+        setupSignal = getAbortSignal();
+        return { success: true, message: "ok" };
+      },
+      waitForConnection: async () => true,
+      isInstalled: async () => true,
+      isVersionCompatible: async () => true,
+    }));
+    await sessionManager.createSession("session-signal-readiness", "device-1", "android");
+    const controller = new AbortController();
+
+    await createToolExecutionContext(
+      "session-signal-readiness",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      undefined,
+      false,
+      controller.signal,
+    );
+
+    expect(setupSignal).toBe(controller.signal);
   });
 
   test("should not run accessibility setup for existing sessions", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -363,6 +363,82 @@ describe("ToolExecutionContext", () => {
     expect(sessionManager.getDeviceReadiness("session-race-window")).toBe("automationReady");
   });
 
+  // #6227 P1 review follow-up: two `automationReady` calls that reach a
+  // freshly-published session (readiness still undefined) *concurrently* must
+  // NOT both run `runDeviceReadinessSetup` — the second observing the first
+  // mid-setup would call `resetSetupState()` on the shared per-device
+  // CtrlProxy manager while the first's `setup()` is still in flight. Setup
+  // must run exactly once (single-flight), and both callers must observe the
+  // upgraded readiness once it resolves.
+  test("serializes concurrent automationReady upgrades on the same session so setup runs exactly once (#6227)", async () => {
+    let setupCalls = 0;
+    let resetCalls = 0;
+    let releaseSetup!: () => void;
+    const setupGate = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    let setupEnteredResolve!: () => void;
+    const setupEntered = new Promise<void>((resolve) => {
+      setupEnteredResolve = resolve;
+    });
+
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {
+          resetCalls += 1;
+        },
+        setup: async () => {
+          setupCalls += 1;
+          setupEnteredResolve();
+          await setupGate;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // Publish the session with readiness NOT YET recorded — the same window
+    // a recovered/newly-published session sits in before this module's own
+    // setup pass records a level.
+    await sessionManager.createSession("session-race-concurrent", "device-1", "android");
+    expect(sessionManager.getDeviceReadiness("session-race-concurrent")).toBeUndefined();
+
+    const call1 = createToolExecutionContext(
+      "session-race-concurrent",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    // Let call1 run until it has actually entered `setup()` (i.e. it has
+    // already registered itself as the in-flight upgrade for this session)
+    // before starting the second, concurrent caller.
+    await setupEntered;
+
+    const call2 = createToolExecutionContext(
+      "session-race-concurrent",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    // Give call2 a chance to observe the in-flight upgrade and start
+    // awaiting it, then let the single in-flight setup complete.
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseSetup();
+
+    const [context1, context2] = await Promise.all([call1, call2]);
+
+    expect(context1.deviceId).toBe("device-1");
+    expect(context2.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(resetCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-race-concurrent")).toBe("automationReady");
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -1004,7 +1004,7 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(0);
   });
 
-  test("runs session readiness setup with the request abort signal in its ambient context (#6280)", async () => {
+  test("runs session readiness setup with a flight signal that is independent of one requester (#6280)", async () => {
     let setupSignal: AbortSignal | undefined;
     setDeviceReadinessProxyDriverProviderForTesting(() => ({
       resetSetupState: () => {},
@@ -1030,7 +1030,53 @@ describe("ToolExecutionContext", () => {
       controller.signal,
     );
 
-    expect(setupSignal).toBe(controller.signal);
+    expect(setupSignal).toBeDefined();
+    expect(setupSignal).not.toBe(controller.signal);
+    expect(setupSignal!.aborted).toBe(false);
+  });
+
+  test("does not let a cancelled readiness-flight initiator cancel a live joiner (#6280)", async () => {
+    let resolveSetup!: () => void;
+    const setupStarted = new Promise<void>((resolve) => {
+      resolveSetup = resolve;
+    });
+    let setupCalls = 0;
+    setDeviceReadinessProxyDriverProviderForTesting(() => ({
+      resetSetupState: () => {},
+      setup: async () => {
+        setupCalls += 1;
+        await setupStarted;
+        return { success: true, message: "ok" };
+      },
+      waitForConnection: async () => true,
+      isInstalled: async () => true,
+      isVersionCompatible: async () => true,
+    }));
+    await sessionManager.createSession("session-shared-flight", "device-1", "android");
+    const firstController = new AbortController();
+    const first = createToolExecutionContext(
+      "session-shared-flight",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      undefined,
+      false,
+      firstController.signal,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    const second = createToolExecutionContext(
+      "session-shared-flight",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    firstController.abort(new Error("first request cancelled"));
+    await expect(first).rejects.toThrow("first request cancelled");
+    resolveSetup();
+    await expect(second).resolves.toMatchObject({ deviceId: "device-1" });
+    expect(setupCalls).toBe(1);
   });
 
   test("should not run accessibility setup for existing sessions", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -4,6 +4,10 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createToolExecutionContext } from "../../src/server/ToolExecutionContext";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import {
+  installNoOpReadinessDriver,
+  setDeviceReadinessProxyDriverProviderForTesting,
+} from "../helpers/stubCtrlProxySetup";
 import { KeepScreenAwakeManager } from "../../src/utils/KeepScreenAwakeManager";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -44,6 +48,14 @@ describe("ToolExecutionContext", () => {
     originalGetInstance = AndroidCtrlProxyManager.getInstance;
     originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
 
+    // These tests exercise the real `ensureAccessibilityServiceReady` path and
+    // stub setup via the `AndroidCtrlProxyManager`/`AndroidCtrlProxyClient`
+    // `getInstance` statics per test. Restore the real readiness driver (which
+    // routes through those statics) so the overrides take effect; the shared
+    // preload's no-op driver (#6227) is re-installed in `afterEach` so the rest
+    // of the process stays neutralized.
+    setDeviceReadinessProxyDriverProviderForTesting(null);
+
     // Reset AndroidCtrlProxyClient instances for clean test state
     AndroidCtrlProxyClient.resetInstances();
   });
@@ -53,6 +65,7 @@ describe("ToolExecutionContext", () => {
     AndroidCtrlProxyManager.getInstance = originalGetInstance;
     AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
     AndroidCtrlProxyClient.resetInstances();
+    installNoOpReadinessDriver();
   });
 
   test("should run accessibility setup when creating a new session", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -1065,12 +1065,10 @@ describe("ToolExecutionContext", () => {
       firstController.signal,
     );
     await new Promise((resolve) => setImmediate(resolve));
-    const second = createToolExecutionContext(
-      "session-shared-flight",
-      sessionManager,
-      devicePool,
-      { ...sessionOptions, deviceReadiness: "automationReady" },
-    );
+    const second = createToolExecutionContext("session-shared-flight", sessionManager, devicePool, {
+      ...sessionOptions,
+      deviceReadiness: "automationReady",
+    });
     await new Promise((resolve) => setImmediate(resolve));
     firstController.abort(new Error("first request cancelled"));
     await expect(first).rejects.toThrow("first request cancelled");

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -9,6 +9,11 @@ import {
   setDeviceReadinessProxyDriverProviderForTesting,
 } from "../helpers/stubCtrlProxySetup";
 import { KeepScreenAwakeManager } from "../../src/utils/KeepScreenAwakeManager";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import {
+  acquireDeviceReadinessLock,
+  deviceReadinessLockKey,
+} from "../../src/utils/deviceReadinessLock";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
@@ -742,8 +747,12 @@ describe("ToolExecutionContext", () => {
     mode = "new";
 
     // The replacement must start its OWN flight rather than joining (and
-    // hanging on) the predecessor's still-pending one.
-    const newContext = await createToolExecutionContext(
+    // resolving from) the predecessor's still-pending one. It queues behind the
+    // old incarnation on the shared per-device readiness lock (#6227 FIX 2), so
+    // release the old (now-released) incarnation's hung setup to free that lock;
+    // the replacement then runs its own setup (setupCalls -> 2) rather than the
+    // predecessor's.
+    const newContextPromise = createToolExecutionContext(
       "session-incarnation-scope",
       sessionManager,
       devicePool,
@@ -752,16 +761,130 @@ describe("ToolExecutionContext", () => {
       replacement,
     );
 
-    expect(newContext.deviceId).toBe("device-1");
-    expect(setupCalls).toBe(2);
-    expect(sessionManager.getDeviceReadiness("session-incarnation-scope")).toBe("automationReady");
-
     releaseOldGate();
     await oldCall.catch(() => {
       // The old incarnation's own call is expected to fail once its setup
       // finally resolves against an already-released session; only the
       // replacement's outcome is under test here.
     });
+
+    const newContext = await newContextPromise;
+
+    expect(newContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(2);
+    expect(sessionManager.getDeviceReadiness("session-incarnation-scope")).toBe("automationReady");
+  });
+
+  // #6227 P1 review follow-up: the readiness UPGRADE path must honor
+  // `--skip-ctrl-proxy-download` exactly as the fresh acquisition path does.
+  // A booted-only session upgraded to automationReady while downloads are
+  // disabled and CtrlProxy is NOT installed must refuse (actionable error)
+  // rather than trigger `setup()`'s download/install of the missing artifact.
+  test("does not download CtrlProxy when upgrading a booted-only session while --skip-ctrl-proxy-download is set (#6227)", async () => {
+    let setupCalls = 0;
+    let installed = false;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        isInstalled: async () => installed,
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    serverConfig.setSkipCtrlProxyDownload(true);
+    try {
+      // A booted-only first touch skips accessibility setup entirely.
+      const bootedContext = await createToolExecutionContext(
+        "session-skip-dl",
+        sessionManager,
+        devicePool,
+        { ...sessionOptions, deviceReadiness: "booted" },
+      );
+      expect(bootedContext.deviceId).toBe("device-1");
+      expect(setupCalls).toBe(0);
+      expect(sessionManager.getDeviceReadiness("session-skip-dl")).toBe("booted");
+
+      // Upgrade to automationReady while CtrlProxy is NOT installed: the fresh
+      // path fails here rather than downloading, so the upgrade must too —
+      // `setup()` (the download/install path) must never run.
+      await expect(
+        createToolExecutionContext("session-skip-dl", sessionManager, devicePool, {
+          ...sessionOptions,
+          deviceReadiness: "automationReady",
+        }),
+      ).rejects.toThrow(/not installed and runner downloads are disabled/);
+      expect(setupCalls).toBe(0);
+      expect(sessionManager.getDeviceReadiness("session-skip-dl")).toBe("booted");
+
+      // With the artifact already present, the upgrade proceeds without a
+      // download (setup runs against an installed package).
+      installed = true;
+      const upgraded = await createToolExecutionContext(
+        "session-skip-dl",
+        sessionManager,
+        devicePool,
+        { ...sessionOptions, deviceReadiness: "automationReady" },
+      );
+      expect(upgraded.deviceId).toBe("device-1");
+      expect(setupCalls).toBe(1);
+      expect(sessionManager.getDeviceReadiness("session-skip-dl")).toBe("automationReady");
+    } finally {
+      serverConfig.setSkipCtrlProxyDownload(false);
+    }
+  });
+
+  // #6227 P1 review follow-up: a session-scoped readiness upgrade must
+  // participate in the SAME per-device readiness lock the acquisition paths
+  // (startDevice/getAndroid/provision, via RunnerReadinessService) hold while
+  // preparing a device, so an upgrade and a concurrent device preparation
+  // never both reset+setup the shared per-device CtrlProxy manager. Here a
+  // concurrent device preparation holds that lock; the upgrade must not run
+  // accessibility setup until the preparation releases it.
+  test("serializes a session upgrade behind a concurrent device preparation holding the per-device readiness lock (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    await sessionManager.createSession("session-device-lock", "device-1", "android");
+
+    // Stand in for a concurrent device preparation (startDevice/getAndroid/
+    // provision via RunnerReadinessService) holding the SAME per-device lock.
+    const release = await acquireDeviceReadinessLock(deviceReadinessLockKey("android", "device-1"));
+
+    const upgrade = createToolExecutionContext("session-device-lock", sessionManager, devicePool, {
+      ...sessionOptions,
+      deviceReadiness: "automationReady",
+    });
+
+    // While the device preparation holds the lock, the upgrade cannot run
+    // accessibility setup — no concurrent reset+setup on the shared manager.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(setupCalls).toBe(0);
+
+    // Once the device preparation releases, the queued upgrade proceeds and
+    // runs setup exactly once.
+    release();
+    const context = await upgrade;
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-device-lock")).toBe("automationReady");
   });
 
   test("should not run accessibility setup for existing sessions", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -439,6 +439,85 @@ describe("ToolExecutionContext", () => {
     expect(sessionManager.getDeviceReadiness("session-race-concurrent")).toBe("automationReady");
   });
 
+  // #6227 P1 follow-up (round 3): the round-2 single-flight above only
+  // serialized the *existing-session upgrade* path. A brand-new sessionUuid
+  // that two callers race for concurrently hits a second, unguarded hole:
+  // `getSessionForNewExecution` returns `null` (existingSession) for BOTH
+  // callers before either's `getOrCreateSession` call has published the
+  // session, so both `setupSession` invocations take the *fresh-session*
+  // branch (`existingSession === session` is false for both) — and, before
+  // this fix, that branch called `runDeviceReadinessSetup` directly,
+  // unguarded by `readinessUpgradeInFlight`. Both callers join the same
+  // `pendingSessionAssignments` entry (so they resolve to the identical
+  // `Session` object), then both would concurrently call
+  // `resetSetupState()`/`setup()` on the shared per-device CtrlProxy manager.
+  // Routing the fresh-session branch through `ensureReadinessUpgraded` too
+  // (same map, keyed by `session.sessionId`) closes this: setup must run
+  // exactly once even when both concurrent callers take the fresh path.
+  test("routes concurrent fresh-session setups for the same new sessionUuid through the single-flight so setup runs exactly once (#6227)", async () => {
+    let setupCalls = 0;
+    let resetCalls = 0;
+    let releaseSetup!: () => void;
+    const setupGate = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    let setupEnteredResolve!: () => void;
+    const setupEntered = new Promise<void>((resolve) => {
+      setupEnteredResolve = resolve;
+    });
+
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {
+          resetCalls += 1;
+        },
+        setup: async () => {
+          setupCalls += 1;
+          setupEnteredResolve();
+          await setupGate;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // Neither call awaits before the other starts: both synchronously
+    // observe `getSessionForNewExecution` returning `null` for this
+    // never-before-seen sessionUuid, then join the same
+    // `pendingSessionAssignments` entry once the second call reaches it —
+    // exactly the race described above.
+    const call1 = createToolExecutionContext(
+      "session-race-fresh-both",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+    const call2 = createToolExecutionContext(
+      "session-race-fresh-both",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    // Let the single in-flight setup actually enter `setup()` before
+    // releasing it, then give any second (would-be) caller a chance to
+    // observe the in-flight upgrade before it completes.
+    await setupEntered;
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseSetup();
+
+    const [context1, context2] = await Promise.all([call1, call2]);
+
+    expect(context1.deviceId).toBe("device-1");
+    expect(context2.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(resetCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-race-fresh-both")).toBe("automationReady");
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -13,6 +13,7 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 import {
   acquireDeviceReadinessLock,
   deviceReadinessLockKey,
+  trackDeviceAcquisitionReadiness,
 } from "../../src/utils/deviceReadinessLock";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -902,6 +903,69 @@ describe("ToolExecutionContext", () => {
     expect(context.deviceId).toBe("device-1");
     expect(setupCalls).toBe(1);
     expect(sessionManager.getDeviceReadiness("session-device-lock")).toBe("automationReady");
+  });
+
+  // #6280 P2 review follow-up: a device acquisition (startDevice/getAndroid)
+  // releases the per-device readiness lock as soon as CtrlProxy setup
+  // finishes — well before it goes on to bind/reuse the session and record
+  // its achieved readiness. A concurrent upgrade for that SAME (already
+  // reused, post-restart recovered) session must not race a second setup in
+  // that gap; it must join the acquisition's marker and observe the recorded
+  // readiness once the acquisition finishes.
+  test("joins an in-flight device acquisition instead of redoing CtrlProxy setup for a reused session (#6280)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // A post-restart recovered session: already tracked, readiness never
+    // recorded — mirrors a session reused by a concurrent acquisition.
+    await sessionManager.createSession("session-acquisition-race", "device-1", "android");
+
+    // Stand in for a device acquisition that has already released the
+    // per-device readiness lock (CtrlProxy setup finished) but has not yet
+    // bound/recorded readiness for the reused session.
+    let resolveAcquisition!: () => void;
+    const acquisitionDone = new Promise<void>((resolve) => {
+      resolveAcquisition = resolve;
+    });
+    const acquisitionPromise = trackDeviceAcquisitionReadiness(
+      deviceReadinessLockKey("android", "device-1"),
+      async () => {
+        await acquisitionDone;
+        sessionManager.setDeviceReadiness("session-acquisition-race", "automationReady");
+      },
+    );
+
+    const upgrade = createToolExecutionContext(
+      "session-acquisition-race",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    // While the acquisition marker is set, the upgrade must wait on it
+    // instead of racing its own CtrlProxy setup on the device just prepared.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(setupCalls).toBe(0);
+
+    resolveAcquisition();
+    await acquisitionPromise;
+    const context = await upgrade;
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(0);
+    expect(sessionManager.getDeviceReadiness("session-acquisition-race")).toBe("automationReady");
   });
 
   test("should not run accessibility setup for existing sessions", async () => {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -229,6 +229,83 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(1);
   });
 
+  // #6227 P1 (round 5): a NORMAL freshly-acquired session (getAndroid /
+  // startDevice) already ran `prepareStartDeviceRunnerReadiness` — CtrlProxy /
+  // accessibility-service setup genuinely completed — before the session was
+  // bound. The acquisition/binding path now records that achieved level via
+  // `setDeviceReadiness` at bind time (mirroring what `bindBootedDeviceSession`
+  // in deviceTools.ts does), so the first subsequent `automationReady` tool
+  // call must NOT see `undefined` and redundantly re-run setup.
+  test("does not redundantly re-run setup for a session whose readiness was recorded at acquisition (#6227 round 5 P1)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // Simulate the acquisition/binding path: the session is created and its
+    // achieved readiness is recorded (as `bindBootedDeviceSession` now does)
+    // BEFORE any tool call reaches `createToolExecutionContext`.
+    await sessionManager.createSession("session-acquired", "device-1", "android");
+    sessionManager.setDeviceReadiness("session-acquired", "automationReady");
+
+    const context = await createToolExecutionContext(
+      "session-acquired",
+      sessionManager,
+      devicePool,
+      {
+        ...sessionOptions,
+        deviceReadiness: "automationReady",
+      },
+    );
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(0);
+  });
+
+  // Companion case: a session recovered without its readiness genuinely
+  // re-established (e.g. mid-recovery, unrecorded) must still be treated as
+  // not-ready and run setup — the acquisition-time recording above must not
+  // widen the concurrency-hole fix in `isReadinessSatisfied`.
+  test("still runs setup for a genuinely-unrecorded recovered session (#6227 round 5 P1)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // No `setDeviceReadiness` call here — this session's readiness was never
+    // recorded, mirroring a recovered session whose acquisition never
+    // completed `prepareStartDeviceRunnerReadiness` cleanly.
+    await sessionManager.createSession("session-unrecorded-recovery", "device-1", "android");
+
+    const context = await createToolExecutionContext(
+      "session-unrecorded-recovery",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+  });
+
   // #6227 P1 follow-up: a session first reached via a `booted` tool must be
   // *upgraded* — not left disconnected — when a later call on the same
   // sessionUuid needs `automationReady`. The `existingSession` fast path must

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -518,6 +518,162 @@ describe("ToolExecutionContext", () => {
     expect(sessionManager.getDeviceReadiness("session-race-fresh-both")).toBe("automationReady");
   });
 
+  // #6227 P1 follow-up (round 4): a `booted`-only caller (e.g. `listApps`)
+  // must not join — or fail because of — an in-flight `automationReady`
+  // setup started by a concurrent caller for the same session. Reaching
+  // `ensureReadinessUpgraded` already implies the device itself is booted
+  // (`devicePool.assertSessionReadyForAutomation` ran earlier), so a booted
+  // caller has nothing to gain from waiting on stricter automation setup and
+  // must not inherit its rejection.
+  test("a concurrent booted call bypasses (and does not fail from) an in-flight automationReady setup that later rejects (#6227)", async () => {
+    let automationSetupCalls = 0;
+    let setupEnteredResolve!: () => void;
+    const setupEntered = new Promise<void>((resolve) => {
+      setupEnteredResolve = resolve;
+    });
+    let triggerReject!: () => void;
+    const rejectSignal = new Promise<void>((resolve) => {
+      triggerReject = resolve;
+    });
+
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          automationSetupCalls += 1;
+          setupEnteredResolve();
+          await rejectSignal;
+          throw new Error("simulated automation setup failure");
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    await sessionManager.createSession("session-booted-bypass", "device-1", "android");
+
+    const automationCall = createToolExecutionContext(
+      "session-booted-bypass",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+
+    // Let the automationReady call actually enter (and register as the
+    // in-flight upgrade for) setup before the concurrent booted call starts.
+    await setupEntered;
+
+    const bootedContext = await createToolExecutionContext(
+      "session-booted-bypass",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "booted" },
+    );
+
+    // The booted call must succeed without waiting for the still-pending
+    // automationReady setup, and must record the booted baseline itself.
+    expect(bootedContext.deviceId).toBe("device-1");
+    expect(sessionManager.getDeviceReadiness("session-booted-bypass")).toBe("booted");
+
+    // Now let the automationReady setup actually reject — the booted call
+    // above already resolved and must be unaffected by this.
+    triggerReject();
+    await expect(automationCall).rejects.toThrow();
+    expect(automationSetupCalls).toBe(1);
+  });
+
+  // #6227 P2 follow-up: the single-flight map must be scoped to the session
+  // INCARNATION, not the bare session UUID. A recreated session with the
+  // same UUID (e.g. restart recovery re-binding it after a nonterminal
+  // release's setup-drain timeout) must never join a stale flight left
+  // behind by its predecessor.
+  test("scopes the readiness single-flight to the session incarnation, not the bare UUID (#6227 P2 follow-up)", async () => {
+    let setupCalls = 0;
+    let oldEnteredResolve!: () => void;
+    const oldEntered = new Promise<void>((resolve) => {
+      oldEnteredResolve = resolve;
+    });
+    let releaseOldGate!: () => void;
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOldGate = resolve;
+    });
+    let mode: "old" | "new" = "old";
+
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          if (mode === "old") {
+            oldEnteredResolve();
+            await oldGate;
+          }
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const original = await sessionManager.createSession(
+      "session-incarnation-scope",
+      "device-1",
+      "android",
+    );
+
+    // The old incarnation's readiness setup starts and hangs mid-flight — it
+    // is never released within this test, standing in for setup that is
+    // still pending when the release below reaches its drain timeout.
+    const oldCall = createToolExecutionContext(
+      "session-incarnation-scope",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      original,
+    );
+    await oldEntered;
+
+    // A nonterminal release reaches the ~1s setup-drain timeout while the
+    // old incarnation's setup is still pending, and proceeds anyway
+    // (fakeTimer auto-advance fires the drain timeout without a real wait).
+    await sessionManager.releaseSession("session-incarnation-scope");
+
+    // The UUID is recreated as a brand-new incarnation (e.g. restart
+    // recovery re-binding it, possibly to a different device).
+    const replacement = await sessionManager.createSession(
+      "session-incarnation-scope",
+      "device-1",
+      "android",
+    );
+    expect(replacement).not.toBe(original);
+    mode = "new";
+
+    // The replacement must start its OWN flight rather than joining (and
+    // hanging on) the predecessor's still-pending one.
+    const newContext = await createToolExecutionContext(
+      "session-incarnation-scope",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      replacement,
+    );
+
+    expect(newContext.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(2);
+    expect(sessionManager.getDeviceReadiness("session-incarnation-scope")).toBe("automationReady");
+
+    releaseOldGate();
+    await oldCall.catch(() => {
+      // The old incarnation's own call is expected to fail once its setup
+      // finally resolves against an already-released session; only the
+      // replacement's outcome is under test here.
+    });
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -1079,6 +1079,55 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(1);
   });
 
+  test("retries after the sole cancelled readiness flight settles (#6280)", async () => {
+    let resolveSetup!: () => void;
+    const setupStarted = new Promise<void>((resolve) => {
+      resolveSetup = resolve;
+    });
+    let setupCalls = 0;
+    setDeviceReadinessProxyDriverProviderForTesting(() => ({
+      resetSetupState: () => {},
+      setup: async () => {
+        setupCalls += 1;
+        await setupStarted;
+        return { success: true, message: "ok" };
+      },
+      waitForConnection: async () => true,
+      isInstalled: async () => true,
+      isVersionCompatible: async () => true,
+    }));
+    await sessionManager.createSession("session-cancelled-flight-retry", "device-1", "android");
+
+    const cancelled = new AbortController();
+    const first = createToolExecutionContext(
+      "session-cancelled-flight-retry",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+      undefined,
+      undefined,
+      false,
+      cancelled.signal,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    cancelled.abort(new Error("first request cancelled"));
+    await expect(first).rejects.toThrow("first request cancelled");
+
+    // This request arrives after the sole subscriber has aborted but before
+    // its setup work settles. It must wait and retry rather than join that
+    // aborted flight.
+    const later = createToolExecutionContext(
+      "session-cancelled-flight-retry",
+      sessionManager,
+      devicePool,
+      { ...sessionOptions, deviceReadiness: "automationReady" },
+    );
+    resolveSetup();
+
+    await expect(later).resolves.toMatchObject({ deviceId: "device-1" });
+    expect(setupCalls).toBe(2);
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -316,6 +316,53 @@ describe("ToolExecutionContext", () => {
     expect(sessionManager.getDeviceReadiness("session-1")).toBe("automationReady");
   });
 
+  // #6227 P1 follow-up: a concurrency window where a `booted` request
+  // publishes the recovered session into `SessionManager`'s in-memory map
+  // (`this.sessions.set(...)`) and then pauses in `ensureKeepScreenAwake`
+  // *before* recording its readiness. A concurrent `automationReady` request
+  // that resolves the same sessionUuid in that window must NOT treat the
+  // still-undefined recorded readiness as satisfied and skip setup.
+  test("runs setup for a concurrent automationReady call that observes a published-but-unrecorded session (#6227)", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // Simulate the race directly: a session already published into the
+    // SessionManager's in-memory map (as `createSession` does), but with its
+    // deviceReadiness NOT YET recorded — exactly the state a concurrent
+    // `booted` request's session is in after publish but before
+    // `runDeviceReadinessSetup` records the level.
+    await sessionManager.createSession("session-race-window", "device-1", "android");
+    expect(sessionManager.getDeviceReadiness("session-race-window")).toBeUndefined();
+
+    // A concurrent automationReady request resolves this same session as
+    // "existing" and must run setup rather than trusting the unrecorded
+    // readiness.
+    const context = await createToolExecutionContext(
+      "session-race-window",
+      sessionManager,
+      devicePool,
+      {
+        ...sessionOptions,
+        deviceReadiness: "automationReady",
+      },
+    );
+
+    expect(context.deviceId).toBe("device-1");
+    expect(setupCalls).toBe(1);
+    expect(sessionManager.getDeviceReadiness("session-race-window")).toBe("automationReady");
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>
@@ -328,6 +375,13 @@ describe("ToolExecutionContext", () => {
       }) as any;
 
     await sessionManager.createSession("session-1", "device-1", "android");
+    // #6227 P1 follow-up: `undefined` recorded readiness is no longer treated
+    // as satisfied on the existingSession path (a session whose readiness was
+    // never recorded must not be assumed ready — see isReadinessSatisfied).
+    // A direct `SessionManager.createSession` call bypasses this module's own
+    // setup entirely, so record the readiness explicitly, exactly as a real
+    // setup pass would have by the time a session is genuinely "existing".
+    sessionManager.setDeviceReadiness("session-1", "automationReady");
     const context = await createToolExecutionContext(
       "session-1",
       sessionManager,
@@ -520,6 +574,11 @@ describe("ToolExecutionContext", () => {
 
   test("rechecks admission after setup releases its session", async () => {
     const session = await sessionManager.createSession("session-releasing", "device-1", "android");
+    // #6227 P1 follow-up: `undefined` readiness is no longer treated as
+    // satisfied on the existingSession path, so record it explicitly here —
+    // this test exercises the post-setup admission recheck, not accessibility
+    // setup, and must not make a real CtrlProxy/adb call.
+    sessionManager.setDeviceReadiness("session-releasing", "automationReady");
     const trackSetup = spyOn(sessionManager, "trackSessionSetup").mockImplementation(
       async (trackedSession, setup) => {
         await setup();

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -168,6 +168,25 @@ describe("platform device preparation tools", () => {
     expect(result.deviceIdentity).toMatchObject({ simulatorUdid: simulator.deviceId });
   });
 
+  test("getApple ignores daemon deadline provenance before strict schema validation", async () => {
+    const simulator: DeviceInfo = {
+      platform: "ios",
+      name: "iPhone 17",
+      deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+      isRunning: false,
+    };
+    deviceUtils.setDeviceImages("ios", [simulator]);
+
+    const result = await callTool("getApple", {
+      deviceId: simulator.deviceId,
+      __mcpRequestTimeoutMs: 120_000,
+      __mcpRequestDeadlineMs: Date.now() + 120_000,
+      __mcpLiveDeadlineKey: "daemon-deadline-key",
+    });
+
+    expect(result.deviceIdentity).toMatchObject({ simulatorUdid: simulator.deviceId });
+  });
+
   test("getAndroid rejects a call with neither avdName nor deviceId, naming the source (#5870)", () => {
     expect(() => getAndroidSchema.parse({})).toThrow(/avdName.*deviceId|deviceId.*avdName/i);
   });

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -10,6 +10,10 @@ import { classifyDisplayCutout } from "../../src/utils/displayCutout";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import {
+  installNoOpReadinessDriver,
+  setDeviceReadinessProxyDriverProviderForTesting,
+} from "../helpers/stubCtrlProxySetup";
 import type {
   ExactDeviceProvisionRequest,
   ExactDeviceProvisioner,
@@ -846,6 +850,11 @@ describe("provisionDevice handler", () => {
       close: async () => {},
     })) as any;
     AndroidCtrlProxyClient.resetInstances();
+    // This test drives the real `ensureAccessibilityServiceReady` path and
+    // counts setup via the `getInstance` overrides above; restore the real
+    // readiness driver so those overrides take effect (the shared preload's
+    // no-op driver is re-installed in `finally`) — #6227.
+    setDeviceReadinessProxyDriverProviderForTesting(null);
 
     try {
       const tool = ToolRegistry.getTool("provisionDevice");
@@ -894,6 +903,7 @@ describe("provisionDevice handler", () => {
       AndroidCtrlProxyManager.getInstance = originalGetInstance;
       AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
       AndroidCtrlProxyClient.resetInstances();
+      installNoOpReadinessDriver();
       sessionManager.stopCleanupTimer();
     }
   });

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
 import {
   provisionDeviceSchema,
   registerDeviceTools,
@@ -7,6 +8,8 @@ import {
 } from "../../src/server/deviceTools";
 import { classifyDisplayCutout } from "../../src/utils/displayCutout";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import type {
   ExactDeviceProvisionRequest,
   ExactDeviceProvisioner,
@@ -739,6 +742,160 @@ describe("provisionDevice handler", () => {
     expect(deviceManager.getCallCount("startDevice")).toBe(1);
     expect(readinessCalls).toBe(2);
     sessionManager.stopCleanupTimer();
+  });
+
+  // #6227 (round 6 P1): `readiness: "none"` deliberately skips CtrlProxy /
+  // accessibility-service setup in `ensureProvisionDeviceReadiness`, so the
+  // freshly-bound session must NOT be recorded as `automationReady` — that
+  // would make a later `automationReady` tool (e.g. `observe`) wrongly treat
+  // setup as already satisfied and run against a device whose CtrlProxy setup
+  // was intentionally skipped.
+  test("records booted (not automationReady) when readiness: 'none' skips CtrlProxy setup (#6227 round 6)", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, deviceManager);
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [
+      {
+        name: "phone-api-36-a",
+        platform: "android",
+        isRunning: false,
+      },
+    ]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    let readinessCalls = 0;
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        readinessCalls++;
+      },
+    });
+
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const response = JSON.parse(
+      (
+        (await tool.handler({
+          operationId: "operation-readiness-none-record",
+          device: {
+            platform: "android",
+            name: "phone-api-36-a",
+            spec: {
+              runtime: "system-images;android-36;google_apis;x86_64",
+              deviceType: "pixel_9",
+            },
+          },
+          boot: true,
+          readiness: "none",
+        })) as any
+      ).content[0].text,
+    );
+
+    expect(readinessCalls).toBe(0);
+    expect(response.sessionId).toEqual(expect.any(String));
+    expect(sessionManager.getDeviceReadiness(response.sessionId)).toBe("booted");
+    sessionManager.stopCleanupTimer();
+  });
+
+  // #6227 (round 6 P1, continued): because the session bound after
+  // `readiness: "none"` is recorded as merely `booted`, a subsequent
+  // `automationReady`-declaring tool call against that same session must
+  // still run CtrlProxy / accessibility-service setup rather than skipping it
+  // as already-satisfied.
+  test("a later automationReady tool runs setup for a session acquired via readiness: 'none' (#6227 round 6)", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, deviceManager);
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [
+      {
+        name: "phone-api-36-a",
+        platform: "android",
+        isRunning: false,
+      },
+    ]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {},
+    });
+
+    let setupCalls = 0;
+    const originalGetInstance = AndroidCtrlProxyManager.getInstance;
+    const originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+    AndroidCtrlProxyClient.resetInstances();
+
+    try {
+      const tool = ToolRegistry.getTool("provisionDevice");
+      if (!tool) {
+        throw new Error("provisionDevice not registered");
+      }
+      const response = JSON.parse(
+        (
+          (await tool.handler({
+            operationId: "operation-readiness-none-upgrade",
+            device: {
+              platform: "android",
+              name: "phone-api-36-a",
+              spec: {
+                runtime: "system-images;android-36;google_apis;x86_64",
+                deviceType: "pixel_9",
+              },
+            },
+            boot: true,
+            readiness: "none",
+          })) as any
+        ).content[0].text,
+      );
+      const sessionUuid = response.sessionId as string;
+      expect(sessionManager.getDeviceReadiness(sessionUuid)).toBe("booted");
+
+      ToolRegistry.registerDeviceAware(
+        "automationReadyAfterProvisionProbe",
+        "Automation-ready probe after provisionDevice readiness: none",
+        z.object({ sessionUuid: z.string().optional() }),
+        async () => ({ success: true }),
+        { deviceReadiness: "automationReady" },
+      );
+
+      const automationResponse = await ToolRegistry.getTool(
+        "automationReadyAfterProvisionProbe",
+      )!.handler({
+        platform: "android",
+        sessionUuid,
+      });
+
+      expect(automationResponse).toMatchObject({ success: true });
+      expect(setupCalls).toBe(1);
+      expect(sessionManager.getDeviceReadiness(sessionUuid)).toBe("automationReady");
+    } finally {
+      AndroidCtrlProxyManager.getInstance = originalGetInstance;
+      AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
+      AndroidCtrlProxyClient.resetInstances();
+      sessionManager.stopCleanupTimer();
+    }
   });
 
   test("associates a live autolock session with a reconnected MCP client", async () => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -375,6 +375,43 @@ describe("startDevice handler", () => {
     expect(childProcess.killed).toBe(false);
   });
 
+  // #6227 (round 5 P1): `prepareStartDeviceRunnerReadiness` already completed
+  // before `bindBootedDeviceSession` binds the session, so the acquisition
+  // path must record `automationReady` on the freshly-bound session — not
+  // leave it `undefined`, which would make the first subsequent
+  // `automationReady` tool call redundantly re-run CtrlProxy setup.
+  it("records automationReady on the session bound after a successful cold boot (#6227 round 5)", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    const discoveredDevice = { ...androidDevice, transportId: "23" };
+    const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    const childProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);
+    fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeDeviceUtils.setMockChildProcess(
+      coldBootImage.name,
+      childProcess as unknown as ChildProcess,
+    );
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(coldBootImage);
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.source).toBe("cold-boot");
+    const sessionUuid = result.sessionUuid as string;
+    expect(sessionUuid).toBeDefined();
+    expect(daemonSessionManager!.getDeviceReadiness(sessionUuid)).toBe("automationReady");
+  });
+
   it("tracks the process handle for a public Android cold boot", async () => {
     const recoveryKeys = [
       "AUTOMOBILE_ANDROID_REBOOT_ON_DEATH",

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -657,6 +657,67 @@ describe("startDevice handler", () => {
     expect(daemonSessionManager.getSession("owner-session")?.assignedDevice).toBe("emulator-5556");
   });
 
+  // #6227 round 7: `bootAndPrepareDevice` bypasses `bindBootedDeviceSession`
+  // (and its `recordAcquiredSessionReadiness` call) entirely when a preserved
+  // session comes back from System UI ANR recovery. By this point
+  // `ensureCtrlProxyReady` already succeeded on the replacement device (the
+  // second `readinessAttempts` call above), so the achieved level is
+  // `automationReady` just like a freshly-bound session — it must be recorded
+  // rather than left `undefined`, or the first `automationReady` tool call
+  // after recovery would redundantly re-run CtrlProxy setup.
+  it("records automationReady for a preserved session recovered from a System UI ANR (#6227 round 7)", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+      },
+    });
+    registerDeviceTools();
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.sessionUuid).toBe("owner-session");
+    expect(daemonSessionManager.getDeviceReadiness("owner-session")).toBe("automationReady");
+  });
+
   it("binds an idle System UI recovery replacement through its own readiness reservation", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());

--- a/test/server/mcpSessionAutolockRouting.integration.test.ts
+++ b/test/server/mcpSessionAutolockRouting.integration.test.ts
@@ -9,7 +9,6 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { stubCtrlProxySetup } from "../helpers/stubCtrlProxySetup";
 
 const captureSchema = z
   .object({
@@ -113,11 +112,10 @@ describe("MCP session autolock routing", () => {
 
     // #6227: `pool.autolockDevice` creates its session directly (bypassing the
     // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
-    // request below through `captureAutolockOwnership` drives real
-    // per-session accessibility-service setup against a fake device with no
-    // real `adb`/network backing it — see test/helpers/stubCtrlProxySetup.ts.
-    const ctrlProxyStub = stubCtrlProxySetup();
-
+    // request below through `captureAutolockOwnership` drives real per-session
+    // accessibility-service setup against a fake device. The shared test
+    // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
+    // that setup cannot block on real `adb`/network.
     ToolRegistry.clearTools();
     ToolRegistry.registerDeviceAware(
       "captureAutolockOwnership",
@@ -169,7 +167,6 @@ describe("MCP session autolock routing", () => {
       DaemonState.getInstance().reset();
       delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
       delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
-      ctrlProxyStub.restore();
     }
   });
 

--- a/test/server/mcpSessionAutolockRouting.integration.test.ts
+++ b/test/server/mcpSessionAutolockRouting.integration.test.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { stubCtrlProxySetup } from "../helpers/stubCtrlProxySetup";
 
 const captureSchema = z
   .object({
@@ -110,6 +111,13 @@ describe("MCP session autolock routing", () => {
     const handlerStarted = Promise.withResolvers<void>();
     const releaseHandler = Promise.withResolvers<void>();
 
+    // #6227: `pool.autolockDevice` creates its session directly (bypassing the
+    // `deviceTools.ts` acquisition recorder), so routing the `tools/call`
+    // request below through `captureAutolockOwnership` drives real
+    // per-session accessibility-service setup against a fake device with no
+    // real `adb`/network backing it — see test/helpers/stubCtrlProxySetup.ts.
+    const ctrlProxyStub = stubCtrlProxySetup();
+
     ToolRegistry.clearTools();
     ToolRegistry.registerDeviceAware(
       "captureAutolockOwnership",
@@ -124,39 +132,45 @@ describe("MCP session autolock routing", () => {
     fixture = new McpTestFixture({ sessionContext: { sessionId: "mcp-session" } });
     await fixture.setup();
 
-    const { client } = fixture.getContext();
-    const request = client.request(
-      {
-        method: "tools/call",
-        params: { name: "captureAutolockOwnership", arguments: {} },
-      },
-      z.any(),
-    );
-    await handlerStarted.promise;
+    try {
+      const { client } = fixture.getContext();
+      const request = client.request(
+        {
+          method: "tools/call",
+          params: { name: "captureAutolockOwnership", arguments: {} },
+        },
+        z.any(),
+      );
+      await handlerStarted.promise;
 
-    const replacementSessionId = await pool.autolockDevice(
-      "emulator-5556",
-      "android",
-      "mcp-session",
-    );
-    expect(executionTracker.hasActiveAutolockSessionExecutions(originalSessionId!)).toBe(true);
-    expect(executionTracker.hasActiveAutolockSessionExecutions(replacementSessionId!)).toBe(false);
+      const replacementSessionId = await pool.autolockDevice(
+        "emulator-5556",
+        "android",
+        "mcp-session",
+      );
+      expect(executionTracker.hasActiveAutolockSessionExecutions(originalSessionId!)).toBe(true);
+      expect(executionTracker.hasActiveAutolockSessionExecutions(replacementSessionId!)).toBe(
+        false,
+      );
 
-    sessionManager.setActiveSessionExecutionChecker(
-      (sessionUuid) =>
-        executionTracker.hasActiveSessionUuidExecutions(sessionUuid) ||
-        executionTracker.hasActiveAutolockSessionExecutions(sessionUuid),
-    );
-    timer.advanceTime(60_001);
-    expect(sessionManager.getSession(originalSessionId!)).not.toBeNull();
-    expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
+      sessionManager.setActiveSessionExecutionChecker(
+        (sessionUuid) =>
+          executionTracker.hasActiveSessionUuidExecutions(sessionUuid) ||
+          executionTracker.hasActiveAutolockSessionExecutions(sessionUuid),
+      );
+      timer.advanceTime(60_001);
+      expect(sessionManager.getSession(originalSessionId!)).not.toBeNull();
+      expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
 
-    releaseHandler.resolve();
-    await request;
-    sessionManager.stopCleanupTimer();
-    DaemonState.getInstance().reset();
-    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
-    delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
+      releaseHandler.resolve();
+      await request;
+    } finally {
+      sessionManager.stopCleanupTimer();
+      DaemonState.getInstance().reset();
+      delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
+      ctrlProxyStub.restore();
+    }
   });
 
   test("does not use the shared daemon loopback MCP session as an implicit autolock key", async () => {

--- a/test/server/planExecutionOrchestrator.integration.test.ts
+++ b/test/server/planExecutionOrchestrator.integration.test.ts
@@ -17,8 +17,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { resolveToolSelectionBaseSessionUuid } from "../../src/features/toolSelection/selectionSessionResolver";
 import { ExecutionTracker } from "../../src/server/executionTracker";
-import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
-import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { stubCtrlProxySetup } from "../helpers/stubCtrlProxySetup";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -317,21 +316,9 @@ steps:
     // setup. This test exercises session-assignment survival through expiry
     // cleanup, not the accessibility-setup mechanism itself, so stub the
     // underlying CtrlProxy calls to succeed immediately instead of hitting
-    // the real device (which fails "toggle not supported" and retries with a
-    // real 3s delay, timing out the test) — mirrors
-    // toolRegistry.deviceReadinessPersistedSession.test.ts's stub.
-    const originalCtrlProxyGetInstance = AndroidCtrlProxyManager.getInstance;
-    const originalCtrlProxyClientGetInstance = AndroidCtrlProxyClient.getInstance;
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => ({ success: true, message: "ok" }),
-      }) as any;
-    AndroidCtrlProxyClient.getInstance = (() => ({
-      waitForConnection: async () => true,
-      close: async () => {},
-    })) as any;
-    AndroidCtrlProxyClient.resetInstances();
+    // the real device (which has no real `adb`/network backing it and can
+    // block well past the test timeout) — see test/helpers/stubCtrlProxySetup.ts.
+    const ctrlProxyStub = stubCtrlProxySetup();
 
     const multiDevicePlan = `
 name: multi-device-test
@@ -376,9 +363,7 @@ steps:
     } finally {
       DaemonState.getInstance().reset();
       sessionManager.stopCleanupTimer();
-      AndroidCtrlProxyManager.getInstance = originalCtrlProxyGetInstance;
-      AndroidCtrlProxyClient.getInstance = originalCtrlProxyClientGetInstance;
-      AndroidCtrlProxyClient.resetInstances();
+      ctrlProxyStub.restore();
     }
   });
 

--- a/test/server/planExecutionOrchestrator.integration.test.ts
+++ b/test/server/planExecutionOrchestrator.integration.test.ts
@@ -17,6 +17,8 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { resolveToolSelectionBaseSessionUuid } from "../../src/features/toolSelection/selectionSessionResolver";
 import { ExecutionTracker } from "../../src/server/executionTracker";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -306,6 +308,31 @@ steps:
       }
     };
 
+    // #6227: `registerDeviceLabelMap` now runs real per-session readiness
+    // setup (`createToolExecutionContext` -> `ensureAccessibilityServiceReady`)
+    // for every labeled session, including "base" and the freshly-allocated
+    // "base:B" — both are `existingSession` by the time it runs (created
+    // directly above / by the `assignMultipleDevices` override), and an
+    // `existingSession` with no recorded readiness no longer short-circuits
+    // setup. This test exercises session-assignment survival through expiry
+    // cleanup, not the accessibility-setup mechanism itself, so stub the
+    // underlying CtrlProxy calls to succeed immediately instead of hitting
+    // the real device (which fails "toggle not supported" and retries with a
+    // real 3s delay, timing out the test) — mirrors
+    // toolRegistry.deviceReadinessPersistedSession.test.ts's stub.
+    const originalCtrlProxyGetInstance = AndroidCtrlProxyManager.getInstance;
+    const originalCtrlProxyClientGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => ({ success: true, message: "ok" }),
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+    AndroidCtrlProxyClient.resetInstances();
+
     const multiDevicePlan = `
 name: multi-device-test
 devices:
@@ -349,6 +376,9 @@ steps:
     } finally {
       DaemonState.getInstance().reset();
       sessionManager.stopCleanupTimer();
+      AndroidCtrlProxyManager.getInstance = originalCtrlProxyGetInstance;
+      AndroidCtrlProxyClient.getInstance = originalCtrlProxyClientGetInstance;
+      AndroidCtrlProxyClient.resetInstances();
     }
   });
 

--- a/test/server/planExecutionOrchestrator.integration.test.ts
+++ b/test/server/planExecutionOrchestrator.integration.test.ts
@@ -17,7 +17,6 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
 import { resolveToolSelectionBaseSessionUuid } from "../../src/features/toolSelection/selectionSessionResolver";
 import { ExecutionTracker } from "../../src/server/executionTracker";
-import { stubCtrlProxySetup } from "../helpers/stubCtrlProxySetup";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -314,12 +313,10 @@ steps:
     // directly above / by the `assignMultipleDevices` override), and an
     // `existingSession` with no recorded readiness no longer short-circuits
     // setup. This test exercises session-assignment survival through expiry
-    // cleanup, not the accessibility-setup mechanism itself, so stub the
-    // underlying CtrlProxy calls to succeed immediately instead of hitting
-    // the real device (which has no real `adb`/network backing it and can
-    // block well past the test timeout) — see test/helpers/stubCtrlProxySetup.ts.
-    const ctrlProxyStub = stubCtrlProxySetup();
-
+    // cleanup, not the accessibility-setup mechanism itself. The shared test
+    // preload (test/setup/testPreload.ts) installs a no-op readiness driver so
+    // that setup succeeds immediately instead of hitting the real device (which
+    // has no real `adb`/network backing it and can block past the test timeout).
     const multiDevicePlan = `
 name: multi-device-test
 devices:
@@ -363,7 +360,6 @@ steps:
     } finally {
       DaemonState.getInstance().reset();
       sessionManager.stopCleanupTimer();
-      ctrlProxyStub.restore();
     }
   });
 

--- a/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
+++ b/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
@@ -172,6 +172,44 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     expect(setupCalls).toBe(1);
   });
 
+  test("upgrades setup when a booted-first persisted session is later reused by an automationReady tool (#6227)", async () => {
+    const sessionUuid = "restarted-session-upgrade";
+    await setupPersistedDaemonSession(sessionUuid);
+
+    ToolRegistry.registerDeviceAware(
+      "bootedFirstProbe",
+      "Booted-first probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ success: true }),
+      { deviceReadiness: "booted" },
+    );
+    ToolRegistry.registerDeviceAware(
+      "automationReadySecondProbe",
+      "Automation-ready-second probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ success: true }),
+      { deviceReadiness: "automationReady" },
+    );
+
+    const bootedResponse = await ToolRegistry.getTool("bootedFirstProbe")!.handler({
+      platform: "android",
+      sessionUuid,
+    });
+    expect(bootedResponse).toMatchObject({ success: true });
+    expect(setupCalls).toBe(0);
+
+    // Same recovered sessionUuid, now reused by an automationReady tool — the
+    // `existingSession` fast path must upgrade rather than leave the session
+    // disconnected/unprepared (#6227 P1 follow-up).
+    const automationResponse = await ToolRegistry.getTool("automationReadySecondProbe")!.handler({
+      platform: "android",
+      sessionUuid,
+    });
+    expect(automationResponse).toMatchObject({ success: true });
+    expect(setupCalls).toBe(1);
+    expect(daemonSessionManager?.getDeviceReadiness(sessionUuid)).toBe("automationReady");
+  });
+
   test("a tool not declaring deviceReadiness is unaffected (defaults to full setup, matching pre-fix behavior)", async () => {
     const sessionUuid = "restarted-session-default";
     await setupPersistedDaemonSession(sessionUuid);

--- a/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
+++ b/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { BootedDevice } from "../../src/models";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import type { DeviceSession } from "../../src/db/types";
+
+/**
+ * #6227: `createToolExecutionContext`'s persisted daemon-session path — a
+ * caller-provided `sessionUuid` recovered from a persisted, non-terminal
+ * device-session row (e.g. live during a daemon restart) rather than freshly
+ * minted — must honor a tool's declared `deviceReadiness` the same way the
+ * legacy/no-session path already does via `DeviceSessionManager.ensureDeviceReady`'s
+ * `readiness` option. A `booted`-only tool must never pay for (or fail on)
+ * full CtrlProxy accessibility-service setup on this path.
+ */
+describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)", () => {
+  const androidA: BootedDevice = {
+    name: "Pixel A",
+    deviceId: "emulator-5554",
+    platform: "android",
+  };
+
+  const nonTerminalPersisted = (sessionUuid: string, deviceId: string): DeviceSession => ({
+    session_uuid: sessionUuid,
+    device_id: deviceId,
+    platform: "android",
+    status: "active",
+    source: null,
+    autolock_enabled: 0,
+    mcp_session_id: null,
+    daemon_session_id: "old-daemon",
+    created_at_ms: 1,
+    last_used_at_ms: 20,
+    expires_at_ms: 30,
+    released_at_ms: null,
+    release_reason: null,
+    session_timeout_ms: 60_000,
+    heartbeat_timeout_ms: 60_000,
+    has_received_heartbeat: 1,
+    created_at: "2026-09-03T00:00:00.000Z",
+    updated_at: "2026-09-03T00:00:00.000Z",
+  });
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+  let daemonSessionManager: SessionManager | undefined;
+  let originalGetInstance: typeof AndroidCtrlProxyManager.getInstance;
+  let originalClientGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+  let setupCalls: number;
+
+  /**
+   * Stand up a daemon with a device pool that has NOT bound `sessionUuid` to any
+   * device yet, but whose persistence layer reports `sessionUuid` as a
+   * persisted, non-terminal row (recovered across a daemon restart). This
+   * drives `createToolExecutionContext` through its persisted-session recovery
+   * branch, which is exactly the "new session" branch that runs
+   * `setupSession`'s automation-only setup — the branch this issue's gate must
+   * skip when the tool declares `deviceReadiness: "booted"`.
+   */
+  async function setupPersistedDaemonSession(sessionUuid: string): Promise<void> {
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const persisted = nonTerminalPersisted(sessionUuid, androidA.deviceId);
+    daemonSessionManager = new SessionManager(timer, {
+      async getSession() {
+        return persisted;
+      },
+      async upsertActiveSession(): Promise<void> {},
+      async recordActivity(): Promise<void> {},
+      async markReleased(): Promise<void> {},
+      async markStaleActiveSessionsExpired(): Promise<void> {},
+    });
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "new-daemon",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    (ToolRegistry as any).toolCallRepository = {
+      async recordToolCall(): Promise<void> {},
+    };
+    setupCalls = 0;
+    originalGetInstance = AndroidCtrlProxyManager.getInstance;
+    originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      }) as any;
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+    daemonSessionManager?.stopCleanupTimer();
+    AndroidCtrlProxyManager.getInstance = originalGetInstance;
+    AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  test("skips accessibility-service setup for a booted-only tool on the persisted session path", async () => {
+    const sessionUuid = "restarted-session-booted";
+    await setupPersistedDaemonSession(sessionUuid);
+
+    ToolRegistry.registerDeviceAware(
+      "bootedOnlyProbe",
+      "Booted-only probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ success: true }),
+      { deviceReadiness: "booted" },
+    );
+
+    const response = await ToolRegistry.getTool("bootedOnlyProbe")!.handler({
+      platform: "android",
+      sessionUuid,
+    });
+
+    expect(response).toMatchObject({ success: true });
+    expect(setupCalls).toBe(0);
+    expect(daemonSessionManager?.getSession(sessionUuid)?.assignedDevice).toBe(androidA.deviceId);
+  });
+
+  test("still runs accessibility-service setup for an automationReady tool on the persisted session path", async () => {
+    const sessionUuid = "restarted-session-automation-ready";
+    await setupPersistedDaemonSession(sessionUuid);
+
+    ToolRegistry.registerDeviceAware(
+      "automationReadyProbe",
+      "Automation-ready probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ success: true }),
+      { deviceReadiness: "automationReady" },
+    );
+
+    const response = await ToolRegistry.getTool("automationReadyProbe")!.handler({
+      platform: "android",
+      sessionUuid,
+    });
+
+    expect(response).toMatchObject({ success: true });
+    expect(setupCalls).toBe(1);
+  });
+
+  test("a tool not declaring deviceReadiness is unaffected (defaults to full setup, matching pre-fix behavior)", async () => {
+    const sessionUuid = "restarted-session-default";
+    await setupPersistedDaemonSession(sessionUuid);
+
+    ToolRegistry.registerDeviceAware(
+      "defaultReadinessProbe",
+      "Default readiness probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ success: true }),
+    );
+
+    const response = await ToolRegistry.getTool("defaultReadinessProbe")!.handler({
+      platform: "android",
+      sessionUuid,
+    });
+
+    expect(response).toMatchObject({ success: true });
+    expect(setupCalls).toBe(1);
+  });
+});

--- a/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
+++ b/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
@@ -51,6 +51,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
 
   let fakeDeviceSessionManager: FakeDeviceSessionManager;
   let originalDeviceSessionManager: unknown;
+  let originalToolCallRepository: unknown;
   let daemonSessionManager: SessionManager | undefined;
   let originalGetInstance: typeof AndroidCtrlProxyManager.getInstance;
   let originalClientGetInstance: typeof AndroidCtrlProxyClient.getInstance;
@@ -98,6 +99,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     fakeDeviceSessionManager = new FakeDeviceSessionManager();
     originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    originalToolCallRepository = (ToolRegistry as any).toolCallRepository;
     (ToolRegistry as any).toolCallRepository = {
       async recordToolCall(): Promise<void> {},
     };
@@ -121,6 +123,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
 
   afterEach(() => {
     (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    (ToolRegistry as any).toolCallRepository = originalToolCallRepository;
     ToolRegistry.clearTools();
     DaemonState.getInstance().reset();
     daemonSessionManager?.stopCleanupTimer();

--- a/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
+++ b/test/server/toolRegistry.deviceReadinessPersistedSession.test.ts
@@ -8,8 +8,7 @@ import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
-import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 import type { DeviceSession } from "../../src/db/types";
 
 /**
@@ -53,9 +52,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
   let originalDeviceSessionManager: unknown;
   let originalToolCallRepository: unknown;
   let daemonSessionManager: SessionManager | undefined;
-  let originalGetInstance: typeof AndroidCtrlProxyManager.getInstance;
-  let originalClientGetInstance: typeof AndroidCtrlProxyClient.getInstance;
-  let setupCalls: number;
+  let ctrlProxyStub: CtrlProxySetupStub;
 
   /**
    * Stand up a daemon with a device pool that has NOT bound `sessionUuid` to any
@@ -103,22 +100,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     (ToolRegistry as any).toolCallRepository = {
       async recordToolCall(): Promise<void> {},
     };
-    setupCalls = 0;
-    originalGetInstance = AndroidCtrlProxyManager.getInstance;
-    originalClientGetInstance = AndroidCtrlProxyClient.getInstance;
-    AndroidCtrlProxyManager.getInstance = () =>
-      ({
-        resetSetupState: () => {},
-        setup: async () => {
-          setupCalls += 1;
-          return { success: true, message: "ok" };
-        },
-      }) as any;
-    AndroidCtrlProxyClient.getInstance = (() => ({
-      waitForConnection: async () => true,
-      close: async () => {},
-    })) as any;
-    AndroidCtrlProxyClient.resetInstances();
+    ctrlProxyStub = stubCtrlProxySetup();
   });
 
   afterEach(() => {
@@ -127,9 +109,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     ToolRegistry.clearTools();
     DaemonState.getInstance().reset();
     daemonSessionManager?.stopCleanupTimer();
-    AndroidCtrlProxyManager.getInstance = originalGetInstance;
-    AndroidCtrlProxyClient.getInstance = originalClientGetInstance;
-    AndroidCtrlProxyClient.resetInstances();
+    ctrlProxyStub.restore();
   });
 
   test("skips accessibility-service setup for a booted-only tool on the persisted session path", async () => {
@@ -150,7 +130,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     });
 
     expect(response).toMatchObject({ success: true });
-    expect(setupCalls).toBe(0);
+    expect(ctrlProxyStub.setupCallCount()).toBe(0);
     expect(daemonSessionManager?.getSession(sessionUuid)?.assignedDevice).toBe(androidA.deviceId);
   });
 
@@ -172,7 +152,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     });
 
     expect(response).toMatchObject({ success: true });
-    expect(setupCalls).toBe(1);
+    expect(ctrlProxyStub.setupCallCount()).toBe(1);
   });
 
   test("upgrades setup when a booted-first persisted session is later reused by an automationReady tool (#6227)", async () => {
@@ -199,7 +179,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
       sessionUuid,
     });
     expect(bootedResponse).toMatchObject({ success: true });
-    expect(setupCalls).toBe(0);
+    expect(ctrlProxyStub.setupCallCount()).toBe(0);
 
     // Same recovered sessionUuid, now reused by an automationReady tool — the
     // `existingSession` fast path must upgrade rather than leave the session
@@ -209,7 +189,7 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
       sessionUuid,
     });
     expect(automationResponse).toMatchObject({ success: true });
-    expect(setupCalls).toBe(1);
+    expect(ctrlProxyStub.setupCallCount()).toBe(1);
     expect(daemonSessionManager?.getDeviceReadiness(sessionUuid)).toBe("automationReady");
   });
 
@@ -230,6 +210,6 @@ describe("ToolRegistry persisted daemon-session deviceReadiness gating (#6227)",
     });
 
     expect(response).toMatchObject({ success: true });
-    expect(setupCalls).toBe(1);
+    expect(ctrlProxyStub.setupCallCount()).toBe(1);
   });
 });

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -13,7 +13,6 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
-import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Internal tool-to-tool no-diff guard (issue #3053 part 2).
@@ -49,7 +48,6 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
   let daemonSessionManager: SessionManager | undefined;
   let originalDiff: boolean;
   let originalNoObserve: boolean;
-  let ctrlProxyStub: CtrlProxySetupStub;
 
   /** Same-screen observation so `isSameObservationScreen` holds between calls. */
   function sameScreenObserve(): ObserveResult {
@@ -169,9 +167,9 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     // #6227: `setupAutolockedSession` creates its session directly via
     // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
     // recorder), so it drives real per-session accessibility-service setup
-    // against a fake device with no real `adb`/network backing it — see
-    // test/helpers/stubCtrlProxySetup.ts.
-    ctrlProxyStub = stubCtrlProxySetup();
+    // against a fake device. The shared test preload (test/setup/testPreload.ts)
+    // installs a no-op readiness driver so that setup cannot block on real
+    // `adb`/network.
   });
 
   afterEach(() => {
@@ -183,7 +181,6 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     serverConfig.setActionsNoObserveEnabled(originalNoObserve);
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
-    ctrlProxyStub.restore();
   });
 
   test("EC2.3: an internal tapOn keeps the full observation; a normal tapOn diffs it", async () => {

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -13,6 +13,7 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
 import { runWithToolSelectionContext } from "../../src/features/toolSelection/toolSelectionContext";
+import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Internal tool-to-tool no-diff guard (issue #3053 part 2).
@@ -48,6 +49,7 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
   let daemonSessionManager: SessionManager | undefined;
   let originalDiff: boolean;
   let originalNoObserve: boolean;
+  let ctrlProxyStub: CtrlProxySetupStub;
 
   /** Same-screen observation so `isSameObservationScreen` holds between calls. */
   function sameScreenObserve(): ObserveResult {
@@ -164,6 +166,12 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     originalDiff = serverConfig.isActionsDiffObserveEnabled();
     originalNoObserve = serverConfig.isActionsNoObserveEnabled();
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    // #6227: `setupAutolockedSession` creates its session directly via
+    // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
+    // recorder), so it drives real per-session accessibility-service setup
+    // against a fake device with no real `adb`/network backing it — see
+    // test/helpers/stubCtrlProxySetup.ts.
+    ctrlProxyStub = stubCtrlProxySetup();
   });
 
   afterEach(() => {
@@ -175,6 +183,7 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     serverConfig.setActionsNoObserveEnabled(originalNoObserve);
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+    ctrlProxyStub.restore();
   });
 
   test("EC2.3: an internal tapOn keeps the full observation; a normal tapOn diffs it", async () => {

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -15,6 +15,7 @@ import {
   stringifyToolResponse,
 } from "../../src/utils/toolUtils";
 import type { ObserveResult } from "../../src/models/ObserveResult";
+import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Integration coverage for the `lastHierarchy` session-cache write. The
@@ -32,6 +33,7 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
   let fakeDeviceSessionManager: FakeDeviceSessionManager;
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
+  let ctrlProxyStub: CtrlProxySetupStub;
 
   function makeObserveResult(): ObserveResult {
     return {
@@ -86,6 +88,12 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    // #6227: `setupAutolockedSession` creates its session directly via
+    // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
+    // recorder), so it drives real per-session accessibility-service setup
+    // against a fake device with no real `adb`/network backing it — see
+    // test/helpers/stubCtrlProxySetup.ts.
+    ctrlProxyStub = stubCtrlProxySetup();
   });
 
   afterEach(() => {
@@ -95,6 +103,7 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     daemonSessionManager?.stopCleanupTimer();
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+    ctrlProxyStub.restore();
   });
 
   const toolSchema = z.object({

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -15,7 +15,6 @@ import {
   stringifyToolResponse,
 } from "../../src/utils/toolUtils";
 import type { ObserveResult } from "../../src/models/ObserveResult";
-import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Integration coverage for the `lastHierarchy` session-cache write. The
@@ -33,7 +32,6 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
   let fakeDeviceSessionManager: FakeDeviceSessionManager;
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
-  let ctrlProxyStub: CtrlProxySetupStub;
 
   function makeObserveResult(): ObserveResult {
     return {
@@ -91,9 +89,9 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     // #6227: `setupAutolockedSession` creates its session directly via
     // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
     // recorder), so it drives real per-session accessibility-service setup
-    // against a fake device with no real `adb`/network backing it — see
-    // test/helpers/stubCtrlProxySetup.ts.
-    ctrlProxyStub = stubCtrlProxySetup();
+    // against a fake device. The shared test preload (test/setup/testPreload.ts)
+    // installs a no-op readiness driver so that setup cannot block on real
+    // `adb`/network.
   });
 
   afterEach(() => {
@@ -103,7 +101,6 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     daemonSessionManager?.stopCleanupTimer();
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
-    ctrlProxyStub.restore();
   });
 
   const toolSchema = z.object({

--- a/test/server/toolRegistry.scrollPositionUpdate.test.ts
+++ b/test/server/toolRegistry.scrollPositionUpdate.test.ts
@@ -12,6 +12,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
 import type { ScrollPosition } from "../../src/utils/interfaces/NavigationGraph";
+import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Integration coverage for issue #2897: the swipeOn scroll-position update block
@@ -33,6 +34,7 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
   let spiedSessionIds: string[];
+  let ctrlProxyStub: CtrlProxySetupStub;
 
   /**
    * Stand up a daemon-backed session locked to `androidA` and pre-seed keep-awake
@@ -85,6 +87,12 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
     spiedSessionIds = [];
+    // #6227: `setupAutolockedSession` creates its session directly via
+    // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
+    // recorder), so it drives real per-session accessibility-service setup
+    // against a fake device with no real `adb`/network backing it — see
+    // test/helpers/stubCtrlProxySetup.ts.
+    ctrlProxyStub = stubCtrlProxySetup();
   });
 
   afterEach(() => {
@@ -97,6 +105,7 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     }
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+    ctrlProxyStub.restore();
   });
 
   const swipeSchema = z.object({

--- a/test/server/toolRegistry.scrollPositionUpdate.test.ts
+++ b/test/server/toolRegistry.scrollPositionUpdate.test.ts
@@ -12,7 +12,6 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
 import type { ScrollPosition } from "../../src/utils/interfaces/NavigationGraph";
-import { stubCtrlProxySetup, type CtrlProxySetupStub } from "../helpers/stubCtrlProxySetup";
 
 /**
  * Integration coverage for issue #2897: the swipeOn scroll-position update block
@@ -34,7 +33,6 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
   let originalDeviceSessionManager: unknown;
   let daemonSessionManager: SessionManager | undefined;
   let spiedSessionIds: string[];
-  let ctrlProxyStub: CtrlProxySetupStub;
 
   /**
    * Stand up a daemon-backed session locked to `androidA` and pre-seed keep-awake
@@ -90,9 +88,9 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     // #6227: `setupAutolockedSession` creates its session directly via
     // `DevicePool.autolockDevice` (bypassing the `deviceTools.ts` acquisition
     // recorder), so it drives real per-session accessibility-service setup
-    // against a fake device with no real `adb`/network backing it — see
-    // test/helpers/stubCtrlProxySetup.ts.
-    ctrlProxyStub = stubCtrlProxySetup();
+    // against a fake device. The shared test preload (test/setup/testPreload.ts)
+    // installs a no-op readiness driver so that setup cannot block on real
+    // `adb`/network.
   });
 
   afterEach(() => {
@@ -105,7 +103,6 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     }
     delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
-    ctrlProxyStub.restore();
   });
 
   const swipeSchema = z.object({

--- a/test/setup/testPreload.ts
+++ b/test/setup/testPreload.ts
@@ -3,6 +3,7 @@ import {
   getNoOpTelemetryRepository,
 } from "../../src/features/telemetry/TelemetryRecorder";
 import { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import { setDeviceReadinessProxyDriverProviderForTesting } from "../../src/server/deviceReadinessProxyProvider";
 
 /**
  * Globally neutralize the {@link TelemetryRecorder} for the whole suite so a
@@ -28,3 +29,29 @@ TelemetryRecorder.setDefaultRepositoryOverride(getNoOpTelemetryRepository());
 AndroidEmulatorClient.setHostPortAvailabilityCheckerForTesting({
   isAvailable: async () => true,
 });
+
+/**
+ * Globally neutralize the per-session Android accessibility-service readiness
+ * setup for the whole `bun test` process (issue #6227).
+ *
+ * `createToolExecutionContext`'s device-readiness upgrade runs real
+ * `AndroidCtrlProxyManager.getInstance(device).setup()` /
+ * `AndroidCtrlProxyClient.getInstance(device).waitForConnection()` for any
+ * existing session with no recorded readiness — including sessions created
+ * directly via `SessionManager.createSession` / `DevicePool` in integration
+ * tests that bypass the `deviceTools.ts` acquisition recorder. Against a fake
+ * device that setup blocks on unbounded real host I/O past bun's 5000ms
+ * timeout; a timed-out test skips its `finally` cleanup and leaks process-wide
+ * singletons into every later test. Installing a fast no-op driver here means
+ * NO test can hang on this path, regardless of which file creates the session.
+ *
+ * This is scoped to the readiness driver only, so the dedicated CtrlProxy
+ * manager/client suites keep exercising the real `getInstance`/`setup` code.
+ * Tests that must assert this path ran (e.g. readiness call counts) install
+ * their own counting provider via `test/helpers/stubCtrlProxySetup.ts`.
+ */
+setDeviceReadinessProxyDriverProviderForTesting(() => ({
+  resetSetupState: () => {},
+  setup: async () => ({ success: true, message: "ok" }),
+  waitForConnection: async () => true,
+}));

--- a/test/setup/testPreload.ts
+++ b/test/setup/testPreload.ts
@@ -54,4 +54,5 @@ setDeviceReadinessProxyDriverProviderForTesting(() => ({
   resetSetupState: () => {},
   setup: async () => ({ success: true, message: "ok" }),
   waitForConnection: async () => true,
+  isInstalled: async () => true,
 }));

--- a/test/setup/testPreload.ts
+++ b/test/setup/testPreload.ts
@@ -55,4 +55,5 @@ setDeviceReadinessProxyDriverProviderForTesting(() => ({
   setup: async () => ({ success: true, message: "ok" }),
   waitForConnection: async () => true,
   isInstalled: async () => true,
+  isVersionCompatible: async () => true,
 }));


### PR DESCRIPTION
## Problem

`createToolExecutionContext` (`src/server/ToolExecutionContext.ts`) ignored a tool's `deviceReadiness` requirement on the persisted daemon-session path — `ToolRegistry`'s branch that resolves a caller-provided `sessionUuid` while `DaemonState` is initialized (`src/server/toolRegistry.ts`, around the session-based device assignment block). It called `createToolExecutionContext` unconditionally, which in turn always ran `ensureAccessibilityServiceReady` (full CtrlProxy accessibility-service setup) for a fresh android session, with no way to opt out.

The legacy/no-session path already honored a tool's declared `deviceReadiness` via `DeviceSessionManager.ensureDeviceReady`'s `readiness` option, skipping automation-only setup for tools declaring `deviceReadiness: "booted"` (e.g. `listApps`, `videoRecordingTools`).

## Fix

- Added an optional `deviceReadiness` field to `SessionOptions` (`src/server/ToolExecutionContext.ts`), mirroring `DeviceReadinessLevel`.
- `setupSession` now skips `ensureAccessibilityServiceReady` when `sessionOptions.deviceReadiness === "booted"`.
- `ToolRegistry`'s daemon-session branch now computes `deviceReadiness` from the tool's `options.deviceReadiness` (function or literal) the same way the legacy branch already does, and threads it into `createToolExecutionContext`.

## Tests

- `test/server/ToolExecutionContext.test.ts`: new-session setup is skipped when `deviceReadiness: "booted"`, still runs for `automationReady`, and a tool omitting `deviceReadiness` is unaffected on both the new-session and existing-session branches.
- `test/server/toolRegistry.deviceReadinessPersistedSession.test.ts` (new): full `ToolRegistry`-level coverage of the persisted daemon-session path — a `sessionUuid` recovered from a persisted, non-terminal device-session row (daemon-restart recovery). A `booted`-only tool skips accessibility setup; an `automationReady` tool and a tool with no declared readiness both still run it, matching pre-fix behavior.

## Validation

- `bun test` (touched files + full suite) — all pass except two pre-existing, unrelated environment failures (missing `node_modules/.bin/oxlint` in this worktree, and a webrtc-integration subprocess-output assertion), unrelated to this change.
- `bun run lint` — no new violations (ratchet baseline count unchanged).
- `bun run typecheck` — no new errors (existing baseline count unchanged).
- `bun run format:check` — clean.
- `bunx turbo run build` — succeeds.

Closes #6227