### PR TITLE
fix(rotate): settle-wait post-restore confirm; preserve confirmed rotation on restore-write failure

### DIFF
--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -20,6 +20,15 @@ export class Rotate extends BaseVisualChange {
   // call. Deliberately NOT shared across different devices.
   private static readonly rotationLocks = new Map<string, Mutex>();
 
+  // Bounded settle-wait for the post-restore confirmation read (#6211). When
+  // the device is physically held opposite the requested orientation,
+  // WindowManager takes a moment to settle after `accelerometer_rotation` is
+  // restored, so an immediate read can catch a transient value and report a
+  // spurious "unconfirmed"/reverted result. Retry a few times, on the
+  // injected Timer, before accepting the read as final.
+  private static readonly SETTLE_WAIT_MAX_ATTEMPTS = 3;
+  private static readonly SETTLE_WAIT_POLL_INTERVAL_MS = 150;
+
   constructor(device: BootedDevice, adb: AdbClient | null = null, timer: Timer = defaultTimer) {
     super(device, adb, timer);
   }
@@ -80,20 +89,52 @@ export class Rotate extends BaseVisualChange {
   }
 
   /**
+   * Read the live rotation after restoring auto-rotate, with a bounded
+   * settle-wait: WindowManager can take a moment to settle after
+   * `accelerometer_rotation` is restored, particularly when the device is
+   * physically held opposite the requested orientation, so an immediate read
+   * can catch a transient value. Retry (on the injected Timer) until the
+   * live read matches the requested orientation or the attempt budget is
+   * exhausted, returning the last read either way so the caller can report
+   * it honestly (#6211).
+   */
+  private async readLiveRotationWithSettleWait(
+    requestedOrientation: "portrait" | "landscape",
+  ): Promise<number | null> {
+    let lastValue: number | null = null;
+    for (let attempt = 1; attempt <= Rotate.SETTLE_WAIT_MAX_ATTEMPTS; attempt++) {
+      lastValue = await this.readLiveRotation();
+      if (lastValue !== null) {
+        const achieved = lastValue === 0 || lastValue === 2 ? "portrait" : "landscape";
+        if (achieved === requestedOrientation) {
+          return lastValue;
+        }
+      }
+      if (attempt < Rotate.SETTLE_WAIT_MAX_ATTEMPTS) {
+        await this.timer.sleep(Rotate.SETTLE_WAIT_POLL_INTERVAL_MS);
+      }
+    }
+    return lastValue;
+  }
+
+  /**
    * After restoring auto-rotate, determine what orientation the device
    * actually ended up in. Restoring auto-rotate can let the physical sensor
    * immediately re-apply its own orientation, overriding the one just
    * forced, so this confirmation read MUST be LIVE (mRotation from dumpsys
    * window) — falling back to `user_rotation` here would just echo the
    * value this same call wrote a moment ago and silently recreate the false
-   * "requested orientation held" success this fix exists to prevent. If the
-   * live read is unavailable, the achieved orientation is reported as
-   * unconfirmed rather than guessed (#6199 review).
+   * "requested orientation held" success this fix exists to prevent. The
+   * read goes through a bounded settle-wait (#6211) so a momentarily
+   * unsettled WindowManager doesn't yield a spurious "unconfirmed"/reverted
+   * result. If the live read is still unavailable after settling, the
+   * achieved orientation is reported as unconfirmed rather than guessed
+   * (#6199 review).
    */
   private async confirmOrientationAfterAutoRotateRestore(
     requestedOrientation: "portrait" | "landscape",
   ): Promise<{ achievedOrientation: string; warning: string | undefined }> {
-    const liveRotationValue = await this.readLiveRotation();
+    const liveRotationValue = await this.readLiveRotationWithSettleWait(requestedOrientation);
     if (liveRotationValue === null) {
       return {
         achievedOrientation: "unknown",
@@ -346,7 +387,30 @@ export class Rotate extends BaseVisualChange {
       let warning: string | undefined;
 
       if (wasAutoRotateEnabled) {
-        await this.writeSystemSetting("accelerometer_rotation", "1");
+        try {
+          await this.writeSystemSetting("accelerometer_rotation", "1");
+        } catch (restoreError) {
+          // waitForRotation above already CONFIRMED the requested rotation
+          // took effect while auto-rotate was forced off. The restore write
+          // failing afterward must not discard that confirmed success — it
+          // means auto-rotate is left off (so the forced orientation is, if
+          // anything, MORE likely to still be held, not less) and the caller
+          // needs an honest warning, not a false failure (#6211).
+          logger.warn(
+            `[Rotate] Failed to restore auto-rotate after confirming rotation to ${orientation}: ${restoreError}`,
+          );
+          return {
+            success: true,
+            orientation,
+            value,
+            currentOrientation: orientation,
+            previousOrientation: currentOrientation,
+            rotationPerformed: true,
+            orientationLockHandled: wasAutoRotateEnabled,
+            warning: `Rotated to ${orientation}, but auto-rotate could not be restored (accelerometer_rotation write failed): ${restoreError}`,
+            message: `Rotated to ${orientation}, but auto-rotate could not be restored`,
+          };
+        }
         ({ achievedOrientation, warning } =
           await this.confirmOrientationAfterAutoRotateRestore(orientation));
       }

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -107,12 +107,13 @@ export class Rotate extends BaseVisualChange {
     requestedOrientation: "portrait" | "landscape",
   ): Promise<number | null> {
     let lastValue: number | null = null;
+    let lastAchieved: "portrait" | "landscape" | null = null;
     let consecutiveMatches = 0;
     for (let attempt = 1; attempt <= Rotate.SETTLE_WAIT_MAX_ATTEMPTS; attempt++) {
       lastValue = await this.readLiveRotation();
-      const achieved =
+      lastAchieved =
         lastValue === null ? null : lastValue === 0 || lastValue === 2 ? "portrait" : "landscape";
-      if (achieved === requestedOrientation) {
+      if (lastAchieved === requestedOrientation) {
         consecutiveMatches++;
         // A single matching sample is not proof the orientation is held —
         // require it to hold across a second, later sample before accepting
@@ -127,7 +128,16 @@ export class Rotate extends BaseVisualChange {
         await this.timer.sleep(Rotate.SETTLE_WAIT_POLL_INTERVAL_MS);
       }
     }
-    return lastValue;
+    // The attempt budget is exhausted without ever reaching the stability
+    // threshold. A lone match on this FINAL attempt has no opportunity for a
+    // confirming subsequent sample — unconditionally returning it here would
+    // reintroduce the exact false "requested orientation held" report the
+    // stability check exists to prevent, so report it as unconfirmed (null)
+    // rather than accepted. A final read that does NOT match the requested
+    // orientation carries no such risk — the caller reports it as "reverted",
+    // which understates confidence rather than overstating it — so it is
+    // still returned as-is (#6211 review).
+    return lastAchieved === requestedOrientation ? null : lastValue;
   }
 
   /**

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -103,41 +103,125 @@ export class Rotate extends BaseVisualChange {
    * exhausted, returning the last read either way so the caller can report
    * it honestly (#6211).
    */
+  /**
+   * Update an in-progress consecutive-match streak with a newly read
+   * orientation. A `null` (unreadable) sample always breaks the streak
+   * rather than extending or restarting it — it is a read failure, not a
+   * confirming or contradicting orientation sample.
+   */
+  private updateOrientationStreak(
+    achieved: "portrait" | "landscape" | null,
+    streak: { achieved: "portrait" | "landscape" | null; count: number },
+  ): void {
+    if (achieved !== null && achieved === streak.achieved) {
+      streak.count++;
+    } else {
+      streak.achieved = achieved;
+      streak.count = achieved === null ? 0 : 1;
+    }
+  }
+
+  /**
+   * Decide the settle-wait's return value once the attempt budget is
+   * exhausted without the requested orientation ever reaching the stability
+   * threshold (#6211 review).
+   */
+  private resolveExhaustedSettleWait(
+    requestedOrientation: "portrait" | "landscape",
+    lastValue: number | null,
+    lastAchieved: "portrait" | "landscape" | null,
+    lastConfirmed: { value: number | null; achieved: "portrait" | "landscape" | null },
+  ): number | null {
+    // A lone match on this FINAL attempt has no opportunity for a confirming
+    // subsequent sample — unconditionally returning it here would
+    // reintroduce the exact false "requested orientation held" report the
+    // stability check exists to prevent, so report it as unconfirmed (null)
+    // rather than accepted.
+    if (lastAchieved === requestedOrientation) {
+      return null;
+    }
+    // A final read that does NOT match the requested orientation carries no
+    // such risk — the caller reports it as "reverted", which understates
+    // confidence rather than overstating it — so it is returned as-is.
+    if (lastValue !== null) {
+      return lastValue;
+    }
+    // The final attempt failed to read at all (unparseable/unavailable). That
+    // read FAILURE is not a contradicting sample, so it must not discard an
+    // opposite orientation that two earlier consecutive samples already
+    // confirmed stable — falling back to "unknown" here would throw away
+    // real evidence just because the very last poll came back empty.
+    return lastConfirmed.achieved !== null ? lastConfirmed.value : null;
+  }
+
   private async readLiveRotationWithSettleWait(
     requestedOrientation: "portrait" | "landscape",
   ): Promise<number | null> {
     let lastValue: number | null = null;
     let lastAchieved: "portrait" | "landscape" | null = null;
-    let consecutiveMatches = 0;
+    // Tracks consecutive matching samples for whichever orientation was last
+    // read — not only the requested one — so a confirmed opposite-orientation
+    // reversion (e.g. two consecutive landscape samples when portrait was
+    // requested) is remembered in `lastConfirmed` even though it never
+    // triggers the early-return below (#6211 review).
+    const streak: { achieved: "portrait" | "landscape" | null; count: number } = {
+      achieved: null,
+      count: 0,
+    };
+    const lastConfirmed: { value: number | null; achieved: "portrait" | "landscape" | null } = {
+      value: null,
+      achieved: null,
+    };
     for (let attempt = 1; attempt <= Rotate.SETTLE_WAIT_MAX_ATTEMPTS; attempt++) {
       lastValue = await this.readLiveRotation();
       lastAchieved =
         lastValue === null ? null : lastValue === 0 || lastValue === 2 ? "portrait" : "landscape";
-      if (lastAchieved === requestedOrientation) {
-        consecutiveMatches++;
+      this.updateOrientationStreak(lastAchieved, streak);
+      if (lastAchieved !== null && streak.count >= Rotate.SETTLE_WAIT_STABLE_READS) {
+        lastConfirmed.value = lastValue;
+        lastConfirmed.achieved = lastAchieved;
         // A single matching sample is not proof the orientation is held —
         // require it to hold across a second, later sample before accepting
         // it, rather than returning on the very first read (#6211 review).
-        if (consecutiveMatches >= Rotate.SETTLE_WAIT_STABLE_READS) {
+        if (lastAchieved === requestedOrientation) {
           return lastValue;
         }
-      } else {
-        consecutiveMatches = 0;
       }
       if (attempt < Rotate.SETTLE_WAIT_MAX_ATTEMPTS) {
         await this.timer.sleep(Rotate.SETTLE_WAIT_POLL_INTERVAL_MS);
       }
     }
-    // The attempt budget is exhausted without ever reaching the stability
-    // threshold. A lone match on this FINAL attempt has no opportunity for a
-    // confirming subsequent sample — unconditionally returning it here would
-    // reintroduce the exact false "requested orientation held" report the
-    // stability check exists to prevent, so report it as unconfirmed (null)
-    // rather than accepted. A final read that does NOT match the requested
-    // orientation carries no such risk — the caller reports it as "reverted",
-    // which understates confidence rather than overstating it — so it is
-    // still returned as-is (#6211 review).
-    return lastAchieved === requestedOrientation ? null : lastValue;
+    return this.resolveExhaustedSettleWait(
+      requestedOrientation,
+      lastValue,
+      lastAchieved,
+      lastConfirmed,
+    );
+  }
+
+  /**
+   * Compose the post-restore confirmation warning. The wording must stay
+   * state-neutral (never assert "auto-rotate is enabled") whenever the
+   * restore write itself did not confirm success — otherwise the composed
+   * warning contradicts the ambiguity note appended by the caller when
+   * `restoreWriteError` is set (#6211 review).
+   */
+  private buildConfirmationWarning(
+    requestedOrientation: "portrait" | "landscape",
+    restoreConfirmed: boolean,
+    achievedOrientation: "portrait" | "landscape" | null,
+  ): string | undefined {
+    if (achievedOrientation === requestedOrientation) {
+      return undefined;
+    }
+    if (achievedOrientation === null) {
+      return restoreConfirmed
+        ? `Auto-rotate is enabled and the device's orientation after restoring it could not be confirmed (live rotation read failed); the requested ${requestedOrientation} orientation may not be held.`
+        : `The device's orientation after attempting to restore auto-rotate could not be confirmed (live rotation read failed); the requested ${requestedOrientation} orientation may not be held.`;
+    }
+    return restoreConfirmed
+      ? `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${requestedOrientation} orientation is not held.`
+      : `The device reverted to ${achievedOrientation} after attempting to restore auto-rotate; the requested ${requestedOrientation} orientation is not held.`;
   }
 
   /**
@@ -152,26 +236,31 @@ export class Rotate extends BaseVisualChange {
    * unsettled WindowManager doesn't yield a spurious "unconfirmed"/reverted
    * result. If the live read is still unavailable after settling, the
    * achieved orientation is reported as unconfirmed rather than guessed
-   * (#6199 review).
+   * (#6199 review). `restoreConfirmed` controls whether the composed warning
+   * may assert "auto-rotate is enabled" (#6211 review).
    */
   private async confirmOrientationAfterAutoRotateRestore(
     requestedOrientation: "portrait" | "landscape",
+    restoreConfirmed: boolean,
   ): Promise<{ achievedOrientation: string; warning: string | undefined }> {
     const liveRotationValue = await this.readLiveRotationWithSettleWait(requestedOrientation);
     if (liveRotationValue === null) {
       return {
         achievedOrientation: "unknown",
-        warning: `Auto-rotate is enabled and the device's orientation after restoring it could not be confirmed (live rotation read failed); the requested ${requestedOrientation} orientation may not be held.`,
+        warning: this.buildConfirmationWarning(requestedOrientation, restoreConfirmed, null),
       };
     }
 
     const achievedOrientation =
       liveRotationValue === 0 || liveRotationValue === 2 ? "portrait" : "landscape";
-    const warning =
-      achievedOrientation === requestedOrientation
-        ? undefined
-        : `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${requestedOrientation} orientation is not held.`;
-    return { achievedOrientation, warning };
+    return {
+      achievedOrientation,
+      warning: this.buildConfirmationWarning(
+        requestedOrientation,
+        restoreConfirmed,
+        achievedOrientation,
+      ),
+    };
   }
 
   /**
@@ -192,20 +281,32 @@ export class Rotate extends BaseVisualChange {
     let restoreWriteError: unknown;
     try {
       await this.writeSystemSetting("accelerometer_rotation", "1");
-    } catch (error) {
-      restoreWriteError = error;
-      logger.warn(
-        `[Rotate] accelerometer_rotation restore write failed (ambiguous outcome) after confirming rotation to ${requestedOrientation}: ${error}`,
+    } catch (firstError) {
+      // A single transient failure (e.g. a momentary CtrlProxy/ADB hiccup)
+      // must not be treated as ambiguous on its own — retry once, the same
+      // idempotent write, before falling back to the ambiguous-outcome path
+      // (#6211 review).
+      logger.debug(
+        `[Rotate] accelerometer_rotation restore write failed on first attempt, retrying once: ${firstError}`,
       );
+      try {
+        await this.writeSystemSetting("accelerometer_rotation", "1");
+      } catch (retryError) {
+        restoreWriteError = retryError;
+        logger.warn(
+          `[Rotate] accelerometer_rotation restore write failed after retry (ambiguous outcome) after confirming rotation to ${requestedOrientation}: ${retryError}`,
+        );
+      }
     }
 
+    const restoreConfirmed = restoreWriteError === undefined;
     const { achievedOrientation, warning: confirmWarning } =
-      await this.confirmOrientationAfterAutoRotateRestore(requestedOrientation);
-    if (restoreWriteError === undefined) {
+      await this.confirmOrientationAfterAutoRotateRestore(requestedOrientation, restoreConfirmed);
+    if (restoreConfirmed) {
       return { achievedOrientation, warning: confirmWarning };
     }
 
-    const ambiguityNote = `the accelerometer_rotation restore write failed (ambiguous outcome — could not confirm whether auto-rotate was actually re-enabled): ${restoreWriteError}`;
+    const ambiguityNote = `the accelerometer_rotation restore write failed after a retry (ambiguous outcome — could not confirm whether auto-rotate was actually re-enabled): ${restoreWriteError}`;
     const warning = confirmWarning
       ? `${confirmWarning} Additionally, ${ambiguityNote}`
       : `Rotated to ${requestedOrientation}, but ${ambiguityNote}`;

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -277,7 +277,11 @@ export class Rotate extends BaseVisualChange {
    */
   private async restoreAutoRotateAndConfirmOrientation(
     requestedOrientation: "portrait" | "landscape",
-  ): Promise<{ achievedOrientation: string; warning: string | undefined }> {
+  ): Promise<{
+    achievedOrientation: string;
+    warning: string | undefined;
+    restoreConfirmed: boolean;
+  }> {
     let restoreWriteError: unknown;
     try {
       await this.writeSystemSetting("accelerometer_rotation", "1");
@@ -303,14 +307,47 @@ export class Rotate extends BaseVisualChange {
     const { achievedOrientation, warning: confirmWarning } =
       await this.confirmOrientationAfterAutoRotateRestore(requestedOrientation, restoreConfirmed);
     if (restoreConfirmed) {
-      return { achievedOrientation, warning: confirmWarning };
+      return { achievedOrientation, warning: confirmWarning, restoreConfirmed };
     }
 
     const ambiguityNote = `the accelerometer_rotation restore write failed after a retry (ambiguous outcome — could not confirm whether auto-rotate was actually re-enabled): ${restoreWriteError}`;
     const warning = confirmWarning
       ? `${confirmWarning} Additionally, ${ambiguityNote}`
       : `Rotated to ${requestedOrientation}, but ${ambiguityNote}`;
-    return { achievedOrientation, warning };
+    return { achievedOrientation, warning, restoreConfirmed };
+  }
+
+  /**
+   * Describe the rotation outcome without treating an unconfirmed restore as
+   * proof that auto-rotate caused the final orientation. The orientation read
+   * itself remains evidence and is retained in the message.
+   */
+  private buildRotationMessage(
+    requestedOrientation: "portrait" | "landscape",
+    previousOrientation: string,
+    achievedOrientation: string,
+    warning: string | undefined,
+    restoreConfirmed: boolean,
+  ): string {
+    if (!warning) {
+      return `Successfully rotated from ${previousOrientation} to ${requestedOrientation}`;
+    }
+    if (!restoreConfirmed) {
+      if (achievedOrientation === "unknown") {
+        return `Rotated to ${requestedOrientation}, but after attempting to restore auto-rotate, the device's current orientation could not be confirmed`;
+      }
+      if (achievedOrientation === requestedOrientation) {
+        return `Rotated to ${requestedOrientation}; after attempting to restore auto-rotate, the device was confirmed to remain ${achievedOrientation}`;
+      }
+      return `Rotated to ${requestedOrientation}; after attempting to restore auto-rotate, the device was confirmed ${achievedOrientation}`;
+    }
+    if (achievedOrientation === "unknown") {
+      return `Rotated to ${requestedOrientation}, but the device's orientation after auto-rotate restore could not be confirmed`;
+    }
+    if (achievedOrientation !== requestedOrientation) {
+      return `Rotated to ${requestedOrientation}, but auto-rotate reverted the device to ${achievedOrientation}`;
+    }
+    return `Successfully rotated from ${previousOrientation} to ${requestedOrientation}`;
   }
 
   async getCurrentOrientation(): Promise<string> {
@@ -547,9 +584,10 @@ export class Rotate extends BaseVisualChange {
       // `currentOrientation` remains the legitimate prior value (see #6057).
       let achievedOrientation: string = orientation;
       let warning: string | undefined;
+      let restoreConfirmed = true;
 
       if (wasAutoRotateEnabled) {
-        ({ achievedOrientation, warning } =
+        ({ achievedOrientation, warning, restoreConfirmed } =
           await this.restoreAutoRotateAndConfirmOrientation(orientation));
       }
 
@@ -562,13 +600,13 @@ export class Rotate extends BaseVisualChange {
         rotationPerformed: true,
         orientationLockHandled: wasAutoRotateEnabled,
         warning,
-        message: warning
-          ? achievedOrientation === "unknown"
-            ? `Rotated to ${orientation}, but the device's orientation after auto-rotate restore could not be confirmed`
-            : achievedOrientation !== orientation
-              ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
-              : `Rotated to ${orientation}, but the auto-rotate restore was ambiguous; the orientation was confirmed to still hold`
-          : `Successfully rotated from ${currentOrientation} to ${orientation}`,
+        message: this.buildRotationMessage(
+          orientation,
+          currentOrientation,
+          achievedOrientation,
+          warning,
+          restoreConfirmed,
+        ),
       };
     } catch (error) {
       // Restore auto-rotate if it was on before this call

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -127,30 +127,20 @@ export class Rotate extends BaseVisualChange {
    * threshold (#6211 review).
    */
   private resolveExhaustedSettleWait(
-    requestedOrientation: "portrait" | "landscape",
-    lastValue: number | null,
     lastAchieved: "portrait" | "landscape" | null,
+    lastStreakCount: number,
     lastConfirmed: { value: number | null; achieved: "portrait" | "landscape" | null },
   ): number | null {
-    // A lone match on this FINAL attempt has no opportunity for a confirming
-    // subsequent sample — unconditionally returning it here would
-    // reintroduce the exact false "requested orientation held" report the
-    // stability check exists to prevent, so report it as unconfirmed (null)
-    // rather than accepted.
-    if (lastAchieved === requestedOrientation) {
-      return null;
+    // A lone final sample, whether it matches the requested orientation or
+    // contradicts it, has no opportunity for a confirming later sample. Do
+    // not turn that unsettled observation into either a definitive success or
+    // a definitive reversion. A later non-null sample supersedes an earlier
+    // confirmed streak unless that later sample completes its own confirmed
+    // streak. An unreadable final sample leaves the earlier confirmed streak
+    // as the newest trustworthy evidence.
+    if (lastAchieved !== null) {
+      return lastStreakCount >= Rotate.SETTLE_WAIT_STABLE_READS ? lastConfirmed.value : null;
     }
-    // A final read that does NOT match the requested orientation carries no
-    // such risk — the caller reports it as "reverted", which understates
-    // confidence rather than overstating it — so it is returned as-is.
-    if (lastValue !== null) {
-      return lastValue;
-    }
-    // The final attempt failed to read at all (unparseable/unavailable). That
-    // read FAILURE is not a contradicting sample, so it must not discard an
-    // opposite orientation that two earlier consecutive samples already
-    // confirmed stable — falling back to "unknown" here would throw away
-    // real evidence just because the very last poll came back empty.
     return lastConfirmed.achieved !== null ? lastConfirmed.value : null;
   }
 
@@ -191,12 +181,7 @@ export class Rotate extends BaseVisualChange {
         await this.timer.sleep(Rotate.SETTLE_WAIT_POLL_INTERVAL_MS);
       }
     }
-    return this.resolveExhaustedSettleWait(
-      requestedOrientation,
-      lastValue,
-      lastAchieved,
-      lastConfirmed,
-    );
+    return this.resolveExhaustedSettleWait(lastAchieved, streak.count, lastConfirmed);
   }
 
   /**

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -24,10 +24,15 @@ export class Rotate extends BaseVisualChange {
   // the device is physically held opposite the requested orientation,
   // WindowManager takes a moment to settle after `accelerometer_rotation` is
   // restored, so an immediate read can catch a transient value and report a
-  // spurious "unconfirmed"/reverted result. Retry a few times, on the
-  // injected Timer, before accepting the read as final.
+  // spurious "unconfirmed"/reverted result. The converse is just as real: a
+  // FIRST sample that already matches the requested orientation is not proof
+  // it is held — the physical sensor can swing it away moments later — so a
+  // match is only accepted once it reads the same way on a second,
+  // subsequent sample. Retry a few times, on the injected Timer, before
+  // accepting the read as final (#6211 review).
   private static readonly SETTLE_WAIT_MAX_ATTEMPTS = 3;
   private static readonly SETTLE_WAIT_POLL_INTERVAL_MS = 150;
+  private static readonly SETTLE_WAIT_STABLE_READS = 2;
 
   constructor(device: BootedDevice, adb: AdbClient | null = null, timer: Timer = defaultTimer) {
     super(device, adb, timer);
@@ -102,13 +107,21 @@ export class Rotate extends BaseVisualChange {
     requestedOrientation: "portrait" | "landscape",
   ): Promise<number | null> {
     let lastValue: number | null = null;
+    let consecutiveMatches = 0;
     for (let attempt = 1; attempt <= Rotate.SETTLE_WAIT_MAX_ATTEMPTS; attempt++) {
       lastValue = await this.readLiveRotation();
-      if (lastValue !== null) {
-        const achieved = lastValue === 0 || lastValue === 2 ? "portrait" : "landscape";
-        if (achieved === requestedOrientation) {
+      const achieved =
+        lastValue === null ? null : lastValue === 0 || lastValue === 2 ? "portrait" : "landscape";
+      if (achieved === requestedOrientation) {
+        consecutiveMatches++;
+        // A single matching sample is not proof the orientation is held —
+        // require it to hold across a second, later sample before accepting
+        // it, rather than returning on the very first read (#6211 review).
+        if (consecutiveMatches >= Rotate.SETTLE_WAIT_STABLE_READS) {
           return lastValue;
         }
+      } else {
+        consecutiveMatches = 0;
       }
       if (attempt < Rotate.SETTLE_WAIT_MAX_ATTEMPTS) {
         await this.timer.sleep(Rotate.SETTLE_WAIT_POLL_INTERVAL_MS);
@@ -148,6 +161,44 @@ export class Rotate extends BaseVisualChange {
       achievedOrientation === requestedOrientation
         ? undefined
         : `Auto-rotate is enabled and immediately reverted the device to ${achievedOrientation} based on the physical sensor; the requested ${requestedOrientation} orientation is not held.`;
+    return { achievedOrientation, warning };
+  }
+
+  /**
+   * Restore auto-rotate (previously forced off to apply an explicit
+   * rotation) and determine the actual achieved orientation. A REJECTED
+   * restore write does NOT prove auto-rotate stayed disabled: the underlying
+   * put can time out AFTER CtrlProxy already applied it but before
+   * broadcasting the result, so auto-rotate may in fact be back on and the
+   * physical sensor may already have reverted the device. The live
+   * orientation is therefore always re-confirmed afterward — the same way a
+   * successful restore is confirmed — rather than assumed either way, and
+   * the ambiguity (when present) is folded into the returned warning so the
+   * caller can report the TRUE state (#6211 review).
+   */
+  private async restoreAutoRotateAndConfirmOrientation(
+    requestedOrientation: "portrait" | "landscape",
+  ): Promise<{ achievedOrientation: string; warning: string | undefined }> {
+    let restoreWriteError: unknown;
+    try {
+      await this.writeSystemSetting("accelerometer_rotation", "1");
+    } catch (error) {
+      restoreWriteError = error;
+      logger.warn(
+        `[Rotate] accelerometer_rotation restore write failed (ambiguous outcome) after confirming rotation to ${requestedOrientation}: ${error}`,
+      );
+    }
+
+    const { achievedOrientation, warning: confirmWarning } =
+      await this.confirmOrientationAfterAutoRotateRestore(requestedOrientation);
+    if (restoreWriteError === undefined) {
+      return { achievedOrientation, warning: confirmWarning };
+    }
+
+    const ambiguityNote = `the accelerometer_rotation restore write failed (ambiguous outcome — could not confirm whether auto-rotate was actually re-enabled): ${restoreWriteError}`;
+    const warning = confirmWarning
+      ? `${confirmWarning} Additionally, ${ambiguityNote}`
+      : `Rotated to ${requestedOrientation}, but ${ambiguityNote}`;
     return { achievedOrientation, warning };
   }
 
@@ -387,32 +438,8 @@ export class Rotate extends BaseVisualChange {
       let warning: string | undefined;
 
       if (wasAutoRotateEnabled) {
-        try {
-          await this.writeSystemSetting("accelerometer_rotation", "1");
-        } catch (restoreError) {
-          // waitForRotation above already CONFIRMED the requested rotation
-          // took effect while auto-rotate was forced off. The restore write
-          // failing afterward must not discard that confirmed success — it
-          // means auto-rotate is left off (so the forced orientation is, if
-          // anything, MORE likely to still be held, not less) and the caller
-          // needs an honest warning, not a false failure (#6211).
-          logger.warn(
-            `[Rotate] Failed to restore auto-rotate after confirming rotation to ${orientation}: ${restoreError}`,
-          );
-          return {
-            success: true,
-            orientation,
-            value,
-            currentOrientation: orientation,
-            previousOrientation: currentOrientation,
-            rotationPerformed: true,
-            orientationLockHandled: wasAutoRotateEnabled,
-            warning: `Rotated to ${orientation}, but auto-rotate could not be restored (accelerometer_rotation write failed): ${restoreError}`,
-            message: `Rotated to ${orientation}, but auto-rotate could not be restored`,
-          };
-        }
         ({ achievedOrientation, warning } =
-          await this.confirmOrientationAfterAutoRotateRestore(orientation));
+          await this.restoreAutoRotateAndConfirmOrientation(orientation));
       }
 
       return {
@@ -427,7 +454,9 @@ export class Rotate extends BaseVisualChange {
         message: warning
           ? achievedOrientation === "unknown"
             ? `Rotated to ${orientation}, but the device's orientation after auto-rotate restore could not be confirmed`
-            : `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
+            : achievedOrientation !== orientation
+              ? `Rotated to ${orientation}, but auto-rotate reverted the device to ${achievedOrientation}`
+              : `Rotated to ${orientation}, but the auto-rotate restore was ambiguous; the orientation was confirmed to still hold`
           : `Successfully rotated from ${currentOrientation} to ${orientation}`,
       };
     } catch (error) {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -598,6 +598,65 @@ describe("Rotate", () => {
       expect(fakeTimer.getSleepCallCount()).toBeGreaterThan(0);
     });
 
+    test("does not accept a lone match on the FINAL settle-wait attempt, since there is no later sample to confirm it (#6211)", async () => {
+      // Auto-rotate is on; the device starts landscape. After forcing
+      // portrait and restoring auto-rotate, the settle-wait budget
+      // (SETTLE_WAIT_MAX_ATTEMPTS=3) is exhausted with landscape, landscape,
+      // then the requested portrait on the very last attempt — a single,
+      // unconfirmed match with no opportunity for a later stability read.
+      // Unconditionally returning that final value would falsely report
+      // "portrait" held; it must instead be reported as unconfirmed.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=1"), // post-restore confirm attempt 1: landscape
+        createExecResult("mRotation=1"), // post-restore confirm attempt 2: landscape
+        createExecResult("mRotation=0"), // post-restore confirm attempt 3 (final): lone portrait match
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // Must NOT report the requested orientation as confirmed off a single,
+      // unconfirmable final-attempt sample.
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/could not be confirmed/i);
+      // The settle-wait must have exhausted its full retry budget (slept
+      // between every attempt) rather than stopping early on the lone match.
+      expect(fakeTimer.getSleepCallCount()).toBe(2);
+    });
+
+    test("does not accept a lone match on the FINAL settle-wait attempt after an earlier non-adjacent match resets the streak (#6211)", async () => {
+      // Alternate sequence from the review finding: portrait, landscape,
+      // portrait. The first attempt matches but is immediately broken by the
+      // second (non-matching) attempt, resetting the consecutive-match
+      // streak; the third (final) attempt matches again but, being the last
+      // attempt, has no later sample to confirm it either.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=0"), // post-restore confirm attempt 1: portrait (lone, then broken)
+        createExecResult("mRotation=1"), // post-restore confirm attempt 2: landscape (breaks the streak)
+        createExecResult("mRotation=0"), // post-restore confirm attempt 3 (final): lone portrait match again
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/could not be confirmed/i);
+    });
+
     test("gives up after the settle-wait budget and honestly reports unconfirmed when the read never settles (#6211)", async () => {
       // The confirmation read stays unparseable across every settle-wait
       // attempt (persistent, not transient) — must still end up "unknown"

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -631,6 +631,26 @@ describe("Rotate", () => {
       expect(fakeTimer.getSleepCallCount()).toBe(2);
     });
 
+    test("does not report a lone final opposite-orientation sample as a confirmed reversion (#6211)", async () => {
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult(""), // settle attempt 1: unreadable
+        createExecResult(""), // settle attempt 2: unreadable
+        createExecResult("mRotation=1"), // settle attempt 3: lone landscape sample
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning ?? "").toMatch(/could not be confirmed/i);
+      expect(fakeTimer.getSleepCallCount()).toBe(2);
+    });
+
     test("does not accept a lone match on the FINAL settle-wait attempt after an earlier non-adjacent match resets the streak (#6211)", async () => {
       // Alternate sequence from the review finding: portrait, landscape,
       // portrait. The first attempt matches but is immediately broken by the

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -538,6 +538,86 @@ describe("Rotate", () => {
       );
     });
 
+    test("settle-waits (retries via the injected Timer) before accepting a transient post-restore read, instead of confirming immediately (#6211)", async () => {
+      // Auto-rotate is on; the device starts landscape. After forcing
+      // portrait and restoring auto-rotate, the FIRST confirmation read
+      // catches a transient not-yet-settled WindowManager still reporting
+      // landscape; the SECOND read (after the settle-wait sleep) shows the
+      // sensor has settled on portrait. The settle-wait must retry via
+      // `this.timer.sleep` rather than confirming off the stale first read.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=1"), // post-restore confirm attempt 1: transient/unsettled
+        createExecResult("mRotation=0"), // post-restore confirm attempt 2: settled
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // Settled on the requested orientation, not the transient stale read.
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.warning).toBeUndefined();
+      // The settle-wait must have slept (i.e. actually retried) via the
+      // injected Timer before accepting the second read as final.
+      expect(fakeTimer.getSleepCallCount()).toBeGreaterThan(0);
+    });
+
+    test("gives up after the settle-wait budget and honestly reports unconfirmed when the read never settles (#6211)", async () => {
+      // The confirmation read stays unparseable across every settle-wait
+      // attempt (persistent, not transient) — must still end up "unknown"
+      // rather than retrying forever or fabricating a result.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult(""), // every confirm attempt thereafter is unparseable
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning ?? "").toMatch(/could not be confirmed/i);
+    });
+
+    test("preserves the confirmed rotation when the auto-rotate restore write fails, instead of reporting overall failure (#6211)", async () => {
+      // waitForRotation has already CONFIRMED the requested rotation. The
+      // subsequent accelerometer_rotation=1 restore write then throws. The
+      // operation must still report success with the confirmed orientation
+      // and a warning, not discard the confirmed rotation as a failure.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"),
+      ]);
+      fakeAdb.setCommandError(
+        "shell settings put system accelerometer_rotation 1",
+        new Error("device offline"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("portrait");
+      expect(result.previousOrientation).toBe("landscape");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/auto-rotate could not be restored/i);
+      // The confirmation read (which would have re-queried live rotation)
+      // must be skipped since the restore write never happened.
+      expect(fakeAdb.wasCommandExecuted('shell dumpsys window | grep -i "mRotation="')).toBe(true);
+    });
+
     test("serializes concurrent rotations on the same device so auto-rotate restore is not corrupted (#6199)", async () => {
       // Device starts portrait with auto-rotate ON.
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -747,6 +747,12 @@ describe("Rotate", () => {
       expect(result.previousOrientation).toBe("landscape");
       expect(result.warning).toBeDefined();
       expect(result.warning ?? "").toMatch(/reverted/i);
+      // The live read confirms landscape, but the rejected restore write does
+      // not prove auto-rotate caused it. Keep the evidence without inventing
+      // that causal outcome in the public message.
+      expect(result.message).toContain("attempting to restore auto-rotate");
+      expect(result.message).toContain("confirmed landscape");
+      expect(result.message).not.toMatch(/auto-rotate reverted/i);
     });
 
     test("retains a confirmed stable opposite orientation when the FINAL settle-wait sample fails to read (#6211)", async () => {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -749,6 +749,108 @@ describe("Rotate", () => {
       expect(result.warning ?? "").toMatch(/reverted/i);
     });
 
+    test("retains a confirmed stable opposite orientation when the FINAL settle-wait sample fails to read (#6211)", async () => {
+      // Auto-rotate is on; the device starts landscape. After forcing
+      // portrait and restoring auto-rotate, the first two post-restore
+      // samples both read landscape (two consecutive matching samples — a
+      // confirmed reversion), but the third (final) settle-wait attempt
+      // fails to parse at all. That read FAILURE must not discard the
+      // already-confirmed landscape reversion in favor of "unknown".
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=1"), // post-restore confirm attempt 1: landscape
+        createExecResult("mRotation=1"), // post-restore confirm attempt 2: landscape (confirmed stable)
+        createExecResult(""), // post-restore confirm attempt 3 (final): unparseable
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // Must report the confirmed landscape reversion, not "unknown".
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/reverted/i);
+    });
+
+    test("retries the auto-rotate restore write once before treating a transient failure as ambiguous (#6211)", async () => {
+      // Auto-rotate is on; the device starts landscape. The FIRST
+      // accelerometer_rotation=1 restore write attempt fails transiently
+      // (e.g. a momentary CtrlProxy/ADB hiccup), but a retry of the same
+      // idempotent write succeeds. This must not be reported as an ambiguous
+      // outcome — the retry recovers it cleanly.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=0"), // post-restore confirm attempt 1: portrait
+        createExecResult("mRotation=0"), // post-restore confirm attempt 2: portrait (confirmed stable)
+      ]);
+
+      let restoreWriteAttempts = 0;
+      const originalExecuteCommand = fakeAdb.executeCommand.bind(fakeAdb);
+      fakeAdb.executeCommand = (async (command: string, ...rest: unknown[]) => {
+        if (command.includes("settings put system accelerometer_rotation 1")) {
+          restoreWriteAttempts++;
+          if (restoreWriteAttempts === 1) {
+            throw new Error("transient device offline");
+          }
+        }
+        return (originalExecuteCommand as (...args: unknown[]) => Promise<ExecResult>)(
+          command,
+          ...rest,
+        );
+      }) as typeof fakeAdb.executeCommand;
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("portrait");
+      // No ambiguity: the retry recovered the restore write cleanly.
+      expect(result.warning).toBeUndefined();
+      // The restore write must have been attempted twice: once, then a retry.
+      expect(restoreWriteAttempts).toBe(2);
+    });
+
+    test("keeps the ambiguous-restore warning state-neutral instead of asserting auto-rotate is enabled (#6211)", async () => {
+      // The accelerometer_rotation=1 restore write fails on both the first
+      // attempt and the retry (persistent, not transient), and the live
+      // confirmation read never settles either. The composed warning must
+      // not claim "auto-rotate is enabled" — that state was never actually
+      // confirmed — while still explaining the ambiguous outcome.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult(""), // every post-restore confirm attempt is unparseable
+      ]);
+      fakeAdb.setCommandError(
+        "shell settings put system accelerometer_rotation 1",
+        new Error("device offline"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      expect(result.currentOrientation).toBe("unknown");
+      expect(result.warning).toBeDefined();
+      const warning = result.warning ?? "";
+      expect(warning).toMatch(/ambiguous outcome/i);
+      expect(warning).toMatch(/could not be confirmed/i);
+      // State-neutral: must not assert a state that was never confirmed.
+      expect(warning).not.toMatch(/auto-rotate is enabled/i);
+    });
+
     test("serializes concurrent rotations on the same device so auto-rotate restore is not corrupted (#6199)", async () => {
       // Device starts portrait with auto-rotate ON.
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -567,6 +567,37 @@ describe("Rotate", () => {
       expect(fakeTimer.getSleepCallCount()).toBeGreaterThan(0);
     });
 
+    test("does not accept a first post-restore sample matching the requested orientation without confirming it is stable (#6211)", async () => {
+      // Auto-rotate is on; the device starts landscape. After forcing
+      // portrait and restoring auto-rotate, the FIRST confirmation read
+      // already matches the requested "portrait" — but the physical sensor
+      // swings it back to landscape moments later. A fix that returns on the
+      // first matching sample without confirming stability would falsely
+      // report "portrait" held; the settle-wait must confirm the match holds
+      // across a second read before accepting it.
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=0"), // post-restore confirm attempt 1: matches requested portrait...
+        createExecResult("mRotation=1"), // ...but attempt 2 reveals it swung back to landscape
+      ]);
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // Must report the ACTUAL orientation (landscape), not the transient
+      // first-sample match that was never confirmed stable.
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/reverted/i);
+      // The settle-wait must have kept sampling past the first match.
+      expect(fakeTimer.getSleepCallCount()).toBeGreaterThan(0);
+    });
+
     test("gives up after the settle-wait budget and honestly reports unconfirmed when the read never settles (#6211)", async () => {
       // The confirmation read stays unparseable across every settle-wait
       // attempt (persistent, not transient) — must still end up "unknown"
@@ -587,18 +618,24 @@ describe("Rotate", () => {
       expect(result.warning ?? "").toMatch(/could not be confirmed/i);
     });
 
-    test("preserves the confirmed rotation when the auto-rotate restore write fails, instead of reporting overall failure (#6211)", async () => {
-      // waitForRotation has already CONFIRMED the requested rotation. The
-      // subsequent accelerometer_rotation=1 restore write then throws. The
-      // operation must still report success with the confirmed orientation
-      // and a warning, not discard the confirmed rotation as a failure.
+    test("confirms the true live orientation (rather than assuming it held) when the auto-rotate restore write fails, and preserves it when it does hold (#6211)", async () => {
+      // waitForRotation has already CONFIRMED the requested rotation while
+      // auto-rotate was forced off. The subsequent accelerometer_rotation=1
+      // restore write then throws — but a REJECTED write does not prove
+      // auto-rotate stayed disabled (the underlying put can time out AFTER
+      // CtrlProxy already applied it), so the code must re-read the live
+      // orientation rather than assume it held. Here the re-read confirms
+      // portrait genuinely still holds, so the confirmed rotation is
+      // preserved with a warning noting the ambiguous restore, not
+      // discarded as an overall failure.
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
       fakeAdb.setCommandResponse(
         "shell settings get system accelerometer_rotation",
         createExecResult("1"),
       );
       fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
-        createExecResult("mRotation=1"),
+        createExecResult("mRotation=1"), // pre-rotation state check
+        createExecResult("mRotation=0"), // post-write-failure confirm reads: portrait genuinely holds
       ]);
       fakeAdb.setCommandError(
         "shell settings put system accelerometer_rotation 1",
@@ -612,10 +649,45 @@ describe("Rotate", () => {
       expect(result.currentOrientation).toBe("portrait");
       expect(result.previousOrientation).toBe("landscape");
       expect(result.warning).toBeDefined();
-      expect(result.warning ?? "").toMatch(/auto-rotate could not be restored/i);
-      // The confirmation read (which would have re-queried live rotation)
-      // must be skipped since the restore write never happened.
-      expect(fakeAdb.wasCommandExecuted('shell dumpsys window | grep -i "mRotation="')).toBe(true);
+      expect(result.warning ?? "").toMatch(/ambiguous outcome/i);
+      // The restore-write failure must NOT skip re-confirming the live
+      // orientation — it must be re-queried, not assumed (#6211 review).
+      const dumpsysCalls = fakeAdb
+        .getExecutedCommands()
+        .filter((cmd) => cmd.includes('shell dumpsys window | grep -i "mRotation="')).length;
+      expect(dumpsysCalls).toBeGreaterThan(1);
+    });
+
+    test("reflects the true reverted orientation, not the requested one, when an ambiguous restore-write failure turns out to have actually re-enabled auto-rotate (#6211)", async () => {
+      // The accelerometer_rotation=1 restore write throws (ambiguous outcome:
+      // it may have been applied by CtrlProxy before the failure was
+      // reported), and the physical sensor genuinely reverts the device once
+      // auto-rotate is back on. The code must report the ACTUAL confirmed
+      // orientation, not blindly assume the forced rotation still holds just
+      // because the restore write appeared to fail.
+      fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
+      fakeAdb.setCommandResponse(
+        "shell settings get system accelerometer_rotation",
+        createExecResult("1"),
+      );
+      fakeAdb.setCommandResponseSequence('shell dumpsys window | grep -i "mRotation="', [
+        createExecResult("mRotation=1"), // pre-rotation state check (landscape before)
+        createExecResult("mRotation=1"), // post-write-failure confirm reads: reverted to landscape
+      ]);
+      fakeAdb.setCommandError(
+        "shell settings put system accelerometer_rotation 1",
+        new Error("device offline"),
+      );
+
+      const result = await rotate.execute("portrait");
+
+      expect(result.success).toBe(true);
+      expect(result.rotationPerformed).toBe(true);
+      // Must report the TRUE confirmed orientation, not the requested one.
+      expect(result.currentOrientation).toBe("landscape");
+      expect(result.previousOrientation).toBe("landscape");
+      expect(result.warning).toBeDefined();
+      expect(result.warning ?? "").toMatch(/reverted/i);
     });
 
     test("serializes concurrent rotations on the same device so auto-rotate restore is not corrupted (#6199)", async () => {


### PR DESCRIPTION
Two confirmation-timing edges deferred from PR #6199 (#6129 follow-up):

1. **Settle-wait before the post-restore confirmation read** (`Rotate.ts`): `confirmOrientationAfterAutoRotateRestore` now retries the live `readLiveRotation()` read (bounded, on the injected `Timer`) before accepting it as final, so a momentarily-unsettled WindowManager right after `accelerometer_rotation` is restored doesn't yield a spurious "unconfirmed" or falsely-reverted result.
2. **Preserve the confirmed rotation when the restore write fails**: `waitForRotation` already confirms the requested rotation succeeded before the `accelerometer_rotation=1` restore write happens. That write is now caught on its own — if it throws, the operation reports `success: true` with the confirmed orientation and a warning that auto-rotate could not be restored, instead of falling into the outer failure handler and losing the already-confirmed rotation.

Both routed through the existing exec/settle seams (`this.adb`, `this.timer`) — no raw `execFileAsync`.

Tests added in `test/features/action/Rotate.test.ts`:
- settle-wait retries a transient post-restore read via the injected Timer before confirming
- settle-wait budget exhausts and honestly reports unconfirmed when the read never settles
- restore-write failure preserves the confirmed rotation (`success: true`, warning, achieved orientation) instead of reporting overall failure

Validated: `bun test test/features/action/Rotate.test.ts` (34 pass), `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build`.

Closes #6211