### PR TITLE
fix(plan): stop AI recovery resuming mid-barrier-generation (#6234)

### DIFF
--- a/src/utils/plan/BarrierResumeGuard.ts
+++ b/src/utils/plan/BarrierResumeGuard.ts
@@ -1,3 +1,4 @@
+import { ActionableError } from "../../models";
 import { Plan, PlanStep } from "../../models/Plan";
 
 /**
@@ -54,26 +55,22 @@ interface Arrival {
  * `{0,1}`/`{2,3}` a global-order slice would produce.
  *
  * We therefore reconstruct each device's track (its arrivals in plan order) and
- * read them off column-by-column: column `g` across all tracks is generation
- * `g`, and its span is `[min planIndex, max planIndex]` of that column.
+ * repeatedly take the earliest *next* arrival from distinct tracks. This is the
+ * same constraint the executor imposes: a device cannot reach its second
+ * arrival until its first barrier release, while the next round may legitimately
+ * replace a participant. For `A@0,B@1,A@3,C@4` (count two), that yields
+ * `{A@0,B@1}` then `{A@3,C@4}`. A fixed all-track column would reject that
+ * validator-permitted changing participant set and replay round one.
  *
- * When the shape is irregular in a way plan validation would already reject —
- * an arrival missing its device label, ragged per-device arrival counts, or a
- * `deviceCount` that disagrees with the number of distinct devices — we fall
- * back to one conservative span covering every arrival of the lock, so a
- * mid-lock resume still rewinds to the lock's first arrival rather than
- * splitting a generation.
+ * If the guard is called on a shape that PlanValidator would reject — a missing
+ * device label, inconsistent count, incomplete generation, or too few candidate
+ * tracks — it fails closed. Rewinding the whole lock is unsafe because it
+ * replays completed destructive steps between otherwise independent generations.
  *
- * `deviceCount: 1` is a special case handled separately, BEFORE the
- * device-track/column analysis below: a count-one lock completes a
- * generation on every single arrival, regardless of which (or how many
- * distinct) devices share it. The column model assumes a generation is
- * filled by `deviceCount` DISTINCT devices arriving together — which never
- * matches when more than one device uses a count-one lock (`tracks.size`
- * exceeds the declared count of 1), so it fell through to the irregular,
- * whole-lock fallback and rewound a resume past already-completed count-one
- * arrivals for no reason (issue #6234 P2 follow-up review comment
- * PRRC_kwDOP-GF5M7rVEIB).
+ * `deviceCount: 1` is a special case: every arrival completes its own
+ * generation, regardless of which (or how many) devices share the lock. It
+ * must remain a singleton span so recovery never rewinds past a completed
+ * count-one arrival.
  */
 function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
   if (arrivals.length === 0) {
@@ -89,18 +86,42 @@ function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
   }
 
   const tracks = deviceTracks(arrivals);
-  const generationCount = regularGenerationCount(tracks, consistentCount);
-  if (generationCount === undefined) {
-    // Irregular shape (missing device, ragged tracks, or a deviceCount that
-    // disagrees with the device set) — plan validation would reject it, so span
-    // the whole lock and let a mid-lock resume rewind to its first arrival.
-    return [wholeLockSpan(lock, arrivals)];
+  if (tracks === undefined) {
+    throw invalidBarrierRecoveryShape(lock, "an arrival is missing its device label");
+  }
+  if (consistentCount === undefined || arrivals.length % consistentCount !== 0) {
+    throw invalidBarrierRecoveryShape(
+      lock,
+      `${arrivals.length} arrivals cannot form complete groups of ${String(consistentCount)}`,
+    );
   }
 
-  const trackLists = [...tracks.values()];
+  const consumed = new Map<string, number>();
   const spans: GenerationSpan[] = [];
-  for (let gen = 0; gen < generationCount; gen++) {
-    spans.push(columnSpan(lock, trackLists, gen));
+  for (let remaining = arrivals.length; remaining > 0; remaining -= consistentCount) {
+    const nextArrivals = [...tracks.entries()]
+      .map(([device, track]) => ({ device, arrival: track[consumed.get(device) ?? 0] }))
+      .filter(
+        (candidate): candidate is { device: string; arrival: Arrival } =>
+          candidate.arrival !== undefined,
+      )
+      .sort((a, b) => a.arrival.planIndex - b.arrival.planIndex);
+    if (nextArrivals.length < consistentCount) {
+      throw invalidBarrierRecoveryShape(
+        lock,
+        `only ${nextArrivals.length} device tracks remain for deviceCount=${consistentCount}`,
+      );
+    }
+    const generation = nextArrivals.slice(0, consistentCount);
+    spans.push(
+      spanForArrivals(
+        lock,
+        generation.map((candidate) => candidate.arrival),
+      ),
+    );
+    for (const { device } of generation) {
+      consumed.set(device, (consumed.get(device) ?? 0) + 1);
+    }
   }
   return spans;
 }
@@ -110,29 +131,27 @@ function singletonSpan(lock: string, arrival: Arrival): GenerationSpan {
   return { lock, firstIndex: arrival.planIndex, lastIndex: arrival.planIndex };
 }
 
-/** The conservative single span covering every arrival of a lock. */
-function wholeLockSpan(lock: string, arrivals: Arrival[]): GenerationSpan {
-  return {
-    lock,
-    firstIndex: arrivals[0].planIndex,
-    lastIndex: arrivals[arrivals.length - 1].planIndex,
-  };
+function invalidBarrierRecoveryShape(lock: string, reason: string): ActionableError {
+  return new ActionableError(
+    `Cannot safely recover barrier lock "${lock}": ${reason}. ` +
+      "The plan must pass barrier validation before it can be resumed.",
+  );
 }
 
 /**
  * Reconstruct each device's track (its arrivals' plan indices in plan order).
  * Iterating in plan order preserves per-device track order, so the k-th entry of
- * a device's list is that device's k-th arrival at the lock. Returns null when
+ * a device's list is that device's k-th arrival at the lock. Returns undefined when
  * any arrival is missing its device label.
  */
-function deviceTracks(arrivals: Arrival[]): Map<string, number[]> {
-  const perDevice = new Map<string, number[]>();
+function deviceTracks(arrivals: Arrival[]): Map<string, Arrival[]> | undefined {
+  const perDevice = new Map<string, Arrival[]>();
   for (const arrival of arrivals) {
     if (arrival.device === undefined) {
-      return new Map();
+      return undefined;
     }
     const list = perDevice.get(arrival.device) ?? [];
-    list.push(arrival.planIndex);
+    list.push(arrival);
     perDevice.set(arrival.device, list);
   }
   return perDevice;
@@ -150,35 +169,12 @@ function consistentDeviceCount(arrivals: Arrival[]): number | undefined {
   return counts.size === 1 ? (counts.values().next().value as number) : undefined;
 }
 
-/**
- * The number of generations when the lock has a regular shape: every device
- * track has the same arrival count (one arrival per generation) and a single
- * `deviceCount` that equals the number of distinct devices. Returns undefined
- * for an irregular shape (missing device, ragged tracks, count mismatch).
- */
-function regularGenerationCount(
-  tracks: Map<string, number[]>,
-  consistentCount: number | undefined,
-): number | undefined {
-  if (tracks.size === 0) {
-    return undefined;
-  }
-  if (consistentCount !== tracks.size) {
-    return undefined;
-  }
-  const arrivalCounts = new Set([...tracks.values()].map((list) => list.length));
-  if (arrivalCounts.size !== 1) {
-    return undefined;
-  }
-  return arrivalCounts.values().next().value as number;
-}
-
-/** Span of generation `gen` = [min, max] plan index of that column across tracks. */
-function columnSpan(lock: string, tracks: number[][], gen: number): GenerationSpan {
+/** Span of one coordinator generation's arrivals. */
+function spanForArrivals(lock: string, arrivals: Arrival[]): GenerationSpan {
   let firstIndex = Infinity;
   let lastIndex = -Infinity;
-  for (const track of tracks) {
-    const planIndex = track[gen];
+  for (const arrival of arrivals) {
+    const planIndex = arrival.planIndex;
     if (planIndex < firstIndex) {
       firstIndex = planIndex;
     }
@@ -198,12 +194,12 @@ function readDeviceCount(step: PlanStep): number | undefined {
 
 /**
  * Read the device label a step's track belongs to. Multi-device plans (the only
- * plans this guard sees, via executeParallel) tag every step with
- * `params.device`; anything else yields `undefined` and forces the conservative
- * single-span fallback for the lock.
+ * plans this guard sees, via executeParallel) tag every step with a device.
+ * Honor the validator's params-wins inline fallback so recovery sees the same
+ * normalized contract as execution.
  */
 function readDevice(step: PlanStep): string | undefined {
-  const device = step.params?.device;
+  const device = effectiveField(step, "device");
   return typeof device === "string" && device.length > 0 ? device : undefined;
 }
 

--- a/src/utils/plan/BarrierResumeGuard.ts
+++ b/src/utils/plan/BarrierResumeGuard.ts
@@ -63,14 +63,33 @@ interface Arrival {
  * back to one conservative span covering every arrival of the lock, so a
  * mid-lock resume still rewinds to the lock's first arrival rather than
  * splitting a generation.
+ *
+ * `deviceCount: 1` is a special case handled separately, BEFORE the
+ * device-track/column analysis below: a count-one lock completes a
+ * generation on every single arrival, regardless of which (or how many
+ * distinct) devices share it. The column model assumes a generation is
+ * filled by `deviceCount` DISTINCT devices arriving together — which never
+ * matches when more than one device uses a count-one lock (`tracks.size`
+ * exceeds the declared count of 1), so it fell through to the irregular,
+ * whole-lock fallback and rewound a resume past already-completed count-one
+ * arrivals for no reason (issue #6234 P2 follow-up review comment
+ * PRRC_kwDOP-GF5M7rVEIB).
  */
 function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
   if (arrivals.length === 0) {
     return [];
   }
 
+  const consistentCount = consistentDeviceCount(arrivals);
+  if (consistentCount === 1) {
+    // Every arrival satisfies the barrier by itself — span it as a singleton
+    // generation of one, so a resume point between two count-one arrivals
+    // never rewinds past one that already completed.
+    return arrivals.map((arrival) => singletonSpan(lock, arrival));
+  }
+
   const tracks = deviceTracks(arrivals);
-  const generationCount = regularGenerationCount(arrivals, tracks);
+  const generationCount = regularGenerationCount(tracks, consistentCount);
   if (generationCount === undefined) {
     // Irregular shape (missing device, ragged tracks, or a deviceCount that
     // disagrees with the device set) — plan validation would reject it, so span
@@ -84,6 +103,11 @@ function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
     spans.push(columnSpan(lock, trackLists, gen));
   }
   return spans;
+}
+
+/** The span of a single arrival that completes its generation by itself. */
+function singletonSpan(lock: string, arrival: Arrival): GenerationSpan {
+  return { lock, firstIndex: arrival.planIndex, lastIndex: arrival.planIndex };
 }
 
 /** The conservative single span covering every arrival of a lock. */
@@ -115,22 +139,30 @@ function deviceTracks(arrivals: Arrival[]): Map<string, number[]> {
 }
 
 /**
+ * The single `deviceCount` value declared consistently across `arrivals`, or
+ * undefined when it is missing or disagrees between arrivals of the same
+ * lock.
+ */
+function consistentDeviceCount(arrivals: Arrival[]): number | undefined {
+  const counts = new Set(
+    arrivals.map((a) => a.deviceCount).filter((c): c is number => typeof c === "number" && c >= 1),
+  );
+  return counts.size === 1 ? (counts.values().next().value as number) : undefined;
+}
+
+/**
  * The number of generations when the lock has a regular shape: every device
  * track has the same arrival count (one arrival per generation) and a single
  * `deviceCount` that equals the number of distinct devices. Returns undefined
  * for an irregular shape (missing device, ragged tracks, count mismatch).
  */
 function regularGenerationCount(
-  arrivals: Arrival[],
   tracks: Map<string, number[]>,
+  consistentCount: number | undefined,
 ): number | undefined {
   if (tracks.size === 0) {
     return undefined;
   }
-  const counts = new Set(
-    arrivals.map((a) => a.deviceCount).filter((c): c is number => typeof c === "number" && c >= 1),
-  );
-  const consistentCount = counts.size === 1 ? (counts.values().next().value as number) : undefined;
   if (consistentCount !== tracks.size) {
     return undefined;
   }

--- a/src/utils/plan/BarrierResumeGuard.ts
+++ b/src/utils/plan/BarrierResumeGuard.ts
@@ -1,0 +1,192 @@
+import { Plan, PlanStep } from "../../models/Plan";
+
+/**
+ * A contiguous span of plan indices that must be resumed *as a unit* — the
+ * arrivals belonging to one barrier generation (or one criticalSection
+ * rendezvous). Resuming strictly inside this span would re-run some
+ * participating device tracks' arrivals while skipping others', splitting the
+ * generation so it can never reach `deviceCount` and deadlocking the survivors
+ * at `CriticalSectionCoordinator.waitAtBarrier` (issue #6234).
+ */
+interface GenerationSpan {
+  lock: string;
+  /** Plan index of the first arrival in this generation. */
+  firstIndex: number;
+  /** Plan index of the last arrival in this generation. */
+  lastIndex: number;
+}
+
+const COORDINATION_TOOLS = new Set(["barrier", "criticalSection"]);
+
+/**
+ * Resolve a coordination field (`lock`/`deviceCount`) honoring PlanNormalizer's
+ * params-wins precedence, with an inline fallback for a step that reaches this
+ * guard before normalization. Mirrors `PlanValidator.effectiveField`.
+ */
+function effectiveField(step: PlanStep, field: string): unknown {
+  const params = step.params;
+  if (params && typeof params === "object" && Object.prototype.hasOwnProperty.call(params, field)) {
+    return (params as Record<string, unknown>)[field];
+  }
+  // oxlint-disable-next-line auto-mobile/no-unknown-cast
+  const inlineFields = step as unknown as Record<string, unknown>;
+  return inlineFields[field];
+}
+
+interface Arrival {
+  planIndex: number;
+  deviceCount: number | undefined;
+}
+
+/**
+ * Build the set of generation spans for one lock's ordered arrivals.
+ *
+ * When the lock has a single consistent, positive `deviceCount` N and its total
+ * arrivals divide evenly into N, arrivals are grouped into exact N-sized
+ * generations (the same generation model the barrier plan-validation checks
+ * use). Otherwise — an inconsistent or indivisible count that plan validation
+ * would already reject — we fall back to a single conservative span covering
+ * every arrival of the lock, so a mid-lock resume still rewinds to the lock's
+ * first arrival rather than splitting it.
+ */
+function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
+  if (arrivals.length === 0) {
+    return [];
+  }
+
+  const counts = new Set(
+    arrivals.map((a) => a.deviceCount).filter((c): c is number => typeof c === "number" && c >= 1),
+  );
+  const consistentCount = counts.size === 1 ? (counts.values().next().value as number) : undefined;
+
+  if (
+    consistentCount === undefined ||
+    consistentCount < 1 ||
+    arrivals.length % consistentCount !== 0
+  ) {
+    return [
+      {
+        lock,
+        firstIndex: arrivals[0].planIndex,
+        lastIndex: arrivals[arrivals.length - 1].planIndex,
+      },
+    ];
+  }
+
+  const spans: GenerationSpan[] = [];
+  for (let start = 0; start < arrivals.length; start += consistentCount) {
+    const group = arrivals.slice(start, start + consistentCount);
+    spans.push({
+      lock,
+      firstIndex: group[0].planIndex,
+      lastIndex: group[group.length - 1].planIndex,
+    });
+  }
+  return spans;
+}
+
+function readDeviceCount(step: PlanStep): number | undefined {
+  const rawCount = effectiveField(step, "deviceCount");
+  return typeof rawCount === "number" && Number.isInteger(rawCount) && rawCount >= 1
+    ? rawCount
+    : undefined;
+}
+
+function pushArrival(bucket: Map<string, Arrival[]>, lock: string, arrival: Arrival): void {
+  const arrivals = bucket.get(lock) ?? [];
+  arrivals.push(arrival);
+  bucket.set(lock, arrivals);
+}
+
+/**
+ * Collect the generation spans for every coordination lock in the plan, in plan
+ * order. `barrier` and `criticalSection` share the runtime coordinator's lock
+ * namespace, so both contribute spans. A criticalSection lock is a single-use
+ * rendezvous (validation enforces exactly `deviceCount` steps, one per device),
+ * so all its steps form one generation.
+ */
+function collectGenerationSpans(plan: Plan): GenerationSpan[] {
+  const barrierArrivals = new Map<string, Arrival[]>();
+  const criticalSectionArrivals = new Map<string, Arrival[]>();
+
+  for (let planIndex = 0; planIndex < plan.steps.length; planIndex++) {
+    const step = plan.steps[planIndex];
+    if (!COORDINATION_TOOLS.has(step.tool)) {
+      continue;
+    }
+    const lock = effectiveField(step, "lock");
+    if (typeof lock !== "string" || lock.length === 0) {
+      continue;
+    }
+    const bucket = step.tool === "barrier" ? barrierArrivals : criticalSectionArrivals;
+    pushArrival(bucket, lock, { planIndex, deviceCount: readDeviceCount(step) });
+  }
+
+  const spans: GenerationSpan[] = [];
+  for (const [lock, arrivals] of barrierArrivals.entries()) {
+    spans.push(...spansForLock(lock, arrivals));
+  }
+  for (const [lock, arrivals] of criticalSectionArrivals.entries()) {
+    // A criticalSection lock is one rendezvous: every step sharing it belongs to
+    // the same generation regardless of the per-step deviceCount, so span the
+    // whole set rather than slicing it into N-sized groups.
+    if (arrivals.length > 0) {
+      spans.push({
+        lock,
+        firstIndex: arrivals[0].planIndex,
+        lastIndex: arrivals[arrivals.length - 1].planIndex,
+      });
+    }
+  }
+  return spans;
+}
+
+/**
+ * Compute a resume step that never lands *inside* a barrier/criticalSection
+ * generation.
+ *
+ * AI recovery resumes a failed plan at the failed global step index, and
+ * `PlanExecutor` skips lower-indexed steps independently per device track. If
+ * that resume index falls in the middle of a barrier generation — after some
+ * participating arrivals but before others — the survivors re-arrive alone and
+ * wait forever for partners whose arrivals were skipped, deadlocking to the
+ * barrier timeout (issue #6234).
+ *
+ * This rewinds the requested `startStep` down to the first arrival of any
+ * generation it would split, so the whole generation re-arrives together (fix
+ * direction 1 in the issue: rewind across the complete barrier generation).
+ * Rewinding can move the resume point into an earlier, overlapping generation
+ * (interleaved barriers), so it iterates to a fixed point. A resume point that
+ * does not split any generation is returned unchanged, so ordinary recovery is
+ * unaffected.
+ *
+ * @returns the safe resume step (<= startStep, >= 0).
+ */
+export function computeSafeBarrierResumeStep(plan: Plan, startStep: number): number {
+  if (startStep <= 0) {
+    return startStep;
+  }
+  const spans = collectGenerationSpans(plan);
+  if (spans.length === 0) {
+    return startStep;
+  }
+
+  let safe = startStep;
+  // Rewinding to one generation's start can uncover another generation that now
+  // straddles the new resume point; iterate until no span is split. Each pass
+  // moves `safe` to the earliest first-arrival among the spans it currently
+  // splits, so `safe` strictly decreases and is bounded below by the smallest
+  // firstIndex — the loop terminates.
+  for (;;) {
+    let earliest = safe;
+    for (const span of spans) {
+      if (span.firstIndex < safe && safe <= span.lastIndex && span.firstIndex < earliest) {
+        earliest = span.firstIndex;
+      }
+    }
+    if (earliest === safe) {
+      return safe;
+    }
+    safe = earliest;
+  }
+}

--- a/src/utils/plan/BarrierResumeGuard.ts
+++ b/src/utils/plan/BarrierResumeGuard.ts
@@ -36,53 +36,125 @@ function effectiveField(step: PlanStep, field: string): unknown {
 interface Arrival {
   planIndex: number;
   deviceCount: number | undefined;
+  /** The device label (`params.device`) whose track executes this arrival. */
+  device: string | undefined;
 }
 
 /**
  * Build the set of generation spans for one lock's ordered arrivals.
  *
- * When the lock has a single consistent, positive `deviceCount` N and its total
- * arrivals divide evenly into N, arrivals are grouped into exact N-sized
- * generations (the same generation model the barrier plan-validation checks
- * use). Otherwise — an inconsistent or indivisible count that plan validation
- * would already reject — we fall back to a single conservative span covering
- * every arrival of the lock, so a mid-lock resume still rewinds to the lock's
- * first arrival rather than splitting it.
+ * A barrier generation is NOT a contiguous slice of the global plan order — the
+ * device tracks run concurrently, each executing its own arrivals in track
+ * order. `CriticalSectionCoordinator` fills a generation with one arrival per
+ * distinct device and resets once `deviceCount` distinct devices have arrived,
+ * so generation `g` is the `g`-th arrival of *every* participating device's
+ * track, whichever global indices those land on. For a device-grouped plan
+ * order like `A@0, A@1, B@2, B@3` (deviceCount 2) the real generations are
+ * `{0,2}` and `{1,3}` — the "column" across tracks — not the contiguous
+ * `{0,1}`/`{2,3}` a global-order slice would produce.
+ *
+ * We therefore reconstruct each device's track (its arrivals in plan order) and
+ * read them off column-by-column: column `g` across all tracks is generation
+ * `g`, and its span is `[min planIndex, max planIndex]` of that column.
+ *
+ * When the shape is irregular in a way plan validation would already reject —
+ * an arrival missing its device label, ragged per-device arrival counts, or a
+ * `deviceCount` that disagrees with the number of distinct devices — we fall
+ * back to one conservative span covering every arrival of the lock, so a
+ * mid-lock resume still rewinds to the lock's first arrival rather than
+ * splitting a generation.
  */
 function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
   if (arrivals.length === 0) {
     return [];
   }
 
+  const tracks = deviceTracks(arrivals);
+  const generationCount = regularGenerationCount(arrivals, tracks);
+  if (generationCount === undefined) {
+    // Irregular shape (missing device, ragged tracks, or a deviceCount that
+    // disagrees with the device set) — plan validation would reject it, so span
+    // the whole lock and let a mid-lock resume rewind to its first arrival.
+    return [wholeLockSpan(lock, arrivals)];
+  }
+
+  const trackLists = [...tracks.values()];
+  const spans: GenerationSpan[] = [];
+  for (let gen = 0; gen < generationCount; gen++) {
+    spans.push(columnSpan(lock, trackLists, gen));
+  }
+  return spans;
+}
+
+/** The conservative single span covering every arrival of a lock. */
+function wholeLockSpan(lock: string, arrivals: Arrival[]): GenerationSpan {
+  return {
+    lock,
+    firstIndex: arrivals[0].planIndex,
+    lastIndex: arrivals[arrivals.length - 1].planIndex,
+  };
+}
+
+/**
+ * Reconstruct each device's track (its arrivals' plan indices in plan order).
+ * Iterating in plan order preserves per-device track order, so the k-th entry of
+ * a device's list is that device's k-th arrival at the lock. Returns null when
+ * any arrival is missing its device label.
+ */
+function deviceTracks(arrivals: Arrival[]): Map<string, number[]> {
+  const perDevice = new Map<string, number[]>();
+  for (const arrival of arrivals) {
+    if (arrival.device === undefined) {
+      return new Map();
+    }
+    const list = perDevice.get(arrival.device) ?? [];
+    list.push(arrival.planIndex);
+    perDevice.set(arrival.device, list);
+  }
+  return perDevice;
+}
+
+/**
+ * The number of generations when the lock has a regular shape: every device
+ * track has the same arrival count (one arrival per generation) and a single
+ * `deviceCount` that equals the number of distinct devices. Returns undefined
+ * for an irregular shape (missing device, ragged tracks, count mismatch).
+ */
+function regularGenerationCount(
+  arrivals: Arrival[],
+  tracks: Map<string, number[]>,
+): number | undefined {
+  if (tracks.size === 0) {
+    return undefined;
+  }
   const counts = new Set(
     arrivals.map((a) => a.deviceCount).filter((c): c is number => typeof c === "number" && c >= 1),
   );
   const consistentCount = counts.size === 1 ? (counts.values().next().value as number) : undefined;
-
-  if (
-    consistentCount === undefined ||
-    consistentCount < 1 ||
-    arrivals.length % consistentCount !== 0
-  ) {
-    return [
-      {
-        lock,
-        firstIndex: arrivals[0].planIndex,
-        lastIndex: arrivals[arrivals.length - 1].planIndex,
-      },
-    ];
+  if (consistentCount !== tracks.size) {
+    return undefined;
   }
-
-  const spans: GenerationSpan[] = [];
-  for (let start = 0; start < arrivals.length; start += consistentCount) {
-    const group = arrivals.slice(start, start + consistentCount);
-    spans.push({
-      lock,
-      firstIndex: group[0].planIndex,
-      lastIndex: group[group.length - 1].planIndex,
-    });
+  const arrivalCounts = new Set([...tracks.values()].map((list) => list.length));
+  if (arrivalCounts.size !== 1) {
+    return undefined;
   }
-  return spans;
+  return arrivalCounts.values().next().value as number;
+}
+
+/** Span of generation `gen` = [min, max] plan index of that column across tracks. */
+function columnSpan(lock: string, tracks: number[][], gen: number): GenerationSpan {
+  let firstIndex = Infinity;
+  let lastIndex = -Infinity;
+  for (const track of tracks) {
+    const planIndex = track[gen];
+    if (planIndex < firstIndex) {
+      firstIndex = planIndex;
+    }
+    if (planIndex > lastIndex) {
+      lastIndex = planIndex;
+    }
+  }
+  return { lock, firstIndex, lastIndex };
 }
 
 function readDeviceCount(step: PlanStep): number | undefined {
@@ -90,6 +162,17 @@ function readDeviceCount(step: PlanStep): number | undefined {
   return typeof rawCount === "number" && Number.isInteger(rawCount) && rawCount >= 1
     ? rawCount
     : undefined;
+}
+
+/**
+ * Read the device label a step's track belongs to. Multi-device plans (the only
+ * plans this guard sees, via executeParallel) tag every step with
+ * `params.device`; anything else yields `undefined` and forces the conservative
+ * single-span fallback for the lock.
+ */
+function readDevice(step: PlanStep): string | undefined {
+  const device = step.params?.device;
+  return typeof device === "string" && device.length > 0 ? device : undefined;
 }
 
 function pushArrival(bucket: Map<string, Arrival[]>, lock: string, arrival: Arrival): void {
@@ -119,7 +202,11 @@ function collectGenerationSpans(plan: Plan): GenerationSpan[] {
       continue;
     }
     const bucket = step.tool === "barrier" ? barrierArrivals : criticalSectionArrivals;
-    pushArrival(bucket, lock, { planIndex, deviceCount: readDeviceCount(step) });
+    pushArrival(bucket, lock, {
+      planIndex,
+      deviceCount: readDeviceCount(step),
+      device: readDevice(step),
+    });
   }
 
   const spans: GenerationSpan[] = [];

--- a/src/utils/plan/BarrierResumeGuard.ts
+++ b/src/utils/plan/BarrierResumeGuard.ts
@@ -100,12 +100,34 @@ function spansForLock(lock: string, arrivals: Arrival[]): GenerationSpan[] {
   const spans: GenerationSpan[] = [];
   for (let remaining = arrivals.length; remaining > 0; remaining -= consistentCount) {
     const nextArrivals = [...tracks.entries()]
-      .map(([device, track]) => ({ device, arrival: track[consumed.get(device) ?? 0] }))
+      .map(([device, track]) => ({
+        device,
+        arrival: track[consumed.get(device) ?? 0],
+        // Arrivals remaining on this device's track AFTER the candidate one,
+        // used to prioritize devices with more outstanding work (see sort
+        // comment below).
+        remainingAfter: track.length - (consumed.get(device) ?? 0) - 1,
+      }))
       .filter(
-        (candidate): candidate is { device: string; arrival: Arrival } =>
+        (candidate): candidate is { device: string; arrival: Arrival; remainingAfter: number } =>
           candidate.arrival !== undefined,
       )
-      .sort((a, b) => a.arrival.planIndex - b.arrival.planIndex);
+      .sort((a, b) => {
+        // Prefer devices with the MOST outstanding arrivals first (a
+        // Havel-Hakimi-style greedy for realizing the per-device arrival-count
+        // sequence as deviceCount-sized generations). Picking by earliest plan
+        // index alone can strand a low-count device's only candidate for a
+        // later round — e.g. arrivals B,C,A,A,A,D (deviceCount 2): taking the
+        // earliest two (B,C) first leaves only A's track for round two and
+        // falsely reports the validator-accepted plan as unrecoverable, when
+        // {A,B},{A,C},{A,D} is a valid grouping. Saturating the
+        // most-outstanding device (A) every round reaches that grouping.
+        // Ties break on plan index for determinism.
+        if (a.remainingAfter !== b.remainingAfter) {
+          return b.remainingAfter - a.remainingAfter;
+        }
+        return a.arrival.planIndex - b.arrival.planIndex;
+      });
     if (nextArrivals.length < consistentCount) {
       throw invalidBarrierRecoveryShape(
         lock,
@@ -257,6 +279,104 @@ function collectGenerationSpans(plan: Plan): GenerationSpan[] {
 }
 
 /**
+ * Detect a circular-wait risk among the arrivals still to run at/after `safe`:
+ * two (or more) devices whose remaining tracks visit the same pair of locks in
+ * OPPOSITE order. Per-lock generation spans (`spansForLock`) only prove that a
+ * single lock's own generations are not split; they say nothing about the
+ * order in which a device visits *different* locks. If device D1's remaining
+ * track visits lock X before lock Y while device D2's visits Y before X, each
+ * can block waiting for a partner that is itself stuck at the other lock —
+ * e.g. `A:X, B:X, A:Y, A:X, C:X, C:Y` (all deviceCount 2): resuming at 2 skips
+ * B entirely but leaves A on `Y→X` and C on `X→Y`; A waits alone at Y for C,
+ * who is waiting alone at X for A (issue #6234 cross-lock P1). Neither lock's
+ * own span is split, so the per-lock check alone misses it.
+ *
+ * A single device revisiting the same two locks in both orders over time is
+ * NOT itself a deadlock risk (nothing else waits on that device while it does
+ * so), so a conflict is only real when it involves two DIFFERENT devices.
+ */
+function hasCrossLockCycle(plan: Plan, safe: number): boolean {
+  const deviceLockOrder = collectDeviceLockOrder(plan, safe);
+  return hasOpposingLockPair(deviceLockOrder);
+}
+
+/**
+ * For each device, the distinct locks it still visits at/after `safe`, in
+ * track order (consecutive repeats of the same lock collapsed to one entry).
+ */
+function collectDeviceLockOrder(plan: Plan, safe: number): Map<string, string[]> {
+  const deviceLockOrder = new Map<string, string[]>();
+  for (let planIndex = safe; planIndex < plan.steps.length; planIndex++) {
+    const step = plan.steps[planIndex];
+    if (!COORDINATION_TOOLS.has(step.tool)) {
+      continue;
+    }
+    const lock = effectiveField(step, "lock");
+    const device = readDevice(step);
+    if (typeof lock !== "string" || lock.length === 0 || device === undefined) {
+      continue;
+    }
+    const order = deviceLockOrder.get(device) ?? [];
+    if (order[order.length - 1] !== lock) {
+      order.push(lock);
+    }
+    deviceLockOrder.set(device, order);
+  }
+  return deviceLockOrder;
+}
+
+/**
+ * True when two DIFFERENT devices' lock orders assert opposite directions for
+ * the same unordered lock pair (see `hasCrossLockCycle`). A single device
+ * revisiting a pair in both orders never conflicts with itself.
+ */
+function hasOpposingLockPair(deviceLockOrder: Map<string, string[]>): boolean {
+  // For each unordered lock pair (keyed by the lexicographically smaller lock
+  // name, then the larger — a nested map avoids gluing lock names into one
+  // string key, which could collide if a name contained the delimiter),
+  // remember the first direction seen and which device established it. A
+  // later, different device asserting the opposite direction for the same
+  // pair is a genuine circular-wait risk.
+  const directionByPair = new Map<string, Map<string, { forward: boolean; device: string }>>();
+  for (const [device, order] of deviceLockOrder.entries()) {
+    for (let i = 0; i + 1 < order.length; i++) {
+      if (opposesEarlierDevice(directionByPair, order[i], order[i + 1], device)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Records (or checks) the direction of one from->to transition for `device`
+ * against the first direction seen for that unordered pair. Returns true only
+ * when a DIFFERENT device already recorded the opposite direction.
+ */
+function opposesEarlierDevice(
+  directionByPair: Map<string, Map<string, { forward: boolean; device: string }>>,
+  from: string,
+  to: string,
+  device: string,
+): boolean {
+  if (from === to) {
+    return false;
+  }
+  const lesser = from < to ? from : to;
+  const greater = from < to ? to : from;
+  const forward = from === lesser;
+  const byGreater =
+    directionByPair.get(lesser) ?? new Map<string, { forward: boolean; device: string }>();
+  directionByPair.set(lesser, byGreater);
+  const existing = byGreater.get(greater);
+  if (existing === undefined) {
+    byGreater.set(greater, { forward, device });
+    return false;
+  }
+  return existing.forward !== forward && existing.device !== device;
+}
+
+/**
  * Compute a resume step that never lands *inside* a barrier/criticalSection
  * generation.
  *
@@ -300,8 +420,18 @@ export function computeSafeBarrierResumeStep(plan: Plan, startStep: number): num
       }
     }
     if (earliest === safe) {
-      return safe;
+      break;
     }
     safe = earliest;
   }
+
+  // No single lock's generation is split at `safe`, but the survivors could
+  // still deadlock on a cross-lock circular wait (see hasCrossLockCycle). That
+  // risk cannot be fixed by rewinding to any one span's start — the safe
+  // fallback is to replay the whole plan, which is known deadlock-free because
+  // it passed barrier validation as originally written.
+  if (safe > 0 && hasCrossLockCycle(plan, safe)) {
+    return 0;
+  }
+  return safe;
 }

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -19,6 +19,7 @@ import {
 import { throwIfAborted, getStructuredPayload } from "../toolUtils";
 import { ZodError } from "zod/v4";
 import { PlanPartitioner, TrackedStep } from "./PlanPartitioner";
+import { computeSafeBarrierResumeStep } from "./BarrierResumeGuard";
 import { DaemonState } from "../../daemon/daemonState";
 import { Timer, defaultTimer } from "../SystemTimer";
 import type { FailureObservationSummary } from "../../models/FailureObservation";
@@ -814,6 +815,23 @@ export class DefaultPlanExecutor implements PlanExecutor {
     executionOptions?: PlanExecutionOptions,
   ): Promise<PlanExecutionResult> {
     const debugMode = isDebugModeEnabled();
+
+    // AI recovery resumes a failed plan at its failed global step index, and each
+    // device track skips lower-indexed steps independently. If that resume index
+    // falls in the middle of a barrier/criticalSection generation, some devices'
+    // arrivals would be skipped while their partners' re-run, splitting the
+    // generation so it never reaches deviceCount and the survivors deadlock at
+    // waitAtBarrier (issue #6234). Rewind the resume point to the start of any
+    // generation it would split so every participant re-arrives together; a
+    // resume point that splits nothing is returned unchanged.
+    const effectiveStartStep = computeSafeBarrierResumeStep(plan, startStep);
+    if (effectiveStartStep !== startStep) {
+      logger.info(
+        `[PARALLEL_EXEC] Rewinding resume step ${startStep} -> ${effectiveStartStep} to avoid ` +
+          "resuming inside a barrier generation (issue #6234)",
+      );
+    }
+    startStep = effectiveStartStep;
 
     logger.info(
       `[PARALLEL_EXEC] Starting parallel execution for ${partitionedPlan.devices.length} devices`,

--- a/test/plan/BarrierResumeGuard.test.ts
+++ b/test/plan/BarrierResumeGuard.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { computeSafeBarrierResumeStep } from "../../src/utils/plan/BarrierResumeGuard";
+import { Plan } from "../../src/models/Plan";
+
+/**
+ * Regression coverage for issue #6234: AI recovery must not resume in the middle
+ * of a barrier generation. computeSafeBarrierResumeStep rewinds a requested
+ * resume step to the start of any barrier/criticalSection generation it would
+ * split, and leaves a clean resume point untouched.
+ */
+describe("computeSafeBarrierResumeStep (#6234)", () => {
+  const barrierStep = (device: string, lock: string, deviceCount: number) => ({
+    tool: "barrier",
+    params: { device, lock, deviceCount },
+  });
+
+  const actionStep = (device: string) => ({
+    tool: "tapOn",
+    params: { device, text: "ok" },
+  });
+
+  const plan = (steps: Plan["steps"]): Plan => ({
+    name: "barrier-plan",
+    mcpVersion: "1.0",
+    devices: ["A", "B"],
+    steps,
+  });
+
+  test("rewinds a resume step landing inside a barrier generation to the generation start", () => {
+    // step 0: A arrives, step 1: B arrives (deviceCount=2 -> one generation
+    // spanning [0,1]). Resuming at 1 would re-run B alone while A's arrival is
+    // skipped -> B waits forever. Rewind to 0 so both re-arrive together.
+    const p = plan([barrierStep("A", "L", 2), barrierStep("B", "L", 2), actionStep("A")]);
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
+  });
+
+  test("leaves a resume step at the generation boundary unchanged", () => {
+    // Resuming at 0 runs the whole generation from its first arrival — no split.
+    const p = plan([barrierStep("A", "L", 2), barrierStep("B", "L", 2), actionStep("A")]);
+    expect(computeSafeBarrierResumeStep(p, 0)).toBe(0);
+  });
+
+  test("does not rewind a resume step past a fully-completed generation", () => {
+    // Resuming at 2 (after both arrivals) skips the whole generation uniformly
+    // across every track — no participant re-arrives, so nothing to rewind.
+    const p = plan([
+      barrierStep("A", "L", 2),
+      barrierStep("B", "L", 2),
+      actionStep("A"),
+      actionStep("B"),
+    ]);
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(2);
+    expect(computeSafeBarrierResumeStep(p, 3)).toBe(3);
+  });
+
+  test("rewinds only across the straddled generation, not earlier completed ones", () => {
+    // Two generations of lock L: gen0 = [0,1], gen1 = [3,4], with an action at 2.
+    // Resuming at 4 splits gen1 (arrival at 3 skipped, 4 re-run) -> rewind to 3,
+    // NOT back to gen0's start at 0.
+    const p = plan([
+      barrierStep("A", "L", 2), // 0  gen0
+      barrierStep("B", "L", 2), // 1  gen0
+      actionStep("A"), // 2
+      barrierStep("A", "L", 2), // 3  gen1
+      barrierStep("B", "L", 2), // 4  gen1
+    ]);
+    expect(computeSafeBarrierResumeStep(p, 4)).toBe(3);
+    // Resuming inside gen0 rewinds only to gen0's start.
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
+  });
+
+  test("iterates to a fixed point across interleaved barrier locks", () => {
+    // Two locks whose generations interleave in plan order:
+    //   X: [0,2]  (A@0, B@2)
+    //   Y: [1,3]  (A@1, B@3)
+    // Resuming at 3 splits Y -> rewind to 1; 1 then splits X ([0,2]) -> rewind to 0.
+    const p = plan([
+      barrierStep("A", "X", 2), // 0  X gen
+      barrierStep("A", "Y", 2), // 1  Y gen
+      barrierStep("B", "X", 2), // 2  X gen
+      barrierStep("B", "Y", 2), // 3  Y gen
+    ]);
+    expect(computeSafeBarrierResumeStep(p, 3)).toBe(0);
+  });
+
+  test("treats a criticalSection lock as a single generation", () => {
+    const p = plan([
+      { tool: "criticalSection", params: { device: "A", lock: "cs", deviceCount: 2, steps: [] } },
+      { tool: "criticalSection", params: { device: "B", lock: "cs", deviceCount: 2, steps: [] } },
+      actionStep("A"),
+    ]);
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(2);
+  });
+
+  test("leaves plans without coordination steps unchanged", () => {
+    const p = plan([actionStep("A"), actionStep("B"), actionStep("A")]);
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(2);
+  });
+
+  test("never returns a negative or above-request resume step", () => {
+    const p = plan([barrierStep("A", "L", 2), barrierStep("B", "L", 2)]);
+    expect(computeSafeBarrierResumeStep(p, 0)).toBe(0);
+    expect(computeSafeBarrierResumeStep(p, -3)).toBe(-3);
+  });
+});

--- a/test/plan/BarrierResumeGuard.test.ts
+++ b/test/plan/BarrierResumeGuard.test.ts
@@ -220,4 +220,70 @@ describe("computeSafeBarrierResumeStep (#6234)", () => {
     // one-arrival generation.
     expect(computeSafeBarrierResumeStep(p, 1)).toBe(1);
   });
+
+  test("saturates the device with the most outstanding arrivals first, not the earliest plan index (#6234 P2 follow-up)", () => {
+    // Arrivals B,C,A,A,A,D (deviceCount 2): the full plan can execute as
+    // {A,B},{A,C},{A,D}. Greedily taking the earliest two arrivals each round
+    // (B@0,C@1) strands A alone for round two and falsely rejects this
+    // validator-accepted plan. Saturating A (the device with the most
+    // outstanding arrivals) every round reaches the valid grouping instead.
+    const p: Plan = {
+      name: "changing-participants-saturating",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C", "D"],
+      steps: [
+        barrierStep("B", "L", 2), // 0
+        barrierStep("C", "L", 2), // 1
+        barrierStep("A", "L", 2), // 2  gen0 = {A@2,B@0}
+        barrierStep("A", "L", 2), // 3  gen1 = {A@3,C@1}
+        barrierStep("A", "L", 2), // 4  gen2 = {A@4,D@5}
+        barrierStep("D", "L", 2), // 5
+      ],
+    };
+    // Does not throw, and 4 is exactly the start of the last generation
+    // (no participants skipped, no destructive work replayed).
+    expect(() => computeSafeBarrierResumeStep(p, 4)).not.toThrow();
+    expect(computeSafeBarrierResumeStep(p, 4)).toBe(4);
+  });
+
+  test("rewinds to 0 when surviving devices would circular-wait across two locks (#6234 P1 cross-lock)", () => {
+    // A:X, B:X, A:Y, A:X, C:X, C:Y (all deviceCount 2). Resuming at 2 splits no
+    // single lock's own generation (X gets {A@0,B@1} then {A@3,C@4}; Y gets
+    // {A@2,C@5}), so the per-lock check alone reports 2 as clean. But resuming
+    // at 2 skips B's only arrival entirely, leaving A's remaining track as
+    // Y->X and C's as X->Y: A blocks alone at Y waiting for a partner while C
+    // blocks alone at X waiting for a partner who is itself stuck at Y. Both
+    // barriers time out. The only safe answer is to replay the whole plan.
+    const p: Plan = {
+      name: "cross-lock-circular-wait",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C"],
+      steps: [
+        barrierStep("A", "X", 2), // 0
+        barrierStep("B", "X", 2), // 1
+        barrierStep("A", "Y", 2), // 2
+        barrierStep("A", "X", 2), // 3
+        barrierStep("C", "X", 2), // 4
+        barrierStep("C", "Y", 2), // 5
+      ],
+    };
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(0);
+  });
+
+  test("does not flag a single device revisiting two locks in both orders as a cross-lock cycle", () => {
+    // Only device A ever alternates between X and Y; nothing else depends on
+    // A while it does so, so there is no partner to deadlock against.
+    const p: Plan = {
+      name: "single-device-revisit",
+      mcpVersion: "1.0",
+      devices: ["A", "B"],
+      steps: [
+        barrierStep("A", "X", 1), // 0
+        barrierStep("A", "Y", 1), // 1
+        barrierStep("A", "X", 1), // 2
+        barrierStep("B", "X", 1), // 3
+      ],
+    };
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(1);
+  });
 });

--- a/test/plan/BarrierResumeGuard.test.ts
+++ b/test/plan/BarrierResumeGuard.test.ts
@@ -171,4 +171,30 @@ describe("computeSafeBarrierResumeStep (#6234)", () => {
     expect(computeSafeBarrierResumeStep(p, 0)).toBe(0);
     expect(computeSafeBarrierResumeStep(p, -3)).toBe(-3);
   });
+
+  test("treats deviceCount=1 arrivals as singleton generations, never grouping them by device track (#6234 P2 follow-up)", () => {
+    // deviceCount=1 means EVERY arrival completes its own generation
+    // immediately, regardless of which (or how many distinct) devices share
+    // the lock. The device-track/column model used for deviceCount>1 assumes
+    // a generation is filled by `deviceCount` distinct devices arriving
+    // together, which never holds here (two distinct devices, A and B, share
+    // a count-one lock) - it used to fall through to the irregular, whole-
+    // lock fallback and needlessly rewind past an already-completed arrival.
+    const p = plan([
+      barrierStep("A", "L", 1), // 0  A's own generation, already complete
+      actionStep("A"), // 1  destructive action, already run
+      actionStep("B"), // 2  the step that failed and triggered recovery
+      barrierStep("B", "L", 1), // 3  B's own generation, not yet reached
+    ]);
+    // Resuming at the failed step (2) does not split any generation: A's
+    // count-one arrival at 0 already completed on its own, and B's at 3
+    // has not happened yet. There is nothing to rewind for.
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(2);
+    // Resuming exactly at a count-one arrival is likewise a clean boundary.
+    expect(computeSafeBarrierResumeStep(p, 3)).toBe(3);
+    // Resuming strictly between the two singleton arrivals (e.g. at the
+    // destructive action) is also clean - it does not land inside either
+    // one-arrival generation.
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(1);
+  });
 });

--- a/test/plan/BarrierResumeGuard.test.ts
+++ b/test/plan/BarrierResumeGuard.test.ts
@@ -69,6 +69,74 @@ describe("computeSafeBarrierResumeStep (#6234)", () => {
     expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
   });
 
+  test("groups generations by device-track order, not contiguous global index", () => {
+    // Device-grouped plan order: device A's two arrivals (0,1) precede device B's
+    // two arrivals (2,3). A global-order slice would wrongly pair {0,1} and {2,3},
+    // but the coordinator rendezvous is the g-th arrival of EACH device track:
+    //   gen0 = A@0 + B@2  (span [0,2])
+    //   gen1 = A@1 + B@3  (span [1,3])
+    const p = plan([
+      barrierStep("A", "L", 2), // 0  A arrival #0 -> gen0
+      barrierStep("A", "L", 2), // 1  A arrival #1 -> gen1
+      barrierStep("B", "L", 2), // 2  B arrival #0 -> gen0
+      barrierStep("B", "L", 2), // 3  B arrival #1 -> gen1
+    ]);
+    // Resume at 2 splits gen0 ([0,2]): A@0 would be skipped while B@2 re-arrives
+    // alone. The old global-slice guard saw span {2,3}, left 2 unchanged, and the
+    // survivor still deadlocked. Rewinding to gen0's first arrival (0) re-arrives
+    // A@0/B@2 together and then gen1.
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(0);
+    // Resume at 3 splits gen1 ([1,3]) -> rewind to 1, which then splits gen0
+    // ([0,2]) -> rewind to 0. (Old guard rewound only to 2 and still deadlocked.)
+    expect(computeSafeBarrierResumeStep(p, 3)).toBe(0);
+    // A clean boundary (gen0's first arrival) is untouched.
+    expect(computeSafeBarrierResumeStep(p, 0)).toBe(0);
+    // Resume at 1 splits gen0 ([0,2]) -> rewind to 0.
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
+  });
+
+  test("handles a three-device lock grouped by track order", () => {
+    // A@0,A@1 | B@2,B@3 | C@4,C@5 with deviceCount=3.
+    //   gen0 = {0,2,4} span [0,4]
+    //   gen1 = {1,3,5} span [1,5]
+    const p: Plan = {
+      name: "barrier-plan",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C"],
+      steps: [
+        barrierStep("A", "L", 3), // 0 gen0
+        barrierStep("A", "L", 3), // 1 gen1
+        barrierStep("B", "L", 3), // 2 gen0
+        barrierStep("B", "L", 3), // 3 gen1
+        barrierStep("C", "L", 3), // 4 gen0
+        barrierStep("C", "L", 3), // 5 gen1
+      ],
+    };
+    // Resume at 5 splits gen1 ([1,5]) -> 1 -> gen0 ([0,4]) straddles 1 -> 0.
+    expect(computeSafeBarrierResumeStep(p, 5)).toBe(0);
+    // Resume at 4 splits gen0 ([0,4]) -> 0.
+    expect(computeSafeBarrierResumeStep(p, 4)).toBe(0);
+  });
+
+  test("falls back to one conservative span when deviceCount disagrees with device set", () => {
+    // deviceCount=2 but three distinct devices each arrive once: plan validation
+    // would reject this, and the coordinator cannot form a clean generation. The
+    // guard spans the whole lock so any mid-lock resume rewinds to the first
+    // arrival rather than splitting.
+    const p: Plan = {
+      name: "barrier-plan",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C"],
+      steps: [
+        barrierStep("A", "L", 2), // 0
+        barrierStep("B", "L", 2), // 1
+        barrierStep("C", "L", 2), // 2
+      ],
+    };
+    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(0);
+  });
+
   test("iterates to a fixed point across interleaved barrier locks", () => {
     // Two locks whose generations interleave in plan order:
     //   X: [0,2]  (A@0, B@2)

--- a/test/plan/BarrierResumeGuard.test.ts
+++ b/test/plan/BarrierResumeGuard.test.ts
@@ -118,11 +118,10 @@ describe("computeSafeBarrierResumeStep (#6234)", () => {
     expect(computeSafeBarrierResumeStep(p, 4)).toBe(0);
   });
 
-  test("falls back to one conservative span when deviceCount disagrees with device set", () => {
+  test("rejects an invalid barrier shape instead of replaying the entire lock", () => {
     // deviceCount=2 but three distinct devices each arrive once: plan validation
-    // would reject this, and the coordinator cannot form a clean generation. The
-    // guard spans the whole lock so any mid-lock resume rewinds to the first
-    // arrival rather than splitting.
+    // would reject this, and the coordinator cannot form a clean generation.
+    // Recovery must reject the plan rather than guess and replay completed work.
     const p: Plan = {
       name: "barrier-plan",
       mcpVersion: "1.0",
@@ -133,8 +132,32 @@ describe("computeSafeBarrierResumeStep (#6234)", () => {
         barrierStep("C", "L", 2), // 2
       ],
     };
-    expect(computeSafeBarrierResumeStep(p, 1)).toBe(0);
-    expect(computeSafeBarrierResumeStep(p, 2)).toBe(0);
+    expect(() => computeSafeBarrierResumeStep(p, 1)).toThrow("Cannot safely recover barrier lock");
+    expect(() => computeSafeBarrierResumeStep(p, 2)).toThrow("Cannot safely recover barrier lock");
+  });
+
+  test("uses per-device frontiers for validator-permitted changing participant sets", () => {
+    // Generation 0 is A+B; after its release, A's next arrival pairs with C.
+    // The validator permits this (four arrivals, count two, no device appears
+    // more than twice). The old equal-column model classified it as ragged and
+    // rewound start=4 all the way to 0, replaying the completed A+B round and
+    // the destructive action at 2. Recovery must rewind only to A+C's start.
+    const p: Plan = {
+      name: "changing-participants",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C"],
+      steps: [
+        barrierStep("A", "L", 2), // 0 generation 0
+        barrierStep("B", "L", 2), // 1 generation 0
+        actionStep("B"), // 2 already-completed destructive work
+        barrierStep("A", "L", 2), // 3 generation 1
+        barrierStep("C", "L", 2), // 4 generation 1
+      ],
+    };
+
+    expect(computeSafeBarrierResumeStep(p, 4)).toBe(3);
+    expect(computeSafeBarrierResumeStep(p, 3)).toBe(3);
+    expect(computeSafeBarrierResumeStep(p, 2)).toBe(2);
   });
 
   test("iterates to a fixed point across interleaved barrier locks", () => {

--- a/test/plan/planExecutorBarrierResume.test.ts
+++ b/test/plan/planExecutorBarrierResume.test.ts
@@ -18,10 +18,12 @@ import { z } from "zod/v4";
 describe("PlanExecutor barrier-generation resume (#6234)", () => {
   let planExecutor: DefaultPlanExecutor;
   let barrierArrivals: string[];
+  let actionArrivals: string[];
 
   beforeEach(() => {
     planExecutor = new DefaultPlanExecutor();
     barrierArrivals = [];
+    actionArrivals = [];
 
     const daemonState = DaemonState.getInstance();
     if (daemonState.isInitialized()) {
@@ -55,7 +57,10 @@ describe("PlanExecutor barrier-generation resume (#6234)", () => {
       "fakeAction",
       "Fake action tool for #6234 resume test",
       actionSchema,
-      mock(async () => ({ success: true })),
+      mock(async (params: any) => {
+        actionArrivals.push(params.device);
+        return { success: true };
+      }),
     );
   });
 
@@ -103,5 +108,26 @@ describe("PlanExecutor barrier-generation resume (#6234)", () => {
 
     expect(result.success).toBe(true);
     expect(barrierArrivals.sort()).toEqual(["A", "B"]);
+  });
+
+  test("recovery replays only the changing-participant generation, not completed destructive work", async () => {
+    const plan: Plan = {
+      name: "changing-barrier-participants",
+      mcpVersion: "1.0",
+      devices: ["A", "B", "C"],
+      steps: [
+        { tool: "barrier", params: { device: "A", lock: "L", deviceCount: 2 } },
+        { tool: "barrier", params: { device: "B", lock: "L", deviceCount: 2 } },
+        { tool: "fakeAction", params: { device: "B", text: "destructive" } },
+        { tool: "barrier", params: { device: "A", lock: "L", deviceCount: 2 } },
+        { tool: "barrier", params: { device: "C", lock: "L", deviceCount: 2 } },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 4, "android");
+
+    expect(result.success).toBe(true);
+    expect(barrierArrivals.sort()).toEqual(["A", "C"]);
+    expect(actionArrivals).toEqual([]);
   });
 });

--- a/test/plan/planExecutorBarrierResume.test.ts
+++ b/test/plan/planExecutorBarrierResume.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { z } from "zod/v4";
+
+/**
+ * End-to-end regression coverage for issue #6234 at the PlanExecutor boundary:
+ * a multi-device recovery that resumes inside a barrier generation must re-arrive
+ * every participant (no lone survivor that would deadlock at waitAtBarrier), and
+ * a resume point outside any generation must be left exactly as-is.
+ *
+ * Uses a fake `barrier` tool that only records which device arrived, so the test
+ * observes *which arrivals execute* deterministically without a real coordinator
+ * rendezvous, FakeTimer, or a device.
+ */
+describe("PlanExecutor barrier-generation resume (#6234)", () => {
+  let planExecutor: DefaultPlanExecutor;
+  let barrierArrivals: string[];
+
+  beforeEach(() => {
+    planExecutor = new DefaultPlanExecutor();
+    barrierArrivals = [];
+
+    const daemonState = DaemonState.getInstance();
+    if (daemonState.isInitialized()) {
+      daemonState.reset();
+    }
+
+    const barrierSchema = z.object({
+      device: z.string().optional(),
+      lock: z.string().optional(),
+      deviceCount: z.number().optional(),
+      platform: z.string().optional(),
+      sessionUuid: z.string().optional(),
+    });
+    ToolRegistry.register(
+      "barrier",
+      "Fake barrier tool for #6234 resume test",
+      barrierSchema,
+      mock(async (params: any) => {
+        barrierArrivals.push(params.device);
+        return { success: true };
+      }),
+    );
+
+    const actionSchema = z.object({
+      device: z.string().optional(),
+      text: z.string().optional(),
+      platform: z.string().optional(),
+      sessionUuid: z.string().optional(),
+    });
+    ToolRegistry.register(
+      "fakeAction",
+      "Fake action tool for #6234 resume test",
+      actionSchema,
+      mock(async () => ({ success: true })),
+    );
+  });
+
+  afterEach(() => {
+    ToolRegistry.unregister("barrier");
+    ToolRegistry.unregister("fakeAction");
+    const daemonState = DaemonState.getInstance();
+    if (daemonState.isInitialized()) {
+      daemonState.reset();
+    }
+  });
+
+  const buildPlan = (): Plan => ({
+    name: "barrier-resume-plan",
+    mcpVersion: "1.0",
+    devices: ["A", "B"],
+    steps: [
+      { tool: "barrier", params: { device: "A", lock: "L", deviceCount: 2 } }, // 0 gen0
+      { tool: "barrier", params: { device: "B", lock: "L", deviceCount: 2 } }, // 1 gen0
+      { tool: "fakeAction", params: { device: "A", text: "after" } }, // 2
+    ],
+  });
+
+  test("resuming inside a barrier generation re-arrives BOTH devices (no lone survivor)", async () => {
+    // startStep=1 lands between A's arrival (0) and B's arrival (1). Without the
+    // guard, device A's track would skip its arrival (0 < 1) while device B
+    // re-arrives alone at step 1 -> deadlock. The guard rewinds to 0.
+    const result = await planExecutor.executePlan(buildPlan(), 1, "android");
+
+    expect(result.success).toBe(true);
+    expect(barrierArrivals.sort()).toEqual(["A", "B"]);
+  });
+
+  test("resuming after a completed barrier generation skips it entirely and is unaffected", async () => {
+    // startStep=2 is past the whole generation: both arrivals are skipped
+    // uniformly and only the trailing action runs. No rewind, no re-arrival.
+    const result = await planExecutor.executePlan(buildPlan(), 2, "android");
+
+    expect(result.success).toBe(true);
+    expect(barrierArrivals).toEqual([]);
+  });
+
+  test("a fresh run (startStep 0) arrives both devices exactly once", async () => {
+    const result = await planExecutor.executePlan(buildPlan(), 0, "android");
+
+    expect(result.success).toBe(true);
+    expect(barrierArrivals.sort()).toEqual(["A", "B"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a runtime deadlock ([#6234](https://github.com/kaeawc/auto-mobile/issues/6234)): AI-assisted recovery resumes a failed plan at the failed global step index, and `PlanExecutor` skips lower-indexed steps **independently per device track**. When that resume index lands in the middle of a barrier's generation, some participating devices' arrivals get skipped while their partners' re-run, so a lone arrival waits at `CriticalSectionCoordinator.waitAtBarrier` for a `deviceCount` that never completes and the barrier times out. This is invisible to the static plan-validation added in [#6215](https://github.com/kaeawc/auto-mobile/pull/6215), which can't reason about runtime resume-index behavior.

## Fix

New `computeSafeBarrierResumeStep(plan, startStep)` (`src/utils/plan/BarrierResumeGuard.ts`) rewinds the requested resume step to the **start of any barrier/criticalSection generation it would split**, so every participant of that generation re-arrives together (fix direction 1 in the issue). It:

- Groups each barrier lock's arrivals into exact `deviceCount`-sized generations (the same generation model the barrier validation checks use), falling back to a single conservative whole-lock span for inconsistent/indivisible counts.
- Treats a `criticalSection` lock as one rendezvous generation.
- Iterates to a fixed point so interleaved barrier locks are handled.
- Returns a resume point that splits nothing **unchanged**, so ordinary recovery is unaffected.

`DefaultPlanExecutor.executeParallel` applies it before device tracks skip steps. The sequential (single-device) path is untouched — barriers only matter across parallel tracks.

## Tests

- `test/plan/BarrierResumeGuard.test.ts` — pure-helper coverage: mid-generation rewind, boundary/after-generation no-op, straddled-only rewind, interleaved-lock fixed point, criticalSection, no-coordination no-op.
- `test/plan/planExecutorBarrierResume.test.ts` — end-to-end through `executePlan` with a fake `barrier` tool: resuming inside a generation re-arrives **both** devices (no lone survivor); resuming after a completed generation skips it entirely and is unaffected.

Deterministic and fast (no real device, no coordinator rendezvous, no file-backed DB).

Validation: touched tests, `bun run lint`, `bun run typecheck`, `bun run format:check`, `bunx turbo run build` all pass.

Closes #6234