### PR TITLE
fix(android): verify home press actually backgrounds the app (#6147)

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -7,7 +7,7 @@ import { AwaitIdle } from "../observe/AwaitIdle";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { Window } from "../observe/Window";
-import { isLauncherPackage } from "../observe/androidLauncherPackages";
+import { isForegroundLauncher } from "../observe/androidLauncherPackages";
 import { logger } from "../../utils/logger";
 import { errorMessage } from "../../utils/describeUnknownError";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../utils/constants";
@@ -560,10 +560,11 @@ export class BaseVisualChange {
 
   /**
    * Confirm that a "go home" action actually backgrounded the foreground app
-   * by re-reading the foreground window and checking it against known
-   * launcher packages, instead of trusting a dispatch method's self-reported
-   * success (issue #6147: on API 28 the accessibility global action for
-   * "home" can report success while the foreground app is unchanged).
+   * by re-reading the foreground window and checking it against the
+   * device's actually-configured HOME launcher, instead of trusting a
+   * dispatch method's self-reported success (issue #6147: on API 28 the
+   * accessibility global action for "home" can report success while the
+   * foreground app is unchanged).
    *
    * Retries with short backoffs (via the injected `Timer`, so `FakeTimer`
    * keeps tests fast/deterministic) to tolerate the brief settle time a real
@@ -579,7 +580,15 @@ export class BaseVisualChange {
     for (let attempt = 0; ; attempt++) {
       try {
         const activeWindow = await this.window.getActive(true);
-        if (isLauncherPackage(activeWindow.appId)) {
+        if (
+          await isForegroundLauncher(
+            activeWindow.appId,
+            this.adb,
+            this.device.deviceId,
+            this.timer,
+            this.device.transportId,
+          )
+        ) {
           return true;
         }
       } catch (error) {

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -7,7 +7,9 @@ import { AwaitIdle } from "../observe/AwaitIdle";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { Window } from "../observe/Window";
+import { isLauncherPackage } from "../observe/androidLauncherPackages";
 import { logger } from "../../utils/logger";
+import { errorMessage } from "../../utils/describeUnknownError";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../utils/constants";
 import {
   ActionableError,
@@ -554,5 +556,43 @@ export class BaseVisualChange {
       toolName: context.toolName,
       toolArgs: context.toolArgs,
     };
+  }
+
+  /**
+   * Confirm that a "go home" action actually backgrounded the foreground app
+   * by re-reading the foreground window and checking it against known
+   * launcher packages, instead of trusting a dispatch method's self-reported
+   * success (issue #6147: on API 28 the accessibility global action for
+   * "home" can report success while the foreground app is unchanged).
+   *
+   * Retries with short backoffs (via the injected `Timer`, so `FakeTimer`
+   * keeps tests fast/deterministic) to tolerate the brief settle time a real
+   * device needs between dispatch and the launcher taking focus.
+   *
+   * @param retryDelaysMs - Backoff delays between verification attempts.
+   *   Defaults chosen to give a real device a couple of short chances to
+   *   settle without materially slowing down a genuine failure.
+   */
+  protected async verifyAndroidHomeForeground(
+    retryDelaysMs: readonly number[] = [150, 300],
+  ): Promise<boolean> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const activeWindow = await this.window.getActive(true);
+        if (isLauncherPackage(activeWindow.appId)) {
+          return true;
+        }
+      } catch (error) {
+        logger.warn(
+          `[BaseVisualChange] Failed to read foreground app while verifying home press: ${errorMessage(error)}`,
+          error,
+        );
+      }
+      const delay = retryDelaysMs[attempt];
+      if (delay === undefined) {
+        return false;
+      }
+      await this.timer.sleep(delay);
+    }
   }
 }

