### PR TITLE
fix(test): amortize McpTestFixture setup cost in internalTimeoutParamProvenance.test.ts

### DIFF
--- a/test/server/internalTimeoutParamProvenance.test.ts
+++ b/test/server/internalTimeoutParamProvenance.test.ts
@@ -7,7 +7,7 @@
  * see `withSocketSessionAutolockKey` in `src/daemon/socketServer.ts`) may
  * have it honored and reattached onto the handler's arguments.
  */
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { z } from "zod/v4";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
@@ -58,14 +58,19 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
   });
 
   describe("daemonMode: false (direct, non-daemon server)", () => {
+    // One shared fixture per describe block (not beforeEach): matches the
+    // McpTestFixture convention used by ping.test.ts / index.progress.test.ts
+    // / planExecutionLock.test.ts, so the server-setup/warmup cost is paid
+    // once per block instead of being re-charged to every individual test's
+    // reported duration under the 100ms unit-test budget.
     let fixture: McpTestFixture;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       fixture = new McpTestFixture({ daemonMode: false });
       await fixture.setup();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       await fixture.teardown();
     });
 
@@ -91,14 +96,16 @@ describe("internal `__mcpRequestTimeoutMs` provenance (issue #6222 P1 review)", 
   });
 
   describe("daemonMode: true (daemon-forwarded loopback server)", () => {
+    // See the daemonMode:false block above for why this is beforeAll/afterAll
+    // rather than per-test beforeEach/afterEach.
     let fixture: McpTestFixture;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       fixture = new McpTestFixture({ daemonMode: true });
       await fixture.setup();
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       await fixture.teardown();
     });
 


### PR DESCRIPTION
## Problem

`test/server/internalTimeoutParamProvenance.test.ts` (landed via #6262) was reddening the required "Node Unit Tests (ubuntu)" check on main via `scripts/validate-bun-test-timings.sh`'s 100ms unit-test budget:

```
Test exceeded 100ms: daemonMode: false (direct, non-daemon server) > internal __mcpRequestTimeoutMs provenance (issue #6222 P1 review).a caller-supplied __mcpRequestTimeoutMs is IGNORED, never reattached (261.36ms)
```

Because the timing script measures the complete unit lane whenever `src/*` changes, this also blocked other in-flight PRs unrelated to this file.

## Investigation

Read `scripts/validate-bun-test-timings.sh` and both CI callers (`merge.yml`, `pull_request.yml`). The unit-vs-integration lane split is by filename convention (`*.integration.test.ts` / `test/stress/*` are excluded from the 100ms unit budget in `scripts/test-ts.sh`), but this test is a genuine unit test — most `McpTestFixture`-based tests in `test/server/` are NOT integration-lane (`ping.test.ts`, `index.progress.test.ts`, `planExecutionLock.test.ts`, etc.), so moving it to the integration lane would have been mis-lane-avoidance, not a root-cause fix.

The actual root cause: this test used per-test `beforeEach`/`afterEach` to build and tear down a fresh `McpTestFixture` (a real `createMcpServer` round-trip) for every individual test, across two `describe` blocks of two tests each — charging the full server-setup/warmup cost to each test's own reported duration. Every other `McpTestFixture`-based unit test instead shares one fixture per `describe` block via `beforeAll`/`afterAll`, amortizing that cost across all tests in the block.

## Fix

Switched both `describe` blocks (`daemonMode: false` and `daemonMode: true`) from `beforeEach`/`afterEach` to `beforeAll`/`afterAll`, matching the established convention. No assertions changed — the #6222 provenance guarantees are preserved verbatim:
- a direct (non-daemon) caller's `__mcpRequestTimeoutMs`/`__mcpRequestDeadlineMs` is still asserted IGNORED, never reattached
- a daemon-forwarded caller's `__mcpRequestTimeoutMs`/`__mcpRequestDeadlineMs` is still asserted honored and reattached

## Verification

- `bun test test/server/internalTimeoutParamProvenance.test.ts` — 4 pass, all 4 testcases now report ≤2.3ms (was 261ms)
- `BUN_TEST_TIMING_BASE_REF=HEAD bash scripts/validate-bun-test-timings.sh` (exact CI invocation shape, changed-file scoped isolation run) — passes
- `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build` — all pass

Closes #6286