### PR TITLE
fix(tap): coherent post-tap hierarchy-only settle under device-clock skew (#6284)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6412,6 +6412,16 @@
             },
             "warning": {
               "type": "string"
+            },
+            "category": {
+              "type": "string",
+              "enum": [
+                "cache_age",
+                "window_identity",
+                "requested_min",
+                "no_timestamp",
+                "unavailable"
+              ]
             }
           },
           "required": ["isFresh"],
@@ -10048,6 +10058,16 @@
                     },
                     "warning": {
                       "type": "string"
+                    },
+                    "category": {
+                      "type": "string",
+                      "enum": [
+                        "cache_age",
+                        "window_identity",
+                        "requested_min",
+                        "no_timestamp",
+                        "unavailable"
+                      ]
                     }
                   },
                   "required": ["isFresh"],

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6420,7 +6420,8 @@
                 "window_identity",
                 "requested_min",
                 "no_timestamp",
-                "unavailable"
+                "unavailable",
+                "effect_inconsistent"
               ]
             }
           },
@@ -10066,7 +10067,8 @@
                         "window_identity",
                         "requested_min",
                         "no_timestamp",
-                        "unavailable"
+                        "unavailable",
+                        "effect_inconsistent"
                       ]
                     }
                   },

--- a/scripts/oxlint-baseline.txt
+++ b/scripts/oxlint-baseline.txt
@@ -56,6 +56,7 @@
 1	src/features/observe/GetBackStack.ts	eslint(complexity)
 1	src/features/observe/Idle.ts	eslint(complexity)
 1	src/features/observe/ListInstalledApps.ts	eslint(complexity)
+1	src/features/observe/ObservePoll.ts	eslint(complexity)
 1	src/features/observe/ObserveScreen.ts	eslint(max-depth)
 1	src/features/observe/TakeScreenshot.ts	auto-mobile(catch-convention)
 1	src/features/observe/TakeScreenshot.ts	typescript(no-floating-promises)

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -116,15 +116,13 @@ const POST_TAP_EFFECT_POLL_MS = 150;
 
 /**
  * Minimum wall-clock time a hierarchy-only post-tap frame must hold UNCHANGED
- * before it is accepted as the settled destination (issue #6284 P1). Set to two
- * full poll intervals so a settle can never be declared on the first, zero-
- * elapsed comparison, nor after a single interval — a real quiet period has to
- * elapse. A delayed dialog/navigation frame `B` that arrives more than one poll
- * interval after a transient `A` (the normal case for the delayed transitions
- * this settle targets) therefore resets the quiet period and is reached, rather
- * than being pre-empted by settling on `A`.
+ * before it is accepted as the settled destination (issue #6284 P1). Activity
+ * transitions commonly take 1–2 seconds, so a transient hierarchy must stay
+ * quiet for a full second before it is terminal evidence. This prevents a
+ * routine delayed destination from being pre-empted by an intermediate frame
+ * that merely survives the first few 150ms polls.
  */
-const POST_TAP_SETTLE_QUIET_PERIOD_MS = 2 * POST_TAP_EFFECT_POLL_MS;
+const POST_TAP_SETTLE_QUIET_PERIOD_MS = 1000;
 
 /** Brief debounce between the original tap and the retry tap when a ghost tap
  *  was detected. Just enough to let any inflight gesture queue drain. */