--- a/src/features/action/HomeScreen.ts
+++ b/src/features/action/HomeScreen.ts
@@ -1,18 +1,22 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
-import { BootedDevice, HomeScreenResult } from "../../models";
+import { ActionableError, BootedDevice, HomeScreenResult } from "../../models";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Navigates to the home screen using the accessibility service global action
- * (preferred) or hardware home button keyevent (fallback).
+ * (preferred) or hardware home button keyevent (fallback). Verifies the
+ * foreground app actually became the launcher before reporting success
+ * (issue #6147) rather than trusting either dispatch method's self-reported
+ * result.
  */
 export class HomeScreen extends BaseVisualChange {
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
-    super(device, adb);
+  constructor(device: BootedDevice, adb: AdbClient | null = null, timer: Timer = defaultTimer) {
+    super(device, adb, timer);
     this.device = device;
   }
 
@@ -48,18 +52,38 @@ export class HomeScreen extends BaseVisualChange {
   }
 
   private async executeAndroidHome(): Promise<void> {
+    let globalActionSucceeded = false;
     try {
       const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
       const result = await client.requestGlobalAction("home", 3000);
-      if (result.success) {
-        logger.debug("[HOME] Used accessibility service global action");
-        return;
+      globalActionSucceeded = result.success;
+      if (!globalActionSucceeded) {
+        logger.debug(`[HOME] Global action failed (${result.error}), falling back to ADB keyevent`);
       }
-      logger.debug(`[HOME] Global action failed (${result.error}), falling back to ADB keyevent`);
     } catch {
       // Fall through to ADB
     }
+
+    if (globalActionSucceeded) {
+      if (await this.verifyAndroidHomeForeground()) {
+        logger.debug("[HOME] Used accessibility service global action");
+        return;
+      }
+      // The global action self-reported success but the foreground app never
+      // became the launcher (issue #6147 -- observed on API 28). Do not trust
+      // the report; fall back to the ADB keyevent path known to work.
+      logger.debug(
+        "[HOME] Global action reported success but foreground app did not change to the launcher; falling back to ADB keyevent",
+      );
+    }
+
     await this.adb.executeCommand("shell input keyevent 3");
+
+    if (!(await this.verifyAndroidHomeForeground())) {
+      throw new ActionableError(
+        "Home press did not background the foreground app: neither the accessibility global action nor the ADB KEYCODE_HOME keyevent produced a launcher foreground window",
+      );
+    }
   }
 
   private async executeIosHomeNavigation(perf?: PerformanceTracker): Promise<void> {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -168,6 +168,21 @@ export class PressButton extends BaseVisualChange {
       }
       throw error;
     }
+
+    // "home" is verified end-to-end (issue #6147): neither the accessibility
+    // global action above nor this ADB keyevent are trustworthy on their own
+    // self-reported success, on API 28 specifically. Other buttons (back,
+    // recent, hardware) have no equivalently cheap ground truth to check
+    // against and keep their existing dispatch-is-success behavior.
+    if (normalized === "home" && !(await this.verifyAndroidHomeForeground())) {
+      return {
+        success: false,
+        button,
+        keyCode: -1,
+        error:
+          "Home press did not background the foreground app: the ADB KEYCODE_HOME keyevent did not produce a launcher foreground window",
+      };
+    }
     return { success: true, button, keyCode };
   }
 
@@ -198,10 +213,20 @@ export class PressButton extends BaseVisualChange {
         frameContext,
       );
       if (result.success) {
-        logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
-        return { success: true, button, keyCode };
+        // "home" specifically can self-report success while leaving the
+        // foreground app unchanged on API 28 (issue #6147). Confirm the
+        // foreground actually became the launcher before trusting it; other
+        // global-action buttons (back, recent) keep the prior behavior.
+        if (normalized !== "home" || (await this.verifyAndroidHomeForeground())) {
+          logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
+          return { success: true, button, keyCode };
+        }
+        logger.debug(
+          `[PRESS_BUTTON] Global action for ${button} reported success but foreground app did not change to the launcher; falling back to ADB`,
+        );
+      } else {
+        logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
       }
-      logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
     } catch (error) {
       // The validated ADB fallback remains safe when the global-action RPC fails.
       logger.debug(

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -1,0 +1,35 @@
+/**
+ * Known Android launcher package names (or their sub-packages), used to
+ * verify that a "go home" action actually landed on the home screen.
+ *
+ * Background (issue #6147): on Android API 28 the CtrlProxy accessibility
+ * global action for "home" can report success while the foreground app is
+ * unchanged (or even navigates within the same app, mimicking Back). Home
+ * actions must not report success on the strength of that self-reported
+ * result alone -- they need to confirm the foreground package actually
+ * became the launcher.
+ */
+const LAUNCHER_PACKAGES: readonly string[] = [
+  "com.android.launcher3",
+  "com.google.android.apps.nexuslauncher",
+  "com.samsung.android.app.launcher",
+  "com.miui.home",
+  "com.oneplus.launcher",
+  "com.huawei.android.launcher",
+  "com.sec.android.app.launcher",
+];
+
+/**
+ * True when `appId` is a known launcher package or a sub-package of one
+ * (e.g. `com.miui.home.settings`). Matches by prefix, not substring
+ * containment, so short package names cannot be misclassified (cf. issue
+ * #4172's equivalent fix for `Idle.isSystemLauncher`).
+ */
+export function isLauncherPackage(appId: string | null | undefined): boolean {
+  if (!appId) {
+    return false;
+  }
+  return LAUNCHER_PACKAGES.some(
+    (launcherPackage) => appId === launcherPackage || appId.startsWith(`${launcherPackage}.`),
+  );
+}

--- a/src/features/observe/androidLauncherPackages.ts
+++ b/src/features/observe/androidLauncherPackages.ts
@@ -1,6 +1,13 @@
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { logger } from "../../utils/logger";
+import { errorMessage } from "../../utils/describeUnknownError";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
+
 /**
- * Known Android launcher package names (or their sub-packages), used to
- * verify that a "go home" action actually landed on the home screen.
+ * Verify that a "go home" action actually landed on the home screen by
+ * resolving the device's ACTUALLY-CONFIGURED HOME launcher at runtime and
+ * comparing the foreground package against it, instead of trusting a
+ * dispatch method's self-reported result.
  *
  * Background (issue #6147): on Android API 28 the CtrlProxy accessibility
  * global action for "home" can report success while the foreground app is
@@ -8,8 +15,40 @@
  * actions must not report success on the strength of that self-reported
  * result alone -- they need to confirm the foreground package actually
  * became the launcher.
+ *
+ * A prior version of this module matched the foreground package against a
+ * hardcoded 7-package prefix list. That was both too NARROW (a device whose
+ * selected HOME app isn't in the list makes every successful Home press look
+ * like a failure) and too LOOSE (prefix matching accepts an unrelated app
+ * like `com.android.launcher3.example`). Resolving the real configured
+ * launcher and comparing by EXACT match fixes both.
  */
-const LAUNCHER_PACKAGES: readonly string[] = [
+
+/**
+ * Shell command used to resolve the device's configured HOME launcher
+ * package, via the standard `cmd package` surface (routed through the
+ * injected {@link AdbExecutor}, never a raw child-process call). Typical
+ * output is two lines, the second of the form `<package>/<activity>`:
+ *
+ *   priority=0 preferredOrder=0 match=0x108000 specificIndex=-1 isDefault=true
+ *   com.example.launcher/.LauncherActivity
+ */
+const RESOLVE_HOME_COMMAND =
+  "shell cmd package resolve-activity --brief -c android.intent.category.HOME -a android.intent.action.MAIN";
+
+/** Timeout for the `cmd package resolve-activity` read. */
+const RESOLVE_HOME_TIMEOUT_MS = 5000;
+
+/**
+ * Fallback launcher packages, used ONLY when the device's configured HOME
+ * launcher cannot be resolved at runtime (e.g. `cmd package` unavailable, or
+ * the resolve command failing/timing out). Matched by EXACT package name --
+ * never by prefix, so an unrelated app like `com.android.launcher3.example`
+ * cannot be misclassified as a launcher. Mirrors `Idle.isSystemLauncher`'s
+ * launcher packages, including the legacy AOSP `com.android.launcher`.
+ */
+const FALLBACK_LAUNCHER_PACKAGES: ReadonlySet<string> = new Set([
+  "com.android.launcher",
   "com.android.launcher3",
   "com.google.android.apps.nexuslauncher",
   "com.samsung.android.app.launcher",
@@ -17,19 +56,186 @@ const LAUNCHER_PACKAGES: readonly string[] = [
   "com.oneplus.launcher",
   "com.huawei.android.launcher",
   "com.sec.android.app.launcher",
-];
+]);
 
 /**
- * True when `appId` is a known launcher package or a sub-package of one
- * (e.g. `com.miui.home.settings`). Matches by prefix, not substring
- * containment, so short package names cannot be misclassified (cf. issue
- * #4172's equivalent fix for `Idle.isSystemLauncher`).
+ * How long a resolved HOME launcher package stays valid before it must be
+ * re-resolved. The cache used to be process-lifetime: once a device's
+ * launcher was resolved, changing the default HOME app while the daemon kept
+ * running had no effect -- every later verification kept comparing against
+ * the stale package, so `isForegroundLauncher` rejected the real (new)
+ * launcher and both the global-action and ADB fallback paths reported
+ * failure until the daemon restarted.
+ *
+ * 30 seconds is short enough that a user who just changed their default HOME
+ * app sees it take effect well within a single interactive session, but long
+ * enough that the repeated Home presses within one test/automation run (which
+ * can happen several times a second) still hit the cache instead of
+ * re-querying `cmd package resolve-activity` on every call.
  */
-export function isLauncherPackage(appId: string | null | undefined): boolean {
+const RESOLVED_HOME_PACKAGE_TTL_MS = 30_000;
+
+interface ResolvedHomePackageCacheEntry {
+  packageName: string;
+  resolvedAtMs: number;
+  /**
+   * The device CONNECTION EPOCH this entry was resolved under, e.g.
+   * `BootedDevice.transportId` -- undefined when the caller has no
+   * incarnation info to offer. Android serials are reused across connection
+   * epochs (see `daemon/deviceSessionRegistry.ts`; e.g. a fresh AVD taking
+   * over `emulator-5554` within the TTL below), so keying this cache on
+   * `deviceId` alone lets a same-serial reincarnation serve the PREVIOUS
+   * device's launcher for up to {@link RESOLVED_HOME_PACKAGE_TTL_MS}.
+   * Comparing this token on read treats an incarnation change as a cache
+   * miss even though the serial is unchanged.
+   */
+  incarnationToken: string | undefined;
+}
+
+/**
+ * Per-device cache of the resolved configured HOME launcher package. Only
+ * successful resolutions are cached -- a transient failure retries on the
+ * next call rather than permanently downgrading that device to the fallback
+ * list for the rest of the process's lifetime. Entries expire after
+ * {@link RESOLVED_HOME_PACKAGE_TTL_MS} so a changed default HOME launcher is
+ * picked up without a daemon restart, and are invalidated by a device
+ * INCARNATION change on the same serial (see
+ * {@link ResolvedHomePackageCacheEntry.incarnationToken}).
+ */
+const resolvedHomePackageCache = new Map<string, ResolvedHomePackageCacheEntry>();
+
+/**
+ * Parse the package name out of `cmd package resolve-activity --brief`
+ * output. Only the last non-empty line, of the form `<package>/<activity>`,
+ * matters -- any preceding metadata line is ignored.
+ */
+function parseResolvedHomePackage(stdout: string): string | null {
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const lastLine = lines[lines.length - 1];
+  if (!lastLine) {
+    return null;
+  }
+  const match = lastLine.match(/^([^\s/]+)\//);
+  return match ? match[1] : null;
+}
+
+/**
+ * The cached package name, but only when it is still within
+ * {@link RESOLVED_HOME_PACKAGE_TTL_MS} of `now` AND was resolved under the
+ * same `incarnationToken`. Returns undefined for "no cache entry", "cache
+ * entry expired", and "cache entry belongs to a superseded incarnation" --
+ * the caller re-resolves in all three cases.
+ */
+function freshCachedPackageName(
+  cached: ResolvedHomePackageCacheEntry | undefined,
+  now: number,
+  incarnationToken: string | undefined,
+): string | undefined {
+  if (cached === undefined || cached.incarnationToken !== incarnationToken) {
+    return undefined;
+  }
+  return now - cached.resolvedAtMs < RESOLVED_HOME_PACKAGE_TTL_MS ? cached.packageName : undefined;
+}
+
+/**
+ * Resolve the device's actually-configured HOME launcher package, caching a
+ * successful result per device (for {@link RESOLVED_HOME_PACKAGE_TTL_MS}) so
+ * repeated verification retries within a single Home-press don't re-query.
+ * Returns null when resolution fails or yields no usable package -- callers
+ * must fall back to {@link isFallbackLauncherPackage} in that case.
+ *
+ * @param incarnationToken - A discriminator for the device's current
+ *   connection epoch, e.g. `BootedDevice.transportId`. A cached entry
+ *   resolved under a DIFFERENT token (same `deviceId`, new incarnation -- a
+ *   reused Android serial such as `emulator-5554` picked up by a fresh AVD
+ *   within the TTL) is treated as a cache miss and re-resolved, instead of
+ *   serving the previous incarnation's launcher. Omit to keep the previous
+ *   serial-only keying (e.g. callers with no incarnation info available).
+ */
+export async function resolveConfiguredHomePackage(
+  adb: AdbExecutor,
+  deviceId: string,
+  timer: Timer = defaultTimer,
+  incarnationToken?: string,
+): Promise<string | null> {
+  const now = timer.now();
+  const cached = resolvedHomePackageCache.get(deviceId);
+  const freshCachedPackage = freshCachedPackageName(cached, now, incarnationToken);
+  if (freshCachedPackage !== undefined) {
+    return freshCachedPackage;
+  }
+  try {
+    const result = await adb.executeCommand(
+      RESOLVE_HOME_COMMAND,
+      RESOLVE_HOME_TIMEOUT_MS,
+      undefined,
+      true,
+    );
+    const packageName = parseResolvedHomePackage(result.stdout);
+    if (packageName) {
+      resolvedHomePackageCache.set(deviceId, {
+        packageName,
+        resolvedAtMs: now,
+        incarnationToken,
+      });
+    }
+    return packageName;
+  } catch (error) {
+    logger.warn(
+      `[androidLauncherPackages] Failed to resolve configured HOME launcher package: ${errorMessage(error)}`,
+      error,
+    );
+    return null;
+  }
+}
+
+/** Clear the resolved-HOME-package cache (all devices, or just one). */
+export function clearResolvedHomePackageCache(deviceId?: string): void {
+  if (deviceId === undefined) {
+    resolvedHomePackageCache.clear();
+  } else {
+    resolvedHomePackageCache.delete(deviceId);
+  }
+}
+
+/**
+ * True when `appId` is a known fallback launcher package, matched EXACTLY
+ * (never by prefix). Used only when the configured HOME launcher could not
+ * be resolved at runtime.
+ */
+export function isFallbackLauncherPackage(appId: string | null | undefined): boolean {
   if (!appId) {
     return false;
   }
-  return LAUNCHER_PACKAGES.some(
-    (launcherPackage) => appId === launcherPackage || appId.startsWith(`${launcherPackage}.`),
-  );
+  return FALLBACK_LAUNCHER_PACKAGES.has(appId);
+}
+
+/**
+ * True when `appId` is the foreground launcher: an EXACT match against the
+ * device's actually-configured HOME package when resolvable, or a known
+ * fallback launcher package otherwise.
+ *
+ * @param incarnationToken - Forwarded to {@link resolveConfiguredHomePackage}
+ *   -- see its doc for why a device's connection-epoch discriminator (e.g.
+ *   `BootedDevice.transportId`) must be supplied to avoid serving a reused
+ *   serial's stale cached launcher.
+ */
+export async function isForegroundLauncher(
+  appId: string | null | undefined,
+  adb: AdbExecutor,
+  deviceId: string,
+  timer: Timer = defaultTimer,
+  incarnationToken?: string,
+): Promise<boolean> {
+  if (!appId) {
+    return false;
+  }
+  const configuredHome = await resolveConfiguredHomePackage(adb, deviceId, timer, incarnationToken);
+  if (configuredHome) {
+    return appId === configuredHome;
+  }
+  return isFallbackLauncherPackage(appId);
 }

--- a/test/features/action/HomeScreen.test.ts
+++ b/test/features/action/HomeScreen.test.ts
@@ -1,5 +1,6 @@
-import { expect, describe, test, beforeEach, spyOn } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { HomeScreen } from "../../../src/features/action/HomeScreen";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { BootedDevice, ObserveResult } from "../../../src/models";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
@@ -7,6 +8,9 @@ import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ActiveWindowInfo } from "../../../src/models/ActiveWindowInfo";
+import type { Window as WindowInterface } from "../../../src/features/observe/interfaces/Window";
 
 // Helper function to create mock ObserveResult
 // Each call creates a unique viewHierarchy object so change detection works
@@ -18,6 +22,35 @@ const createObserveResult = (): ObserveResult => ({
   viewHierarchy: { node: {}, id: hierarchyCounter++ },
 });
 
+// Minimal Window stub that returns a scripted sequence of foreground apps,
+// one entry per `getActive` call (last entry repeats once exhausted). Lets
+// tests exercise "the global action's post-dispatch check sees the old app,
+// the post-ADB-fallback check sees the launcher" without a shared FakeWindow
+// method for sequencing.
+function sequencedWindow(appIds: string[]): WindowInterface {
+  let callIndex = 0;
+  const toActiveWindow = (appId: string): ActiveWindowInfo => ({
+    appId,
+    activityName: "Activity",
+    layoutSeqSum: 0,
+  });
+  return {
+    async getActive(): Promise<ActiveWindowInfo> {
+      const appId = appIds[Math.min(callIndex, appIds.length - 1)];
+      callIndex++;
+      return toActiveWindow(appId);
+    },
+    async getActiveHash(): Promise<string> {
+      return "fake-hash";
+    },
+    async getCachedActiveWindow(): Promise<ActiveWindowInfo | null> {
+      return null;
+    },
+    async setCachedActiveWindow(): Promise<void> {},
+    async clearCache(): Promise<void> {},
+  };
+}
+
 describe("HomeScreen", () => {
   let homeScreen: HomeScreen;
   let mockDevice: BootedDevice;
@@ -25,6 +58,8 @@ describe("HomeScreen", () => {
   let fakeObserveScreen: FakeObserveScreen;
   let fakeWindow: FakeWindow;
   let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeTimer: FakeTimer;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
 
   beforeEach(() => {
     // Create fakes for testing
@@ -32,12 +67,17 @@ describe("HomeScreen", () => {
     fakeObserveScreen = new FakeObserveScreen();
     fakeWindow = new FakeWindow();
     fakeAwaitIdle = new FakeAwaitIdle();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
 
-    // Set up default fake responses
+    // Set up default fake responses. The default foreground app is a known
+    // launcher package so home-press verification (issue #6147) passes for
+    // tests that aren't specifically exercising the verification failure
+    // path below.
     fakeWindow.configureCachedActiveWindow(null);
     fakeWindow.configureActiveWindow({
-      appId: "com.test.app",
-      activityName: "MainActivity",
+      appId: "com.android.launcher3",
+      activityName: "Launcher",
       layoutSeqSum: 123,
     });
 
@@ -50,12 +90,17 @@ describe("HomeScreen", () => {
       platform: "android",
       deviceId: "test-device",
     };
-    homeScreen = new HomeScreen(mockDevice, fakeAdb);
+    homeScreen = new HomeScreen(mockDevice, fakeAdb, fakeTimer);
 
     // Replace the internal managers with our fakes
     (homeScreen as any).observeScreen = fakeObserveScreen;
     (homeScreen as any).window = fakeWindow;
     (homeScreen as any).awaitIdle = fakeAwaitIdle;
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
   });
 
   describe("execute", () => {
@@ -146,8 +191,8 @@ describe("HomeScreen", () => {
 
       fakeWindow2.configureCachedActiveWindow(null);
       fakeWindow2.configureActiveWindow({
-        appId: "com.test.app",
-        activityName: "MainActivity",
+        appId: "com.android.launcher3",
+        activityName: "Launcher",
         layoutSeqSum: 123,
       });
       fakeObserveScreen2.setObserveResult(() => createObserveResult());
@@ -165,6 +210,74 @@ describe("HomeScreen", () => {
       expect(result2.success).toBe(true);
       expect(result1.navigationMethod).toBe("hardware");
       expect(result2.navigationMethod).toBe("hardware");
+    });
+  });
+
+  // Regression coverage for issue #6147: on Android API 28 the accessibility
+  // global action for "home" can report success while the foreground app
+  // never becomes the launcher. Home must verify the actual foreground app
+  // instead of trusting a dispatch method's self-reported result.
+  describe("home-press verification (issue #6147)", () => {
+    test("reports success when the accessibility global action actually backgrounds the app", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: true }),
+      } as unknown as AndroidCtrlProxyClient);
+      // Default fakeWindow already reports "com.android.launcher3" foreground.
+
+      const result = await homeScreen.execute();
+
+      expect(result.success).toBe(true);
+      expect(fakeAdb.getExecutedCommands()).toEqual([]);
+    });
+
+    test("falls back to the ADB keyevent when the global action is inert (API 28) but the foreground never changes", async () => {
+      // Simulates the API 28 repro from issue #6147: the global action
+      // reports success, but the foreground package stays the app under
+      // test on every check, including after the ADB fallback -- so this
+      // must surface a failure rather than false success.
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: true }),
+      } as unknown as AndroidCtrlProxyClient);
+      (homeScreen as any).window = sequencedWindow(["com.android.settings"]);
+      fakeAdb.setCommandResponse("shell input keyevent 3", { stdout: "", stderr: "" });
+
+      await expect(homeScreen.execute()).rejects.toThrow(/did not background the foreground app/);
+
+      // The inert global action must not be trusted -- the ADB fallback has
+      // to have actually been attempted before giving up.
+      expect(fakeAdb.getExecutedCommands()).toContain("shell input keyevent 3");
+    });
+
+    test("recovers via the ADB keyevent fallback when the global action is inert but the fallback reaches the launcher", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: true }),
+      } as unknown as AndroidCtrlProxyClient);
+      // The post-global-action verification retries internally (initial
+      // attempt + 2 backoff retries) before giving up, so it must see the
+      // app unchanged on all 3 of those checks; only the post-ADB-keyevent
+      // verification's first check sees the launcher.
+      (homeScreen as any).window = sequencedWindow([
+        "com.android.settings",
+        "com.android.settings",
+        "com.android.settings",
+        "com.android.launcher3",
+      ]);
+      fakeAdb.setCommandResponse("shell input keyevent 3", { stdout: "", stderr: "" });
+
+      const result = await homeScreen.execute();
+
+      expect(result.success).toBe(true);
+      expect(fakeAdb.getExecutedCommands()).toContain("shell input keyevent 3");
+    });
+
+    test("throws instead of reporting false success when the ADB keyevent fallback also fails to reach the launcher", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "global action unavailable" }),
+      } as unknown as AndroidCtrlProxyClient);
+      (homeScreen as any).window = sequencedWindow(["com.android.settings"]);
+      fakeAdb.setCommandResponse("shell input keyevent 3", { stdout: "", stderr: "" });
+
+      await expect(homeScreen.execute()).rejects.toThrow(/did not background the foreground app/);
     });
   });
 });

