### PR TITLE
fix(daemon): refuse lock-less socket bind over a live sibling (#6232)

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -68,14 +68,12 @@ export function toDaemonTransportError(error: Error): DaemonUnavailableError {
  *
  * `DaemonClient` used to perform client-side stale-socket recovery: on a failed
  * connect with the PID file's recorded owner confirmed dead, it would unlink the
- * socket/PID files and retry. That unlink had no lock to coordinate against —
- * `UnixSocketServer.start()` (`socketServer.ts`) already unconditionally unlinks
- * the socket path before `listen()`, and that runs under `DaemonManager`'s
- * `O_EXCL` startup lock (`manager.ts`) — so a client-side unlink outside that
- * lock could only ever race a concurrent startup winner and delete ITS live
- * socket: the exact brick #6140 is about. Recovery already happens, correctly,
- * at daemon bind time under a lock; the client now never touches the
- * filesystem, only reads the PID file to decide whether a hint is warranted.
+ * socket/PID files and retry. That unlink had no ownership proof and could race
+ * a concurrent startup winner, deleting its live socket: the exact brick #6140
+ * is about. Recovery is now limited to the daemon bind guard, which requires an
+ * unreachable socket and a positively-dead recorded owner before unlinking; the
+ * client never touches the filesystem and only reads the PID file to decide
+ * whether a hint is warranted.
  */
 export interface DaemonClientRecoveryOptions {
   /** PID-file path consulted for the stale-socket diagnostic hint. Defaults to `PID_FILE_PATH`. */
@@ -216,10 +214,9 @@ export class DaemonClient {
    *
    * Purely observation-only (issue #6140 design change): this NEVER unlinks the
    * socket or PID file, even when the path is a stale non-socket file or the
-   * connect attempt fails. Stale-socket recovery already happens, correctly, at
-   * daemon bind time under `DaemonManager`'s startup lock (`UnixSocketServer.start()`
-   * unconditionally unlinks before `listen()`); a client-side unlink here had no
-   * lock to coordinate against and could only ever delete a concurrent startup
+   * connect attempt fails. The bind guard performs any permitted stale-socket
+   * reclamation only after proving the recorded owner dead; a client-side unlink
+   * here has no equivalent ownership proof and could delete a concurrent startup
    * winner's live socket.
    */
   static async isAvailable(socketPath: string = SOCKET_PATH): Promise<boolean> {
@@ -273,10 +270,9 @@ export class DaemonClient {
    * change): a failed connect is rethrown as-is, annotated with a diagnostic
    * hint when the PID file names a confirmed-dead process ({@link
    * annotateStaleSocketHint}), but the socket and PID file are never touched.
-   * Recovery is the daemon's own job — `UnixSocketServer.start()` unconditionally
-   * unlinks a stale socket path before `listen()`, under `DaemonManager`'s
-   * `O_EXCL` startup lock — so the next daemon start reclaims a stale socket
-   * regardless of anything this client does.
+   * Recovery is the daemon bind guard's job. It only unlinks after the listener
+   * is unreachable and its recorded owner is positively known to be dead, so a
+   * client can never clobber a concurrent startup winner.
    */
   async connect(timeoutMs: number = this.connectionTimeout, signal?: AbortSignal): Promise<void> {
     if (this.connected) {

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -134,6 +134,23 @@ export const LOCK_FILE_PATH = lockFilePathOverride
   : `/tmp/auto-mobile-daemon-${uid}.lock`;
 
 /**
+ * Env var the manager stamps on a daemon child it spawns while HOLDING the
+ * O_EXCL startup lock (issue #6232). The child's control-socket bind reads it to
+ * decide whether it may reclaim an existing socket unconditionally: a daemon
+ * launched this way inherits the manager's lock protection, so it keeps today's
+ * unconditional stale-socket reclaim; a daemon launched BY HAND never sees this
+ * flag and so its bind must instead probe for a live sibling and refuse to
+ * clobber it. Set to "1" when present.
+ */
+export const DAEMON_STARTUP_LOCK_HELD_ENV = "AUTOMOBILE_DAEMON_STARTUP_LOCK_HELD";
+
+/**
+ * Whether THIS process was launched under the manager's O_EXCL startup lock
+ * (issue #6232). Read once at module load from {@link DAEMON_STARTUP_LOCK_HELD_ENV}.
+ */
+export const DAEMON_LAUNCHED_UNDER_STARTUP_LOCK = process.env[DAEMON_STARTUP_LOCK_HELD_ENV] === "1";
+
+/**
  * Connection timeout in milliseconds
  * How long to wait for daemon to respond to a request.
  * Set to 120s to accommodate long-running operations like device cold boot (26-60s+).

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -134,23 +134,6 @@ export const LOCK_FILE_PATH = lockFilePathOverride
   : `/tmp/auto-mobile-daemon-${uid}.lock`;
 
 /**
- * Env var the manager stamps on a daemon child it spawns while HOLDING the
- * O_EXCL startup lock (issue #6232). The child's control-socket bind reads it to
- * decide whether it may reclaim an existing socket unconditionally: a daemon
- * launched this way inherits the manager's lock protection, so it keeps today's
- * unconditional stale-socket reclaim; a daemon launched BY HAND never sees this
- * flag and so its bind must instead probe for a live sibling and refuse to
- * clobber it. Set to "1" when present.
- */
-export const DAEMON_STARTUP_LOCK_HELD_ENV = "AUTOMOBILE_DAEMON_STARTUP_LOCK_HELD";
-
-/**
- * Whether THIS process was launched under the manager's O_EXCL startup lock
- * (issue #6232). Read once at module load from {@link DAEMON_STARTUP_LOCK_HELD_ENV}.
- */
-export const DAEMON_LAUNCHED_UNDER_STARTUP_LOCK = process.env[DAEMON_STARTUP_LOCK_HELD_ENV] === "1";
-
-/**
  * Connection timeout in milliseconds
  * How long to wait for daemon to respond to a request.
  * Set to 120s to accommodate long-running operations like device cold boot (26-60s+).

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -26,7 +26,7 @@ import {
 import { DaemonOptions, PidFileData } from "./types";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { PID_FILE_PATH, DAEMON_VERSION, DAEMON_LAUNCHED_UNDER_STARTUP_LOCK } from "./constants";
+import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { IncumbentOwnerGuard } from "./incumbentOwnerGuard";
@@ -581,7 +581,6 @@ export class Daemon {
         // incumbent snapshot, not the PID file we already overwrote above, so an
         // inconclusive probe still sees the live sibling.
         {
-          startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK,
           ownerLiveness: this.incumbentOwnerGuard.asSocketOwnerLiveness(),
         },
       );
@@ -1119,6 +1118,7 @@ export class Daemon {
     // record on refusal instead of unlinking/orphaning it (issue #6232).
     this.incumbentOwnerGuard.captureIncumbentBeforeOverwrite();
     await this.persistPidFileData(pidData);
+    this.incumbentOwnerGuard.recordContenderEarlyOwner(pidData);
     logger.info(`Early daemon owner record written to ${PID_FILE_PATH} (dbPath ${pidData.dbPath})`);
   }
 
@@ -2189,10 +2189,10 @@ export class Daemon {
           FeatureFlagService.getInstance(),
           undefined,
           this.idGenerator,
-          // Same launch-derived authorization as the initial bind (issue #6232):
-          // an in-process recovery rebind reclaims only its own now-dead socket,
-          // and a hand-launched daemon still must not clobber a live sibling.
-          { startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK },
+          // Recovery reuses the same ownership evidence as initial startup. A
+          // replacement socket is never reclaimed merely because this daemon
+          // previously held the namespace.
+          { ownerLiveness: this.incumbentOwnerGuard.asSocketOwnerLiveness() },
         );
         try {
           await this.socketServer.start();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -29,6 +29,7 @@ import { dirname } from "node:path";
 import { PID_FILE_PATH, DAEMON_VERSION, DAEMON_LAUNCHED_UNDER_STARTUP_LOCK } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
+import { IncumbentOwnerGuard } from "./incumbentOwnerGuard";
 import { executionTracker } from "../server/executionTracker";
 import { SessionReleaseBroadcaster } from "../server/sessionReleaseBroadcast";
 import { resolveToolSelectionBaseSessionUuid } from "../features/toolSelection/selectionSessionResolver";
@@ -261,6 +262,10 @@ export class Daemon {
   private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
   private socketBindCommitted = false;
+  // Preserves a live incumbent daemon's PID record across our own early-owner
+  // overwrite so the lock-less bind guard can (a) still see the live sibling on
+  // an inconclusive probe and (b) restore its record if we refuse (issue #6232).
+  private readonly incumbentOwnerGuard = new IncumbentOwnerGuard();
   private deviceDisconnectMisses: Map<string, number> = new Map();
   private deviceDisconnectMissIncarnations: Map<string, DisconnectCandidateIncarnation> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
@@ -560,12 +565,26 @@ export class Daemon {
       this.idGenerator,
       // A hand-launched daemon (no startup lock) must refuse to unlink a live
       // sibling's socket; only a manager-launched, lock-protected daemon may
-      // reclaim it (issue #6232).
-      { startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK },
+      // reclaim it (issue #6232). The owner-liveness check reads the CAPTURED
+      // incumbent snapshot, not the PID file we already overwrote above, so an
+      // inconclusive probe still sees the live sibling.
+      {
+        startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK,
+        ownerLiveness: this.incumbentOwnerGuard.asSocketOwnerLiveness(),
+      },
     );
     logger.info("Starting Unix socket server...");
     startupBenchmark.startPhase("socketServerStart");
-    await this.socketServer.start();
+    try {
+      await this.socketServer.start();
+    } catch (error) {
+      // The bind guard refused a live sibling. Our early-owner overwrite left the
+      // shared PID file naming this (about-to-exit) contender; restore the live
+      // incumbent's record so status()/`--daemon stop` still find the winner
+      // (issue #6232).
+      this.incumbentOwnerGuard.restoreIncumbentAfterRefusal();
+      throw error;
+    }
     // We now hold the socket bind. Only past this point may this process's exit /
     // shutdown cleanup delete the shared socket/PID files: before it, the early
     // owner record (issue #2871) makes the `expectedPid` self-check pass even
@@ -1083,6 +1102,10 @@ export class Daemon {
       assetVersion: resolveAssetVersion(resolvePinnedVersion()),
       options: this.options,
     };
+    // Snapshot any live incumbent BEFORE this overwrite clobbers its PID record,
+    // so the lock-less bind guard can still see the live sibling and restore its
+    // record on refusal instead of unlinking/orphaning it (issue #6232).
+    this.incumbentOwnerGuard.captureIncumbentBeforeOverwrite();
     await this.persistPidFileData(pidData);
     logger.info(`Early daemon owner record written to ${PID_FILE_PATH} (dbPath ${pidData.dbPath})`);
   }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -260,6 +260,7 @@ export class Daemon {
   private navigationRetentionMonitor: NavigationRetentionMonitor | null = null;
   private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
+  private socketBindCommitted = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
   private deviceDisconnectMissIncarnations: Map<string, DisconnectCandidateIncarnation> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
@@ -565,6 +566,14 @@ export class Daemon {
     logger.info("Starting Unix socket server...");
     startupBenchmark.startPhase("socketServerStart");
     await this.socketServer.start();
+    // We now hold the socket bind. Only past this point may this process's exit /
+    // shutdown cleanup delete the shared socket/PID files: before it, the early
+    // owner record (issue #2871) makes the `expectedPid` self-check pass even
+    // though we do not own the socket, so a lock-less contender refused over a
+    // live sibling (issue #6232) must NOT clean up on exit and brick the winner
+    // (the #6140 failure mode via a bypassed launch). The socket bind is the
+    // single event that authorizes destructive cleanup.
+    this.socketBindCommitted = true;
     startupBenchmark.endPhase("socketServerStart");
     logger.info("Unix socket server started");
 
@@ -2575,12 +2584,25 @@ export class Daemon {
     reportFailures(await settled);
   }
 
-  private getDaemonFileCleanupOptions(): { expectedPid?: number } {
+  private getDaemonFileCleanupOptions(): {
+    expectedPid?: number;
+    socketBindCommitted: boolean;
+  } {
+    // Gate destructive cleanup on actually holding the socket bind. A lock-less
+    // contender refused over a live sibling (issue #6232) has written its early
+    // owner record (issue #2871) — so `pidFileWritten` is already true and the
+    // `expectedPid` self-check would authorize deletion — yet it never bound the
+    // socket. Threading `socketBindCommitted` through makes the cleanup a no-op
+    // for that loser, so the live winner's socket/PID files survive its exit
+    // (the #6140 brick, prevented here rather than reached).
+    const socketBindCommitted = this.socketBindCommitted;
     if (this.pidFileWritten) {
-      return { expectedPid: process.pid };
+      return { expectedPid: process.pid, socketBindCommitted };
     }
     const pidData = readPidFileDataSync();
-    return pidData && pidData.pid !== process.pid ? { expectedPid: process.pid } : {};
+    return pidData && pidData.pid !== process.pid
+      ? { expectedPid: process.pid, socketBindCommitted }
+      : { socketBindCommitted };
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -514,86 +514,98 @@ export class Daemon {
     // isolated-path launch during our own multi-second startup window, instead
     // of failing closed on an unknown path. The ordering lives behind
     // runStartupPrologue() so it can be asserted with fakes (issue #2871).
-    await startupBenchmark.runPhase("daemonDatabaseInitialization", () =>
-      runStartupPrologue({
-        writeEarlyOwnerRecord: () => this.writeEarlyOwnerRecord(),
-        initializeDatabase: () => this.initializeDatabase(),
-      }),
-    );
-
-    // Find an available port. In strict-port mode (issue #6260, restart's
-    // atomic guard) we deliberately skip findAvailablePort()'s probe-then-
-    // release preflight and its port+1..3 fallback: that preflight releases
-    // its probe socket before this process actually binds, leaving a window
-    // for a competitor to claim the canonical port and for the fallback to
-    // paper over it with a "successful" restart on the wrong port. Leaving
-    // `this.port` as the requested port makes the real `listen()` call below
-    // (in startHttpServer) the single atomic bind-or-fail attempt.
-    if (!this.strictPort) {
-      this.port = await this.findAvailablePort(this.port);
-    }
-
-    // Start HTTP MCP server
-    startupBenchmark.startPhase("httpServerStart");
-    await this.startHttpServer();
-    startupBenchmark.endPhase("httpServerStart");
-
-    // Initialize device pool BEFORE starting socket server
-    // This ensures clients connecting via socket will see initialized device pool
-    // Wait up to 5 seconds - emulators should already be running
-    logger.info("Initializing device pool...");
-    startupBenchmark.startPhase("deviceDiscovery");
-    await this.initializeDevicePoolWithTimeout(5000);
-    startupBenchmark.endPhase("deviceDiscovery");
-
-    // Initialize iOS CtrlProxy iOS connections for discovered iOS devices
-    // This establishes WebSocket connections early so observe calls are fast
-    await startupBenchmark.runPhase("iosServices", () => this.initializeIosServices());
-
-    // Start Unix socket server AFTER device pool is ready
-    logger.info(`Daemon host: "${this.host}", port: ${this.port}`);
-    logger.info(`MCP_STREAMABLE_PATH: "${MCP_STREAMABLE_PATH}"`);
-    const mcpEndpoint = `http://${this.host}:${this.port}${MCP_STREAMABLE_PATH}`;
-    logger.info(`Creating UnixSocketServer with endpoint: "${mcpEndpoint}"`);
-    this.socketServer = new UnixSocketServer(
-      SOCKET_PATH,
-      mcpEndpoint,
-      undefined,
-      undefined,
-      FeatureFlagService.getInstance(),
-      undefined,
-      this.idGenerator,
-      // A hand-launched daemon (no startup lock) must refuse to unlink a live
-      // sibling's socket; only a manager-launched, lock-protected daemon may
-      // reclaim it (issue #6232). The owner-liveness check reads the CAPTURED
-      // incumbent snapshot, not the PID file we already overwrote above, so an
-      // inconclusive probe still sees the live sibling.
-      {
-        startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK,
-        ownerLiveness: this.incumbentOwnerGuard.asSocketOwnerLiveness(),
-      },
-    );
-    logger.info("Starting Unix socket server...");
-    startupBenchmark.startPhase("socketServerStart");
+    // The early-owner overwrite (issue #2871) inside runStartupPrologue() clobbers
+    // any live incumbent's PID record BEFORE we own anything, and cannot be
+    // deferred (the DB-ownership guard needs the owned path published first). So
+    // every step from that overwrite until a committed socket bind runs under a
+    // single restoration path: any failure in the interval — DB init, HTTP bind,
+    // device discovery, iOS services, OR the socket bind itself — leaves the
+    // shared PID file naming this about-to-exit contender, and because
+    // `socketBindCommitted` stays false exit cleanup is (correctly) suppressed and
+    // will not repair it. Restoring the captured live incumbent here keeps
+    // status()/`--daemon stop` pointed at the real winner (issue #6232; the
+    // socket-bind step was only one point in this interval).
     try {
+      await startupBenchmark.runPhase("daemonDatabaseInitialization", () =>
+        runStartupPrologue({
+          writeEarlyOwnerRecord: () => this.writeEarlyOwnerRecord(),
+          initializeDatabase: () => this.initializeDatabase(),
+        }),
+      );
+
+      // Find an available port. In strict-port mode (issue #6260, restart's
+      // atomic guard) we deliberately skip findAvailablePort()'s probe-then-
+      // release preflight and its port+1..3 fallback: that preflight releases
+      // its probe socket before this process actually binds, leaving a window
+      // for a competitor to claim the canonical port and for the fallback to
+      // paper over it with a "successful" restart on the wrong port. Leaving
+      // `this.port` as the requested port makes the real `listen()` call below
+      // (in startHttpServer) the single atomic bind-or-fail attempt.
+      if (!this.strictPort) {
+        this.port = await this.findAvailablePort(this.port);
+      }
+
+      // Start HTTP MCP server
+      startupBenchmark.startPhase("httpServerStart");
+      await this.startHttpServer();
+      startupBenchmark.endPhase("httpServerStart");
+
+      // Initialize device pool BEFORE starting socket server
+      // This ensures clients connecting via socket will see initialized device pool
+      // Wait up to 5 seconds - emulators should already be running
+      logger.info("Initializing device pool...");
+      startupBenchmark.startPhase("deviceDiscovery");
+      await this.initializeDevicePoolWithTimeout(5000);
+      startupBenchmark.endPhase("deviceDiscovery");
+
+      // Initialize iOS CtrlProxy iOS connections for discovered iOS devices
+      // This establishes WebSocket connections early so observe calls are fast
+      await startupBenchmark.runPhase("iosServices", () => this.initializeIosServices());
+
+      // Start Unix socket server AFTER device pool is ready
+      logger.info(`Daemon host: "${this.host}", port: ${this.port}`);
+      logger.info(`MCP_STREAMABLE_PATH: "${MCP_STREAMABLE_PATH}"`);
+      const mcpEndpoint = `http://${this.host}:${this.port}${MCP_STREAMABLE_PATH}`;
+      logger.info(`Creating UnixSocketServer with endpoint: "${mcpEndpoint}"`);
+      this.socketServer = new UnixSocketServer(
+        SOCKET_PATH,
+        mcpEndpoint,
+        undefined,
+        undefined,
+        FeatureFlagService.getInstance(),
+        undefined,
+        this.idGenerator,
+        // A hand-launched daemon (no startup lock) must refuse to unlink a live
+        // sibling's socket; only a manager-launched, lock-protected daemon may
+        // reclaim it (issue #6232). The owner-liveness check reads the CAPTURED
+        // incumbent snapshot, not the PID file we already overwrote above, so an
+        // inconclusive probe still sees the live sibling.
+        {
+          startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK,
+          ownerLiveness: this.incumbentOwnerGuard.asSocketOwnerLiveness(),
+        },
+      );
+      logger.info("Starting Unix socket server...");
+      startupBenchmark.startPhase("socketServerStart");
       await this.socketServer.start();
+      // We now hold the socket bind. Only past this point may this process's exit /
+      // shutdown cleanup delete the shared socket/PID files: before it, the early
+      // owner record (issue #2871) makes the `expectedPid` self-check pass even
+      // though we do not own the socket, so a lock-less contender refused over a
+      // live sibling (issue #6232) must NOT clean up on exit and brick the winner
+      // (the #6140 failure mode via a bypassed launch). The socket bind is the
+      // single event that authorizes destructive cleanup.
+      this.socketBindCommitted = true;
+      startupBenchmark.endPhase("socketServerStart");
     } catch (error) {
-      // The bind guard refused a live sibling. Our early-owner overwrite left the
-      // shared PID file naming this (about-to-exit) contender; restore the live
-      // incumbent's record so status()/`--daemon stop` still find the winner
-      // (issue #6232).
-      this.incumbentOwnerGuard.restoreIncumbentAfterRefusal();
+      // Restore the live incumbent's record on any pre-bind failure in the
+      // interval above (issue #6232). Guarded on the committed flag so a throw
+      // after the bind is committed never rewrites the file this process now owns.
+      if (!this.socketBindCommitted) {
+        this.incumbentOwnerGuard.restoreIncumbentAfterRefusal();
+      }
       throw error;
     }
-    // We now hold the socket bind. Only past this point may this process's exit /
-    // shutdown cleanup delete the shared socket/PID files: before it, the early
-    // owner record (issue #2871) makes the `expectedPid` self-check pass even
-    // though we do not own the socket, so a lock-less contender refused over a
-    // live sibling (issue #6232) must NOT clean up on exit and brick the winner
-    // (the #6140 failure mode via a bypassed launch). The socket bind is the
-    // single event that authorizes destructive cleanup.
-    this.socketBindCommitted = true;
-    startupBenchmark.endPhase("socketServerStart");
     logger.info("Unix socket server started");
 
     startupBenchmark.startPhase("auxiliarySocketServerStart");

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -26,7 +26,7 @@ import {
 import { DaemonOptions, PidFileData } from "./types";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
+import { PID_FILE_PATH, DAEMON_VERSION, DAEMON_LAUNCHED_UNDER_STARTUP_LOCK } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
@@ -557,6 +557,10 @@ export class Daemon {
       FeatureFlagService.getInstance(),
       undefined,
       this.idGenerator,
+      // A hand-launched daemon (no startup lock) must refuse to unlink a live
+      // sibling's socket; only a manager-launched, lock-protected daemon may
+      // reclaim it (issue #6232).
+      { startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK },
     );
     logger.info("Starting Unix socket server...");
     startupBenchmark.startPhase("socketServerStart");
@@ -2141,6 +2145,10 @@ export class Daemon {
           FeatureFlagService.getInstance(),
           undefined,
           this.idGenerator,
+          // Same launch-derived authorization as the initial bind (issue #6232):
+          // an in-process recovery rebind reclaims only its own now-dead socket,
+          // and a hand-launched daemon still must not clobber a live sibling.
+          { startupLockHeld: DAEMON_LAUNCHED_UNDER_STARTUP_LOCK },
         );
         try {
           await this.socketServer.start();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -601,7 +601,15 @@ export class Daemon {
       // interval above (issue #6232). Guarded on the committed flag so a throw
       // after the bind is committed never rewrites the file this process now owns.
       if (!this.socketBindCommitted) {
-        this.incumbentOwnerGuard.restoreIncumbentAfterRefusal();
+        try {
+          this.incumbentOwnerGuard.restoreIncumbentAfterRefusal();
+        } catch (restoreError) {
+          // Repairing a displaced PID record is best effort. The startup
+          // failure remains the actionable diagnostic for the operator.
+          logger.warn(
+            `Failed to restore the incumbent daemon owner record after a refused start: ${restoreError}`,
+          );
+        }
       }
       throw error;
     }

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -93,6 +93,17 @@ export interface DaemonFileCleanupOptions {
   pidFilePath?: string;
   socketPaths?: string[];
   expectedPid?: number;
+  /**
+   * Whether this process actually acquired the daemon socket bind. When
+   * explicitly `false`, ALL deletion is suppressed: the process holds an early
+   * owner PID record (issue #2871) — so its own pid passes the `expectedPid`
+   * self-check — yet it never owned the socket. A lock-less contender refused
+   * over a live sibling (issue #6232) is exactly this case; letting its exit
+   * cleanup unlink the shared socket/PID files would brick the live winner (the
+   * #6140 failure mode, new variant). `undefined` preserves the legacy behavior
+   * for callers that do not track socket ownership.
+   */
+  socketBindCommitted?: boolean;
 }
 
 /**
@@ -113,6 +124,10 @@ export function getDaemonSocketPathList(): string[] {
 export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<boolean> {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPathList();
+
+  if (options.socketBindCommitted === false) {
+    return false;
+  }
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
     return false;
@@ -142,6 +157,10 @@ export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {})
 export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): boolean {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPathList();
+
+  if (options.socketBindCommitted === false) {
+    return false;
+  }
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
     return false;

--- a/src/daemon/incumbentOwnerGuard.ts
+++ b/src/daemon/incumbentOwnerGuard.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { PID_FILE_PATH } from "./constants";
 import { isProcessRunning, readPidFileDataSync } from "./daemonFiles";
-import type { SocketOwnerLiveness } from "./socketServer";
+import type { SocketOwnerLiveness, SocketOwnerStatus } from "./socketServer";
 import type { PidFileData } from "./types";
 import { logger } from "../utils/logger";
 
@@ -58,6 +58,7 @@ export interface IncumbentOwnerGuardDeps {
  */
 export class IncumbentOwnerGuard {
   private incumbent: PidFileData | null = null;
+  private contenderEarlyOwner: PidFileData | null = null;
   /**
    * Latched when the on-disk record at capture time named a LIVE foreign process
    * that had NOT committed the socket bind — i.e. another hand-launched contender
@@ -83,30 +84,31 @@ export class IncumbentOwnerGuard {
   }
 
   /**
-   * Snapshot a live foreign incumbent's PID record. MUST be called BEFORE the
+   * Snapshot a foreign committed owner's PID record. MUST be called BEFORE the
    * caller overwrites the shared PID file with its own early-owner record;
    * afterwards the on-disk record names the caller and the incumbent is lost.
-   * A record that is absent, ours, or names a dead process is captured as "no
-   * incumbent" so a stale socket stays reclaimable.
+   * A dead committed owner proves a leftover socket reclaimable; an absent,
+   * self, or uncommitted record remains unknown and fails closed.
    */
   captureIncumbentBeforeOverwrite(): void {
     this.incumbent = null;
+    this.contenderEarlyOwner = null;
     this.sawLiveContender = false;
     const record = this.deps.readPidFile();
-    if (!this.isLiveForeign(record)) {
-      // Absent, ours, or dead: a genuinely stale (post-crash) socket stays
-      // reclaimable and there is no live sibling to preserve.
-      return;
-    }
-    if (isCommittedOwnerRecord(record)) {
+    if (record && record.pid !== this.deps.selfPid && isCommittedOwnerRecord(record)) {
       // Only a record written AFTER a committed socket bind carries build
       // identity (issue #2871's pre-bind early record never does), so its
-      // presence proves the named process actually owned the socket. This is the
-      // one record we trust enough to snapshot for liveness AND to restore.
+      // presence proves the named process actually owned the socket. This is
+      // the only record trusted enough to authorize stale reclaim or restore.
       this.incumbent = record;
-      logger.info(
-        `Captured live incumbent daemon owner record (pid ${record.pid}) before overwriting it (issue #6232)`,
-      );
+      if (this.isLiveForeign(record)) {
+        logger.info(
+          `Captured live incumbent daemon owner record (pid ${record.pid}) before overwriting it (issue #6232)`,
+        );
+      }
+      return;
+    }
+    if (!this.isLiveForeign(record)) {
       return;
     }
     // A LIVE foreign process left only an EARLY owner record: another
@@ -129,7 +131,7 @@ export class IncumbentOwnerGuard {
    * early-owner record now sits in the PID file.
    */
   asSocketOwnerLiveness(): SocketOwnerLiveness {
-    return { hasLiveForeignOwner: () => this.hasLiveForeignOwner() };
+    return { getOwnerStatus: () => this.getOwnerStatus() };
   }
 
   /**
@@ -141,6 +143,21 @@ export class IncumbentOwnerGuard {
     return this.sawLiveContender || this.isLiveForeign(this.incumbent);
   }
 
+  private getOwnerStatus(): SocketOwnerStatus {
+    if (this.sawLiveContender) {
+      return "unknown";
+    }
+    if (this.incumbent === null) {
+      return "unknown";
+    }
+    return this.isLiveForeign(this.incumbent) ? "live" : "dead";
+  }
+
+  /** Record the exact early-owner record this contender successfully published. */
+  recordContenderEarlyOwner(record: PidFileData): void {
+    this.contenderEarlyOwner = record;
+  }
+
   /**
    * Restore the captured incumbent's record after a refused bind so
    * `status()` / `--daemon stop` keep naming the live winner instead of the
@@ -150,7 +167,13 @@ export class IncumbentOwnerGuard {
    */
   restoreIncumbentAfterRefusal(): boolean {
     const incumbent = this.incumbent;
-    if (!this.isLiveForeign(incumbent)) {
+    // A later daemon can legitimately replace this contender before its failure
+    // path runs. Compare the current record with the exact early record we wrote
+    // before restoring, so a stale loser never overwrites that replacement.
+    if (
+      !this.isLiveForeign(incumbent) ||
+      !sameOwnerRecord(this.deps.readPidFile(), this.contenderEarlyOwner)
+    ) {
       return false;
     }
     this.deps.persistPidFile(incumbent);
@@ -165,6 +188,17 @@ export class IncumbentOwnerGuard {
       record !== null && record.pid !== this.deps.selfPid && this.deps.isProcessRunning(record.pid)
     );
   }
+}
+
+function sameOwnerRecord(a: PidFileData | null, b: PidFileData | null): boolean {
+  return (
+    a !== null &&
+    b !== null &&
+    a.pid === b.pid &&
+    a.startedAt === b.startedAt &&
+    a.socketPath === b.socketPath &&
+    a.dbPath === b.dbPath
+  );
 }
 
 /**

--- a/src/daemon/incumbentOwnerGuard.ts
+++ b/src/daemon/incumbentOwnerGuard.ts
@@ -46,9 +46,31 @@ export interface IncumbentOwnerGuardDeps {
  * It only ever preserves/consults a record that named a LIVE process OTHER than
  * this one at capture time, so a genuinely stale (post-crash) socket stays
  * reclaimable and this guard never fabricates a live owner.
+ *
+ * Overlapping hand-launched contenders (issue #6232, the overlapping
+ * interleaving): the on-disk record may itself be ANOTHER contender's early
+ * record (it clobbered the true incumbent before we read it). Such a record is
+ * not proof of who owns the socket, so this guard distinguishes it from a
+ * committed owner via {@link isCommittedOwnerRecord}: a committed owner is
+ * snapshotted and restorable; a live non-owner contender only latches a
+ * fail-closed flag so the lock-less bind refuses instead of restoring a
+ * non-owner's PID or unlinking the real winner after that contender exits.
  */
 export class IncumbentOwnerGuard {
   private incumbent: PidFileData | null = null;
+  /**
+   * Latched when the on-disk record at capture time named a LIVE foreign process
+   * that had NOT committed the socket bind — i.e. another hand-launched contender
+   * racing us, whose early-owner record (issue #2871) had already overwritten the
+   * true incumbent's. Such a record is NOT proof of who owns the socket, so we
+   * neither adopt it as the restorable incumbent nor let its later death read
+   * back as "socket is stale". Instead we fail CLOSED for the rest of this start
+   * so the lock-less bind refuses rather than unlinking a still-live winner
+   * (issue #6232, the overlapping-contender interleaving). The latch stays set
+   * even if that contender dies, because its death proves nothing about the true
+   * owner and a refused lock-less bind is always recoverable via `--daemon restart`.
+   */
+  private sawLiveContender = false;
   private readonly deps: IncumbentOwnerGuardDeps;
 
   constructor(deps?: Partial<IncumbentOwnerGuardDeps>) {
@@ -68,13 +90,36 @@ export class IncumbentOwnerGuard {
    * incumbent" so a stale socket stays reclaimable.
    */
   captureIncumbentBeforeOverwrite(): void {
+    this.incumbent = null;
+    this.sawLiveContender = false;
     const record = this.deps.readPidFile();
-    this.incumbent = this.isLiveForeign(record) ? record : null;
-    if (this.incumbent) {
-      logger.info(
-        `Captured live incumbent daemon owner record (pid ${this.incumbent.pid}) before overwriting it (issue #6232)`,
-      );
+    if (!this.isLiveForeign(record)) {
+      // Absent, ours, or dead: a genuinely stale (post-crash) socket stays
+      // reclaimable and there is no live sibling to preserve.
+      return;
     }
+    if (isCommittedOwnerRecord(record)) {
+      // Only a record written AFTER a committed socket bind carries build
+      // identity (issue #2871's pre-bind early record never does), so its
+      // presence proves the named process actually owned the socket. This is the
+      // one record we trust enough to snapshot for liveness AND to restore.
+      this.incumbent = record;
+      logger.info(
+        `Captured live incumbent daemon owner record (pid ${record.pid}) before overwriting it (issue #6232)`,
+      );
+      return;
+    }
+    // A LIVE foreign process left only an EARLY owner record: another
+    // hand-launched contender is racing us and has already clobbered the true
+    // incumbent's record with its own. Do NOT adopt its PID (restoring it would
+    // write a non-owner over the real record) and do NOT let its later death
+    // authorize unlinking the live winner — fail closed for this start instead
+    // (issue #6232, overlapping-contender interleaving).
+    this.sawLiveContender = true;
+    logger.info(
+      `Detected a live hand-launched contender (pid ${record.pid}) mid-startup; ` +
+        "failing the lock-less socket bind closed rather than treating its record as the socket owner (issue #6232)",
+    );
   }
 
   /**
@@ -93,7 +138,7 @@ export class IncumbentOwnerGuard {
    * is not reported as live.
    */
   hasLiveForeignOwner(): boolean {
-    return this.isLiveForeign(this.incumbent);
+    return this.sawLiveContender || this.isLiveForeign(this.incumbent);
   }
 
   /**
@@ -120,6 +165,21 @@ export class IncumbentOwnerGuard {
       record !== null && record.pid !== this.deps.selfPid && this.deps.isProcessRunning(record.pid)
     );
   }
+}
+
+/**
+ * Whether a PID record was written AFTER a committed socket bind. Only
+ * `Daemon.writePidFile()` (post-bind) stamps build identity onto the record; the
+ * pre-bind early-owner record (issue #2871) never carries `entryScript`/`buildId`.
+ * Presence of BOTH build-identity fields therefore proves the named process
+ * actually bound the socket, which is what separates the true incumbent from
+ * another hand-launched contender's early record. Requiring both (rather than
+ * either) fails safe: a real incumbent misread as a contender only makes a
+ * lock-less bind refuse (recoverable), whereas a contender misread as an owner
+ * would resurrect the #6232 brick.
+ */
+function isCommittedOwnerRecord(record: PidFileData): boolean {
+  return record.entryScript !== undefined && record.buildId !== undefined;
 }
 
 function defaultPersistPidFile(data: PidFileData): void {

--- a/src/daemon/incumbentOwnerGuard.ts
+++ b/src/daemon/incumbentOwnerGuard.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { PID_FILE_PATH } from "./constants";
+import { isProcessRunning, readPidFileDataSync } from "./daemonFiles";
+import type { SocketOwnerLiveness } from "./socketServer";
+import type { PidFileData } from "./types";
+import { logger } from "../utils/logger";
+
+/**
+ * Injected seams for {@link IncumbentOwnerGuard} (issue #6232). Kept behind an
+ * interface so a unit test can drive the incumbent-record lifecycle
+ * deterministically without touching the real `~/.auto-mobile` PID path — the
+ * default implementations wrap the real file/process primitives.
+ */
+export interface IncumbentOwnerGuardDeps {
+  /** Read the on-disk daemon PID record (or null if missing/malformed). */
+  readPidFile: () => PidFileData | null;
+  /** Persist a PID record back to disk synchronously (restore-on-refusal path). */
+  persistPidFile: (data: PidFileData) => void;
+  /** Liveness check for a recorded PID. */
+  isProcessRunning: (pid: number) => boolean;
+  /** This process's PID; a record naming it is our own, never a foreign owner. */
+  selfPid: number;
+}
+
+/**
+ * Guards the incumbent daemon's PID record across a hand-launched contender's
+ * early-owner overwrite (issue #6232, the #6140 socket-brick family).
+ *
+ * `Daemon.start()` writes its OWN early-owner PID record (issue #2871) BEFORE it
+ * reaches the socket-bind guard. That overwrite destroys the evidence the guard
+ * needs: once the shared PID file names the contender, a plain re-read of it
+ * (a) cannot tell the bind guard that a LIVE sibling still owns the socket — so a
+ * transiently-failed reachability probe would unlink the live socket (P1) — and
+ * (b) leaves `status()` / `--daemon stop` pointing at the now-dead contender
+ * after a refused bind (P2).
+ *
+ * This guard closes both holes with a single mechanism: it SNAPSHOTS a live
+ * foreign incumbent's record immediately before the overwrite, then
+ *  - answers the bind guard's owner-liveness question from that snapshot
+ *    ({@link asSocketOwnerLiveness}) instead of the clobbered file, and
+ *  - restores the snapshot to disk if the bind is refused
+ *    ({@link restoreIncumbentAfterRefusal}), re-checking liveness so it never
+ *    resurrects a record for a process that has since died.
+ *
+ * It only ever preserves/consults a record that named a LIVE process OTHER than
+ * this one at capture time, so a genuinely stale (post-crash) socket stays
+ * reclaimable and this guard never fabricates a live owner.
+ */
+export class IncumbentOwnerGuard {
+  private incumbent: PidFileData | null = null;
+  private readonly deps: IncumbentOwnerGuardDeps;
+
+  constructor(deps?: Partial<IncumbentOwnerGuardDeps>) {
+    this.deps = {
+      readPidFile: deps?.readPidFile ?? (() => readPidFileDataSync()),
+      persistPidFile: deps?.persistPidFile ?? defaultPersistPidFile,
+      isProcessRunning: deps?.isProcessRunning ?? isProcessRunning,
+      selfPid: deps?.selfPid ?? process.pid,
+    };
+  }
+
+  /**
+   * Snapshot a live foreign incumbent's PID record. MUST be called BEFORE the
+   * caller overwrites the shared PID file with its own early-owner record;
+   * afterwards the on-disk record names the caller and the incumbent is lost.
+   * A record that is absent, ours, or names a dead process is captured as "no
+   * incumbent" so a stale socket stays reclaimable.
+   */
+  captureIncumbentBeforeOverwrite(): void {
+    const record = this.deps.readPidFile();
+    this.incumbent = this.isLiveForeign(record) ? record : null;
+    if (this.incumbent) {
+      logger.info(
+        `Captured live incumbent daemon owner record (pid ${this.incumbent.pid}) before overwriting it (issue #6232)`,
+      );
+    }
+  }
+
+  /**
+   * A {@link SocketOwnerLiveness} backed by the captured snapshot, NOT the
+   * (possibly self-overwritten) on-disk file. This is what lets the bind guard
+   * fail closed on an inconclusive reachability probe even though our own
+   * early-owner record now sits in the PID file.
+   */
+  asSocketOwnerLiveness(): SocketOwnerLiveness {
+    return { hasLiveForeignOwner: () => this.hasLiveForeignOwner() };
+  }
+
+  /**
+   * Whether a live foreign owner was captured AND is still running. Re-checks
+   * liveness on every call so a sibling that dies between capture and the probe
+   * is not reported as live.
+   */
+  hasLiveForeignOwner(): boolean {
+    return this.isLiveForeign(this.incumbent);
+  }
+
+  /**
+   * Restore the captured incumbent's record after a refused bind so
+   * `status()` / `--daemon stop` keep naming the live winner instead of the
+   * dead contender that overwrote it. Re-checks liveness first (identity +
+   * running), so a record for a since-dead process is never written back.
+   * Returns whether a record was restored.
+   */
+  restoreIncumbentAfterRefusal(): boolean {
+    const incumbent = this.incumbent;
+    if (!this.isLiveForeign(incumbent)) {
+      return false;
+    }
+    this.deps.persistPidFile(incumbent);
+    logger.info(
+      `Restored live incumbent daemon owner record (pid ${incumbent.pid}) after refusing the bind (issue #6232)`,
+    );
+    return true;
+  }
+
+  private isLiveForeign(record: PidFileData | null): record is PidFileData {
+    return (
+      record !== null && record.pid !== this.deps.selfPid && this.deps.isProcessRunning(record.pid)
+    );
+  }
+}
+
+function defaultPersistPidFile(data: PidFileData): void {
+  mkdirSync(dirname(PID_FILE_PATH), { recursive: true });
+  writeFileSync(PID_FILE_PATH, JSON.stringify(data, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_PID_FILE_PATH,
   DEFAULT_SOCKET_PATH,
   LOCK_FILE_PATH,
+  DAEMON_STARTUP_LOCK_HELD_ENV,
   DAEMON_STARTUP_TIMEOUT_MS,
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
@@ -990,6 +991,11 @@ export class DaemonManager implements DaemonManagerLike {
     // resolves to the same locations this manager polls.
     const childEnv = { ...process.env };
     childEnv[DAEMON_LAUNCH_CWD_ENV] = resolveDaemonLaunchWorkingDirectory();
+    // startUnlocked only runs while this manager holds the O_EXCL startup lock, so
+    // the child it spawns inherits that lock's protection: its control-socket bind
+    // may reclaim a stale socket unconditionally. A hand-launched daemon never gets
+    // this flag and so must refuse to clobber a live sibling (issue #6232).
+    childEnv[DAEMON_STARTUP_LOCK_HELD_ENV] = "1";
     if (this.pidFilePath !== PID_FILE_PATH) {
       childEnv.AUTOMOBILE_DAEMON_PID_FILE_PATH = this.pidFilePath;
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -26,7 +26,6 @@ import {
   DEFAULT_PID_FILE_PATH,
   DEFAULT_SOCKET_PATH,
   LOCK_FILE_PATH,
-  DAEMON_STARTUP_LOCK_HELD_ENV,
   DAEMON_STARTUP_TIMEOUT_MS,
   DAEMON_EXISTING_REACHABILITY_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
@@ -536,8 +535,8 @@ const LOCK_HOLDER_PROBE_TIMEOUT_MS = 1000;
  * binding and publishing its own record — closing the window where a
  * concurrent start rewrites the PID file between `stop()`'s liveness check and
  * its unlink. Bounded so `stop()` can never hang if a start holds the lock
- * unusually long; on timeout the stale file is left for the next locked bind
- * to reclaim instead (safe — see {@link DaemonManager.removeConfirmedDeadPidFile}).
+ * unusually long; on timeout the stale PID record is left for a later explicit
+ * cleanup or startup to supersede safely (see {@link DaemonManager.removeConfirmedDeadPidFile}).
  */
 const PID_FILE_DELETE_LOCK_ACQUIRE_TIMEOUT_MS = 2000;
 
@@ -967,8 +966,11 @@ export class DaemonManager implements DaemonManagerLike {
       );
     }
 
-    // Clean up stale socket and PID files from previous sessions
-    await cleanupDaemonFiles({ pidFilePath: this.pidFilePath });
+    // Do not pre-emptively remove namespace files here. The lock serializes
+    // cooperative managers, but a direct daemon may still own a socket which
+    // this manager cannot prove stale. The child uses the shared bind guard to
+    // reclaim only a socket with an unreachable listener and a positively-dead
+    // recorded owner; it publishes its own early PID record before that bind.
 
     stderrLog("Starting AutoMobile daemon...");
 
@@ -991,11 +993,6 @@ export class DaemonManager implements DaemonManagerLike {
     // resolves to the same locations this manager polls.
     const childEnv = { ...process.env };
     childEnv[DAEMON_LAUNCH_CWD_ENV] = resolveDaemonLaunchWorkingDirectory();
-    // startUnlocked only runs while this manager holds the O_EXCL startup lock, so
-    // the child it spawns inherits that lock's protection: its control-socket bind
-    // may reclaim a stale socket unconditionally. A hand-launched daemon never gets
-    // this flag and so must refuse to clobber a live sibling (issue #6232).
-    childEnv[DAEMON_STARTUP_LOCK_HELD_ENV] = "1";
     if (this.pidFilePath !== PID_FILE_PATH) {
       childEnv.AUTOMOBILE_DAEMON_PID_FILE_PATH = this.pidFilePath;
     }
@@ -1619,9 +1616,9 @@ export class DaemonManager implements DaemonManagerLike {
    * cheap way to establish current ownership — the lsof/inode ownership-proof
    * machinery was deliberately removed earlier in #6140 for exactly this
    * reason) would delete that winner's live socket: the exact brick #6140 is
-   * about. A leftover socket file is harmless; it is unconditionally reclaimed
-   * by the next daemon start's unlink-before-`listen()`, under the O_EXCL
-   * startup lock (`UnixSocketServer.start()`).
+   * about. A leftover socket file is harmless. A later daemon start may reclaim
+   * it only after its bind guard proves the listener unreachable and its recorded
+   * owner dead; the startup lock itself is not that proof.
    *
    * Even the PID file alone is NOT unconditionally safe to delete on a single
    * read, though: a concurrent daemon start can rewrite it — with its own LIVE
@@ -1658,7 +1655,7 @@ export class DaemonManager implements DaemonManagerLike {
     if (!acquired) {
       logger.warn(
         "Could not acquire the startup lock to remove a stale PID file during stop(); " +
-          "leaving it for the next daemon start to reclaim.",
+          "leaving it for a later safe startup or explicit cleanup to supersede.",
       );
       return;
     }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -41,6 +41,7 @@ import {
   DaemonSocketReachability,
   type DaemonSocketReachabilityLike,
 } from "./daemonSocketReachability";
+import { isProcessRunning, readPidFileDataSync } from "./daemonFiles";
 import {
   ListChangedBroadcaster,
   LIST_CHANGED_NOTIFICATION_METHODS,
@@ -159,7 +160,46 @@ export interface SocketBindGuardOptions {
    * socket; defaults to the real {@link DaemonSocketReachability}.
    */
   reachability?: DaemonSocketReachabilityLike;
+  /**
+   * Observation-only owner-liveness check used by a lock-less bind to
+   * disambiguate a NOT-reachable probe (issue #6232). A probe that fails to
+   * connect is NOT proof the socket is dead — a live daemon can transiently
+   * refuse or time out under an accept backlog or mid-startup (see
+   * {@link DaemonManager.status}). Consulting whether a live process is still
+   * recorded as the socket's owner lets the guard fail CLOSED on that
+   * inconclusive case instead of unlinking a live daemon's socket. Injected so a
+   * test can drive the outcome deterministically without a real PID file;
+   * defaults to reading the daemon PID record.
+   */
+  ownerLiveness?: SocketOwnerLiveness;
 }
+
+/**
+ * Observation-only check for whether a live daemon process (other than this one)
+ * is still recorded as the control socket's owner (issue #6232). Reads the PID
+ * record only — it never touches the socket file, so it introduces no new
+ * destructive actor on the path.
+ */
+export interface SocketOwnerLiveness {
+  hasLiveForeignOwner(): boolean;
+}
+
+/**
+ * Default {@link SocketOwnerLiveness}: the socket has a live foreign owner when
+ * the daemon PID record names a running process that is NOT this process. A
+ * record naming this process (our own early owner record, issue #2871) or a dead
+ * process is not a live foreign owner, so a genuinely stale socket stays
+ * reclaimable.
+ */
+const defaultSocketOwnerLiveness: SocketOwnerLiveness = {
+  hasLiveForeignOwner(): boolean {
+    const pidData = readPidFileDataSync();
+    if (!pidData || pidData.pid === process.pid) {
+      return false;
+    }
+    return isProcessRunning(pidData.pid);
+  },
+};
 
 /**
  * Resolve {@link SocketBindGuardOptions} to their concrete defaults (issue #6232).
@@ -169,10 +209,12 @@ export interface SocketBindGuardOptions {
 function resolveSocketBindGuard(bindGuard: SocketBindGuardOptions): {
   startupLockHeld: boolean;
   reachability: DaemonSocketReachabilityLike;
+  ownerLiveness: SocketOwnerLiveness;
 } {
   return {
     startupLockHeld: bindGuard.startupLockHeld ?? true,
     reachability: bindGuard.reachability ?? new DaemonSocketReachability(),
+    ownerLiveness: bindGuard.ownerLiveness ?? defaultSocketOwnerLiveness,
   };
 }
 
@@ -402,6 +444,8 @@ export class UnixSocketServer {
   private readonly startupLockHeld: boolean;
   /** Observation-only liveness probe used before a LOCK-LESS bind's reclaim (issue #6232). */
   private readonly socketReachability: DaemonSocketReachabilityLike;
+  /** Observation-only owner-liveness check that fails a LOCK-LESS bind closed on an inconclusive probe (issue #6232). */
+  private readonly socketOwnerLiveness: SocketOwnerLiveness;
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
@@ -483,6 +527,7 @@ export class UnixSocketServer {
     const resolvedBindGuard = resolveSocketBindGuard(bindGuard);
     this.startupLockHeld = resolvedBindGuard.startupLockHeld;
     this.socketReachability = resolvedBindGuard.reachability;
+    this.socketOwnerLiveness = resolvedBindGuard.ownerLiveness;
     this.featureFlagService = featureFlagService;
     this.handshakeEnforced = handshakeConfig.enforce ?? DAEMON_HANDSHAKE_ENABLED;
     this.sessionToolSelectionService = handshakeConfig.sessionToolSelectionService;
@@ -571,10 +616,18 @@ export class UnixSocketServer {
    * A LOCK-LESS bind (a hand-launched daemon) first runs an observation-only
    * liveness probe. If a daemon is still accepting on the path, it throws an
    * ActionableError rather than unlinking — only the locked bind is allowed to
-   * remove a live socket. If the probe finds no live listener the socket is
-   * genuinely stale, so it is safe to unlink and bind. The probe itself never
-   * touches the socket file, so this introduces no new destructive actor on the
-   * path (the #6140 brick class stays fixed).
+   * remove a live socket.
+   *
+   * A probe that does NOT get a connection is treated as INCONCLUSIVE, not as
+   * proof the socket is dead: a live daemon can transiently refuse or time out a
+   * probe under an accept backlog or mid-startup (see {@link DaemonManager}'s
+   * `status()` note). Mapping every such refusal to "dead" and unlinking would
+   * brick that live daemon's clients (the #6140 failure mode). So the guard fails
+   * CLOSED — it reclaims (unlinks) ONLY when no live process is recorded as the
+   * socket's owner. If a live owner is still recorded, the refusal is inconclusive
+   * and the bind is refused with an actionable error. Both checks are
+   * observation-only (they never touch the socket file), so this introduces no new
+   * destructive actor on the path (the #6140 brick class stays fixed).
    */
   private async reclaimExistingSocketBeforeBind(): Promise<void> {
     if (!this.startupLockHeld) {
@@ -587,6 +640,18 @@ export class UnixSocketServer {
           `Refusing to bind: another AutoMobile daemon is already listening on ${this.socketPath}. ` +
             "This process did not acquire the daemon startup lock, so it must not unlink a live daemon's " +
             "socket out from under its clients. Stop the running daemon or run `--daemon restart` to replace it.",
+        );
+      }
+      // Not reachable is NOT the same as confidently dead. Fail closed: only a
+      // socket with no live recorded owner may be reclaimed. A live owner that
+      // merely refused the probe (accept backlog / mid-startup) is inconclusive.
+      if (this.socketOwnerLiveness.hasLiveForeignOwner()) {
+        throw new ActionableError(
+          `Refusing to bind: the AutoMobile daemon socket ${this.socketPath} did not answer a liveness probe, ` +
+            "but a live daemon process is still recorded as its owner, so the probe is inconclusive (e.g. a " +
+            "transient refusal under an accept backlog) rather than proof the socket is dead. This process did not " +
+            "acquire the daemon startup lock, so it must not unlink a socket that may still be live. Stop the running " +
+            "daemon or run `--daemon restart` to replace it.",
         );
       }
     }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -190,6 +190,15 @@ export interface SocketOwnerLiveness {
  * record naming this process (our own early owner record, issue #2871) or a dead
  * process is not a live foreign owner, so a genuinely stale socket stays
  * reclaimable.
+ *
+ * IMPORTANT: this default reads the CURRENT on-disk record. A caller that
+ * overwrites the shared PID file with its own record BEFORE it reaches the bind
+ * guard (as `Daemon.start()` does via its early-owner record) MUST NOT rely on
+ * this default — by then the file names the caller, so a live sibling reads back
+ * as `pid === process.pid` and this returns `false`, which would authorize
+ * unlinking the live socket. Such a caller injects an
+ * {@link import("./incumbentOwnerGuard").IncumbentOwnerGuard}-backed liveness that
+ * consults an incumbent snapshot captured before the overwrite (issue #6232).
  */
 const defaultSocketOwnerLiveness: SocketOwnerLiveness = {
   hasLiveForeignOwner(): boolean {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -38,6 +38,10 @@ import {
 } from "./constants";
 import { registerLiveDeadline, unregisterLiveDeadline } from "./liveDeadlineRegistry";
 import {
+  DaemonSocketReachability,
+  type DaemonSocketReachabilityLike,
+} from "./daemonSocketReachability";
+import {
   ListChangedBroadcaster,
   LIST_CHANGED_NOTIFICATION_METHODS,
   type ListChangedKind,
@@ -116,6 +120,61 @@ import {
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
 /** Keep shutdown bounded if a request handler ignores its disconnected peer. */
 const DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS = 1_000;
+
+/**
+ * Bound on the observation-only liveness probe a LOCK-LESS bind runs against an
+ * existing socket before it would unlink it (issue #6232). Kept short — it only
+ * needs to answer "is a daemon accepting right now?" — and matches the sibling
+ * probe timeouts in {@link DaemonManager}.
+ */
+const SOCKET_BIND_LIVENESS_PROBE_TIMEOUT_MS = 1_000;
+
+/**
+ * Seams governing whether a socket bind may reclaim an EXISTING socket file
+ * (issue #6232).
+ *
+ * The unlink-before-`listen()` in {@link UnixSocketServer.start} is safe only
+ * when it runs under `DaemonManager`'s `O_EXCL` startup lock — that lock is what
+ * serializes daemon starts so the unlink cannot race a live winner. A daemon
+ * launched BY HAND (invoking the entry point with `--daemon-mode` directly)
+ * reaches the same bind holding no such lock; if it unlinked a live sibling's
+ * socket it would brick every existing client (the #6140 failure mode via a
+ * different actor). So a lock-less bind must PROBE the existing socket and refuse
+ * to clobber a live listener, while a locked bind keeps today's unconditional
+ * reclaim of a stale (post-crash) socket.
+ */
+export interface SocketBindGuardOptions {
+  /**
+   * Whether this daemon process was launched under `DaemonManager`'s `O_EXCL`
+   * startup lock. Only such a locked bind may unlink a LIVE sibling's socket.
+   * Defaults to `true` so every existing (already lock-coordinated) construction
+   * path keeps its exact behavior; the production daemon passes the value it
+   * derives from its launch environment, and a lock-less/hand-launched daemon
+   * passes `false`.
+   */
+  startupLockHeld?: boolean;
+  /**
+   * Observation-only reachability probe used by a lock-less bind. Injected so a
+   * test can drive the live/stale outcome deterministically without a real
+   * socket; defaults to the real {@link DaemonSocketReachability}.
+   */
+  reachability?: DaemonSocketReachabilityLike;
+}
+
+/**
+ * Resolve {@link SocketBindGuardOptions} to their concrete defaults (issue #6232).
+ * Kept out of the constructor so its `??` fallbacks do not add to the
+ * constructor's already-at-threshold complexity.
+ */
+function resolveSocketBindGuard(bindGuard: SocketBindGuardOptions): {
+  startupLockHeld: boolean;
+  reachability: DaemonSocketReachabilityLike;
+} {
+  return {
+    startupLockHeld: bindGuard.startupLockHeld ?? true,
+    reachability: bindGuard.reachability ?? new DaemonSocketReachability(),
+  };
+}
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -335,6 +394,14 @@ export class UnixSocketServer {
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
   private readonly idGenerator: IdGenerator;
+  /**
+   * Whether this bind runs under `DaemonManager`'s `O_EXCL` startup lock and may
+   * therefore reclaim (unlink) an existing socket unconditionally (issue #6232).
+   * A lock-less bind must not clobber a live sibling.
+   */
+  private readonly startupLockHeld: boolean;
+  /** Observation-only liveness probe used before a LOCK-LESS bind's reclaim (issue #6232). */
+  private readonly socketReachability: DaemonSocketReachabilityLike;
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
@@ -406,12 +473,16 @@ export class UnixSocketServer {
       sessionToolSelectionService?: Pick<SessionToolSelectionService, "isEnabled" | "setEnabled">;
     } = {},
     idGenerator: IdGenerator = defaultIdGenerator,
+    bindGuard: SocketBindGuardOptions = {},
   ) {
     this.socketPath = socketPath;
     this.mcpEndpoint = mcpEndpoint;
     this.daemonState = daemonState;
     this.timer = timer;
     this.idGenerator = idGenerator;
+    const resolvedBindGuard = resolveSocketBindGuard(bindGuard);
+    this.startupLockHeld = resolvedBindGuard.startupLockHeld;
+    this.socketReachability = resolvedBindGuard.reachability;
     this.featureFlagService = featureFlagService;
     this.handshakeEnforced = handshakeConfig.enforce ?? DAEMON_HANDSHAKE_ENABLED;
     this.sessionToolSelectionService = handshakeConfig.sessionToolSelectionService;
@@ -437,9 +508,15 @@ export class UnixSocketServer {
     // access control (issue #4750).
     await ensureSecureDir(path.dirname(this.socketPath));
 
-    // Remove existing socket file if it exists
+    // Reclaim any existing socket file before listen(). Under DaemonManager's
+    // O_EXCL startup lock this unlink is safe (starts are serialized, so it only
+    // ever removes a stale post-crash socket). A LOCK-LESS bind — a hand-launched
+    // daemon that bypassed the manager — must NOT unlink a live sibling's socket:
+    // doing so bricks every existing client (issue #6232, the #6140 failure mode
+    // via a bypassed launch path). So probe first and refuse when a live daemon
+    // still owns it.
     if (existsSync(this.socketPath)) {
-      await unlink(this.socketPath);
+      await this.reclaimExistingSocketBeforeBind();
     }
 
     this.server = createServer((socket) => {
@@ -481,6 +558,39 @@ export class UnixSocketServer {
         reject(error);
       });
     });
+  }
+
+  /**
+   * Reclaim an existing socket file before `listen()`, refusing to clobber a live
+   * sibling when this bind is not lock-protected (issue #6232).
+   *
+   * A locked bind (the normal `DaemonManager.start()` path) keeps today's
+   * behavior exactly: unlink unconditionally, since the O_EXCL startup lock has
+   * already serialized starts and any leftover socket is a stale post-crash one.
+   *
+   * A LOCK-LESS bind (a hand-launched daemon) first runs an observation-only
+   * liveness probe. If a daemon is still accepting on the path, it throws an
+   * ActionableError rather than unlinking — only the locked bind is allowed to
+   * remove a live socket. If the probe finds no live listener the socket is
+   * genuinely stale, so it is safe to unlink and bind. The probe itself never
+   * touches the socket file, so this introduces no new destructive actor on the
+   * path (the #6140 brick class stays fixed).
+   */
+  private async reclaimExistingSocketBeforeBind(): Promise<void> {
+    if (!this.startupLockHeld) {
+      const reachable = await this.socketReachability.isReachable(
+        this.socketPath,
+        SOCKET_BIND_LIVENESS_PROBE_TIMEOUT_MS,
+      );
+      if (reachable) {
+        throw new ActionableError(
+          `Refusing to bind: another AutoMobile daemon is already listening on ${this.socketPath}. ` +
+            "This process did not acquire the daemon startup lock, so it must not unlink a live daemon's " +
+            "socket out from under its clients. Stop the running daemon or run `--daemon restart` to replace it.",
+        );
+      }
+    }
+    await unlink(this.socketPath);
   }
 
   /**

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -134,34 +134,19 @@ const SOCKET_BIND_LIVENESS_PROBE_TIMEOUT_MS = 1_000;
  * Seams governing whether a socket bind may reclaim an EXISTING socket file
  * (issue #6232).
  *
- * The unlink-before-`listen()` in {@link UnixSocketServer.start} is safe only
- * when it runs under `DaemonManager`'s `O_EXCL` startup lock — that lock is what
- * serializes daemon starts so the unlink cannot race a live winner. A daemon
- * launched BY HAND (invoking the entry point with `--daemon-mode` directly)
- * reaches the same bind holding no such lock; if it unlinked a live sibling's
- * socket it would brick every existing client (the #6140 failure mode via a
- * different actor). So a lock-less bind must PROBE the existing socket and refuse
- * to clobber a live listener, while a locked bind keeps today's unconditional
- * reclaim of a stale (post-crash) socket.
+ * Every launch path must prove an existing socket is stale before unlinking it.
+ * A startup lock coordinates cooperating managers, but does not prove that a
+ * direct daemon does not still own the socket.
  */
 export interface SocketBindGuardOptions {
   /**
-   * Whether this daemon process was launched under `DaemonManager`'s `O_EXCL`
-   * startup lock. Only such a locked bind may unlink a LIVE sibling's socket.
-   * Defaults to `true` so every existing (already lock-coordinated) construction
-   * path keeps its exact behavior; the production daemon passes the value it
-   * derives from its launch environment, and a lock-less/hand-launched daemon
-   * passes `false`.
-   */
-  startupLockHeld?: boolean;
-  /**
-   * Observation-only reachability probe used by a lock-less bind. Injected so a
+   * Observation-only reachability probe used by every bind. Injected so a
    * test can drive the live/stale outcome deterministically without a real
    * socket; defaults to the real {@link DaemonSocketReachability}.
    */
   reachability?: DaemonSocketReachabilityLike;
   /**
-   * Observation-only owner-liveness check used by a lock-less bind to
+   * Observation-only owner-liveness check used by every bind to
    * disambiguate a NOT-reachable probe (issue #6232). A probe that fails to
    * connect is NOT proof the socket is dead — a live daemon can transiently
    * refuse or time out under an accept backlog or mid-startup (see
@@ -181,15 +166,15 @@ export interface SocketBindGuardOptions {
  * destructive actor on the path.
  */
 export interface SocketOwnerLiveness {
-  hasLiveForeignOwner(): boolean;
+  getOwnerStatus(): SocketOwnerStatus;
 }
 
+export type SocketOwnerStatus = "live" | "dead" | "unknown";
+
 /**
- * Default {@link SocketOwnerLiveness}: the socket has a live foreign owner when
- * the daemon PID record names a running process that is NOT this process. A
- * record naming this process (our own early owner record, issue #2871) or a dead
- * process is not a live foreign owner, so a genuinely stale socket stays
- * reclaimable.
+ * Default {@link SocketOwnerLiveness}: only a recorded foreign PID that is
+ * positively dead proves the socket reclaimable. Missing or self-overwritten
+ * records are unknown, never permission to unlink.
  *
  * IMPORTANT: this default reads the CURRENT on-disk record. A caller that
  * overwrites the shared PID file with its own record BEFORE it reaches the bind
@@ -201,12 +186,12 @@ export interface SocketOwnerLiveness {
  * consults an incumbent snapshot captured before the overwrite (issue #6232).
  */
 const defaultSocketOwnerLiveness: SocketOwnerLiveness = {
-  hasLiveForeignOwner(): boolean {
+  getOwnerStatus(): SocketOwnerStatus {
     const pidData = readPidFileDataSync();
     if (!pidData || pidData.pid === process.pid) {
-      return false;
+      return "unknown";
     }
-    return isProcessRunning(pidData.pid);
+    return isProcessRunning(pidData.pid) ? "live" : "dead";
   },
 };
 
@@ -216,12 +201,10 @@ const defaultSocketOwnerLiveness: SocketOwnerLiveness = {
  * constructor's already-at-threshold complexity.
  */
 function resolveSocketBindGuard(bindGuard: SocketBindGuardOptions): {
-  startupLockHeld: boolean;
   reachability: DaemonSocketReachabilityLike;
   ownerLiveness: SocketOwnerLiveness;
 } {
   return {
-    startupLockHeld: bindGuard.startupLockHeld ?? true,
     reachability: bindGuard.reachability ?? new DaemonSocketReachability(),
     ownerLiveness: bindGuard.ownerLiveness ?? defaultSocketOwnerLiveness,
   };
@@ -445,15 +428,9 @@ export class UnixSocketServer {
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
   private readonly idGenerator: IdGenerator;
-  /**
-   * Whether this bind runs under `DaemonManager`'s `O_EXCL` startup lock and may
-   * therefore reclaim (unlink) an existing socket unconditionally (issue #6232).
-   * A lock-less bind must not clobber a live sibling.
-   */
-  private readonly startupLockHeld: boolean;
-  /** Observation-only liveness probe used before a LOCK-LESS bind's reclaim (issue #6232). */
+  /** Observation-only liveness probe used before an existing socket's reclaim (issue #6232). */
   private readonly socketReachability: DaemonSocketReachabilityLike;
-  /** Observation-only owner-liveness check that fails a LOCK-LESS bind closed on an inconclusive probe (issue #6232). */
+  /** Observation-only owner check that fails every bind closed on an inconclusive probe (issue #6232). */
   private readonly socketOwnerLiveness: SocketOwnerLiveness;
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
@@ -534,7 +511,6 @@ export class UnixSocketServer {
     this.timer = timer;
     this.idGenerator = idGenerator;
     const resolvedBindGuard = resolveSocketBindGuard(bindGuard);
-    this.startupLockHeld = resolvedBindGuard.startupLockHeld;
     this.socketReachability = resolvedBindGuard.reachability;
     this.socketOwnerLiveness = resolvedBindGuard.ownerLiveness;
     this.featureFlagService = featureFlagService;
@@ -616,53 +592,20 @@ export class UnixSocketServer {
 
   /**
    * Reclaim an existing socket file before `listen()`, refusing to clobber a live
-   * sibling when this bind is not lock-protected (issue #6232).
-   *
-   * A locked bind (the normal `DaemonManager.start()` path) keeps today's
-   * behavior exactly: unlink unconditionally, since the O_EXCL startup lock has
-   * already serialized starts and any leftover socket is a stale post-crash one.
-   *
-   * A LOCK-LESS bind (a hand-launched daemon) first runs an observation-only
-   * liveness probe. If a daemon is still accepting on the path, it throws an
-   * ActionableError rather than unlinking — only the locked bind is allowed to
-   * remove a live socket.
-   *
-   * A probe that does NOT get a connection is treated as INCONCLUSIVE, not as
-   * proof the socket is dead: a live daemon can transiently refuse or time out a
-   * probe under an accept backlog or mid-startup (see {@link DaemonManager}'s
-   * `status()` note). Mapping every such refusal to "dead" and unlinking would
-   * brick that live daemon's clients (the #6140 failure mode). So the guard fails
-   * CLOSED — it reclaims (unlinks) ONLY when no live process is recorded as the
-   * socket's owner. If a live owner is still recorded, the refusal is inconclusive
-   * and the bind is refused with an actionable error. Both checks are
-   * observation-only (they never touch the socket file), so this introduces no new
-   * destructive actor on the path (the #6140 brick class stays fixed).
+   * sibling (issue #6232). A startup lock is not ownership evidence, and a
+   * failed probe is inconclusive. Reclaim requires both an unreachable probe and
+   * a positively dead recorded owner.
    */
   private async reclaimExistingSocketBeforeBind(): Promise<void> {
-    if (!this.startupLockHeld) {
-      const reachable = await this.socketReachability.isReachable(
-        this.socketPath,
-        SOCKET_BIND_LIVENESS_PROBE_TIMEOUT_MS,
+    const reachable = await this.socketReachability.isReachable(
+      this.socketPath,
+      SOCKET_BIND_LIVENESS_PROBE_TIMEOUT_MS,
+    );
+    if (reachable || this.socketOwnerLiveness.getOwnerStatus() !== "dead") {
+      throw new ActionableError(
+        `Refusing to bind: the AutoMobile daemon socket ${this.socketPath} is still reachable or its former owner is not positively known to be dead. ` +
+          "A startup lock and an inconclusive liveness probe do not authorize unlinking a socket that may still be live. Stop the running daemon or run `--daemon restart` to replace it.",
       );
-      if (reachable) {
-        throw new ActionableError(
-          `Refusing to bind: another AutoMobile daemon is already listening on ${this.socketPath}. ` +
-            "This process did not acquire the daemon startup lock, so it must not unlink a live daemon's " +
-            "socket out from under its clients. Stop the running daemon or run `--daemon restart` to replace it.",
-        );
-      }
-      // Not reachable is NOT the same as confidently dead. Fail closed: only a
-      // socket with no live recorded owner may be reclaimed. A live owner that
-      // merely refused the probe (accept backlog / mid-startup) is inconclusive.
-      if (this.socketOwnerLiveness.hasLiveForeignOwner()) {
-        throw new ActionableError(
-          `Refusing to bind: the AutoMobile daemon socket ${this.socketPath} did not answer a liveness probe, ` +
-            "but a live daemon process is still recorded as its owner, so the probe is inconclusive (e.g. a " +
-            "transient refusal under an accept backlog) rather than proof the socket is dead. This process did not " +
-            "acquire the daemon startup lock, so it must not unlink a socket that may still be live. Stop the running " +
-            "daemon or run `--daemon restart` to replace it.",
-        );
-      }
     }
     await unlink(this.socketPath);
   }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -42,6 +42,7 @@ import {
   type DaemonSocketReachabilityLike,
 } from "./daemonSocketReachability";
 import { isProcessRunning, readPidFileDataSync } from "./daemonFiles";
+import { tryAcquireExclusiveLock, releaseExclusiveLock } from "../utils/fileLock";
 import {
   ListChangedBroadcaster,
   LIST_CHANGED_NOTIFICATION_METHODS,
@@ -157,6 +158,51 @@ export interface SocketBindGuardOptions {
    * defaults to reading the daemon PID record.
    */
   ownerLiveness?: SocketOwnerLiveness;
+  /**
+   * Cross-process lock held across the whole probe → reclaim → `listen()`
+   * sequence so two concurrent binders cannot both reclaim/unlink the same
+   * socket path (issue #6232, W5). The reachability probe and owner-liveness
+   * checks are observation-only: two lock-less `start()` calls over a
+   * genuinely-dead ownerless socket can BOTH pass them, then one binds while
+   * the other unlinks the freshly-bound path in the gap before its own
+   * `listen()`. Serializing the sequence on a single shared lock closes that
+   * TOCTOU: the loser cannot enter the reclaim window until the winner has
+   * bound, at which point its probe sees a reachable socket and it refuses.
+   * Injected so a test can drive contention deterministically; defaults to the
+   * canonical {@link tryAcquireExclusiveLock} primitive keyed on a lock file
+   * beside the socket path.
+   */
+  bindLock?: SocketReclaimLock;
+}
+
+/**
+ * The cross-process lock guarding the reclaim → bind sequence (issue #6232, W5).
+ * A non-blocking single attempt: {@link acquire} returns false when another live
+ * process already holds it (a concurrent bind is in flight), and the caller then
+ * fails CLOSED rather than racing it. {@link release} drops the lock once the
+ * socket is bound (or the bind fails), so the window it covers is only the brief
+ * reclaim-and-listen interval, never the daemon's whole lifetime.
+ */
+export interface SocketReclaimLock {
+  acquire(): boolean;
+  release(): void;
+}
+
+/**
+ * Default {@link SocketReclaimLock}: the canonical `O_EXCL` file lock
+ * ({@link tryAcquireExclusiveLock}) on `<socketPath>.bind.lock`. Deterministic
+ * per socket path so every binder — manager-launched or hand-launched —
+ * contends on the same file, and distinct from both the socket itself and the
+ * `DaemonManager` startup lock. A per-instance owner token makes release
+ * incarnation-aware, and a lock left by a crashed holder is reclaimed on the
+ * next attempt via the primitive's dead-PID check.
+ */
+function defaultSocketReclaimLock(socketPath: string, ownerToken: string): SocketReclaimLock {
+  const lockFilePath = `${socketPath}.bind.lock`;
+  return {
+    acquire: () => tryAcquireExclusiveLock(lockFilePath, { ownerToken }),
+    release: () => releaseExclusiveLock(lockFilePath, process.pid, ownerToken),
+  };
 }
 
 /**
@@ -200,13 +246,19 @@ const defaultSocketOwnerLiveness: SocketOwnerLiveness = {
  * Kept out of the constructor so its `??` fallbacks do not add to the
  * constructor's already-at-threshold complexity.
  */
-function resolveSocketBindGuard(bindGuard: SocketBindGuardOptions): {
+function resolveSocketBindGuard(
+  bindGuard: SocketBindGuardOptions,
+  socketPath: string,
+  bindLockOwnerToken: string,
+): {
   reachability: DaemonSocketReachabilityLike;
   ownerLiveness: SocketOwnerLiveness;
+  bindLock: SocketReclaimLock;
 } {
   return {
     reachability: bindGuard.reachability ?? new DaemonSocketReachability(),
     ownerLiveness: bindGuard.ownerLiveness ?? defaultSocketOwnerLiveness,
+    bindLock: bindGuard.bindLock ?? defaultSocketReclaimLock(socketPath, bindLockOwnerToken),
   };
 }
 
@@ -432,6 +484,8 @@ export class UnixSocketServer {
   private readonly socketReachability: DaemonSocketReachabilityLike;
   /** Observation-only owner check that fails every bind closed on an inconclusive probe (issue #6232). */
   private readonly socketOwnerLiveness: SocketOwnerLiveness;
+  /** Cross-process lock serializing the reclaim → bind sequence against a concurrent binder (issue #6232, W5). */
+  private readonly socketReclaimLock: SocketReclaimLock;
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
@@ -510,9 +564,18 @@ export class UnixSocketServer {
     this.daemonState = daemonState;
     this.timer = timer;
     this.idGenerator = idGenerator;
-    const resolvedBindGuard = resolveSocketBindGuard(bindGuard);
+    // The reclaim lock's per-instance owner token comes from the module default
+    // generator, NOT the injected `idGenerator` — that one is reserved for socket
+    // SESSION ids, and consuming it here would shift every session id a test
+    // pins to the injected sequence.
+    const resolvedBindGuard = resolveSocketBindGuard(
+      bindGuard,
+      socketPath,
+      defaultIdGenerator.next(),
+    );
     this.socketReachability = resolvedBindGuard.reachability;
     this.socketOwnerLiveness = resolvedBindGuard.ownerLiveness;
+    this.socketReclaimLock = resolvedBindGuard.bindLock;
     this.featureFlagService = featureFlagService;
     this.handshakeEnforced = handshakeConfig.enforce ?? DAEMON_HANDSHAKE_ENABLED;
     this.sessionToolSelectionService = handshakeConfig.sessionToolSelectionService;
@@ -538,56 +601,79 @@ export class UnixSocketServer {
     // access control (issue #4750).
     await ensureSecureDir(path.dirname(this.socketPath));
 
-    // Reclaim any existing socket file before listen(). Under DaemonManager's
-    // O_EXCL startup lock this unlink is safe (starts are serialized, so it only
-    // ever removes a stale post-crash socket). A LOCK-LESS bind — a hand-launched
-    // daemon that bypassed the manager — must NOT unlink a live sibling's socket:
-    // doing so bricks every existing client (issue #6232, the #6140 failure mode
-    // via a bypassed launch path). So probe first and refuse when a live daemon
-    // still owns it.
-    if (existsSync(this.socketPath)) {
-      await this.reclaimExistingSocketBeforeBind();
+    // Hold a single cross-process lock across the whole reclaim → `listen()`
+    // sequence (issue #6232, W5). The reachability/owner checks below are
+    // observation-only, so two concurrent binders can BOTH judge a stale socket
+    // reclaimable and then race unlink-vs-listen, leaving the winner bound to an
+    // fd whose pathname the loser deleted. Serializing on `<socket>.bind.lock`
+    // makes the sequence atomic: a losing binder cannot enter the reclaim window
+    // until the winner has bound, at which point its own probe sees a reachable
+    // socket and it refuses. A live holder means another launch is mid-bind, so
+    // fail CLOSED rather than racing it (recoverable via `--daemon restart`).
+    // A stale lock from a crashed holder is reclaimed by the primitive's dead-PID
+    // check on the next attempt.
+    if (!this.socketReclaimLock.acquire()) {
+      throw new ActionableError(
+        `Refusing to bind: another AutoMobile process is currently reclaiming or binding the daemon socket ${this.socketPath}. ` +
+          "Two concurrent launches cannot bind the same socket; let the in-flight one finish, then re-observe, or run `--daemon restart`.",
+      );
     }
+    try {
+      // Reclaim any existing socket file before listen(). Under this reclaim lock
+      // the unlink is exclusive across processes. A LOCK-LESS bind — a
+      // hand-launched daemon that bypassed the manager — must still NOT unlink a
+      // live sibling's socket: doing so bricks every existing client (issue #6232,
+      // the #6140 failure mode via a bypassed launch path). So probe first and
+      // refuse when a live daemon still owns it.
+      if (existsSync(this.socketPath)) {
+        await this.reclaimExistingSocketBeforeBind();
+      }
 
-    this.server = createServer((socket) => {
-      this.handleConnection(socket);
-    });
-
-    // Fan list-changed events out to subscribed socket clients (issue #3223).
-    // Subscribed here (not in the daemon) so a socket-server recreation during
-    // recovery re-wires itself; close() unsubscribes symmetrically.
-    this.listChangedUnsubscribe?.();
-    this.listChangedUnsubscribe = ListChangedBroadcaster.subscribe((kind) => {
-      this.broadcastListChanged(kind);
-    });
-
-    // Fan session-release events out to subscribed proxy clients (issue #4610),
-    // so a proxy clears its remembered binding on a real release instead of the
-    // replay-TTL guess. Subscribed here (not in the daemon) for the same
-    // recovery-rewire reason as list-changed; close() unsubscribes symmetrically.
-    this.sessionReleaseUnsubscribe?.();
-    this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe(
-      (sessionId, reason, snapshot) => {
-        this.clearBoundMcpClientsForReleasedSession(sessionId);
-        this.broadcastSessionReleased(sessionId, reason, snapshot);
-      },
-    );
-
-    return new Promise((resolve, reject) => {
-      this.server!.listen(this.socketPath, () => {
-        this.socketFileIdentity = this.readSocketFileIdentity();
-        logger.info(`Unix socket server listening on ${this.socketPath}`);
-        // Restrict the bound socket to the owner (0o600) before start() resolves,
-        // so no client can connect while it is still world-accessible. listen()
-        // creates the socket at the umask default (issue #4750).
-        secureFile(this.socketPath).then(resolve).catch(reject);
+      this.server = createServer((socket) => {
+        this.handleConnection(socket);
       });
 
-      this.server!.on("error", (error) => {
-        logger.error(`Unix socket server error: ${error}`);
-        reject(error);
+      // Fan list-changed events out to subscribed socket clients (issue #3223).
+      // Subscribed here (not in the daemon) so a socket-server recreation during
+      // recovery re-wires itself; close() unsubscribes symmetrically.
+      this.listChangedUnsubscribe?.();
+      this.listChangedUnsubscribe = ListChangedBroadcaster.subscribe((kind) => {
+        this.broadcastListChanged(kind);
       });
-    });
+
+      // Fan session-release events out to subscribed proxy clients (issue #4610),
+      // so a proxy clears its remembered binding on a real release instead of the
+      // replay-TTL guess. Subscribed here (not in the daemon) for the same
+      // recovery-rewire reason as list-changed; close() unsubscribes symmetrically.
+      this.sessionReleaseUnsubscribe?.();
+      this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe(
+        (sessionId, reason, snapshot) => {
+          this.clearBoundMcpClientsForReleasedSession(sessionId);
+          this.broadcastSessionReleased(sessionId, reason, snapshot);
+        },
+      );
+
+      await new Promise<void>((resolve, reject) => {
+        this.server!.listen(this.socketPath, () => {
+          this.socketFileIdentity = this.readSocketFileIdentity();
+          logger.info(`Unix socket server listening on ${this.socketPath}`);
+          // Restrict the bound socket to the owner (0o600) before start() resolves,
+          // so no client can connect while it is still world-accessible. listen()
+          // creates the socket at the umask default (issue #4750).
+          secureFile(this.socketPath).then(resolve).catch(reject);
+        });
+
+        this.server!.on("error", (error) => {
+          logger.error(`Unix socket server error: ${error}`);
+          reject(error);
+        });
+      });
+    } finally {
+      // Release once the socket is bound (or the bind failed): the lock only
+      // needs to cover the brief unlink-and-listen window. Past a committed bind
+      // the reachability probe alone protects the live socket from later binders.
+      this.socketReclaimLock.release();
+    }
   }
 
   /**

--- a/test/daemon/daemonClientStaleSocketRecovery.integration.test.ts
+++ b/test/daemon/daemonClientStaleSocketRecovery.integration.test.ts
@@ -10,16 +10,13 @@ const isWindows = platform() === "win32";
 /**
  * Issue #6140 design change: `DaemonClient` no longer performs ANY client-side
  * destructive stale-socket recovery. `UnixSocketServer.start()`
- * (`src/daemon/socketServer.ts`) already unconditionally unlinks the socket path
- * before `listen()`, and that runs under `DaemonManager`'s `O_EXCL` startup lock
- * (`src/daemon/manager.ts`) — so stale-socket recovery already happens,
- * correctly, at daemon bind time under a lock. The client-side unlink this suite
- * used to cover had no lock to coordinate against: a concurrent startup winner
- * could bind a NEW socket at the same path between the client's "is this dead?"
- * check and its unlink, and the client would delete the winner's live socket —
- * the exact brick #6140 is about. Removing the client-side unlink makes that
- * brick impossible by construction and loses no auto-recovery: the next daemon
- * start reclaims a stale socket under its lock regardless.
+ * (`src/daemon/socketServer.ts`) is the sole recovery point: it requires an
+ * unreachable listener and a positively-dead recorded owner before unlinking.
+ * A startup lock alone is not permission to reclaim. The client-side unlink this
+ * suite used to cover had no ownership proof: a concurrent startup winner could
+ * bind a new socket between the client's check and its unlink, and the client
+ * would delete that winner's live socket — the exact brick #6140 is about.
+ * Removing the client-side unlink makes that brick impossible by construction.
  *
  * This suite asserts the invariant that replaces the old multi-layered
  * probe/holder/inode recovery machinery: `connect()` and `isAvailable()` NEVER

--- a/test/daemon/daemonFiles.test.ts
+++ b/test/daemon/daemonFiles.test.ts
@@ -64,6 +64,56 @@ describe("daemon file cleanup", () => {
     expect(existsSync(socketPath)).toBe(true);
     expect(existsSync(pidFilePath)).toBe(true);
   });
+
+  // Issue #6232: a lock-less contender refused over a live sibling has written
+  // its OWN early owner record (issue #2871), so `expectedPid` would authorize
+  // deletion of the shared socket/PID files even though it never bound the socket.
+  // `socketBindCommitted: false` must suppress ALL deletion so the live winner's
+  // files survive the loser's exit (the #6140 brick, prevented here).
+  test("cleanupDaemonFilesSync removes nothing when the socket bind was never committed, even for our own PID", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const removed = cleanupDaemonFilesSync({
+      pidFilePath,
+      socketPaths: [socketPath],
+      expectedPid: 12345,
+      socketBindCommitted: false,
+    });
+
+    expect(removed).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  test("cleanupDaemonFiles removes nothing when the socket bind was never committed, even for our own PID", async () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const removed = await cleanupDaemonFiles({
+      pidFilePath,
+      socketPaths: [socketPath],
+      expectedPid: 12345,
+      socketBindCommitted: false,
+    });
+
+    expect(removed).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  test("cleanupDaemonFilesSync still cleans a committed bind's own files", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const removed = cleanupDaemonFilesSync({
+      pidFilePath,
+      socketPaths: [socketPath],
+      expectedPid: 12345,
+      socketBindCommitted: true,
+    });
+
+    expect(removed).toBe(true);
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
 });
 
 describe("isProcessRunning", () => {

--- a/test/daemon/incumbentOwnerGuard.test.ts
+++ b/test/daemon/incumbentOwnerGuard.test.ts
@@ -11,7 +11,30 @@ import type { PidFileData } from "../../src/daemon/types";
  * #6140 socket-brick family). Every seam is injected so no test touches the real
  * `~/.auto-mobile` PID path.
  */
+/**
+ * A COMMITTED owner record: what a real incumbent daemon leaves after it has
+ * bound the socket. Only such a record carries build identity
+ * (`entryScript`/`buildId`), which is how the guard tells the true owner apart
+ * from another hand-launched contender's pre-bind early record (issue #6232).
+ */
 function record(pid: number): PidFileData {
+  return {
+    pid,
+    socketPath: "/tmp/daemon.sock",
+    port: 8080,
+    startedAt: 0,
+    version: "test",
+    entryScript: "/opt/auto-mobile/index.js",
+    buildId: "deadbeefcafef00d",
+  };
+}
+
+/**
+ * A pre-bind EARLY owner record (issue #2871): no build identity. Written by a
+ * contender still in startup that has NOT bound the socket — it is not proof of
+ * who owns the socket.
+ */
+function earlyRecord(pid: number): PidFileData {
   return { pid, socketPath: "/tmp/daemon.sock", port: 8080, startedAt: 0, version: "test" };
 }
 
@@ -124,5 +147,49 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
 
     expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
     expect(writes).toHaveLength(0);
+  });
+
+  describe("overlapping hand-launched contenders (issue #6232)", () => {
+    const CONTENDER_PID = 5150;
+
+    test("P1: fails closed when the captured record is a live contender's EARLY record", () => {
+      // The true incumbent's record was already clobbered by another contender's
+      // early record before we read it, so the file names a live non-owner.
+      const { guard, file, running } = makeGuard();
+      running.add(CONTENDER_PID);
+      file.data = earlyRecord(CONTENDER_PID);
+
+      guard.captureIncumbentBeforeOverwrite();
+
+      // No committed owner was proven, so the lock-less bind must refuse rather
+      // than treat the contender's record as the socket owner.
+      expect(guard.hasLiveForeignOwner()).toBe(true);
+      expect(guard.asSocketOwnerLiveness().hasLiveForeignOwner()).toBe(true);
+    });
+
+    test("P1: stays closed even after the contender exits (its death proves nothing about the winner)", () => {
+      const { guard, file, running } = makeGuard();
+      running.add(CONTENDER_PID);
+      file.data = earlyRecord(CONTENDER_PID);
+
+      guard.captureIncumbentBeforeOverwrite();
+      // The contender refuses its own bind and exits; a naive re-check would now
+      // read "dead" and authorize unlinking the still-live winner's socket.
+      running.delete(CONTENDER_PID);
+
+      expect(guard.hasLiveForeignOwner()).toBe(true);
+    });
+
+    test("P2: never restores a contender's EARLY record over the real owner's", () => {
+      const { guard, file, running, writes } = makeGuard();
+      running.add(CONTENDER_PID);
+      file.data = earlyRecord(CONTENDER_PID);
+
+      guard.captureIncumbentBeforeOverwrite();
+
+      // Restoring the contender's PID would clobber the true incumbent's record.
+      expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
+      expect(writes).toHaveLength(0);
+    });
   });
 });

--- a/test/daemon/incumbentOwnerGuard.test.ts
+++ b/test/daemon/incumbentOwnerGuard.test.ts
@@ -41,6 +41,15 @@ function earlyRecord(pid: number): PidFileData {
 const SELF_PID = 4242;
 const INCUMBENT_PID = 9001;
 
+function writeContenderEarlyRecord(
+  guard: IncumbentOwnerGuard,
+  file: { data: PidFileData | null },
+): void {
+  const contender = earlyRecord(SELF_PID);
+  file.data = contender;
+  guard.recordContenderEarlyOwner(contender);
+}
+
 function makeGuard(overrides: Partial<IncumbentOwnerGuardDeps> = {}): {
   guard: IncumbentOwnerGuard;
   file: { data: PidFileData | null };
@@ -76,7 +85,7 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
     // Snapshot-backed liveness still sees the live sibling, so the bind guard
     // fails closed on an inconclusive probe instead of unlinking the live socket.
     expect(guard.hasLiveForeignOwner()).toBe(true);
-    expect(guard.asSocketOwnerLiveness().hasLiveForeignOwner()).toBe(true);
+    expect(guard.asSocketOwnerLiveness().getOwnerStatus()).toBe("live");
   });
 
   test("captures no incumbent when the file already names this process", () => {
@@ -88,13 +97,14 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
     expect(guard.hasLiveForeignOwner()).toBe(false);
   });
 
-  test("captures no incumbent when the recorded foreign process is dead (stale socket stays reclaimable)", () => {
+  test("records a dead committed owner as permission to reclaim its stale socket", () => {
     const { guard, running } = makeGuard();
     running.delete(INCUMBENT_PID);
 
     guard.captureIncumbentBeforeOverwrite();
 
     expect(guard.hasLiveForeignOwner()).toBe(false);
+    expect(guard.asSocketOwnerLiveness().getOwnerStatus()).toBe("dead");
   });
 
   test("captures no incumbent when no PID file exists", () => {
@@ -120,7 +130,7 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
 
     guard.captureIncumbentBeforeOverwrite();
     // Contender overwrote the file with its own record before refusing the bind.
-    file.data = record(SELF_PID);
+    writeContenderEarlyRecord(guard, file);
 
     expect(guard.restoreIncumbentAfterRefusal()).toBe(true);
     expect(writes).toHaveLength(1);
@@ -130,13 +140,29 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
   });
 
   test("P2: does NOT restore a record for a process that died between capture and refusal", () => {
-    const { guard, running, writes } = makeGuard();
+    const { guard, file, running, writes } = makeGuard();
 
     guard.captureIncumbentBeforeOverwrite();
+    writeContenderEarlyRecord(guard, file);
     running.delete(INCUMBENT_PID);
 
     expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
     expect(writes).toHaveLength(0);
+  });
+
+  test("P2: does not overwrite a replacement that claimed the PID record before restore", () => {
+    const { guard, file, writes } = makeGuard();
+    const replacement = record(7171);
+
+    guard.captureIncumbentBeforeOverwrite();
+    writeContenderEarlyRecord(guard, file);
+    // Another daemon completed startup while the refused contender was
+    // unwinding. Its committed record is authoritative and must survive.
+    file.data = replacement;
+
+    expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
+    expect(writes).toHaveLength(0);
+    expect(file.data).toBe(replacement);
   });
 
   test("restore is a no-op when no live incumbent was captured", () => {
@@ -164,7 +190,7 @@ describe("IncumbentOwnerGuard (issue #6232)", () => {
       // No committed owner was proven, so the lock-less bind must refuse rather
       // than treat the contender's record as the socket owner.
       expect(guard.hasLiveForeignOwner()).toBe(true);
-      expect(guard.asSocketOwnerLiveness().hasLiveForeignOwner()).toBe(true);
+      expect(guard.asSocketOwnerLiveness().getOwnerStatus()).toBe("unknown");
     });
 
     test("P1: stays closed even after the contender exits (its death proves nothing about the winner)", () => {

--- a/test/daemon/incumbentOwnerGuard.test.ts
+++ b/test/daemon/incumbentOwnerGuard.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IncumbentOwnerGuard,
+  type IncumbentOwnerGuardDeps,
+} from "../../src/daemon/incumbentOwnerGuard";
+import type { PidFileData } from "../../src/daemon/types";
+
+/**
+ * {@link IncumbentOwnerGuard} preserves a live incumbent daemon's PID record
+ * across a hand-launched contender's early-owner overwrite (issue #6232, the
+ * #6140 socket-brick family). Every seam is injected so no test touches the real
+ * `~/.auto-mobile` PID path.
+ */
+function record(pid: number): PidFileData {
+  return { pid, socketPath: "/tmp/daemon.sock", port: 8080, startedAt: 0, version: "test" };
+}
+
+const SELF_PID = 4242;
+const INCUMBENT_PID = 9001;
+
+function makeGuard(overrides: Partial<IncumbentOwnerGuardDeps> = {}): {
+  guard: IncumbentOwnerGuard;
+  file: { data: PidFileData | null };
+  running: Set<number>;
+  writes: PidFileData[];
+} {
+  // A mutable "PID file" and a "process table" the test drives directly.
+  const file: { data: PidFileData | null } = { data: record(INCUMBENT_PID) };
+  const running = new Set<number>([SELF_PID, INCUMBENT_PID]);
+  const writes: PidFileData[] = [];
+  const guard = new IncumbentOwnerGuard({
+    readPidFile: () => file.data,
+    persistPidFile: (data) => {
+      writes.push(data);
+      file.data = data;
+    },
+    isProcessRunning: (pid) => running.has(pid),
+    selfPid: SELF_PID,
+    ...overrides,
+  });
+  return { guard, file, running, writes };
+}
+
+describe("IncumbentOwnerGuard (issue #6232)", () => {
+  test("P1: liveness reads the captured snapshot, not the self-overwritten file", () => {
+    const { guard, file } = makeGuard();
+
+    guard.captureIncumbentBeforeOverwrite();
+    // The contender now overwrites the shared PID file with its OWN record — the
+    // exact production ordering that made a plain re-read return `pid === self`.
+    file.data = record(SELF_PID);
+
+    // Snapshot-backed liveness still sees the live sibling, so the bind guard
+    // fails closed on an inconclusive probe instead of unlinking the live socket.
+    expect(guard.hasLiveForeignOwner()).toBe(true);
+    expect(guard.asSocketOwnerLiveness().hasLiveForeignOwner()).toBe(true);
+  });
+
+  test("captures no incumbent when the file already names this process", () => {
+    const { guard, file } = makeGuard();
+    file.data = record(SELF_PID);
+
+    guard.captureIncumbentBeforeOverwrite();
+
+    expect(guard.hasLiveForeignOwner()).toBe(false);
+  });
+
+  test("captures no incumbent when the recorded foreign process is dead (stale socket stays reclaimable)", () => {
+    const { guard, running } = makeGuard();
+    running.delete(INCUMBENT_PID);
+
+    guard.captureIncumbentBeforeOverwrite();
+
+    expect(guard.hasLiveForeignOwner()).toBe(false);
+  });
+
+  test("captures no incumbent when no PID file exists", () => {
+    const { guard, file } = makeGuard();
+    file.data = null;
+
+    guard.captureIncumbentBeforeOverwrite();
+
+    expect(guard.hasLiveForeignOwner()).toBe(false);
+  });
+
+  test("re-checks liveness: a sibling that dies after capture is no longer a live owner", () => {
+    const { guard, running } = makeGuard();
+
+    guard.captureIncumbentBeforeOverwrite();
+    running.delete(INCUMBENT_PID);
+
+    expect(guard.hasLiveForeignOwner()).toBe(false);
+  });
+
+  test("P2: restores the captured incumbent record after a refused bind", () => {
+    const { guard, file, writes } = makeGuard();
+
+    guard.captureIncumbentBeforeOverwrite();
+    // Contender overwrote the file with its own record before refusing the bind.
+    file.data = record(SELF_PID);
+
+    expect(guard.restoreIncumbentAfterRefusal()).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.pid).toBe(INCUMBENT_PID);
+    // status()/`--daemon stop` now read back the live winner, not the dead contender.
+    expect(file.data!.pid).toBe(INCUMBENT_PID);
+  });
+
+  test("P2: does NOT restore a record for a process that died between capture and refusal", () => {
+    const { guard, running, writes } = makeGuard();
+
+    guard.captureIncumbentBeforeOverwrite();
+    running.delete(INCUMBENT_PID);
+
+    expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
+    expect(writes).toHaveLength(0);
+  });
+
+  test("restore is a no-op when no live incumbent was captured", () => {
+    const { guard, file, writes } = makeGuard();
+    file.data = record(SELF_PID);
+
+    guard.captureIncumbentBeforeOverwrite();
+
+    expect(guard.restoreIncumbentAfterRefusal()).toBe(false);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -290,9 +290,9 @@ describe("DaemonManager stop", () => {
   // loser. stop()'s confirmed-dead cleanup must remove ONLY the stale PID
   // file — never the socket by pathname, which it cannot prove is still the
   // loser's (no lock held, no cheap ownership-proof mechanism, by design). A
-  // leftover socket file is harmless: the next daemon start reclaims it under
-  // the O_EXCL lock.
-  test("removes only the stale PID file for a well-formed PID file naming an already-exited daemon; the socket is left for the next locked bind to reclaim", async () => {
+  // leftover socket file is harmless: a later bind can reclaim it only after
+  // proving its recorded owner dead.
+  test("removes only the stale PID file for a well-formed PID file naming an already-exited daemon; a later guarded bind may reclaim the socket", async () => {
     const directory = mkdtempSync(join(tmpdir(), "daemon-manager-stop-already-exited-"));
     const pidFilePath = join(directory, "daemon.pid");
     const socketPath = join(directory, "daemon.sock");
@@ -2585,11 +2585,15 @@ describe("Daemon manager process detection", () => {
     }
   });
 
-  test("start takeover does not signal transient daemon-mode candidates that are gone by liveness re-check", async () => {
+  test("start takeover neither signals transient candidates nor unlinks the socket before the shared bind guard", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-transient-takeover-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
+    const socketPath = join(dir, "daemon.sock");
     writeDaemonPidFile(pidFilePath, 201);
+    // This may be a direct daemon's live socket. Manager startup must leave
+    // reclamation to the child bind guard, which has the ownership evidence.
+    writeFileSync(socketPath, "socket owned by another launcher");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const killCalls: Array<{ pid: number; signal: NodeJS.Signals | number | undefined }> = [];
@@ -2642,7 +2646,7 @@ describe("Daemon manager process detection", () => {
         fakeTimer,
         join(dir, "daemon.lock"),
         pidFilePath,
-        join(dir, "daemon.sock"),
+        socketPath,
         processFinder,
         processSpawner,
       );
@@ -2650,6 +2654,7 @@ describe("Daemon manager process detection", () => {
       await manager.start();
 
       expect(killCalls).toEqual([]);
+      expect(existsSync(socketPath)).toBe(true);
     } finally {
       killSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });

--- a/test/daemon/socketServerBindGuard.integration.test.ts
+++ b/test/daemon/socketServerBindGuard.integration.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import { createConnection, createServer, type Server as NetServer, type Socket } from "node:net";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { UnixSocketServer, type SocketOwnerLiveness } from "../../src/daemon/socketServer";
 import type { DaemonSocketReachabilityLike } from "../../src/daemon/daemonSocketReachability";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -15,8 +14,10 @@ const isWindows = platform() === "win32";
  * The bind-guard (issue #6232): a LOCK-LESS bind — a daemon launched by hand,
  * bypassing DaemonManager's O_EXCL startup lock — must refuse to unlink a live
  * sibling's socket, while a LOCK-HELD bind keeps today's unconditional
- * stale-socket reclaim. These tests drive the injected liveness probe so the
- * live/stale decision is deterministic and needs no real socket timing.
+ * stale-socket reclaim. A NOT-reachable probe is treated as INCONCLUSIVE (fail
+ * closed) unless no live owner is recorded. These tests drive the injected
+ * liveness probe and owner-liveness check so the live/stale/inconclusive decision
+ * is deterministic and needs no real socket timing.
  */
 function createFakeDaemonState() {
   return {
@@ -34,15 +35,29 @@ function reachability(result: boolean): DaemonSocketReachabilityLike {
   return { isReachable: async () => result };
 }
 
+function ownerLiveness(hasLiveForeignOwner: boolean): SocketOwnerLiveness {
+  return { hasLiveForeignOwner: () => hasLiveForeignOwner };
+}
+
 const throwingReachability: DaemonSocketReachabilityLike = {
   isReachable: async () => {
     throw new Error("liveness probe must not run on a lock-held bind");
   },
 };
 
+const throwingOwnerLiveness: SocketOwnerLiveness = {
+  hasLiveForeignOwner: () => {
+    throw new Error("owner-liveness check must not run on a lock-held bind");
+  },
+};
+
 function makeServer(
   socketPath: string,
-  bindGuard: { startupLockHeld?: boolean; reachability?: DaemonSocketReachabilityLike },
+  bindGuard: {
+    startupLockHeld?: boolean;
+    reachability?: DaemonSocketReachabilityLike;
+    ownerLiveness?: SocketOwnerLiveness;
+  },
 ): UnixSocketServer {
   return new UnixSocketServer(
     socketPath,
@@ -58,6 +73,15 @@ function makeServer(
 
 describe("UnixSocketServer bind guard (issue #6232)", () => {
   const cleanups: Array<() => Promise<void>> = [];
+  const tempDirs: string[] = [];
+
+  function tempSocketPath(): string {
+    // A secure, unique per-test directory (not a predictable os.tmpdir() path)
+    // holds the socket, avoiding insecure-temp-file creation (CodeQL).
+    const dir = mkdtempSync(join(tmpdir(), "socket-bindguard-"));
+    tempDirs.push(dir);
+    return join(dir, "daemon.sock");
+  }
 
   afterEach(async () => {
     while (cleanups.length > 0) {
@@ -66,18 +90,24 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
         await cleanup();
       }
     }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
   });
 
   (isWindows ? test.skip : test)(
     "lock-less bind refuses a LIVE sibling socket and does not unlink it",
     async () => {
-      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      const socketPath = tempSocketPath();
       const sibling = await listenOnSocket(socketPath);
       cleanups.push(() => closeServer(sibling));
 
       const server = makeServer(socketPath, {
         startupLockHeld: false,
         reachability: reachability(true),
+        // The reachable branch decides on its own; owner-liveness must not be needed.
+        ownerLiveness: throwingOwnerLiveness,
       });
 
       await expect(server.start()).rejects.toThrow(/Refusing to bind/);
@@ -91,15 +121,40 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   );
 
   (isWindows ? test.skip : test)(
+    "lock-less bind refuses an INCONCLUSIVE probe (a live owner is still recorded) and does not unlink it",
+    async () => {
+      const socketPath = tempSocketPath();
+      // A socket file whose listener refuses the probe (accept backlog / mid-startup):
+      // the probe reports NOT reachable, but a live owner is still recorded, so the
+      // refusal is inconclusive and the bind must fail closed rather than unlink.
+      writeFileSync(socketPath, "");
+
+      const server = makeServer(socketPath, {
+        startupLockHeld: false,
+        reachability: reachability(false),
+        ownerLiveness: ownerLiveness(true),
+      });
+
+      await expect(server.start()).rejects.toThrow(/Refusing to bind/);
+
+      // The (possibly still live) socket must survive — an inconclusive probe never
+      // reclaims it.
+      expect(existsSync(socketPath)).toBe(true);
+      expect(server.isListening()).toBe(false);
+    },
+  );
+
+  (isWindows ? test.skip : test)(
     "lock-held bind reclaims a stale socket and binds without probing",
     async () => {
-      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      const socketPath = tempSocketPath();
       // A leftover post-crash socket file with no live listener behind it.
       writeFileSync(socketPath, "");
 
       const server = makeServer(socketPath, {
         startupLockHeld: true,
         reachability: throwingReachability,
+        ownerLiveness: throwingOwnerLiveness,
       });
       cleanups.push(() => server.close());
 
@@ -115,12 +170,14 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   (isWindows ? test.skip : test)(
     "lock-less bind reclaims a genuinely stale (dead) socket and binds",
     async () => {
-      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      const socketPath = tempSocketPath();
       writeFileSync(socketPath, "");
 
       const server = makeServer(socketPath, {
         startupLockHeld: false,
         reachability: reachability(false),
+        // No live owner recorded: the socket is confidently dead and reclaimable.
+        ownerLiveness: ownerLiveness(false),
       });
       cleanups.push(() => server.close());
 

--- a/test/daemon/socketServerBindGuard.integration.test.ts
+++ b/test/daemon/socketServerBindGuard.integration.test.ts
@@ -4,20 +4,19 @@ import { createConnection, createServer, type Server as NetServer, type Socket }
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { UnixSocketServer, type SocketOwnerLiveness } from "../../src/daemon/socketServer";
+import {
+  UnixSocketServer,
+  type SocketOwnerLiveness,
+  type SocketOwnerStatus,
+} from "../../src/daemon/socketServer";
 import type { DaemonSocketReachabilityLike } from "../../src/daemon/daemonSocketReachability";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 const isWindows = platform() === "win32";
 
 /**
- * The bind-guard (issue #6232): a LOCK-LESS bind — a daemon launched by hand,
- * bypassing DaemonManager's O_EXCL startup lock — must refuse to unlink a live
- * sibling's socket, while a LOCK-HELD bind keeps today's unconditional
- * stale-socket reclaim. A NOT-reachable probe is treated as INCONCLUSIVE (fail
- * closed) unless no live owner is recorded. These tests drive the injected
- * liveness probe and owner-liveness check so the live/stale/inconclusive decision
- * is deterministic and needs no real socket timing.
+ * Manager and direct launches share proof-before-unlink: an unreachable socket
+ * is reclaimable only when a recorded former owner is positively dead.
  */
 function createFakeDaemonState() {
   return {
@@ -35,26 +34,19 @@ function reachability(result: boolean): DaemonSocketReachabilityLike {
   return { isReachable: async () => result };
 }
 
-function ownerLiveness(hasLiveForeignOwner: boolean): SocketOwnerLiveness {
-  return { hasLiveForeignOwner: () => hasLiveForeignOwner };
+function ownerLiveness(status: SocketOwnerStatus): SocketOwnerLiveness {
+  return { getOwnerStatus: () => status };
 }
 
-const throwingReachability: DaemonSocketReachabilityLike = {
-  isReachable: async () => {
-    throw new Error("liveness probe must not run on a lock-held bind");
-  },
-};
-
 const throwingOwnerLiveness: SocketOwnerLiveness = {
-  hasLiveForeignOwner: () => {
-    throw new Error("owner-liveness check must not run on a lock-held bind");
+  getOwnerStatus: () => {
+    throw new Error("owner-liveness check must not run when the socket is reachable");
   },
 };
 
 function makeServer(
   socketPath: string,
   bindGuard: {
-    startupLockHeld?: boolean;
     reachability?: DaemonSocketReachabilityLike;
     ownerLiveness?: SocketOwnerLiveness;
   },
@@ -97,14 +89,13 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   });
 
   (isWindows ? test.skip : test)(
-    "lock-less bind refuses a LIVE sibling socket and does not unlink it",
+    "direct bind refuses a LIVE sibling socket and does not unlink it",
     async () => {
       const socketPath = tempSocketPath();
       const sibling = await listenOnSocket(socketPath);
       cleanups.push(() => closeServer(sibling));
 
       const server = makeServer(socketPath, {
-        startupLockHeld: false,
         reachability: reachability(true),
         // The reachable branch decides on its own; owner-liveness must not be needed.
         ownerLiveness: throwingOwnerLiveness,
@@ -121,7 +112,7 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   );
 
   (isWindows ? test.skip : test)(
-    "lock-less bind refuses an INCONCLUSIVE probe (a live owner is still recorded) and does not unlink it",
+    "direct bind refuses an INCONCLUSIVE probe with a live recorded owner",
     async () => {
       const socketPath = tempSocketPath();
       // A socket file whose listener refuses the probe (accept backlog / mid-startup):
@@ -130,9 +121,8 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
       writeFileSync(socketPath, "");
 
       const server = makeServer(socketPath, {
-        startupLockHeld: false,
         reachability: reachability(false),
-        ownerLiveness: ownerLiveness(true),
+        ownerLiveness: ownerLiveness("live"),
       });
 
       await expect(server.start()).rejects.toThrow(/Refusing to bind/);
@@ -145,16 +135,35 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   );
 
   (isWindows ? test.skip : test)(
-    "lock-held bind reclaims a stale socket and binds without probing",
+    "manager bind refuses a LIVE sibling socket and does not unlink it",
     async () => {
       const socketPath = tempSocketPath();
-      // A leftover post-crash socket file with no live listener behind it.
+      const sibling = await listenOnSocket(socketPath);
+      cleanups.push(() => closeServer(sibling));
+
+      const server = makeServer(socketPath, {
+        reachability: reachability(true),
+        ownerLiveness: throwingOwnerLiveness,
+      });
+
+      await expect(server.start()).rejects.toThrow(/Refusing to bind/);
+
+      expect(existsSync(socketPath)).toBe(true);
+      const client = await connectClient(socketPath);
+      expect(client.destroyed).toBe(false);
+      client.destroy();
+    },
+  );
+
+  (isWindows ? test.skip : test)(
+    "bind reclaims a socket only when the recorded former owner is dead",
+    async () => {
+      const socketPath = tempSocketPath();
       writeFileSync(socketPath, "");
 
       const server = makeServer(socketPath, {
-        startupLockHeld: true,
-        reachability: throwingReachability,
-        ownerLiveness: throwingOwnerLiveness,
+        reachability: reachability(false),
+        ownerLiveness: ownerLiveness("dead"),
       });
       cleanups.push(() => server.close());
 
@@ -168,25 +177,17 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
   );
 
   (isWindows ? test.skip : test)(
-    "lock-less bind reclaims a genuinely stale (dead) socket and binds",
+    "refuses an unreachable socket when ownership is unknown",
     async () => {
       const socketPath = tempSocketPath();
       writeFileSync(socketPath, "");
-
       const server = makeServer(socketPath, {
-        startupLockHeld: false,
         reachability: reachability(false),
-        // No live owner recorded: the socket is confidently dead and reclaimable.
-        ownerLiveness: ownerLiveness(false),
+        ownerLiveness: ownerLiveness("unknown"),
       });
-      cleanups.push(() => server.close());
 
-      await server.start();
-
-      expect(server.isListening()).toBe(true);
-      const client = await connectClient(socketPath);
-      expect(client.destroyed).toBe(false);
-      client.destroy();
+      await expect(server.start()).rejects.toThrow(/positively known to be dead/);
+      expect(existsSync(socketPath)).toBe(true);
     },
   );
 });

--- a/test/daemon/socketServerBindGuard.integration.test.ts
+++ b/test/daemon/socketServerBindGuard.integration.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { createConnection, createServer, type Server as NetServer, type Socket } from "node:net";
+import { existsSync, writeFileSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import type { DaemonSocketReachabilityLike } from "../../src/daemon/daemonSocketReachability";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const isWindows = platform() === "win32";
+
+/**
+ * The bind-guard (issue #6232): a LOCK-LESS bind — a daemon launched by hand,
+ * bypassing DaemonManager's O_EXCL startup lock — must refuse to unlink a live
+ * sibling's socket, while a LOCK-HELD bind keeps today's unconditional
+ * stale-socket reclaim. These tests drive the injected liveness probe so the
+ * live/stale decision is deterministic and needs no real socket timing.
+ */
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function reachability(result: boolean): DaemonSocketReachabilityLike {
+  return { isReachable: async () => result };
+}
+
+const throwingReachability: DaemonSocketReachabilityLike = {
+  isReachable: async () => {
+    throw new Error("liveness probe must not run on a lock-held bind");
+  },
+};
+
+function makeServer(
+  socketPath: string,
+  bindGuard: { startupLockHeld?: boolean; reachability?: DaemonSocketReachabilityLike },
+): UnixSocketServer {
+  return new UnixSocketServer(
+    socketPath,
+    "http://localhost:0/mcp",
+    createFakeDaemonState(),
+    new FakeTimer(),
+    null,
+    undefined,
+    undefined,
+    bindGuard,
+  );
+}
+
+describe("UnixSocketServer bind guard (issue #6232)", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      const cleanup = cleanups.pop();
+      if (cleanup) {
+        await cleanup();
+      }
+    }
+  });
+
+  (isWindows ? test.skip : test)(
+    "lock-less bind refuses a LIVE sibling socket and does not unlink it",
+    async () => {
+      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      const sibling = await listenOnSocket(socketPath);
+      cleanups.push(() => closeServer(sibling));
+
+      const server = makeServer(socketPath, {
+        startupLockHeld: false,
+        reachability: reachability(true),
+      });
+
+      await expect(server.start()).rejects.toThrow(/Refusing to bind/);
+
+      // The live sibling's socket must survive untouched, and still accept clients.
+      expect(existsSync(socketPath)).toBe(true);
+      const client = await connectClient(socketPath);
+      expect(client.destroyed).toBe(false);
+      client.destroy();
+    },
+  );
+
+  (isWindows ? test.skip : test)(
+    "lock-held bind reclaims a stale socket and binds without probing",
+    async () => {
+      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      // A leftover post-crash socket file with no live listener behind it.
+      writeFileSync(socketPath, "");
+
+      const server = makeServer(socketPath, {
+        startupLockHeld: true,
+        reachability: throwingReachability,
+      });
+      cleanups.push(() => server.close());
+
+      await server.start();
+
+      expect(server.isListening()).toBe(true);
+      const client = await connectClient(socketPath);
+      expect(client.destroyed).toBe(false);
+      client.destroy();
+    },
+  );
+
+  (isWindows ? test.skip : test)(
+    "lock-less bind reclaims a genuinely stale (dead) socket and binds",
+    async () => {
+      const socketPath = join(tmpdir(), `socket-bindguard-${randomUUID()}.sock`);
+      writeFileSync(socketPath, "");
+
+      const server = makeServer(socketPath, {
+        startupLockHeld: false,
+        reachability: reachability(false),
+      });
+      cleanups.push(() => server.close());
+
+      await server.start();
+
+      expect(server.isListening()).toBe(true);
+      const client = await connectClient(socketPath);
+      expect(client.destroyed).toBe(false);
+      client.destroy();
+    },
+  );
+});
+
+async function connectClient(socketPath: string): Promise<Socket> {
+  const client = createConnection(socketPath);
+  await once(client, "connect");
+  return client;
+}
+
+function listenOnSocket(socketPath: string): Promise<NetServer> {
+  const server = createServer();
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+function closeServer(server: NetServer): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/test/daemon/socketServerBindGuard.integration.test.ts
+++ b/test/daemon/socketServerBindGuard.integration.test.ts
@@ -8,6 +8,7 @@ import {
   UnixSocketServer,
   type SocketOwnerLiveness,
   type SocketOwnerStatus,
+  type SocketReclaimLock,
 } from "../../src/daemon/socketServer";
 import type { DaemonSocketReachabilityLike } from "../../src/daemon/daemonSocketReachability";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -49,6 +50,7 @@ function makeServer(
   bindGuard: {
     reachability?: DaemonSocketReachabilityLike;
     ownerLiveness?: SocketOwnerLiveness;
+    bindLock?: SocketReclaimLock;
   },
 ): UnixSocketServer {
   return new UnixSocketServer(
@@ -188,6 +190,83 @@ describe("UnixSocketServer bind guard (issue #6232)", () => {
 
       await expect(server.start()).rejects.toThrow(/positively known to be dead/);
       expect(existsSync(socketPath)).toBe(true);
+    },
+  );
+
+  // Issue #6232, W5: the reachability/owner checks are observation-only, so two
+  // concurrent binders can both judge a stale socket reclaimable. A single
+  // cross-process reclaim lock serializes the probe → unlink → listen sequence.
+  (isWindows ? test.skip : test)(
+    "refuses to bind while the reclaim lock is held, without probing or unlinking",
+    async () => {
+      const socketPath = tempSocketPath();
+      // A stale socket a lone binder could otherwise reclaim; a held reclaim lock
+      // must short-circuit BEFORE any probe/owner check or unlink runs.
+      writeFileSync(socketPath, "");
+
+      let released = false;
+      const server = makeServer(socketPath, {
+        reachability: {
+          isReachable: async () => {
+            throw new Error("probe must not run while the reclaim lock is unavailable");
+          },
+        },
+        ownerLiveness: throwingOwnerLiveness,
+        bindLock: {
+          acquire: () => false,
+          release: () => {
+            released = true;
+          },
+        },
+      });
+
+      await expect(server.start()).rejects.toThrow(/reclaiming or binding/);
+
+      // The socket a concurrent winner may have just bound is left untouched.
+      expect(existsSync(socketPath)).toBe(true);
+      expect(server.isListening()).toBe(false);
+      // A lock we never acquired must never be released out from under its holder.
+      expect(released).toBe(false);
+    },
+  );
+
+  (isWindows ? test.skip : test)(
+    "two concurrent lock-less binds over a dead socket: exactly one reclaims, the other refuses",
+    async () => {
+      const socketPath = tempSocketPath();
+      // A stale, ownerless-dead socket that BOTH contenders' observation-only
+      // checks would judge reclaimable. Only the real shared `<socket>.bind.lock`
+      // (no bindLock injected here) keeps them from both unlinking it.
+      writeFileSync(socketPath, "");
+
+      const a = makeServer(socketPath, {
+        reachability: reachability(false),
+        ownerLiveness: ownerLiveness("dead"),
+      });
+      const b = makeServer(socketPath, {
+        reachability: reachability(false),
+        ownerLiveness: ownerLiveness("dead"),
+      });
+      cleanups.push(() => a.close());
+      cleanups.push(() => b.close());
+
+      const results = await Promise.allSettled([a.start(), b.start()]);
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+
+      // Exactly one binder wins; the loser refuses rather than racing the unlink.
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(
+        /reclaiming or binding/,
+      );
+
+      // The winner is bound and its socket is reachable; the loser never unlinked it.
+      expect(a.isListening() !== b.isListening()).toBe(true);
+      expect(existsSync(socketPath)).toBe(true);
+      const client = await connectClient(socketPath);
+      expect(client.destroyed).toBe(false);
+      client.destroy();
     },
   );
 });


### PR DESCRIPTION
## Summary

`UnixSocketServer.start()` unlinked an existing control socket unconditionally before `listen()` ([`src/daemon/socketServer.ts`](../blob/main/src/daemon/socketServer.ts)). That is safe only under [`DaemonManager.start()`](../blob/main/src/daemon/manager.ts)'s `O_EXCL` startup lock, which serializes daemon starts. A daemon launched **by hand** (invoking the entry point with `--daemon-mode` directly) bypasses that lock yet reaches the same unlink, so it could unlink a **live** daemon's socket out from under every client — the [#6140](https://github.com/kaeawc/auto-mobile/issues/6140) brick class via a bypassed launch path, which was explicitly out of scope for [#6140](https://github.com/kaeawc/auto-mobile/issues/6140)/[#6224](https://github.com/kaeawc/auto-mobile/issues/6224).

## Fix

Gate the bind on whether it holds the startup lock:

- The manager stamps `AUTOMOBILE_DAEMON_STARTUP_LOCK_HELD=1` on every daemon child it spawns — it only ever spawns while holding the lock — and the daemon derives `startupLockHeld` from it for both its initial and its in-process recovery bind.
- A **lock-held** bind keeps today's behavior exactly: unconditional reclaim of a stale post-crash socket.
- A **lock-less** bind first runs the existing observation-only `DaemonSocketReachability` probe. If a daemon is still listening it throws an `ActionableError` (another daemon owns this socket; use `--daemon restart`) instead of unlinking. Only a genuinely stale/dead socket is reclaimed.

The probe never touches the socket file, so no new destructive actor is introduced on the socket path — the [#6140](https://github.com/kaeawc/auto-mobile/issues/6140) client-side-unlink brick class stays fixed. Both seams (`startupLockHeld`, `reachability`) are injected for deterministic tests.

## Tests

`test/daemon/socketServerBindGuard.integration.test.ts`:
- lock-less bind against a **live** sibling socket → refuses (throws), does **not** unlink; sibling stays reachable.
- lock-held bind reclaims a **stale** socket and binds, without ever probing.
- lock-less bind against a genuinely **dead/stale** socket → reclaims and binds safely.

## Validation

`bun test test/daemon/` (1940 pass), `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build` — all green.

Closes #6232