### PR TITLE
ci: self-host swiftlint for kaeawc-authored PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1648,10 +1648,16 @@ jobs:
   swiftlint:
     timeout-minutes: 20
     name: "SwiftLint"
-    # PR workflow definitions are supplied by the pull request, so every PR job
-    # stays on a GitHub-hosted runner. Trusted post-merge work retains the
-    # automobile-mac route in merge.yml.
-    runs-on: macos-26
+    # Deliberate exception to the "PR jobs stay hosted" rule (the other PR jobs
+    # below keep that rule). SwiftLint is the cheapest PR job to self-host: it
+    # checks out and runs a lint script only — no secrets, no Xcode toolchain, no
+    # simulator — so kaeawc-authored PRs route to the self-hosted Apple Silicon
+    # runner (label automobile-mac) for fast feedback; every other author falls
+    # back to GitHub-hosted macos-26. NOTE: the author guard is a default, not a
+    # security boundary — a PR supplies its own workflow file and could target
+    # self-hosted regardless. The real gate is the repo's all_external_contributors
+    # fork-PR approval policy, which holds untrusted PRs until manually approved.
+    runs-on: ${{ github.event.pull_request.user.login == 'kaeawc' && fromJSON('["self-hosted", "automobile-mac"]') || 'macos-26' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
     steps:

--- a/test/scripts/spmRootToolchainWorkflow.test.ts
+++ b/test/scripts/spmRootToolchainWorkflow.test.ts
@@ -2,14 +2,34 @@ import { describe, expect, test } from "bun:test";
 import { loadJobSteps, loadJobs, stepNamed } from "../helpers/workflowSteps";
 
 describe("root SPM toolchain floor workflow", () => {
-  test("keeps pull-request jobs off the self-hosted runner", () => {
+  // swiftlint is a deliberate, documented exception to the "PR jobs stay hosted"
+  // rule: it is the cheapest PR job to self-host (checkout + lint script only, no
+  // secrets, no Xcode toolchain, no simulator), so kaeawc-authored PRs route it to
+  // the self-hosted runner. Every other PR job must stay on a GitHub-hosted runner.
+  const SELF_HOSTED_PR_EXCEPTIONS = new Set(["swiftlint"]);
+
+  test("keeps every non-excepted pull-request job off the self-hosted runner", () => {
     const jobs = loadJobs(".github/workflows/pull_request.yml");
     const prohibitedRunners = ["self-hosted", "automobile-mac"];
-    const selfHostedJobs = Object.entries(jobs).filter(([, job]) =>
-      prohibitedRunners.some((runner) => JSON.stringify(job["runs-on"] ?? "").includes(runner)),
-    );
+    const selfHostedJobs = Object.entries(jobs)
+      .filter(
+        ([name, job]) =>
+          !SELF_HOSTED_PR_EXCEPTIONS.has(name) &&
+          prohibitedRunners.some((runner) => JSON.stringify(job["runs-on"] ?? "").includes(runner)),
+      )
+      .map(([name]) => name);
 
     expect(selfHostedJobs).toEqual([]);
+  });
+
+  test("routes swiftlint to the self-hosted runner behind the kaeawc author guard", () => {
+    const jobs = loadJobs(".github/workflows/pull_request.yml");
+    const runsOn = JSON.stringify(jobs["swiftlint"]?.["runs-on"] ?? "");
+
+    expect(runsOn).toContain("automobile-mac");
+    expect(runsOn).toContain("github.event.pull_request.user.login == 'kaeawc'");
+    // Fallback to a GitHub-hosted runner for every other author.
+    expect(runsOn).toContain("macos-26");
   });
 
   test("pins the Swift package matrix to its configured Xcode floor", () => {


### PR DESCRIPTION
## What

Routes the `swiftlint` PR job to the self-hosted Apple Silicon runner (label `automobile-mac`) for **kaeawc-authored** PRs, falling back to GitHub-hosted `macos-26` for every other author.

```yaml
runs-on: ${{ github.event.pull_request.user.login == 'kaeawc'
  && fromJSON('["self-hosted", "automobile-mac"]') || 'macos-26' }}
```

## Why swiftlint specifically

It's the cheapest PR job to self-host: checkout + `validate_swiftlint.sh` only — no secrets, no Xcode toolchain, no simulator. So it gets fast local feedback with the least surface area. Every **other** PR job deliberately stays GitHub-hosted.

## Security note

This is a conscious exception to the "PR jobs stay hosted" rule. The `github.actor`/author guard is a **default, not a security boundary** — a `pull_request` run uses the workflow file from the PR's own head, so a PR can target any runner regardless of the guard. The real gate is the repo's `all_external_contributors` fork-PR approval policy, which holds untrusted PRs until manually approved. Only `swiftlint` is opted in; the rest of the PR matrix is untouched.

## Test

`test/scripts/spmRootToolchainWorkflow.test.ts` updated:
- `keeps every non-excepted pull-request job off the self-hosted runner` — still forbids self-hosting on all PR jobs **except** the documented `swiftlint` exception.
- new: `routes swiftlint to the self-hosted runner behind the kaeawc author guard` — locks in the routing + fallback.

All 4 tests pass locally (185ms). actionlint clean on the expression; YAML valid; `pr-gate-wiring.bats` + `workflow-artifact-name-uniqueness.bats` pass; oxfmt/oxlint clean.

## Note on exercising this

This PR touches no `ios/` source, so `detect-changes` skips the iOS jobs (including `swiftlint`) on its own CI — the routing first exercises on your next iOS-affecting PR.