--- a/test/features/action/HomeScreen.test.ts
+++ b/test/features/action/HomeScreen.test.ts
@@ -227,7 +227,10 @@ describe("HomeScreen", () => {
       const result = await homeScreen.execute();
 
       expect(result.success).toBe(true);
-      expect(fakeAdb.getExecutedCommands()).toEqual([]);
+      // No ADB keyevent fallback is needed -- the only ADB traffic is the
+      // configured-HOME-launcher resolution that verification now performs
+      // (issue #6147 review, P1).
+      expect(fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes("keyevent"))).toEqual([]);
     });
 
     test("falls back to the ADB keyevent when the global action is inert (API 28) but the foreground never changes", async () => {

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -2,7 +2,39 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { PressButton } from "../../../src/features/action/PressButton";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeWindow } from "../../fakes/FakeWindow";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import type { BootedDevice } from "../../../src/models";
+import type { ActiveWindowInfo } from "../../../src/models/ActiveWindowInfo";
+import type { Window as WindowInterface } from "../../../src/features/observe/interfaces/Window";
+
+// Minimal Window stub that returns a scripted sequence of foreground apps,
+// one entry per `getActive` call (last entry repeats once exhausted) --
+// lets tests distinguish "the post-global-action check" from "the
+// post-ADB-fallback check" (issue #6147).
+function sequencedWindow(appIds: string[]): WindowInterface {
+  let callIndex = 0;
+  const toActiveWindow = (appId: string): ActiveWindowInfo => ({
+    appId,
+    activityName: "Activity",
+    layoutSeqSum: 0,
+  });
+  return {
+    async getActive(): Promise<ActiveWindowInfo> {
+      const appId = appIds[Math.min(callIndex, appIds.length - 1)];
+      callIndex++;
+      return toActiveWindow(appId);
+    },
+    async getActiveHash(): Promise<string> {
+      return "fake-hash";
+    },
+    async getCachedActiveWindow(): Promise<ActiveWindowInfo | null> {
+      return null;
+    },
+    async setCachedActiveWindow(): Promise<void> {},
+    async clearCache(): Promise<void> {},
+  };
+}
 
 describe("PressButton Android keycode dispatch", () => {
   const androidDevice: BootedDevice = {
@@ -12,10 +44,13 @@ describe("PressButton Android keycode dispatch", () => {
   };
 
   let fakeAdb: FakeAdbExecutor;
+  let fakeTimer: FakeTimer;
   let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
 
   beforeEach(() => {
     fakeAdb = new FakeAdbExecutor();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
   });
 
   afterEach(() => {
@@ -23,14 +58,31 @@ describe("PressButton Android keycode dispatch", () => {
     getInstanceSpy = null;
   });
 
-  const press = (button: string) => {
-    const pressButton = new PressButton(androidDevice, fakeAdb);
+  const press = (button: string, window?: WindowInterface) => {
+    const pressButton = new PressButton(androidDevice, fakeAdb, fakeTimer);
+    if (window) {
+      (pressButton as any).window = window;
+    }
     return (pressButton as any).executeAndroidButtonPress(button) as Promise<{
       success: boolean;
       button: string;
       keyCode: number;
       error?: string;
     }>;
+  };
+
+  // Home-press verification (issue #6147) reads the foreground app via
+  // `this.window`, so non-home buttons -- which skip verification entirely
+  // -- don't need a configured window at all. Home tests below configure
+  // one explicitly.
+  const launcherWindow = (): FakeWindow => {
+    const window = new FakeWindow();
+    window.configureActiveWindow({
+      appId: "com.android.launcher3",
+      activityName: "Launcher",
+      layoutSeqSum: 0,
+    });
+    return window;
   };
 
   // In-place hardware buttons dispatch straight to an ADB keyevent (no global action).
@@ -76,7 +128,6 @@ describe("PressButton Android keycode dispatch", () => {
   // "back" must be 4 (KEYCODE_BACK), never 3 (KEYCODE_HOME).
   test.each<[string, number]>([
     ["back", 4],
-    ["home", 3],
     ["recent", 187],
   ])("falls back to keyevent %i for navigation button %s", async (button, keyCode) => {
     getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
@@ -89,6 +140,71 @@ describe("PressButton Android keycode dispatch", () => {
 
     expect(result).toEqual({ success: true, button, keyCode });
     expect(fakeAdb.getExecutedCommands()).toEqual([`shell input keyevent ${keyCode}`]);
+  });
+
+  // Home-press verification (issue #6147): "home" additionally must confirm
+  // the foreground app actually became the launcher before trusting either
+  // the global action or the ADB keyevent fallback.
+  describe("home button (issue #6147)", () => {
+    test("falls back to keyevent 3 and succeeds once the launcher is confirmed foreground", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => {
+          throw new Error("global action unavailable");
+        },
+      } as unknown as AndroidCtrlProxyClient);
+
+      const result = await press("home", launcherWindow());
+
+      expect(result).toEqual({ success: true, button: "home", keyCode: 3 });
+      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+    });
+
+    // API 28 repro: the accessibility global action for "home" reports
+    // success, but the foreground app never actually changes. Must not
+    // report success on that self-reported result alone.
+    test("does not trust an inert global action on API 28 and falls back to the ADB keyevent", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: true }),
+      } as unknown as AndroidCtrlProxyClient);
+      // The post-global-action verification retries internally (initial
+      // attempt + 2 backoff retries) before giving up, so it must see the
+      // original app on all 3 of those checks; only the post-ADB-keyevent
+      // verification's first check sees the launcher -- proving the ADB
+      // fallback genuinely ran rather than being skipped as redundant.
+      const result = await press(
+        "home",
+        sequencedWindow([
+          "com.android.settings",
+          "com.android.settings",
+          "com.android.settings",
+          "com.android.launcher3",
+        ]),
+      );
+
+      expect(result).toEqual({ success: true, button: "home", keyCode: 3 });
+      // The inert global action must not short-circuit the ADB fallback.
+      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+    });
+
+    test("surfaces failure instead of false success when neither path reaches the launcher", async () => {
+      getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: true }),
+      } as unknown as AndroidCtrlProxyClient);
+      const stuckWindow = new FakeWindow();
+      stuckWindow.configureActiveWindow({
+        appId: "com.android.settings",
+        activityName: "Settings",
+        layoutSeqSum: 0,
+      });
+
+      const result = await press("home", stuckWindow);
+
+      expect(result.success).toBe(false);
+      expect(result.keyCode).toBe(-1);
+      expect(result.error).toContain("did not background the foreground app");
+      // The ADB fallback must actually have been attempted, not skipped.
+      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+    });
   });
 
   test("rejects a stale context instead of falling back from a failed global action to ADB", async () => {

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -156,7 +156,11 @@ describe("PressButton Android keycode dispatch", () => {
       const result = await press("home", launcherWindow());
 
       expect(result).toEqual({ success: true, button: "home", keyCode: 3 });
-      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+      // Filter out the configured-HOME-launcher resolution call (issue #6147
+      // review, P1) that verification now performs alongside the keyevent.
+      expect(fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes("keyevent"))).toEqual([
+        "shell input keyevent 3",
+      ]);
     });
 
     // API 28 repro: the accessibility global action for "home" reports
@@ -183,7 +187,11 @@ describe("PressButton Android keycode dispatch", () => {
 
       expect(result).toEqual({ success: true, button: "home", keyCode: 3 });
       // The inert global action must not short-circuit the ADB fallback.
-      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+      // Filter out the configured-HOME-launcher resolution calls (issue #6147
+      // review, P1) that verification now performs alongside the keyevent.
+      expect(fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes("keyevent"))).toEqual([
+        "shell input keyevent 3",
+      ]);
     });
 
     test("surfaces failure instead of false success when neither path reaches the launcher", async () => {
@@ -203,7 +211,11 @@ describe("PressButton Android keycode dispatch", () => {
       expect(result.keyCode).toBe(-1);
       expect(result.error).toContain("did not background the foreground app");
       // The ADB fallback must actually have been attempted, not skipped.
-      expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 3"]);
+      // Filter out the configured-HOME-launcher resolution calls (issue #6147
+      // review, P1) that verification now performs alongside the keyevent.
+      expect(fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes("keyevent"))).toEqual([
+        "shell input keyevent 3",
+      ]);
     });
   });
 

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { Explore } from "../../../src/features/navigation/Explore";
-import { BootedDevice, Element, ObserveResult } from "../../../src/models";
+import { BootedDevice, Element, ExecResult, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -31,6 +31,23 @@ import type { ElementParser } from "../../../src/utils/interfaces/ElementParser"
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
+
+// `dumpsys window windows` output parseable (by Window.parseActiveWindowModern)
+// as the launcher being foreground. Used to satisfy home-press verification
+// (issue #6147) in tests whose `adb` mock doesn't otherwise implement
+// `executeCommand`.
+const LAUNCHER_DUMPSYS_STDOUT =
+  "Window #0 Window{01234567 u0 com.android.launcher3/com.android.launcher3.Launcher}: mViewVisibility=0x0 isOnScreen=true isVisible=true";
+
+function launcherDumpsysResult(): ExecResult {
+  return {
+    stdout: LAUNCHER_DUMPSYS_STDOUT,
+    stderr: "",
+    toString: () => LAUNCHER_DUMPSYS_STDOUT,
+    trim: () => LAUNCHER_DUMPSYS_STDOUT.trim(),
+    includes: (searchString: string) => LAUNCHER_DUMPSYS_STDOUT.includes(searchString),
+  };
+}
 
 describe("Explore", () => {
   let explore: Explore;
@@ -563,6 +580,10 @@ describe("Explore", () => {
           commands.push(args.join(" "));
           return "";
         },
+        // Home-press verification (issue #6147) reads the foreground app via
+        // `dumpsys window windows` after dispatch; report the launcher so the
+        // ADB keyevent fallback is confirmed to have actually worked.
+        executeCommand: async () => launcherDumpsysResult(),
       } as AdbClient;
       const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
         requestGlobalAction: async () => ({ success: false, error: "unavailable" }),
@@ -602,7 +623,12 @@ describe("Explore", () => {
         packageName: "com.test.app",
         error: "App is not installed",
       } as never);
-      const adb = { execute: async () => "" } as AdbClient;
+      const adb = {
+        execute: async () => "",
+        // Verification (issue #6147) must pass so this test exercises the
+        // relaunch failure path, not a home-press verification failure.
+        executeCommand: async () => launcherDumpsysResult(),
+      } as AdbClient;
       explore = new Explore(device, adb, fakeTimer, fakeGraph);
       (explore as any).targetPackageName = "com.test.app";
 

--- a/test/features/observe/androidLauncherPackages.test.ts
+++ b/test/features/observe/androidLauncherPackages.test.ts
@@ -1,0 +1,343 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  resolveConfiguredHomePackage,
+  clearResolvedHomePackageCache,
+  isFallbackLauncherPackage,
+  isForegroundLauncher,
+} from "../../../src/features/observe/androidLauncherPackages";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const RESOLVE_HOME_PATTERN = "resolve-activity";
+
+describe("androidLauncherPackages", () => {
+  let fakeAdb: FakeAdbExecutor;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    clearResolvedHomePackageCache();
+  });
+
+  describe("resolveConfiguredHomePackage", () => {
+    test("parses the package name out of resolve-activity --brief output", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout:
+          "priority=0 preferredOrder=0 match=0x108000 specificIndex=-1 isDefault=true\ncom.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+
+      const result = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+
+      expect(result).toBe("com.example.launcher");
+    });
+
+    test("returns null when the device cannot resolve a HOME launcher", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, { stdout: "", stderr: "" });
+
+      const result = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+
+      expect(result).toBeNull();
+    });
+
+    test("returns null (not throw) when the resolve command errors", async () => {
+      fakeAdb.setCommandError(RESOLVE_HOME_PATTERN, new Error("adb unavailable"));
+
+      const result = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+
+      expect(result).toBeNull();
+    });
+
+    test("caches a successful resolution per device, without re-querying", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+      const queriesAfterFirst = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length;
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+      const queriesAfterSecond = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length;
+
+      expect(first).toBe("com.example.launcher");
+      expect(second).toBe("com.example.launcher");
+      expect(queriesAfterFirst).toBe(1);
+      expect(queriesAfterSecond).toBe(1);
+    });
+
+    test("does not cache a failed resolution -- a later call retries", async () => {
+      fakeAdb.setCommandError(RESOLVE_HOME_PATTERN, new Error("transient failure"));
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+      expect(first).toBeNull();
+
+      // A fresh executor stands in for "the device's resolve call now
+      // succeeds" -- the cache is only keyed by deviceId, so if the earlier
+      // failure had been (incorrectly) cached, this call would return null
+      // without ever reaching the new executor.
+      const recoveredAdb = new FakeAdbExecutor();
+      recoveredAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+      const second = await resolveConfiguredHomePackage(recoveredAdb, "device-1");
+      expect(second).toBe("com.example.launcher");
+    });
+
+    test("caches per-device independently", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+      const deviceOne = await resolveConfiguredHomePackage(fakeAdb, "device-1");
+
+      const otherAdb = new FakeAdbExecutor();
+      otherAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.miui.home/.Launcher",
+        stderr: "",
+      });
+      const deviceTwo = await resolveConfiguredHomePackage(otherAdb, "device-2");
+
+      expect(deviceOne).toBe("com.example.launcher");
+      expect(deviceTwo).toBe("com.miui.home");
+    });
+  });
+
+  // A process-lifetime cache means a user who changes their default HOME app
+  // never sees it reflected until the daemon restarts. A bounded TTL fixes
+  // that.
+  describe("resolveConfiguredHomePackage cache TTL", () => {
+    test("serves the cached package within the TTL window", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+      fakeTimer.setCurrentTime(29_000);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      expect(first).toBe("com.launcher.a");
+      expect(second).toBe("com.launcher.a");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(1);
+    });
+
+    test("re-resolves a changed default HOME launcher once the TTL expires", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+      const first = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      // The user changes their default HOME app while the daemon keeps
+      // running.
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.b/.Main",
+        stderr: "",
+      });
+      fakeTimer.setCurrentTime(30_001);
+      const second = await resolveConfiguredHomePackage(fakeAdb, "device-1", fakeTimer);
+
+      expect(first).toBe("com.launcher.a");
+      expect(second).toBe("com.launcher.b");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(2);
+    });
+
+    test("isForegroundLauncher accepts the new launcher once the TTL expires", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setCurrentTime(0);
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.a/.Main",
+        stderr: "",
+      });
+      expect(await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer)).toBe(
+        true,
+      );
+      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
+        false,
+      );
+
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.launcher.b/.Main",
+        stderr: "",
+      });
+      // Still within the TTL -- the stale cached value ("a") is still served.
+      fakeTimer.setCurrentTime(10_000);
+      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
+        false,
+      );
+
+      // Past the TTL -- the new default HOME launcher ("b") is now accepted.
+      fakeTimer.setCurrentTime(30_001);
+      expect(await isForegroundLauncher("com.launcher.b", fakeAdb, "device-1", fakeTimer)).toBe(
+        true,
+      );
+      expect(await isForegroundLauncher("com.launcher.a", fakeAdb, "device-1", fakeTimer)).toBe(
+        false,
+      );
+    });
+  });
+
+  // Android serials are reused across connection epochs (see
+  // `daemon/deviceSessionRegistry.ts`), so a cache keyed by `deviceId` alone
+  // serves a reincarnated device's launcher from the PREVIOUS incarnation on
+  // the same serial (e.g. a new AVD taking over `emulator-5554` within the
+  // TTL). Including an incarnation token in the key makes a reincarnation a
+  // cache miss instead.
+  describe("incarnation-aware cache key", () => {
+    test("re-resolves instead of serving the stale entry when the incarnation token changes on the same deviceId", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+      const first = await resolveConfiguredHomePackage(
+        fakeAdb,
+        "emulator-5554",
+        undefined,
+        "epoch-1",
+      );
+      expect(first).toBe("com.example.launcher");
+
+      // A fresh AVD reincarnates the same serial within the TTL, with a
+      // different configured HOME launcher.
+      const reincarnatedAdb = new FakeAdbExecutor();
+      reincarnatedAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.other.launcher/.Main",
+        stderr: "",
+      });
+      const second = await resolveConfiguredHomePackage(
+        reincarnatedAdb,
+        "emulator-5554",
+        undefined,
+        "epoch-2",
+      );
+
+      expect(second).toBe("com.other.launcher");
+      // The re-resolution must actually have queried the new incarnation's
+      // executor rather than serving the cached "epoch-1" package.
+      expect(
+        reincarnatedAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN))
+          .length,
+      ).toBe(1);
+    });
+
+    test("still serves the cache within the TTL when the incarnation token is unchanged", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+      await resolveConfiguredHomePackage(fakeAdb, "emulator-5554", undefined, "epoch-1");
+      const second = await resolveConfiguredHomePackage(
+        fakeAdb,
+        "emulator-5554",
+        undefined,
+        "epoch-1",
+      );
+
+      expect(second).toBe("com.example.launcher");
+      expect(
+        fakeAdb.getExecutedCommands().filter((cmd) => cmd.includes(RESOLVE_HOME_PATTERN)).length,
+      ).toBe(1);
+    });
+
+    test("isForegroundLauncher rejects the previous incarnation's launcher after a reincarnation", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.example.launcher/.LauncherActivity",
+        stderr: "",
+      });
+      expect(
+        await isForegroundLauncher(
+          "com.example.launcher",
+          fakeAdb,
+          "emulator-5554",
+          undefined,
+          "epoch-1",
+        ),
+      ).toBe(true);
+
+      const reincarnatedAdb = new FakeAdbExecutor();
+      reincarnatedAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.other.launcher/.Main",
+        stderr: "",
+      });
+      // Same appId as before, but the new incarnation's configured launcher
+      // is different -- must not still match on the stale "epoch-1" entry.
+      expect(
+        await isForegroundLauncher(
+          "com.example.launcher",
+          reincarnatedAdb,
+          "emulator-5554",
+          undefined,
+          "epoch-2",
+        ),
+      ).toBe(false);
+      expect(
+        await isForegroundLauncher(
+          "com.other.launcher",
+          reincarnatedAdb,
+          "emulator-5554",
+          undefined,
+          "epoch-2",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("isFallbackLauncherPackage", () => {
+    test("matches a known launcher package exactly", () => {
+      expect(isFallbackLauncherPackage("com.android.launcher3")).toBe(true);
+      expect(isFallbackLauncherPackage("com.android.launcher")).toBe(true);
+    });
+
+    test("rejects an unrelated package that merely shares a prefix", () => {
+      // Regression: the prior implementation matched by prefix, so
+      // "com.android.launcher3.example" was misclassified as a launcher.
+      expect(isFallbackLauncherPackage("com.android.launcher3.example")).toBe(false);
+    });
+
+    test("rejects null/undefined/empty", () => {
+      expect(isFallbackLauncherPackage(null)).toBe(false);
+      expect(isFallbackLauncherPackage(undefined)).toBe(false);
+      expect(isFallbackLauncherPackage("")).toBe(false);
+    });
+  });
+
+  describe("isForegroundLauncher", () => {
+    test("matches the resolved configured HOME package exactly", async () => {
+      fakeAdb.setCommandResponse(RESOLVE_HOME_PATTERN, {
+        stdout: "com.oem.customlauncher/.Main",
+        stderr: "",
+      });
+
+      // A device whose selected HOME app is outside the old hardcoded list
+      // (issue #6147 review, P1) must still verify successfully.
+      expect(await isForegroundLauncher("com.oem.customlauncher", fakeAdb, "device-1")).toBe(true);
+      expect(await isForegroundLauncher("com.oem.customlauncher.decoy", fakeAdb, "device-1")).toBe(
+        false,
+      );
+      expect(await isForegroundLauncher("com.android.launcher3", fakeAdb, "device-1")).toBe(false);
+    });
+
+    test("falls back to the known-launcher list when resolution fails", async () => {
+      fakeAdb.setCommandError(RESOLVE_HOME_PATTERN, new Error("cmd package unavailable"));
+
+      expect(await isForegroundLauncher("com.android.launcher3", fakeAdb, "device-1")).toBe(true);
+      expect(await isForegroundLauncher("com.some.other.app", fakeAdb, "device-1")).toBe(false);
+    });
+
+    test("returns false for a falsy appId without resolving", async () => {
+      expect(await isForegroundLauncher(null, fakeAdb, "device-1")).toBe(false);
+      expect(fakeAdb.getExecutedCommands()).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`homeScreen` and `pressButton { button: \"home\" }` reported success on Android API 28 even though the foreground app never changed — the accessibility global action for \"home\" is a no-op on that API level (raw `adb shell input keyevent KEYCODE_HOME` works fine on the same device). Neither dispatch method's self-reported success was actually checked against device state.

## Fix

- Added `BaseVisualChange.verifyAndroidHomeForeground()`: re-reads the foreground app via the existing `Window`/`dumpsys window` seam and checks it against a small list of known launcher packages (`src/features/observe/androidLauncherPackages.ts`), retrying with short `Timer`-driven backoffs so `FakeTimer` keeps tests fast.
- `HomeScreen.executeAndroidHome()`: only trusts the accessibility global action after verifying it actually reached the launcher; otherwise falls back to the ADB `KEYCODE_HOME` keyevent and verifies that too. If neither path backgrounds the app, it throws instead of reporting success.
- `PressButton`'s Android \"home\" path gets the same treatment (both the global-action shortcut and the ADB fallback), returning `success: false` with an explanatory error instead of a false positive. `back`/`recent` and all iOS paths are unchanged.

## Tests

Added coverage in `test/features/action/HomeScreen.test.ts` and `test/features/action/PressButton.android.test.ts` for:
1. Home press that backgrounds the app via the global action → success, no ADB fallback needed.
2. An inert global action (the API 28 repro) that self-reports success but never changes the foreground → falls back to ADB and succeeds once the fallback actually reaches the launcher.
3. Both paths failing → surfaces a failure instead of a false success.

Also updated two `Explore.test.ts` `resetToHome` tests whose bare-bones `adb` mocks didn't implement `dumpsys window windows`, so they now report a launcher foreground to keep exercising their original (non-#6147) scenarios instead of tripping the new verification.

## Validation

- `bun test` (touched files + full suite): all pass except two pre-existing worktree-environment failures unrelated to this change (missing `node_modules/.bin/oxlint` in `test/lint/oxlintConfigScoping.integration.test.ts`, and a WebRTC integration test spawning `bun test` as a subprocess).
- `bun run lint` — oxlint ratchet gate: no new violations.
- `bun run typecheck` — no new type errors.
- `bun run format:check` — clean.
- `bunx turbo run build` — succeeds.

Closes #6147