### PR TITLE
fix(performance): re-derive inert touch point before each latency tap (#6228)

### DIFF
--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -2,6 +2,7 @@ import type { ObserveResult } from "../../models";
 import type { ObserveScreen } from "./interfaces/ObserveScreen";
 import { Timer } from "../../utils/SystemTimer";
 import { throwIfAborted } from "../../utils/toolUtils";
+import { updatedAtToMillis } from "./observeTimestamp";
 
 /**
  * Shared observe poll loop for the settle / wait-for-condition primitives
@@ -34,25 +35,6 @@ export interface ObservePollOutcome {
    * the loop exited on the budget or a screen-off fast-fail.
    */
   stopped: boolean;
-}
-
-/**
- * `ObserveResult.updatedAt` is documented as ms-since-epoch but typed
- * `string | number` (it falls back to a server timestamp). Coerce to a number so
- * the next poll's `minTimestamp` is monotonic; a numeric string parses directly,
- * an ISO string via `Date.parse`, and anything unparseable falls back to 0 so a
- * bad timestamp degrades to "accept any fresh read" rather than throwing.
- */
-function toMillis(updatedAt: string | number): number {
-  if (typeof updatedAt === "number") {
-    return updatedAt;
-  }
-  const numeric = Number(updatedAt);
-  if (Number.isFinite(numeric)) {
-    return numeric;
-  }
-  const parsed = Date.parse(updatedAt);
-  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 /**
@@ -92,7 +74,7 @@ export async function pollObserveUntil(
   while (true) {
     throwIfAborted(options.signal);
 
-    const minTimestamp = previous !== undefined ? toMillis(previous.updatedAt) : start;
+    const minTimestamp = previous !== undefined ? updatedAtToMillis(previous.updatedAt) : start;
     const observation = await observeScreen.execute({
       minTimestamp,
       skipWaitForFresh: false,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -553,6 +553,11 @@ export class RealObserveScreen implements ObserveScreen {
       new PerformanceAuditor({
         device,
         adbFactory: this.adbFactory,
+        // Lazy `() => this`: the auditor re-observes through this same
+        // ObserveScreen to re-validate the synthetic-tap point before each tap
+        // (issue #6228); a provider defers resolving `this` until after
+        // construction completes.
+        observeScreenProvider: () => this,
       });
     this.accessibilityAuditor =
       dependencies?.accessibilityAuditor ??
@@ -714,7 +719,9 @@ export class RealObserveScreen implements ObserveScreen {
       await RecompositionTracker.getInstance().processObservation(result, this.device);
 
       // Audits + accessibility state detection (each is config-gated; failures don't propagate)
-      await this.performanceAuditor.run(result, perf);
+      if (!options?.skipPerformanceAudit) {
+        await this.performanceAuditor.run(result, perf);
+      }
       if (!options?.skipAccessibilityAudit) {
         await this.accessibilityAuditor.run(result, perf);
       }

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -1,8 +1,10 @@
 import { logger } from "../../../utils/logger";
 import { PerformanceAudit } from "../../performance/PerformanceAudit";
+import type { InertTouchPointResolver } from "../../performance/TouchLatencyTracker";
 import { ThresholdManager } from "../../performance/ThresholdManager";
 import { isPerformanceAuditEnabled } from "../../performance/performanceAuditConfig";
 import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
+import type { ObserveScreen } from "../interfaces/ObserveScreen";
 import type {
   BootedDevice,
   ElementBounds,
@@ -429,6 +431,52 @@ export function deriveTouchLatencyPoint(
   return { touchPoint: point, skipTouchLatency: false };
 }
 
+/**
+ * Production `InertTouchPointResolver`: re-captures a fresh, device-verified
+ * view hierarchy through the observe layer and re-derives an inert tap point
+ * for the audited app right before each synthetic tap, closing the TOCTOU where
+ * a control moves under a previously-selected point between taps (issue #6228).
+ *
+ * The re-capture asks for `skipWaitForFresh: false` (a genuinely
+ * device-verified tree, not an age-based cache hit) and `skipPerformanceAudit`
+ * so re-observing from inside the performance audit cannot recurse. Screenshot,
+ * back-stack, and accessibility-audit work are skipped as well - only the
+ * hierarchy and window attribution matter for deriving the point.
+ */
+export class ObserveInertTouchPointResolver implements InertTouchPointResolver {
+  constructor(
+    private readonly observeScreen: ObserveScreen,
+    private readonly appId: string,
+    private readonly perf?: PerformanceTracker,
+  ) {}
+
+  async resolveInertTouchPoint(): Promise<{ x: number; y: number } | null> {
+    try {
+      const fresh = await this.observeScreen.execute({
+        perf: this.perf,
+        skipWaitForFresh: false,
+        skipScreenshot: true,
+        skipBackStack: true,
+        skipAccessibilityAudit: true,
+        skipPerformanceAudit: true,
+      });
+
+      const windowBounds = findAppWindowBounds(fresh, this.appId);
+      const { touchPoint, skipTouchLatency } = deriveTouchLatencyPoint(windowBounds, fresh);
+      if (skipTouchLatency || !touchPoint) {
+        return null;
+      }
+      return touchPoint;
+    } catch (error) {
+      // Best-effort re-validation: on any capture failure, treat the point as
+      // no-longer-verifiable so the tracker aborts the sample rather than
+      // tapping a stale point (issue #6228).
+      logger.warn(`[PerformanceAudit] Failed to re-derive inert touch point: ${error}`);
+      return null;
+    }
+  }
+}
+
 export interface PerformanceAuditorOptions {
   device: BootedDevice;
   /**
@@ -439,6 +487,15 @@ export interface PerformanceAuditorOptions {
   adbFactory?: AdbClientFactory;
   /** Allow tests to stub the config gate */
   isEnabled?: () => boolean;
+  /**
+   * Lazily supplies the `ObserveScreen` used to re-capture a fresh hierarchy
+   * for per-tap inert-point re-validation (issue #6228). A provider (rather than
+   * a direct reference) avoids an initialization-order cycle: `ObserveScreen`
+   * constructs this auditor in its own constructor, so `() => this` isn't
+   * resolvable until after construction. Omitted in tests that don't exercise
+   * the touch-latency path.
+   */
+  observeScreenProvider?: () => ObserveScreen;
 }
 
 /**
@@ -451,11 +508,13 @@ export class PerformanceAuditor {
   private readonly device: BootedDevice;
   private readonly adbFactory: AdbClientFactory;
   private readonly isEnabled: () => boolean;
+  private readonly observeScreenProvider?: () => ObserveScreen;
 
   constructor(opts: PerformanceAuditorOptions) {
     this.device = opts.device;
     this.adbFactory = opts.adbFactory ?? defaultAdbClientFactory;
     this.isEnabled = opts.isEnabled ?? isPerformanceAuditEnabled;
+    this.observeScreenProvider = opts.observeScreenProvider;
   }
 
   async run(result: ObserveResult, perf: PerformanceTracker): Promise<void> {
@@ -485,7 +544,20 @@ export class PerformanceAuditor {
         // Initialize components
         const capabilitiesDetector = new DeviceCapabilitiesDetector(this.device, this.adbFactory);
         const thresholdManager = new ThresholdManager();
-        const performanceAudit = new PerformanceAudit(this.device, this.adbFactory);
+
+        // Re-validate the synthetic-tap point against a freshly captured
+        // hierarchy immediately before each tap, so a control that moved under
+        // the point since it was first derived (carousel/snackbar/nav) can't be
+        // activated during this read-only audit (TOCTOU, issue #6228).
+        const observeScreen = this.observeScreenProvider?.();
+        const inertTouchPointResolver = observeScreen
+          ? new ObserveInertTouchPointResolver(observeScreen, result.activeWindow!.appId, perf)
+          : undefined;
+        const performanceAudit = new PerformanceAudit(
+          this.device,
+          this.adbFactory,
+          inertTouchPointResolver,
+        );
 
         // Get device capabilities
         const capabilities = await capabilitiesDetector.getCapabilities();

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -16,7 +16,9 @@ import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../../utils/android-cmdline-tools/AdbClientFactory";
+import { NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import { updatedAtToMillis } from "../observeTimestamp";
 import { hasAccessibilityAction, isTruthyFlag } from "../../../utils/elementProperties";
 import type { ElementParser } from "../../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../../utility/ElementParser";
@@ -442,24 +444,67 @@ export function deriveTouchLatencyPoint(
  * so re-observing from inside the performance audit cannot recurse. Screenshot,
  * back-stack, and accessibility-audit work are skipped as well - only the
  * hierarchy and window attribution matter for deriving the point.
+ *
+ * `skipWaitForFresh: false` does NOT by itself force a new device capture:
+ * `CtrlProxyHierarchy.getLatestHierarchy` only waits for a fresh tree when the
+ * cache is absent or already stale, so with no floor it can hand back the SAME
+ * cached hierarchy the enclosing audit already saw - defeating the TOCTOU
+ * re-validation. So the re-capture also passes a `minTimestamp` strictly newer
+ * than the enclosing observation's `updatedAt`, and if the returned tree is not
+ * actually newer than that floor the sample is aborted rather than reusing a
+ * stale capture (issue #6228).
  */
 export class ObserveInertTouchPointResolver implements InertTouchPointResolver {
   constructor(
     private readonly observeScreen: ObserveScreen,
     private readonly appId: string,
-    private readonly perf?: PerformanceTracker,
+    private readonly enclosingUpdatedAt: string | number,
   ) {}
 
   async resolveInertTouchPoint(): Promise<{ x: number; y: number } | null> {
     try {
+      // Force a hierarchy strictly newer than the enclosing observation so the
+      // re-validation can't reuse the cached tree the audit already saw.
+      const minTimestamp = updatedAtToMillis(this.enclosingUpdatedAt) + 1;
       const fresh = await this.observeScreen.execute({
-        perf: this.perf,
+        // Isolated tracker: sharing the enclosing `PerformanceTracker` would let
+        // this nested execute's `getTimings()` close the parent's still-open
+        // blocks, corrupting the outer audit's debug timing (issue #6228).
+        perf: new NoOpPerformanceTracker(),
         skipWaitForFresh: false,
+        minTimestamp,
         skipScreenshot: true,
         skipBackStack: true,
         skipAccessibilityAudit: true,
         skipPerformanceAudit: true,
       });
+
+      // The device-timestamp floor is best-effort in the capture layer (a late
+      // push or a sync fallback can still surface an older tree). If the tree we
+      // got back is not strictly newer than the enclosing observation, treat it
+      // as no fresh point available and abort rather than tapping off a stale
+      // capture (issue #6228).
+      if (updatedAtToMillis(fresh.updatedAt) < minTimestamp) {
+        logger.warn(
+          "[PerformanceAudit] Re-observation did not yield a hierarchy newer than the " +
+            "enclosing observation; aborting inert-point re-derivation rather than reusing a " +
+            "stale capture",
+        );
+        return null;
+      }
+
+      // If the foreground moved off the audited app during the audit, do not
+      // derive bounds for the wrong app. Real Android window entries often omit
+      // `packageName`, so `findAppWindowBounds` can mis-associate; compare the
+      // fresh active-window attribution and abort the sample when it changed
+      // (issue #6228).
+      if (fresh.activeWindow?.appId !== this.appId) {
+        logger.warn(
+          `[PerformanceAudit] Foreground changed from ${this.appId} to ` +
+            `${fresh.activeWindow?.appId ?? "none"} during audit; aborting inert-point re-derivation`,
+        );
+        return null;
+      }
 
       const windowBounds = findAppWindowBounds(fresh, this.appId);
       const { touchPoint, skipTouchLatency } = deriveTouchLatencyPoint(windowBounds, fresh);
@@ -551,7 +596,11 @@ export class PerformanceAuditor {
         // activated during this read-only audit (TOCTOU, issue #6228).
         const observeScreen = this.observeScreenProvider?.();
         const inertTouchPointResolver = observeScreen
-          ? new ObserveInertTouchPointResolver(observeScreen, result.activeWindow!.appId, perf)
+          ? new ObserveInertTouchPointResolver(
+              observeScreen,
+              result.activeWindow!.appId,
+              result.updatedAt,
+            )
           : undefined;
         const performanceAudit = new PerformanceAudit(
           this.device,

--- a/src/features/observe/interfaces/ObserveScreen.ts
+++ b/src/features/observe/interfaces/ObserveScreen.ts
@@ -12,6 +12,12 @@ export interface ObserveScreenExecuteOptions {
   skipScreenshot?: boolean;
   /** Skip screenshot-dependent accessibility auditing for intermediate observations. */
   skipAccessibilityAudit?: boolean;
+  /**
+   * Skip the performance audit for this observation. Set when re-observing from
+   * inside the performance audit itself (per-tap inert-point re-validation,
+   * issue #6228) so the nested capture cannot recurse back into the auditor.
+   */
+  skipPerformanceAudit?: boolean;
 }
 
 /**

--- a/src/features/observe/observeTimestamp.ts
+++ b/src/features/observe/observeTimestamp.ts
@@ -1,0 +1,23 @@
+/**
+ * Coerce an `ObserveResult.updatedAt` to a number of milliseconds since epoch.
+ *
+ * `updatedAt` is documented as ms-since-epoch but typed `string | number` (it
+ * falls back to a server timestamp). A numeric string parses directly, an ISO
+ * string via `Date.parse`, and anything unparseable falls back to 0 so a bad
+ * timestamp degrades to "accept any fresh read" rather than throwing.
+ *
+ * Shared by `ObservePoll` (monotonic `minTimestamp` across polls) and the
+ * touch-latency inert-point re-validation (forcing a hierarchy strictly newer
+ * than the enclosing observation, issue #6228).
+ */
+export function updatedAtToMillis(updatedAt: string | number): number {
+  if (typeof updatedAt === "number") {
+    return updatedAt;
+  }
+  const numeric = Number(updatedAt);
+  if (Number.isFinite(numeric)) {
+    return numeric;
+  }
+  const parsed = Date.parse(updatedAt);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -8,7 +8,7 @@ import { BootedDevice, ElementBounds, ScreenSize } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Idle } from "../observe/Idle";
 import { DeviceCapabilitiesDetector, DeviceCapabilities } from "../../utils/DeviceCapabilities";
-import { TouchLatencyTracker } from "./TouchLatencyTracker";
+import { TouchLatencyTracker, InertTouchPointResolver } from "./TouchLatencyTracker";
 import { serverConfig } from "../../utils/ServerConfig";
 import { PerformanceAuditRepository } from "../../db/performanceAuditRepository";
 import { defaultTimer } from "../../utils/SystemTimer";
@@ -119,12 +119,28 @@ export class PerformanceAudit {
   private touchLatencyTracker: TouchLatencyTracker;
   private repository = new PerformanceAuditRepository();
 
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    /**
+     * Re-derives a currently-inert tap point immediately before each synthetic
+     * tap so a point that became obstructed since it was first selected is
+     * never reused (issue #6228). Supplied by `PerformanceAuditor`, which has
+     * the observe-layer machinery to capture a fresh hierarchy; omitted (e.g.
+     * in unit tests) leaves the caller-provided point in place unchanged.
+     */
+    inertTouchPointResolver?: InertTouchPointResolver,
+  ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.idle = new Idle(device, adbFactory);
     this.capabilitiesDetector = new DeviceCapabilitiesDetector(device, adbFactory);
-    this.touchLatencyTracker = new TouchLatencyTracker(device, adbFactory);
+    this.touchLatencyTracker = new TouchLatencyTracker(
+      device,
+      adbFactory,
+      defaultTimer,
+      inertTouchPointResolver,
+    );
   }
 
   /**

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -91,6 +91,35 @@ function hasFrameActivity(before: FrameStats, current: FrameStats): boolean {
 }
 
 /**
+ * Re-derives a currently-inert synthetic-touch point immediately before each
+ * tap. The point `PerformanceAuditor` originally derived was validated against
+ * one hierarchy snapshot captured well before the tap; between that capture and
+ * the tap, `runAudit` awaits a device-capabilities query and four parallel
+ * metric collections, and each additional sample adds its own pre-tap settle
+ * delay. A carousel auto-advance, nav transition, or a snackbar/toast appearing
+ * in that window can move a real control under the chosen coordinate, so reusing
+ * the stale point risks activating it during a read-only audit (TOCTOU, issue
+ * #6228).
+ *
+ * `TouchLatencyTracker` holds only an `AdbExecutor` + `Idle`, so it cannot fetch
+ * a hierarchy itself; this seam lets the observe layer (which has that
+ * machinery) supply a freshly-derived, device-verified point per tap. The
+ * implementation MUST capture a hierarchy synchronously with (or immediately
+ * before) the request and return `null` when no inert point is currently
+ * available, so the tracker aborts the sample rather than tapping.
+ */
+export interface InertTouchPointResolver {
+  /**
+   * Capture a fresh, device-verified view hierarchy and derive a
+   * currently-inert synthetic-touch point for the audited app, or `null` when
+   * none is available (the capture wasn't reliable, or every candidate point is
+   * now obstructed). Called once immediately before each synthetic tap, outside
+   * the timed latency window.
+   */
+  resolveInertTouchPoint(): Promise<{ x: number; y: number } | null>;
+}
+
+/**
  * Measures touch input latency by injecting synthetic touches
  * and measuring the time until UI response is detected via gfxinfo
  */
@@ -99,16 +128,19 @@ export class TouchLatencyTracker {
   private device: BootedDevice;
   private idle: Idle;
   private timer: Timer;
+  private inertTouchPointResolver?: InertTouchPointResolver;
 
   constructor(
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     timer: Timer = defaultTimer,
+    inertTouchPointResolver?: InertTouchPointResolver,
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.idle = new Idle(device, adbFactory);
     this.timer = timer;
+    this.inertTouchPointResolver = inertTouchPointResolver;
   }
 
   /**
@@ -238,7 +270,12 @@ export class TouchLatencyTracker {
     maxWaitMs: number,
     perf: PerformanceTracker,
     sampleIndex: number,
-  ): Promise<{ latencyMs: number | null; animating: boolean }> {
+  ): Promise<{
+    latencyMs: number | null;
+    animating: boolean;
+    obstructed: boolean;
+    tapPoint: { x: number; y: number };
+  }> {
     // Reset gfxinfo to get a clean counter baseline.
     await perf.track("adbGfxinfoReset", () =>
       this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName} reset`),
@@ -266,14 +303,37 @@ export class TouchLatencyTracker {
         `[TouchLatency] Sample ${sampleIndex + 1}: frame activity detected across two ` +
           "consecutive no-input snapshots - app is animating, skipping this sample",
       );
-      return { latencyMs: null, animating: true };
+      return { latencyMs: null, animating: true, obstructed: false, tapPoint: touchLocation };
+    }
+
+    // Re-derive a currently-inert point immediately before tapping so a point
+    // that became obstructed since it was first selected (a carousel advancing,
+    // a snackbar/dialog appearing, a nav transition) is never reused across
+    // taps - the TOCTOU this guards against (issue #6228). The re-capture runs
+    // here, BEFORE the timed `measureFrameResponse` window below, so it doesn't
+    // skew the latency being measured. When no inert point is currently
+    // available, abort this sample rather than tapping a possibly-live control.
+    let tapPoint = touchLocation;
+    if (this.inertTouchPointResolver) {
+      const freshPoint = await perf.track("touchLatencyRevalidatePoint", () =>
+        this.inertTouchPointResolver!.resolveInertTouchPoint(),
+      );
+      if (!freshPoint) {
+        logger.warn(
+          `[TouchLatency] Sample ${sampleIndex + 1}: no verified-inert touch point on a ` +
+            "freshly captured hierarchy - aborting this sample instead of tapping a possibly-" +
+            "live control (issue #6228)",
+        );
+        return { latencyMs: null, animating: false, obstructed: true, tapPoint: touchLocation };
+      }
+      tapPoint = freshPoint;
     }
 
     // Inject touch and immediately start measuring
-    await this.injectTouch(touchLocation.x, touchLocation.y, perf);
+    await this.injectTouch(tapPoint.x, tapPoint.y, perf);
 
     const latencyMs = await this.measureFrameResponse(packageName, baselineStats, maxWaitMs, perf);
-    return { latencyMs, animating: false };
+    return { latencyMs, animating: false, obstructed: false, tapPoint };
   }
 
   /**
@@ -289,18 +349,33 @@ export class TouchLatencyTracker {
     measurements: number[],
     animatingCount: number,
     otherFailureCount: number,
+    obstructedCount: number,
   ): TouchLatencyResult {
     const anySampleAnimating = animatingCount > 0;
 
     if (measurements.length === 0) {
-      const allFailuresAnimating = anySampleAnimating && otherFailureCount === 0;
+      const allFailuresAnimating =
+        anySampleAnimating && otherFailureCount === 0 && obstructedCount === 0;
+      const allFailuresObstructed =
+        obstructedCount > 0 && otherFailureCount === 0 && !anySampleAnimating;
+      let error: string;
+      if (allFailuresAnimating) {
+        error = "App renders continuously (animating); touch latency cannot be isolated";
+      } else if (allFailuresObstructed) {
+        // Every sample aborted because no verified-inert point was available on
+        // a fresh hierarchy - the safe outcome (no tap) rather than a failure to
+        // hide (issue #6228).
+        error =
+          "Touch point was no longer inert on a freshly captured hierarchy; " +
+          "aborted touch-latency measurement rather than tapping a possibly-live control";
+      } else {
+        error = "No successful measurements - UI may be frozen or gfxinfo unavailable";
+      }
       return {
         latencyMs: 0,
         touchCoordinates: touchLocation,
         success: false,
-        error: allFailuresAnimating
-          ? "App renders continuously (animating); touch latency cannot be isolated"
-          : "No successful measurements - UI may be frozen or gfxinfo unavailable",
+        error,
         sampleCount: 0,
         animating: allFailuresAnimating,
       };
@@ -358,15 +433,24 @@ export class TouchLatencyTracker {
     const measurements: number[] = [];
     let animatingCount = 0;
     let otherFailureCount = 0;
+    let obstructedCount = 0;
+    // The point actually tapped can differ per sample when an
+    // InertTouchPointResolver re-derives it before each tap; report the most
+    // recent one so `touchCoordinates` reflects a coordinate genuinely used,
+    // not a stale initial selection (issue #6228).
+    let reportedLocation = touchLocation;
 
     try {
       for (let i = 0; i < sampleCount; i++) {
         logger.debug(`[TouchLatency] Taking sample ${i + 1}/${sampleCount}`);
 
         const sampleResult = await this.takeSample(packageName, touchLocation, maxWaitMs, perf, i);
+        reportedLocation = sampleResult.tapPoint;
 
         if (sampleResult.animating) {
           animatingCount++;
+        } else if (sampleResult.obstructed) {
+          obstructedCount++;
         } else if (sampleResult.latencyMs !== null) {
           measurements.push(sampleResult.latencyMs);
           logger.debug(`[TouchLatency] Sample ${i + 1}: ${sampleResult.latencyMs}ms`);
@@ -381,7 +465,13 @@ export class TouchLatencyTracker {
         }
       }
 
-      return this.buildResult(touchLocation, measurements, animatingCount, otherFailureCount);
+      return this.buildResult(
+        reportedLocation,
+        measurements,
+        animatingCount,
+        otherFailureCount,
+        obstructedCount,
+      );
     } catch (error) {
       logger.error(`[TouchLatency] Failed to measure touch latency: ${error}`);
       return {

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -314,6 +314,14 @@ export class TouchLatencyTracker {
     // skew the latency being measured. When no inert point is currently
     // available, abort this sample rather than tapping a possibly-live control.
     let tapPoint = touchLocation;
+    // The frame-response baseline must reflect the counter state immediately
+    // before the timed tap. When the inert-point re-validation runs it awaits a
+    // device round-trip (re-capturing a hierarchy) during which the app may
+    // render frames of its own; those must be folded into the baseline below,
+    // not misattributed to the synthetic touch (issue #6228). Refreshed after
+    // the re-observation await; falls back to the quiescence snapshot when no
+    // resolver is wired (no intervening await, so it is already current).
+    let responseBaseline = baselineStats;
     if (this.inertTouchPointResolver) {
       const freshPoint = await perf.track("touchLatencyRevalidatePoint", () =>
         this.inertTouchPointResolver!.resolveInertTouchPoint(),
@@ -327,12 +335,25 @@ export class TouchLatencyTracker {
         return { latencyMs: null, animating: false, obstructed: true, tapPoint: touchLocation };
       }
       tapPoint = freshPoint;
+
+      // Re-read the gfxinfo counters AFTER the re-observation await, right before
+      // the tap, so any frame rendered during re-observe is part of the baseline
+      // and the first post-tap poll doesn't read it as the tap's response.
+      const { stdout: refreshedStdout } = await perf.track("adbGfxinfoBaselinePostRevalidate", () =>
+        this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`),
+      );
+      responseBaseline = this.idle.parseMetrics(refreshedStdout);
     }
 
     // Inject touch and immediately start measuring
     await this.injectTouch(tapPoint.x, tapPoint.y, perf);
 
-    const latencyMs = await this.measureFrameResponse(packageName, baselineStats, maxWaitMs, perf);
+    const latencyMs = await this.measureFrameResponse(
+      packageName,
+      responseBaseline,
+      maxWaitMs,
+      perf,
+    );
     return { latencyMs, animating: false, obstructed: false, tapPoint };
   }
 

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -8,8 +8,13 @@ import {
   findAppWindowBounds,
   findInertTouchPoint,
   isHierarchyReliableForTapProbe,
+  ObserveInertTouchPointResolver,
   PerformanceAuditor,
 } from "../../../../src/features/observe/audits/PerformanceAuditor";
+import type {
+  ObserveScreen,
+  ObserveScreenExecuteOptions,
+} from "../../../../src/features/observe/interfaces/ObserveScreen";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
 import {
   NoOpPerformanceTracker,
@@ -843,5 +848,114 @@ describe("isHierarchyReliableForTapProbe / deriveTouchLatencyPoint unverified ca
     expect(decision.skipTouchLatency).toBe(false);
     expect(decision.touchPoint).toBeDefined();
     expect(isHierarchyReliableForTapProbe(appWindow, result)).toBe(true);
+  });
+});
+
+describe("ObserveInertTouchPointResolver (#6228)", () => {
+  const appId = "com.example.app";
+  const fullWindow: ViewHierarchyWindowInfo = {
+    type: 1,
+    isFocused: true,
+    bounds: { left: 0, top: 0, right: 1080, bottom: 1920 },
+  } as ViewHierarchyWindowInfo;
+
+  /**
+   * Minimal ObserveScreen double that returns queued observations and records
+   * the options each `execute` was called with.
+   */
+  class FakeObserveScreen implements ObserveScreen {
+    executeOptions: ObserveScreenExecuteOptions[] = [];
+    private queue: Array<ObserveResult | Error>;
+
+    constructor(queue: Array<ObserveResult | Error>) {
+      this.queue = queue;
+    }
+
+    async execute(options?: ObserveScreenExecuteOptions): Promise<ObserveResult> {
+      this.executeOptions.push(options ?? {});
+      const next = this.queue.shift();
+      if (next instanceof Error) {
+        throw next;
+      }
+      return next ?? makeResult();
+    }
+
+    async appendRawViewHierarchy(): Promise<void> {}
+
+    async getMostRecentCachedObserveResult(): Promise<ObserveResult> {
+      return makeResult();
+    }
+  }
+
+  function resultWithControlAt(control?: Element): ObserveResult {
+    return makeResult({
+      activeWindow: { appId, activityName: "Main" } as any,
+      viewHierarchy: {
+        hierarchy: control
+          ? { node: { $: { clickable: "true", bounds: control.bounds } } }
+          : ({} as any),
+        windows: [fullWindow],
+      } as any,
+      elements: { clickable: control ? [control] : [], scrollable: [], text: [], media: [] },
+    });
+  }
+
+  test("re-captures a fresh, device-verified hierarchy without recursing into the audit", async () => {
+    const observeScreen = new FakeObserveScreen([resultWithControlAt()]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+
+    const point = await resolver.resolveInertTouchPoint();
+
+    expect(point).not.toBeNull();
+    expect(observeScreen.executeOptions).toHaveLength(1);
+    const opts = observeScreen.executeOptions[0];
+    // Genuinely device-verified, not an age-based cache hit (addendum to #6228).
+    expect(opts.skipWaitForFresh).toBe(false);
+    // Must not recurse back into the performance audit.
+    expect(opts.skipPerformanceAudit).toBe(true);
+    // The re-capture only needs the hierarchy - the rest is skipped.
+    expect(opts.skipScreenshot).toBe(true);
+    expect(opts.skipAccessibilityAudit).toBe(true);
+  });
+
+  // The core #6228 scenario: a control moved over the window center between
+  // taps. The resolver re-derives from the fresh capture and returns an inert
+  // point that is NOT under the now-covering control.
+  test("re-derives away from a control that moved under the previous point", async () => {
+    const centerControl: Element = {
+      // Covers the window center (540, 960) so the center candidate is rejected.
+      bounds: { left: 400, top: 800, right: 700, bottom: 1100 },
+      clickable: true,
+    } as Element;
+    const observeScreen = new FakeObserveScreen([resultWithControlAt(centerControl)]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+
+    const point = await resolver.resolveInertTouchPoint();
+
+    expect(point).not.toBeNull();
+    const insideControl =
+      point!.x >= centerControl.bounds!.left &&
+      point!.x < centerControl.bounds!.right &&
+      point!.y >= centerControl.bounds!.top &&
+      point!.y < centerControl.bounds!.bottom;
+    expect(insideControl).toBe(false);
+  });
+
+  test("returns null when the fresh capture has no app window (skipTouchLatency)", async () => {
+    const noWindow = makeResult({
+      activeWindow: { appId, activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: {} as any } as any,
+    });
+    const observeScreen = new FakeObserveScreen([noWindow]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+
+    expect(await resolver.resolveInertTouchPoint()).toBeNull();
+  });
+
+  test("returns null (aborts the tap) when the re-capture throws", async () => {
+    const observeScreen = new FakeObserveScreen([new Error("ctrlproxy timeout")]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+
+    expect(await resolver.resolveInertTouchPoint()).toBeNull();
   });
 });

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -900,9 +900,13 @@ describe("ObserveInertTouchPointResolver (#6228)", () => {
     });
   }
 
+  // Enclosing observation timestamp: fresh captures default to 2026-01-01, so
+  // this earlier value makes them strictly newer (passes the minTimestamp floor).
+  const enclosingUpdatedAt = Date.parse("2025-12-31T00:00:00.000Z");
+
   test("re-captures a fresh, device-verified hierarchy without recursing into the audit", async () => {
     const observeScreen = new FakeObserveScreen([resultWithControlAt()]);
-    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
 
     const point = await resolver.resolveInertTouchPoint();
 
@@ -918,6 +922,64 @@ describe("ObserveInertTouchPointResolver (#6228)", () => {
     expect(opts.skipAccessibilityAudit).toBe(true);
   });
 
+  // #6228 (PRRT...Jdu): skipWaitForFresh:false alone can reuse the SAME cached
+  // hierarchy the audit already saw, so the re-capture must pass a minTimestamp
+  // strictly newer than the enclosing observation to force a genuinely new tree.
+  test("forces a hierarchy newer than the enclosing observation via minTimestamp", async () => {
+    const observeScreen = new FakeObserveScreen([resultWithControlAt()]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
+
+    await resolver.resolveInertTouchPoint();
+
+    const opts = observeScreen.executeOptions[0];
+    expect(opts.minTimestamp).toBe(enclosingUpdatedAt + 1);
+    expect(opts.minTimestamp!).toBeGreaterThan(enclosingUpdatedAt);
+  });
+
+  // #6228 (PRRT...Jdu): if the capture layer surfaces a tree that is NOT newer
+  // than the enclosing observation (late push / sync fallback), the resolver
+  // must abort rather than reuse that stale capture.
+  test("aborts when the re-capture is not newer than the enclosing observation", async () => {
+    // Fresh result carries the SAME timestamp as the enclosing observation.
+    const staleReuse = makeResult({
+      updatedAt: enclosingUpdatedAt,
+      activeWindow: { appId, activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: {} as any, windows: [fullWindow] } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+    const observeScreen = new FakeObserveScreen([staleReuse]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
+
+    expect(await resolver.resolveInertTouchPoint()).toBeNull();
+  });
+
+  // #6228 (PRRT...Jdv): if the foreground moves from the audited app to another
+  // app mid-audit, deriving bounds for the audited app would target the wrong
+  // window - abort the sample instead.
+  test("aborts when the foreground app changed during the audit", async () => {
+    const otherApp = makeResult({
+      activeWindow: { appId: "com.other.app", activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: {} as any, windows: [fullWindow] } as any,
+      elements: { clickable: [], scrollable: [], text: [], media: [] },
+    });
+    const observeScreen = new FakeObserveScreen([otherApp]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
+
+    expect(await resolver.resolveInertTouchPoint()).toBeNull();
+  });
+
+  // #6228 (PRRT...Jd4): the nested observation must not share the enclosing
+  // PerformanceTracker, whose open blocks it would close via getTimings().
+  test("uses an isolated performance tracker for the nested observation", async () => {
+    const observeScreen = new FakeObserveScreen([resultWithControlAt()]);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
+
+    await resolver.resolveInertTouchPoint();
+
+    const opts = observeScreen.executeOptions[0];
+    expect(opts.perf).toBeInstanceOf(NoOpPerformanceTracker);
+  });
+
   // The core #6228 scenario: a control moved over the window center between
   // taps. The resolver re-derives from the fresh capture and returns an inert
   // point that is NOT under the now-covering control.
@@ -928,7 +990,7 @@ describe("ObserveInertTouchPointResolver (#6228)", () => {
       clickable: true,
     } as Element;
     const observeScreen = new FakeObserveScreen([resultWithControlAt(centerControl)]);
-    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
 
     const point = await resolver.resolveInertTouchPoint();
 
@@ -947,14 +1009,14 @@ describe("ObserveInertTouchPointResolver (#6228)", () => {
       viewHierarchy: { hierarchy: {} as any } as any,
     });
     const observeScreen = new FakeObserveScreen([noWindow]);
-    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
 
     expect(await resolver.resolveInertTouchPoint()).toBeNull();
   });
 
   test("returns null (aborts the tap) when the re-capture throws", async () => {
     const observeScreen = new FakeObserveScreen([new Error("ctrlproxy timeout")]);
-    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId);
+    const resolver = new ObserveInertTouchPointResolver(observeScreen, appId, enclosingUpdatedAt);
 
     expect(await resolver.resolveInertTouchPoint()).toBeNull();
   });

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -1102,20 +1102,24 @@ describe("TouchLatencyTracker - Unit Tests", function () {
     // must use the CURRENT inert point, not the stale one from the first tap.
     test("re-derives the inert point before each tap so a moved control never reuses a stale point (#6228)", async function () {
       const dynamicAdb = new DynamicFakeAdbExecutor();
-      let pollInSample = 0;
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      // Model frames as rendered only AFTER the tap, not by pure poll count: the
+      // quiescence snapshots AND the refreshed post-revalidation baseline (#6228)
+      // all read idle, then real frames land once the synthetic tap fires. Gate
+      // on the recorded tap count (per sample, relative to the last reset).
+      let tapsAtReset = 0;
+      let framesAfterTap = 0;
 
       dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        const taps = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap")).length;
         if (command.includes("reset")) {
-          pollInSample = 0;
+          tapsAtReset = taps;
+          framesAfterTap = 0;
           return { stdout: "", stderr: "" };
         }
-        pollInSample++;
-        // Both pre-tap snapshots idle, then a real frame after the tap - every
-        // sample produces a clean measurement.
-        const totalFrames = pollInSample <= 2 ? 0 : 3;
+        const totalFrames = taps > tapsAtReset ? (framesAfterTap += 3) : 0;
         return { stdout: `Total frames rendered: ${totalFrames}`, stderr: "" };
       });
-      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
       const factory: AdbClientFactory = { create: () => dynamicAdb };
 
       // A stale first point, then a DIFFERENT current point on the second tap -
@@ -1197,6 +1201,59 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.sampleCount).toBe(0);
       expect(result.animating).toBeFalsy();
       expect(result.error?.toLowerCase()).toContain("no longer inert");
+    });
+
+    // Regression (#6228, PRRT...Jdy): the frame-response baseline must be
+    // refreshed AFTER the re-observation await, immediately before the timed
+    // tap. A frame the app renders WHILE the hierarchy is being re-observed must
+    // be folded into the baseline, not misattributed as the tap's response.
+    test("does not attribute a frame rendered during re-observe to the tap (#6228)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      let frames = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          frames = 0;
+          return { stdout: "", stderr: "" };
+        }
+        // Frames only ever come from the re-observe render below; the tap itself
+        // renders nothing. So if the baseline is refreshed after re-observe, the
+        // post-tap polls see no NEW frame and the sample correctly times out.
+        return { stdout: `Total frames rendered: ${frames}`, stderr: "" };
+      });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      // The resolver simulates the app rendering a frame *while* the hierarchy is
+      // being re-observed (before the tap). If this frame leaked into the tap's
+      // measurement window it would be a false, ~0ms latency reading.
+      const resolver = {
+        resolveInertTouchPoint: async () => {
+          frames += 5;
+          return { x: 500, y: 900 };
+        },
+      };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer, resolver);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 50 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // A tap WAS injected (we got past re-validation with a fresh point)...
+      const tapCommands = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap"));
+      expect(tapCommands).toHaveLength(1);
+      // ...but the frame rendered during re-observe was already in the refreshed
+      // baseline, so it was NOT counted as the tap's response - the sample reads
+      // as no-response rather than a spurious ~0ms latency.
+      expect(result.success).toBe(false);
+      expect(result.latencyMs).toBe(0);
     });
 
     test("should handle errors gracefully and return error result", async function () {

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -1096,6 +1096,109 @@ describe("TouchLatencyTracker - Unit Tests", function () {
       expect(result.touchCoordinates.x).toBeLessThanOrEqual(lowerHalfWindow.right);
     });
 
+    // Regression (#6228): the inert tap point must be re-derived immediately
+    // before EACH tap. If a control moves under the originally-selected point
+    // between the first and second tap (carousel/snackbar/nav), the second tap
+    // must use the CURRENT inert point, not the stale one from the first tap.
+    test("re-derives the inert point before each tap so a moved control never reuses a stale point (#6228)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      let pollInSample = 0;
+
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          pollInSample = 0;
+          return { stdout: "", stderr: "" };
+        }
+        pollInSample++;
+        // Both pre-tap snapshots idle, then a real frame after the tap - every
+        // sample produces a clean measurement.
+        const totalFrames = pollInSample <= 2 ? 0 : 3;
+        return { stdout: `Total frames rendered: ${totalFrames}`, stderr: "" };
+      });
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      // A stale first point, then a DIFFERENT current point on the second tap -
+      // as if the audit re-observed and found the first point now obstructed and
+      // a fresh inert point elsewhere.
+      const points = [
+        { x: 111, y: 222 },
+        { x: 333, y: 444 },
+      ];
+      let resolveCallCount = 0;
+      const resolver = {
+        resolveInertTouchPoint: async () => points[resolveCallCount++] ?? null,
+      };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer, resolver);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 2, maxWaitMs: 200 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.sampleCount).toBe(2);
+      // The point was resolved once per tap, not once for the whole run.
+      expect(resolveCallCount).toBe(2);
+
+      const tapCommands = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap"));
+      expect(tapCommands).toHaveLength(2);
+      // First tap used the first-resolved point; the second tap used the CURRENT
+      // (second) point, not the stale first one.
+      expect(tapCommands[0]).toContain("input tap 111 222");
+      expect(tapCommands[1]).toContain("input tap 333 444");
+      expect(tapCommands[1]).not.toContain("111 222");
+      // touchCoordinates reflect a coordinate genuinely tapped.
+      expect(result.touchCoordinates).toEqual({ x: 333, y: 444 });
+    });
+
+    // Regression (#6228): when the freshly captured hierarchy has no
+    // verified-inert point (a control now covers every candidate), the sample
+    // must abort WITHOUT tapping rather than reuse a stale point.
+    test("aborts the sample without tapping when no inert point is available on a fresh hierarchy (#6228)", async function () {
+      const dynamicAdb = new DynamicFakeAdbExecutor();
+      dynamicAdb.setDynamicCommandHandler("dumpsys gfxinfo", (command, _callCount) => {
+        if (command.includes("reset")) {
+          return { stdout: "", stderr: "" };
+        }
+        // Idle baseline snapshots so the sample reaches the re-validation step.
+        return { stdout: `Total frames rendered: 0`, stderr: "" };
+      });
+      dynamicAdb.setCommandResponse("input tap", { stdout: "", stderr: "" });
+      const factory: AdbClientFactory = { create: () => dynamicAdb };
+
+      const resolver = {
+        resolveInertTouchPoint: async () => null,
+      };
+
+      tracker = new TouchLatencyTracker(device, factory, fakeTimer, resolver);
+
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 2, maxWaitMs: 50 },
+          perf,
+        ),
+        fakeTimer,
+      );
+
+      // No tap was ever injected - the whole point of aborting.
+      const tapCommands = dynamicAdb.getExecutedCommands().filter((c) => c.includes("input tap"));
+      expect(tapCommands).toHaveLength(0);
+
+      expect(result.success).toBe(false);
+      expect(result.sampleCount).toBe(0);
+      expect(result.animating).toBeFalsy();
+      expect(result.error?.toLowerCase()).toContain("no longer inert");
+    });
+
     test("should handle errors gracefully and return error result", async function () {
       const errorAdb = new FakeAdbExecutor();
       errorAdb.setDefaultError(new Error("ADB connection failed"));


### PR DESCRIPTION
## Problem

`PerformanceAuditor` derived a single verified-inert touch point from one hierarchy snapshot, then handed it to `PerformanceAudit.runAudit()`. Before that point was ever tapped, `runAudit` awaited a device-capabilities query and four parallel metric collections, and `TouchLatencyTracker.measureLatency()` then reused the *same* coordinate for all 3 latency samples — never re-validating it against a fresh hierarchy (a TOCTOU, [#6228](https://github.com/kaeawc/auto-mobile/issues/6228)). A carousel auto-advance, nav transition, or a snackbar/toast appearing in that window can move a real control under the chosen coordinate, so a read-only performance audit could activate it — and a later tap's latency is measured against a stale inert reference.

## Fix

Introduce an injected `InertTouchPointResolver` seam so `TouchLatencyTracker` (which holds only an `AdbExecutor` + `Idle`) can obtain a freshly-derived, device-verified inert point from the observe layer immediately before **each** tap:

- `InertTouchPointResolver` interface + per-tap re-derivation in `TouchLatencyTracker.takeSample`. The re-capture runs *before* the timed `measureFrameResponse` window, so it doesn't skew the latency being measured. When no inert point is available on the fresh hierarchy, the sample aborts **without tapping** rather than reusing a stale point.
- Threaded (optional) through `PerformanceAudit` → `TouchLatencyTracker`; omitting it preserves existing behavior, so all prior tests/callers are unaffected.
- Production resolver `ObserveInertTouchPointResolver` re-observes through the same `ObserveScreen` with `skipWaitForFresh: false` (genuinely device-verified, not an age-based cache hit — closing the addendum's cache-freshness gap too) and a new `skipPerformanceAudit` option so the nested capture can't recurse into the auditor. It re-runs the existing `findAppWindowBounds` + `deriveTouchLatencyPoint` path, returning `null` on an unreliable/obstructed capture or any failure.
- `PerformanceAuditor` wires the resolver via a lazy `observeScreenProvider: () => this` (avoids the constructor init-order cycle).

## Tests

- `TouchLatencyTracker`: two sequential taps where the inert point changes between them — the second tap uses the **current** point (`333,444`), not the stale first one (`111,222`); and a resolver returning `null` aborts with **no tap injected**.
- `ObserveInertTouchPointResolver`: re-captures with `skipWaitForFresh:false` + `skipPerformanceAudit:true` (no recursion), re-derives away from a control that moved under the previous point, and returns `null` on no-window / thrown capture.

Validated: touched tests (259 pass), `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build`.

Closes #6228