### PR TITLE
fix(deviceMatcher): total ordering for lettered/QPR Android release qualifiers

### DIFF
--- a/src/utils/deviceMatcher.ts
+++ b/src/utils/deviceMatcher.ts
@@ -20,7 +20,7 @@ export interface DeviceMatcher {
   ): DeviceInfo | null;
 }
 
-interface ParsedDeviceVersion {
+export interface ParsedDeviceVersion {
   components: number[];
   /** A trailing single-letter release qualifier, e.g. Android 12L's "L" (#6132 follow-up). */
   letter?: string;
@@ -81,19 +81,56 @@ export function compareStrictNumericVersions(a: string, b: string): number {
   return compareParsedVersions(a.split(".").map(Number), b.split(".").map(Number));
 }
 
+/**
+ * Orders the numeric-components-then-letter prefix shared by `compareVersions`
+ * (a strict total order used to pick LATEST/MINIMUM) and `compareVersionToBound`
+ * (bound semantics, which may separately widen or ignore a QPR suffix
+ * depending on the bound's own precision). Extracted so the two QPR-handling
+ * call sites can't drift out of sync on how components and the letter
+ * qualifier order against each other (#6182).
+ */
+function compareComponentsThenLetter(
+  componentsA: number[],
+  letterA: string | undefined,
+  componentsB: number[],
+  letterB: string | undefined,
+): number {
+  const componentsDelta = compareParsedVersions(componentsA, componentsB);
+  if (componentsDelta !== 0) {
+    return componentsDelta;
+  }
+  return compareLetterQualifier(letterA, letterB);
+}
+
+/**
+ * Total ordering over a parsed Android release qualifier's (components,
+ * letter, qpr) triple: numeric dotted components take precedence, then the
+ * trailing letter qualifier (Android 12L), then the QPR suffix. A missing
+ * letter or QPR sorts before any present value, so `11 < 12 < 12L < 13` and
+ * `14 < 14-QPR1 < 14-QPR2` (#6182).
+ *
+ * This is a general total order over the triple -- it does NOT claim to
+ * encode Android's actual release calendar for comparing a letter release
+ * against a QPR release of the same major (e.g. `12L` vs `12-QPR1`); that
+ * relationship is undocumented and explicitly out of scope (see the tracking
+ * issue). The rule adopted here -- the letter qualifier outranks the QPR
+ * qualifier -- exists only to keep the relation total, reflexive, antisymmetric
+ * and transitive over every input this parser accepts, not to assert calendar
+ * accuracy for that specific pairing.
+ */
+export function compareReleaseQualifiers(a: ParsedDeviceVersion, b: ParsedDeviceVersion): number {
+  const delta = compareComponentsThenLetter(a.components, a.letter, b.components, b.letter);
+  if (delta !== 0) {
+    return delta;
+  }
+  return (a.qpr ?? 0) - (b.qpr ?? 0);
+}
+
 export function compareVersions(a: string, b: string): number {
   const parsedA = parseDeviceVersion(a);
   const parsedB = parseDeviceVersion(b);
   if (parsedA && parsedB) {
-    const delta = compareParsedVersions(parsedA.components, parsedB.components);
-    if (delta !== 0) {
-      return delta;
-    }
-    const letterDelta = compareLetterQualifier(parsedA.letter, parsedB.letter);
-    if (letterDelta !== 0) {
-      return letterDelta;
-    }
-    return (parsedA.qpr ?? 0) - (parsedB.qpr ?? 0);
+    return compareReleaseQualifiers(parsedA, parsedB);
   }
   if (parsedA || parsedB) {
     return Number.NaN;
@@ -172,9 +209,8 @@ function compareVersionToBound(version: string, bound: string, platform: Platfor
     // bound (e.g. "14-QPR1") must be excluded from widening too, even though
     // it also has exactly one numeric component: without this guard "14.1"
     // would slice down to "14" and false-match a "14-QPR1" bound it has
-    // nothing to do with (review follow-up; full QPR/letter ordering between
-    // arbitrary numeric versions is out of scope here -- see the tracking
-    // issue linked from the PR body).
+    // nothing to do with (review follow-up, generalized into
+    // compareReleaseQualifiers by #6182).
     const isMajorOnlyBound =
       platform === "android" &&
       parsedBound.components.length === 1 &&
@@ -183,17 +219,21 @@ function compareVersionToBound(version: string, bound: string, platform: Platfor
     const comparableVersion = isMajorOnlyBound
       ? parsedVersion.components.slice(0, 1)
       : parsedVersion.components;
-    const delta = compareParsedVersions(comparableVersion, parsedBound.components);
+    // Components and the letter qualifier always compare the same way here as
+    // in compareVersions/compareReleaseQualifiers (Android 12L must still
+    // sort above a plain "12" bound and below "13" -- #6132 follow-up --
+    // rather than being swallowed as equal to every unlettered point release
+    // of major 12); only the QPR handling below diverges, because a bound
+    // that doesn't name a QPR is deliberately QPR-agnostic rather than
+    // treating "no QPR" as QPR 0 (#6182).
+    const delta = compareComponentsThenLetter(
+      comparableVersion,
+      parsedVersion.letter,
+      parsedBound.components,
+      parsedBound.letter,
+    );
     if (delta !== 0) {
       return delta;
-    }
-    // Always compare the letter qualifier, even under major-only widening:
-    // Android 12L (letter "L") must still sort above a plain "12" bound and
-    // below "13" (#6132 follow-up) rather than being swallowed as equal to
-    // every unlettered point release of major 12.
-    const letterDelta = compareLetterQualifier(parsedVersion.letter, parsedBound.letter);
-    if (letterDelta !== 0) {
-      return letterDelta;
     }
     if (parsedBound.qpr === undefined) {
       return 0;

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -52,6 +52,53 @@ describe("compareVersions", () => {
     expect(Number.isNaN(compareVersions("Tiramisu", "Tiramisu"))).toBe(false);
     expect(compareVersions("Tiramisu", "Tiramisu")).toBe(0);
   });
+
+  it("orders a lettered release between its neighboring numeric majors (#6182)", () => {
+    // 11 < 12 < 12L < 13
+    expect(compareVersions("11", "12")).toBeLessThan(0);
+    expect(compareVersions("12", "12L")).toBeLessThan(0);
+    expect(compareVersions("12L", "13")).toBeLessThan(0);
+    expect(compareVersions("11", "13")).toBeLessThan(0);
+    // and the reverse direction
+    expect(compareVersions("12L", "12")).toBeGreaterThan(0);
+    expect(compareVersions("13", "12L")).toBeGreaterThan(0);
+  });
+
+  it("orders letters alphabetically at the same numeric components (#6182)", () => {
+    expect(compareVersions("12A", "12B")).toBeLessThan(0);
+    expect(compareVersions("12Z", "12A")).toBeGreaterThan(0);
+    expect(compareVersions("12", "12A")).toBeLessThan(0);
+  });
+
+  it("orders QPR builds of the same major strictly by QPR number (#6182)", () => {
+    expect(compareVersions("14-QPR0", "14-QPR1")).toBeLessThan(0);
+    expect(compareVersions("14-QPR1", "14-QPR2")).toBeLessThan(0);
+    expect(compareVersions("14-QPR2", "14-QPR1")).toBeGreaterThan(0);
+    // QPR0 is equal to the bare release: absent QPR defaults to 0.
+    expect(compareVersions("14", "14-QPR0")).toBe(0);
+    expect(compareVersions("14", "14-QPR1")).toBeLessThan(0);
+  });
+
+  it("treats equal (components, letter, qpr) triples as equal regardless of formatting (#6182)", () => {
+    expect(compareVersions("12L", "12L")).toBe(0);
+    expect(compareVersions("14-QPR1", "14-QPR1")).toBe(0);
+    expect(compareVersions("12.0L", "12L")).toBe(0);
+    expect(compareVersions("14.0-QPR1", "14-QPR1")).toBe(0);
+  });
+
+  it("ranks the letter qualifier above a QPR qualifier of the same major (#6182)", () => {
+    // Out-of-scope per the tracking issue as a claim about Android's actual
+    // release calendar, but the comparator must still return a well-defined,
+    // total, transitive answer for every input it accepts.
+    expect(compareVersions("12L", "12-QPR1")).toBeGreaterThan(0);
+    expect(compareVersions("12-QPR1", "12L")).toBeLessThan(0);
+  });
+
+  it("combines a letter and a QPR suffix on the same version (#6182)", () => {
+    expect(compareVersions("12L-QPR1", "12L-QPR2")).toBeLessThan(0);
+    expect(compareVersions("12L-QPR1", "12L")).toBeGreaterThan(0);
+    expect(compareVersions("12L-QPR1", "12")).toBeGreaterThan(0);
+  });
 });
 
 describe("DefaultDeviceMatcher.matchBootedDevice", () => {

--- a/test/utils/deviceMatcher.property.test.ts
+++ b/test/utils/deviceMatcher.property.test.ts
@@ -84,6 +84,92 @@ describe("compareVersions (property-based)", () => {
   });
 });
 
+// Lettered/QPR release qualifiers (#6182). A dedicated generator + independent
+// oracle over the full (components, letter, qpr) triple, rather than only
+// example-based tests, per the tracking issue's explicit ask -- the
+// interactions between the three parts are easy to under-specify by hand.
+const letterOrUndefined = fc.option(fc.constantFrom("A", "L", "Q", "Z"), { nil: undefined });
+const qprOrUndefined = fc.option(fc.nat(5), { nil: undefined });
+const releaseQualifier = fc.record({
+  parts: versionParts,
+  letter: letterOrUndefined,
+  qpr: qprOrUndefined,
+});
+type ReleaseQualifier = { parts: number[]; letter: string | undefined; qpr: number | undefined };
+
+const qualifierToString = (q: ReleaseQualifier): string =>
+  `${versionOf(q.parts)}${q.letter ?? ""}${q.qpr === undefined ? "" : `-QPR${q.qpr}`}`;
+
+// Independent oracle: components first (missing trailing components as 0),
+// then the letter qualifier (absent sorts before any letter, otherwise
+// alphabetical), then the QPR suffix (absent treated as 0).
+const refQualifierCompareSign = (a: ReleaseQualifier, b: ReleaseQualifier): number => {
+  const componentsSign = refCompareSign(a.parts, b.parts);
+  if (componentsSign !== 0) {
+    return componentsSign;
+  }
+  if (a.letter !== b.letter) {
+    if (a.letter === undefined) {
+      return -1;
+    }
+    if (b.letter === undefined) {
+      return 1;
+    }
+    return a.letter < b.letter ? -1 : 1;
+  }
+  return Math.sign((a.qpr ?? 0) - (b.qpr ?? 0));
+};
+
+describe("compareVersions over lettered/QPR release qualifiers (property-based)", () => {
+  test("is reflexive", () => {
+    fc.assert(
+      fc.property(
+        releaseQualifier,
+        (q) => compareVersions(qualifierToString(q), qualifierToString(q)) === 0,
+      ),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("is sign-antisymmetric", () => {
+    fc.assert(
+      fc.property(releaseQualifier, releaseQualifier, (a, b) => {
+        const sa = qualifierToString(a);
+        const sb = qualifierToString(b);
+        return Math.sign(compareVersions(sa, sb)) === -Math.sign(compareVersions(sb, sa));
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("agrees in sign with the independent (components, letter, qpr) oracle", () => {
+    fc.assert(
+      fc.property(releaseQualifier, releaseQualifier, (a, b) => {
+        return (
+          Math.sign(compareVersions(qualifierToString(a), qualifierToString(b))) ===
+          refQualifierCompareSign(a, b)
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+
+  test("ordering is transitive", () => {
+    fc.assert(
+      fc.property(releaseQualifier, releaseQualifier, releaseQualifier, (a, b, c) => {
+        const sa = qualifierToString(a);
+        const sb = qualifierToString(b);
+        const sc = qualifierToString(c);
+        return (
+          !(compareVersions(sa, sb) <= 0 && compareVersions(sb, sc) <= 0) ||
+          compareVersions(sa, sc) <= 0
+        );
+      }),
+      RUN_OPTIONS,
+    );
+  });
+});
+
 const platform = fc.constantFrom<Platform>("android", "ios");
 const device: fc.Arbitrary<BootedDevice> = fc.record({
   name: fc.string({ maxLength: 12 }),


### PR DESCRIPTION
## Summary

Generalizes `deviceMatcher`'s release-qualifier ordering into a single, well-documented, pure total-ordering function over the `(components, letter, qpr)` triple, and backs it with thorough example-based and property-based tests, per the design suggested in #6182.

## Changes

- Extract `compareComponentsThenLetter` (shared numeric-components + trailing-letter ordering) and `compareReleaseQualifiers` (the full total order including QPR) in `src/utils/deviceMatcher.ts`.
- `compareVersions` now delegates to `compareReleaseQualifiers` directly instead of duplicating the walk inline.
- `compareVersionToBound` reuses `compareComponentsThenLetter` for its components/letter comparison, keeping only its bound-specific QPR semantics (a bound without a QPR is QPR-agnostic, unlike `compareVersions`' strict total order) as a local difference — so the two call sites can no longer drift apart on how components and letters compare.
- Documented, as a deliberate and total (not calendar-accurate) rule, that a letter qualifier outranks a QPR qualifier of the same major (e.g. `12L > 12-QPR1`) — this specific pairing is explicitly called out as undocumented/out of scope in the issue, so the rule exists only to keep the relation total/transitive, not to assert Android release-calendar accuracy.

## Tests

- `test/server/deviceMatcher.test.ts`: new example-based cases for `11 < 12 < 12L < 13`, alphabetical letter ordering, QPR ordering (including QPR0 == bare release), equality across formatting variants, the letter-vs-QPR boundary, and combined letter+QPR suffixes.
- `test/utils/deviceMatcher.property.test.ts`: new property-based suite generating lettered/QPR release qualifiers, checking reflexivity, antisymmetry, transitivity, and agreement with an independent oracle — addressing the issue's suggestion to exercise these interactions via property tests rather than only hand-picked examples.

## Out of scope (per the issue)

- Multi-letter codenames beyond a single trailing letter.
- A canonical/shared ordering table cross-checked against `AvdConfigReader.versionToApiLevelRange`.

## Validation

- `bun test test/server/deviceMatcher.test.ts test/utils/deviceMatcher.property.test.ts` — 64 pass
- `bun run lint` — no new ratchet violations
- `bun run typecheck` — no new baseline errors
- `bun run format:check` — clean
- `bunx turbo run build` — succeeds

Closes #6182