### PR TITLE
fix(recovery): WaitForTool evaluates unredacted observe result

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -134,11 +134,13 @@ open class AutoMobileAgent(
       // prompt is already redacted by the executor (#6092); this closes the loop channel. With no
       // secrets the raw client is used unchanged (no wrapper allocated).
       //
-      // Known limitation (follow-up): the wrapper also redacts the intermediate observe result that
-      // the composite WaitForTool searches locally — its own output to the model is synthesized and
-      // safe, so there is no leak, but a wait target that is a substring of an on-screen secret can
-      // falsely time out. A clean fix hands composite tools the raw client; deferred to keep this
-      // security change scoped.
+      // #6145 fix: the wrapper also redacts the intermediate observe result that the composite
+      // WaitForTool searches locally. Its own output to the model is synthesized ("found" /
+      // "timeout") and never leaks that observe text, so redacting the copy it searches only
+      // produces a false timeout when the wait target is a substring of an on-screen secret value
+      // — it buys no security. So WaitForTool is wired to the RAW (unwrapped) client below via
+      // createAIAgentWithMCPTools's rawMcpClient param, while every pass-through tool (whose result
+      // DOES reach the model) keeps using agentMcpClient, the redacting wrapper.
       //
       // Normalize the incoming concrete secret values into every scrub form (NFC/NFD + the
       // transport-encoding depths) HERE, at the public recovery entry point, so the loop is safe
@@ -149,7 +151,12 @@ open class AutoMobileAgent(
       val agentMcpClient =
         if (redactionValues.isEmpty()) mcpClient else RedactingMCPClient(mcpClient, redactionValues)
       val aiAgent =
-        aiAgentFactory.createAIAgentWithMCPTools(modelConfig, agentMcpClient, maxToolCalls)
+        aiAgentFactory.createAIAgentWithMCPTools(
+          modelConfig,
+          agentMcpClient,
+          maxToolCalls,
+          mcpClient,
+        )
 
       // Redact the STATIC context fields that go into the initial prompt too (#6094). The executor
       // already redacts these on the FailedStepContext (#6092), so this is a no-op for that path;
@@ -680,7 +687,15 @@ open class AutoMobileAgent(
     }
   }
 
-  /** Wait for elements to appear or conditions to be met */
+  /**
+   * Wait for elements to appear or conditions to be met.
+   *
+   * A composite tool: unlike the pass-through tools above, its RESULT to the model is a synthesized
+   * "found"/"timeout" string, never the observe text it searches. So [AutoMobileMCPToolFactory]
+   * wires this to the RAW (unredacted) client — searching a redacted copy would falsely time out
+   * whenever the wait target is a substring of an on-screen secret value, with no security benefit
+   * (issue #6145; the intermediate observe text itself never reaches the model through this tool).
+   */
   class WaitForTool(private val mcpClient: MCPClient) :
     SimpleTool<WaitForTool.Args>(
       argsType = typeToken<Args>(),
@@ -857,8 +872,19 @@ open class AutoMobileAgent(
     }
   }
 
-  /** Helper to create all MCP tools for an agent */
-  class AutoMobileMCPToolFactory(private val mcpClient: MCPClient) {
+  /**
+   * Helper to create all MCP tools for an agent.
+   *
+   * [mcpClient] backs every pass-through tool (its result reaches the model, so during recovery
+   * this is the redacting wrapper). [rawMcpClient] backs [WaitForTool] alone — a composite tool
+   * whose model-facing result is a synthesized string, so redacting the observe text it searches
+   * locally only produces false timeouts, not a leak (issue #6145). Defaults to [mcpClient] so
+   * non-recovery callers (no secrets, no wrapper) are unaffected.
+   */
+  class AutoMobileMCPToolFactory(
+    private val mcpClient: MCPClient,
+    private val rawMcpClient: MCPClient = mcpClient,
+  ) {
     fun createAllTools(): List<SimpleTool<*>> =
       listOf(
         ObserveTool(mcpClient),
@@ -867,7 +893,7 @@ open class AutoMobileAgent(
         InputTextTool(mcpClient),
         SwipeTool(mcpClient),
         ScrollTool(mcpClient),
-        WaitForTool(mcpClient),
+        WaitForTool(rawMcpClient),
         GoBackTool(mcpClient),
         PressButtonTool(mcpClient),
         ClearTextTool(mcpClient),
@@ -906,6 +932,7 @@ open class AutoMobileAgent(
       config: ModelConfig,
       mcpClient: MCPClient,
       maxToolCalls: Int = 5,
+      rawMcpClient: MCPClient = mcpClient,
     ): AIAgent<String, String>
   }
 
@@ -1020,12 +1047,15 @@ open class AutoMobileAgent(
       config: ModelConfig,
       mcpClient: MCPClient,
       maxToolCalls: Int,
+      rawMcpClient: MCPClient,
     ): AIAgent<String, String> {
       val executor = createPromptExecutor(config)
       val model = selectModel(config.provider)
 
-      // Create AutoMobile MCP tools using class-based pattern (no reflection)
-      val toolFactory = AutoMobileMCPToolFactory(mcpClient)
+      // Create AutoMobile MCP tools using class-based pattern (no reflection). WaitForTool gets the
+      // raw client (#6145); every other, pass-through tool gets mcpClient (the redacting wrapper
+      // during recovery).
+      val toolFactory = AutoMobileMCPToolFactory(mcpClient, rawMcpClient)
       val toolRegistry = ToolRegistry { toolFactory.createAllTools().forEach { tool(it) } }
 
       val systemPrompt =

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -897,8 +897,19 @@ open class AutoMobileAgent(
    * locally only produces false timeouts, not a leak (issue #6145) — though a FAILED call is still
    * redacted before it can be logged (see [FailureRedactingMCPClient]). Defaults to [mcpClient] so
    * non-recovery callers (no secrets, no wrapper) are unaffected.
+   *
+   * `@JvmOverloads` on the primary constructor (issue #6145 P2 — binary compatibility): a bare
+   * Kotlin default parameter only generates a synthetic mask/marker constructor, not the original
+   * one-argument JVM descriptor. Replacing the old `(MCPClient)` constructor with a defaulted
+   * two-argument one therefore removed `<init>(MCPClient)V` entirely, breaking already-compiled
+   * consumers that call `AutoMobileMCPToolFactory(mcpClient)` directly with `NoSuchMethodError`.
+   * `@JvmOverloads` makes Kotlin emit the original one-argument constructor (delegating to the
+   * two-argument one with `rawMcpClient` defaulted to [mcpClient], the pre-#6145 behavior) in
+   * addition to the two-argument one, so both descriptors exist.
    */
-  class AutoMobileMCPToolFactory(
+  class AutoMobileMCPToolFactory
+  @JvmOverloads
+  constructor(
     private val mcpClient: MCPClient,
     private val rawMcpClient: MCPClient = mcpClient,
   ) {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -138,9 +138,18 @@ open class AutoMobileAgent(
       // WaitForTool searches locally. Its own output to the model is synthesized ("found" /
       // "timeout") and never leaks that observe text, so redacting the copy it searches only
       // produces a false timeout when the wait target is a substring of an on-screen secret value
-      // — it buys no security. So WaitForTool is wired to the RAW (unwrapped) client below via
-      // createAIAgentWithMCPTools's rawMcpClient param, while every pass-through tool (whose result
-      // DOES reach the model) keeps using agentMcpClient, the redacting wrapper.
+      // — it buys no security. So WaitForTool is wired to the RAW (unredacted-on-success) client
+      // below via createAIAgentWithMCPTools's rawMcpClient param, while every pass-through tool
+      // (whose result DOES reach the model) keeps using agentMcpClient, the redacting wrapper.
+      //
+      // #6145 follow-up: a FAILED observe call bypasses that "never leaks" argument —
+      // DefaultMCPClient
+      // throws with the server's response body / error in the message, which can echo on-screen
+      // data,
+      // and WaitForTool logs it on every failed poll. rawMcpClient is wrapped in
+      // FailureRedactingMCPClient so a successful result still reaches WaitForTool byte-for-byte
+      // unredacted (the local match keeps working), while a thrown exception's message is redacted
+      // before WaitForTool can log or surface it.
       //
       // Normalize the incoming concrete secret values into every scrub form (NFC/NFD + the
       // transport-encoding depths) HERE, at the public recovery entry point, so the loop is safe
@@ -150,12 +159,15 @@ open class AutoMobileAgent(
       val redactionValues = SecretRedactor.secretValues(secretValues)
       val agentMcpClient =
         if (redactionValues.isEmpty()) mcpClient else RedactingMCPClient(mcpClient, redactionValues)
+      val waitForRawMcpClient =
+        if (redactionValues.isEmpty()) mcpClient
+        else FailureRedactingMCPClient(mcpClient, redactionValues)
       val aiAgent =
         aiAgentFactory.createAIAgentWithMCPTools(
           modelConfig,
           agentMcpClient,
           maxToolCalls,
-          mcpClient,
+          waitForRawMcpClient,
         )
 
       // Redact the STATIC context fields that go into the initial prompt too (#6094). The executor
@@ -692,9 +704,13 @@ open class AutoMobileAgent(
    *
    * A composite tool: unlike the pass-through tools above, its RESULT to the model is a synthesized
    * "found"/"timeout" string, never the observe text it searches. So [AutoMobileMCPToolFactory]
-   * wires this to the RAW (unredacted) client — searching a redacted copy would falsely time out
-   * whenever the wait target is a substring of an on-screen secret value, with no security benefit
-   * (issue #6145; the intermediate observe text itself never reaches the model through this tool).
+   * wires this to a client that is RAW (unredacted) on a successful call — searching a redacted
+   * copy would falsely time out whenever the wait target is a substring of an on-screen secret
+   * value, with no security benefit (issue #6145; the intermediate observe text itself never
+   * reaches the model through this tool). During recovery that client is
+   * [FailureRedactingMCPClient], which still redacts a thrown exception's message — a FAILED
+   * observe call's error content is a different leak channel this tool logs on every failed poll
+   * attempt, unlike the synthesized success result.
    */
   class WaitForTool(private val mcpClient: MCPClient) :
     SimpleTool<WaitForTool.Args>(
@@ -878,7 +894,8 @@ open class AutoMobileAgent(
    * [mcpClient] backs every pass-through tool (its result reaches the model, so during recovery
    * this is the redacting wrapper). [rawMcpClient] backs [WaitForTool] alone — a composite tool
    * whose model-facing result is a synthesized string, so redacting the observe text it searches
-   * locally only produces false timeouts, not a leak (issue #6145). Defaults to [mcpClient] so
+   * locally only produces false timeouts, not a leak (issue #6145) — though a FAILED call is still
+   * redacted before it can be logged (see [FailureRedactingMCPClient]). Defaults to [mcpClient] so
    * non-recovery callers (no secrets, no wrapper) are unaffected.
    */
   class AutoMobileMCPToolFactory(
@@ -928,12 +945,40 @@ open class AutoMobileAgent(
   interface AIAgentFactory {
     fun createAIAgent(config: ModelConfig): AIAgent<String, String>
 
+    /**
+     * The original (pre-#6145) abstract method, kept as its OWN method rather than folded into the
+     * 4-arg overload below via a defaulted `rawMcpClient` parameter (issue #6145 P2 — binary
+     * compatibility). A Kotlin default parameter value is resolved at the CALL SITE from the
+     * declaration visible to the compiler; it is not something an implementing class provides, so
+     * it does nothing to preserve what an implementor's `.class` actually links against. Adding
+     * `rawMcpClient` as a 4th defaulted parameter directly on this method (the #6145 mistake)
+     * silently replaced the 3-arg abstract method the interface published with a 4-arg one — any
+     * external [AIAgentFactory] implementer compiled against the old 3-arg descriptor would stop
+     * satisfying the interface (`AbstractMethodError` at link time), because their `.class` only
+     * ever contained a 3-arg method.
+     */
     fun createAIAgentWithMCPTools(
       config: ModelConfig,
       mcpClient: MCPClient,
       maxToolCalls: Int = 5,
-      rawMcpClient: MCPClient = mcpClient,
     ): AIAgent<String, String>
+
+    /**
+     * New overload (#6145): [rawMcpClient] backs [WaitForTool] with a client that is raw
+     * (unredacted) on success while [mcpClient] backs every pass-through tool. Carries a default
+     * body — it is NOT abstract — that forwards to the 3-arg method above, discarding the separate
+     * raw client (the pre-#6145 behavior: [WaitForTool] shared whatever client every other tool
+     * used). That keeps this method optional: an external [AIAgentFactory] implementer that
+     * predates #6145 and only overrides the 3-arg method above still compiles and links against
+     * this interface without ever knowing this overload exists. [DefaultAIAgentFactory] overrides
+     * it directly to route `rawMcpClient` to [WaitForTool] distinctly.
+     */
+    fun createAIAgentWithMCPTools(
+      config: ModelConfig,
+      mcpClient: MCPClient,
+      maxToolCalls: Int,
+      rawMcpClient: MCPClient,
+    ): AIAgent<String, String> = createAIAgentWithMCPTools(config, mcpClient, maxToolCalls)
   }
 
   interface TimeProvider {
@@ -1042,6 +1087,17 @@ open class AutoMobileAgent(
         systemPrompt = systemPrompt,
       )
     }
+
+    // The original (pre-#6145) abstract method's mandatory override; see the interface doc on the
+    // 3-arg createAIAgentWithMCPTools for why this is a distinct method rather than a defaulted
+    // rawMcpClient parameter. Delegates to the 4-arg overload with rawMcpClient=mcpClient — no
+    // separate raw client, matching the pre-#6145 behavior this method's callers expect.
+    override fun createAIAgentWithMCPTools(
+      config: ModelConfig,
+      mcpClient: MCPClient,
+      maxToolCalls: Int,
+    ): AIAgent<String, String> =
+      createAIAgentWithMCPTools(config, mcpClient, maxToolCalls, mcpClient)
 
     override fun createAIAgentWithMCPTools(
       config: ModelConfig,

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/FailureRedactingMCPClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/FailureRedactingMCPClient.kt
@@ -1,0 +1,49 @@
+package dev.jasonpearson.automobile.junit
+
+/**
+ * Wraps the RAW (unredacted) [AutoMobileAgent.MCPClient] handed to [AutoMobileAgent.WaitForTool]
+ * during AI-assisted recovery so a tool-call FAILURE cannot leak on-screen secret data (issue #6145
+ * follow-up).
+ *
+ * [AutoMobileAgent.WaitForTool] is deliberately wired to the raw client rather than
+ * [RedactingMCPClient] so its local "did the element appear" text search runs against the real
+ * observe result — searching a redacted copy would falsely time out whenever the wait target is a
+ * substring of an on-screen secret value (see [AutoMobileAgent.WaitForTool]'s class doc). That is
+ * safe for a SUCCESSFUL call because [AutoMobileAgent.WaitForTool] never forwards the observe text
+ * itself to the model — only a synthesized "found"/"timeout" string does.
+ *
+ * A FAILED call is a different channel: [DefaultMCPClient.callTool] throws with the MCP server's
+ * response body / error in the exception message, which can echo on-screen data (a validation error
+ * quoting the request, a server error including partial state). [AutoMobileAgent.WaitForTool] logs
+ * that message (`println("Warning: waitFor observe failed, will retry: ${e.message}")`) on every
+ * failed poll attempt, so an unredacted exception message leaks to the recovery log even though the
+ * happy-path text search never leaks anything. Wrapping the raw client here keeps the happy path
+ * exactly as before (the delegate's successful result is returned UNCHANGED, byte for byte, so the
+ * local match still works) while scrubbing anything that escapes via a thrown exception, mirroring
+ * [RedactingMCPClient]'s failure-path handling. The cause is dropped so the raw text cannot survive
+ * in the exception chain.
+ *
+ * `internal` — its only consumer is [AutoMobileAgent.attemptAiRecovery]; unit-tested via
+ * `WaitForToolRedactionTest`.
+ */
+internal class FailureRedactingMCPClient(
+  private val delegate: AutoMobileAgent.MCPClient,
+  private val secretValues: List<String>,
+) : AutoMobileAgent.MCPClient {
+
+  override fun isConnected(): Boolean = delegate.isConnected()
+
+  override fun connect(serverUrl: String) = delegate.connect(serverUrl)
+
+  override fun disconnect() = delegate.disconnect()
+
+  override fun callTool(toolName: String, parameters: Map<String, Any>): String =
+    try {
+      delegate.callTool(toolName, parameters)
+    } catch (e: Exception) {
+      throw RuntimeException(SecretRedactor.redact(e.message ?: e.toString(), secretValues))
+    }
+
+  override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> =
+    delegate.listAvailableTools()
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AIAgentFactoryBinaryCompatTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AIAgentFactoryBinaryCompatTest.kt
@@ -1,0 +1,98 @@
+package dev.jasonpearson.automobile.junit
+
+import ai.koog.agents.core.agent.AIAgent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for issue #6145 P2 (binary compatibility): adding `rawMcpClient` as a 4th
+ * defaulted parameter directly on [AutoMobileAgent.AIAgentFactory.createAIAgentWithMCPTools]
+ * replaced its published 3-arg JVM abstract-method descriptor with a 4-arg one — a Kotlin default
+ * parameter value is resolved at the call site from the visible declaration, it is not something an
+ * implementing class provides, so it did nothing to preserve what an external implementer's
+ * `.class` actually linked against. The fix keeps the 3-arg method as its own abstract method
+ * (unchanged descriptor) and adds the 4-arg capability as a separate, non-abstract overload that
+ * forwards to it by default.
+ */
+class AIAgentFactoryBinaryCompatTest {
+
+  /**
+   * Stands in for an external [AutoMobileAgent.AIAgentFactory] implementer that predates #6145: it
+   * overrides ONLY the original 3-arg method, exactly like code compiled against the pre-#6145
+   * interface. If the interface still required the 4-arg method to be implemented too, this class
+   * would fail to compile ("class ... must be declared abstract or implement abstract member") — so
+   * this file compiling at all is most of the regression proof.
+   */
+  private class LegacyThreeArgFactory : AutoMobileAgent.AIAgentFactory {
+    var lastCallArgs: Triple<AutoMobileAgent.ModelConfig, AutoMobileAgent.MCPClient, Int>? = null
+
+    override fun createAIAgent(config: AutoMobileAgent.ModelConfig): AIAgent<String, String> {
+      throw UnsupportedOperationException("not used")
+    }
+
+    override fun createAIAgentWithMCPTools(
+      config: AutoMobileAgent.ModelConfig,
+      mcpClient: AutoMobileAgent.MCPClient,
+      maxToolCalls: Int,
+    ): AIAgent<String, String> {
+      lastCallArgs = Triple(config, mcpClient, maxToolCalls)
+      throw UnsupportedOperationException("legacy factory stub")
+    }
+  }
+
+  private class StubMCPClient : AutoMobileAgent.MCPClient {
+    override fun isConnected() = false
+
+    override fun connect(serverUrl: String) {}
+
+    override fun disconnect() {}
+
+    override fun callTool(toolName: String, parameters: Map<String, Any>) = ""
+
+    override fun listAvailableTools() = emptyList<AutoMobileAgent.MCPToolDefinition>()
+  }
+
+  @Test
+  fun `a factory overriding only the 3-arg method still satisfies AIAgentFactory`() {
+    val factory: AutoMobileAgent.AIAgentFactory = LegacyThreeArgFactory()
+    assertTrue(factory is AutoMobileAgent.AIAgentFactory)
+  }
+
+  @Test
+  fun `the 4-arg overload's default body forwards to the 3-arg method on a legacy factory`() {
+    val factory = LegacyThreeArgFactory()
+    val config = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val mcpClient = StubMCPClient()
+    val otherRawMcpClient = StubMCPClient()
+
+    // Call the NEW 4-arg overload (unknown to LegacyThreeArgFactory's author) with a distinct
+    // rawMcpClient; its default body must forward to the 3-arg override (dropping rawMcpClient —
+    // the pre-#6145 behavior) rather than throwing AbstractMethodError.
+    try {
+      factory.createAIAgentWithMCPTools(config, mcpClient, 7, otherRawMcpClient)
+    } catch (e: UnsupportedOperationException) {
+      // Expected: the stub 3-arg override throws once actually invoked; reaching it proves the
+      // forwarding worked.
+    }
+
+    assertEquals(Triple(config, mcpClient, 7), factory.lastCallArgs)
+  }
+
+  @Test
+  fun `DefaultAIAgentFactory's 3-arg method delegates to the 4-arg one with rawMcpClient=mcpClient`() {
+    // The reverse direction: DefaultAIAgentFactory must implement the mandatory 3-arg method by
+    // routing through its own 4-arg logic rather than duplicating it, using mcpClient as the raw
+    // client (no separate one) — the pre-#6145 behavior for any caller still using the 3-arg entry
+    // point. Constructing the AIAgent requires no network I/O, so this exercises real wiring.
+    val factory = AutoMobileAgent.DefaultAIAgentFactory()
+    val config = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val mcpClient = StubMCPClient()
+
+    val threeArgAgent = factory.createAIAgentWithMCPTools(config, mcpClient, 5)
+    val fourArgAgent = factory.createAIAgentWithMCPTools(config, mcpClient, 5, mcpClient)
+
+    assertTrue(threeArgAgent is AIAgent<*, *>)
+    assertTrue(fourArgAgent is AIAgent<*, *>)
+  }
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
@@ -207,8 +207,9 @@ class AutoMobileAgentTest {
     every { mockMcpClient.connect("http://localhost:3000") } just runs
     every { mockMcpClient.disconnect() } just runs
     every { mockConfigProvider.getModelConfig() } returns modelConfig
-    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5) } returns
-      mockAIAgent
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5, mockMcpClient)
+    } returns mockAIAgent
     every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
 
     coEvery { mockAIAgent.run(any()) } returns "Recovery actions taken"
@@ -258,7 +259,12 @@ class AutoMobileAgentTest {
       """{"elements":{"field":"token $secret"},"env":"$visible"}"""
     every { mockMcpClient.callTool("tapOn", any()) } returns """{"status":"typed $secret"}"""
     every {
-      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, capture(agentClientSlot), 5)
+      mockAiAgentFactory.createAIAgentWithMCPTools(
+        modelConfig,
+        capture(agentClientSlot),
+        5,
+        mockMcpClient,
+      )
     } returns mockAIAgent
     coEvery { mockAIAgent.run(any()) } returns "done"
 
@@ -329,7 +335,7 @@ class AutoMobileAgentTest {
     every { mockMcpClient.disconnect() } just runs
     every { mockConfigProvider.getModelConfig() } returns modelConfig
     every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
-    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, any(), 5) } returns
+    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, any(), 5, any()) } returns
       mockAIAgent
     coEvery { mockAIAgent.run(capture(promptSlot)) } returns "done"
 
@@ -374,7 +380,12 @@ class AutoMobileAgentTest {
     // The JSON observe result carries the secret in its escaped form (a `"` becomes `\"`).
     every { mockMcpClient.callTool("observe", any()) } returns """{"field":"token pa\"ss-TOKEN"}"""
     every {
-      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, capture(agentClientSlot), 5)
+      mockAiAgentFactory.createAIAgentWithMCPTools(
+        modelConfig,
+        capture(agentClientSlot),
+        5,
+        mockMcpClient,
+      )
     } returns mockAIAgent
     coEvery { mockAIAgent.run(any()) } returns "done"
 
@@ -452,8 +463,9 @@ class AutoMobileAgentTest {
     every { mockMcpClient.connect("http://localhost:3000") } just runs
     every { mockMcpClient.disconnect() } just runs
     every { mockConfigProvider.getModelConfig() } returns modelConfig
-    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5) } returns
-      mockAIAgent
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5, mockMcpClient)
+    } returns mockAIAgent
     every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
     coEvery { mockAIAgent.run(capture(promptSlot)) } returns "Dismissed the dialog"
 
@@ -516,8 +528,9 @@ class AutoMobileAgentTest {
     every { mockMcpClient.connect("http://localhost:3000") } just runs
     every { mockMcpClient.disconnect() } just runs
     every { mockConfigProvider.getModelConfig() } returns modelConfig
-    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5) } returns
-      mockAIAgent
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5, mockMcpClient)
+    } returns mockAIAgent
 
     coEvery { mockAIAgent.run(any()) } throws RuntimeException("AI failed")
 
@@ -586,7 +599,12 @@ class AutoMobileAgentTest {
     every { mockMcpClient.disconnect() } just runs
     every { mockConfigProvider.getModelConfig() } returns modelConfig
     every {
-      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, customMaxToolCalls)
+      mockAiAgentFactory.createAIAgentWithMCPTools(
+        modelConfig,
+        mockMcpClient,
+        customMaxToolCalls,
+        mockMcpClient,
+      )
     } returns mockAIAgent
     every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
 
@@ -597,7 +615,12 @@ class AutoMobileAgentTest {
 
     // Assert - verify factory was called with the custom max tool calls
     verify {
-      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, customMaxToolCalls)
+      mockAiAgentFactory.createAIAgentWithMCPTools(
+        modelConfig,
+        mockMcpClient,
+        customMaxToolCalls,
+        mockMcpClient,
+      )
     }
   }
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
@@ -263,7 +263,10 @@ class AutoMobileAgentTest {
         modelConfig,
         capture(agentClientSlot),
         5,
-        mockMcpClient,
+        // #6145 follow-up: with secrets present the raw client handed to WaitForTool is wrapped in
+        // FailureRedactingMCPClient (still delegates unredacted successes to mockMcpClient), not
+        // mockMcpClient itself — match any() rather than the exact pre-wrap reference.
+        any(),
       )
     } returns mockAIAgent
     coEvery { mockAIAgent.run(any()) } returns "done"
@@ -306,6 +309,69 @@ class AutoMobileAgentTest {
     assertTrue(
       rawObserve.contains(secret),
       "the underlying client (device execution) still receives real values",
+    )
+  }
+
+  @Test
+  fun `WaitForTool's raw client redacts a failure but leaves a success untouched during recovery`() {
+    // Issue #6145 follow-up: WaitForTool is wired to the RAW client so its local text match keeps
+    // working (a redacted copy would falsely time out). But DefaultMCPClient throws with the MCP
+    // server's response body / error in the message on FAILURE, which can echo on-screen secret
+    // data,
+    // and WaitForTool logs that message on every failed poll. attemptAiRecovery must wrap the raw
+    // client it hands WaitForTool in FailureRedactingMCPClient rather than passing mcpClient itself
+    // unwrapped, so a thrown exception is redacted while a successful call stays byte-for-byte raw.
+    val secret = "SECRET-hunter2-TOKEN"
+    val context =
+      FailedStepContext(
+        failedStepIndex = 1,
+        failedTool = "inputText",
+        error = "step failed",
+        succeededSteps = emptyList(),
+        planContent = "name: test\nsteps: []",
+        deviceId = "emulator-5554",
+      )
+    val modelConfig = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val rawClientSlot = slot<AutoMobileAgent.MCPClient>()
+
+    every { mockTimeProvider.currentTimeMillis() } returns 1000L andThen 2000L
+    every { mockConfigProvider.getMcpServerUrl() } returns "http://localhost:3000"
+    every { mockMcpClient.isConnected() } returns false
+    every { mockMcpClient.connect(any()) } just runs
+    every { mockMcpClient.disconnect() } just runs
+    every { mockConfigProvider.getModelConfig() } returns modelConfig
+    every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
+    every {
+      mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, any(), 5, capture(rawClientSlot))
+    } returns mockAIAgent
+    coEvery { mockAIAgent.run(any()) } returns "done"
+
+    autoMobileAgent.attemptAiRecovery(context, secretValues = listOf(secret))
+
+    val rawClient = rawClientSlot.captured
+
+    // A successful call must return the RAW, unredacted result unchanged — WaitForTool's local
+    // match relies on this.
+    every { mockMcpClient.callTool("waitForCheck", any()) } returns
+      """{"elements":[{"text":"$secret"}]}"""
+    assertEquals(
+      """{"elements":[{"text":"$secret"}]}""",
+      rawClient.callTool("waitForCheck", emptyMap()),
+      "a successful observe must reach WaitForTool's local match completely unredacted",
+    )
+
+    // A FAILED call's thrown message must be redacted — this is what WaitForTool logs on every
+    // failed poll attempt.
+    every { mockMcpClient.callTool("waitForFailure", any()) } throws
+      RuntimeException("MCP server error: token $secret leaked in the error body")
+    val error = assertThrows<RuntimeException> { rawClient.callTool("waitForFailure", emptyMap()) }
+    assertFalse(
+      error.message!!.contains(secret),
+      "a failed observe's exception message must not leak the secret",
+    )
+    assertTrue(
+      error.message!!.contains(SecretRedactor.PLACEHOLDER),
+      "the secret must be replaced by the placeholder",
     )
   }
 
@@ -384,7 +450,10 @@ class AutoMobileAgentTest {
         modelConfig,
         capture(agentClientSlot),
         5,
-        mockMcpClient,
+        // #6145 follow-up: with secrets present the raw client handed to WaitForTool is wrapped in
+        // FailureRedactingMCPClient (still delegates unredacted successes to mockMcpClient), not
+        // mockMcpClient itself — match any() rather than the exact pre-wrap reference.
+        any(),
       )
     } returns mockAIAgent
     coEvery { mockAIAgent.run(any()) } returns "done"

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
@@ -369,6 +369,7 @@ private class FakeAIAgentFactory : AutoMobileAgent.AIAgentFactory {
     config: AutoMobileAgent.ModelConfig,
     mcpClient: AutoMobileAgent.MCPClient,
     maxToolCalls: Int,
+    rawMcpClient: AutoMobileAgent.MCPClient,
   ): ai.koog.agents.core.agent.AIAgent<String, String> {
     throw UnsupportedOperationException("Not used in recovery tests")
   }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
@@ -369,6 +369,14 @@ private class FakeAIAgentFactory : AutoMobileAgent.AIAgentFactory {
     config: AutoMobileAgent.ModelConfig,
     mcpClient: AutoMobileAgent.MCPClient,
     maxToolCalls: Int,
+  ): ai.koog.agents.core.agent.AIAgent<String, String> {
+    throw UnsupportedOperationException("Not used in recovery tests")
+  }
+
+  override fun createAIAgentWithMCPTools(
+    config: AutoMobileAgent.ModelConfig,
+    mcpClient: AutoMobileAgent.MCPClient,
+    maxToolCalls: Int,
     rawMcpClient: AutoMobileAgent.MCPClient,
   ): ai.koog.agents.core.agent.AIAgent<String, String> {
     throw UnsupportedOperationException("Not used in recovery tests")

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
@@ -1,0 +1,106 @@
+package dev.jasonpearson.automobile.junit
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for issue #6145: a composite [AutoMobileAgent.WaitForTool] must evaluate its
+ * local "did the element appear" check against the UNREDACTED observe result.
+ *
+ * Recovery redaction (#6094 / [RedactingMCPClient]) scrubs every intermediate tool/observe result
+ * before it reaches the model. [AutoMobileAgent.WaitForTool] never forwards that observe text to
+ * the model itself — its own result is a synthesized "found"/"timeout" string — so redacting the
+ * copy it searches locally buys no security and only produces a false timeout whenever the wait
+ * target is a substring of an on-screen secret value.
+ */
+class WaitForToolRedactionTest {
+
+  private class FixedResultClient(private val result: String) : AutoMobileAgent.MCPClient {
+    override fun isConnected() = true
+
+    override fun connect(serverUrl: String) {}
+
+    override fun disconnect() {}
+
+    override fun callTool(toolName: String, parameters: Map<String, Any>): String = result
+
+    override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> = emptyList()
+  }
+
+  /** Fails any call — proves WaitForTool never queries the redacting client. */
+  private class FailingClient : AutoMobileAgent.MCPClient {
+    override fun isConnected() = true
+
+    override fun connect(serverUrl: String) {}
+
+    override fun disconnect() {}
+
+    override fun callTool(toolName: String, parameters: Map<String, Any>): String =
+      throw AssertionError(
+        "WaitForTool must query the raw client for its internal condition check, not the " +
+          "redacting one"
+      )
+
+    override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> = emptyList()
+  }
+
+  @Test
+  fun `WaitForTool matches a wait target that is only a substring of an on-screen secret`() =
+    runBlocking {
+      // "OK" only ever appears as a substring of the declared secret, so a WaitForTool that
+      // searched the REDACTED observe result would never match and would time out (#6145).
+      val secret = "TOKEN-OK-123"
+      val rawObserveResult = """{"elements":[{"text":"$secret"}]}"""
+      val redactionValues = SecretRedactor.secretValues(listOf(secret))
+
+      // Sanity: the redacted copy really does lose the substring, proving the bug would
+      // reproduce if WaitForTool searched this instead of the raw text.
+      val redacted = SecretRedactor.redact(rawObserveResult, redactionValues)
+      assertFalse("test setup: redaction must remove the substring", redacted.contains("OK"))
+
+      val waitForTool = AutoMobileAgent.WaitForTool(FixedResultClient(rawObserveResult))
+
+      val result =
+        waitForTool.execute(AutoMobileAgent.WaitForTool.Args(text = "OK", timeout = 2000))
+
+      assertEquals("Element with text 'OK' found", result)
+    }
+
+  @Test
+  fun `AutoMobileMCPToolFactory wires WaitForTool to the raw client, not the redacting one`() =
+    runBlocking {
+      // Structural check on the #6145 fix itself: the factory must hand WaitForTool the raw
+      // client while every pass-through tool keeps using the (possibly redacting) primary one.
+      val secret = "TOKEN-OK-123"
+      val rawClient = FixedResultClient("""{"elements":[{"text":"$secret"}]}""")
+      val redactingClient = FailingClient()
+      val factory = AutoMobileAgent.AutoMobileMCPToolFactory(redactingClient, rawClient)
+
+      val waitForTool =
+        factory.createAllTools().filterIsInstance<AutoMobileAgent.WaitForTool>().single()
+
+      // Would throw from FailingClient if WaitForTool queried the wrong (redacting) client.
+      val result =
+        waitForTool.execute(AutoMobileAgent.WaitForTool.Args(text = "OK", timeout = 2000))
+      assertEquals("Element with text 'OK' found", result)
+    }
+
+  @Test
+  fun `secrets stay redacted in the pass-through observe result the model sees`() = runBlocking {
+    // The other half of #6145: fixing WaitForTool's local check must not reopen the #6094 leak —
+    // ObserveTool (and the rest of the pass-through tools) still go through the redacting client.
+    val secret = "TOKEN-OK-123"
+    val rawClient = FixedResultClient("""{"elements":[{"text":"$secret"}]}""")
+    val redactionValues = SecretRedactor.secretValues(listOf(secret))
+    val redactingClient = RedactingMCPClient(rawClient, redactionValues)
+
+    val observeResult =
+      AutoMobileAgent.ObserveTool(redactingClient).execute(AutoMobileAgent.ObserveTool.Args())
+
+    assertFalse(observeResult.contains(secret))
+    assertTrue(observeResult.contains(SecretRedactor.PLACEHOLDER))
+  }
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.junit
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -103,4 +104,84 @@ class WaitForToolRedactionTest {
     assertFalse(observeResult.contains(secret))
     assertTrue(observeResult.contains(SecretRedactor.PLACEHOLDER))
   }
+
+  /**
+   * Throws with a secret echoed in the exception message — mimics DefaultMCPClient's failure mode.
+   */
+  private class ThrowingClient(private val message: String) : AutoMobileAgent.MCPClient {
+    override fun isConnected() = true
+
+    override fun connect(serverUrl: String) {}
+
+    override fun disconnect() {}
+
+    override fun callTool(toolName: String, parameters: Map<String, Any>): String =
+      throw RuntimeException(message)
+
+    override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> = emptyList()
+  }
+
+  @Test
+  fun `FailureRedactingMCPClient returns a successful result completely unredacted`() =
+    runBlocking {
+      // WaitForTool's local match must see the RAW text, or a wait target that is only a substring
+      // of
+      // an on-screen secret would falsely time out (#6145).
+      val secret = "TOKEN-OK-123"
+      val rawResult = """{"elements":[{"text":"$secret"}]}"""
+      val client =
+        FailureRedactingMCPClient(
+          FixedResultClient(rawResult),
+          SecretRedactor.secretValues(listOf(secret)),
+        )
+
+      assertEquals(rawResult, client.callTool("observe", emptyMap()))
+    }
+
+  @Test
+  fun `FailureRedactingMCPClient redacts a thrown exception's message`() {
+    // #6145 follow-up: a FAILED observe call bypasses the "WaitForTool never leaks observe text"
+    // argument — DefaultMCPClient throws with the server's response body / error in the message,
+    // and WaitForTool logs it on every failed poll attempt.
+    val secret = "TOKEN-OK-123"
+    val client =
+      FailureRedactingMCPClient(
+        ThrowingClient("MCP server error: token $secret leaked in the error body"),
+        SecretRedactor.secretValues(listOf(secret)),
+      )
+
+    val error =
+      assertThrows(RuntimeException::class.java) { client.callTool("observe", emptyMap()) }
+
+    assertFalse("the thrown message must not contain the secret", error.message!!.contains(secret))
+    assertTrue(
+      "the secret must be replaced by the placeholder",
+      error.message!!.contains(SecretRedactor.PLACEHOLDER),
+    )
+    assertEquals(
+      "the cause must be dropped so the raw text cannot survive",
+      null,
+      error.cause,
+    )
+  }
+
+  @Test
+  fun `WaitForTool wrapped in FailureRedactingMCPClient still matches an unredacted substring`() =
+    runBlocking {
+      // End-to-end: WaitForTool wired to the failure-redacting wrapper must behave identically to
+      // the plain raw client on the success path this suite already covers above.
+      val secret = "TOKEN-OK-123"
+      val rawObserveResult = """{"elements":[{"text":"$secret"}]}"""
+      val client =
+        FailureRedactingMCPClient(
+          FixedResultClient(rawObserveResult),
+          SecretRedactor.secretValues(listOf(secret)),
+        )
+
+      val result =
+        AutoMobileAgent.WaitForTool(client)
+          .execute(AutoMobileAgent.WaitForTool.Args(text = "OK", timeout = 2000))
+
+      assertEquals("Element with text 'OK' found", result)
+    }
 }

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolRedactionTest.kt
@@ -90,6 +90,37 @@ class WaitForToolRedactionTest {
     }
 
   @Test
+  fun `AutoMobileMCPToolFactory preserves the original one-argument JVM constructor`() {
+    // Issue #6145 P2 — binary compatibility: a bare Kotlin default parameter
+    // (`rawMcpClient: MCPClient = mcpClient`) only generates a synthetic mask/marker
+    // constructor, not the original `<init>(MCPClient)V` descriptor, so an already-compiled
+    // consumer that directly instantiates `AutoMobileMCPToolFactory(mcpClient)` would fail
+    // with NoSuchMethodError once the primary constructor grew a second parameter. Assert the
+    // one-argument descriptor is actually present on the compiled class (not just that calling
+    // it from source compiles, which would pass even without @JvmOverloads since source callers
+    // are recompiled against the new descriptor).
+    val ctor =
+      AutoMobileAgent.AutoMobileMCPToolFactory::class
+        .java
+        .getDeclaredConstructor(AutoMobileAgent.MCPClient::class.java)
+
+    assertEquals(1, ctor.parameterCount)
+
+    // And it must behave like the pre-#6145 factory: WaitForTool gets the same (single) client
+    // as every pass-through tool when the raw client isn't supplied.
+    val secret = "TOKEN-OK-123"
+    val client = FixedResultClient("""{"elements":[{"text":"$secret"}]}""")
+    val factory: AutoMobileAgent.AutoMobileMCPToolFactory = ctor.newInstance(client)
+
+    val waitForTool =
+      factory.createAllTools().filterIsInstance<AutoMobileAgent.WaitForTool>().single()
+    val result = runBlocking {
+      waitForTool.execute(AutoMobileAgent.WaitForTool.Args(text = "OK", timeout = 2000))
+    }
+    assertEquals("Element with text 'OK' found", result)
+  }
+
+  @Test
   fun `secrets stay redacted in the pass-through observe result the model sees`() = runBlocking {
     // The other half of #6145: fixing WaitForTool's local check must not reopen the #6094 leak —
     // ObserveTool (and the rest of the pass-through tools) still go through the redacting client.


### PR DESCRIPTION
## Summary

Follow-up to #6094 / #6143. During AI-assisted recovery, `RedactingMCPClient` scrubs every intermediate tool/observe result before it reaches the model. The composite `WaitForTool` searches that same intermediate observe result **locally** to decide whether its wait condition is met — so a wait target that is only a substring of an on-screen declared-secret value was scrubbed away before the check ran, producing a false timeout even though the real (unredacted) observation would have matched.

`WaitForTool`'s own result to the model is a synthesized `"found"` / `"timeout"` string, never the observe text itself, so redacting the copy it searches locally bought no security — it was a pure regression in reliability.

## Fix

- Added a `rawMcpClient` parameter to `AIAgentFactory.createAIAgentWithMCPTools` and `AutoMobileMCPToolFactory` (defaults to `mcpClient` for non-recovery callers).
- `attemptAiRecovery` now passes the raw (unredacted) client alongside the redacting `agentMcpClient`.
- `AutoMobileMCPToolFactory` wires `WaitForTool` to the raw client while every pass-through tool (whose result does reach the model) keeps using the redacting wrapper.

## Tests

Added `WaitForToolRedactionTest`:
- `WaitForTool` matches a wait target that is only a substring of an on-screen secret (would time out pre-fix).
- `AutoMobileMCPToolFactory` wires `WaitForTool` to the raw client, not the redacting one (fails loudly if wiring regresses).
- Pass-through tool output (`ObserveTool`) stays redacted — confirms the fix does not reopen #6094's leak.

Also updated existing `AutoMobileAgentTest` / `RecoveryLoopTest` call sites for the new `AIAgentFactory` parameter.

## Validation

- `./gradlew :junit-runner:test` (targeted + full suite; 2 pre-existing, unrelated failures from `ANDROID_HOME` not being set in this env)
- `./gradlew :junit-runner:detektMain :junit-runner:detektTest`
- `scripts/ktfmt/validate_ktfmt.sh`
- `bun run lint` / `bun run typecheck` / `bun run format:check` / `bunx turbo run build`

Closes #6145