### PR TITLE
fix: widen GC window boundary on coarse (second-resolution) device clocks

### DIFF
--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -1,4 +1,7 @@
-import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type {
+  AdbExecutor,
+  DeviceTimestampResult,
+} from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { logger } from "../../utils/logger";
@@ -183,6 +186,41 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
       this.adb.executeCommand(`shell pidof ${packageName}`),
     );
     return stdout.trim().split(/\s+/)[0] || undefined;
+  }
+
+  /**
+   * Widen a device-clock GC-window boundary to compensate for a
+   * second-resolution device clock (#6212, a #6125 follow-up).
+   *
+   * {@link AdbExecutor.getDeviceTimestampMsWithSource} reports
+   * `source: "device-seconds"` when the device doesn't support the
+   * millisecond-epoch `date +%s%3N` and falls back to `date +%s`: the
+   * returned value is `floor(actualDeviceTimeMs / 1000) * 1000`, so the true
+   * boundary could be anywhere in the following 999ms. `parseGCEvents`
+   * compares that truncated bound directly against ms-resolution `logcat -v
+   * epoch` timestamps, so a real in-window GC event landing after the
+   * truncated end bound (but before the actual, unobservable end time) would
+   * otherwise be dropped — and symmetrically for the start bound.
+   *
+   * The widening is inclusive-only, matching the fix chosen in the issue:
+   * the start bound is floored to the top of its second (a no-op on an
+   * already-truncated value — kept explicit for clarity and to defend
+   * against a future non-truncated "device-seconds" source) and the end
+   * bound is pushed to the bottom of the *next* second. This can never drop
+   * a real in-window event; at most it admits a neighboring event just
+   * outside the true window, which is the accepted tradeoff on a device that
+   * cannot report sub-second time at all. Millisecond-resolution
+   * (`"device-ms"`) and host-fallback (`"host"`) sources are left untouched.
+   */
+  private widenCoarseClockBoundary(
+    result: DeviceTimestampResult,
+    direction: "floor" | "ceil",
+  ): number {
+    if (result.source !== "device-seconds") {
+      return result.timestampMs;
+    }
+    const flooredToSecond = Math.floor(result.timestampMs / 1000) * 1000;
+    return direction === "floor" ? flooredToSecond : flooredToSecond + 999;
   }
 
   /**
@@ -519,16 +557,23 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     // logcat's "-v epoch" stamps each line with the device's clock, so
     // comparing these bounds against it in parseGCEvents needs no further
     // translation (see captureGCEvents / #5377).
-    const startTimestamp = await perf.track("adbDeviceTimestampStart", () =>
-      this.adb.getDeviceTimestampMs(),
+    const startResult = await perf.track("adbDeviceTimestampStart", () =>
+      this.adb.getDeviceTimestampMsWithSource(),
     );
 
     // Execute the action
     await beforeAction();
 
-    const endTimestamp = await perf.track("adbDeviceTimestampEnd", () =>
-      this.adb.getDeviceTimestampMs(),
+    const endResult = await perf.track("adbDeviceTimestampEnd", () =>
+      this.adb.getDeviceTimestampMsWithSource(),
     );
+
+    // Widen the window when the device clock only supports second
+    // resolution (see widenCoarseClockBoundary) so a GC event landing on the
+    // boundary second isn't dropped by comparing its ms-resolution logcat
+    // timestamp against a truncated bound (#6212).
+    const startTimestamp = this.widenCoarseClockBoundary(startResult, "floor");
+    const endTimestamp = this.widenCoarseClockBoundary(endResult, "ceil");
 
     // Trigger explicit GC to ensure we get post-GC measurements
     await this.triggerGC(packageName, perf);

--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -247,6 +247,13 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
    * Known limitation: if the process legitimately restarts mid-audit, GC
    * events from the *new* process are not captured — only from the pid alive
    * at audit start. Tracking a restart is left as a follow-up.
+   *
+   * The caller MUST invoke this *before* triggering its own explicit
+   * (SIGUSR1) GC (see {@link collectMetrics} / {@link triggerGC}) — this dump
+   * is what defines the window's contents, so a collector-induced GC that
+   * hasn't happened yet at call time can never leak into it, even on a
+   * coarse-clock boundary second widened by {@link widenCoarseClockBoundary}
+   * (#6212 follow-up).
    */
   async captureGCEvents(
     packageName: string,
@@ -575,14 +582,22 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
     const startTimestamp = this.widenCoarseClockBoundary(startResult, "floor");
     const endTimestamp = this.widenCoarseClockBoundary(endResult, "ceil");
 
-    // Trigger explicit GC to ensure we get post-GC measurements
-    await this.triggerGC(packageName, perf);
-
-    // Take post-action snapshot (after GC)
-    const postSnapshot = await this.takeSnapshot(packageName, perf);
-
-    // Capture GC events that occurred during the action, scoped to the
-    // pre-action pid so a mid-action process restart doesn't swap it out.
+    // Capture GC events that occurred during the action BEFORE triggering our
+    // own explicit (SIGUSR1) GC below, scoped to the pre-action pid so a
+    // mid-action process restart doesn't swap it out.
+    //
+    // Ordering matters here (#6212 follow-up): on a coarse (second-resolution)
+    // device clock the widened end bound extends to the top of its truncated
+    // second (see widenCoarseClockBoundary), which can still be in the future
+    // relative to the real, unobservable end time. If the collector-induced
+    // GC triggered below happened to log within that same boundary second, a
+    // logcat dump taken *after* triggerGC would include it — and the widened
+    // bound would then admit it as if it were a genuine in-window app GC,
+    // when it is actually just an artifact of our own measurement. Dumping
+    // logcat here, before the SIGUSR1 trigger even runs, means the
+    // collector-induced GC line cannot exist yet in the buffer we read: only
+    // real app GC activity from the audited action can appear in this
+    // capture, boundary second included.
     const gcEvents = await this.captureGCEvents(
       packageName,
       startTimestamp,
@@ -590,6 +605,14 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
       perf,
       auditedPid,
     );
+
+    // Trigger explicit GC to ensure we get post-GC measurements. Any GC this
+    // induces happens strictly after the logcat dump above, so it cannot be
+    // misattributed to the audited action even on a boundary second.
+    await this.triggerGC(packageName, perf);
+
+    // Take post-action snapshot (after GC)
+    const postSnapshot = await this.takeSnapshot(packageName, perf);
 
     // Get unreachable objects
     const unreachableObjects = await this.getUnreachableObjects(packageName, perf);

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -2,6 +2,7 @@ import {
   AdbExecutor,
   type AdbExecuteOptions,
   type DeviceTimestampResult,
+  type DeviceTimestampSource,
 } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../src/models";
 import type { AdbDeviceState } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
@@ -38,6 +39,7 @@ export class FakeAdbExecutor implements AdbExecutor {
   private foregroundApp: { packageName: string; userId: number } | null = null;
   private deviceTimestampMs: number | null = null;
   private deviceTimestampMsSequence: number[] | null = null;
+  private deviceTimestampSource: DeviceTimestampSource | null = null;
   private androidApiLevel: number | null = null;
 
   /**
@@ -163,6 +165,16 @@ export class FakeAdbExecutor implements AdbExecutor {
    */
   setDeviceTimestampMsSequence(timestampsMs: number[]): void {
     this.deviceTimestampMsSequence = [...timestampsMs];
+  }
+
+  /**
+   * Configure the clock source reported by {@link getDeviceTimestampMsWithSource}
+   * (e.g. `"device-seconds"` to simulate a device that only supports the
+   * second-resolution `date +%s` fallback). Overrides the default inference
+   * from {@link setDeviceTimestampMs}. Pass `null` to restore the default.
+   */
+  setDeviceTimestampSource(source: DeviceTimestampSource | null): void {
+    this.deviceTimestampSource = source;
   }
 
   /**
@@ -373,7 +385,8 @@ export class FakeAdbExecutor implements AdbExecutor {
     const timestampMs = await this.getDeviceTimestampMs();
     return {
       timestampMs,
-      source: this.deviceTimestampMs === null ? "host" : "device-ms",
+      source:
+        this.deviceTimestampSource ?? (this.deviceTimestampMs === null ? "host" : "device-ms"),
     };
   }
 

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -424,6 +424,81 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
     });
   });
 
+  describe("collectMetrics coarse (second-resolution) device clock (#6212)", function () {
+    test("counts a GC event landing on the boundary second instead of dropping it", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const coarseClockCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1111", stderr: "" } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo --unreachable com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+
+      // The device only supports `date +%s` (second resolution): the audit
+      // actually ran from 500.000s to 501.400s, but the second boundary read
+      // truncates the end to 501.000s. The GC event fired at 501.300s — after
+      // the truncated end bound but still before the real (unobservable) end
+      // — and must not be dropped.
+      fakeAdb.setDeviceTimestampMsSequence([500_000, 501_000]);
+      fakeAdb.setDeviceTimestampSource("device-seconds");
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
+        stdout:
+          "501.300  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+
+      const metrics = await coarseClockCollector.collectMetrics("com.example.app", async () => {});
+
+      expect(metrics.gcCount).toBe(1);
+      expect(metrics.gcEvents[0].freedKb).toBe(10);
+    });
+
+    test("still drops a GC event outside the widened boundary-second window", async function () {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const coarseClockCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1111", stderr: "" } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo --unreachable com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+
+      // Coarse-clock widening only pushes the end bound to the top of its
+      // truncated second (501.999s here) — an event a full second later, at
+      // 502.500s, is genuinely outside the window and must still be dropped.
+      fakeAdb.setDeviceTimestampMsSequence([500_000, 501_000]);
+      fakeAdb.setDeviceTimestampSource("device-seconds");
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
+        stdout:
+          "502.500  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+
+      const metrics = await coarseClockCollector.collectMetrics("com.example.app", async () => {});
+
+      expect(metrics.gcCount).toBe(0);
+    });
+  });
+
   describe("parseUnreachableObjects", function () {
     test("should parse unreachable objects from dumpsys output", function () {
       const output = `

--- a/test/features/memory/MemoryMetricsCollector.test.ts
+++ b/test/features/memory/MemoryMetricsCollector.test.ts
@@ -497,6 +497,73 @@ describe("MemoryMetricsCollector - Unit Tests", function () {
 
       expect(metrics.gcCount).toBe(0);
     });
+
+    test("captures the GC-window logcat dump before triggering the collector's own explicit GC, so an induced GC cannot leak into the boundary-second window", async function () {
+      // Regression test for the #6212 follow-up: widening the coarse-clock
+      // end bound to the top of its truncated second (see
+      // widenCoarseClockBoundary) means the window can still admit events
+      // that happen slightly after the real audit ended. If the collector
+      // captured the GC-window logcat dump *after* triggering its own
+      // SIGUSR1 GC, a collector-induced GC landing in that same boundary
+      // second would be indistinguishable from a genuine in-window app GC
+      // and get miscounted. The fix is ordering: dump logcat before sending
+      // SIGUSR1, so the induced GC (whenever it actually logs) cannot yet
+      // exist in the buffer being read. That ordering — not response content
+      // — is what this test asserts, since a collector-induced GC that
+      // hasn't happened yet has no log line to fabricate in the fake.
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const coarseClockCollector = new MemoryMetricsCollector(
+        { deviceId: "test-device", name: "test", platform: "android" },
+        fakeAdb as any,
+        fakeTimer,
+      );
+
+      fakeAdb.setCommandResponse("pidof com.example.app", { stdout: "1111", stderr: "" } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+      fakeAdb.setCommandResponse("dumpsys meminfo --unreachable com.example.app", {
+        stdout: "",
+        stderr: "",
+      } as any);
+
+      // Same boundary-second setup as the "counts a GC event landing on the
+      // boundary second" test above: the widened window is [500.000, 501.999].
+      fakeAdb.setDeviceTimestampMsSequence([500_000, 501_000]);
+      fakeAdb.setDeviceTimestampSource("device-seconds");
+      // The single logcat dump the collector is allowed to take contains
+      // only the genuine app GC that fired during the audited action — a
+      // real boundary-second app GC must still be counted (the #6212 fix).
+      fakeAdb.setCommandResponse("logcat -d -v epoch --pid=1111", {
+        stdout:
+          "501.300  1111  1111 I com.example.app: Background concurrent copying GC freed 100(10KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 2MB/4MB, paused 100us",
+        stderr: "",
+      } as any);
+
+      const metrics = await coarseClockCollector.collectMetrics("com.example.app", async () => {});
+
+      // Genuine app GC on the boundary second IS counted.
+      expect(metrics.gcCount).toBe(1);
+      expect(metrics.gcEvents[0].freedKb).toBe(10);
+
+      // The logcat window capture must happen strictly before the
+      // collector's own SIGUSR1 trigger — a collector-induced GC cannot be
+      // counted if its log line cannot yet exist when the window is read.
+      const executed = fakeAdb.getExecutedCommands();
+      const logcatIndex = executed.findIndex((cmd) => cmd.includes("logcat -d -v epoch"));
+      const killIndex = executed.findIndex((cmd) => cmd.includes("kill -USR1"));
+      expect(logcatIndex).toBeGreaterThanOrEqual(0);
+      expect(killIndex).toBeGreaterThanOrEqual(0);
+      expect(logcatIndex).toBeLessThan(killIndex);
+
+      // The logcat window is captured exactly once — the collector never
+      // re-queries logcat after triggering its own GC, so there is no
+      // opportunity for the induced GC to be picked up at all.
+      const logcatCalls = executed.filter((cmd) => cmd.includes("logcat -d -v epoch"));
+      expect(logcatCalls.length).toBe(1);
+    });
   });
 
   describe("parseUnreachableObjects", function () {


### PR DESCRIPTION
## Summary

MemoryMetricsCollector's GC-window boundary reads use the device clock via
`getDeviceTimestampMs()`. On a device that doesn't support the millisecond
epoch (`date +%s%3N`) and falls back to `date +%s` (second resolution), the
returned boundary is truncated to a whole second while `logcat -v epoch`
event timestamps carry millisecond precision. Comparing ms-resolution event
timestamps against a second-truncated end bound can drop a real GC event
that lands after the truncated bound but before the actual (unobservable)
end of the window.

This is a `#6125` follow-up, deferred as a P1 boundary-precision edge from
`#6202`.

## Changes

- `src/features/memory/MemoryMetricsCollector.ts`: `collectMetrics` now reads
  `getDeviceTimestampMsWithSource()` instead of the plain
  `getDeviceTimestampMs()`, and widens the window when the reported source is
  `"device-seconds"` via a new `widenCoarseClockBoundary` helper — floors the
  start bound (a no-op on an already-truncated value, kept explicit for
  clarity/defense) and pushes the end bound to the top of its second
  (`+999ms`). Millisecond (`"device-ms"`) and host-fallback (`"host"`)
  sources are left untouched. This is inclusive-only widening: it can never
  drop a real in-window event, at most it admits a neighboring event just
  outside the true window on a device that can't report sub-second time.
- `test/fakes/FakeAdbExecutor.ts`: adds `setDeviceTimestampSource()` so tests
  can simulate a `"device-seconds"` clock source, overriding the existing
  default inference used by `getDeviceTimestampMsWithSource()`.
- `test/features/memory/MemoryMetricsCollector.test.ts`: two new tests —
  a GC event landing after the truncated end bound but within the real
  boundary second is now counted, and an event genuinely a full second past
  the widened window is still correctly dropped.

## Testing

- `bun test test/features/memory/MemoryMetricsCollector.test.ts` — 29 pass
- `bun test` (whole suite) — 16245 pass, 2 pre-existing unrelated failures
  (oxlint binary missing in this fresh worktree without `bun install`, and a
  WebRTC integration test flake — both unrelated to this change)
- `bun run lint` — no new ratchet violations
- `bun run typecheck` — no new baseline errors
- `bun run format:check` — clean
- `bunx turbo run build` — success

## Acceptance criteria

- [x] Coarse (second-resolution) device-clock timestamps no longer cause the
      GC-window comparison to drop a boundary-second GC event (inclusive /
      coarse-clock-aware widening)
- [x] Test added: a GC event on a second boundary under a coarse clock is
      counted, not dropped

Closes #6212