### PR TITLE
ci: drop macos-14 / Xcode 15.4 from GitHub Actions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -959,7 +959,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
@@ -1010,7 +1009,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
@@ -1051,7 +1049,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
@@ -1506,17 +1503,12 @@ jobs:
 
   swift-code-coverage:
     name: "Swift Code Coverage"
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
         with:
           lfs: false
-
-      - name: "Select Xcode 15.4"
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "15.4"
 
       - name: "Generate Swift Coverage Badge"
         run: bash scripts/coverage/generate-swift-coverage.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -258,7 +258,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
           - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
@@ -311,7 +310,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
           - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1648,7 +1648,7 @@ jobs:
   swiftlint:
     timeout-minutes: 20
     name: "SwiftLint"
-    runs-on: macos-14
+    runs-on: macos-26
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
     steps:
@@ -1676,7 +1676,7 @@ jobs:
   swift-code-coverage:
     timeout-minutes: 20
     name: "Swift Code Coverage"
-    runs-on: macos-14
+    runs-on: macos-26
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
     steps:
@@ -1684,11 +1684,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
-
-      - name: "Select Xcode 15.4"
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "15.4"
 
       - name: "Generate Swift Coverage Badge"
         run: bash scripts/coverage/generate-swift-coverage.sh
@@ -1720,7 +1715,7 @@ jobs:
       fail-fast: false
       matrix:
         # PR runs only the primary Xcode toolchain. The full version sweep
-        # (15.4 / 26.0 / 26.5) runs on nightly.yml — Xcode-toolchain drift is
+        # (26.0 / 26.5 / 26.6) runs on nightly.yml — Xcode-toolchain drift is
         # slow-moving and does not need per-PR macOS minutes.
         config:
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }


### PR DESCRIPTION
## What

Removes all `macos-14` usage from GitHub Actions, consolidating macOS jobs onto `macos-26` and ending Xcode 15.4 compatibility coverage.

- **`swiftlint`, `swift-code-coverage`** → `macos-26`. SwiftLint has no Xcode dependency, so it's a clean relabel. The coverage job's `Select Xcode 15.4` step is **dropped** (not repinned) — it now runs on the macos-26 default toolchain.
- **Removed the 5 `{ name: "Xcode 15", runner: "macos-14", xcode: "15.4" }` matrix entries** — 2 in `nightly.yml`, 3 in `merge.yml`. Xcode 26.0/26.5/26.6 coverage remains.
- Refreshed the stale PR toolchain-sweep comment (`15.4 / 26.0 / 26.5` → `26.0 / 26.5 / 26.6`).

## Why

macOS runner capacity/consolidation. `macos-26` (Tahoe) does **not** carry Xcode 15.4, so the Xcode-15-pinned jobs could not simply be relabeled — removing `macos-14` necessarily ends Xcode 15 compatibility coverage. That trade-off was made deliberately.

## Reviewer notes

- **No merge-wedge risk.** The `green-main` ruleset has no Xcode-15-specific required check; its iOS-related required checks are `SwiftLint`, `Swift Code Coverage`, and `iOS Build` — all names preserved by this change.
- **Path-filtering + concurrency-cancel were already in place** on `pull_request.yml` (top-level `cancel-in-progress`, plus `detect-changes` gating every macOS job on `ios_should_run`/`ios_integration_should_run`/`webrtc_should_run`), so no slot-waste changes were needed here.
- The iOS/Swift tree is henceforth verified only against Xcode 26.x.