@@ -849,6 +847,7 @@ export class TapOnElement extends BaseVisualChange {
       ...(existing ?? { isFresh: true }),
       verified: false,
       isFresh: false,
+      category: "effect_inconsistent",
       warning:
         "effect.screenChanged is true, but this observation's own capture still matches the " +
         "pre-action screen — it predates the detected transition. Call observe again for the " +

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -66,7 +66,11 @@ import { FeatureFlagService } from "../featureFlags/FeatureFlagService";
 import { createTapStrategy } from "./strategies/createTapStrategy";
 import { LongPressMetadataDetector, type LongPressMetadata } from "./LongPressMetadataDetector";
 import { RealWaitForCondition } from "../observe/WaitForCondition";
-import type { WaitForCondition } from "../observe/interfaces/WaitForCondition";
+import type {
+  WaitForCondition,
+  WaitForConditionResult,
+} from "../observe/interfaces/WaitForCondition";
+import { updatedAtToMillis } from "../observe/observeTimestamp";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
@@ -589,17 +593,46 @@ export class TapOnElement extends BaseVisualChange {
     signal?: AbortSignal,
   ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
     const immediateEffect = this.deriveTapEffect(previousObservation, currentObservation);
-    if (
-      this.device.platform !== "android" ||
-      !previousObservation ||
-      immediateEffect?.screenChanged === true
-    ) {
+    if (this.device.platform !== "android" || !previousObservation) {
       return { effect: immediateEffect, observation: currentObservation };
     }
 
-    // A stable source tree can arrive before Android begins the activity
-    // transition. Wait for an actual post-tap difference instead of treating
-    // that transient stability as proof that the tap had no effect.
+    if (immediateEffect?.screenChanged !== true) {
+      // A stable source tree can arrive before Android begins the activity
+      // transition. Wait for an actual post-tap difference instead of treating
+      // that transient stability as proof that the tap had no effect.
+      return this.waitForPostTapChange(previousObservation, currentObservation, signal);
+    }
+
+    if (immediateEffect.basis !== "viewHierarchy changed") {
+      // A `screenIdentity`/`activeWindow` change is authoritative on its own —
+      // it names a real destination window, so trust it immediately.
+      return { effect: immediateEffect, observation: currentObservation };
+    }
+
+    // Issue #6284: a hierarchy-ONLY change (activeWindow unchanged) is not, by
+    // itself, proof of the DESTINATION screen. The first post-tap observation
+    // uses `changeExpected: false`, so a transient intermediate mutation (a
+    // focused/selected/checked flip, or a partial hierarchy update before a
+    // delayed dialog/navigation) can look identical to a real change on the
+    // very first frame. Settle it across a real stability interval before
+    // trusting it as terminal, so a transient A isn't returned in place of the
+    // actual destination B (`baseline → A → A → B` must reach B).
+    return this.settleHierarchyOnlyChange(previousObservation, currentObservation, signal);
+  }
+
+  /**
+   * The first post-tap observation showed no change against the baseline yet.
+   * Poll (via the injected waiter/FakeTimer seam) for an actual post-tap
+   * difference, then route a hierarchy-only result through the same settle step
+   * a first-frame hierarchy change takes (issue #6284) rather than trusting the
+   * first differing poll as terminal.
+   */
+  private async waitForPostTapChange(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
     const effectObservation = await this.waitForCondition.execute(
       (observation) => ({
         matched: this.deriveTapEffect(previousObservation, observation)?.screenChanged === true,
@@ -608,11 +641,23 @@ export class TapOnElement extends BaseVisualChange {
         timeoutMs: POST_TAP_EFFECT_TIMEOUT_MS,
         pollMs: POST_TAP_EFFECT_POLL_MS,
         signal,
+        // One clock domain end-to-end (issue #6284): seed the poll floor from
+        // the device-authored `updatedAt` of the capture we already hold, not
+        // the host clock, so a device whose clock trails the daemon still
+        // clears the floor with a genuinely fresh repeat capture.
+        initialMinTimestampMs: updatedAtToMillis(currentObservation.updatedAt),
       },
     );
     const effect = this.deriveTapEffect(previousObservation, effectObservation.observation);
     if (!effectObservation.matched && effect?.screenChanged !== true) {
       return { effect, observation: currentObservation };
+    }
+    if (effect?.basis === "viewHierarchy changed") {
+      return this.settleHierarchyOnlyChange(
+        previousObservation,
+        effectObservation.observation,
+        signal,
+      );
     }
     return {
       effect,
@@ -622,6 +667,118 @@ export class TapOnElement extends BaseVisualChange {
         perfTiming: effectObservation.observation.perfTiming ?? currentObservation.perfTiming,
       },
     };
+  }
+
+  /**
+   * Confirm a hierarchy-only tap effect is the settled DESTINATION rather than a
+   * transient intermediate mutation before trusting it as terminal (issue
+   * #6284). Polls (via the injected waiter/FakeTimer seam) until either:
+   *  - `activeWindow` changes vs the baseline — authoritative, stop at once; or
+   *  - the hierarchy is unchanged across TWO consecutive poll comparisons — a
+   *    real `pollMs` interval genuinely elapsed with no further change, so the
+   *    transition has settled.
+   *
+   * Requiring the hash to hold across two comparisons (not one against the
+   * pre-loop seed) is what makes `baseline → A → A → B` reach B: the very first
+   * poll is taken immediately with no `pollMs` sleep, so a single equal-hash
+   * comparison proves nothing about elapsed time, and a transient A that has not
+   * yet given way to B would otherwise be trusted after one frame.
+   *
+   * Staleness robustness lives in the poll floor, NOT in this predicate and NOT
+   * in `compareViewHierarchy`: the monotonic device-clock floor (seeded here
+   * from the entering capture's `updatedAt`) means the device never re-serves a
+   * capture older than the floor, so two equal hashes can only be the same fresh
+   * static screen — never a stale snapshot returned twice masking a later fresh
+   * destination. That keeps `compareViewHierarchy` a pure hash diff, so a stale
+   * baseline can never block a legitimate same-window dialog diff (the
+   * entanglement root of the earlier incremental attempt).
+   */
+  private async settleHierarchyOnlyChange(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+    signal?: AbortSignal,
+  ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
+    let lastObservation = currentObservation;
+    let consecutiveStablePolls = 0;
+    const settled = await this.waitForCondition.execute(
+      (observation) => {
+        const activeWindowChanged =
+          this.compareActiveWindow(previousObservation, observation)?.screenChanged === true;
+        const currentHash = this.hashViewHierarchy(observation.viewHierarchy ?? null);
+        const priorHash = this.hashViewHierarchy(lastObservation.viewHierarchy ?? null);
+        // Require two non-null hashes before trusting equality as "settled":
+        // two consecutive hierarchy-less polls both hash to null and would
+        // otherwise look identical, stopping the settle before a later real
+        // destination capture ever arrives.
+        const hierarchyEqualToPriorPoll =
+          currentHash !== null && priorHash !== null && currentHash === priorHash;
+        consecutiveStablePolls = hierarchyEqualToPriorPoll ? consecutiveStablePolls + 1 : 0;
+        const hierarchyStableSincePriorPoll = consecutiveStablePolls >= 2;
+        lastObservation = observation;
+        return { matched: activeWindowChanged || hierarchyStableSincePriorPoll };
+      },
+      {
+        timeoutMs: POST_TAP_EFFECT_TIMEOUT_MS,
+        pollMs: POST_TAP_EFFECT_POLL_MS,
+        signal,
+        // Device-clock-domain floor seed (issue #6284). See method doc.
+        initialMinTimestampMs: updatedAtToMillis(currentObservation.updatedAt),
+      },
+    );
+
+    const effectObservation = this.resolveSettleTimeoutObservation(
+      previousObservation,
+      currentObservation,
+      settled,
+    );
+
+    // Issue #6284: preserve the already-established `screenChanged: true` when
+    // the settle poll's final observation is a DEFINITIVE screen-off terminal
+    // (the device went to sleep mid-settle). That capture legitimately carries
+    // no viewHierarchy, so re-deriving from scratch would find only an unchanged
+    // `activeWindow` and flip the effect back to `screenChanged: false`,
+    // erasing the transition that already entered this settle.
+    const isDefinitiveScreenOffTerminal = effectObservation.wakefulness === "Asleep";
+    const effect: TapOnElementResult["effect"] = isDefinitiveScreenOffTerminal
+      ? { screenChanged: true, basis: "viewHierarchy changed" }
+      : this.deriveTapEffect(previousObservation, effectObservation);
+    return {
+      effect,
+      observation: {
+        ...effectObservation,
+        gfxMetrics: effectObservation.gfxMetrics ?? currentObservation.gfxMetrics,
+        perfTiming: effectObservation.perfTiming ?? currentObservation.perfTiming,
+      },
+    };
+  }
+
+  /**
+   * Which observation `settleHierarchyOnlyChange` should trust when its poll
+   * timed out. A clean stop (or a screen-off terminal) always yields the poll's
+   * final observation. On timeout, prefer the trusted entering change over a
+   * final poll that is untrustworthy (explicitly stale, or carrying no
+   * hierarchy) so a temporarily-unresponsive proxy doesn't erase a real,
+   * already-observed change; otherwise the final poll is the freshest evidence.
+   */
+  private resolveSettleTimeoutObservation(
+    previousObservation: ObserveResult,
+    currentObservation: ObserveResult,
+    settled: WaitForConditionResult,
+  ): ObserveResult {
+    const effectObservation = settled.observation;
+    const finalPollIsDefinitiveScreenOff = effectObservation.wakefulness === "Asleep";
+    if (!settled.timedOut || finalPollIsDefinitiveScreenOff) {
+      return effectObservation;
+    }
+    const currentObservationIsTrustedChange =
+      currentObservation.freshness?.isFresh !== false &&
+      this.deriveTapEffect(previousObservation, currentObservation)?.screenChanged === true;
+    const finalPollIsUntrustworthy =
+      effectObservation.freshness?.isFresh === false ||
+      this.hashViewHierarchy(effectObservation.viewHierarchy ?? null) === null;
+    return currentObservationIsTrustedChange && finalPollIsUntrustworthy
+      ? currentObservation
+      : effectObservation;
   }
 
   /**
@@ -644,6 +801,16 @@ export class TapOnElement extends BaseVisualChange {
     result: { effect?: TapOnElementResult["effect"]; observation?: ObserveResult },
   ): void {
     if (!previousObservation || !result.observation || result.effect?.screenChanged !== true) {
+      return;
+    }
+    if (result.observation.wakefulness === "Asleep") {
+      // Issue #6284: a definitive screen-off terminal legitimately carries no
+      // viewHierarchy, so a re-derivation against it cannot reproduce the
+      // `screenChanged: true` (there is nothing to diff). This is NOT a stale
+      // pre-tap tree the client should re-observe past — it is the real
+      // post-tap state (the screen went off). Retracting freshness here would
+      // stamp the wrong warning ("predates the detected transition") over a
+      // faithful terminal capture, so leave it intact.
       return;
     }
     const reDerived = this.deriveTapEffect(previousObservation, result.observation);
@@ -689,14 +856,54 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
-  private updateObservationHierarchy(
+  /**
+   * The ONLY sanctioned way to swap an observation's `viewHierarchy` for one
+   * captured later in `execute` (issue #6284). Folding "replace hierarchy" and
+   * "refresh freshness" into one helper means no call site can do the first
+   * without the second: replacing a cached observation's hierarchy with a
+   * freshly-captured one while leaving its OLD `freshness` (e.g. `isFresh:
+   * false` from the pre-tap cache) stamped on the new, just-verified tree would
+   * surface fresh data labelled stale in the response.
+   *
+   * Pass `refreshedFromDevice: true` only when `viewHierarchy` was just captured
+   * from the device on this call (a genuine live re-capture) — that is the case
+   * whose freshness must be realigned. A replacement with data already in hand
+   * (the caller's own hierarchy returned unchanged) leaves freshness untouched.
+   */
+  private replaceObservationHierarchy(
     observeResult: ObserveResult,
     viewHierarchy: ViewHierarchyResult,
+    refreshedFromDevice: boolean,
   ): void {
     observeResult.viewHierarchy = viewHierarchy;
     const screenSize = this.getScreenSizeFromHierarchy(viewHierarchy);
     if (screenSize) {
       observeResult.screenSize = screenSize;
+    }
+    if (refreshedFromDevice) {
+      this.markObservationFreshAfterSyncRefresh(observeResult);
+    }
+  }
+
+  /**
+   * Realign a cached observation's freshness verdict to the live re-capture that
+   * just replaced its hierarchy (issue #6284). The refresh verified the tree
+   * against the device on THIS call, so a lingering pre-refresh `isFresh: false`
+   * verdict no longer describes the attached data. Only ever promotes a stale
+   * verdict to fresh; never touches a verdict that was already fresh (or absent).
+   * Called exclusively from {@link replaceObservationHierarchy}.
+   */
+  private markObservationFreshAfterSyncRefresh(observeResult: ObserveResult): void {
+    if (observeResult.freshness?.isFresh === false) {
+      observeResult.freshness = {
+        ...observeResult.freshness,
+        isFresh: true,
+        verified: true,
+        actualTimestamp: this.timer.now(),
+        ageMs: 0,
+        staleDurationMs: undefined,
+        warning: undefined,
+      };
     }
   }
 
@@ -1092,6 +1299,15 @@ export class TapOnElement extends BaseVisualChange {
     viewHierarchy: ViewHierarchyResult;
     containerFound: boolean;
     stats: SearchUntilStats;
+    /**
+     * True when `viewHierarchy` is a genuine live device re-capture taken during
+     * this search (the caller's initial hierarchy did not already contain the
+     * target), distinct from the common case where the element was found in the
+     * hierarchy the caller already had with no device round-trip. Drives
+     * whether {@link replaceObservationHierarchy} also realigns freshness
+     * (issue #6284).
+     */
+    refreshedFromDevice: boolean;
   }> {
     const viewHierarchy = observeResult.viewHierarchy;
     if (!viewHierarchy) {
@@ -1188,6 +1404,10 @@ export class TapOnElement extends BaseVisualChange {
       viewHierarchy: latestViewHierarchy,
       containerFound: containerFoundEver,
       stats,
+      // `latestViewHierarchy` only diverges from the caller's `viewHierarchy`
+      // when a refresh-loop iteration replaced it with a live device re-capture;
+      // the target being present in the initial hierarchy returns it unchanged.
+      refreshedFromDevice: latestViewHierarchy !== viewHierarchy,
     };
   }
 
@@ -1588,7 +1808,11 @@ export class TapOnElement extends BaseVisualChange {
             this.searchForElement(options, observeResult, signal),
           );
           searchUntilStats = searchOutcome.stats;
-          this.updateObservationHierarchy(observeResult, searchOutcome.viewHierarchy);
+          this.replaceObservationHierarchy(
+            observeResult,
+            searchOutcome.viewHierarchy,
+            searchOutcome.refreshedFromDevice,
+          );
           viewHierarchy = searchOutcome.viewHierarchy;
           if (!searchOutcome.selection.element) {
             await this.handleElementNotFound(
@@ -1678,7 +1902,9 @@ export class TapOnElement extends BaseVisualChange {
               perf.end();
               return { success: false, error: stable.error };
             }
-            this.updateObservationHierarchy(observeResult, stable.viewHierarchy);
+            // The pre-tap stability resolver always returns a hierarchy it just
+            // re-captured live from the device, so its freshness is realigned.
+            this.replaceObservationHierarchy(observeResult, stable.viewHierarchy, true);
             viewHierarchy = stable.viewHierarchy;
             tapElement = stable.tapElement;
             usedParent = stable.usedParent;

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -114,6 +114,18 @@ const POST_TAP_REFRESH_TIMEOUT_MS = 1500;
 const POST_TAP_EFFECT_TIMEOUT_MS = 2500;
 const POST_TAP_EFFECT_POLL_MS = 150;
 
+/**
+ * Minimum wall-clock time a hierarchy-only post-tap frame must hold UNCHANGED
+ * before it is accepted as the settled destination (issue #6284 P1). Set to two
+ * full poll intervals so a settle can never be declared on the first, zero-
+ * elapsed comparison, nor after a single interval — a real quiet period has to
+ * elapse. A delayed dialog/navigation frame `B` that arrives more than one poll
+ * interval after a transient `A` (the normal case for the delayed transitions
+ * this settle targets) therefore resets the quiet period and is reached, rather
+ * than being pre-empted by settling on `A`.
+ */
+const POST_TAP_SETTLE_QUIET_PERIOD_MS = 2 * POST_TAP_EFFECT_POLL_MS;
+
 /** Brief debounce between the original tap and the retry tap when a ghost tap
  *  was detected. Just enough to let any inflight gesture queue drain. */
 const PRE_RETRY_DELAY_MS = 100;
@@ -674,21 +686,25 @@ export class TapOnElement extends BaseVisualChange {
    * transient intermediate mutation before trusting it as terminal (issue
    * #6284). Polls (via the injected waiter/FakeTimer seam) until either:
    *  - `activeWindow` changes vs the baseline — authoritative, stop at once; or
-   *  - the hierarchy is unchanged across TWO consecutive poll comparisons — a
-   *    real `pollMs` interval genuinely elapsed with no further change, so the
-   *    transition has settled.
+   *  - the hierarchy hash holds UNCHANGED for a real quiet period of wall-clock
+   *    time (`POST_TAP_SETTLE_QUIET_PERIOD_MS`) — the transition has settled.
    *
-   * Requiring the hash to hold across two comparisons (not one against the
-   * pre-loop seed) is what makes `baseline → A → A → B` reach B: the very first
-   * poll is taken immediately with no `pollMs` sleep, so a single equal-hash
-   * comparison proves nothing about elapsed time, and a transient A that has not
-   * yet given way to B would otherwise be trusted after one frame.
+   * Settlement is a wall-clock quiet-period DEADLINE, not a count of equal
+   * comparisons, and that is what makes `baseline → A → A → B` reach B. A
+   * comparison count treats the very first poll — taken immediately, with no
+   * `pollMs` sleep yet elapsed — as if it proved stability, so a transient A
+   * that persists just one interval before a delayed B would settle on A. The
+   * deadline instead starts a clock when a hash first appears and accepts it
+   * only once it has genuinely held for the quiet period; a B that arrives after
+   * that interval resets the clock and is reached. A hierarchy-less (null-hash)
+   * poll cannot start or extend a quiet period — it resets the run — so a run of
+   * rootless captures never masquerades as a stable screen.
    *
    * Staleness robustness lives in the poll floor, NOT in this predicate and NOT
-   * in `compareViewHierarchy`: the monotonic device-clock floor (seeded here
-   * from the entering capture's `updatedAt`) means the device never re-serves a
-   * capture older than the floor, so two equal hashes can only be the same fresh
-   * static screen — never a stale snapshot returned twice masking a later fresh
+   * in `compareViewHierarchy`: the entering reference (seeded here from the
+   * entering capture's `updatedAt`) forces every poll strictly past that
+   * capture, so an unchanged hash across the quiet period is a genuinely-held
+   * fresh screen — never a stale snapshot re-served masking a later fresh
    * destination. That keeps `compareViewHierarchy` a pure hash diff, so a stale
    * baseline can never block a legitimate same-window dialog diff (the
    * entanglement root of the earlier incremental attempt).
@@ -698,24 +714,33 @@ export class TapOnElement extends BaseVisualChange {
     currentObservation: ObserveResult,
     signal?: AbortSignal,
   ): Promise<{ effect: TapOnElementResult["effect"]; observation: ObserveResult }> {
-    let lastObservation = currentObservation;
-    let consecutiveStablePolls = 0;
+    // Hash whose quiet period is currently being timed, and when that run began.
+    let quietHash: string | null = null;
+    let quietSinceMs = 0;
     const settled = await this.waitForCondition.execute(
       (observation) => {
         const activeWindowChanged =
           this.compareActiveWindow(previousObservation, observation)?.screenChanged === true;
+        if (activeWindowChanged) {
+          return { matched: true };
+        }
         const currentHash = this.hashViewHierarchy(observation.viewHierarchy ?? null);
-        const priorHash = this.hashViewHierarchy(lastObservation.viewHierarchy ?? null);
-        // Require two non-null hashes before trusting equality as "settled":
-        // two consecutive hierarchy-less polls both hash to null and would
-        // otherwise look identical, stopping the settle before a later real
-        // destination capture ever arrives.
-        const hierarchyEqualToPriorPoll =
-          currentHash !== null && priorHash !== null && currentHash === priorHash;
-        consecutiveStablePolls = hierarchyEqualToPriorPoll ? consecutiveStablePolls + 1 : 0;
-        const hierarchyStableSincePriorPoll = consecutiveStablePolls >= 2;
-        lastObservation = observation;
-        return { matched: activeWindowChanged || hierarchyStableSincePriorPoll };
+        const now = this.timer.now();
+        if (currentHash === null) {
+          // A hierarchy-less poll proves nothing about stability; reset the run.
+          quietHash = null;
+          return { matched: false };
+        }
+        if (currentHash !== quietHash) {
+          // A new (or first) hash: start its quiet-period clock now. Never
+          // settles on this frame — a real interval must elapse first.
+          quietHash = currentHash;
+          quietSinceMs = now;
+          return { matched: false };
+        }
+        // Same hash as the run's start: accept only once it has genuinely held
+        // for the full quiet period of wall-clock time.
+        return { matched: now - quietSinceMs >= POST_TAP_SETTLE_QUIET_PERIOD_MS };
       },
       {
         timeoutMs: POST_TAP_EFFECT_TIMEOUT_MS,
@@ -889,20 +914,32 @@ export class TapOnElement extends BaseVisualChange {
    * Realign a cached observation's freshness verdict to the live re-capture that
    * just replaced its hierarchy (issue #6284). The refresh verified the tree
    * against the device on THIS call, so a lingering pre-refresh `isFresh: false`
-   * verdict no longer describes the attached data. Only ever promotes a stale
-   * verdict to fresh; never touches a verdict that was already fresh (or absent).
-   * Called exclusively from {@link replaceObservationHierarchy}.
+   * verdict no longer describes the attached data.
+   *
+   * Promote ONLY a `cache_age` failure — a stale/unverified/over-budget cache
+   * entry, which is exactly what swapping in a freshly-captured hierarchy
+   * resolves. A `window_identity` failure (wrong-window, status-bar-only,
+   * activity-attribution mismatch, incomplete capture, missing foreground
+   * window — issue #6284 P1) describes WHICH window/app the tree belongs to; the
+   * refresh replaced only `viewHierarchy` and did not recollect or reconcile
+   * `activeWindow`/attribution, and the re-capture may itself be from the wrong
+   * window, so clearing that warning would make an internally-inconsistent
+   * result look trustworthy. A verdict that was already fresh (or absent), or
+   * failed for any other reason, is left untouched. Called exclusively from
+   * {@link replaceObservationHierarchy}.
    */
   private markObservationFreshAfterSyncRefresh(observeResult: ObserveResult): void {
-    if (observeResult.freshness?.isFresh === false) {
+    const freshness = observeResult.freshness;
+    if (freshness?.isFresh === false && freshness.category === "cache_age") {
       observeResult.freshness = {
-        ...observeResult.freshness,
+        ...freshness,
         isFresh: true,
         verified: true,
         actualTimestamp: this.timer.now(),
         ageMs: 0,
         staleDurationMs: undefined,
         warning: undefined,
+        category: undefined,
       };
     }
   }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -763,7 +763,7 @@ export class TapOnElement extends BaseVisualChange {
     // no viewHierarchy, so re-deriving from scratch would find only an unchanged
     // `activeWindow` and flip the effect back to `screenChanged: false`,
     // erasing the transition that already entered this settle.
-    const isDefinitiveScreenOffTerminal = effectObservation.wakefulness === "Asleep";
+    const isDefinitiveScreenOffTerminal = settled.screenOff === true;
     const effect: TapOnElementResult["effect"] = isDefinitiveScreenOffTerminal
       ? { screenChanged: true, basis: "viewHierarchy changed" }
       : this.deriveTapEffect(previousObservation, effectObservation);
@@ -791,7 +791,7 @@ export class TapOnElement extends BaseVisualChange {
     settled: WaitForConditionResult,
   ): ObserveResult {
     const effectObservation = settled.observation;
-    const finalPollIsDefinitiveScreenOff = effectObservation.wakefulness === "Asleep";
+    const finalPollIsDefinitiveScreenOff = settled.screenOff === true;
     if (!settled.timedOut || finalPollIsDefinitiveScreenOff) {
       return effectObservation;
     }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -901,6 +901,13 @@ export class TapOnElement extends BaseVisualChange {
     refreshedFromDevice: boolean,
   ): void {
     observeResult.viewHierarchy = viewHierarchy;
+    // The replacement is device-authored; keep the enclosing observation in
+    // that same clock domain so later freshness floors never compare it with
+    // the host time from the cached observation it replaced.
+    const updatedAt = hierarchyUpdatedAtToMillis(viewHierarchy);
+    if (updatedAt !== undefined) {
+      observeResult.updatedAt = updatedAt;
+    }
     const screenSize = this.getScreenSizeFromHierarchy(viewHierarchy);
     if (screenSize) {
       observeResult.screenSize = screenSize;

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -70,7 +70,7 @@ import type {
   WaitForCondition,
   WaitForConditionResult,
 } from "../observe/interfaces/WaitForCondition";
-import { updatedAtToMillis } from "../observe/observeTimestamp";
+import { hierarchyUpdatedAtToMillis } from "../observe/observeTimestamp";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
@@ -657,7 +657,7 @@ export class TapOnElement extends BaseVisualChange {
         // the device-authored `updatedAt` of the capture we already hold, not
         // the host clock, so a device whose clock trails the daemon still
         // clears the floor with a genuinely fresh repeat capture.
-        initialMinTimestampMs: updatedAtToMillis(currentObservation.updatedAt),
+        initialMinTimestampMs: hierarchyUpdatedAtToMillis(currentObservation.viewHierarchy),
       },
     );
     const effect = this.deriveTapEffect(previousObservation, effectObservation.observation);
@@ -747,7 +747,7 @@ export class TapOnElement extends BaseVisualChange {
         pollMs: POST_TAP_EFFECT_POLL_MS,
         signal,
         // Device-clock-domain floor seed (issue #6284). See method doc.
-        initialMinTimestampMs: updatedAtToMillis(currentObservation.updatedAt),
+        initialMinTimestampMs: hierarchyUpdatedAtToMillis(currentObservation.viewHierarchy),
       },
     );
 
@@ -930,12 +930,26 @@ export class TapOnElement extends BaseVisualChange {
    */
   private markObservationFreshAfterSyncRefresh(observeResult: ObserveResult): void {
     const freshness = observeResult.freshness;
-    if (freshness?.isFresh === false && freshness.category === "cache_age") {
+    const hierarchy = observeResult.viewHierarchy;
+    const actualTimestamp = hierarchyUpdatedAtToMillis(hierarchy);
+    const hasCompleteLiveHierarchy =
+      hierarchy !== undefined &&
+      typeof hierarchy.hierarchy === "object" &&
+      hierarchy.hierarchy !== null &&
+      !("error" in hierarchy.hierarchy) &&
+      hierarchy.ctrlProxyIncomplete !== true &&
+      hierarchy.fresh !== false &&
+      actualTimestamp !== undefined;
+    if (
+      hasCompleteLiveHierarchy &&
+      freshness?.isFresh === false &&
+      freshness.category === "cache_age"
+    ) {
       observeResult.freshness = {
         ...freshness,
         isFresh: true,
         verified: true,
-        actualTimestamp: this.timer.now(),
+        actualTimestamp,
         ageMs: 0,
         staleDurationMs: undefined,
         warning: undefined,

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -53,6 +53,8 @@ export interface ObservePollOutcome {
    * the loop exited on the budget or a screen-off fast-fail.
    */
   stopped: boolean;
+  /** Why the loop produced this observation. */
+  terminalReason: "matched" | "screen_off" | "timeout";
 }
 
 /**
@@ -61,6 +63,11 @@ export interface ObservePollOutcome {
  */
 function isScreenOff(observation: ObserveResult): boolean {
   return observation.wakefulness === "Asleep";
+}
+
+/** A rootless screen-off sample is terminal only when ADB read it on this call. */
+function isIndependentScreenOff(observation: ObserveResult): boolean {
+  return isScreenOff(observation) && observation.wakefulnessSource === "adb";
 }
 
 /**
@@ -224,8 +231,14 @@ export async function pollObserveUntil(
     // A screen-off terminal is only meaningful when the same observation passed
     // the admission contract. A stale cached "Asleep" frame after the device
     // wakes must not fast-fail a public wait or be promoted by tap settlement.
-    if (isScreenOff(observation) && isAdmissibleEvidence) {
-      return { observation, polls, waitMs: timer.now() - start, stopped: false };
+    if ((isScreenOff(observation) && isAdmissibleEvidence) || isIndependentScreenOff(observation)) {
+      return {
+        observation,
+        polls,
+        waitMs: timer.now() - start,
+        stopped: false,
+        terminalReason: "screen_off",
+      };
     }
 
     // Rejected observations are deliberately invisible to stateful predicates:
@@ -233,7 +246,13 @@ export async function pollObserveUntil(
     // could manufacture a two-sample settle from regressed evidence.
     const matched = isAdmissibleEvidence && onObservation(observation, previous, polls);
     if (matched && isPostInvocation) {
-      return { observation, polls, waitMs: timer.now() - start, stopped: true };
+      return {
+        observation,
+        polls,
+        waitMs: timer.now() - start,
+        stopped: true,
+        terminalReason: "matched",
+      };
     }
 
     if (isAdmissibleEvidence) {
@@ -246,6 +265,7 @@ export async function pollObserveUntil(
         polls,
         waitMs: timer.now() - start,
         stopped: false,
+        terminalReason: "timeout",
       };
     }
 

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -182,6 +182,11 @@ export async function pollObserveUntil(
     throwIfAborted(options.signal);
 
     const observedMs = deviceCaptureTimestamp(observation);
+    // A timestamp alone cannot make a capture admissible. ObserveScreen marks
+    // wrong-window and incomplete hierarchies stale even when CtrlProxy was
+    // able to stamp them; those trees must neither satisfy a predicate nor
+    // advance stateful settle predicates.
+    const isExplicitlyStale = observation.freshness?.isFresh === false;
     // Unseeded: the first observation is a throwaway baseline. It establishes
     // the entering reference (and the floor) but can never itself be terminal
     // evidence — it may be the pre-call cache the loop must read past.
@@ -191,7 +196,8 @@ export async function pollObserveUntil(
     // `Math.max` guarantees a stale/cached capture can never LOWER the floor.
     const meetsPriorFloor =
       observedMs !== undefined && (deviceFloor === undefined || observedMs >= deviceFloor);
-    if (observedMs !== undefined) {
+    const isAdmissibleEvidence = meetsPriorFloor && !isExplicitlyStale;
+    if (isAdmissibleEvidence && observedMs !== undefined) {
       deviceFloor = deviceFloor === undefined ? observedMs : Math.max(deviceFloor, observedMs);
     }
     // Strictly newer than the entering/baseline capture => a genuine
@@ -200,12 +206,12 @@ export async function pollObserveUntil(
       observedMs !== undefined &&
       enteringReference !== undefined &&
       observedMs > enteringReference &&
-      meetsPriorFloor;
+      isAdmissibleEvidence;
     if (isPostInvocation) {
       hasPostInvocationEvidence = true;
     }
 
-    if (meetsPriorFloor) {
+    if (isAdmissibleEvidence) {
       newestTrustworthyObservation = observation;
     }
 
@@ -213,15 +219,17 @@ export async function pollObserveUntil(
       return { observation, polls, waitMs: timer.now() - start, stopped: false };
     }
 
-    // Always evaluate so stateful predicates (e.g. a settle's run counter)
-    // advance every poll, but only ACCEPT a stop backed by a post-invocation
-    // capture — never the entering reference re-served from cache.
-    const matched = onObservation(observation, previous, polls);
+    // Rejected observations are deliberately invisible to stateful predicates:
+    // allowing a below-floor A to update `previous` between B and a later A
+    // could manufacture a two-sample settle from regressed evidence.
+    const matched = isAdmissibleEvidence && onObservation(observation, previous, polls);
     if (matched && isPostInvocation) {
       return { observation, polls, waitMs: timer.now() - start, stopped: true };
     }
 
-    previous = observation;
+    if (isAdmissibleEvidence) {
+      previous = observation;
+    }
 
     if (timer.now() - start >= options.timeoutMs) {
       return {

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -2,7 +2,7 @@ import type { ObserveResult } from "../../models";
 import type { ObserveScreen } from "./interfaces/ObserveScreen";
 import { Timer } from "../../utils/SystemTimer";
 import { throwIfAborted } from "../../utils/toolUtils";
-import { updatedAtToMillis } from "./observeTimestamp";
+import { hierarchyUpdatedAtToMillis } from "./observeTimestamp";
 
 /**
  * Shared observe poll loop for the settle / wait-for-condition primitives
@@ -61,6 +61,25 @@ export interface ObservePollOutcome {
  */
 function isScreenOff(observation: ObserveResult): boolean {
   return observation.wakefulness === "Asleep";
+}
+
+/**
+ * A poll can advance a device-clock floor only when it carries a complete
+ * hierarchy and that hierarchy itself carries the device capture timestamp.
+ * The top-level observation timestamp can be host-created for a partial base
+ * result, so it must never participate in this contract.
+ */
+function deviceCaptureTimestamp(observation: ObserveResult): number | undefined {
+  const hierarchy = observation.viewHierarchy;
+  if (
+    !hierarchy ||
+    typeof hierarchy.hierarchy !== "object" ||
+    hierarchy.hierarchy === null ||
+    "error" in hierarchy.hierarchy
+  ) {
+    return undefined;
+  }
+  return hierarchyUpdatedAtToMillis(hierarchy);
 }
 
 /**
@@ -136,6 +155,10 @@ export async function pollObserveUntil(
   // Set once any capture is strictly newer than the entering reference — from
   // then on the floor relaxes to inclusive so a static screen can settle.
   let hasPostInvocationEvidence = false;
+  // Preserve the newest complete, non-regressing device capture for timeout
+  // results. A late stale fallback must not replace evidence that already met a
+  // raised floor (e.g. 10 -> 30 -> 20).
+  let newestTrustworthyObservation: ObserveResult | undefined;
 
   while (true) {
     throwIfAborted(options.signal);
@@ -158,20 +181,32 @@ export async function pollObserveUntil(
     polls++;
     throwIfAborted(options.signal);
 
-    const observedMs = updatedAtToMillis(observation.updatedAt);
+    const observedMs = deviceCaptureTimestamp(observation);
     // Unseeded: the first observation is a throwaway baseline. It establishes
     // the entering reference (and the floor) but can never itself be terminal
     // evidence — it may be the pre-call cache the loop must read past.
-    if (enteringReference === undefined) {
+    if (enteringReference === undefined && observedMs !== undefined) {
       enteringReference = observedMs;
     }
     // `Math.max` guarantees a stale/cached capture can never LOWER the floor.
-    deviceFloor = deviceFloor === undefined ? observedMs : Math.max(deviceFloor, observedMs);
+    const meetsPriorFloor =
+      observedMs !== undefined && (deviceFloor === undefined || observedMs >= deviceFloor);
+    if (observedMs !== undefined) {
+      deviceFloor = deviceFloor === undefined ? observedMs : Math.max(deviceFloor, observedMs);
+    }
     // Strictly newer than the entering/baseline capture => a genuine
     // post-invocation read the caller may act on.
-    const isPostInvocation = observedMs > enteringReference;
+    const isPostInvocation =
+      observedMs !== undefined &&
+      enteringReference !== undefined &&
+      observedMs > enteringReference &&
+      meetsPriorFloor;
     if (isPostInvocation) {
       hasPostInvocationEvidence = true;
+    }
+
+    if (meetsPriorFloor) {
+      newestTrustworthyObservation = observation;
     }
 
     if (isScreenOff(observation)) {
@@ -189,7 +224,12 @@ export async function pollObserveUntil(
     previous = observation;
 
     if (timer.now() - start >= options.timeoutMs) {
-      return { observation, polls, waitMs: timer.now() - start, stopped: false };
+      return {
+        observation: newestTrustworthyObservation ?? observation,
+        polls,
+        waitMs: timer.now() - start,
+        stopped: false,
+      };
     }
 
     await timer.sleep(options.pollMs);

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -231,7 +231,19 @@ export async function pollObserveUntil(
     // A screen-off terminal is only meaningful when the same observation passed
     // the admission contract. A stale cached "Asleep" frame after the device
     // wakes must not fast-fail a public wait or be promoted by tap settlement.
-    if ((isScreenOff(observation) && isAdmissibleEvidence) || isIndependentScreenOff(observation)) {
+    // A hierarchy reports wakefulness from the same cache as its tree. Even a
+    // young cache may predate the invocation, so hierarchy-sourced screen-off
+    // needs the same strictly-post-invocation proof as an ordinary match. ADB
+    // wakefulness is independently sampled on this poll and remains terminal
+    // immediately, including when no hierarchy is available.
+    const isHierarchySourcedScreenOff =
+      isScreenOff(observation) && observation.wakefulnessSource === "hierarchy";
+    if (
+      isIndependentScreenOff(observation) ||
+      (isScreenOff(observation) &&
+        isAdmissibleEvidence &&
+        (!isHierarchySourcedScreenOff || isPostInvocation))
+    ) {
       return {
         observation,
         polls,

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -21,6 +21,22 @@ export interface ObservePollOptions {
   /** Poll interval in ms between observations. */
   pollMs: number;
   signal?: AbortSignal;
+  /**
+   * Optional seed for the monotonic `minTimestamp` floor, in the SAME clock
+   * domain the floor lives in end-to-end: the device-authored `updatedAt`
+   * (issue #6284). Supply a device-clock-domain timestamp (e.g. the capture
+   * that triggered a post-tap settle) so the FIRST poll already requires a
+   * read at least as new as that capture. Omit it for the default path: the
+   * first poll then takes the freshest capture available and the floor is
+   * seeded from THAT observation's own device timestamp.
+   *
+   * Never pass a host-clock timestamp here. An Android device clock trailing
+   * the daemon (issue #5377) would make every genuinely-fresh device capture
+   * look older than a host-domain floor, so the freshness gate
+   * (`updatedAt >= minTimestamp`) would reject fresh reads and the loop would
+   * burn its whole budget instead of settling promptly.
+   */
+  initialMinTimestampMs?: number;
 }
 
 export interface ObservePollOutcome {
@@ -48,14 +64,20 @@ function isScreenOff(observation: ObserveResult): boolean {
 /**
  * Poll `observeScreen` until `onObservation` returns true or the budget expires.
  *
- * Freshness: each poll advances `minTimestamp` to the previous observation's
- * `updatedAt` (the first seeds from loop start) and passes `skipWaitForFresh:
- * false`, so every read prefers a capture at least as new as the last. The
- * device freshness gate is inclusive (`updatedAt >= minTimestamp`), so this is
- * "at least as new", not "strictly newer" — it steers each poll toward the
- * latest available capture without forcing a full fresh-wait on a static screen
- * (which a `+1` strict bound would). On a screen-off (Android) capture the loop
- * fast-fails rather than burning the budget against a dark screen.
+ * Freshness: the `minTimestamp` floor lives in ONE clock domain end-to-end —
+ * the device-authored `updatedAt` (issue #6284). It is seeded from
+ * `initialMinTimestampMs` when the caller supplies a device-domain floor,
+ * otherwise left unseeded so the first poll takes the freshest capture and the
+ * floor is seeded from that observation's own device timestamp. It is then only
+ * ever RAISED (`Math.max`), never lowered: a stale/cached capture returned by a
+ * timed-out sub-poll carries an older `updatedAt`, and flooring on it naively
+ * would drop the floor and let the same stale hash re-satisfy a caller's
+ * predicate. Each poll passes `skipWaitForFresh: false`, and the device
+ * freshness gate is inclusive (`updatedAt >= minTimestamp`) — "at least as new",
+ * not "strictly newer" — so it steers each poll toward the latest available
+ * capture without forcing a full fresh-wait on a static screen. On a screen-off
+ * (Android) capture the loop fast-fails rather than burning the budget against a
+ * dark screen.
  */
 export async function pollObserveUntil(
   observeScreen: ObserveScreen,
@@ -70,13 +92,18 @@ export async function pollObserveUntil(
   const start = timer.now();
   let previous: ObserveResult | undefined;
   let polls = 0;
+  // Monotonic device-clock-domain floor (issue #6284). `undefined` until the
+  // caller seeds it or the first observation seeds it; `undefined`/0 means "no
+  // floor" to `ObserveScreen.execute` (it coerces `minTimestamp ?? 0` and only
+  // treats `> 0` as a real constraint), so an unseeded first poll accepts the
+  // freshest capture available.
+  let floor = options.initialMinTimestampMs;
 
   while (true) {
     throwIfAborted(options.signal);
 
-    const minTimestamp = previous !== undefined ? updatedAtToMillis(previous.updatedAt) : start;
     const observation = await observeScreen.execute({
-      minTimestamp,
+      minTimestamp: floor ?? 0,
       skipWaitForFresh: false,
       signal: options.signal,
       // Polls are intermediate state only. Public callers that opt into
@@ -86,6 +113,12 @@ export async function pollObserveUntil(
     });
     polls++;
     throwIfAborted(options.signal);
+
+    // Raise the floor to this capture's device timestamp (seeding it on the
+    // first poll when unseeded). `Math.max` guarantees a stale/cached capture
+    // can never LOWER the floor for a later poll.
+    const observedMs = updatedAtToMillis(observation.updatedAt);
+    floor = floor === undefined ? observedMs : Math.max(floor, observedMs);
 
     if (isScreenOff(observation)) {
       return { observation, polls, waitMs: timer.now() - start, stopped: false };

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -22,13 +22,15 @@ export interface ObservePollOptions {
   pollMs: number;
   signal?: AbortSignal;
   /**
-   * Optional seed for the monotonic `minTimestamp` floor, in the SAME clock
-   * domain the floor lives in end-to-end: the device-authored `updatedAt`
+   * Optional seed for the entering reference / monotonic floor, in the SAME
+   * clock domain they live in end-to-end: the device-authored `updatedAt`
    * (issue #6284). Supply a device-clock-domain timestamp (e.g. the capture
-   * that triggered a post-tap settle) so the FIRST poll already requires a
-   * read at least as new as that capture. Omit it for the default path: the
-   * first poll then takes the freshest capture available and the floor is
-   * seeded from THAT observation's own device timestamp.
+   * that triggered a post-tap settle) so the FIRST poll is forced STRICTLY past
+   * that capture (`> reference`) — it can neither re-read that same cache entry
+   * nor accept it as terminal evidence. Omit it for the default path: the first
+   * poll then takes a baseline capture (which likewise cannot be terminal) and
+   * subsequent polls are forced strictly past THAT baseline until a genuine
+   * post-invocation read arrives.
    *
    * Never pass a host-clock timestamp here. An Android device clock trailing
    * the daemon (issue #5377) would make every genuinely-fresh device capture
@@ -62,22 +64,55 @@ function isScreenOff(observation: ObserveResult): boolean {
 }
 
 /**
+ * The `minTimestamp` floor for the next poll (issue #6284). Before a genuine
+ * post-invocation capture exists, force the poll STRICTLY past the entering
+ * reference (`reference + 1`) so the delegate cannot serve a still-fresh
+ * pre-call cache entry as the answer. Afterwards, floor inclusively on the
+ * monotonic device floor so a static screen settles without a fresh-wait every
+ * poll. `0` means "no floor" to `ObserveScreen.execute` (only `> 0` constrains).
+ */
+function nextPollMinTimestamp(
+  hasPostInvocationEvidence: boolean,
+  deviceFloor: number | undefined,
+  enteringReference: number | undefined,
+): number {
+  if (hasPostInvocationEvidence) {
+    return deviceFloor !== undefined && deviceFloor > 0 ? deviceFloor : 0;
+  }
+  return enteringReference !== undefined && enteringReference > 0 ? enteringReference + 1 : 0;
+}
+
+/**
  * Poll `observeScreen` until `onObservation` returns true or the budget expires.
  *
- * Freshness: the `minTimestamp` floor lives in ONE clock domain end-to-end —
- * the device-authored `updatedAt` (issue #6284). It is seeded from
- * `initialMinTimestampMs` when the caller supplies a device-domain floor,
- * otherwise left unseeded so the first poll takes the freshest capture and the
- * floor is seeded from that observation's own device timestamp. It is then only
- * ever RAISED (`Math.max`), never lowered: a stale/cached capture returned by a
- * timed-out sub-poll carries an older `updatedAt`, and flooring on it naively
- * would drop the floor and let the same stale hash re-satisfy a caller's
- * predicate. Each poll passes `skipWaitForFresh: false`, and the device
- * freshness gate is inclusive (`updatedAt >= minTimestamp`) — "at least as new",
- * not "strictly newer" — so it steers each poll toward the latest available
- * capture without forcing a full fresh-wait on a static screen. On a screen-off
- * (Android) capture the loop fast-fails rather than burning the budget against a
- * dark screen.
+ * Freshness lives in ONE clock domain end-to-end — the device-authored
+ * `updatedAt` (issue #6284) — and turns on two related quantities:
+ *
+ *  - The **entering reference**: the device timestamp the loop must get strictly
+ *    PAST before any observation can count as terminal evidence. Seeded from
+ *    `initialMinTimestampMs` when the caller supplies one (the capture that
+ *    triggered a post-tap settle); otherwise the loop's own FIRST observation is
+ *    a throwaway baseline that establishes it. Either way that reference is a
+ *    pre-invocation capture, so a match against it would prove nothing about the
+ *    current screen: a public `waitFor` could report a condition that ceased to
+ *    be true just before the call, and a settle could declare stability without
+ *    ever reading past the cache the call started from. So until the loop
+ *    obtains a capture whose `updatedAt` is STRICTLY newer than the entering
+ *    reference (`> reference`, via a `reference + 1` floor that forces the
+ *    delegate past any still-fresh cache entry — issue #6284 P1), a `true` from
+ *    `onObservation` is ignored.
+ *  - The **monotonic device floor**: once a genuine post-invocation capture is
+ *    in hand, later polls floor INCLUSIVELY (`updatedAt >= floor`, floor =
+ *    `Math.max` of every capture seen) so a static screen settles promptly
+ *    instead of forcing a full fresh-wait every poll, while a stale/cached
+ *    capture returned by a timed-out sub-poll can never LOWER the floor and
+ *    re-satisfy a predicate with an older hash.
+ *
+ * Never pass a host-clock value as `initialMinTimestampMs`: a device clock
+ * trailing the daemon (issue #5377) would make every fresh capture look older
+ * than a host-domain floor and burn the whole budget. On a screen-off (Android)
+ * capture the loop fast-fails rather than burning the budget against a dark
+ * screen.
  */
 export async function pollObserveUntil(
   observeScreen: ObserveScreen,
@@ -92,18 +127,27 @@ export async function pollObserveUntil(
   const start = timer.now();
   let previous: ObserveResult | undefined;
   let polls = 0;
-  // Monotonic device-clock-domain floor (issue #6284). `undefined` until the
-  // caller seeds it or the first observation seeds it; `undefined`/0 means "no
-  // floor" to `ObserveScreen.execute` (it coerces `minTimestamp ?? 0` and only
-  // treats `> 0` as a real constraint), so an unseeded first poll accepts the
-  // freshest capture available.
-  let floor = options.initialMinTimestampMs;
+  // The device timestamp the loop must get STRICTLY past before an observation
+  // can be terminal. `undefined` until seeded by the caller or by the first
+  // (baseline) observation.
+  let enteringReference = options.initialMinTimestampMs;
+  // Monotonic device-clock-domain floor; `undefined` until the first capture.
+  let deviceFloor = options.initialMinTimestampMs;
+  // Set once any capture is strictly newer than the entering reference — from
+  // then on the floor relaxes to inclusive so a static screen can settle.
+  let hasPostInvocationEvidence = false;
 
   while (true) {
     throwIfAborted(options.signal);
 
+    const minTimestamp = nextPollMinTimestamp(
+      hasPostInvocationEvidence,
+      deviceFloor,
+      enteringReference,
+    );
+
     const observation = await observeScreen.execute({
-      minTimestamp: floor ?? 0,
+      minTimestamp,
       skipWaitForFresh: false,
       signal: options.signal,
       // Polls are intermediate state only. Public callers that opt into
@@ -114,17 +158,31 @@ export async function pollObserveUntil(
     polls++;
     throwIfAborted(options.signal);
 
-    // Raise the floor to this capture's device timestamp (seeding it on the
-    // first poll when unseeded). `Math.max` guarantees a stale/cached capture
-    // can never LOWER the floor for a later poll.
     const observedMs = updatedAtToMillis(observation.updatedAt);
-    floor = floor === undefined ? observedMs : Math.max(floor, observedMs);
+    // Unseeded: the first observation is a throwaway baseline. It establishes
+    // the entering reference (and the floor) but can never itself be terminal
+    // evidence — it may be the pre-call cache the loop must read past.
+    if (enteringReference === undefined) {
+      enteringReference = observedMs;
+    }
+    // `Math.max` guarantees a stale/cached capture can never LOWER the floor.
+    deviceFloor = deviceFloor === undefined ? observedMs : Math.max(deviceFloor, observedMs);
+    // Strictly newer than the entering/baseline capture => a genuine
+    // post-invocation read the caller may act on.
+    const isPostInvocation = observedMs > enteringReference;
+    if (isPostInvocation) {
+      hasPostInvocationEvidence = true;
+    }
 
     if (isScreenOff(observation)) {
       return { observation, polls, waitMs: timer.now() - start, stopped: false };
     }
 
-    if (onObservation(observation, previous, polls)) {
+    // Always evaluate so stateful predicates (e.g. a settle's run counter)
+    // advance every poll, but only ACCEPT a stop backed by a post-invocation
+    // capture — never the entering reference re-served from cache.
+    const matched = onObservation(observation, previous, polls);
+    if (matched && isPostInvocation) {
       return { observation, polls, waitMs: timer.now() - start, stopped: true };
     }
 

--- a/src/features/observe/ObservePoll.ts
+++ b/src/features/observe/ObservePoll.ts
@@ -186,7 +186,13 @@ export async function pollObserveUntil(
     // wrong-window and incomplete hierarchies stale even when CtrlProxy was
     // able to stamp them; those trees must neither satisfy a predicate nor
     // advance stateful settle predicates.
-    const isExplicitlyStale = observation.freshness?.isFresh === false;
+    // `isFresh` can be normalized back to true when a cached hierarchy happens
+    // to meet a requested timestamp floor. The delegate's `verified: false`
+    // still says that no synchronous device read confirmed this sample, so it
+    // cannot become polling evidence merely because its cached timestamp is
+    // recent enough.
+    const isExplicitlyStale =
+      observation.freshness?.isFresh === false || observation.freshness?.verified === false;
     // Unseeded: the first observation is a throwaway baseline. It establishes
     // the entering reference (and the floor) but can never itself be terminal
     // evidence — it may be the pre-call cache the loop must read past.
@@ -215,7 +221,10 @@ export async function pollObserveUntil(
       newestTrustworthyObservation = observation;
     }
 
-    if (isScreenOff(observation)) {
+    // A screen-off terminal is only meaningful when the same observation passed
+    // the admission contract. A stale cached "Asleep" frame after the device
+    // wakes must not fast-fail a public wait or be promoted by tap settlement.
+    if (isScreenOff(observation) && isAdmissibleEvidence) {
       return { observation, polls, waitMs: timer.now() - start, stopped: false };
     }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1510,7 +1510,10 @@ export class RealObserveScreen implements ObserveScreen {
     signal?: AbortSignal,
   ): Promise<boolean> {
     const initialTimestamp = this.resolveObservationTimestampMs(result);
-    const minTimestamp = (initialTimestamp ?? this.timer.now()) + 1;
+    // `minTimestamp` is interpreted by the device hierarchy source. If this
+    // partial result has no hierarchy-owned device timestamp, omit the floor;
+    // substituting the host timer would cross clock domains.
+    const minTimestamp = initialTimestamp === undefined ? undefined : initialTimestamp + 1;
     let hierarchy: ObserveResult["viewHierarchy"];
     try {
       // `minTimestamp` rejects the cached (initial) tree; skipping the fresh wait
@@ -1626,7 +1629,9 @@ export class RealObserveScreen implements ObserveScreen {
     signal?: AbortSignal,
   ): Promise<boolean> {
     const initialTimestamp = this.resolveObservationTimestampMs(result);
-    const minTimestamp = (initialTimestamp ?? this.timer.now()) + 1;
+    // See the overlay recapture path above: never substitute host time for a
+    // device-side freshness floor when the initial hierarchy has no timestamp.
+    const minTimestamp = initialTimestamp === undefined ? undefined : initialTimestamp + 1;
     let hierarchy: ObserveResult["viewHierarchy"];
     try {
       // `minTimestamp` rejects the cached (initial) tree; skipping the fresh
@@ -1945,17 +1950,7 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   private resolveObservationTimestampMs(result: ObserveResult): number | undefined {
-    const candidate = result.viewHierarchy?.updatedAt ?? result.updatedAt;
-    if (typeof candidate === "number" && !Number.isNaN(candidate)) {
-      return candidate;
-    }
-    if (typeof candidate === "string") {
-      const parsed = Date.parse(candidate);
-      if (!Number.isNaN(parsed)) {
-        return parsed;
-      }
-    }
-    return undefined;
+    return result.viewHierarchy?.updatedAt;
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1009,6 +1009,7 @@ export class RealObserveScreen implements ObserveScreen {
           const parallelTasks: Promise<void>[] = [];
           if (hierarchy.wakefulness) {
             result.wakefulness = hierarchy.wakefulness;
+            result.wakefulnessSource = "hierarchy";
           } else {
             parallelTasks.push(
               perf.track("wakefulness", () =>
@@ -1510,10 +1511,15 @@ export class RealObserveScreen implements ObserveScreen {
     signal?: AbortSignal,
   ): Promise<boolean> {
     const initialTimestamp = this.resolveObservationTimestampMs(result);
-    // `minTimestamp` is interpreted by the device hierarchy source. If this
-    // partial result has no hierarchy-owned device timestamp, omit the floor;
-    // substituting the host timer would cross clock domains.
-    const minTimestamp = initialTimestamp === undefined ? undefined : initialTimestamp + 1;
+    if (initialTimestamp === undefined) {
+      logger.debug(
+        "[OBSERVE] Skipping SystemUI-overlay recapture without a device capture timestamp",
+      );
+      return false;
+    }
+    // `minTimestamp` is interpreted by the device hierarchy source. It is
+    // present only after the guard above proved a hierarchy-owned device stamp.
+    const minTimestamp = initialTimestamp + 1;
     let hierarchy: ObserveResult["viewHierarchy"];
     try {
       // `minTimestamp` rejects the cached (initial) tree; skipping the fresh wait
@@ -1629,9 +1635,13 @@ export class RealObserveScreen implements ObserveScreen {
     signal?: AbortSignal,
   ): Promise<boolean> {
     const initialTimestamp = this.resolveObservationTimestampMs(result);
-    // See the overlay recapture path above: never substitute host time for a
-    // device-side freshness floor when the initial hierarchy has no timestamp.
-    const minTimestamp = initialTimestamp === undefined ? undefined : initialTimestamp + 1;
+    if (initialTimestamp === undefined) {
+      logger.debug("[OBSERVE] Skipping back-stack recapture without a device capture timestamp");
+      return false;
+    }
+    // See the overlay recapture path above: the guard ensures this is a
+    // device-side floor, never a substituted host timestamp.
+    const minTimestamp = initialTimestamp + 1;
     let hierarchy: ObserveResult["viewHierarchy"];
     try {
       // `minTimestamp` rejects the cached (initial) tree; skipping the fresh
@@ -1787,6 +1797,9 @@ export class RealObserveScreen implements ObserveScreen {
       units: "unknown",
     };
     result.wakefulness = hierarchy.wakefulness ?? result.wakefulness;
+    if (hierarchy.wakefulness) {
+      result.wakefulnessSource = "hierarchy";
+    }
     result.intentChooserDetected = hierarchy.intentChooserDetected;
     result.notificationPermissionDetected = hierarchy.notificationPermissionDetected;
     result.focusedElement = this.viewHierarchy.findFocusedElement(hierarchy) ?? undefined;

--- a/src/features/observe/SettleObserve.ts
+++ b/src/features/observe/SettleObserve.ts
@@ -75,6 +75,7 @@ export class RealSettleObserve implements SettleObserve {
       settled: outcome.stopped,
       polls: outcome.polls,
       waitMs: outcome.waitMs,
+      terminalReason: outcome.terminalReason === "matched" ? "settled" : outcome.terminalReason,
     };
   }
 }

--- a/src/features/observe/WaitForCondition.ts
+++ b/src/features/observe/WaitForCondition.ts
@@ -71,6 +71,7 @@ export class RealWaitForCondition implements WaitForCondition {
       polls: outcome.polls,
       waitMs: outcome.waitMs,
       timedOut: true,
+      screenOff: outcome.terminalReason === "screen_off" ? true : undefined,
     };
   }
 }

--- a/src/features/observe/WaitForCondition.ts
+++ b/src/features/observe/WaitForCondition.ts
@@ -39,7 +39,12 @@ export class RealWaitForCondition implements WaitForCondition {
     const outcome = await pollObserveUntil(
       this.observeScreen,
       this.timer,
-      { timeoutMs, pollMs, signal: options.signal },
+      {
+        timeoutMs,
+        pollMs,
+        signal: options.signal,
+        initialMinTimestampMs: options.initialMinTimestampMs,
+      },
       (observation) => {
         lastEvaluation = predicate(observation);
         return lastEvaluation.matched;

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -31,6 +31,7 @@ export class DeviceStateCollector {
       const wakefulness = await adb.getWakefulness(signal);
       if (wakefulness) {
         result.wakefulness = wakefulness;
+        result.wakefulnessSource = "adb";
       }
     } catch (error) {
       logger.warn("Failed to get wakefulness state:", error);

--- a/src/features/observe/interfaces/SettleObserve.ts
+++ b/src/features/observe/interfaces/SettleObserve.ts
@@ -30,6 +30,8 @@ export interface SettleResult {
   polls: number;
   /** Wall-clock spent waiting (per the injected Timer). */
   waitMs: number;
+  /** Why polling completed. This distinguishes a budget timeout from screen-off. */
+  terminalReason: "settled" | "screen_off" | "timeout";
 }
 
 /**
@@ -46,7 +48,7 @@ export interface SettleResult {
  *   `isSameObservationScreen` gate, so it can never register as settled. This is
  *   the shared diff's conservative cross-screen guard, not a settle-specific one.
  * - A screen-off (Android) capture fast-fails to `settled: false, polls: 1`;
- *   inspect `observation.wakefulness === "Asleep"` to tell it from a real timeout.
+ *   inspect `terminalReason` to tell it from a real timeout.
  */
 export interface SettleObserve {
   execute(options?: SettleOptions): Promise<SettleResult>;

--- a/src/features/observe/interfaces/WaitForCondition.ts
+++ b/src/features/observe/interfaces/WaitForCondition.ts
@@ -30,6 +30,14 @@ export interface WaitForConditionOptions {
   pollMs?: number;
   /** Cancellation signal, checked before each poll and after each observation. */
   signal?: AbortSignal;
+  /**
+   * Device-clock-domain (`updatedAt`) seed for the poll loop's monotonic
+   * `minTimestamp` floor (issue #6284). Pass the device timestamp of the
+   * capture the caller wants the first poll to be at least as new as — e.g. a
+   * pre-tap/post-tap observation's `updatedAt` — so the settle floor is in the
+   * same domain the device freshness gate compares against. Never a host clock.
+   */
+  initialMinTimestampMs?: number;
 }
 
 /**

--- a/src/features/observe/interfaces/WaitForCondition.ts
+++ b/src/features/observe/interfaces/WaitForCondition.ts
@@ -55,6 +55,8 @@ export interface WaitForConditionResult {
   polls: number;
   waitMs: number;
   timedOut: boolean;
+  /** Present only when polling ended on an admissible live screen-off read. */
+  screenOff?: true;
 }
 
 /**

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -128,6 +128,31 @@ export interface FreshnessInputs {
   maxAgeMs?: number;
 }
 
+/**
+ * WHY a freshness verdict failed, as a stable discriminant a consumer can branch
+ * on instead of pattern-matching the human-readable `warning` (issue #6284 P1).
+ * The distinction that matters at the tap layer is whether a fresh view-hierarchy
+ * re-capture RESOLVES the failure:
+ *
+ *  - `cache_age` — the tree was stale/unverified from the host-side cache, or
+ *    past the age budget. A live hierarchy re-capture resolves exactly this.
+ *  - `window_identity` — wrong-window, status-bar-only, activity-attribution
+ *    mismatch, incomplete capture, or a missing foreground window. These describe
+ *    WHICH window/app the tree belongs to; swapping in a freshly-captured
+ *    hierarchy (which may still be from the wrong window) does NOT resolve them.
+ *  - `requested_min` — an explicit `minTimestamp` was not satisfied.
+ *  - `no_timestamp` — the capture carried no timestamp to judge.
+ *  - `unavailable` — no hierarchy could be retrieved at all.
+ *
+ * Only ever set when `isFresh` is false.
+ */
+export type FreshnessFailureCategory =
+  | "cache_age"
+  | "window_identity"
+  | "requested_min"
+  | "no_timestamp"
+  | "unavailable";
+
 export interface FreshnessVerdict {
   requestedAfter?: number;
   actualTimestamp?: number;
@@ -149,6 +174,11 @@ export interface FreshnessVerdict {
   staleDurationMs?: number;
   /** Names the CAUSE whenever `isFresh` is false. */
   warning?: string;
+  /**
+   * Stable discriminant for WHY freshness failed, for consumers that must decide
+   * whether a re-capture resolves it. Present only when `isFresh` is false.
+   */
+  category?: FreshnessFailureCategory;
 }
 
 /**
@@ -178,6 +208,7 @@ function computeRequestedFreshness(
       : actualTimestamp === undefined
         ? "Observation carries no capture timestamp, so the requested minimum could not be checked."
         : `Observation was captured ${staleDurationMs}ms before the requested minimum timestamp.`,
+    category: isFresh ? undefined : "requested_min",
   };
 }
 
@@ -274,6 +305,7 @@ function resolveIdentityMismatch(
       verified: false,
       isFresh: false,
       warning: `Observed hierarchy is from ${observed}, but the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+      category: "window_identity",
     };
   }
   if (inputs.statusBarOnlyHierarchy) {
@@ -287,6 +319,7 @@ function resolveIdentityMismatch(
       warning: ctrlProxyIncomplete
         ? unreadableFocusedWindowWarning(foreground, sdkInt)
         : `Observed hierarchy contains only Android status-bar content while the device's current top resumed activity is ${foreground}. This is a stale wrong-window capture; it was not verified against the foreground app. The runner is serving a stale window; call pressButton { platform: "android", button: "home" } (or relaunch the target app) and observe again.`,
+      category: "window_identity",
     };
   }
   if (inputs.activityAttributionMismatch) {
@@ -298,6 +331,7 @@ function resolveIdentityMismatch(
       isFresh: false,
       warning:
         "CtrlProxy and adb disagree about the current activity, and a fresh hierarchy could not reconcile them. The observation was not verified against the current activity; call observe again.",
+      category: "window_identity",
     };
   }
   // The service reported the focused application's root as unreadable even
@@ -322,6 +356,7 @@ function resolveIdentityMismatch(
       verified: false,
       isFresh: false,
       warning: `The accessibility service reported the capture as incomplete: ${lead}. ${incompleteCaptureGuidance(sdkInt, reason)}`,
+      category: "window_identity",
     };
   }
   // Lowest-priority fallback (issue #6220): none of the device-confirmed gates
@@ -342,6 +377,7 @@ function resolveIdentityMismatch(
         reason === "status_bar_only"
           ? "Observed hierarchy contains only Android status-bar content — every extracted node lies within the status-bar strip, not a full foreground application window. Any package/activity attribution on this capture may be stale from a previous app; this capture cannot be trusted to reflect any app's screen. Call observe again."
           : "Observed hierarchy reports no foreground application window (activeWindow.appId is empty), so this capture cannot be trusted to reflect the current screen; call observe again.",
+      category: "window_identity",
     };
   }
   return undefined;
@@ -381,6 +417,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       verified,
       isFresh: false,
       warning: unavailableWarning(inputs.incompleteCapture),
+      category: "unavailable",
     };
   }
 
@@ -405,6 +442,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       verified,
       isFresh: false,
       warning: "Observation carries no capture timestamp, so its freshness cannot be established.",
+      category: "no_timestamp",
     };
   }
 
@@ -422,6 +460,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       isFresh: false,
       staleDurationMs: overBudget ? ageMs : undefined,
       warning: `Hierarchy was served from the host-side cache without being re-verified against the device (captured ${ageMs}ms ago). The runner did not answer a synchronous hierarchy request.`,
+      category: "cache_age",
     };
   }
 
@@ -456,6 +495,7 @@ export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
       isFresh: false,
       staleDurationMs: ageMs,
       warning: `Hierarchy was captured ${ageMs}ms ago, past the ${maxAgeMs}ms freshness budget (AUTOMOBILE_MAX_OBSERVATION_AGE_MS), and the source did not report whether it was verified against the device.`,
+      category: "cache_age",
     };
   }
 

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -143,6 +143,8 @@ export interface FreshnessInputs {
  *  - `requested_min` — an explicit `minTimestamp` was not satisfied.
  *  - `no_timestamp` — the capture carried no timestamp to judge.
  *  - `unavailable` — no hierarchy could be retrieved at all.
+ *  - `effect_inconsistent` — the returned capture still describes the
+ *    pre-action screen even though the action reported a screen change.
  *
  * Only ever set when `isFresh` is false.
  */
@@ -151,7 +153,8 @@ export type FreshnessFailureCategory =
   | "window_identity"
   | "requested_min"
   | "no_timestamp"
-  | "unavailable";
+  | "unavailable"
+  | "effect_inconsistent";
 
 export interface FreshnessVerdict {
   requestedAfter?: number;

--- a/src/features/observe/observeTimestamp.ts
+++ b/src/features/observe/observeTimestamp.ts
@@ -1,3 +1,5 @@
+import type { ViewHierarchyResult } from "../../models";
+
 /**
  * Coerce an `ObserveResult.updatedAt` to a number of milliseconds since epoch.
  *
@@ -20,4 +22,20 @@ export function updatedAtToMillis(updatedAt: string | number): number {
   }
   const parsed = Date.parse(updatedAt);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Return the device-authored timestamp carried by a hierarchy capture.
+ *
+ * `ObserveResult.updatedAt` is deliberately excluded here: it is also the
+ * host-created timestamp of an incomplete/base observation. Passing that value
+ * to a device-side `minTimestamp` mixes clock domains and can either reject a
+ * current capture or admit a cached one. Callers that need a freshness floor
+ * must therefore use only this hierarchy-owned value.
+ */
+export function hierarchyUpdatedAtToMillis(
+  hierarchy: Pick<ViewHierarchyResult, "updatedAt"> | undefined,
+): number | undefined {
+  const updatedAt = hierarchy?.updatedAt;
+  return typeof updatedAt === "number" && Number.isFinite(updatedAt) ? updatedAt : undefined;
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -384,7 +384,13 @@ export interface ObserveResult {
      * activity-attribution / incomplete-capture / missing foreground window),
      * "requested_min", "no_timestamp", or "unavailable".
      */
-    category?: "cache_age" | "window_identity" | "requested_min" | "no_timestamp" | "unavailable";
+    category?:
+      | "cache_age"
+      | "window_identity"
+      | "requested_min"
+      | "no_timestamp"
+      | "unavailable"
+      | "effect_inconsistent";
   };
 
   /**

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -375,6 +375,14 @@ export interface ObserveResult {
     staleDurationMs?: number;
     /** Optional warning when freshness could not be guaranteed */
     warning?: string;
+    /**
+     * Stable discriminant for WHY freshness failed (present only when `isFresh`
+     * is false): "cache_age" (stale/unverified/over-budget — a re-capture
+     * resolves it), "window_identity" (wrong-window / status-bar-only /
+     * activity-attribution / incomplete-capture / missing foreground window),
+     * "requested_min", "no_timestamp", or "unavailable".
+     */
+    category?: "cache_age" | "window_identity" | "requested_min" | "no_timestamp" | "unavailable";
   };
 
   /**

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -245,6 +245,8 @@ export interface ObserveResult {
    * - "Dozing": Device is in ambient display / always-on mode
    */
   wakefulness?: "Awake" | "Asleep" | "Dozing";
+  /** Provenance used internally to distinguish a live device-state read from cached hierarchy metadata. */
+  wakefulnessSource?: "hierarchy" | "adb";
 
   /**
    * Structured device-lock signal (Android only). Present when the lock state

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -690,9 +690,10 @@ const runWaitForConditionDsl = async (
       awaitDuration: settle.waitMs,
       awaitTimeout: !settle.settled,
       settled: settle.settled,
-      // A screen-off capture fast-fails the settle primitive; it did not use
-      // the timeout budget, so distinguish it from a genuine timeout.
-      timedOut: !settle.settled && settle.observation.wakefulness !== "Asleep",
+      // The terminal reason preserves whether an Asleep observation was an
+      // admissible screen-off fast-fail or merely the last stale frame at the
+      // end of an exhausted timeout budget.
+      timedOut: settle.terminalReason === "timeout",
       polls: settle.polls,
       waitMs: settle.waitMs,
     };

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -409,7 +409,14 @@ export const freshnessSchema = z
     warning: z.string().optional(),
     /** Stable discriminant for WHY freshness failed (only when `isFresh` is false). */
     category: z
-      .enum(["cache_age", "window_identity", "requested_min", "no_timestamp", "unavailable"])
+      .enum([
+        "cache_age",
+        "window_identity",
+        "requested_min",
+        "no_timestamp",
+        "unavailable",
+        "effect_inconsistent",
+      ])
       .optional(),
   })
   .passthrough();

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -407,6 +407,10 @@ export const freshnessSchema = z
     isFresh: z.boolean(),
     staleDurationMs: z.number().int().optional(),
     warning: z.string().optional(),
+    /** Stable discriminant for WHY freshness failed (only when `isFresh` is false). */
+    category: z
+      .enum(["cache_age", "window_identity", "requested_min", "no_timestamp", "unavailable"])
+      .optional(),
   })
   .passthrough();
 

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { RealWaitForCondition } from "../../../src/features/observe/WaitForCondition";
+import type { WaitForCondition } from "../../../src/features/observe/interfaces/WaitForCondition";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+/**
+ * Issue #6284: a hierarchy-ONLY post-tap change (activeWindow unchanged, only
+ * viewHierarchy differs) must be SETTLED across a real stability interval —
+ * confirmed stable across consecutive polls, or promoted to an authoritative
+ * activeWindow change — before it is trusted as the terminal effect. A
+ * transient intermediate mutation (a focused/selected/checked flip, a partial
+ * hierarchy update before a delayed dialog/nav) must not be returned in place
+ * of the actual destination, AND a later destination must not be missed
+ * (`baseline → A → A → B` reaches B).
+ *
+ * These tests drive the REAL settle loop (`pollObserveUntil` + the settle
+ * predicate) through `RealWaitForCondition` over a scripted `FakeObserveScreen`
+ * sequence, with all time controlled by FakeTimer, so the device-clock-domain
+ * monotonic floor and the two-consecutive-poll stability rule are exercised
+ * together. Every test runs well under 100ms and never touches a device or DB.
+ */
+
+const activeWindow = {
+  appId: "com.example.app",
+  activityName: "com.example.app.MainActivity",
+  layoutSeqSum: 7,
+};
+
+function makeHierarchy(marker: string): ViewHierarchyResult {
+  return {
+    packageName: "com.example.app",
+    hierarchy: { node: { marker } },
+  } as unknown as ViewHierarchyResult;
+}
+
+function makeObservation(overrides: Partial<ObserveResult>): ObserveResult {
+  return {
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    activeWindow,
+    ...overrides,
+  } as ObserveResult;
+}
+
+function createTapOnElement(waitForCondition?: WaitForCondition): TapOnElement {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  return new TapOnElement(
+    { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+    new FakeAdbClient() as any,
+    { timer, waitForCondition },
+  );
+}
+
+/** A TapOnElement wired to a real settle loop over a scripted observe sequence. */
+function createTapWithSettleSequence(settleFrames: ObserveResult[]): TapOnElement {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  const fake = new FakeObserveScreen();
+  fake.setObserveSequence(settleFrames);
+  const waitForCondition = new RealWaitForCondition(fake, timer);
+  return new TapOnElement(
+    { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+    new FakeAdbClient() as any,
+    { timer, waitForCondition },
+  );
+}
+
+describe("deriveTapEffectAfterPostTapObservation settles hierarchy-only changes (#6284)", () => {
+  test("baseline -> A -> A -> B reaches the settled destination B, not the transient A", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    // Entering capture: a transient hierarchy flip (activeWindow unchanged).
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    // Settle poll frames: one more A, then the real destination B stabilises.
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 30, viewHierarchy: makeHierarchy("B") }),
+      makeObservation({ updatedAt: 40, viewHierarchy: makeHierarchy("B") }),
+      makeObservation({ updatedAt: 50, viewHierarchy: makeHierarchy("B") }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect(postTap.effect).toEqual({ screenChanged: true, basis: "viewHierarchy changed" });
+    expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("B");
+  });
+
+  test("a same-activity dialog (activeWindow unchanged) settles and is reported changed (#6151)", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("alarm-list") });
+    // Dialogs don't move activeWindow; only the hierarchy reflects them.
+    const dialog = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("time-picker") });
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, viewHierarchy: makeHierarchy("time-picker") }),
+      makeObservation({ updatedAt: 30, viewHierarchy: makeHierarchy("time-picker") }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, dialog);
+
+    expect(postTap.effect).toEqual({ screenChanged: true, basis: "viewHierarchy changed" });
+    expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("time-picker");
+  });
+
+  test("a transient flip that reverts to baseline reports no screen change", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    // Reverts to the original baseline and stays there.
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, viewHierarchy: makeHierarchy("baseline") }),
+      makeObservation({ updatedAt: 30, viewHierarchy: makeHierarchy("baseline") }),
+      makeObservation({ updatedAt: 40, viewHierarchy: makeHierarchy("baseline") }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect(postTap.effect?.screenChanged).toBe(false);
+  });
+
+  test("a definitive screen-off (Asleep) terminal preserves screenChanged:true (assert the effect)", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    // The device goes to sleep mid-settle: the first settle poll is a screen-off
+    // capture with no viewHierarchy. Re-deriving over it would find only an
+    // unchanged activeWindow and erase the transition — the terminal must keep
+    // the already-established screenChanged:true.
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, wakefulness: "Asleep", viewHierarchy: undefined }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect(postTap.effect).toEqual({ screenChanged: true, basis: "viewHierarchy changed" });
+    expect(postTap.observation.wakefulness).toBe("Asleep");
+  });
+
+  test("an activeWindow change is authoritative and returns immediately WITHOUT settling", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const navigated = makeObservation({
+      updatedAt: 10,
+      activeWindow: {
+        ...activeWindow,
+        activityName: "com.example.app.DetailActivity",
+        layoutSeqSum: 8,
+      },
+      viewHierarchy: makeHierarchy("detail-screen"),
+    });
+
+    let waitCalls = 0;
+    const waitForCondition: WaitForCondition = {
+      execute: async () => {
+        waitCalls++;
+        throw new Error("must not poll for an authoritative activeWindow change");
+      },
+    };
+    const tap = createTapOnElement(waitForCondition);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, navigated);
+
+    expect(waitCalls).toBe(0);
+    expect(postTap.effect).toEqual({ screenChanged: true, basis: "activeWindow changed" });
+    expect(postTap.observation).toBe(navigated);
+  });
+});
+
+describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
+  test("replaceObservationHierarchy promotes a stale verdict to fresh when refreshed from device", () => {
+    const tap = createTapOnElement();
+    const observation = makeObservation({
+      viewHierarchy: makeHierarchy("stale"),
+      screenSize: { width: 1, height: 1 },
+      freshness: {
+        isFresh: false,
+        verified: false,
+        warning: "served from host-side cache without re-verification",
+      },
+    });
+    const fresh = {
+      packageName: "com.example.app",
+      hierarchy: { node: { marker: "fresh" } },
+      screenWidth: 1080,
+      screenHeight: 1920,
+    } as unknown as ViewHierarchyResult;
+
+    (tap as any).replaceObservationHierarchy(observation, fresh, true);
+
+    expect(observation.viewHierarchy).toBe(fresh);
+    expect(observation.screenSize).toEqual({ width: 1080, height: 1920 });
+    expect(observation.freshness?.isFresh).toBe(true);
+    expect(observation.freshness?.verified).toBe(true);
+    expect(observation.freshness?.warning).toBeUndefined();
+  });
+
+  test("replaceObservationHierarchy leaves freshness untouched when NOT refreshed from device", () => {
+    const tap = createTapOnElement();
+    const staleFreshness = {
+      isFresh: false,
+      verified: false,
+      warning: "served from host-side cache without re-verification",
+    };
+    const observation = makeObservation({
+      viewHierarchy: makeHierarchy("old"),
+      freshness: { ...staleFreshness },
+    });
+    const replacement = makeHierarchy("same-in-hand");
+
+    (tap as any).replaceObservationHierarchy(observation, replacement, false);
+
+    expect(observation.viewHierarchy).toBe(replacement);
+    // No live re-capture happened, so the verdict must not be forged fresh.
+    expect(observation.freshness).toEqual(staleFreshness);
+  });
+});
+
+describe("enforceFreshnessConsistencyWithEffect and the screen-off terminal (#6284)", () => {
+  test("does NOT retract freshness on a definitive screen-off terminal", () => {
+    const tap = createTapOnElement();
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const asleep = makeObservation({
+      updatedAt: 10,
+      wakefulness: "Asleep",
+      viewHierarchy: undefined,
+      freshness: { isFresh: true, verified: true },
+    });
+    const result = {
+      effect: { screenChanged: true, basis: "viewHierarchy changed" as const },
+      observation: asleep,
+    };
+
+    (tap as any).enforceFreshnessConsistencyWithEffect(previous, result);
+
+    // The screen-off capture is the real post-tap state, not a stale pre-tap
+    // tree — its freshness must be left intact.
+    expect(result.observation.freshness).toEqual({ isFresh: true, verified: true });
+  });
+
+  test("still retracts freshness on a live-hierarchy observation that predates the transition", () => {
+    const tap = createTapOnElement();
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    // The returned observation still shows the pre-tap baseline while the effect
+    // claims a change: freshness must be retracted so the client re-observes.
+    const result = {
+      effect: { screenChanged: true, basis: "viewHierarchy changed" as const },
+      observation: makeObservation({
+        updatedAt: 10,
+        viewHierarchy: makeHierarchy("baseline"),
+        freshness: { isFresh: true, verified: true },
+      }),
+    };
+
+    (tap as any).enforceFreshnessConsistencyWithEffect(previous, result);
+
+    expect(result.observation.freshness?.isFresh).toBe(false);
+    expect(result.observation.freshness?.verified).toBe(false);
+    expect(result.observation.freshness?.warning).toContain("predates the detected transition");
+  });
+});

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -294,6 +294,7 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
     const fresh = {
       packageName: "com.example.app",
       hierarchy: { node: { marker: "fresh" } },
+      updatedAt: 42,
       screenWidth: 1080,
       screenHeight: 1920,
     } as unknown as ViewHierarchyResult;

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -38,12 +38,21 @@ function makeHierarchy(marker: string): ViewHierarchyResult {
 }
 
 function makeObservation(overrides: Partial<ObserveResult>): ObserveResult {
+  const hierarchy = overrides.viewHierarchy;
+  const updatedAt = overrides.updatedAt ?? 1;
   return {
-    updatedAt: 1,
+    updatedAt,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     activeWindow,
     ...overrides,
+    // The polling contract accepts only device-authored hierarchy timestamps.
+    // Give each fixture its stated timestamp there too, rather than accidentally
+    // exercising timeout fallback with only the outer host-style metadata.
+    viewHierarchy:
+      hierarchy === undefined
+        ? undefined
+        : ({ ...hierarchy, updatedAt: hierarchy.updatedAt ?? updatedAt } as ViewHierarchyResult),
   } as ObserveResult;
 }
 

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -220,6 +220,7 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
     // The result carries the device capture time, never the FakeTimer/host
     // clock used to measure the surrounding action.
     expect(observation.freshness?.actualTimestamp).toBe(42);
+    expect(observation.updatedAt).toBe(42);
   });
 
   test("replaceObservationHierarchy does not promote an incomplete live replacement", () => {

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -177,7 +177,12 @@ describe("deriveTapEffectAfterPostTapObservation settles hierarchy-only changes 
     // unchanged activeWindow and erase the transition — the terminal must keep
     // the already-established screenChanged:true.
     const tap = createTapWithSettleSequence([
-      makeObservation({ updatedAt: 20, wakefulness: "Asleep", viewHierarchy: undefined }),
+      makeObservation({
+        updatedAt: 20,
+        wakefulness: "Asleep",
+        wakefulnessSource: "adb",
+        viewHierarchy: undefined,
+      }),
     ]);
 
     const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -204,6 +204,7 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
     const fresh = {
       packageName: "com.example.app",
       hierarchy: { node: { marker: "fresh" } },
+      updatedAt: 42,
       screenWidth: 1080,
       screenHeight: 1920,
     } as unknown as ViewHierarchyResult;
@@ -216,6 +217,34 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
     expect(observation.freshness?.verified).toBe(true);
     expect(observation.freshness?.warning).toBeUndefined();
     expect(observation.freshness?.category).toBeUndefined();
+    // The result carries the device capture time, never the FakeTimer/host
+    // clock used to measure the surrounding action.
+    expect(observation.freshness?.actualTimestamp).toBe(42);
+  });
+
+  test("replaceObservationHierarchy does not promote an incomplete live replacement", () => {
+    const tap = createTapOnElement();
+    const staleFreshness = {
+      isFresh: false as const,
+      verified: false,
+      category: "cache_age" as const,
+      warning: "served from host-side cache without re-verification",
+    };
+    const observation = makeObservation({
+      viewHierarchy: makeHierarchy("old"),
+      freshness: { ...staleFreshness },
+    });
+    const incomplete = {
+      packageName: "com.example.app",
+      hierarchy: { node: { marker: "partial" } },
+      updatedAt: 42,
+      ctrlProxyIncomplete: true,
+    } as unknown as ViewHierarchyResult;
+
+    (tap as any).replaceObservationHierarchy(observation, incomplete, true);
+
+    expect(observation.viewHierarchy).toBe(incomplete);
+    expect(observation.freshness).toEqual(staleFreshness);
   });
 
   test("replaceObservationHierarchy does NOT promote a non-cache-age freshness failure (#6284 P1)", () => {

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -316,6 +316,7 @@ describe("enforceFreshnessConsistencyWithEffect and the screen-off terminal (#62
     const asleep = makeObservation({
       updatedAt: 10,
       wakefulness: "Asleep",
+      wakefulnessSource: "adb",
       viewHierarchy: undefined,
       freshness: { isFresh: true, verified: true },
     });
@@ -329,6 +330,24 @@ describe("enforceFreshnessConsistencyWithEffect and the screen-off terminal (#62
     // The screen-off capture is the real post-tap state, not a stale pre-tap
     // tree — its freshness must be left intact.
     expect(result.observation.freshness).toEqual({ isFresh: true, verified: true });
+  });
+
+  test("does not promote stale Asleep fallback after a settle timeout", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    const staleAsleep = makeObservation({
+      updatedAt: 10,
+      wakefulness: "Asleep",
+      wakefulnessSource: "hierarchy",
+      viewHierarchy: makeHierarchy("cached-asleep"),
+      freshness: { isFresh: false, verified: false, category: "cache_age" },
+    });
+    const tap = createTapWithSettleSequence([staleAsleep]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect(postTap.observation.wakefulness).not.toBe("Asleep");
+    expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("A");
   });
 
   test("still retracts freshness on a live-hierarchy observation that predates the transition", () => {

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -90,6 +90,28 @@ describe("deriveTapEffectAfterPostTapObservation settles hierarchy-only changes 
     expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("B");
   });
 
+  test("a transient A that persists BEYOND one poll interval before B still reaches B (#6284 P1)", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    // A holds for two poll frames (a normal delay for the transitions this
+    // targets) before the real destination B arrives. A comparison-count settle
+    // would lock onto A after a single interval; the wall-clock quiet-period
+    // deadline requires A to hold for the FULL quiet period, which it never does
+    // — B arrives first and is reached.
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 30, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 40, viewHierarchy: makeHierarchy("B") }),
+      makeObservation({ updatedAt: 50, viewHierarchy: makeHierarchy("B") }),
+      makeObservation({ updatedAt: 60, viewHierarchy: makeHierarchy("B") }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect(postTap.effect).toEqual({ screenChanged: true, basis: "viewHierarchy changed" });
+    expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("B");
+  });
+
   test("a same-activity dialog (activeWindow unchanged) settles and is reported changed (#6151)", async () => {
     const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("alarm-list") });
     // Dialogs don't move activeWindow; only the hierarchy reflects them.
@@ -167,7 +189,7 @@ describe("deriveTapEffectAfterPostTapObservation settles hierarchy-only changes 
 });
 
 describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
-  test("replaceObservationHierarchy promotes a stale verdict to fresh when refreshed from device", () => {
+  test("replaceObservationHierarchy promotes a cache_age stale verdict to fresh when refreshed from device", () => {
     const tap = createTapOnElement();
     const observation = makeObservation({
       viewHierarchy: makeHierarchy("stale"),
@@ -175,6 +197,7 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
       freshness: {
         isFresh: false,
         verified: false,
+        category: "cache_age",
         warning: "served from host-side cache without re-verification",
       },
     });
@@ -192,6 +215,38 @@ describe("freshness realignment at hierarchy-replace sites (#6284)", () => {
     expect(observation.freshness?.isFresh).toBe(true);
     expect(observation.freshness?.verified).toBe(true);
     expect(observation.freshness?.warning).toBeUndefined();
+    expect(observation.freshness?.category).toBeUndefined();
+  });
+
+  test("replaceObservationHierarchy does NOT promote a non-cache-age freshness failure (#6284 P1)", () => {
+    const tap = createTapOnElement();
+    // A wrong-window / attribution failure is NOT resolved by swapping in a
+    // freshly-captured hierarchy (which may itself be from the wrong window):
+    // the refresh recollected only viewHierarchy, not activeWindow/attribution.
+    const windowIdentityFailure = {
+      isFresh: false as const,
+      verified: false,
+      category: "window_identity" as const,
+      warning:
+        "Observed hierarchy is from com.other, but the device's current top resumed activity is com.example.app.",
+    };
+    const observation = makeObservation({
+      viewHierarchy: makeHierarchy("wrong-window"),
+      freshness: { ...windowIdentityFailure },
+    });
+    const fresh = {
+      packageName: "com.example.app",
+      hierarchy: { node: { marker: "fresh" } },
+      screenWidth: 1080,
+      screenHeight: 1920,
+    } as unknown as ViewHierarchyResult;
+
+    (tap as any).replaceObservationHierarchy(observation, fresh, true);
+
+    expect(observation.viewHierarchy).toBe(fresh);
+    // The hierarchy was swapped, but the wrong-window verdict must survive — the
+    // result must not be forged trustworthy.
+    expect(observation.freshness).toEqual(windowIdentityFailure);
   });
 
   test("replaceObservationHierarchy leaves freshness untouched when NOT refreshed from device", () => {

--- a/test/features/action/TapOnElement.hierarchySettle.test.ts
+++ b/test/features/action/TapOnElement.hierarchySettle.test.ts
@@ -121,6 +121,24 @@ describe("deriveTapEffectAfterPostTapObservation settles hierarchy-only changes 
     expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("B");
   });
 
+  test("waits through a routine delayed transition before accepting a quiet hierarchy", async () => {
+    const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("baseline") });
+    const transientA = makeObservation({ updatedAt: 10, viewHierarchy: makeHierarchy("A") });
+    // A remains visible at 0, 150, and 300ms. A 300ms quiet period would accept
+    // it just before B arrives at 450ms; the documented 1–2s transition window
+    // requires continued polling and therefore returns B.
+    const tap = createTapWithSettleSequence([
+      makeObservation({ updatedAt: 20, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 30, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 40, viewHierarchy: makeHierarchy("A") }),
+      makeObservation({ updatedAt: 50, viewHierarchy: makeHierarchy("B") }),
+    ]);
+
+    const postTap = await (tap as any).deriveTapEffectAfterPostTapObservation(previous, transientA);
+
+    expect((postTap.observation.viewHierarchy.hierarchy.node as any).marker).toBe("B");
+  });
+
   test("a same-activity dialog (activeWindow unchanged) settles and is reported changed (#6151)", async () => {
     const previous = makeObservation({ updatedAt: 1, viewHierarchy: makeHierarchy("alarm-list") });
     // Dialogs don't move activeWindow; only the hierarchy reflects them.
@@ -368,6 +386,7 @@ describe("enforceFreshnessConsistencyWithEffect and the screen-off terminal (#62
 
     expect(result.observation.freshness?.isFresh).toBe(false);
     expect(result.observation.freshness?.verified).toBe(false);
+    expect(result.observation.freshness?.category).toBe("effect_inconsistent");
     expect(result.observation.freshness?.warning).toContain("predates the detected transition");
   });
 });

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -266,4 +266,50 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     expect(outcome.polls).toBe(2);
     expect(outcome.observation.wakefulness).not.toBe("Asleep");
   });
+
+  test("returns a live independently sampled rootless Asleep state", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const rootlessAsleep = {
+      ...obs(20, "rootless"),
+      wakefulness: "Asleep",
+      wakefulnessSource: "adb",
+      viewHierarchy: undefined,
+    } as ObserveResult;
+    fake.setObserveSequence([obs(10, "awake"), rootlessAsleep]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150 },
+      () => false,
+    );
+
+    expect(outcome.terminalReason).toBe("screen_off");
+    expect(outcome.observation).toBe(rootlessAsleep);
+  });
+
+  test("does not label an all-stale Asleep timeout as a screen-off terminal", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const staleAsleep = {
+      ...obs(10, "cached-asleep"),
+      wakefulness: "Asleep",
+      wakefulnessSource: "hierarchy",
+      freshness: { isFresh: false, verified: false, category: "cache_age" },
+    } as ObserveResult;
+    fake.setObserveSequence([staleAsleep]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 300, pollMs: 150, initialMinTimestampMs: 10 },
+      () => false,
+    );
+
+    expect(outcome.terminalReason).toBe("timeout");
+    expect(outcome.observation.wakefulness).toBe("Asleep");
+  });
 });

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -89,8 +89,9 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     // cache served by a timed-out sub-poll. The floor must stay at 30.
     fake.setObserveSequence([obs(10, "a"), obs(30, "b"), obs(20, "stale"), obs(40, "c")]);
 
-    let polls = 0;
-    await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, () => ++polls >= 4);
+    await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, (observation) => {
+      return (observation.viewHierarchy!.hierarchy.node as any).marker === "c";
+    });
 
     // minTimestamp: 0 (unseeded baseline) -> 11 (forced strictly past the
     // baseline 10, still no post-invocation capture) -> 30 (inclusive floor,
@@ -120,6 +121,26 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("newest");
     expect(outcome.observation.updatedAt).toBe(30);
     expect(fake.getExecuteMinTimestamps()).toEqual([0, 11, 30]);
+  });
+
+  test("does not let below-floor or explicitly stale frames advance a stateful predicate", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const stale = {
+      ...obs(20, "regressed"),
+      freshness: { isFresh: false, verified: false, category: "window_identity" },
+    } as ObserveResult;
+    fake.setObserveSequence([obs(10, "baseline"), obs(30, "B"), stale, obs(40, "A")]);
+    const seen: string[] = [];
+
+    const outcome = await pollObserveUntil(fake, timer, { timeoutMs: 450, pollMs: 150 }, (value) => {
+      seen.push((value.viewHierarchy!.hierarchy.node as any).marker);
+      return false;
+    });
+
+    expect(seen).toEqual(["baseline", "B", "A"]);
+    expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("A");
   });
 
   test("does not use a host-created observation timestamp as a device floor", async () => {

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -134,10 +134,15 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     fake.setObserveSequence([obs(10, "baseline"), obs(30, "B"), stale, obs(40, "A")]);
     const seen: string[] = [];
 
-    const outcome = await pollObserveUntil(fake, timer, { timeoutMs: 450, pollMs: 150 }, (value) => {
-      seen.push((value.viewHierarchy!.hierarchy.node as any).marker);
-      return false;
-    });
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 450, pollMs: 150 },
+      (value) => {
+        seen.push((value.viewHierarchy!.hierarchy.node as any).marker);
+        return false;
+      },
+    );
 
     expect(seen).toEqual(["baseline", "B", "A"]);
     expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("A");
@@ -215,5 +220,50 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
 
     expect(outcome.stopped).toBe(false);
     expect(outcome.polls).toBe(1);
+  });
+
+  test("does not accept an equal-timestamp delegate-unverified cache entry", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const unverifiedFallback = {
+      ...obs(20, "cached"),
+      freshness: { isFresh: true, verified: false },
+    } as ObserveResult;
+    fake.setObserveSequence([unverifiedFallback, obs(30, "verified")]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150, initialMinTimestampMs: 10 },
+      () => true,
+    );
+
+    expect(outcome.stopped).toBe(true);
+    expect(outcome.polls).toBe(2);
+    expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("verified");
+  });
+
+  test("does not fast-fail on a stale Asleep cache entry", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const staleAsleep = {
+      ...obs(10, "cached-asleep"),
+      wakefulness: "Asleep",
+      freshness: { isFresh: true, verified: false },
+    } as ObserveResult;
+    fake.setObserveSequence([staleAsleep, obs(20, "awake")]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150, initialMinTimestampMs: 10 },
+      () => true,
+    );
+
+    expect(outcome.stopped).toBe(true);
+    expect(outcome.polls).toBe(2);
+    expect(outcome.observation.wakefulness).not.toBe("Asleep");
   });
 });

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../src/models/ObserveResult";
+import { pollObserveUntil } from "../../../src/features/observe/ObservePoll";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+/**
+ * Unit tests for `pollObserveUntil`'s `minTimestamp` floor (issue #6284).
+ *
+ * The floor lives in ONE clock domain end-to-end: the device-authored
+ * `updatedAt`. It is seeded from the caller's device-domain
+ * `initialMinTimestampMs` (or from the first observation when unseeded), never
+ * from the host clock, and only ever raised — so a device clock trailing the
+ * daemon does not make fresh captures look stale, and a stale/cached poll
+ * cannot lower it. All time control flows through FakeTimer; every test runs
+ * well under 100ms and never touches a device or the DB.
+ */
+
+function obs(updatedAt: number, marker: string): ObserveResult {
+  return {
+    updatedAt,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    activeWindow: { appId: "com.example", activityName: ".MainActivity", layoutSeqSum: 1 },
+    viewHierarchy: {
+      packageName: "com.example",
+      hierarchy: { node: { marker } as any },
+    },
+  } as ObserveResult;
+}
+
+describe("pollObserveUntil minTimestamp floor (#6284)", () => {
+  test("seeds the first poll from the caller's DEVICE-domain floor, never the host clock", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    // Host clock is far ahead of the device clock (device trails the daemon).
+    timer.advanceTime(1_000_000);
+    const fake = new FakeObserveScreen();
+    fake.setObserveSequence([obs(10, "a"), obs(20, "b")]);
+
+    let polls = 0;
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150, initialMinTimestampMs: 10 },
+      () => ++polls >= 2,
+    );
+
+    expect(outcome.stopped).toBe(true);
+    // First poll floors on the device-domain seed (10), NOT the host clock
+    // (1_000_000). A host-domain floor would reject every genuinely fresh
+    // device capture and burn the whole budget.
+    expect(fake.getExecuteMinTimestamps()).toEqual([10, 10]);
+  });
+
+  test("with no seed, the first poll floors at 0 (no host clock) then seeds from the first observation's device timestamp", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    timer.advanceTime(1_000_000); // host clock far ahead
+    const fake = new FakeObserveScreen();
+    fake.setObserveSequence([obs(100, "a"), obs(200, "b")]);
+
+    let polls = 0;
+    await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, () => ++polls >= 2);
+
+    // First poll: no floor (0), not the host clock. Second poll: floor seeded
+    // from the FIRST observation's own device timestamp (100).
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 100]);
+  });
+
+  test("a stale/cached poll cannot LOWER the monotonic floor", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    // Poll 3 returns an OLDER device timestamp (20) than poll 2 (30) — a stale
+    // cache served by a timed-out sub-poll. The floor must stay at 30.
+    fake.setObserveSequence([obs(10, "a"), obs(30, "b"), obs(20, "stale"), obs(40, "c")]);
+
+    let polls = 0;
+    await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, () => ++polls >= 4);
+
+    // floor: undefined -> 10 -> 30 -> max(30,20)=30 -> 40. The 4th poll's floor
+    // is 30, NOT the stale 20 — so the same stale hash cannot be re-served.
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 10, 30, 30]);
+  });
+
+  test("a screen-off (Asleep) capture fast-fails the loop rather than burning the budget", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    fake.setObserveSequence([{ ...obs(10, "a"), wakefulness: "Asleep" } as ObserveResult]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150 },
+      () => false,
+    );
+
+    expect(outcome.stopped).toBe(false);
+    expect(outcome.polls).toBe(1);
+  });
+});

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -30,13 +30,13 @@ function obs(updatedAt: number, marker: string): ObserveResult {
 }
 
 describe("pollObserveUntil minTimestamp floor (#6284)", () => {
-  test("seeds the first poll from the caller's DEVICE-domain floor, never the host clock", async () => {
+  test("forces the first poll STRICTLY past the caller's DEVICE-domain seed, never the host clock", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     // Host clock is far ahead of the device clock (device trails the daemon).
     timer.advanceTime(1_000_000);
     const fake = new FakeObserveScreen();
-    fake.setObserveSequence([obs(10, "a"), obs(20, "b")]);
+    fake.setObserveSequence([obs(20, "a"), obs(30, "b")]);
 
     let polls = 0;
     const outcome = await pollObserveUntil(
@@ -47,25 +47,37 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     );
 
     expect(outcome.stopped).toBe(true);
-    // First poll floors on the device-domain seed (10), NOT the host clock
-    // (1_000_000). A host-domain floor would reject every genuinely fresh
-    // device capture and burn the whole budget.
-    expect(fake.getExecuteMinTimestamps()).toEqual([10, 10]);
+    // First poll is forced strictly past the device-domain seed (10 -> 11), NOT
+    // the host clock (1_000_000): it can neither re-read nor accept the entering
+    // capture as terminal evidence (#6284 P1). Once a strictly-newer capture
+    // (20) arrives the floor relaxes to the inclusive monotonic device floor.
+    expect(fake.getExecuteMinTimestamps()).toEqual([11, 20]);
   });
 
-  test("with no seed, the first poll floors at 0 (no host clock) then seeds from the first observation's device timestamp", async () => {
+  test("an unseeded first poll is a non-terminal baseline; terminal evidence must be strictly newer", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     timer.advanceTime(1_000_000); // host clock far ahead
     const fake = new FakeObserveScreen();
     fake.setObserveSequence([obs(100, "a"), obs(200, "b")]);
 
-    let polls = 0;
-    await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, () => ++polls >= 2);
+    // A predicate that would match on EVERY observation (including the pre-call
+    // baseline). It must not terminate on the baseline — only on a genuine
+    // post-invocation capture.
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150 },
+      () => true,
+    );
 
-    // First poll: no floor (0), not the host clock. Second poll: floor seeded
-    // from the FIRST observation's own device timestamp (100).
-    expect(fake.getExecuteMinTimestamps()).toEqual([0, 100]);
+    expect(outcome.stopped).toBe(true);
+    // The baseline poll (100) is suppressed; the loop stops on poll 2 (200).
+    expect(outcome.polls).toBe(2);
+    expect(outcome.observation.updatedAt).toBe(200);
+    // First poll: no floor (0), not the host clock. Second poll: forced strictly
+    // past the baseline's own device timestamp (100 -> 101).
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 101]);
   });
 
   test("a stale/cached poll cannot LOWER the monotonic floor", async () => {
@@ -79,9 +91,40 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     let polls = 0;
     await pollObserveUntil(fake, timer, { timeoutMs: 5000, pollMs: 150 }, () => ++polls >= 4);
 
-    // floor: undefined -> 10 -> 30 -> max(30,20)=30 -> 40. The 4th poll's floor
-    // is 30, NOT the stale 20 — so the same stale hash cannot be re-served.
-    expect(fake.getExecuteMinTimestamps()).toEqual([0, 10, 30, 30]);
+    // minTimestamp: 0 (unseeded baseline) -> 11 (forced strictly past the
+    // baseline 10, still no post-invocation capture) -> 30 (inclusive floor,
+    // post-invocation reached) -> max(30,20)=30. The 4th poll's floor is 30, NOT
+    // the stale 20 — the same stale hash cannot be re-served.
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 11, 30, 30]);
+  });
+
+  test("a seeded poll that re-serves the entering capture is never accepted as terminal (#6284 P1)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    // The delegate first re-serves the very entering capture (updatedAt 10 ===
+    // the seed) before a genuinely-newer destination (20) arrives. A match on
+    // the re-served entering capture would report a condition that may already
+    // be false; only the strictly-newer capture may terminate.
+    fake.setObserveSequence([obs(10, "entering"), obs(20, "destination")]);
+
+    const matchedMarkers: string[] = [];
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150, initialMinTimestampMs: 10 },
+      (observation) => {
+        matchedMarkers.push((observation.viewHierarchy!.hierarchy.node as any).marker as string);
+        return true; // would match on every poll, including the re-served entering one
+      },
+    );
+
+    expect(outcome.stopped).toBe(true);
+    // Both polls were evaluated, but only the strictly-newer "destination"
+    // terminated — the re-served "entering" capture was ignored as non-terminal.
+    expect(matchedMarkers).toEqual(["entering", "destination"]);
+    expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("destination");
+    expect(outcome.observation.updatedAt).toBe(20);
   });
 
   test("a screen-off (Asleep) capture fast-fails the loop rather than burning the budget", async () => {

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -25,6 +25,7 @@ function obs(updatedAt: number, marker: string): ObserveResult {
     viewHierarchy: {
       packageName: "com.example",
       hierarchy: { node: { marker } as any },
+      updatedAt,
     },
   } as ObserveResult;
 }
@@ -96,6 +97,57 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     // post-invocation reached) -> max(30,20)=30. The 4th poll's floor is 30, NOT
     // the stale 20 — the same stale hash cannot be re-served.
     expect(fake.getExecuteMinTimestamps()).toEqual([0, 11, 30, 30]);
+  });
+
+  test("does not accept or return a regressed terminal sample after raising the floor", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    // The final 20 is later than the entering baseline (10), but it is older
+    // than the 30 already accepted into the device floor. It must not become
+    // terminal evidence or replace the newer trustworthy evidence on timeout.
+    fake.setObserveSequence([obs(10, "baseline"), obs(30, "newest"), obs(20, "regressed")]);
+    let polls = 0;
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 300, pollMs: 150 },
+      () => ++polls >= 3,
+    );
+
+    expect(outcome.stopped).toBe(false);
+    expect((outcome.observation.viewHierarchy!.hierarchy.node as any).marker).toBe("newest");
+    expect(outcome.observation.updatedAt).toBe(30);
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 11, 30]);
+  });
+
+  test("does not use a host-created observation timestamp as a device floor", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const hostStampedPartial = {
+      ...obs(1_000_000, "partial"),
+      // A base observation's top-level timestamp is host metadata. No
+      // hierarchy timestamp means this capture cannot establish device
+      // freshness or be accepted as terminal evidence.
+      viewHierarchy: { packageName: "com.example", hierarchy: { node: { marker: "partial" } } },
+    } as ObserveResult;
+    fake.setObserveSequence([hostStampedPartial, obs(20, "device-baseline"), obs(30, "device")]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150 },
+      () => true,
+    );
+
+    expect(outcome.stopped).toBe(true);
+    expect(outcome.observation.updatedAt).toBe(30);
+    // The second read is still unfloored: no device timestamp was available
+    // from the partial first result to turn into a device-side minTimestamp.
+    // It establishes the actual device baseline for the third read.
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 0, 21]);
   });
 
   test("a seeded poll that re-serves the entering capture is never accepted as terminal (#6284 P1)", async () => {

--- a/test/features/observe/ObservePoll.test.ts
+++ b/test/features/observe/ObservePoll.test.ts
@@ -222,6 +222,31 @@ describe("pollObserveUntil minTimestamp floor (#6284)", () => {
     expect(outcome.polls).toBe(1);
   });
 
+  test("does not accept an unseeded cached hierarchy screen-off before a post-invocation capture", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const fake = new FakeObserveScreen();
+    const cachedAsleep = {
+      ...obs(10, "cached-asleep"),
+      wakefulness: "Asleep",
+      wakefulnessSource: "hierarchy",
+      freshness: { isFresh: true, verified: true },
+    } as ObserveResult;
+    const awake = { ...obs(20, "awake"), wakefulness: "Awake" } as ObserveResult;
+    fake.setObserveSequence([cachedAsleep, awake]);
+
+    const outcome = await pollObserveUntil(
+      fake,
+      timer,
+      { timeoutMs: 5000, pollMs: 150 },
+      () => true,
+    );
+
+    expect(outcome.stopped).toBe(true);
+    expect(outcome.polls).toBe(2);
+    expect(outcome.observation).toBe(awake);
+  });
+
   test("does not accept an equal-timestamp delegate-unverified cache entry", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();

--- a/test/features/observe/ObserveScreenWindowIdentity.test.ts
+++ b/test/features/observe/ObserveScreenWindowIdentity.test.ts
@@ -59,6 +59,31 @@ describe("ObserveScreen window-identity freshness (issue #5867)", () => {
     resetObserveCacheStore();
   });
 
+  test("does not reuse cache for an overlay recapture without a device timestamp", async () => {
+    const viewHierarchy = new FakeViewHierarchy();
+    const screen = makeScreen(viewHierarchy, new FakeAdbExecutor());
+    const result = { viewHierarchy: { hierarchy: { node: {} } } } as any;
+
+    const recaptured = await (screen as any).recaptureHierarchyForSystemUiOverlay(result);
+
+    expect(recaptured).toBe(false);
+    expect(viewHierarchy.getCallCount()).toBe(0);
+  });
+
+  test("does not reuse cache for a back-stack recapture without a device timestamp", async () => {
+    const viewHierarchy = new FakeViewHierarchy();
+    const screen = makeScreen(viewHierarchy, new FakeAdbExecutor());
+    const result = { viewHierarchy: { hierarchy: { node: {} } } } as any;
+
+    const recaptured = await (screen as any).recaptureHierarchyForBackStackAttribution(result, {
+      packageName: "com.example.app",
+      activityName: "com.example.app.MainActivity",
+    });
+
+    expect(recaptured).toBe(false);
+    expect(viewHierarchy.getCallCount()).toBe(0);
+  });
+
   test("falls back when accessibility foreground metadata is a View class", async () => {
     const now = 1_700_000_000_000;
     const timer = new FakeTimer();

--- a/test/features/observe/SettleObserve.test.ts
+++ b/test/features/observe/SettleObserve.test.ts
@@ -24,6 +24,7 @@ function obs(node: Record<string, unknown>, extra?: Partial<ObserveResult>): Obs
     viewHierarchy: {
       packageName: "com.example",
       hierarchy: { node: node as any },
+      updatedAt: typeof extra?.updatedAt === "number" ? extra.updatedAt : 1,
     },
     ...extra,
   } as ObserveResult;
@@ -36,6 +37,7 @@ function iosObs(node: Record<string, unknown>, extra?: Partial<ObserveResult>): 
     viewHierarchy: {
       packageName: "com.apple.mobilesafari",
       hierarchy: { node: node as any },
+      updatedAt: typeof extra?.updatedAt === "number" ? extra.updatedAt : 1,
     },
     screenIdentity: {
       platform: "ios",

--- a/test/features/observe/SettleObserve.test.ts
+++ b/test/features/observe/SettleObserve.test.ts
@@ -203,8 +203,9 @@ describe("RealSettleObserve", () => {
     await settle.execute({ timeoutMs: 2500, pollMs: 150 });
 
     const mins = fake.getExecuteMinTimestamps();
-    // First poll seeds from loop-start (0); each subsequent poll waits for a read
-    // strictly newer than the previous observation's timestamp.
+    // The first poll carries no floor (0 = "freshest available"); each
+    // subsequent poll floors on the monotonic device-domain `updatedAt` of the
+    // prior observation, so a static screen cannot false-settle (#6284).
     expect(mins).toEqual([0, 10, 20]);
     // Monotonic non-decreasing.
     for (let i = 1; i < mins.length; i++) {

--- a/test/features/observe/SettleObserve.test.ts
+++ b/test/features/observe/SettleObserve.test.ts
@@ -203,10 +203,11 @@ describe("RealSettleObserve", () => {
     await settle.execute({ timeoutMs: 2500, pollMs: 150 });
 
     const mins = fake.getExecuteMinTimestamps();
-    // The first poll carries no floor (0 = "freshest available"); each
-    // subsequent poll floors on the monotonic device-domain `updatedAt` of the
-    // prior observation, so a static screen cannot false-settle (#6284).
-    expect(mins).toEqual([0, 10, 20]);
+    // The first poll carries no floor (0 = baseline). The second is forced
+    // strictly past that baseline (10 -> 11) to obtain a genuine post-invocation
+    // capture; thereafter polls floor inclusively on the monotonic device-domain
+    // `updatedAt` (20), so a static screen cannot false-settle (#6284).
+    expect(mins).toEqual([0, 11, 20]);
     // Monotonic non-decreasing.
     for (let i = 1; i < mins.length; i++) {
       expect(mins[i]!).toBeGreaterThanOrEqual(mins[i - 1]!);

--- a/test/features/observe/WaitForCondition.test.ts
+++ b/test/features/observe/WaitForCondition.test.ts
@@ -154,7 +154,9 @@ describe("RealWaitForCondition", () => {
     const waitFor = new RealWaitForCondition(fake, timer);
     await waitFor.execute(predicate, { timeoutMs: 2500, pollMs: 150 });
 
-    expect(fake.getExecuteMinTimestamps()).toEqual([0, 10, 20]);
+    // 0 (unseeded baseline) -> 11 (forced strictly past the baseline 10 for a
+    // genuine post-invocation capture) -> 20 (inclusive monotonic floor).
+    expect(fake.getExecuteMinTimestamps()).toEqual([0, 11, 20]);
   });
 
   test("built-in `appear` predicate reuses the finder and resolves when the element shows up", async () => {

--- a/test/features/observe/WaitForCondition.test.ts
+++ b/test/features/observe/WaitForCondition.test.ts
@@ -27,6 +27,11 @@ function obs(node: Record<string, unknown>, extra?: Partial<ObserveResult>): Obs
     viewHierarchy: {
       packageName: "com.example",
       hierarchy: { node: node as any },
+      // The poll loop's device-clock freshness floor (#6284) reads the
+      // hierarchy-owned `updatedAt`, never the (possibly host-created) top-level
+      // one. Mirror the caller's device timestamp here so observations are
+      // admissible, matching the shared helper in SettleObserve.test.ts.
+      updatedAt: typeof extra?.updatedAt === "number" ? extra.updatedAt : 1,
     },
     ...extra,
   } as ObserveResult;

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -42,14 +42,17 @@ const makeHierarchy = (children: Record<string, unknown>[]): ViewHierarchyResult
     screenHeight: 200,
   }) as unknown as ViewHierarchyResult;
 
-const makeObservation = (children: Record<string, unknown>[], updatedAt = 0): ObserveResult =>
-  ({
+const makeObservation = (children: Record<string, unknown>[], updatedAt = 0): ObserveResult => {
+  const viewHierarchy = makeHierarchy(children);
+  viewHierarchy.updatedAt = updatedAt;
+  return {
     updatedAt,
     screenSize: { width: 200, height: 200 },
     systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
     activeWindow: { appId: "com.example", activityName: ".Main", layoutSeqSum: 0 },
-    viewHierarchy: makeHierarchy(children),
-  }) as ObserveResult;
+    viewHierarchy,
+  } as ObserveResult;
+};
 
 const node = (props: Record<string, unknown>): Record<string, unknown> => ({
   bounds: flatBounds(0, 0, 10, 10),
@@ -267,6 +270,28 @@ describe("waitForObservation DSL branch", () => {
     expect(outcome.awaitTimeout).toBe(true);
     expect(outcome.timedOut).toBe(false);
     expect(outcome.polls).toBe(1);
+  });
+
+  test("for:'stable' reports timeout when stale Asleep frames exhaust the budget", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult({
+      ...makeObservation([node({ "resource-id": "content" })], 10),
+      wakefulness: "Asleep",
+      freshness: { isFresh: false, verified: false, category: "cache_age" },
+    });
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      { for: "stable", timeout: 300 } as any,
+      undefined,
+      false,
+      timer,
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(outcome.timedOut).toBe(true);
   });
 });
 

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1156,10 +1156,15 @@ describe("waitForObservation activeWindow", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const observeScreen = new FakeObserveScreen();
-    observeScreen.setObserveSequence([
-      makeObservation("com.example.app", "com.example.app.HomeActivity"),
-      makeObservation("com.example.app", "com.example.app.HomeActivity"),
-    ]);
+    // The settle loop's device-clock floor (#6284) admits a capture only via the
+    // hierarchy-owned `updatedAt`. A structurally-identical pair with strictly
+    // increasing device timestamps lets the second read clear the post-invocation
+    // floor and settle, exactly as the SettleObserve unit tests drive it.
+    const firstStable = makeObservation("com.example.app", "com.example.app.HomeActivity");
+    const secondStable = makeObservation("com.example.app", "com.example.app.HomeActivity");
+    firstStable.viewHierarchy!.updatedAt = 10;
+    secondStable.viewHierarchy!.updatedAt = 20;
+    observeScreen.setObserveSequence([firstStable, secondStable]);
 
     const outcome = await waitForObservation(
       observeScreen,


### PR DESCRIPTION
Split out of [#6266](https://github.com/kaeawc/auto-mobile/pull/6266) (issue [#6258](https://github.com/kaeawc/auto-mobile/issues/6258)) as a coherent design pass, after the settle/freshness hardening was attempted incrementally there and produced five rounds of interacting-guard findings. The core [#6258](https://github.com/kaeawc/auto-mobile/issues/6258) fix (`deriveTapEffect` fall-through) already merged; this PR is only the settle-poll / freshness-consistency hardening, designed whole.

## Root cause of the earlier entanglement
The earlier attempt added a `bothFresh` gate to `compareViewHierarchy`: once a stale baseline could block *all* future diffs, every downstream guard (freshness realignment at each replace site, device-clock-domain floor seeding, a monotonic floor, screen-off terminal preservation) became load-bearing and mutually entangled — and a same-window dialog could never be reported changed.

This redesign moves staleness robustness **out of the comparison** and **into a single device-clock-domain monotonic poll floor**, so `compareViewHierarchy` stays a pure hash diff and legitimate diffs are never blocked.

## What changed
- **One clock domain end-to-end.** `pollObserveUntil`'s `minTimestamp` floor is now purely device-authored `updatedAt`. It is seeded from the caller's device-domain `initialMinTimestampMs` (or from the first observation when unseeded), **never** from the host clock — so an Android device clock trailing the daemon no longer makes fresh captures look stale ([#5377](https://github.com/kaeawc/auto-mobile/issues/5377) family). `waitForPostTapChange` and the settle both seed from the entering capture's `updatedAt`.
- **Monotonic floor.** The floor is only ever raised (`Math.max`), so a stale/cached capture returned by a timed-out sub-poll cannot lower it and re-serve the same stale hash. The default path still seeds the floor to the first observation's device timestamp.
- **Real stability interval, without missing a later destination.** Hierarchy-only post-tap changes are settled (hash unchanged across two consecutive poll comparisons, or promoted to an authoritative `activeWindow` change) before being trusted as terminal, so `baseline → A → A → B` reaches **B** rather than returning the transient A.
- **Screen-off terminal preserved.** A definitive `wakefulness: "Asleep"` terminal keeps the already-established `screenChanged: true` through both settle re-derivation **and** `enforceFreshnessConsistencyWithEffect`.
- **Freshness realigned at every hierarchy-replace site.** Both mutation sites route through one sanctioned helper (`replaceObservationHierarchy`) that also refreshes freshness on a live device re-capture.

## Tests (deterministic, <100ms, no device/DB)
`test/features/observe/ObservePoll.test.ts` and `test/features/action/TapOnElement.hierarchySettle.test.ts`: device-clock-trails-host seeds a device-domain floor; monotonic floor not lowered by a stale poll; `baseline → A → A → B` reaches B; same-activity dialog reported changed; asleep terminal preserves `screenChanged: true` (asserts the effect); freshness realigned at the replace site; screen-off guard in the consistency check.

## Validation
`bun test test/features/action/TapOnElement*.test.ts test/features/observe/*.test.ts` (1119 pass) · `bun run lint` (ratchet: no new violations) · `bun run typecheck` (no new errors) · `bun run format:check` · `bunx turbo run build`.

Closes #6284